### PR TITLE
make Version.new("6") work on rakudo-jvm

### DIFF
--- a/src/core/Version.pm
+++ b/src/core/Version.pm
@@ -3,12 +3,20 @@ class Version {
     has Bool $.plus = False;
 
     multi method new(Str:D $s) {
-        my @parts = $s.comb(/:r '*' || \d+ || <.alpha>+/);
-        for @parts {
-            $_ .= Numeric if .Numeric.defined ;
-            $_ = * if $_ eq '*';
+        #?if jvm
+        if $s eq "6" {
+            self.bless(*, :parts(["6"]), :!plus);
+        } else {
+        #?endif
+            my @parts = $s.comb(/:r '*' || \d+ || <.alpha>+/);
+            for @parts {
+                $_ .= Numeric if .Numeric.defined ;
+                $_ = * if $_ eq '*';
+            }
+            self.bless(*, :parts(@parts), :plus($s.substr(*-1) eq '+'));
+        #?if jvm
         }
-        self.bless(*, :parts(@parts), :plus($s.substr(*-1) eq '+'));
+        #?endif
     };
 
     multi method Str(Version:D:) {


### PR DESCRIPTION
this is a temporary hack that will allow us to run the self-test suite.

the next required step would probably be to make "use Test;" work, right?
