### PR TITLE
fix IO::Spec::Win32 warn due to ?-quantifier

### DIFF
--- a/src/core/IO/Spec/Win32.pm
+++ b/src/core/IO/Spec/Win32.pm
@@ -168,7 +168,7 @@ my class IO::Spec::Win32 is IO::Spec::Unix {
              $first ~~ /^ ([   <$driveletter> <$slash>?
                             | <$UNCpath>
                             | [<$slash> ** 2] <$notslash>+
-                            | <$slash> ])?
+                            | <$slash> ]?)
                            (.*)
                        /;
         my $volume = ~$volumematch[0];


### PR DESCRIPTION
a fix for a tiny bug that I noticed when writing tests
