### PR TITLE
Fix broken DOC INIT blocks

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -1427,7 +1427,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
     method statement_prefix:sym<POST>($/)  { make $*W.add_phaser($/, 'POST', ($<blorst>.ast).ann('code_object'), ($<blorst>.ast).ann('past_block')); }
 
     method statement_prefix:sym<DOC>($/)   {
-        $*W.add_phaser($/, ~$<phase>, ($<blorst>.ast).ann('code_object'))
+        $*W.add_phaser($/, ~$<phase>, ($<blorst>.ast).ann('code_object'), ($<blorst>.ast).ann('past_block'))
             if %*COMPILING<%?OPTIONS><doc>;
     }
 


### PR DESCRIPTION
Before this fix, DOC INIT blocks (like the following) would crash:

``` perl6
DOC INIT { say 'got some docs!' }
```
