### PR TITLE
raise X::Method::NotFound even for '' methods.

### DIFF
--- a/src/core/Exception.pm
+++ b/src/core/Exception.pm
@@ -97,8 +97,7 @@ sub EXCEPTION(|) {
         my int $type = nqp::atkey_i($parrot_ex, 'type');
         my $ex;
         if $type == pir::const::EXCEPTION_METHOD_NOT_FOUND  &&
-            nqp::p6box_s(nqp::atkey_s($parrot_ex, 'message'))
-                ~~ /"Method '" (.+?) "' not found for invocant of class '" (.+)\'$/ {
+            nqp::p6box_s(nqp::atkey_s($parrot_ex, 'message')) ~~ /"Method '" (.*?) "' not found for invocant of class '" (.+)\'$/ {
 
             $ex := X::Method::NotFound.new(
                 method   => ~$0,


### PR DESCRIPTION
until now, a too restrictive regex was matching the error message for not found methods which failed to match the case where you invoke an empty method on some object. this patch raises X::Method::NotFound even in that case. There's a test for it in roast, too.
