### PR TITLE
inch IO::Path closer to the recent spec changes (path, volume, Str)

### DIFF
--- a/src/core/IO.pm
+++ b/src/core/IO.pm
@@ -31,37 +31,37 @@ sub prompt($msg) {
 
 my role IO::FileTestable {
     method d() {
-        self.e && nqp::p6bool(nqp::stat(nqp::unbox_s($.path), nqp::const::STAT_ISDIR))
+        self.e && nqp::p6bool(nqp::stat(nqp::unbox_s(self.Str), nqp::const::STAT_ISDIR))
     }
 
     method e() {
-        nqp::p6bool(nqp::stat(nqp::unbox_s($.path), nqp::const::STAT_EXISTS))
+        nqp::p6bool(nqp::stat(nqp::unbox_s(self.Str), nqp::const::STAT_EXISTS))
     }
 
     method f() {
-        self.e && nqp::p6bool(nqp::stat(nqp::unbox_s($.path), nqp::const::STAT_ISREG))
+        self.e && nqp::p6bool(nqp::stat(nqp::unbox_s(self.Str), nqp::const::STAT_ISREG))
     }
 
     method l() {
-        nqp::p6bool(pir::new__Ps('File').is_link(nqp::unbox_s($.path)))
+        nqp::p6bool(pir::new__Ps('File').is_link(nqp::unbox_s(self.Str)))
     }
 
     method r() {
-        nqp::p6bool(pir::new__Ps('OS').can_read(nqp::unbox_s($.path)))
+        nqp::p6bool(pir::new__Ps('OS').can_read(nqp::unbox_s(self.Str)))
     }
 
     method s() {
         self.e 
-          && nqp::p6box_i( nqp::stat(nqp::unbox_s($.path), 
+          && nqp::p6box_i( nqp::stat(nqp::unbox_s(self.Str), 
                                  nqp::const::STAT_FILESIZE) );
     }
 
     method w() {
-        nqp::p6bool(pir::new__Ps('OS').can_write(nqp::unbox_s($.path)))
+        nqp::p6bool(pir::new__Ps('OS').can_write(nqp::unbox_s(self.Str)))
     }
 
     method x() {
-        nqp::p6bool(pir::new__Ps('OS').can_execute(nqp::unbox_s($.path)))
+        nqp::p6bool(pir::new__Ps('OS').can_execute(nqp::unbox_s(self.Str)))
     }
     
     method z() {
@@ -69,15 +69,15 @@ my role IO::FileTestable {
     }
 
     method modified() {
-         nqp::p6box_i(nqp::stat(nqp::unbox_s($.path), nqp::const::STAT_MODIFYTIME));
+         nqp::p6box_i(nqp::stat(nqp::unbox_s(self.Str), nqp::const::STAT_MODIFYTIME));
     }
 
     method accessed() {
-         nqp::p6box_i(nqp::stat(nqp::unbox_s($.path), nqp::const::STAT_ACCESSTIME));
+         nqp::p6box_i(nqp::stat(nqp::unbox_s(self.Str), nqp::const::STAT_ACCESSTIME));
     }
 
     method changed() { 
-         nqp::p6box_i(nqp::stat(nqp::unbox_s($.path), nqp::const::STAT_CHANGETIME));
+         nqp::p6box_i(nqp::stat(nqp::unbox_s(self.Str), nqp::const::STAT_CHANGETIME));
     }
 }
 
@@ -247,11 +247,12 @@ class IO does IO::FileTestable {
 my class IO::Path is Cool does IO::FileTestable {
     has Str $.basename;
     has Str $.directory = '.';
+    has Str $.volume = '';
 
     method dir() {
         die "IO::Path.dir is deprecated in favor of .directory";
     }
-    submethod BUILD(:$!basename, :$!directory, :$dir) {
+    submethod BUILD(:$!basename, :$!directory, :$!volume, :$dir) {
         die "Named paramter :dir in IO::Path.new deprecated in favor of :directory"
             if defined $dir;
     }
@@ -260,14 +261,14 @@ my class IO::Path is Cool does IO::FileTestable {
         my @chunks    = $path.split('/');
         my $basename  = @chunks.pop;
         my $directory = @chunks ?? @chunks.join('/') !! '.';
-        self.new(:$basename, :$directory);
+        self.new(:$basename, :$directory, :volume(""));
     }
 
     multi method Str(IO::Path:D:) {
-        self.basename;
+        $.directory eq '.' ?? $.basename !! join('/', $.directory, $.basename);
     }
     multi method gist(IO::Path:D:) {
-        "{self.^name}<{self.path}>";
+        "{self.^name}<{self.basename}>";
     }
     multi method Numeric(IO::Path:D:) {
         self.basename.Numeric;
@@ -280,17 +281,17 @@ my class IO::Path is Cool does IO::FileTestable {
     }
 
     method path(IO::Path:D:) {
-        $.directory eq '.' ?? $.basename !! join('/', $.directory, $.basename);
+        self;
     }
 
-    method IO(IO::Path:D:) {
-        IO.new(:$.path);
+    method IO(IO::Path:D: *%opts) {
+        IO.new(:path(~self), |%opts);
     }
     method open(IO::Path:D: *%opts) {
-        open($.path, |%opts);
+        open(~self, |%opts);
     }
-    method contents(IO::Path:D:) {
-        dir($.path);
+    method contents(IO::Path:D: *%opts) {
+        dir(~self, |%opts);
     }
 }
 
@@ -303,7 +304,8 @@ sub dir(Cool $path = '.', Mu :$test = none('.', '..')) {
 			nqp::atpos_s($RSA, $i),
 			pir::find_encoding__Is('utf8')));
         if $file ~~ $test {
-            @res.push: IO::Path.new(:basename($file), :directory($path.Str));
+            #this should be like IO::Path.child(:basename($file)) because of :volume
+            @res.push: IO::Path.new(:basename($file), :directory($path.Str), :volume(""));
         }
     }
     return @res.list;


### PR DESCRIPTION
Start to support .volume (though eventually we'll need File::Spec for that)

.Str now returns full path, .path now returns self.  IO::FileTestable changed to work with that.
