### PR TITLE
Change quoting to capture the version correctly under Windows.

### DIFF
--- a/tools/build/gen-version.pl
+++ b/tools/build/gen-version.pl
@@ -14,7 +14,7 @@ close($fh);
 chomp $VERSION;
 my ($version, $release, $codename) = split(' ', $VERSION, 3);
 
-if (-d '.git' && open(my $GIT, '-|', "git describe --match '2*'")) {
+if (-d '.git' && open(my $GIT, '-|', q|git describe --match "2*"|)) {
     $version = <$GIT>;
     close($GIT);
 }


### PR DESCRIPTION
Windows Command.exe does not understand single quoted parameters so perl6 -v returned no version number.
