### PR TITLE
Tune the eval server max heap and permgen for best spectest time.

### DIFF
--- a/tools/build/create-jvm-runner.pl
+++ b/tools/build/create-jvm-runner.pl
@@ -64,7 +64,7 @@ if ($debugger) {
 else {
     install "perl6-j", "java $jopts perl6";
     install "perl6-jdb-server", "java -Xdebug -Xrunjdwp:transport=dt_socket,address=8000,server=y,suspend=n $jopts perl6";
-    install "perl6-eval-server", "java -Xmx2500m -XX:MaxPermSize=250m $jopts org.perl6.nqp.tools.EvalServer";
+    install "perl6-eval-server", "java -Xmx3000m -XX:MaxPermSize=200m $jopts org.perl6.nqp.tools.EvalServer";
     cp(File::Spec->catfile($nqpprefix,'bin','eval-client.pl'), '.')
         or die "Couldn't copy 'eval-client.pl' from $nqpprefix: $!";
 }


### PR DESCRIPTION
Increasing the max heap to 3000m cuts the spectest time by around 20% on my OSX machine.
Reduced the MaxPermSize to 200m because currently only using a little over 100m during a spectest run.
