### PR TITLE
Implement nodal operators/methods, mark Any, Iteratable and Parcel as nodal.

### DIFF
--- a/src/Perl6/Metamodel/BOOTSTRAP.nqp
+++ b/src/Perl6/Metamodel/BOOTSTRAP.nqp
@@ -595,7 +595,7 @@ BEGIN {
     Routine.HOW.add_attribute(Routine, BOOTSTRAPATTR.new(:name<$!dispatchees>, :type(Mu), :package(Routine)));
     Routine.HOW.add_attribute(Routine, BOOTSTRAPATTR.new(:name<$!dispatcher_cache>, :type(Mu), :package(Routine)));
     Routine.HOW.add_attribute(Routine, BOOTSTRAPATTR.new(:name<$!dispatcher>, :type(Mu), :package(Routine)));
-    Routine.HOW.add_attribute(Routine, BOOTSTRAPATTR.new(:name<$!rw>, :type(int), :package(Routine)));
+    Routine.HOW.add_attribute(Routine, BOOTSTRAPATTR.new(:name<$!flags>, :type(int), :package(Routine)));
     Routine.HOW.add_attribute(Routine, BOOTSTRAPATTR.new(:name<$!inline_info>, :type(Mu), :package(Routine)));
     Routine.HOW.add_attribute(Routine, BOOTSTRAPATTR.new(:name<$!yada>, :type(int), :package(Routine)));
     Routine.HOW.add_attribute(Routine, BOOTSTRAPATTR.new(:name<$!package>, :type(Mu), :package(Routine)));
@@ -1419,7 +1419,16 @@ BEGIN {
         }));
     Routine.HOW.add_method(Routine, 'set_rw', nqp::getstaticcode(sub ($self) {
             my $dcself := nqp::decont($self);
-            nqp::bindattr_i($dcself, Routine, '$!rw', 1);
+            my $flags := nqp::getattr_i($dcself, Routine, '$!flags');
+            $flags := $flags +| 1;
+            nqp::bindattr_i($dcself, Routine, '$!flags', $flags);
+            $dcself
+        }));
+    Routine.HOW.add_method(Routine, 'set_nodal', nqp::getstaticcode(sub ($self) {
+            my $dcself := nqp::decont($self);
+            my $flags := nqp::getattr_i($dcself, Routine, '$!flags');
+            $flags := $flags +| 2;
+            nqp::bindattr_i($dcself, Routine, '$!flags', $flags);
             $dcself
         }));
     Routine.HOW.add_method(Routine, 'set_inline_info', nqp::getstaticcode(sub ($self, $info) {

--- a/src/Perl6/Metamodel/MethodContainer.nqp
+++ b/src/Perl6/Metamodel/MethodContainer.nqp
@@ -9,6 +9,9 @@ role Perl6::Metamodel::MethodContainer {
     # Cache that expires when we add methods (primarily to support NFA stuff).
     has %!cache;
 
+    # Should methods be marked nodal in this class?
+    has $!meth_nodal_by_default;
+
     # Add a method.
     method add_method($obj, $name, $code_obj) {
         # Adding a method means any cache is no longer authoritative.
@@ -33,6 +36,10 @@ role Perl6::Metamodel::MethodContainer {
         }
         %!cache := {};
         @!method_order[+@!method_order] := $code_obj;
+        # Add a nodal trait if we're nodal by default
+        if $!meth_nodal_by_default {
+            $code_obj.set_nodal;
+        }
     }
 
     # Gets the method hierarchy.
@@ -82,5 +89,9 @@ role Perl6::Metamodel::MethodContainer {
         nqp::existskey(%!cache, $key) ??
             %!cache{$key} !!
             (%!cache{$key} := $value_generator())
+    }
+
+    method set_nodal($obj) {
+        $!meth_nodal_by_default := 1;
     }
 }

--- a/src/core/Any.pm
+++ b/src/core/Any.pm
@@ -3,7 +3,7 @@ my class Range { ... }
 my class X::Bind::Slice { ... }
 my class X::Bind::ZenSlice { ... }
 
-my class Any {
+my class Any is nodal {
     my $default= [];  # so that we can check passing of parameters to ".hash"
     multi method ACCEPTS(Any:D: Mu \a) { self === a }
 

--- a/src/core/Bag.pm
+++ b/src/core/Bag.pm
@@ -1,6 +1,6 @@
 my role Baggy { Any }
 
-my class Bag is Iterable does Associative does Baggy {
+my class Bag is Iterable is nodal does Associative does Baggy {
     has %!elems; # should be UInt
 
     method default { 0 }

--- a/src/core/Iterable.pm
+++ b/src/core/Iterable.pm
@@ -1,4 +1,4 @@
-my class Iterable {
+my class Iterable is nodal {
     method elems()    { self.list.elems }
     method infinite() { Mu }
     method item($self:) { $self }

--- a/src/core/List.pm
+++ b/src/core/List.pm
@@ -1,4 +1,4 @@
-my class List does Positional {
+my class List is nodal does Positional {
     # declared in BOOTSTRAP.pm:
     #   is Iterable;           # parent class
     #   has Mu $!items;        # RPA of our reified elements

--- a/src/core/Mu.pm
+++ b/src/core/Mu.pm
@@ -528,7 +528,13 @@ my class Mu {
     }
 
     method dispatch:<hyper>(Mu \SELF: $name, |c) {
-        hyper( -> \obj { obj."$name"(|c) }, SELF )
+        my Mu $own_meth = SELF.^find_method($name);
+        if $own_meth && nqp::can($own_meth, 'IS_NODAL') && $own_meth.IS_NODAL {
+            # XXX should be able to pass $own_meth instead of the pointy block?
+            hyper( -> \obj { obj."$name"(|c) }, SELF, :nodal )
+        } else {
+            hyper( -> \obj { obj."$name"(|c) }, SELF )
+        }
     }
     
     method WALK(:$name!, :$canonical, :$ascendant, :$descendant, :$preorder, :$breadth,

--- a/src/core/Mu.pm
+++ b/src/core/Mu.pm
@@ -528,9 +528,13 @@ my class Mu {
     }
 
     method dispatch:<hyper>(Mu \SELF: $name, |c) {
-        my Mu $own_meth = SELF.^find_method($name);
-        if $own_meth && nqp::can($own_meth, 'nodal') && $own_meth.nodal {
-            # XXX should be able to pass $own_meth instead of the pointy block?
+        # this is an approximation for correct nodality-or-not behavior
+        # we inspect the first element of our list and try to find the least
+        # derived version of the method we're supposed to call. If it's
+        # marked nodal, we consider the rest of the list's elements to have
+        # a method of the same name that's nodal as well.
+        my Mu $least_derived_meth = (SELF[0].^can($name) || [Mu])[*-1];
+        if $least_derived_meth && nqp::can($least_derived_meth, 'nodal') && $least_derived_meth.nodal {
             hyper( -> \obj { obj."$name"(|c) }, SELF, :nodal )
         } else {
             hyper( -> \obj { obj."$name"(|c) }, SELF )

--- a/src/core/Mu.pm
+++ b/src/core/Mu.pm
@@ -533,7 +533,8 @@ my class Mu {
         # derived version of the method we're supposed to call. If it's
         # marked nodal, we consider the rest of the list's elements to have
         # a method of the same name that's nodal as well.
-        my Mu $least_derived_meth = (SELF[0].^can($name) || [Mu])[*-1];
+        my @candidates := (SELF[0].^can($name) || [Mu]);
+        my Mu $least_derived_meth = @candidates[+@candidates-1];
         if $least_derived_meth && nqp::can($least_derived_meth, 'nodal') && $least_derived_meth.nodal {
             hyper( -> \obj { obj."$name"(|c) }, SELF, :nodal )
         } else {

--- a/src/core/Mu.pm
+++ b/src/core/Mu.pm
@@ -529,7 +529,7 @@ my class Mu {
 
     method dispatch:<hyper>(Mu \SELF: $name, |c) {
         my Mu $own_meth = SELF.^find_method($name);
-        if $own_meth && nqp::can($own_meth, 'IS_NODAL') && $own_meth.IS_NODAL {
+        if $own_meth && nqp::can($own_meth, 'nodal') && $own_meth.nodal {
             # XXX should be able to pass $own_meth instead of the pointy block?
             hyper( -> \obj { obj."$name"(|c) }, SELF, :nodal )
         } else {

--- a/src/core/Parcel.pm
+++ b/src/core/Parcel.pm
@@ -38,7 +38,7 @@ my class Parcel does Positional {
 
     method at_pos(Parcel:D: \x) is rw { self.flat.at_pos(x); }
 
-    proto method postcircumfix:<[ ]>(|)                  { * }
+    proto method postcircumfix:<[ ]>(|) is nodal         { * }
     multi method postcircumfix:<[ ]>() is rw              { self.flat }
     multi method postcircumfix:<[ ]>(Parcel:D: \x) is rw  { self.flat.[x] }
 

--- a/src/core/Parcel.pm
+++ b/src/core/Parcel.pm
@@ -1,4 +1,4 @@
-my class Parcel does Positional {
+my class Parcel does Positional is nodal {
     # declared in BOOTSTRAP.pm:
     #    is Cool;              # parent class
     #    has $!storage;        # RPA of Parcel's elements
@@ -38,7 +38,7 @@ my class Parcel does Positional {
 
     method at_pos(Parcel:D: \x) is rw { self.flat.at_pos(x); }
 
-    proto method postcircumfix:<[ ]>(|) is nodal         { * }
+    proto method postcircumfix:<[ ]>(|)                   { * }
     multi method postcircumfix:<[ ]>() is rw              { self.flat }
     multi method postcircumfix:<[ ]>(Parcel:D: \x) is rw  { self.flat.[x] }
 

--- a/src/core/Routine.pm
+++ b/src/core/Routine.pm
@@ -10,7 +10,8 @@ my role SoftRoutine {
 my class Routine {
     method of() { self.signature.returns }
     method returns() { self.signature.returns }
-    method rw() { $!rw }
+    method rw() { $!flags +& 1 }
+    method nodal() { $!flags +& 2 }
     method onlystar() { nqp::p6bool($!onlystar) }
     
     method assuming($r: *@curried_pos, *%curried_named) {

--- a/src/core/Set.pm
+++ b/src/core/Set.pm
@@ -1,4 +1,4 @@
-my class Set is Iterable does Associative {
+my class Set is nodal is Iterable does Associative {
     has %!elems;
 
     method default { False }

--- a/src/core/metaops.pm
+++ b/src/core/metaops.pm
@@ -198,7 +198,7 @@ multi sub hyper(\op, \a, \b, :$dwim-left, :$dwim-right) {
 
 multi sub hyper(\op, \obj, :$nodal) {
     my Mu $rpa := nqp::list();
-    my int $descend = !($nodal || nqp::can(op, 'IS_NODAL') && op.IS_NODAL);
+    my int $descend = !($nodal || (nqp::can(op, 'nodal') && op.nodal));
     my Mu $items;
     if $descend {
         $items := nqp::p6listitems(obj.flat.eager);
@@ -236,9 +236,9 @@ multi sub hyper(\op, \obj, :$nodal) {
     nqp::p6parcel($rpa, Nil);
 }
 
-multi sub hyper(\op, Associative \h) {
+multi sub hyper(\op, Associative \h, :$nodal) {
     my @keys = h.keys;
-    hash @keys Z hyper(op, h{@keys})
+    hash @keys Z hyper(op, h{@keys}, :$nodal)
 }
 
 multi sub hyper(\op, Associative \a, Associative \b, :$dwim-left, :$dwim-right) {

--- a/src/core/traits.pm
+++ b/src/core/traits.pm
@@ -261,6 +261,12 @@ multi trait_mod:<is>(Routine:D $r, :$pure!) {
     });
 }
 
+multi trait_mod:<is>(Routine $r, :$nodal!) {
+    $r.HOW.mixin($r, role {
+        method IS_NODAL { True }
+    });
+}
+
 proto trait_mod:<returns>(|) { * }
 multi trait_mod:<returns>(Routine:D $target, Mu:U $type) {
     my $sig := $target.signature;

--- a/src/core/traits.pm
+++ b/src/core/traits.pm
@@ -261,10 +261,11 @@ multi trait_mod:<is>(Routine:D $r, :$pure!) {
     });
 }
 
-multi trait_mod:<is>(Routine $r, :$nodal!) {
-    $r.HOW.mixin($r, role {
-        method IS_NODAL { True }
-    });
+multi trait_mod:<is>(Routine:D $r, :$nodal!) {
+    $r.HOW.set_nodal($r);
+}
+multi trait_mod:<is>(Mu:U $type, :$nodal!) {
+    $type.HOW.set_nodal($type);
 }
 
 proto trait_mod:<returns>(|) { * }

--- a/src/vm/jvm/runtime/org/perl6/rakudo/RakOps.java
+++ b/src/vm/jvm/runtime/org/perl6/rakudo/RakOps.java
@@ -58,7 +58,7 @@ public final class RakOps {
     private static final int HINT_PARCEL_STORAGE = 0;
     private static final int HINT_CODE_DO = 0;
     private static final int HINT_CODE_SIG = 1;
-    private static final int HINT_ROUTINE_RW = 7;
+    private static final int HINT_ROUTINE_FLAGS = 7;
     private static final int HINT_SIG_PARAMS = 0;
     private static final int HINT_SIG_CODE = 4;
     public static final int HINT_CD_OF = 0;
@@ -403,8 +403,8 @@ public final class RakOps {
     public static SixModelObject p6decontrv(SixModelObject cont, ThreadContext tc) {
         GlobalExt gcx = key.getGC(tc);
         if (cont != null && isRWScalar(tc, gcx, cont)) {
-            tc.curFrame.codeRef.codeObject.get_attribute_native(tc, gcx.Routine, "$!rw", HINT_ROUTINE_RW);
-            if (tc.native_i == 0) {
+            tc.curFrame.codeRef.codeObject.get_attribute_native(tc, gcx.Routine, "$!flags", HINT_ROUTINE_FLAGS);
+            if (tc.native_i & 1 == 0) {
                 /* Recontainerize to RO. */
                 SixModelObject roCont = gcx.Scalar.st.REPR.allocate(tc, gcx.Scalar.st);
                 roCont.bind_attribute_boxed(tc, gcx.Scalar, "$!value",

--- a/src/vm/parrot/guts/bind.h
+++ b/src/vm/parrot/guts/bind.h
@@ -74,7 +74,7 @@ typedef struct {
     PMC    *dispatchees;        /* List of dispatchees, if any. */
     PMC    *dispatcher_cache;   /* Holder for any dispatcher cache. */
     PMC    *dispatcher;         /* The parent dispatcher, if any. */
-    INTVAL  rw;                 /* Is it rw? */
+    INTVAL  flags;              /* Is it rw (0b1) or nodal (0b10)? */
 } Rakudo_Code;
 
 /* 

--- a/src/vm/parrot/ops/perl6.ops
+++ b/src/vm/parrot/ops/perl6.ops
@@ -933,7 +933,7 @@ inline op perl6_decontainerize_return_value(out PMC, in PMC) :base_core {
         Rakudo_Code *code;
         GETATTR_Sub_multi_signature(interp, parrot_sub, p6sub);
         code = (Rakudo_Code *)PMC_data(p6sub);
-        $1 = code->rw ? $2 : Rakudo_cont_scalar_with_value_no_descriptor(interp, 
+        $1 = (code->flags & 1) ? $2 : Rakudo_cont_scalar_with_value_no_descriptor(interp,
             Rakudo_cont_decontainerize(interp, $2));
     }
     else {


### PR DESCRIPTION
This gives us an "is nodal" for classes as well as for Routines, turns $!rw for Routine into $!flags that keeps "is nodal" in the second and "is rw" in the first bit.

I'm not sure if marking Parcel as nodal is sensible and wether or not marking Hash or Associative or more different things as nodal would be necessary.

There's a few tests for this in the perl6/roast in the nodal_tests branch. I'd like to hear more suggestions for cases that ought to be tested.