### PR TITLE
Nom

### DIFF
--- a/src/core/Any.pm
+++ b/src/core/Any.pm
@@ -73,7 +73,7 @@ my class Any {
         for @.list {
             .defined or next;
 
-            if .^isa(Range) {
+            if .isa(Range) {
                 if $cmp($_.min, $min) < 0 {
                     $min = $_;
                     $excludes_min = $_.excludes_min;


### PR DESCRIPTION
10:05:18 < pmichaud> also, can we get the $by param to default to  &infix:<cmp> or &[cmp]  ?
10:05:26 < pmichaud> that would be better than the explicit block
