### PR TITLE
Marked S02-literals/version.t as # icu

### DIFF
--- a/t/spectest.data
+++ b/t/spectest.data
@@ -43,7 +43,7 @@ S02-literals/sub-calls.t
 S02-literals/subscript.t
 S02-literals/types.t
 S02-literals/underscores.t
-S02-literals/version.t
+S02-literals/version.t          # icu
 S02-magicals/args.t
 S02-magicals/config.t
 S02-magicals/dollar_bang.t


### PR DESCRIPTION
Tests with Greek letters in versions fail if ICU is not installed.
