### PR TITLE
Make Hash.new() and hash() accept the same typed parameters as .hash()

### DIFF
--- a/src/core/Hash.pm
+++ b/src/core/Hash.pm
@@ -209,4 +209,4 @@ my class Hash {
 
 
 sub circumfix:<{ }>(*@elems) { my $x = Hash.new.STORE(@elems); }
-sub hash(*@a, *%h) { @a.hash(|%h) }
+sub hash(*@a, *%h) { my % = @a, %h }


### PR DESCRIPTION
Spectests ok except for t/spec/S04-statement-parsing/hash.t test 6+7

Please note that according to S04:1639 and S06:3298, tests 6+7 are
actually wrong.  They just happen to be right for the previous implementation
of hash().
