### PR TITLE
Spectest updates

### DIFF
--- a/t/spectest.data
+++ b/t/spectest.data
@@ -149,7 +149,7 @@ S03-operators/not.t
 S03-operators/precedence.t
 S03-operators/range-basic.t
 S03-operators/range-int.t                       # stress
-# S03-operators/range.t # err: No applicable candidates found to dispatch to for 'Numeric'
+S03-operators/range.t
 S03-operators/reduce-le1arg.t
 S03-operators/relational.t
 S03-operators/repeat.t
@@ -598,7 +598,7 @@ integration/advent2009-day01.t
 integration/advent2009-day03.t
 integration/advent2009-day04.t
 # integration/advent2009-day05.t # err: chaining reduce NYI
-# integration/advent2009-day06.t # err: Could not find sub &METAOP_HYPER
+integration/advent2009-day06.t
 integration/advent2009-day07.t
 # integration/advent2009-day08.t # err: Nominal type check failed for parameter '$a'; expected Any but got Mu
 # integration/advent2009-day09.t # err: Not enough positional parameters passed


### PR DESCRIPTION
enable passing test: integration/advent2009-day06.t (pmichaud++'s metaop work) and S03-operators/range.t
