### PR TITLE
Fail typed slurpy early

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -3104,7 +3104,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
         # Stash any traits.
         %*PARAM_INFO<traits> := $<trait>;
 
-        if %*PARAM_INFO<pos_slurpy> && $<type_constraint> {
+        if (%*PARAM_INFO<pos_slurpy> || %*PARAM_INFO<pos_lol>) && $<type_constraint> {
             $/.CURSOR.sorry("Slurpy positionals with type constraints are not supported.");
         }
 


### PR DESCRIPTION
in response to https://rt.perl.org/rt3//Public/Bug/Display.html?id=113964 moritz said this:

```
< moritz> it's not at all clear how that one should work
< moritz> I mean if you write   sub f(Int @f) { }, then it only allows an
          Array[Int], not an Array containing only ints
< moritz> now how do you check that for a slurply, lazily?
```

This pull request makes rakudo complain at compile time if there's a typed _@ or *_@ in a sub signature. There will probably have to be a spec change to make this clear and some spectests, too.
