### PR TITLE
Allow #`[space] in regexes (Unrelated to RT#77522)

### DIFF
--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -4124,6 +4124,8 @@ grammar Perl6::RegexGrammar is QRegex::P6Regex::Grammar does STD {
         self.typed_sorry('X::Syntax::Regex::NullRegex');
     }
 
+    token normspace { <?before \s | '#'> <.LANG('MAIN', 'ws')> }
+
     token rxstopper { <stopper> }
 
     token metachar:sym<:my> {


### PR DESCRIPTION
```
19:16 <Mouq> r: "abcd" ~~ / ab #`[You don't see me] cd /
19:16 <camelia> rakudo b1d675: OUTPUT«===SORRY!=== Error while compiling
                /tmp/_JkAY_k11Q␤Regex not terminated␤at
                /tmp/_JkAY_k11Q:1␤------> "abcd" ~~ / ab #`[You don't see me]
                cd /⏏<EOL>␤    expecting any of:␤        postfix␤        infix
                stopper␤        infix or…»
19:16 <Mouq> std: "abcd" ~~ / ab #`[You don't see me] cd /
19:16 <camelia> std 7c17586: OUTPUT«ok 00:00 43m␤»
```
