### PR TITLE
It doesn't make sense to do .kv on hash slices, does not do what you think

### DIFF
--- a/src/core/Int.pm
+++ b/src/core/Int.pm
@@ -64,6 +64,10 @@ my class Int does Real {
     method floor(Int:D:) { self }
     method round(Int:D:) { self }
     method ceiling(Int:D:) { self }
+
+    method kv(Int:D:) {
+        nqp::die( "It doesn't make sense to call .kv on an Int.  Did you mean :kv?" );
+    }
 }
 
 multi prefix:<++>(Int:D \a is rw) {   # XXX

--- a/src/core/Numeric.pm
+++ b/src/core/Numeric.pm
@@ -24,6 +24,10 @@ my role Numeric {
 
     method succ() { self + 1 }
     method pred() { self - 1 }
+
+    method kv(Numeric:D:) {
+        nqp::die( "It doesn't make sense to call .kv on a Numeric.  Did you mean :kv?" );
+    }
 }
 
 multi sub infix:<eqv>(Numeric:D $a, Numeric:D $b) {

--- a/src/core/Rational.pm
+++ b/src/core/Rational.pm
@@ -29,6 +29,10 @@ my role Rational[::NuT, ::DeT] does Real {
         $new;
     }
 
+    method kv(Rational:D:) {
+        nqp::die( "It doesn't make sense to call .kv on a Rational.  Did you mean :kv?" );
+    }
+
     method nude() { $!numerator, $!denominator }
     method Num() {
         $!denominator == 0

--- a/src/core/Str.pm
+++ b/src/core/Str.pm
@@ -51,6 +51,10 @@ my class Str does Stringy {
     method Int(Str:D:) { self.Numeric.Int; }
     method Num(Str:D:) { self.Numeric.Num; }
 
+    method kv(Str:D:) {
+        nqp::die( "It doesn't make sense to call .kv on a Str.  Did you mean :kv?" );
+    }
+
     multi method ACCEPTS(Str:D: $other) { $other eq self }
 
     method chomp(Str:D:) {


### PR DESCRIPTION
...think.

Instead you should use :kv.  However, since .kv _also_ generates Pairs, but
with different key values, this has the potential of silently corrupting your
data.  Therefor I think it is wise to simply not allow .kv to be called on
scalar values.  Did I miss any?
