### PR TITLE
[src/core/IO.pm] nicer &dir

### DIFF
--- a/src/core/IO.pm
+++ b/src/core/IO.pm
@@ -316,7 +316,7 @@ sub dir($path = '.', Mu :$test = none('.', '..')) {
     my @res;
     loop (my int $i = 0; $i < $elems; $i = $i + 1) {
         my Str $file := nqp::p6box_s(nqp::atpos($RSA, $i));
-        @res.push: ($path ~~ m/\/$/ ?? "$path$file" !! "$path/$file").IO if $test.ACCEPTS($file);
+        @res.push: ($path.substr(*-1) eq '/' ?? "$path$file" !! "$path/$file").IO if $test.ACCEPTS($file);
     }
     return @res;
 


### PR DESCRIPTION
No change 'inside', only 'outside'. Works the same way.
'/' is unnecessary in particular calls.

before:

> .Str.say for dir './'
> .//file2
> .//file1
> .//dir2
> .//dir1

after:

> .Str.say for dir './'
> ./file2
> ./file1
> ./dir2
> ./dir1
