### PR TITLE
Be more specific about linking to libmoar on OS X

### DIFF
--- a/Configure.pl
+++ b/Configure.pl
@@ -244,7 +244,7 @@ MAIN: {
         # Add moar library to link command
         # TODO: Get this from Moar somehow
         $config{'moarimplib'} = $^O eq 'MSWin32' ? "$prefix/bin/moar.dll.lib"
-                              : $^O eq 'darwin'  ? '-lmoar'
+                              : $^O eq 'darwin'  ? "$prefix/lib/libmoar.dylib"
                               : '';
 
         fill_template_file('tools/build/Makefile-Moar.in', $MAKEFILE, %config, %nqp_config);


### PR DESCRIPTION
ld doesn't seem to pay attention to rpath when looking for -lmoar,
which made the build fail when installing to an install/ directory
instead of something like /usr/local.

Reported by lee__++
