### PR TITLE
Lazily initialize $!WHICH in Set

### DIFF
--- a/src/core/Set.pm
+++ b/src/core/Set.pm
@@ -3,10 +3,11 @@ my class Set does Setty {
     has $!WHICH;
 
     method total { $!total //= %!elems.elems }
-    submethod WHICH { $!WHICH }
+    submethod WHICH {
+        $!WHICH := self.^name ~ '|' ~ %!elems.keys.sort if !$!WHICH.defined;
+        $!WHICH
+    }
     submethod BUILD (:%elems) {
-        my @keys := %elems.keys.sort;
-        $!WHICH  := self.^name ~ '|' ~ @keys;
         nqp::bindattr(self, Set, '%!elems', %elems);
     }
 


### PR DESCRIPTION
$!WHICH is only needed if we use a Set as a hash key, but
we pay the penalty for sorting the members on every set construction
