### PR TITLE
Fix .get and .lines for sockets

### DIFF
--- a/src/core/IO/Socket/INET.pm
+++ b/src/core/IO/Socket/INET.pm
@@ -113,7 +113,9 @@ my class IO::Socket::INET does IO::Socket {
     }
 
     method lines() {
-        gather { take self.get() };
+        gather while (my $line = self.get()).defined {
+            take $line;
+        }
     }
 
     method accept() {


### PR DESCRIPTION
Aligns `IO::Socket::INET.get` with `IO.get` and fixes an encoding issue. Also adds an actual loop to `IO::Socket::INET.lines`, which only gathered a single line instead of all of them.

This does not unbreak `HTTP::Easy`, which blocks on a Parrot fix.
