### PR TITLE
Give the eval server more heap and permgen.

### DIFF
--- a/tools/build/Makefile-JVM.in
+++ b/tools/build/Makefile-JVM.in
@@ -273,7 +273,7 @@ $(SETTING_JAR): $(PERL6_JAR) $(PERL6_B_JAR) $(J_CORE_SOURCES)
 	@echo "The following step can take a long time, please be patient."
 	$(J_RUN_PERL6) --setting=NULL --ll-exception --optimize=3 --target=jar --stagestats --output=$(SETTING_JAR) $(J_BUILD_DIR)/CORE.setting
 
-$(J_RUNNER):
+$(J_RUNNER):    tools/build/create-jvm-runner.pl
 	$(PERL) tools/build/create-jvm-runner.pl dev . . $(NQP_PREFIX) $(NQP_JARS)
 
 j-runner-default: j-all

--- a/tools/build/create-jvm-runner.pl
+++ b/tools/build/create-jvm-runner.pl
@@ -64,7 +64,7 @@ if ($debugger) {
 else {
     install "perl6-j", "java $jopts perl6";
     install "perl6-jdb-server", "java -Xdebug -Xrunjdwp:transport=dt_socket,address=8000,server=y,suspend=n $jopts perl6";
-    install "perl6-eval-server", "java $jopts org.perl6.nqp.tools.EvalServer";
+    install "perl6-eval-server", "java -Xmx2500m -XX:MaxPermSize=250m $jopts org.perl6.nqp.tools.EvalServer";
     cp(File::Spec->catfile($nqpprefix,'bin','eval-client.pl'), '.')
         or die "Couldn't copy 'eval-client.pl' from $nqpprefix: $!";
 }


### PR DESCRIPTION
This unbusts the spectests on the JVM backend on OSX.
