### PR TITLE
turn Wval to Want after compile-time-evaluating pure ops

### DIFF
--- a/src/Perl6/Optimizer.pm
+++ b/src/Perl6/Optimizer.pm
@@ -410,12 +410,24 @@ class Perl6::Optimizer {
                             if $op.named {
                                 $wval.named($op.named);
                             }
-                            # if it's an Int, we can create a Want from it witth an int value.
-                            try {
-                                if nqp::istype($ret_value, self.find_in_setting("Int")) && !nqp::isbig_I(nqp::decont($ret_value)) {
-                                    return QAST::Want.new($wval,
-                                        "Ii", QAST::IVal.new(:value(nqp::unbox_i($ret_value))));
+                            # if it's an Int, Num or Str, we can create a Want
+                            # from it witt an int, num or str value.
+                            my $want;
+                            if nqp::istype($ret_value, self.find_in_setting("Int")) && !nqp::isbig_I(nqp::decont($ret_value)) {
+                                $want := QAST::Want.new($wval,
+                                    "Ii", QAST::IVal.new(:value(nqp::unbox_i($ret_value))));
+                            } elsif nqp::istype($ret_value, self.find_in_setting("Num")) {
+                                $want := QAST::Want.new($wval,
+                                    "Nn", QAST::NVal.new(:value(nqp::unbox_n($ret_value))));
+                            } elsif nqp::istype($ret_value, self.find_in_setting("Str")) {
+                                $want := QAST::Want.new($wval,
+                                    "Ss", QAST::SVal.new(:value(nqp::unbox_s($ret_value))));
+                            }
+                            if nqp::defined($want) {
+                                if $op.named {
+                                    $want.named($op.named);
                                 }
+                                return $want;
                             }
                             return $wval;
                         }


### PR DESCRIPTION
At the moment, the optimizer turns literals like -5 into a WVal(-5), which is better than the previous call to prefix:<-> + Want(5), but now it's no longer a Want and cannot be used to dispatch to subs that take native values.

This branch creates a Want for Int, Num and Str results of compile-time evaluation in the Optimizer.

The changes have passed spectests on my machine, but then i re-arranged some commits and pulled in some recent changes, so i'll run the spectests again.
