### PR TITLE
RFC: Partially inline junctions in bool context at compile time

### DIFF
--- a/src/Perl6/Optimizer.pm
+++ b/src/Perl6/Optimizer.pm
@@ -216,7 +216,7 @@ class Perl6::Optimizer {
         }
 
         # we may be able to unfold a junction at compile time.
-        if $*LEVEL >= 3 && is_outer_foldable() && nqp::istype($op[0], QAST::Op) && $op[0].op eq "chain" {
+        if $*LEVEL >= 2 && is_outer_foldable() && nqp::istype($op[0], QAST::Op) && $op[0].op eq "chain" {
             my $exp-side := self.can_chain_junction_be_warped($op[0]);
             if $exp-side != -1 {
                 my $juncop := $op[0][$exp-side].name eq '&infix:<&>' ?? 'if' !! 'unless';


### PR DESCRIPTION
In this branch, I've implemented a runtime optimisation that turns this:

```
if 1 | 2 | 3 == $x { ... }
```

into (more or less) this:

```
if 1 == (my $temp_var = $x) || 2 == $temp_var || 3 == $temp_var { ... }
```

in if, unless, while and until statements. On my machine, it doesn't change the run time of the whole spectest by any significant amount, but in this simple benchmark it reduces run time from 5.2 seconds down to 3.2 (down to 60%!):

```
my $ct = 0;
for (-20..20)X(-20..20) -> $x, $y {
    if $x & $y == -1 | 0 | 1 { # only the left junction will be unfolded here.
        $ct++
    }
}
say $ct;
```

And even a simple test suite that doesn't contain loops gets the same 40% reduction apparently :)

Building rakudo itself takes only 1.5 seconds longer out of 180 seconds on this branch, so about 1% time increase. Doesn't sound too bad.

Looking for more things to put in or examples that break with this branch. One example is, that any(), all() and one() aren't touched yet, they generate a call to infix:<,>, which I don't handle yet. Also, apparently if the op between the junction and the other side is ~~, it gets skipped, too - it seems that's because the tree gets a bind for $_ out of it.

Tests have been added to the spec suite to make sure nothing strange happens accidentally.
- [x] Unfold one side of simple junctions with chain ops
- [x] make sure side effects are only evaluated once
- [x] maybe try to handle any(...), all(...) and none(...) at optimisation time, too.
- [x] when can this optimization be considered level 2 "default" instead of level 3 "experimental"?
- [x] does the "analysis" part abort sufficiently early when the level is too low? it's supposed to "still do analysis" when at level 0, ISTR.
