### PR TITLE
Add a few typed exceptions and override P6Regex::Grammar methods to throw them.

### DIFF
--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -4386,6 +4386,12 @@ grammar Perl6::RegexGrammar is QRegex::P6Regex::Grammar does STD {
         self.typed_sorry('X::Syntax::Regex::NullRegex');
     }
 
+    method throw_malformed_range() { self.typed_sorry('X::Syntax::Regex::MalformedRange') }
+    method throw_confused() { self.typed_sorry('X::Syntax::Confused') }
+    method throw_unspace($char) { self.typed_sorry('X::Syntax::Regex::Unspace', :$char) }
+    method throw_regex_not_terminated() { self.typed_sorry('X::Syntax::Regex::Unterminated') }
+    method throw_spaces_in_bare_range() { self.typed_sorry('X::Syntax::Regex::SpacesInBareRange') }
+    
     token normspace { <?before \s | '#'> <.LANG('MAIN', 'ws')> }
 
     token rxstopper { <stopper> }

--- a/src/core/Exception.pm
+++ b/src/core/Exception.pm
@@ -1038,6 +1038,26 @@ my class X::Syntax::Regex::NullRegex does X::Syntax {
     method message() { 'Null regex not allowed' }
 }
 
+my class X::Syntax::Regex::MalformedRange does X::Syntax {
+    method message() { 'Malformed Range' }
+}
+
+my class X::Syntax::Regex::Unspace does X::Syntax {
+    has $.char;
+    method message { "No unspace allowed in regex; if you meant to match the literal character, " ~
+        "please enclose in single quotes ('" ~ $.char ~ "') or use a backslashed form like \\x" ~ 
+        sprintf('%02x', $.char.ord)
+    }
+}
+
+my class X::Syntax::Regex::Unterminated does X::Syntax { 
+    method message { 'Regex not terminated.' }
+}
+
+my class X::Syntax::Regex::SpacesInBareRange does X::Syntax {
+    method message { 'Spaces not allowed in bare range.' }
+}
+
 my class X::Syntax::Signature::InvocantMarker does X::Syntax {
     method message() {
         "Can only use : as invocant marker in a signature after the first parameter"


### PR DESCRIPTION
This lets us test sensibly for RT #77380, RT #77522 and similar.

This implements the Perl 6 side of [nqp PR #173](https://github.com/perl6/nqp/pull/173).
