### PR TITLE
The last patch almost worked but not quite.  The old copy of the announc...

### DIFF
--- a/tools/build/Makefile.in
+++ b/tools/build/Makefile.in
@@ -321,7 +321,7 @@ install: all
 	$(MKPATH)                     $(DESTDIR)$(DOCDIR)/rakudo
 	$(MKPATH)                     $(DESTDIR)$(DOCDIR)/rakudo/announce
 	-$(CP)    $(DOCS)             $(DESTDIR)$(DOCDIR)/rakudo
-	$(CP)     $(DOCS)/announce    $(DESTDIR)$(DOCDIR)/rakudo/announce
+	$(CP)     docs/announce/*     $(DESTDIR)$(DOCDIR)/rakudo/announce
 	$(MKPATH) $(DESTDIR)$(MANDIR)/man1
 	-$(POD2MAN) docs/running.pod --name=perl6 > $(DESTDIR)$(MANDIR)/man1/perl6.1
 	-$(POD2MAN) docs/running.pod --name=rakudo > $(DESTDIR)$(MANDIR)/man1/rakudo.1


### PR DESCRIPTION
...e directory copy wrongly expanded as below:

/bin/cp     README CREDITS LICENSE docs/*/announce    /home/ron/rakudo/install/share/doc/rakudo/announce

and got a stat error on docs/*/announce and failed.  One might also remove the nearby announce lines but if the announcements are wanted my patch will put them there without crashing.  In the rakudo build this crash does relatively little harm since it is near the end of the install.  In rakudo star the crash stops the process before module builds.
