### PR TITLE
rename class IO to IO::Handle, tag IO subclasses with base class IO

### DIFF
--- a/src/RESTRICTED.setting
+++ b/src/RESTRICTED.setting
@@ -19,5 +19,6 @@ my class RESTRICTED is Mu {
 }
 
 my class IO is RESTRICTED { }
+my class IO::Handle is RESTRICTED { }
 my class IO::Socket is RESTRICTED { }
 

--- a/src/core/Cool.pm
+++ b/src/core/Cool.pm
@@ -1,4 +1,5 @@
 my class IO { ... }
+my class IO::Handle { ... }
 
 my class Cool {
 
@@ -181,7 +182,7 @@ my class Cool {
     method printf (*@args) {  printf(self, @args) };
     method samecase(Cool:D: Cool $pattern) { self.Stringy.samecase($pattern) }
 
-    method IO() { IO.new(:path(self.Stringy)) }
+    method IO() { IO::Handle.new(:path(self.Stringy)) }
     method trim         () { self.Stringy.trim          };
     method trim-leading () { self.Stringy.trim-leading  };
     method trim-trailing() { self.Stringy.trim-trailing };

--- a/src/core/IO/ArgFiles.pm
+++ b/src/core/IO/ArgFiles.pm
@@ -1,4 +1,4 @@
-my class IO::ArgFiles is IO {
+my class IO::ArgFiles is IO::Handle {
     has $.args;
     has $.filename;
     has $!io;
@@ -17,7 +17,7 @@ my class IO::ArgFiles is IO {
         my $x = $!io.get;
         while !$x.defined {
             $!io.close;
-            $!io = IO;
+            $!io = IO::Handle;
             fail "End of argfiles reached" unless $!args;
             $x = self.get;
         }

--- a/src/core/IO/Socket.pm
+++ b/src/core/IO/Socket.pm
@@ -1,4 +1,4 @@
-my role IO::Socket {
+my role IO::Socket is IO {
     has $!PIO;
     has $!buffer = '';
 


### PR DESCRIPTION
This conforms mostly with moritz++'s changes to S32::IO, with the exception that IO is now an empty class, not an empty role -- I had trouble creating IO::\* classes under a role.

S16 and S32 tests pass here, and panda is fine.  Since Cool.IO now produces IO::Handle, the only code this will break is when people use IO.new() directly.
