### PR TITLE
Don't parse <sigil> <rxstopper> as a variable in the search pattern for s///.

### DIFF
--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -4401,6 +4401,7 @@ grammar Perl6::RegexGrammar is QRegex::P6Regex::Grammar does STD {
 
     token metachar:sym<rakvar> {
         <?before <sigil> $<twigil>=[<alpha> | \W<alpha> | '(']>
+        <!before <sigil> <rxstopper> >
         <var=.LANG('MAIN', 'variable')>
         [
         || $<binding> = ( \s* '=' \s* <quantified_atom> )


### PR DESCRIPTION
This fixes RT #122349.

For reference: https://rt.perl.org/Ticket/Display.html?id=122349
