### PR TITLE
add freebsd to moar DISTROnames

### DIFF
--- a/src/core/Perl.pm
+++ b/src/core/Perl.pm
@@ -19,7 +19,7 @@ class Perl does Systemic {
         <macosx linux mswin32>
 #?endif
 #?if moar
-        <macosx linux mswin32>
+        <macosx linux freebsd mswin32>
 #?endif
         )
     }


### PR DESCRIPTION
most tests pass for FreeBSD 10 moar
