### PR TITLE
Check for filename length instead of truthiness.

### DIFF
--- a/src/core/IO.pm
+++ b/src/core/IO.pm
@@ -563,7 +563,7 @@ my class IO::Path is Cool does IO::FileTestable {
 #?if !parrot
             loop {
                 my Str $elem := nqp::nextfiledir($dirh);
-                if nqp::isnull_s($elem) || !$elem {
+                if nqp::isnull_s($elem) || !$elem.chars {
                     nqp::closedir($dirh);
                     last;
                 } else {


### PR DESCRIPTION
Otherwise, if a directory contains a file named '0', we assume no more
files exist (while there could still be any number left)
