### PR TITLE
Make sure --gen-moar implies --gen-nqp

### DIFF
--- a/tools/lib/NQP/Configure.pm
+++ b/tools/lib/NQP/Configure.pm
@@ -335,7 +335,7 @@ sub gen_nqp {
         $impls{parrot}{config} = \%c;
     }
 
-    return %impls unless defined($gen_nqp) || defined($gen_parrot);
+    return %impls unless defined($gen_nqp) || defined($gen_parrot) || defined($gen_moar);
 
     my $backends_to_build = join ',', sort keys %need;
     my @cmd = ($^X, 'Configure.pl', "--prefix=$prefix",


### PR DESCRIPTION
It does only if --backends is not set.  Well, it did.  Now it always
does!
