### PR TITLE
make semilists in postcircumfix [] work (a bit)

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -4888,8 +4888,16 @@ class Perl6::Actions is HLL::Actions does STDActions {
     method postcircumfix:sym<[ ]>($/) {
         my $past := QAST::Op.new( :name('postcircumfix:<[ ]>'), :op('callmethod'), :node($/) );
         if $<semilist><statement> {
-            my $slast := $<semilist>.ast;
-            $past.push($slast);
+            if +$<semilist><statement> > 1 {
+                my $commast := QAST::Op.new( :op('call'), :name('&infix:<,>'));
+                while +@($<semilist>.ast) {
+                    $commast.unshift($<semilist>.ast.pop);
+                }
+                $past.push( QAST::Op.new( :op('callmethod'), :name('lol'), $commast) );
+            } else {
+                my $slast := $<semilist>.ast;
+                $past.push($slast);
+            }
         }
         make $past;
     }

--- a/src/core/Any.pm
+++ b/src/core/Any.pm
@@ -275,6 +275,16 @@ my class Any {
         X::Bind::Slice.new(type => self.WHAT).throw;
     }
 
+    multi method postcircumfix:<[ ]>(\SELF: LoL $coords) is rw {
+        my $subcoords = $coords[1..^*].lol;
+        if +@$subcoords == 1 {
+            $subcoords = $subcoords[0].list;
+        }
+        return-rw do for $coords[0].list {
+            SELF[$_][@$subcoords];
+        }
+    }
+
     proto method at_pos(|) {*}
     multi method at_pos(Any:D: $pos) {
         fail X::OutOfRange.new(


### PR DESCRIPTION
These two commits make the following Todos pass:

t/spec/S02-types/multi_dimensional_array.rakudo.parrot        (Wstat: 0 Tests: 41 Failed: 0)
  TODO passed:   16-18, 27-29, 36-38


Otherwise, they do not regress.

Something that is missing is assigning to a slice from a list, as in:

    my @a = (1, 2, 3), (4, 5, 6);
    my @a[0, 1;1] = <foo bar>;
    # a is supposed to be (1, foo, 3), (4, bar, 6) now

I'd like some assistance with that.