### PR TITLE
Add hash test

### DIFF
--- a/t/spectest.data
+++ b/t/spectest.data
@@ -507,6 +507,7 @@ S29-context/die.t
 S29-context/eval.t
 S29-context/exit.t
 S29-context/sleep.t
+S29-conversions/hash.t
 S29-conversions/ord_and_chr.t                              #icu
 S32-array/bool.t
 S32-array/create.t


### PR DESCRIPTION
Hello,

I've added a new test file (S29-conversions/hash.t) to roast to test hash().  This patch adds it to spectest.data.

Cheers,
Fitz
