### PR TITLE
throwing typed exception for unrecognized metacharacters in regexes

### DIFF
--- a/src/Perl6/Grammar.pm
+++ b/src/Perl6/Grammar.pm
@@ -3485,8 +3485,12 @@ grammar Perl6::QGrammar is HLL::Grammar does STD {
 }
 
 grammar Perl6::RegexGrammar is QRegex::P6Regex::Grammar does STD {
+    method throw_unrecognized_metachar ($metachar) {
+        $*W.throw(self.MATCH(), <X Syntax Regex UnrecognizedMetachar>, :$metachar);
+    }
+
     token rxstopper { <stopper> }
-    
+
     token metachar:sym<:my> {
         ':' <?before 'my'|'constant'|'state'|'our'> <statement=.LANG('MAIN', 'statement')> <.ws> ';'
     }

--- a/src/core/Exception.pm
+++ b/src/core/Exception.pm
@@ -660,6 +660,11 @@ my class X::Syntax::Regex::Adverb does X::Syntax {
     method message() { "Adverb $.adverb not allowed on $.construct" }
 }
 
+my class X::Syntax::Regex::UnrecognizedMetachar does X::Syntax {
+    has $.metachar;
+    method message() { "Unrecognized regex metacharacter $.metachar (must be quoted to match literally)" }
+}
+
 my class X::Syntax::Signature::InvocantMarker does X::Syntax {
     method message() {
         "Can only use : as invocant marker in a signature after the first parameter"


### PR DESCRIPTION
Requires NQP's 'throw_unrecognized_metachar' branch in order to work, but wont break anything if the patch in NQP or rakudo isnt applied.
