### PR TITLE
Allow more windows environments with git to work correctly with build process

### DIFF
--- a/Configure.pl
+++ b/Configure.pl
@@ -158,6 +158,7 @@ sub create_makefile {
 
     my $maketext = slurp( 'build/Makefile.in' );
 
+    $config{'shell'} = $^O eq 'MSWin32' ? 'cmd' : 'sh';
     $config{'stagestats'} = $makefile_timing ? '--stagestats' : '';
     $config{'win32_libparrot_copy'} = $^O eq 'MSWin32' ? 'copy $(PARROT_BIN_DIR)\libparrot.dll .' : '';
     $maketext =~ s/@(\w+)@/$config{$1}/g;

--- a/build/Makefile.in
+++ b/build/Makefile.in
@@ -1,6 +1,7 @@
 # Copyright (C) 2006-2010, The Perl Foundation.
 # $Id$
 
+SHELL            = @shell@
 PARROT_ARGS      =
 
 # values from parrot_config


### PR DESCRIPTION
this fixed build problem on windows with sysgit.
see http://trac.parrot.org/parrot/ticket/1865 for detail. 
