### PR TITLE
Add ACCEPTS to tests equality with its own type

### DIFF
--- a/src/core/Signature.pm
+++ b/src/core/Signature.pm
@@ -17,6 +17,16 @@ my class Signature {
         self.ACCEPTS(%topic.Capture)
     }
 
+    multi method ACCEPTS(Signature:D: Signature:D $topic) {
+        return False unless $topic.params == self.params;
+
+        for $topic.params Z self.params -> $t, $s {
+            return False unless $t.type ~~ $s.type;
+        }
+
+        return True;
+    }
+
     method arity() {
         self.count if nqp::isnull($!arity) || !$!arity.defined;
         $!arity;

--- a/t/spectest.data
+++ b/t/spectest.data
@@ -204,6 +204,7 @@ S03-smartmatch/hash-hash.t
 S03-smartmatch/range-range.t
 S03-smartmatch/regex-hash.t
 S03-smartmatch/scalar-hash.t
+S03-smartmatch/signature-signature.t
 S04-blocks-and-statements/let.t
 S04-blocks-and-statements/pointy-rw.t
 S04-blocks-and-statements/pointy.t


### PR DESCRIPTION
The method was mostly written by jnthn and suggested on IRC.

This is supposed to fix RT #82308: [TODO] [EASY] Implement signature-signature smartmatch.

I submitted a pull request with tests, too:
https://github.com/perl6/roast/pull/27

It's my first significant patch to Rakudo, and you are absolutely welcome to be critical.
