### PR TITLE
typecheck the arguments of Array[Type].new.

### DIFF
--- a/src/core/List.pm
+++ b/src/core/List.pm
@@ -10,6 +10,7 @@ my class List does Positional { # declared in BOOTSTRAP
     method new(|) {
         my Mu $args := nqp::p6argvmarray();
         nqp::shift($args);
+
         nqp::p6list($args, self.WHAT, Mu);
     }
 


### PR DESCRIPTION
this makes stuff like Array[Int].new(1, 2, "surprise!") die.
