### PR TITLE
Simplify program name in $?USAGE if in PATH

### DIFF
--- a/src/core/Main.pm
+++ b/src/core/Main.pm
@@ -67,7 +67,22 @@ my sub MAIN_HELPER($retval = 0) is hidden_from_backtrace {
     # Generate $?USAGE string (default usage info for MAIN)
     my sub gen-usage () {
         my @help-msgs;
-        my $prog-name = $*PROGRAM_NAME eq '-e' ?? "-e '...'" !! $*PROGRAM_NAME;
+
+        my sub strip_path_prefix($name) {
+            my ($vol, $dir, $base) = IO::Spec.splitpath($name);
+            $dir = IO::Spec.canonpath($dir);
+            for IO::Spec.path() -> $elem {
+                if IO::Spec.catpath($vol, $elem, $base).IO.x {
+                    return $base if IO::Spec.canonpath($elem) eq $dir;
+                    # Shadowed command found in earlier PATH element
+                    return $name;
+                }
+            }
+            # Not in PATH
+            return $name;
+        }
+
+        my $prog-name = $*PROGRAM_NAME eq '-e' ?? "-e '...'" !! strip_path_prefix($*PROGRAM_NAME);
         for $m.candidates -> $sub {
             my (@required-named, @optional-named, @positional, $docs);
             for $sub.signature.params -> $param {


### PR DESCRIPTION
Before:

```
$ panda
Usage:
  /Users/tsmith/local/src/p6/rakudo/install/languages/perl6/site/bin/panda [--notests] [--nodeps] install [<modules> ...] -- Install the specified modules
  /Users/tsmith/local/src/p6/rakudo/install/languages/perl6/site/bin/panda [--installed] [--verbose] list -- List all available modules
  …
```

After:

```
$ panda
Usage:
  panda [--notests] [--nodeps] install [<modules> ...] -- Install the specified modules
  panda [--installed] [--verbose] list -- List all available modules
  …
```
