### PR TITLE
Fix take over-flattening

### DIFF
--- a/src/core/Array.pm
+++ b/src/core/Array.pm
@@ -81,4 +81,4 @@ class Array {
 }
 
 
-sub circumfix:<[ ]>(*@elems) is rw { my $x = @elems }
+sub circumfix:<[ ]>(*@elems) is rw { my $x = @elems.eager }

--- a/src/core/control.pm
+++ b/src/core/control.pm
@@ -56,9 +56,7 @@ my &take-rw := -> |$ {
 my &take := -> |$ { 
     my $parcel := 
         &RETURN-PARCEL(nqp::p6parcel(pir::perl6_current_args_rpa__PP(), Nil));
-    # XXX Should be nqp::p6recont_ro, but it's currently masking a bug
-    # where [...] doesn't decontainerize enough.
-    THROW(nqp::p6decont($parcel), 
+    THROW(nqp::p6recont_ro($parcel),
           pir::const::CONTROL_TAKE) 
 };
 


### PR DESCRIPTION
circumfix:<[ ]> needs to be made eager as well.  This
seems to match the wording of the spec (it's an Array,
not a List) and doesn't introduce any regressions in
roast.

Fixes RT#101316 and RT#106986
