### PR TITLE
Fix Routine.multi

### DIFF
--- a/src/core/Routine.pm
+++ b/src/core/Routine.pm
@@ -53,7 +53,7 @@ my class Routine { # declared in BOOTSTRAP
     }
     
     method multi() {
-        self.dispatcher.defined
+        self.dispatcher.defined || +self.candidates > 1
     }
     
     multi method perl(Routine:D:) {


### PR DESCRIPTION
``` perl6
    use Test;

    plan 1;

    my class Foo {
        multi method test(Str $) {}
        multi method test(Int $) {}
    }

    my $test = Foo.^method_table<test>;
    ok $test.multi, 'Making sure a multi method says it is one';
```

Without this patch, the preceding test doesn't work.

For some reason, `t/spec/S32-io/IO-Socket-Async.t` fails with this patch, though.
