### PR TITLE
D:\src\rakudo>perl ConfigureJVM.pl

### DIFF
--- a/ConfigureJVM.pl
+++ b/ConfigureJVM.pl
@@ -56,7 +56,7 @@ MAIN: {
     }
     
     # require --with-nqp or --gen-nqp or find executable nqp at default locaton
-    if (!defined $gen_nqp && !defined $options{'with-nqp'} && ! -x $with_nqp) {
+    if (!defined $gen_nqp && !defined $options{'with-nqp'} && ! -x $with_nqp && !-x $with_nqp.".bat") {
         die("$with_nqp is not executable; use --with-nqp or use --gen-nqp");
     }
     


### PR DESCRIPTION
causes install-jvm\bin\nqp is not executable; use --with-nqp or use --gen-nqp at ConfigureJVM.pl line 60.

fixed
