### PR TITLE
Add Bool method to Capture

### DIFF
--- a/src/core/Capture.pm
+++ b/src/core/Capture.pm
@@ -69,6 +69,10 @@ my class Capture {
         nqp::p6box_s(nqp::join(' ', $str))
     }
     
+    multi method Bool(Capture:D:) {
+        $!list || $!hash ?? True !! False
+    }
+    
     method Capture(Capture:D:) {
         self
     }


### PR DESCRIPTION
Right now, defined captures evaluate to `True`, but empty captures should probably be `False`.
