### PR TITLE
allow a dot before hyper postfix (also unspace).

### DIFF
--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -3013,7 +3013,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         [ <!{ $*QSIGIL }> [ <.unsp> | '\\' ] ]?
 
         :dba('postfix')
-        <postfix_prefix_meta_operator>**0..1
+        [ ['.' <.unsp>?]? <postfix_prefix_meta_operator> <.unsp>?]**0..1
         [
         | <OPER=postfix>
         | <OPER=postcircumfix>


### PR DESCRIPTION
this runs all spectests, plus a few tests that are currently skipped.
