### PR TITLE
give the user a way to disable perl5 warnings (only one so far)

### DIFF
--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -1290,6 +1290,8 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
                     $*P5_WARNINGS := 0;
                     $*GENERAL_WARNINGS := 0;
                 }
+            } else {
+                $/.CURSOR.panic("'no " ~ $<module_name>.Str ~ "' not implemented");
             }
         }
         <.ws>


### PR DESCRIPTION
when writing 

```
no warnings :p5;
```

you can get rid of the warning that numbers starting with 0 are not parsed as octals.

I'd like to get some feedback; Especially what else to change. Maybe I should have a look at the P6Regex grammar/actions for more things?
