### PR TITLE
Io smartmatch

### DIFF
--- a/src/core/IO.pm
+++ b/src/core/IO.pm
@@ -147,25 +147,118 @@ class IO is Cool {
         $.stat.exists;
     }
     multi method f() {
-        self.e ?? !$.stat.isdir !! Bool;
+        self.e ?? (!$.stat.isdir and !$.stat.isdev) !! Bool;
     }
 
     multi method s() {
         self.e ?? $.stat.size !! Any;
     }
 
-    multi method l() {
-        my $fn = $.path;
-        ? Q:PIR{
-            .local pmc filename, file
-            filename = find_lex '$fn'
-            $S0 = filename
-
-            file = root_new ['parrot';'File']
-            $I0 = file.'is_link'($S0)
-            %r = box $I0
-        }
+    multi method R() {
+        ?pir::new__PS('OS').can_read($.path);
     }
+
+    multi method W() {
+        ?pir::new__PS('OS').can_write($.path);
+    }
+
+    multi method X() {
+        ?pir::new__PS('OS').can_execute($.path);
+    }
+
+    multi method r() {
+        return self.R if $*OSNAME -eq "MSWin32";
+        my $path = $.path;
+        return ?Q:PIR {
+            .local pmc uid,euid,suid,undef,os
+
+            uid = get_hll_global '$UID'
+            euid = get_hll_global '$EUID'
+            undef = new ['Undef']
+            os = new ['OS']
+
+            .local pmc setresuid,res,path
+            path = find_lex '$path'
+            setresuid = dlfunc undef, 'setresuid', 'iiii'
+
+            setresuid(euid, uid, uid)
+            res = os.'can_read'(path)
+            setresuid(uid, euid, uid)
+
+            %r = res
+        };
+    }
+
+    multi method w() {
+        return self.W if $*OSNAME -eq "MSWin32";
+        my $path = $.path;
+        return ?Q:PIR {
+            .local pmc uid,euid,suid,undef,os
+
+            uid = get_hll_global '$UID'
+            euid = get_hll_global '$EUID'
+            undef = new ['Undef']
+            os = new ['OS']
+
+            .local pmc setresuid,res,path
+            path = find_lex '$path'
+            setresuid = dlfunc undef, 'setresuid', 'iiii'
+
+            setresuid(euid, uid, uid)
+            res = os.'can_write'(path)
+            setresuid(uid, euid, uid)
+
+            %r = res
+        };
+    }
+
+    multi method x() {
+        return self.X if $*OSNAME -eq "MSWin32";
+        my $path = $.path;
+        return ?Q:PIR {
+            .local pmc uid,euid,suid,undef,os
+
+            uid = get_hll_global '$UID'
+            euid = get_hll_global '$EUID'
+            undef = new ['Undef']
+            os = new ['OS']
+
+            .local pmc setresuid,res,path
+            path = find_lex '$path'
+            setresuid = dlfunc undef, 'setresuid', 'iiii'
+
+            setresuid(euid, uid, uid)
+            res = os.'can_execute'(path)
+            setresuid(uid, euid, uid)
+
+            %r = res
+        };
+    }
+
+    multi method l() {
+        $.stat.islnk;
+    }
+
+    multi method O() {
+        pir::new__PS('OS').get_user_id() ~~ $.stat.uid;
+    }
+
+    # Can't get effective uid in parrot
+    multi method o() {
+        pir::new__PS('OS').get_user_id() ~~ $.stat.uid;
+    }
+
+	multi method u() {
+		?($.stat.permissions +& 0o4000);
+	}
+
+	multi method g() {
+		?($.stat.permissions +& 0o2000);
+	}
+
+	multi method k() {
+		?($.stat.permissions +& 0o1000);
+	}
 
     multi method z() {
         $.e && $.s == 0;

--- a/src/glue/run.pir
+++ b/src/glue/run.pir
@@ -59,6 +59,39 @@ of the compilation unit.
     env = root_new ['parrot';'Env']
     $P2 = '&CREATE_HASH_FROM_LOW_LEVEL'(env)
     set_hll_global '%ENV', $P2
+
+    $P4 = new['OS']
+    $P5 = new ['Int']
+    $P5 = $P4.'get_user_id'()
+    set_hll_global '$UID', $P5
+
+    $P6 = new ['Str']
+    $S0 = sysinfo .SYSINFO_PARROT_OS
+    $P6 = $S0
+    set_hll_global '$OSNAME', $P6
+
+    .local pmc undef,nci,euid,gid,egid
+    undef = new ['Undef']
+    euid = box 0
+    set_hll_global '$EUID', euid
+    set_hll_global '$GID', euid
+    set_hll_global '$EGID', euid
+
+    if $S0 == "MSWin32" goto post_vars
+
+    nci = dlfunc undef, 'geteuid', 'i'
+    euid = nci()
+    set_hll_global '$EUID', euid
+
+    nci = dlfunc undef, 'getgid', 'i'
+    gid = nci()
+    set_hll_global '$GID', gid
+
+    nci = dlfunc undef, 'getegid', 'i'
+    egid = nci()
+    set_hll_global '$EGID', egid
+
+  post_vars:
 .end
 
 


### PR DESCRIPTION
I implemented as many of the file test methods listed in the spec as parrot would allow.
https://github.com/perl6/specs/blob/master/S32-setting-library/IO.pod

I also re-implemented IO.l in Perl6 as opposed to pir. Finally, I fixed IO.f so that it wouldn't return Bool::True when testing device files.
