### PR TITLE
Added rmdir to IO::Path

### DIFF
--- a/src/core/IO.pm
+++ b/src/core/IO.pm
@@ -486,6 +486,16 @@ my class IO::Path is Cool does IO::FileTestable {
 #?endif
     }
 
+    method rmdir(IO::Path:D:) {
+        try nqp::rmdir($!path);
+        if ($!) {
+            fail X::IO::Rmdir.new(
+                    :$!path,
+                    os-error => .Str);
+        }
+
+        return True;
+    }
 }
 
 my class IO::Path::Unix   is IO::Path { method SPEC { IO::Spec::Unix   };  }
@@ -511,17 +521,8 @@ sub unlink($path as Str) {
     }
 }
 
-sub rmdir($path as Str) {
-    nqp::rmdir($path);
-    return True;
-    CATCH {
-        default {
-            X::IO::Rmdir.new(
-                :$path,
-                os-error => .Str,
-            ).throw;
-        }
-    }
+sub rmdir(Cool $path) {
+    return $path.path.rmdir();
 }
 
 proto sub open(|) { * }


### PR DESCRIPTION
Added rmdir to IO::Path, made rmdir fail instead of throw.

I have created (at the moment unpushed) additional spec tests for these changes.
