### PR TITLE
implement orelse

### DIFF
--- a/src/Perl6/Grammar.pm
+++ b/src/Perl6/Grammar.pm
@@ -1974,7 +1974,7 @@ token infix:sym<and>  { <sym> >> <O('%loose_and, :pasttype<if>')> }
 
 token infix:sym<or>   { <sym> >> <O('%loose_or, :assoc<left>, :pasttype<unless>')> }
 token infix:sym<xor>  { <sym> >> <O('%loose_or, :pasttype<xor>')> }
-token infix:sym<err>  { <sym> >> <O('%loose_or, :assoc<left>, :pasttype<def_or>')> }
+token infix:sym<orelse> { <sym> >> <O('%loose_or, :assoc<left>, :pasttype<def_or>')> }
 
 token infix:sym«<==»  { <sym> <O('%sequencer')> }
 token infix:sym«==>»  { <sym> <O('%sequencer')> }

--- a/src/core/metaops.pm
+++ b/src/core/metaops.pm
@@ -320,6 +320,7 @@ our multi sub infix:<or>(Mu $x = Bool::False)     { $x }
 our multi sub infix:<^^>(Mu $x = Bool::False)     { $x }
 our multi sub infix:<xor>(Mu $x = Bool::False)    { $x }
 our multi sub infix:<//>()     { Any }
+our multi sub infix:<orelse>() { Any }
 #our multi sub infix:<min>()    { +Inf }
 #our multi sub infix:<max>()    { -Inf }
 #our multi sub infix:<=>()      { Nil }

--- a/src/core/operators.pm
+++ b/src/core/operators.pm
@@ -210,7 +210,11 @@ our sub hash(*@list, *%hash) {
 }
 
 our multi infix:sym<//>(Mu $a, Mu $b) {
-    $a.defined ?? $a !! $b
+     $a.defined ?? $a !! $b
+}
+
+our multi infix:sym<orelse>(Mu $a, Mu $b) {
+     $a.defined ?? $a !! $b
 }
 
 our multi infix:<==>($a, $b) {


### PR DESCRIPTION
Hello,

This patch adds the orelse operator to Rakudo.  It does not implement the full functionality, specifically passing on $! to the right hand side, but it does behave as a loose-or precedent version of //.  I will be adding tests to the spectest in a moment. 

Thanks!
Fitz Elliott
