### PR TITLE
Change nqp and parrot repo URLs to use HTTPS so they work

### DIFF
--- a/tools/lib/NQP/Configure.pm
+++ b/tools/lib/NQP/Configure.pm
@@ -29,8 +29,8 @@ our @required_nqp_files = qw(
     @bindir@/nqp-p@exe@
 );
 
-our $nqp_git = 'http://github.com/perl6/nqp.git';
-our $par_git = 'http://github.com/parrot/parrot.git';
+our $nqp_git = 'https://github.com/perl6/nqp.git';
+our $par_git = 'https://github.com/parrot/parrot.git';
 our $moar_git= 'https://github.com/MoarVM/MoarVM.git';
 
 our $nqp_push = 'git@github.com:perl6/nqp.git';


### PR DESCRIPTION
Github is stalling indefinitely on repos clones through http, so Configure.pl is unable to auto-build parrot and (more importantly, because it affects all back-ends) nqp.
