### PR TITLE
add freebsd to KERNELnames

### DIFF
--- a/src/core/Kernel.pm
+++ b/src/core/Kernel.pm
@@ -14,7 +14,8 @@ class Kernel does Systemic {
     method name {
         $!name //= do {
             given $*DISTRO.name {
-                when any <linux macosx freebsd> { # needs adapting
+                # needs adapting, also $*PERL.KERNELnames in src/core/Perl.pm
+                when any <linux macosx freebsd> { 
                     qx/uname -s/.chomp.lc;
                 }
                 default {

--- a/src/core/Perl.pm
+++ b/src/core/Perl.pm
@@ -24,7 +24,7 @@ class Perl does Systemic {
         )
     }
 
-    method KERNELnames { <darwin linux win32> }
+    method KERNELnames { <darwin linux freebsd win32> }
 }
 
 multi sub INITIALIZE_DYNAMIC('$*PERL') {


### PR DESCRIPTION
since we have freebsd in PERL.DISTROnames (at least for moar)
and in KERNEL.name (for all backends)

Without the change in src/core/Perl.pm test 29 in t/spec/S02-magicals/KERNEL.t
failed with perl6-m on FreeBSD (10.0-RELEASE-p9). After the change spectest-m
is clean.

Regarding the comment in src/core/Kernel.pm: If a new $*DISTRO.name is added
(as in commit 52b1dc3430025cda6b7d0617647af58c740995ef) KERNELnames
should probably be modified as well.
