### PR TITLE
Added reason "Missing semicolon" for RT #75230.

### DIFF
--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -1156,7 +1156,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         || <?before ')' | ']' | '}' >
         || $
         || <?stopper>
-        || <.typed_panic: 'X::Syntax::Confused'>
+        || { $/.CURSOR.typed_panic( 'X::Syntax::Confused', reason => "Missing semicolon." ) }
     }
 
     token xblock($*IMPLICIT = 0) {


### PR DESCRIPTION
For reference: https://rt.perl.org/Ticket/Display.html?id=75230
