### PR TITLE
properly remove left margin from raw blocks

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -519,7 +519,10 @@ class Perl6::Actions is HLL::Actions does STDActions {
     }
 
     method pod_block:sym<delimited_raw>($/) {
-        make Perl6::Pod::raw_block($/);
+        my $s := $<spaces>.Str;
+        my $t := subst($<pod_content>.Str, /\n$s/, "\n", :global);
+        $t    := subst($t, /\n$/, ''); # chomp!
+        make Perl6::Pod::raw_block($/, $t);
     }
 
     method pod_block:sym<delimited_table>($/) {
@@ -531,7 +534,10 @@ class Perl6::Actions is HLL::Actions does STDActions {
     }
 
     method pod_block:sym<paragraph_raw>($/) {
-        make Perl6::Pod::raw_block($/);
+        my $s := $<spaces>.Str;
+        my $t := subst($<pod_content>.Str, /\n$s/, "\n", :global);
+        $t    := subst($t, /\n$/, ''); # chomp!
+        make Perl6::Pod::raw_block($/, $t);
     }
 
     method pod_block:sym<paragraph_table>($/) {
@@ -543,7 +549,10 @@ class Perl6::Actions is HLL::Actions does STDActions {
     }
 
     method pod_block:sym<abbreviated_raw>($/) {
-        make Perl6::Pod::raw_block($/);
+        my $s := $<spaces>.Str;
+        my $t := subst($<pod_content>.Str, /\n$s/, "\n", :global);
+        $t    := subst($t, /\n$/, ''); # chomp!
+        make Perl6::Pod::raw_block($/, $t);
     }
 
     method pod_block:sym<abbreviated_table>($/) {

--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -607,7 +607,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         '=begin' \h+ $<type>=[ 'code' | 'comment' ] {}
         <pod_configuration($<spaces>)> <pod_newline>+
         [
-         $<pod_content> = [ .*? ]
+         $<spaces> $<pod_content> = [ .*? ]
          ^^ $<spaces> '=end' \h+ $<type> <pod_newline>
          ||  <.typed_panic: 'X::Syntax::Pod::BeginWithoutEnd'>
         ]
@@ -689,7 +689,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         '=for' \h+ $<type>=[ 'code' | 'comment' ]
         :my $*POD_ALLOW_FCODES := nqp::getlexdyn('$*POD_ALLOW_FCODES');
         <pod_configuration($<spaces>)> <pod_newline>
-        $<pod_content> = [ \h* <!before '=' \w> \N+ \n ]+
+        $<spaces> $<pod_content> = [ \h* <!before '=' \w> \N+ \n ]+
     }
 
     token pod_block:sym<paragraph_table> {
@@ -725,7 +725,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         '=' $<type>=[ 'code' | 'comment' ]
         :my $*POD_ALLOW_FCODES := nqp::getlexdyn('$*POD_ALLOW_FCODES');
         <pod_configuration($<spaces>)> [\r\n|\s]
-        $<pod_content> = [ \h* <!before '=' \w> \N+ \n ]*
+        $<spaces> $<pod_content> = [ \h* <!before '=' \w> \N+ \n ]*
     }
 
     token pod_block:sym<abbreviated_table> {

--- a/src/Perl6/Pod.nqp
+++ b/src/Perl6/Pod.nqp
@@ -57,9 +57,14 @@ class Perl6::Pod {
         return $past.compile_time_value;
     }
 
-    our sub raw_block($/) {
+    our sub raw_block($/, $override_text?) {
         my $config := $<pod_configuration>.ast;
-        my $str := $*W.add_constant('Str', 'str', ~$<pod_content>);
+        my $str;
+        if $override_text {
+            $str := $*W.add_constant('Str', 'str', ~$override_text);
+        } else {
+            $str := $*W.add_constant('Str', 'str', ~$<pod_content>);
+        }
         my $content := serialize_array([$str.compile_time_value]);
         my $type := $<type>.Str eq 'code' ?? 'Pod::Block::Code'
                                           !! 'Pod::Block::Comment';


### PR DESCRIPTION
delimited_raw, abbreviated_raw and paragraph_raw will now have all spaces from the beginning removed from all lines.

```
=begin pod
    =begin code
    foo
    bar
    =end code
=end pod
```

used to result in 4 spaces left of "foo" and "bar" and no longer does.
