### PR TITLE
mark S02-types/version.t as requiring ICU

### DIFF
--- a/t/spectest.data
+++ b/t/spectest.data
@@ -109,7 +109,7 @@ S02-types/subscripts_and_context.t
 S02-types/subset.t
 S02-types/type.t
 S02-types/undefined-types.t
-S02-types/version.t
+S02-types/version.t                                # icu
 S02-types/whatever.t
 S03-binding/arrays.t
 S03-binding/attributes.t


### PR DESCRIPTION
/<alpha>/ dont match greek letters if libICU is absent.
say Version.new("1α1") cmp Version.new("1β1") give you 'Same' (wrong) instead of 'Increase' (correct)
