### PR TITLE
WIP: Use simpler syntax in grammar names

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -546,7 +546,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
         make $child;
     }
 
-    method pod_content:sym<block>($/) {
+    method pod_content:block ($/) {
         make $<pod_block>.ast;
     }
 
@@ -554,50 +554,50 @@ class Perl6::Actions is HLL::Actions does STDActions {
         make Perl6::Pod::make_config($/);
     }
 
-    method pod_block:sym<delimited>($/) {
+    method pod_block:delimited ($/) {
         make Perl6::Pod::any_block($/);
     }
 
-    method pod_block:sym<delimited_raw>($/) {
+    method pod_block:delimited_raw ($/) {
         make Perl6::Pod::raw_block($/);
     }
 
-    method pod_block:sym<delimited_table>($/) {
+    method pod_block:delimited_table ($/) {
         make Perl6::Pod::table($/);
     }
 
-    method pod_block:sym<paragraph>($/) {
+    method pod_block:paragraph ($/) {
         make Perl6::Pod::any_block($/);
     }
 
-    method pod_block:sym<paragraph_raw>($/) {
+    method pod_block:paragraph_raw ($/) {
         make Perl6::Pod::raw_block($/);
     }
 
-    method pod_block:sym<paragraph_table>($/) {
+    method pod_block:paragraph_table ($/) {
         make Perl6::Pod::table($/);
     }
 
-    method pod_block:sym<abbreviated>($/) {
+    method pod_block:abbreviated ($/) {
         make Perl6::Pod::any_block($/);
     }
 
-    method pod_block:sym<abbreviated_raw>($/) {
+    method pod_block:abbreviated_raw ($/) {
         make Perl6::Pod::raw_block($/);
     }
 
-    method pod_block:sym<abbreviated_table>($/) {
+    method pod_block:abbreviated_table ($/) {
         make Perl6::Pod::table($/);
     }
 
-    method pod_block:sym<end>($/) {
+    method pod_block:end ($/) {
     }
 
-    method pod_content:sym<config>($/) {
+    method pod_content:config ($/) {
         make Perl6::Pod::config($/);
     }
 
-    method pod_content:sym<text>($/) {
+    method pod_content:text ($/) {
         my @ret := [];
         for $<pod_textcontent> {
             @ret.push($_.ast);
@@ -606,7 +606,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
         make $past.compile_time_value;
     }
 
-    method pod_textcontent:sym<regular>($/) {
+    method pod_textcontent:regular ($/) {
         my @t     := Perl6::Pod::merge_twines($<pod_string>);
         my $twine := Perl6::Pod::serialize_array(@t).compile_time_value;
         make Perl6::Pod::serialize_object(
@@ -614,7 +614,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
         ).compile_time_value
     }
 
-    method pod_textcontent:sym<code>($/) {
+    method pod_textcontent:code ($/) {
         my $s := $<spaces>.Str;
         my $t := subst($<text>.Str, /\n$s/, "\n", :global);
         $t    := subst($t, /\n$/, ''); # chomp!
@@ -984,7 +984,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
 
     ## Statement control
 
-    method statement_control:sym<if>($/) {
+    method statement_control:if ($/) {
         my $count := +$<xblock> - 1;
         my $past := xblock_immediate( $<xblock>[$count].ast );
         # push the else block if any, otherwise 'if' returns C<Nil> (per S04)
@@ -1002,19 +1002,19 @@ class Perl6::Actions is HLL::Actions does STDActions {
         make $past;
     }
 
-    method statement_control:sym<unless>($/) {
+    method statement_control:unless ($/) {
         my $past := xblock_immediate( $<xblock>.ast );
         $past.op('unless');
         make $past;
     }
 
-    method statement_control:sym<while>($/) {
+    method statement_control:while ($/) {
         my $past := xblock_immediate( $<xblock>.ast );
         $past.op(~$<sym>);
         make tweak_loop($past);
     }
 
-    method statement_control:sym<repeat>($/) {
+    method statement_control:repeat ($/) {
         my $op := 'repeat_' ~ ~$<wu>;
         my $past;
         if $<xblock> {
@@ -1028,7 +1028,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
         make tweak_loop($past);
     }
 
-    method statement_control:sym<for>($/) {
+    method statement_control:for ($/) {
         my $xblock := $<xblock>.ast;
         my $past := QAST::Op.new(
                         :op<callmethod>, :name<map>, :node($/),
@@ -1041,7 +1041,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
         make $past;
     }
 
-    method statement_control:sym<loop>($/) {
+    method statement_control:loop ($/) {
         my $block := pblock_immediate($<block>.ast);
         my $cond := $<e2> ?? $<e2>[0].ast !! QAST::Var.new(:name<True>, :scope<lexical>);
         my $loop := QAST::Op.new( $cond, :op('while'), :node($/) );
@@ -1091,7 +1091,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
         $loop
     }
 
-    method statement_control:sym<need>($/) {
+    method statement_control:need ($/) {
         my $past := QAST::Var.new( :name('Nil'), :scope('lexical') );
         for $<version> {
             # XXX TODO: Version checks.
@@ -1099,12 +1099,12 @@ class Perl6::Actions is HLL::Actions does STDActions {
         make $past;
     }
 
-    method statement_control:sym<import>($/) {
+    method statement_control:import ($/) {
         my $past := QAST::Var.new( :name('Nil'), :scope('lexical') );
         make $past;
     }
 
-    method statement_control:sym<use>($/) {
+    method statement_control:use ($/) {
         my $past := QAST::Var.new( :name('Nil'), :scope('lexical') );
         if $<version> {
             # TODO: replace this by code that doesn't always die with
@@ -1139,7 +1139,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
         make $past;
     }
 
-    method statement_control:sym<require>($/) {
+    method statement_control:require ($/) {
         my $past := QAST::Stmts.new(:node($/));
         my $name_past := $<module_name>
                         ?? $*W.dissect_longname($<module_name><longname>).name_past()
@@ -1191,14 +1191,14 @@ class Perl6::Actions is HLL::Actions does STDActions {
         make $past;
     }
 
-    method statement_control:sym<given>($/) {
+    method statement_control:given ($/) {
         my $past := $<xblock>.ast;
         $past.push($past.shift); # swap [0] and [1] elements
         $past.op('call');
         make $past;
     }
 
-    method statement_control:sym<when>($/) {
+    method statement_control:when ($/) {
         # Get hold of the smartmatch expression and the block.
         my $xblock := $<xblock>.ast;
         my $sm_exp := $xblock.shift;
@@ -1219,13 +1219,13 @@ class Perl6::Actions is HLL::Actions does STDActions {
         );
     }
 
-    method statement_control:sym<default>($/) {
+    method statement_control:default ($/) {
         # We always execute this, so just need the block, however we also
         # want to make sure we succeed after running it.
         make when_handler_helper($<block>.ast);
     }
 
-    method statement_control:sym<CATCH>($/) {
+    method statement_control:CATCH ($/) {
         if nqp::existskey(%*HANDLERS, 'CATCH') {
             $*W.throw($/, ['X', 'Phaser', 'Multiple'], block => 'CATCH');
         }
@@ -1234,7 +1234,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
         make QAST::Var.new( :name('Nil'), :scope('lexical') );
     }
 
-    method statement_control:sym<CONTROL>($/) {
+    method statement_control:CONTROL ($/) {
         if nqp::existskey(%*HANDLERS, 'CONTROL') {
             $*W.throw($/, ['X', 'Phaser', 'Multiple'], block => 'CONTROL');
         }
@@ -1243,38 +1243,38 @@ class Perl6::Actions is HLL::Actions does STDActions {
         make QAST::Var.new( :name('Nil'), :scope('lexical') );
     }
 
-    method statement_prefix:sym<BEGIN>($/)   { make $*W.add_phaser($/, 'BEGIN', ($<blorst>.ast)<code_object>); }
-    method statement_prefix:sym<COMPOSE>($/) { make $*W.add_phaser($/, 'COMPOSE', ($<blorst>.ast)<code_object>); }
-    method statement_prefix:sym<CHECK>($/)   { make $*W.add_phaser($/, 'CHECK', ($<blorst>.ast)<code_object>); }
-    method statement_prefix:sym<INIT>($/)    { make $*W.add_phaser($/, 'INIT', ($<blorst>.ast)<code_object>, ($<blorst>.ast)<past_block>); }
-    method statement_prefix:sym<ENTER>($/)   { make $*W.add_phaser($/, 'ENTER', ($<blorst>.ast)<code_object>); }
-    method statement_prefix:sym<FIRST>($/)   { make $*W.add_phaser($/, 'FIRST', ($<blorst>.ast)<code_object>); }
+    method statement_prefix:BEGIN ($/)   { make $*W.add_phaser($/, 'BEGIN', ($<blorst>.ast)<code_object>); }
+    method statement_prefix:COMPOSE ($/) { make $*W.add_phaser($/, 'COMPOSE', ($<blorst>.ast)<code_object>); }
+    method statement_prefix:CHECK ($/)   { make $*W.add_phaser($/, 'CHECK', ($<blorst>.ast)<code_object>); }
+    method statement_prefix:INIT ($/)    { make $*W.add_phaser($/, 'INIT', ($<blorst>.ast)<code_object>, ($<blorst>.ast)<past_block>); }
+    method statement_prefix:ENTER ($/)   { make $*W.add_phaser($/, 'ENTER', ($<blorst>.ast)<code_object>); }
+    method statement_prefix:FIRST ($/)   { make $*W.add_phaser($/, 'FIRST', ($<blorst>.ast)<code_object>); }
     
-    method statement_prefix:sym<END>($/)   { make $*W.add_phaser($/, 'END', ($<blorst>.ast)<code_object>); }
-    method statement_prefix:sym<LEAVE>($/) { make $*W.add_phaser($/, 'LEAVE', ($<blorst>.ast)<code_object>); }
-    method statement_prefix:sym<KEEP>($/)  { make $*W.add_phaser($/, 'KEEP', ($<blorst>.ast)<code_object>); }
-    method statement_prefix:sym<UNDO>($/)  { make $*W.add_phaser($/, 'UNDO', ($<blorst>.ast)<code_object>); }
-    method statement_prefix:sym<NEXT>($/)  { make $*W.add_phaser($/, 'NEXT', ($<blorst>.ast)<code_object>); }
-    method statement_prefix:sym<LAST>($/)  { make $*W.add_phaser($/, 'LAST', ($<blorst>.ast)<code_object>); }
-    method statement_prefix:sym<PRE>($/)   { make $*W.add_phaser($/, 'PRE', ($<blorst>.ast)<code_object>, ($<blorst>.ast)<past_block>); }
-    method statement_prefix:sym<POST>($/)  { make $*W.add_phaser($/, 'POST', ($<blorst>.ast)<code_object>, ($<blorst>.ast)<past_block>); }
+    method statement_prefix:END ($/)   { make $*W.add_phaser($/, 'END', ($<blorst>.ast)<code_object>); }
+    method statement_prefix:LEAVE ($/) { make $*W.add_phaser($/, 'LEAVE', ($<blorst>.ast)<code_object>); }
+    method statement_prefix:KEEP ($/)  { make $*W.add_phaser($/, 'KEEP', ($<blorst>.ast)<code_object>); }
+    method statement_prefix:UNDO ($/)  { make $*W.add_phaser($/, 'UNDO', ($<blorst>.ast)<code_object>); }
+    method statement_prefix:NEXT ($/)  { make $*W.add_phaser($/, 'NEXT', ($<blorst>.ast)<code_object>); }
+    method statement_prefix:LAST ($/)  { make $*W.add_phaser($/, 'LAST', ($<blorst>.ast)<code_object>); }
+    method statement_prefix:PRE ($/)   { make $*W.add_phaser($/, 'PRE', ($<blorst>.ast)<code_object>, ($<blorst>.ast)<past_block>); }
+    method statement_prefix:POST ($/)  { make $*W.add_phaser($/, 'POST', ($<blorst>.ast)<code_object>, ($<blorst>.ast)<past_block>); }
 
-    method statement_prefix:sym<DOC>($/)   {
+    method statement_prefix:DOC ($/)   {
         $*W.add_phaser($/, ~$<phase>, ($<blorst>.ast)<code_object>)
             if %*COMPILING<%?OPTIONS><doc>;
     }
 
-    method statement_prefix:sym<do>($/) {
+    method statement_prefix:do ($/) {
         make QAST::Op.new( :op('call'), $<blorst>.ast );
     }
 
-    method statement_prefix:sym<gather>($/) {
+    method statement_prefix:gather ($/) {
         my $past := block_closure($<blorst>.ast);
         $past<past_block>.push(QAST::Var.new( :name('Nil'), :scope('lexical') ));
         make QAST::Op.new( :op('call'), :name('&GATHER'), $past );
     }
 
-    method statement_prefix:sym<once>($/) {
+    method statement_prefix:once ($/) {
 
         # create state variable to remember whether we ran the block
         my $pad := $*W.cur_lexpad();
@@ -1299,7 +1299,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
         );
     }
 
-    method statement_prefix:sym<sink>($/) {
+    method statement_prefix:sink ($/) {
         my $blast := QAST::Op.new( :op('call'), $<blorst>.ast );
         make QAST::Stmts.new(
             QAST::Op.new( :name('&eager'), :op('call'), $blast ),
@@ -1308,7 +1308,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
         );
     }
 
-    method statement_prefix:sym<try>($/) {
+    method statement_prefix:try ($/) {
         my $block := $<blorst>.ast;
         my $past;
         if $block<past_block><handlers> && $block<past_block><handlers><CATCH> {
@@ -1365,15 +1365,15 @@ class Perl6::Actions is HLL::Actions does STDActions {
 
     method modifier_expr($/) { make $<EXPR>.ast; }
 
-    method statement_mod_cond:sym<if>($/)     {
+    method statement_mod_cond:if ($/)     {
         make QAST::Op.new( :op<if>, $<modifier_expr>.ast, :node($/) );
     }
 
-    method statement_mod_cond:sym<unless>($/) {
+    method statement_mod_cond:unless ($/) {
         make QAST::Op.new( :op<unless>, $<modifier_expr>.ast, :node($/) );
     }
 
-    method statement_mod_cond:sym<when>($/) {
+    method statement_mod_cond:when ($/) {
         make QAST::Op.new( :op<if>,
             QAST::Op.new( :name('ACCEPTS'), :op('callmethod'),
                           $<modifier_expr>.ast, 
@@ -1382,27 +1382,27 @@ class Perl6::Actions is HLL::Actions does STDActions {
         );
     }
 
-    method statement_mod_loop:sym<while>($/)  { make $<smexpr>.ast; }
-    method statement_mod_loop:sym<until>($/)  { make $<smexpr>.ast; }
-    method statement_mod_loop:sym<for>($/)    { make $<smexpr>.ast; }
-    method statement_mod_loop:sym<given>($/)  { make $<smexpr>.ast; }
+    method statement_mod_loop:while ($/)  { make $<smexpr>.ast; }
+    method statement_mod_loop:until ($/)  { make $<smexpr>.ast; }
+    method statement_mod_loop:for ($/)    { make $<smexpr>.ast; }
+    method statement_mod_loop:given ($/)  { make $<smexpr>.ast; }
 
     ## Terms
 
-    method term:sym<fatarrow>($/)           { make $<fatarrow>.ast; }
-    method term:sym<colonpair>($/)          { make $<colonpair>.ast; }
-    method term:sym<variable>($/)           { make $<variable>.ast; }
-    method term:sym<package_declarator>($/) { make $<package_declarator>.ast; }
-    method term:sym<scope_declarator>($/)   { make $<scope_declarator>.ast; }
-    method term:sym<routine_declarator>($/) { make $<routine_declarator>.ast; }
-    method term:sym<multi_declarator>($/)   { make $<multi_declarator>.ast; }
-    method term:sym<regex_declarator>($/)   { make $<regex_declarator>.ast; }
-    method term:sym<type_declarator>($/)    { make $<type_declarator>.ast; }
-    method term:sym<circumfix>($/)          { make $<circumfix>.ast; }
-    method term:sym<statement_prefix>($/)   { make $<statement_prefix>.ast; }
-    method term:sym<lambda>($/)             { make block_closure($<pblock>.ast); }
-    method term:sym<sigterm>($/)            { make $<sigterm>.ast; }
-    method term:sym<unquote>($/) {
+    method term:fatarrow ($/)           { make $<fatarrow>.ast; }
+    method term:colonpair ($/)          { make $<colonpair>.ast; }
+    method term:variable ($/)           { make $<variable>.ast; }
+    method term:package_declarator ($/) { make $<package_declarator>.ast; }
+    method term:scope_declarator ($/)   { make $<scope_declarator>.ast; }
+    method term:routine_declarator ($/) { make $<routine_declarator>.ast; }
+    method term:multi_declarator ($/)   { make $<multi_declarator>.ast; }
+    method term:regex_declarator ($/)   { make $<regex_declarator>.ast; }
+    method term:type_declarator ($/)    { make $<type_declarator>.ast; }
+    method term:circumfix ($/)          { make $<circumfix>.ast; }
+    method term:statement_prefix ($/)   { make $<statement_prefix>.ast; }
+    method term:lambda ($/)             { make block_closure($<pblock>.ast); }
+    method term:sigterm ($/)            { make $<sigterm>.ast; }
+    method term:unquote ($/) {
         make QAST::Unquote.new(:position(+@*UNQUOTE_ASTS));
         @*UNQUOTE_ASTS.push($<statementlist>.ast);
     }
@@ -1706,19 +1706,19 @@ class Perl6::Actions is HLL::Actions does STDActions {
         $attr
     }
 
-    method package_declarator:sym<package>($/) { make $<package_def>.ast; }
-    method package_declarator:sym<module>($/)  { make $<package_def>.ast; }
-    method package_declarator:sym<class>($/)   { make $<package_def>.ast; }
-    method package_declarator:sym<grammar>($/) { make $<package_def>.ast; }
-    method package_declarator:sym<role>($/)    { make $<package_def>.ast; }
-    method package_declarator:sym<knowhow>($/) { make $<package_def>.ast; }
-    method package_declarator:sym<native>($/)  { make $<package_def>.ast; }
+    method package_declarator:package ($/) { make $<package_def>.ast; }
+    method package_declarator:module ($/)  { make $<package_def>.ast; }
+    method package_declarator:class ($/)   { make $<package_def>.ast; }
+    method package_declarator:grammar ($/) { make $<package_def>.ast; }
+    method package_declarator:role ($/)    { make $<package_def>.ast; }
+    method package_declarator:knowhow ($/) { make $<package_def>.ast; }
+    method package_declarator:native ($/)  { make $<package_def>.ast; }
 
-    method package_declarator:sym<trusts>($/) {
+    method package_declarator:trusts ($/) {
         $*W.apply_trait($/, '&trait_mod:<trusts>', $*PACKAGE, $<typename>.ast);
     }
 
-    method package_declarator:sym<also>($/) {
+    method package_declarator:also ($/) {
         for $<trait> {
             if $_.ast { ($_.ast)($*DECLARAND) }
         }
@@ -1836,12 +1836,12 @@ class Perl6::Actions is HLL::Actions does STDActions {
         );
     }
 
-    method scope_declarator:sym<my>($/)      { make $<scoped>.ast; }
-    method scope_declarator:sym<our>($/)     { make $<scoped>.ast; }
-    method scope_declarator:sym<has>($/)     { make $<scoped>.ast; }
-    method scope_declarator:sym<anon>($/)    { make $<scoped>.ast; }
-    method scope_declarator:sym<augment>($/) { make $<scoped>.ast; }
-    method scope_declarator:sym<state>($/)   { make $<scoped>.ast; }
+    method scope_declarator:my ($/)      { make $<scoped>.ast; }
+    method scope_declarator:our ($/)     { make $<scoped>.ast; }
+    method scope_declarator:has ($/)     { make $<scoped>.ast; }
+    method scope_declarator:anon ($/)    { make $<scoped>.ast; }
+    method scope_declarator:augment ($/) { make $<scoped>.ast; }
+    method scope_declarator:state ($/)   { make $<scoped>.ast; }
 
     method declarator($/) {
         if    $<routine_declarator>  { make $<routine_declarator>.ast  }
@@ -1978,10 +1978,10 @@ class Perl6::Actions is HLL::Actions does STDActions {
         }
     }
 
-    method multi_declarator:sym<multi>($/) { make $<declarator> ?? $<declarator>.ast !! $<routine_def>.ast }
-    method multi_declarator:sym<proto>($/) { make $<declarator> ?? $<declarator>.ast !! $<routine_def>.ast }
-    method multi_declarator:sym<only>($/)  { make $<declarator> ?? $<declarator>.ast !! $<routine_def>.ast }
-    method multi_declarator:sym<null>($/)  { make $<declarator>.ast }
+    method multi_declarator:multi ($/) { make $<declarator> ?? $<declarator>.ast !! $<routine_def>.ast }
+    method multi_declarator:proto ($/) { make $<declarator> ?? $<declarator>.ast !! $<routine_def>.ast }
+    method multi_declarator:only ($/)  { make $<declarator> ?? $<declarator>.ast !! $<routine_def>.ast }
+    method multi_declarator:null ($/)  { make $<declarator>.ast }
 
     method scoped($/) {
         make $<DECL>.ast;
@@ -2164,9 +2164,9 @@ class Perl6::Actions is HLL::Actions does STDActions {
         install_method($/, $meth_name, 'has', $code, $install_in);
     }
 
-    method routine_declarator:sym<sub>($/) { make $<routine_def>.ast; }
-    method routine_declarator:sym<method>($/) { make $<method_def>.ast; }
-    method routine_declarator:sym<submethod>($/) { make $<method_def>.ast; }
+    method routine_declarator:sub ($/) { make $<routine_def>.ast; }
+    method routine_declarator:method ($/) { make $<method_def>.ast; }
+    method routine_declarator:submethod ($/) { make $<method_def>.ast; }
 
     method routine_def($/) {
         my $block;
@@ -2926,15 +2926,15 @@ class Perl6::Actions is HLL::Actions does STDActions {
         make $BLOCK;
     }
 
-    method regex_declarator:sym<regex>($/, $key?) {
+    method regex_declarator:regex ($/, $key?) {
         make $<regex_def>.ast;
     }
 
-    method regex_declarator:sym<token>($/, $key?) {
+    method regex_declarator:token ($/, $key?) {
         make $<regex_def>.ast;
     }
 
-    method regex_declarator:sym<rule>($/, $key?) {
+    method regex_declarator:rule ($/, $key?) {
         make $<regex_def>.ast;
     }
 
@@ -3024,7 +3024,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
         reference_to_code_object($code, $past);
     }
 
-    method type_declarator:sym<enum>($/) {
+    method type_declarator:enum ($/) {
         # If it's an anonymous enum, just call anonymous enum former
         # and we're done.
         unless $<longname> || $<variable> {
@@ -3157,7 +3157,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
         make QAST::WVal.new( :value($type_obj) );
     }
 
-    method type_declarator:sym<subset>($/) {
+    method type_declarator:subset ($/) {
         # We refine Any by default; "of" may override.
         my $refinee := $*W.find_symbol(['Any']);
 
@@ -3187,7 +3187,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
         make QAST::WVal.new( :value($subset) );
     }
 
-    method type_declarator:sym<constant>($/) {
+    method type_declarator:constant ($/) {
         # Get constant value.
         my $con_block := $*W.pop_lexpad();
         my $value_ast := $<initializer>.ast;
@@ -3645,7 +3645,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
         make $<trait_mod> ?? $<trait_mod>.ast !! $<colonpair>.ast;
     }
 
-    method trait_mod:sym<is>($/) {
+    method trait_mod:is ($/) {
         # Handle is repr specially.
         if ~$<longname> eq 'repr' {
             if $<circumfix> {
@@ -3687,19 +3687,19 @@ class Perl6::Actions is HLL::Actions does STDActions {
         }
     }
 
-    method trait_mod:sym<hides>($/) {
+    method trait_mod:hides ($/) {
         make -> $declarand {
             $*W.apply_trait($/, '&trait_mod:<hides>', $declarand, $<typename>.ast);
         };
     }
 
-    method trait_mod:sym<does>($/) {
+    method trait_mod:does ($/) {
         make -> $declarand {
             $*W.apply_trait($/, '&trait_mod:<does>', $declarand, $<typename>.ast);
         };
     }
 
-    method trait_mod:sym<will>($/) {
+    method trait_mod:will ($/) {
         my %arg;
         %arg{~$<identifier>} := ($*W.add_constant('Int', 'int', 1)).compile_time_value;
         make -> $declarand {
@@ -3708,25 +3708,25 @@ class Perl6::Actions is HLL::Actions does STDActions {
         };
     }
 
-    method trait_mod:sym<of>($/) {
+    method trait_mod:of ($/) {
         make -> $declarand {
             $*W.apply_trait($/, '&trait_mod:<of>', $declarand, $<typename>.ast);
         };
     }
 
-    method trait_mod:sym<as>($/) {
+    method trait_mod:as ($/) {
         make -> $declarand {
             $*W.apply_trait($/, '&trait_mod:<as>', $declarand, $<typename>.ast);
         };
     }
 
-    method trait_mod:sym<returns>($/) {
+    method trait_mod:returns ($/) {
         make -> $declarand {
             $*W.apply_trait($/, '&trait_mod:<returns>', $declarand, $<typename>.ast);
         };
     }
 
-    method trait_mod:sym<handles>($/) {
+    method trait_mod:handles ($/) {
         # The term may be fairly complex. Thus we make it into a thunk
         # which the trait handler can use to get the term and work with
         # it.
@@ -3901,7 +3901,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
         make QAST::Op.new( :op('call'), :name('&set'), :node($/) );
     }
 
-    method term:sym<rand>($/) {
+    method term:rand ($/) {
         make QAST::Op.new( :op('call'), :name('&rand'), :node($/) );
     }
 
@@ -3927,7 +3927,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
         make make_yada('&die', $/);
     }
 
-    method term:sym<dotty>($/) {
+    method term:dotty ($/) {
         my $past := $<dotty>.ast;
         $past.unshift(QAST::Var.new( :name('$_'), :scope('lexical') ) );
         make QAST::Op.new( :op('hllize'), $past);
@@ -3977,7 +3977,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
         return $past;
     }
 
-    method term:sym<identifier>($/) {
+    method term:identifier ($/) {
         my $macro := find_macro_routine(['&' ~ ~$<identifier>]);
         if $macro {
             make expand_macro($macro, ~$<identifier>, $/, sub () {
@@ -4040,7 +4040,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
         $past;
     }
 
-    method term:sym<name>($/) {
+    method term:name ($/) {
         my $past;
         if $*longname.contains_indirect_lookup() {
             if $<args> {
@@ -4191,11 +4191,11 @@ class Perl6::Actions is HLL::Actions does STDActions {
         )
     }
 
-    method term:sym<capterm>($/) {
+    method term:capterm ($/) {
         make $<capterm>.ast;
     }
     
-    method term:sym<onlystar>($/) {
+    method term:onlystar ($/) {
         my $dc_name := QAST::Node.unique('dispatch_cap');
         my $stmts := QAST::Stmts.new(
             QAST::Op.new(
@@ -4308,7 +4308,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
         make $past; # TODO figure out how to work a locallifetime in here
     }
 
-    method term:sym<value>($/) { make $<value>.ast; }
+    method term:value ($/) { make $<value>.ast; }
 
     method circumfix:sym<( )>($/) {
         my $past := $<semilist>.ast;
@@ -4326,7 +4326,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
         make $past;
     }
 
-    method circumfix:sym<ang>($/) { make $<nibble>.ast; }
+    method circumfix:sym«< >»($/) { make $<nibble>.ast; }
 
     method circumfix:sym«<< >>»($/) { make $<nibble>.ast; }
     
@@ -5019,7 +5019,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
         }
     }
 
-    method term:sym<reduce>($/) {
+    method term:reduce ($/) {
         my $base     := $<op>;
         my $basepast := $base.ast
                           ?? $base.ast[0]
@@ -5112,7 +5112,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
         make $past;
     }
 
-    method postcircumfix:sym<ang>($/) {
+    method postcircumfix:sym«< >»($/) {
         my $past := QAST::Op.new( :name('&postcircumfix:<{ }>'), :op('call'), :node($/) );
         my $nib  := $<nibble>.ast;
         $past.push($nib)
@@ -5143,14 +5143,14 @@ class Perl6::Actions is HLL::Actions does STDActions {
         make $<arglist>.ast;
     }
 
-    method value:sym<quote>($/) {
+    method value:quote ($/) {
         make $<quote>.ast;
     }
 
-    method value:sym<number>($/) {
+    method value:number ($/) {
         make $<number>.ast;
     }
-    method value:sym<version>($/) {
+    method value:version ($/) {
         make $<version>.ast;
     }
 
@@ -5166,13 +5166,13 @@ class Perl6::Actions is HLL::Actions does STDActions {
     method binint($/) { make string_to_bigint( $/, 2 ); }
 
 
-    method number:sym<complex>($/) {
+    method number:complex ($/) {
         my $re := $*W.add_constant('Num', 'num', 0e0);
         my $im := $*W.add_constant('Num', 'num', +~$<im>);
         make $*W.add_constant('Complex', 'type_new', $re.compile_time_value, $im.compile_time_value);
     }
 
-    method number:sym<numish>($/) {
+    method number:numish ($/) {
         make $<numish>.ast;
     }
 
@@ -5365,11 +5365,11 @@ class Perl6::Actions is HLL::Actions does STDActions {
         $value;
     }
 
-    method quote:sym<apos>($/) { make $<nibble>.ast; }
-    method quote:sym<dblq>($/) { make $<nibble>.ast; }
-    method quote:sym<qq>($/)   { make $<quibble>.ast; }
-    method quote:sym<q>($/)    { make $<quibble>.ast; }
-    method quote:sym<Q>($/)    { make $<quibble>.ast; }
+    method quote:sym<' '>($/) { make $<nibble>.ast; }
+    method quote:sym<" ">($/) { make $<nibble>.ast; }
+    method quote:qq ($/)   { make $<quibble>.ast; }
+    method quote:q ($/)    { make $<quibble>.ast; }
+    method quote:Q ($/)    { make $<quibble>.ast; }
     method quote:sym<Q:PIR>($/) {
         if $FORBID_PIR {
             nqp::die("Q:PIR forbidden in safe mode\n");
@@ -5388,7 +5388,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
         make $closure;
     }
 
-    method quote:sym<rx>($/) {
+    method quote:rx ($/) {
         my $block := QAST::Block.new(QAST::Stmts.new, QAST::Stmts.new, :node($/));
         self.handle_and_check_adverbs($/, %SHARED_ALLOWED_ADVERBS, 'rx', $block);
         my %sig_info := hash(parameters => []);
@@ -5398,7 +5398,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
         $past<sink_past> := QAST::Op.new(:op<callmethod>, :name<Bool>, $past);
         make $past;
     }
-    method quote:sym<m>($/) {
+    method quote:m ($/) {
         my $block := QAST::Block.new(QAST::Stmts.new, QAST::Stmts.new, :node($/));
         my %sig_info := hash(parameters => []);
         my $coderef := regex_coderef($/, $*W.stub_code_object('Regex'),
@@ -5441,7 +5441,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
         $multiple;
     }
 
-    method quote:sym<tr>($/) {
+    method quote:tr ($/) {
         if nqp::elems($<rx_adverbs><quotepair>) {
             $*W.throw($/, 'X::Comp::NYI', feature => 'tr/// adverbs');
         }
@@ -5456,7 +5456,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
         );
     }
 
-    method quote:sym<s>($/) {
+    method quote:s ($/) {
         # Build the regex.
         my $rx_block := QAST::Block.new(QAST::Stmts.new, QAST::Stmts.new, :node($/));
         my %sig_info := hash(parameters => []);
@@ -5491,7 +5491,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
         $past
 }
 
-    method quote:sym<quasi>($/) {
+    method quote:quasi ($/) {
         my $ast_class := $*W.find_symbol(['AST']);
         my $quasi_ast := $ast_class.new();
         my $past := $<block>.ast<past_block>.pop;
@@ -6225,22 +6225,22 @@ class Perl6::QActions is HLL::Actions does STDActions {
     }
 
     method escape:sym<\\>($/) { make $<item>.ast; }
-    method backslash:sym<qq>($/) { make $<quote>.ast; }
+    method backslash:qq ($/) { make $<quote>.ast; }
     method backslash:sym<\\>($/) { make $<text>.Str; }
-    method backslash:sym<stopper>($/) { make $<text>.Str; }
-    method backslash:sym<miscq>($/) { make '\\' ~ ~$/; }
-    method backslash:sym<misc>($/) { make ~$/; }
+    method backslash:stopper ($/) { make $<text>.Str; }
+    method backslash:miscq ($/) { make '\\' ~ ~$/; }
+    method backslash:misc ($/) { make ~$/; }
     
-    method backslash:sym<a>($/) { make nqp::chr(7) }
-    method backslash:sym<b>($/) { make "\b" }
-    method backslash:sym<c>($/) { make $<charspec>.ast }
-    method backslash:sym<e>($/) { make "\c[27]" }
-    method backslash:sym<f>($/) { make "\c[12]" }
-    method backslash:sym<n>($/) { make "\n" }
-    method backslash:sym<o>($/) { make self.ints_to_string( $<octint> ?? $<octint> !! $<octints><octint> ) }
-    method backslash:sym<r>($/) { make "\r" }
-    method backslash:sym<t>($/) { make "\t" }
-    method backslash:sym<x>($/) { make self.ints_to_string( $<hexint> ?? $<hexint> !! $<hexints><hexint> ) }
+    method backslash:a ($/) { make nqp::chr(7) }
+    method backslash:b ($/) { make "\b" }
+    method backslash:c ($/) { make $<charspec>.ast }
+    method backslash:e ($/) { make "\c[27]" }
+    method backslash:f ($/) { make "\c[12]" }
+    method backslash:n ($/) { make "\n" }
+    method backslash:o ($/) { make self.ints_to_string( $<octint> ?? $<octint> !! $<octints><octint> ) }
+    method backslash:r ($/) { make "\r" }
+    method backslash:t ($/) { make "\t" }
+    method backslash:x ($/) { make self.ints_to_string( $<hexint> ?? $<hexint> !! $<hexints><hexint> ) }
     method backslash:sym<0>($/) { make "\c[0]" }
 
     method escape:sym<{ }>($/) {
@@ -6259,7 +6259,7 @@ class Perl6::QActions is HLL::Actions does STDActions {
 
     method escape:sym<' '>($/) { make mark_ww_atom($<quote>.ast); }
     method escape:sym<" ">($/) { make mark_ww_atom($<quote>.ast); }
-    method escape:sym<colonpair>($/) { make mark_ww_atom($<colonpair>.ast); }
+    method escape:colonpair ($/) { make mark_ww_atom($<colonpair>.ast); }
     sub mark_ww_atom($ast) {
         $ast<ww_atom> := 1;
         $ast;

--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -521,21 +521,21 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
 
     proto token pod_content { <...> }
 
-    token pod_content:sym<block> {
+    token pod_content:block {
         <pod_newline>*
         <pod_block>
         <pod_newline>*
     }
 
     # any number of paragraphs of text
-    token pod_content:sym<text> {
+    token pod_content:text {
         <pod_newline>*
         <pod_textcontent>+ % <pod_newline>+
         <pod_newline>*
     }
 
     # not a block, just a directive
-    token pod_content:sym<config> {
+    token pod_content:config {
         <pod_newline>*
         ^^ \h* '=config' \h+ $<type>=\S+ <pod_configuration>
         <pod_newline>+
@@ -544,7 +544,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
     proto token pod_textcontent { <...> }
 
     # text not being code
-    token pod_textcontent:sym<regular> {
+    token pod_textcontent:regular {
         $<spaces>=[ \h* ]
          <?{ !$*ALLOW_CODE
              || ($<spaces>.to - $<spaces>.from) <= $*VMARGIN }>
@@ -554,7 +554,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         ] +
     }
 
-    token pod_textcontent:sym<code> {
+    token pod_textcontent:code {
         $<spaces>=[ \h* ]
         <?{ $*ALLOW_CODE
             && ($<spaces>.to - $<spaces>.from) > $*VMARGIN }>
@@ -635,7 +635,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         [ [\n $spaces '=']? \h+ <colonpair> ]*
     }
 
-    token pod_block:sym<delimited_raw> {
+    token pod_block:delimited_raw {
         ^^
         $<spaces> = [ \h* ]
         '=begin' \h+ $<type>=[ 'code' | 'comment' ] {}
@@ -647,7 +647,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         ]
     }
 
-    token pod_block:sym<delimited> {
+    token pod_block:delimited {
         ^^
         $<spaces> = [ \h* ]
         '=begin'
@@ -673,7 +673,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
     }
 
 
-    token pod_block:sym<delimited_table> {
+    token pod_block:delimited_table {
         ^^
         $<spaces> = [ \h* ]
         '=begin' \h+ 'table'
@@ -690,7 +690,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         \h* <!before '=' \w> \N* \n
     }
 
-    token pod_block:sym<end> {
+    token pod_block:end {
         ^^ \h*
         [
             | '=begin' \h+ 'END' <pod_newline>
@@ -700,7 +700,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         .*
     }
 
-    token pod_block:sym<paragraph> {
+    token pod_block:paragraph {
         ^^
         $<spaces> = [ \h* ]
         '=for' \h+ <!before 'END'>
@@ -717,7 +717,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         <pod_content=.pod_textcontent>**0..1
     }
 
-    token pod_block:sym<paragraph_raw> {
+    token pod_block:paragraph_raw {
         ^^
         $<spaces> = [ \h* ]
         '=for' \h+ $<type>=[ 'code' | 'comment' ]
@@ -726,7 +726,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         $<pod_content> = [ \h* <!before '=' \w> \N+ \n ]+
     }
 
-    token pod_block:sym<paragraph_table> {
+    token pod_block:paragraph_table {
         ^^
         $<spaces> = [ \h* ]
         '=for' \h+ 'table'
@@ -735,7 +735,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         [ <!before \h* \n> <table_row>]*
     }
 
-    token pod_block:sym<abbreviated> {
+    token pod_block:abbreviated {
         ^^
         $<spaces> = [ \h* ]
         '=' <!before begin || end || for || END || config>
@@ -753,7 +753,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         <pod_content=.pod_textcontent>**0..1
     }
 
-    token pod_block:sym<abbreviated_raw> {
+    token pod_block:abbreviated_raw {
         ^^
         $<spaces> = [ \h* ]
         '=' $<type>=[ 'code' | 'comment' ]
@@ -762,7 +762,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         $<pod_content> = [ \h* <!before '=' \w> \N+ \n ]*
     }
 
-    token pod_block:sym<abbreviated_table> {
+    token pod_block:abbreviated_table {
         ^^
         $<spaces> = [ \h* ]
         :my $*POD_ALLOW_FCODES := nqp::getlexdyn('$*POD_ALLOW_FCODES');
@@ -1133,15 +1133,15 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
     token terminator:sym<)> { <?[)]> }
     token terminator:sym<]> { <?[\]]> }
     token terminator:sym<}> { <?[}]> }
-    token terminator:sym<ang> { <?[>]> <?{ $*IN_REGEX_ASSERTION }> }
-    token terminator:sym<if>     { 'if'     <.end_keyword> }
-    token terminator:sym<unless> { 'unless' <.end_keyword> }
-    token terminator:sym<while>  { 'while'  <.end_keyword> }
-    token terminator:sym<until>  { 'until'  <.end_keyword> }
-    token terminator:sym<for>    { 'for'    <.end_keyword> }
-    token terminator:sym<given>  { 'given'  <.end_keyword> }
-    token terminator:sym<when>   { 'when'   <.end_keyword> }
-    token terminator:sym<arrow>  { '-->' }
+    token terminator:sym«>» { <?[>]> <?{ $*IN_REGEX_ASSERTION }> }
+    token terminator:if     { 'if'     <.end_keyword> }
+    token terminator:unless { 'unless' <.end_keyword> }
+    token terminator:while  { 'while'  <.end_keyword> }
+    token terminator:until  { 'until'  <.end_keyword> }
+    token terminator:for    { 'for'    <.end_keyword> }
+    token terminator:given  { 'given'  <.end_keyword> }
+    token terminator:when   { 'when'   <.end_keyword> }
+    token terminator:sym«-->»  { <sym> }
     
 
     token stdstopper {
@@ -1158,7 +1158,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
 
     proto rule statement_control { <...> }
 
-    rule statement_control:sym<if> {
+    rule statement_control:if {
         <sym><.end_keyword> {}
         <xblock>
         [
@@ -1171,18 +1171,18 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         [ 'else'\s <else=.pblock> ]**0..1
     }
 
-    rule statement_control:sym<unless> {
+    rule statement_control:unless {
         <sym><.end_keyword> {}
         <xblock>
         [ <!before 'else'> || <.typed_panic: 'X::Syntax::UnlessElse'> ]
     }
 
-    rule statement_control:sym<while> {
+    rule statement_control:while {
         $<sym>=[while|until]<.end_keyword> {}
         <xblock>
     }
 
-    rule statement_control:sym<repeat> {
+    rule statement_control:repeat {
         <sym><.end_keyword> {}
         [
         | $<wu>=[while|until]\s <xblock>
@@ -1192,7 +1192,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         ]
     }
 
-    rule statement_control:sym<for> {
+    rule statement_control:for {
         <sym><.end_keyword> {}
         [ <?before 'my'? '$'\w+ '(' >
             <.typed_panic: 'X::Syntax::P5'> ]?
@@ -1201,11 +1201,11 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         <xblock(1)>
     }
 
-    rule statement_control:sym<foreach> {
+    rule statement_control:foreach {
         <sym><.end_keyword> <.obs("'foreach'", "'for'")>
     }
 
-    token statement_control:sym<loop> {
+    token statement_control:loop {
         <sym><.end_keyword>
         [ <?[({]> <.sorry: "Whitespace required after 'loop'"> ]?
         :s''
@@ -1217,7 +1217,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         <block>
     }
 
-    rule statement_control:sym<need> {
+    rule statement_control:need {
         <sym>
         [
         | <version>
@@ -1233,7 +1233,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         }
     }
 
-    token statement_control:sym<import> {
+    token statement_control:import {
         <sym> <.ws>
         <module_name> [ <.spacey> <arglist> ]? <.ws>
         :my $*HAS_SELF := '';
@@ -1259,7 +1259,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         }
     }
 
-    token statement_control:sym<use> {
+    token statement_control:use {
         :my $longname;
         :my $*IN_DECL := 'use';
         :my $*HAS_SELF := '';
@@ -1370,7 +1370,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         }
     }
 
-    rule statement_control:sym<require> {
+    rule statement_control:require {
         <sym>
         [
         | <module_name>
@@ -1380,43 +1380,43 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         [ <EXPR> ]**0..1
     }
 
-    rule statement_control:sym<given> {
+    rule statement_control:given {
         <sym><.end_keyword> <xblock(1)>
     }
-    rule statement_control:sym<when> {
+    rule statement_control:when {
         <sym><.end_keyword> <xblock>
     }
-    rule statement_control:sym<default> {
+    rule statement_control:default {
         <sym><.end_keyword> <block>
     }
 
-    rule statement_control:sym<CATCH> {<sym> <block(1)> }
-    rule statement_control:sym<CONTROL> {<sym> <block(1)> }
+    rule statement_control:CATCH {<sym> <block(1)> }
+    rule statement_control:CONTROL {<sym> <block(1)> }
 
     proto token statement_prefix { <...> }
-    token statement_prefix:sym<BEGIN>   { <sym> <blorst> }
-    token statement_prefix:sym<COMPOSE> { <sym> <blorst> }
-    token statement_prefix:sym<TEMP>    { <sym> <blorst> }
-    token statement_prefix:sym<CHECK>   { <sym> <blorst> }
-    token statement_prefix:sym<INIT>    { <sym> <blorst> }
-    token statement_prefix:sym<ENTER>   { <sym> <blorst> }
-    token statement_prefix:sym<FIRST>   { <sym> <blorst> }
+    token statement_prefix:BEGIN   { <sym> <blorst> }
+    token statement_prefix:COMPOSE { <sym> <blorst> }
+    token statement_prefix:TEMP    { <sym> <blorst> }
+    token statement_prefix:CHECK   { <sym> <blorst> }
+    token statement_prefix:INIT    { <sym> <blorst> }
+    token statement_prefix:ENTER   { <sym> <blorst> }
+    token statement_prefix:FIRST   { <sym> <blorst> }
     
-    token statement_prefix:sym<END>   { <sym> <blorst> }
-    token statement_prefix:sym<LEAVE> { <sym> <blorst> }
-    token statement_prefix:sym<KEEP>  { <sym> <blorst> }
-    token statement_prefix:sym<UNDO>  { <sym> <blorst> }
-    token statement_prefix:sym<NEXT>  { <sym> <blorst> }
-    token statement_prefix:sym<LAST>  { <sym> <blorst> }
-    token statement_prefix:sym<PRE>   { <sym> <blorst> }
-    token statement_prefix:sym<POST>  { <sym> <blorst> }
+    token statement_prefix:END   { <sym> <blorst> }
+    token statement_prefix:LEAVE { <sym> <blorst> }
+    token statement_prefix:KEEP  { <sym> <blorst> }
+    token statement_prefix:UNDO  { <sym> <blorst> }
+    token statement_prefix:NEXT  { <sym> <blorst> }
+    token statement_prefix:LAST  { <sym> <blorst> }
+    token statement_prefix:PRE   { <sym> <blorst> }
+    token statement_prefix:POST  { <sym> <blorst> }
     
-    token statement_prefix:sym<sink>  { <sym> <blorst> }
-    token statement_prefix:sym<try>   { <sym> <blorst> }
-    token statement_prefix:sym<gather>{ <sym> <blorst> }
-    token statement_prefix:sym<once>  { <sym> <blorst> }
-    token statement_prefix:sym<do>    { <sym> <blorst> }
-    token statement_prefix:sym<DOC>   {
+    token statement_prefix:sink   { <sym> <blorst> }
+    token statement_prefix:try    { <sym> <blorst> }
+    token statement_prefix:gather { <sym> <blorst> }
+    token statement_prefix:once   { <sym> <blorst> }
+    token statement_prefix:do     { <sym> <blorst> }
+    token statement_prefix:DOC    {
         <sym> \s <.ws> $<phase>=['BEGIN' || 'CHECK' || 'INIT']
         <blorst>
     }
@@ -1431,41 +1431,41 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
 
     token modifier_expr { <EXPR> }
 
-    rule statement_mod_cond:sym<if>     { <sym> <modifier_expr> }
-    rule statement_mod_cond:sym<unless> { <sym> <modifier_expr> }
-    rule statement_mod_cond:sym<when>   { <sym> <modifier_expr> }
+    rule statement_mod_cond:if     { <sym> <modifier_expr> }
+    rule statement_mod_cond:unless { <sym> <modifier_expr> }
+    rule statement_mod_cond:when   { <sym> <modifier_expr> }
 
     proto rule statement_mod_loop { <...> }
 
-    rule statement_mod_loop:sym<while> { <sym> <smexpr=.EXPR> }
-    rule statement_mod_loop:sym<until> { <sym> <smexpr=.EXPR> }
-    rule statement_mod_loop:sym<for>   { <sym> <smexpr=.EXPR> }
-    rule statement_mod_loop:sym<given> { <sym> <smexpr=.EXPR> }
+    rule statement_mod_loop:while { <sym> <smexpr=.EXPR> }
+    rule statement_mod_loop:until { <sym> <smexpr=.EXPR> }
+    rule statement_mod_loop:for   { <sym> <smexpr=.EXPR> }
+    rule statement_mod_loop:given { <sym> <smexpr=.EXPR> }
 
     ## Terms
 
-    token term:sym<fatarrow>           { <fatarrow> }
-    token term:sym<colonpair>          { <colonpair> }
-    token term:sym<variable>           { <variable> { $*VAR := $<variable> } }
-    token term:sym<package_declarator> { <package_declarator> }
-    token term:sym<scope_declarator>   { <scope_declarator> }
-    token term:sym<routine_declarator> { <routine_declarator> }
-    token term:sym<multi_declarator>   { <?before 'multi'|'proto'|'only'> <multi_declarator> }
-    token term:sym<regex_declarator>   { <regex_declarator> }
-    token term:sym<circumfix>          { <circumfix> }
-    token term:sym<statement_prefix>   { <statement_prefix> }
+    token term:fatarrow           { <fatarrow> }
+    token term:colonpair          { <colonpair> }
+    token term:variable           { <variable> { $*VAR := $<variable> } }
+    token term:package_declarator { <package_declarator> }
+    token term:scope_declarator   { <scope_declarator> }
+    token term:routine_declarator { <routine_declarator> }
+    token term:multi_declarator   { <?before 'multi'|'proto'|'only'> <multi_declarator> }
+    token term:regex_declarator   { <regex_declarator> }
+    token term:circumfix          { <circumfix> }
+    token term:statement_prefix   { <statement_prefix> }
     token term:sym<**>                 { <sym> <.NYI('HyperWhatever (**)')> }
     token term:sym<*>                  { <sym> }
-    token term:sym<lambda>             { <?lambda> <pblock> }
-    token term:sym<type_declarator>    { <type_declarator> }
-    token term:sym<value>              { <value> }
-    token term:sym<unquote>            { '{{{' <?{ $*IN_QUASI }> <statementlist> '}}}' }
+    token term:lambda             { <?lambda> <pblock> }
+    token term:type_declarator    { <type_declarator> }
+    token term:value              { <value> }
+    token term:unquote            { '{{{' <?{ $*IN_QUASI }> <statementlist> '}}}' }
 
     token term:sym<::?IDENT> {
         $<sym> = [ '::?' <identifier> ] »
     }
     
-    token infix:sym<lambda> {
+    token infix:lambda {
         <?before '{' | '->' > <!{ $*IN_META }> {
             my $needparens := 0;
             my $pos := $/.from;
@@ -1518,7 +1518,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         <.obs('undef as a value', "something more specific:\n\tAny (the \"whatever\" type object),\n\tan undefined type object such as Int,\n\t:!defined as a matcher,\n\tAny:U as a type constraint,\n\tNil as the absence of a value\n\tor fail() as a failure return\n\t   ")>
     }
 
-    token term:sym<new> {
+    token term:new {
         'new' \h+ <longname> \h* <![:]> <.obs("C++ constructor syntax", "method call syntax")>
     }
 
@@ -1835,50 +1835,50 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
     token twigil:sym<=> { <sym> <?before \w> }
 
     proto token package_declarator { <...> }
-    token package_declarator:sym<package> {
+    token package_declarator:package {
         :my $*OUTERPACKAGE := $*PACKAGE;
         :my $*PKGDECL := 'package';
         <sym> <.end_keyword> <package_def>
     }
-    token package_declarator:sym<module> {
+    token package_declarator:module {
         :my $*OUTERPACKAGE := $*PACKAGE;
         :my $*PKGDECL := 'module';
         <sym> <.end_keyword> <package_def>
     }
-    token package_declarator:sym<class> {
+    token package_declarator:class {
         :my $*OUTERPACKAGE := $*PACKAGE;
         :my $*PKGDECL := 'class';
         <sym> <.end_keyword> <package_def>
     }
-    token package_declarator:sym<grammar> {
+    token package_declarator:grammar {
         :my $*OUTERPACKAGE := $*PACKAGE;
         :my $*PKGDECL := 'grammar';
         <sym> <.end_keyword> <package_def>
     }
-    token package_declarator:sym<role> {
+    token package_declarator:role {
         :my $*OUTERPACKAGE := $*PACKAGE;
         :my $*PKGDECL := 'role';
         <sym> <.end_keyword> <package_def>
     }
-    token package_declarator:sym<knowhow> {
+    token package_declarator:knowhow {
         :my $*OUTERPACKAGE := $*PACKAGE;
         :my $*PKGDECL := 'knowhow';
         <sym> <.end_keyword> <package_def>
     }
-    token package_declarator:sym<native> {
+    token package_declarator:native {
         :my $*OUTERPACKAGE := $*PACKAGE;
         :my $*PKGDECL := 'native';
         <sym> <.end_keyword> <package_def>
     }
-    token package_declarator:sym<slang> {
+    token package_declarator:slang {
         :my $*OUTERPACKAGE := $*PACKAGE;
         :my $*PKGDECL := 'slang';
         <sym> <.end_keyword> <package_def>
     }
-    token package_declarator:sym<trusts> {
+    token package_declarator:trusts {
         <sym> <.ws> <typename>
     }
-    rule package_declarator:sym<also> {
+    rule package_declarator:also {
         <sym>
         [ <trait>+ || <.panic: "No valid trait found after also"> ]
     }
@@ -2101,36 +2101,36 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
     }
 
     proto token multi_declarator { <...> }
-    token multi_declarator:sym<multi> {
+    token multi_declarator:multi {
         <sym> :my $*MULTINESS := 'multi'; <.end_keyword>
         <.ws> [ <declarator> || <routine_def('sub')> || <.malformed('multi')> ]
     }
-    token multi_declarator:sym<proto> {
+    token multi_declarator:proto {
         <sym> :my $*MULTINESS := 'proto'; :my $*IN_PROTO := 1; <.end_keyword>
         <.ws> [ <declarator> || <routine_def('sub')> || <.malformed('proto')> ]
     }
-    token multi_declarator:sym<only> {
+    token multi_declarator:only {
         <sym> :my $*MULTINESS := 'only'; <.end_keyword>
         <.ws> [ <declarator> || <routine_def('sub')> || <.malformed('only')>]
     }
-    token multi_declarator:sym<null> {
+    token multi_declarator:null {
         :my $*MULTINESS := '';
         <declarator>
     }
 
     proto token scope_declarator { <...> }
-    token scope_declarator:sym<my>        { <sym> <scoped('my')> }
-    token scope_declarator:sym<our>       { <sym> <scoped('our')> }
-    token scope_declarator:sym<has>       {
+    token scope_declarator:my        { <sym> <scoped('my')> }
+    token scope_declarator:our       { <sym> <scoped('our')> }
+    token scope_declarator:has       {
         <sym>
         :my $*HAS_SELF := 'partial';
         :my $*ATTR_INIT_BLOCK;
         <scoped('has')>
     }
-    token scope_declarator:sym<augment>   { <sym> <scoped('augment')> }
-    token scope_declarator:sym<anon>      { <sym> <scoped('anon')> }
-    token scope_declarator:sym<state>     { <sym> <scoped('state')> }
-    token scope_declarator:sym<supersede> {
+    token scope_declarator:augment   { <sym> <scoped('augment')> }
+    token scope_declarator:anon      { <sym> <scoped('anon')> }
+    token scope_declarator:state     { <sym> <scoped('state')> }
+    token scope_declarator:supersede {
         <sym> <scoped('supersede')> <.NYI('"supersede"')>
     }
 
@@ -2207,13 +2207,13 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
     }
 
     proto token routine_declarator { <...> }
-    token routine_declarator:sym<sub>
+    token routine_declarator:sub
         { <sym> <.end_keyword> <routine_def('sub')> }
-    token routine_declarator:sym<method>
+    token routine_declarator:method
         { <sym> <.end_keyword> <method_def('method')> }
-    token routine_declarator:sym<submethod>
+    token routine_declarator:submethod
         { <sym> <.end_keyword> <method_def('submethod')> }
-    token routine_declarator:sym<macro>
+    token routine_declarator:macro
         { <sym> <.end_keyword> <macro_def()> }
 
     rule routine_def($d) {
@@ -2478,7 +2478,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
     }
 
     proto token regex_declarator { <...> }
-    token regex_declarator:sym<rule> {
+    token regex_declarator:rule {
         <sym>
         :my %*RX;
         :my $*METHODTYPE := 'rule';
@@ -2489,7 +2489,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         }
         <regex_def>
     }
-    token regex_declarator:sym<token> {
+    token regex_declarator:token {
         <sym>
         :my %*RX;
         :my $*METHODTYPE := 'token';
@@ -2499,7 +2499,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         }
         <regex_def>
     }
-    token regex_declarator:sym<regex> {
+    token regex_declarator:regex {
         <sym>
         :my %*RX;
         :my $*METHODTYPE := 'regex';
@@ -2530,7 +2530,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
 
     proto token type_declarator { <...> }
 
-    token type_declarator:sym<enum> {
+    token type_declarator:enum {
         :my $*IN_DECL := 'enum';
         :my $*DECLARAND;
         <sym>  <.end_keyword> <.ws>
@@ -2554,7 +2554,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         <?[<(«]> <term> <.ws>
     }
 
-    rule type_declarator:sym<subset> {
+    rule type_declarator:subset {
         <sym><.end_keyword> :my $*IN_DECL := 'subset';
         [
             [
@@ -2578,7 +2578,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         ]
     }
 
-    token type_declarator:sym<constant> {
+    token type_declarator:constant {
         :my $*IN_DECL := 'constant';
         <sym> <.end_keyword> <.ws>
 
@@ -2630,14 +2630,14 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
     }
 
     proto rule trait_mod { <...> }
-    rule trait_mod:sym<is>      { <sym> <longname><circumfix>**0..1 }
-    rule trait_mod:sym<hides>   { <sym> <typename> }
-    rule trait_mod:sym<does>    { <sym> <typename> }
-    rule trait_mod:sym<will>    { <sym> <identifier> <pblock> }
-    rule trait_mod:sym<of>      { <sym> <typename> }
-    rule trait_mod:sym<as>      { <sym> <typename> }
-    rule trait_mod:sym<returns> { <sym> <typename> }
-    rule trait_mod:sym<handles> { <sym> <term> }
+    rule trait_mod:is      { <sym> <longname><circumfix>**0..1 }
+    rule trait_mod:hides   { <sym> <typename> }
+    rule trait_mod:does    { <sym> <typename> }
+    rule trait_mod:will    { <sym> <identifier> <pblock> }
+    rule trait_mod:of      { <sym> <typename> }
+    rule trait_mod:as      { <sym> <typename> }
+    rule trait_mod:returns { <sym> <typename> }
+    rule trait_mod:handles { <sym> <term> }
 
 
     ## Terms
@@ -2657,7 +2657,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
 
     token term:sym<<∅>> { <sym> <.end_keyword> }
 
-    token term:sym<rand> {
+    token term:rand {
         <sym> »
         [ <?before '('? \h* [\d|'$']> <.obs('rand(N)', 'N.rand or (1..N).pick')> ]?
         [ <?before '()'> <.obs('rand()', 'rand')> ]?
@@ -2668,7 +2668,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
     token term:sym<???> { <sym> <args> }
     token term:sym<!!!> { <sym> <args> }
 
-    token term:sym<identifier> {
+    token term:identifier {
         <identifier> <!{ $*W.is_type([~$<identifier>]) }> <?before <.unsp>|'('> <args>
         { self.add_mystery($<identifier>, $<args>.from, nqp::substr(~$<args>, 0, 1)) }
     }
@@ -2689,7 +2689,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         'nqp::const::' $<const>=[\w+]
     }
 
-    token term:sym<name> {
+    token term:name {
         <longname>
         :my $*longname;
         { $*longname := $*W.dissect_longname($<longname>) }
@@ -2705,11 +2705,11 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         ]
     }
 
-    token term:sym<dotty> { <dotty> }
+    token term:dotty { <dotty> }
 
-    token term:sym<capterm> { <capterm> }
+    token term:capterm { <capterm> }
     
-    token term:sym<onlystar> {
+    token term:onlystar {
         '{*}' <?ENDSTMT>
         [ <?{ $*IN_PROTO }> || <.panic: '{*} may only appear in proto'> ]
     }
@@ -2743,13 +2743,13 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
     }
 
     proto token value { <...> }
-    token value:sym<quote>  { <quote> }
-    token value:sym<number> { <number> }
-    token value:sym<version> { <version> }
+    token value:quote  { <quote> }
+    token value:number { <number> }
+    token value:version { <version> }
 
     proto token number { <...> }
-    token number:sym<complex>  { <im=.numish>'\\'?'i' }
-    token number:sym<numish>   { <numish> }
+    token number:complex  { <im=.numish>'\\'?'i' }
+    token number:numish   { <numish> }
 
     token numish {
         [
@@ -2876,23 +2876,23 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
     }
     
     proto token quote_mod   {*}
-    token quote_mod:sym<w>  { <sym> }
-    token quote_mod:sym<ww> { <sym> }
+    token quote_mod:w  { <sym> }
+    token quote_mod:ww { <sym> }
     # XXX uncomment this when it's implemented
-    #token quote_mod:sym<p>  { <sym> }
-    token quote_mod:sym<x>  { <sym> }
-    token quote_mod:sym<to> { <sym> }
-    token quote_mod:sym<s>  { <sym> }
-    token quote_mod:sym<a>  { <sym> }
-    token quote_mod:sym<h>  { <sym> }
-    token quote_mod:sym<f>  { <sym> }
-    token quote_mod:sym<c>  { <sym> }
-    token quote_mod:sym<b>  { <sym> }
+    #token quote_mod:p  { <sym> }
+    token quote_mod:x  { <sym> }
+    token quote_mod:to { <sym> }
+    token quote_mod:s  { <sym> }
+    token quote_mod:a  { <sym> }
+    token quote_mod:h  { <sym> }
+    token quote_mod:f  { <sym> }
+    token quote_mod:c  { <sym> }
+    token quote_mod:b  { <sym> }
 
     proto token quote { <...> }
-    token quote:sym<apos>  { :dba('single quotes') "'" ~ "'" <nibble(self.quote_lang(%*LANG<Q>, "'", "'", ['q']))> }
-    token quote:sym<dblq>  { :dba('double quotes') '"' ~ '"' <nibble(self.quote_lang(%*LANG<Q>, '"', '"', ['qq']))> }
-    token quote:sym<q> {
+    token quote:sym<' '>  { :dba('single quotes') "'" ~ "'" <nibble(self.quote_lang(%*LANG<Q>, "'", "'", ['q']))> }
+    token quote:sym<" ">  { :dba('double quotes') '"' ~ '"' <nibble(self.quote_lang(%*LANG<Q>, '"', '"', ['qq']))> }
+    token quote:q {
         :my $qm;
         'q'
         [
@@ -2900,7 +2900,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         | » <![(]> <.ws> <quibble(%*LANG<Q>, 'q')>
         ]
     }
-    token quote:sym<qq> {
+    token quote:qq {
         :my $qm;
         'qq'
         [
@@ -2908,7 +2908,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         | » <![(]> <.ws> <quibble(%*LANG<Q>, 'qq')>
         ]
     }
-    token quote:sym<Q> {
+    token quote:Q {
         :my $qm;
         'Q'
         [
@@ -2924,7 +2924,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         '/' <nibble(self.quote_lang(%*LANG<Regex>, '/', '/'))> [ '/' || <.panic: "Unable to parse regex; couldn't find final '/'"> ]
         <.old_rx_mods>?
     }
-    token quote:sym<rx>   {
+    token quote:rx   {
         <sym> >> 
         :my %*RX;
         <rx_adverbs>
@@ -2932,7 +2932,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         <!old_rx_mods>
     }
 
-    token quote:sym<m> {
+    token quote:m {
         <sym> (s)**0..1>>
         :my %*RX;
         { %*RX<s> := 1 if $/[0] }
@@ -2941,7 +2941,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         <!old_rx_mods>
     }
 
-    token quote:sym<qr> {
+    token quote:qr {
         <sym> <.end_keyword> <.obs('qr for regex quoting', 'rx//')>
     }
 
@@ -2969,7 +2969,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         ]
     }
 
-    token quote:sym<s> {
+    token quote:s {
         <sym> (s)**0..1 >>
         :my %*RX;
         {
@@ -2997,7 +2997,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         ]
     }
 
-    token quote:sym<tr> {
+    token quote:tr {
         <sym>
         :my %*RX;
         <rx_adverbs>
@@ -3020,7 +3020,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         }
     }
 
-    token quote:sym<quasi> {
+    token quote:quasi {
         <sym> <.ws> <![(]>
         :my $*IN_QUASI := 1;
         :my @*UNQUOTE_ASTS := [];
@@ -3029,7 +3029,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
 
     token circumfix:sym<( )> { :dba('parenthesized expression') '(' ~ ')' <semilist> }
     token circumfix:sym<[ ]> { :dba('array composer') '[' ~ ']' <semilist> }
-    token circumfix:sym<ang> {
+    token circumfix:sym«< >» {
         :dba('quote words')
         '<' ~ '>'
         [
@@ -3191,7 +3191,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         self;
     }
     
-    regex term:sym<reduce> {
+    regex term:reduce {
         :my $*IN_REDUCE := 1;
         :my $op;
         <?before '['\S+']'>
@@ -3312,7 +3312,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         <O('%methodcall')>
     }
 
-    token postcircumfix:sym<ang> {
+    token postcircumfix:sym«< >» {
         '<'
         [
         || <nibble(self.quote_lang(%*LANG<Q>, "<", ">", ['q', 'w']))> '>'
@@ -3410,7 +3410,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
     token infix:sym<?^>   { <sym>  <O('%additive')> }
 
     token infix:sym<x>    { <sym> >> <O('%replication')> }
-    token infix:sym<xx>    { <sym> >> <O('%replication')> }
+    token infix:sym<xx>   { <sym> >> <O('%replication')> }
 
     token infix:sym<~>    { <sym>  <O('%concatenation')> }
     token infix:sym<.>    { <sym> <[\]\)\},:\s\$"']>  <.obs('. to concatenate strings', '~')> }
@@ -3432,8 +3432,8 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
     token infix:sym<(-)>  { <!before <sym> <infixish> > <sym> <O('%junctive_or')> }
     token infix:sym«∖»    { <!before <sym> <infixish> > <sym> <O('%junctive_or')> }
 
-    token prefix:sym<let>  { <sym> \s+ <!before '=>'> <O('%named_unary')> { $*W.give_cur_block_let($/) } }
-    token prefix:sym<temp> { <sym> \s+ <!before '=>'> <O('%named_unary')> { $*W.give_cur_block_temp($/) } }
+    token prefix:let  { <sym> \s+ <!before '=>'> <O('%named_unary')> { $*W.give_cur_block_let($/) } }
+    token prefix:temp { <sym> \s+ <!before '=>'> <O('%named_unary')> { $*W.give_cur_block_temp($/) } }
 
     token infix:sym«==»   { <sym>  <O('%chaining')> }
     token infix:sym«!=»   { <sym> <?before \s|']'> <O('%chaining')> }
@@ -3555,14 +3555,14 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
 
     token infix:sym<?>    { <sym> {} <![?]> <?before <-[;]>*?':'> <.obs('?: for the conditional operator', '??!!')> <O('%conditional')> }
 
-    token infix:sym<ff> { <sym> <O('%conditional')> }
-    token infix:sym<^ff> { <sym> <O('%conditional')> }
-    token infix:sym<ff^> { <sym> <O('%conditional')> }
+    token infix:sym<ff>   { <sym> <O('%conditional')> }
+    token infix:sym<^ff>  { <sym> <O('%conditional')> }
+    token infix:sym<ff^>  { <sym> <O('%conditional')> }
     token infix:sym<^ff^> { <sym> <O('%conditional')> }
     
-    token infix:sym<fff> { <sym> <O('%conditional')> }
-    token infix:sym<^fff> { <sym> <O('%conditional')> }
-    token infix:sym<fff^> { <sym> <O('%conditional')> }
+    token infix:sym<fff>   { <sym> <O('%conditional')> }
+    token infix:sym<^fff>  { <sym> <O('%conditional')> }
+    token infix:sym<fff^>  { <sym> <O('%conditional')> }
     token infix:sym<^fff^> { <sym> <O('%conditional')> }
 
     token infix:sym<=> {
@@ -3827,19 +3827,19 @@ grammar Perl6::QGrammar is HLL::Grammar does STD {
 
     role b1 {
         token escape:sym<\\> { <sym> {} <item=.backslash> }
-        token backslash:sym<qq> { <?[q]> <quote=.LANG('MAIN','quote')> }
+        token backslash:qq { <?[q]> <quote=.LANG('MAIN','quote')> }
         token backslash:sym<\\> { <text=.sym> }
-        token backslash:sym<stopper> { <text=.stopper> }
-        token backslash:sym<a> { <sym> }
-        token backslash:sym<b> { <sym> }
-        token backslash:sym<c> { <sym> <charspec> }
-        token backslash:sym<e> { <sym> }
-        token backslash:sym<f> { <sym> }
-        token backslash:sym<n> { <sym> }
-        token backslash:sym<o> { :dba('octal character') <sym> [ <octint> | '[' ~ ']' <octints> ] }
-        token backslash:sym<r> { <sym> }
-        token backslash:sym<t> { <sym> }
-        token backslash:sym<x> { :dba('hex character') <sym> [ <hexint> | '[' ~ ']' <hexints> ] }
+        token backslash:stopper { <text=.stopper> }
+        token backslash:a { <sym> }
+        token backslash:b { <sym> }
+        token backslash:c { <sym> <charspec> }
+        token backslash:e { <sym> }
+        token backslash:f { <sym> }
+        token backslash:n { <sym> }
+        token backslash:o { :dba('octal character') <sym> [ <octint> | '[' ~ ']' <octints> ] }
+        token backslash:r { <sym> }
+        token backslash:t { <sym> }
+        token backslash:x { :dba('hex character') <sym> [ <hexint> | '[' ~ ']' <hexints> ] }
         token backslash:sym<0> { <sym> }
     }
 
@@ -3935,7 +3935,7 @@ grammar Perl6::QGrammar is HLL::Grammar does STD {
         token escape:sym<" "> {
             <?["]> <quote=.LANG('MAIN','quote')>
         }
-        token escape:sym<colonpair> {
+        token escape:colonpair {
             <?[:]> <colonpair=.LANG('MAIN','colonpair')>
         }
     }
@@ -3962,11 +3962,11 @@ grammar Perl6::QGrammar is HLL::Grammar does STD {
 
         token escape:sym<\\> { <sym> <item=.backslash> }
 
-        token backslash:sym<qq> { <?[q]> <quote=.LANG('MAIN','quote')> }
+        token backslash:qq { <?[q]> <quote=.LANG('MAIN','quote')> }
         token backslash:sym<\\> { <text=.sym> }
-        token backslash:sym<stopper> { <text=.stopper> }
+        token backslash:stopper { <text=.stopper> }
 
-        token backslash:sym<miscq> { {} . }
+        token backslash:miscq { {} . }
 
         method tweak_q($v) { self.panic("Too late for :q") }
         method tweak_qq($v) { self.panic("Too late for :qq") }
@@ -3974,8 +3974,8 @@ grammar Perl6::QGrammar is HLL::Grammar does STD {
 
     role qq does b1 does c1 does s1 does a1 does h1 does f1 {
         token stopper { \" }
-        token backslash:sym<unrec> { {} (\w) { self.throw_unrecog_backslash_seq: $/[0].Str } }
-        token backslash:sym<misc> { \W }
+        token backslash:unrec { {} (\w) { self.throw_unrecog_backslash_seq: $/[0].Str } }
+        token backslash:misc { \W }
 
         method tweak_q($v) { self.panic("Too late for :q") }
         method tweak_qq($v) { self.panic("Too late for :qq") }
@@ -4187,7 +4187,7 @@ grammar Perl6::RegexGrammar is QRegex::P6Regex::Grammar does STD {
     }
 
     token assertion:sym<var> {
-        <?sigil> <var=.LANG('MAIN', 'term:sym<variable>')>
+        <?sigil> <var=.LANG('MAIN', 'term:variable<1>')>
     }
     
     token assertion:sym<~~> {


### PR DESCRIPTION
Things like `token package_declarator:sym<grammar>` become `token package_declarator:grammar`

The only nits here are that the line
`<?sigil> <var=.LANG('MAIN', 'term:variable')>`
which seems like it should work, doesn't in NQP, and must be:
`<?sigil> <var=.LANG('MAIN', 'term:variable<1>')>`
and that we can't use
`method package_declarator:grammar($/)`
but instead
`method package_declarator:grammar ($/)`
because NQP (and Perl) will think `($/)` is the value of the :grammar colonpair
