### PR TITLE
Add conjugate method (for RT 76602)

### DIFF
--- a/src/core/Complex.pm
+++ b/src/core/Complex.pm
@@ -35,6 +35,10 @@ class Complex does Numeric is Cool {
         "Complex.new($.re, $.im)";
     }
 
+    method conjugate() {
+      Complex.new($.re, -$.im);
+    }
+
     method abs(Complex $x:) {
         ($x.re * $x.re + $x.im * $x.im).sqrt
     }

--- a/src/core/Cool-num.pm
+++ b/src/core/Cool-num.pm
@@ -23,6 +23,10 @@ augment class Cool {
         (+$x).abs;
     }
 
+    method conjugate($x:) {
+        (+$x).conjugate;
+    }
+
     method exp($x: $base = e) {
         (+$x).exp(+$base);
     }
@@ -194,6 +198,8 @@ augment class Cool {
 
 proto sub abs($x) { $x.abs }
 multi sub prefix:<abs>($x) { $x.abs }
+proto sub conjugate($x) { $x.conjugate }
+multi sub prefix:<conjugate>($x) { $x.conjugate }
 proto sub sign($x) { $x.sign }
 proto sub exp($exponent, $base = e) { $exponent.exp($base) }
 proto sub log($x, $base = e) { $x.log($base) }

--- a/src/core/Numeric.pm
+++ b/src/core/Numeric.pm
@@ -41,6 +41,12 @@ role Numeric {
         fail "$.WHAT() needs a version of .reals";
     }
 
+    method conjugate() {
+      return self if self.reals.elems == 1;
+      note "$.WHAT() needs a version of .reals";
+      fail "$.WHAT() needs a version of .reals";
+    }
+
     method isNaN() {
         ?(self.reals.grep({.isNaN}));
     }


### PR DESCRIPTION
With this change you can conjugate a complex number (or a real/int/rat, but that doesn't do much).

I pushed the spec change and tests to the perl6 repositories, but I don't have commit-bit for rakudo itself.
