### PR TITLE
Zero/one arg ne should be False

### DIFF
--- a/src/core/Stringy.pm
+++ b/src/core/Stringy.pm
@@ -20,7 +20,7 @@ multi infix:<eq>($x?)          { Bool::True }
 multi infix:<eq>(\$a, \$b)     { $a.Stringy eq $b.Stringy }
 
 proto infix:<ne>(|$)             { * }
-multi infix:<ne>($x?)            { Bool::True }
+multi infix:<ne>($x?)            { Bool::False }
 multi infix:<ne>(Mu \$a, Mu \$b) { $a !eq $b }
 
 proto infix:<lt>(|$)           { * }


### PR DESCRIPTION
Mostly because the similar version of eq is True and as 886f677 said, we want ne to be like !eq.

---

This change makes it so that (which chaining metaop works)

```
my @a = 'a';
say [eq] @a;
say [ne] @a;
```

Outputs

```
True
False
```

instead of

```
True
True
```

which I think is rather confusing.
