### PR TITLE
Remove --gen-nqp from config instructions

### DIFF
--- a/README
+++ b/README
@@ -19,7 +19,7 @@ Rakudo Perl 6
     installation instructions. The short version is
 
     $ # recommended: install libicu-dev and libreadline-dev packages
-    $ perl Configure.pl --gen-parrot --gen-nqp
+    $ perl Configure.pl --gen-parrot
     $ make
     $ make spectest # optional
     $ make install # IMPORTANT, installs to install/bin/perl6


### PR DESCRIPTION
It appears that --gen-nqp is implied in --gen-parrot.
