### PR TITLE
fixed build with perl 5.10.1 on windows7. Without '?', $nqp_exe will be '

### DIFF
--- a/Configure.pl
+++ b/Configure.pl
@@ -101,7 +101,7 @@ END
     my $nqp_exe = $parrot_config;
     # the .* is needed of somebody has the string 'parrot_config' in
     # the build path - we always want to substitute the last occorence
-    $nqp_exe =~ s/(.*)parrot_config/$1nqp/s;
+    $nqp_exe =~ s/(.*?)parrot_config/$1nqp/s;
     if (system $nqp_exe, '-e', '') {
         die "Cannot execute nqp - maybe try the --gen-nqp option to automatically build one?\n";
     }


### PR DESCRIPTION
fixed build with perl 5.10.1 on windows7. Without '?', $nqp_exe will be '...', which broke the build.
