### PR TITLE
better error messages for hash shapes.

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -165,14 +165,16 @@ class Perl6::Actions is HLL::Actions does STDActions {
                                 }
                             }
                         } else {
-                            nqp::die("Invalid hash shape; type expected");
+                            $*W.throw($/, "X::Comp::AdHoc",
+                                payload => "Invalid hash shape; type expected");
                         }
                     } elsif +@($shape_ast) > 1 {
                         $*W.throw($/, 'X::Comp::NYI',
                             feature => "multidimensional shaped hashes");
                     }
                 } else {
-                    nqp::die("Invalid hash shape; type expected");
+                    $*W.throw($/, "X::Comp::AdHoc",
+                        payload => "Invalid hash shape; type expected");
                 }
             }
             if @value_type {


### PR DESCRIPTION
my %h{Str;Str}
local: multidimensional shaped hashes not yet implemented. Sorry.
nom: Invalid hash shape; type expected

my %h{Str(Any)}
local: coercive type declarations not yet implemented. Sorry.
nom: Invalid hash shape; type expected
