### PR TITLE
Fix for changed parrot 5.0 libsearch path: Add . to the front

### DIFF
--- a/tools/build/Makefile-Parrot.in
+++ b/tools/build/Makefile-Parrot.in
@@ -1,5 +1,5 @@
 SHELL            = @shell@
-PARROT_ARGS      =
+PARROT_ARGS      = -L. -X.
 
 # values from parrot_config
 PARROT_BIN_DIR     = @bindir@


### PR DESCRIPTION
Required if older rakudo or parrot libs are already installed.

Pull #93 went too old.