### PR TITLE
Allow slice with :exists adverb on hashes

### DIFF
--- a/src/core/Any.pm
+++ b/src/core/Any.pm
@@ -343,7 +343,7 @@ my class Any {
     multi method postcircumfix:<{ }>(\SELF: Positional \key, :$exists!) is rw {
         nqp::iscont(key) 
           ?? SELF.exists(key) 
-          !! die("Cannot use exists adverb with a slice")
+          !! key.map({ !( SELF.exists($_) ?^ $exists ) }).eager.Parcel;
     }
     multi method postcircumfix:<{ }>(\SELF: Positional \key, :$p!) is rw {
         nqp::iscont(key) 


### PR DESCRIPTION
For some reason a "die" was here, whereas the spec says it should return a
Parcel of Bool.
