### PR TITLE
Remove special-casing for tr/// in make_smartmatch.

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -4937,14 +4937,6 @@ class Perl6::Actions is HLL::Actions does STDActions {
                 )
             );
         }
-        # Transliteration shuffles values around itself and returns the
-        # Right Thing regardless of whether we're in a smart-match or
-        # implicitely against $_, so we just do the RHS here.
-        elsif $rhs.ann('is_trans') {
-            $sm_call := QAST::Stmt.new(
-                $rhs
-            );
-        }
         else {
             # Call $rhs.ACCEPTS( $_ ), where $_ is $lhs.
             $sm_call := QAST::Op.new(
@@ -5906,7 +5898,6 @@ class Perl6::Actions is HLL::Actions does STDActions {
             )
         );
 
-        $past.annotate('is_trans', 1);
         $past
     }
 

--- a/src/core/StrDistance.pm
+++ b/src/core/StrDistance.pm
@@ -31,4 +31,8 @@ my class StrDistance is Cool {
             @d[*-1][*-1];
         }
     }
+
+    method ACCEPTS(StrDistance:D:, Mu \other) {
+        self
+    }
 }


### PR DESCRIPTION
Simplify make_smartmatch in Perl6/Actions.nqp by implementing ACCEPTS for StrDistance.

Together with [PR#295](https://github.com/rakudo/rakudo/pull/295) we can get rid of all special-casing in make_smartmatch and simply call through to ACCEPTS with a topicalized LHS for all smart matches.