### PR TITLE
A temporary fix for faster module loading

### DIFF
--- a/src/Perl6/ModuleLoader.nqp
+++ b/src/Perl6/ModuleLoader.nqp
@@ -96,18 +96,21 @@ class Perl6::ModuleLoader {
                         %cand<load> := "$prefix/$pbc_path";
                     }
                     @candidates.push(%cand);
++last; # temporary, until we actually don't do just @candidates[0]
                 }
                 elsif $have_pir {
                     my %cand;
                     %cand<key>  := "$prefix/$pir_path";
                     %cand<load> := "$prefix/$pir_path";
                     @candidates.push(%cand);
++last; # temporary, until we actually don't do just @candidates[0]
                 }
                 elsif $have_pbc {
                     my %cand;
                     %cand<key>  := "$prefix/$pbc_path";
                     %cand<load> := "$prefix/$pbc_path";
                     @candidates.push(%cand);
++last; # temporary, until we actually don't do just @candidates[0]
                 }
             }
         }


### PR DESCRIPTION
_All_ directories and _all_ types were being checked, whereas always only the
first was being used.  This quick fix short-circuits search as soon as the
first candidate is found.
