### PR TITLE
Support binding of array elements.

### DIFF
--- a/src/core/Any.pm
+++ b/src/core/Any.pm
@@ -110,13 +110,22 @@ my class Any {
 
     proto method postcircumfix:<[ ]>(|$) { * }
     multi method postcircumfix:<[ ]>() { self.list }
+    multi method postcircumfix:<[ ]>(:$BIND!) { die "Cannot bind to a zen array slice" }
     multi method postcircumfix:<[ ]>($pos) is rw {
         fail "Cannot use negative index $pos on {self.WHAT.perl}" if $pos < 0;
         self.at_pos($pos)
     }
+    multi method postcircumfix:<[ ]>($pos, :$BIND! is parcel) is rw {
+        fail "Cannot use negative index $pos on {self.WHAT.perl}" if $pos < 0;
+        self.bind_pos($pos, $BIND)
+    }
     multi method postcircumfix:<[ ]>(int $pos) is rw {
         fail "Cannot use negative index $pos on {self.WHAT.perl}" if $pos < 0;
         self.at_pos($pos)
+    }
+    multi method postcircumfix:<[ ]>(int $pos, :$BIND! is parcel) is rw {
+        fail "Cannot use negative index $pos on {self.WHAT.perl}" if $pos < 0;
+        self.bind_pos($pos, $BIND)
     }
     multi method postcircumfix:<[ ]>(Positional $pos) is rw {
         my $list = $pos.flat;
@@ -125,12 +134,21 @@ my class Any {
                    ?? { last if $_ >= self.gimme($_ + 1); self[$_] }
                    !! { self[$_] }).eager.Parcel;
     }
+#    multi method postcircumfix:<[ ]>(Positional $pos, :$BIND!) is rw {
+#        die "Cannot bind to an array slice"
+#    }
     multi method postcircumfix:<[ ]>(Callable $block) is rw {
         self[$block(|(self.elems xx $block.count))]
     }
+#    multi method postcircumfix:<[ ]>(Callable $block, :$BIND!) is rw {
+#        die "Cannot bind to a callable array slice"; # WhateverCode?
+#    }
     multi method postcircumfix:<[ ]>(Whatever) is rw {
         self[^self.elems]
     }
+#    multi method postcircumfix:<[ ]>(Whatever, :$BIND!) is rw {
+#        die "Cannot bind to a whatever array slice"
+#    }
 
     method at_pos($pos) is rw {
         if self.defined {

--- a/src/core/Array.pm
+++ b/src/core/Array.pm
@@ -14,11 +14,22 @@ class Array {
           !! pir::setattribute__0PPsP(my $v, Scalar, '$!whence',
                  -> { nqp::bindpos(nqp::getattr(self, List, '$!items'), nqp::unbox_i($pos), $v) } )
     }
-    multi method at_pos(int $pos ) is rw {
+    multi method at_pos(int $pos) is rw {
         self.exists($pos)
           ?? nqp::atpos(nqp::getattr(self, List, '$!items'), $pos)
           !! pir::setattribute__0PPsP(my $v, Scalar, '$!whence',
                  -> { nqp::bindpos(nqp::getattr(self, List, '$!items'), $pos, $v) } )
+    }
+
+    proto method bind_pos(|$) { * }
+    multi method bind_pos($pos is copy, \$bindval) is rw {
+        $pos = $pos.Int;
+        self.gimme($pos);
+        nqp::bindpos(nqp::getattr(self, List, '$!items'), nqp::unbox_i($pos), $bindval);
+    }
+    multi method bind_pos(int $pos, \$bindval) is rw {
+        self.gimme($pos);
+        nqp::bindpos(nqp::getattr(self, List, '$!items'), $pos, $bindval)
     }
     
     method delete(@array is rw: *@indices) {
@@ -92,6 +103,15 @@ class Array {
               ?? nqp::atpos(nqp::getattr(self, List, '$!items'), $pos)
               !! pir::setattribute__0PPsP($v, Scalar, '$!whence',
                      -> { nqp::bindpos(nqp::getattr(self, List, '$!items'), $pos, $v) } )
+        }
+        multi method bind_pos($pos is copy, TValue \$bindval) is rw {
+            $pos = $pos.Int;
+            self.gimme($pos);
+            nqp::bindpos(nqp::getattr(self, List, '$!items'), nqp::unbox_i($pos), $bindval)
+        }
+        multi method bind_pos(int $pos, TValue \$bindval) is rw {
+            self.gimme($pos);
+            nqp::bindpos(nqp::getattr(self, List, '$!items'), $pos, $bindval)
         }
         # XXX some methods to come here...
     }


### PR DESCRIPTION
not sure if the patch is 100% correct but it makes rakudo pass the following test:
t/spec/S03-operators/binding-arrays.t (autounfudge'd, all but one test)
t/spec/S03-operators/binding-nested.t (no fudges, all tests)

note: When enabling of the commented out "multi method postcircumfix:<[ ]>" (those that are responsible for die'ing with a good error message) makes the multidispatcher say: "Circularity detected in multi sub types."
