### PR TITLE
Fix .clone() when providing new array/hash attributes

### DIFF
--- a/src/core/Mu.pm
+++ b/src/core/Mu.pm
@@ -432,7 +432,7 @@ my class Mu {
             unless nqp::objprimspec($attr.type) {
                 my $attr_val := nqp::getattr($cloned, $package, $name);
                 nqp::bindattr($cloned, $package, $name, nqp::clone($attr_val.VAR))
-                    if nqp::iscont($attr_val);
+                    if nqp::iscont($attr_val) || nqp::index('@%', nqp::substr($name, 0, 1)) >= 0;
             }
             my $acc_name := $name.substr(2);
             if $attr.has-accessor && %twiddles.exists($acc_name) {


### PR DESCRIPTION
This fixes https://rt.perl.org/rt3/Ticket/Display.html?id=118559, passing spectests.

~~It accomplishes this by cloning hash and array attributes, identified by their sigil, when deciding whether to clone attributes.~~

It accomplishes this by ensuring that new lists are assigned to the new object rather than updating that objects list, which points at the list of the original object.