### PR TITLE
added stat times (modified/changed/accessed) for IO

### DIFF
--- a/src/core/IO.pm
+++ b/src/core/IO.pm
@@ -189,6 +189,18 @@ class IO {
         self.e && self.s == 0;
     }
 
+    method modified() {
+         nqp::p6box_i(pir::stat__Isi(nqp::unbox_s($!path), pir::const::STAT_MODIFYTIME));
+    }
+
+    method accessed() {
+         nqp::p6box_i(pir::stat__Isi(nqp::unbox_s($!path), pir::const::STAT_ACCESSTIME));
+    }
+
+    method changed() { 
+         nqp::p6box_i(pir::stat__Isi(nqp::unbox_s($!path), pir::const::STAT_CHANGETIME));
+    }
+
     # not spec'd
     method copy($dest) {
         if self.d() {


### PR DESCRIPTION
Re-adding implementations for IO.modified, IO.changed and IO.accessed, since these were lost after the switch to nom. Other than minor boxing updates, they should be identical to the original versions.
