### PR TITLE
Implement tr

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -5858,6 +5858,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
     }
 
     my %SUBST_ALLOWED_ADVERBS;
+    my %TRANS_ALLOWED_ADVERBS;
     my %SHARED_ALLOWED_ADVERBS;
     my %MATCH_ALLOWED_ADVERBS;
     my %MATCH_ADVERBS_MULTIPLE := hash(
@@ -5885,6 +5886,9 @@ class Perl6::Actions is HLL::Actions does STDActions {
         Perl5       => 'P5',
         samecase    => 'ii',
         samespace   => 'ss',
+        squash      => 's',
+        complement  => 'c',
+        delete      => 'd',
     );
     my %REGEX_ADVERB_IMPLIES := hash(
         ii        => 'i',
@@ -5904,6 +5908,11 @@ class Perl6::Actions is HLL::Actions does STDActions {
         $mods := 'x c continue p pos nth th st nd rd g global ov overlap ex exhaustive';
         for nqp::split(' ', $mods) {
             %MATCH_ALLOWED_ADVERBS{$_} := 1;
+        }
+
+        $mods := 'd delete cm complement sq squash';
+        for nqp::split(' ', $mods) {
+            %TRANS_ALLOWED_ADVERBS{$_} := 1;
         }
     }
 
@@ -6039,9 +6048,6 @@ class Perl6::Actions is HLL::Actions does STDActions {
     }
 
     method quote:sym<tr>($/) {
-        if nqp::elems($<rx_adverbs><quotepair>) {
-            $*W.throw($/, 'X::Comp::NYI', feature => 'tr/// adverbs');
-        }
         my $left  := $<tribble><left>.ast;
         my $right := $<tribble><right>.ast;
 
@@ -6073,6 +6079,10 @@ class Perl6::Actions is HLL::Actions does STDActions {
             QAST::Var.new(:name('$_'), :scope<lexical>),
             $pair
         );
+
+        if nqp::elems($<rx_adverbs><quotepair>) {
+            self.handle_and_check_adverbs($/, %TRANS_ALLOWED_ADVERBS, 'transliteration', $trans);
+        }
 
         my $StrDistance := $*W.find_symbol(['StrDistance']);
         # Putting it all together.

--- a/src/core/Str.pm
+++ b/src/core/Str.pm
@@ -1083,11 +1083,9 @@ my class Str does Stringy { # declared in BOOTSTRAP
         has Str $!source;
         has @!substitutions;
         has $!squash;
-        has $!complement;
 
         has int $!index;
         has int $!next_match;
-        has $!prev_substitution;
         has $!next_substitution;
         has $!substitution_length;
         has $!prev_result;
@@ -1097,7 +1095,7 @@ my class Str does Stringy { # declared in BOOTSTRAP
         has str $.unsubstituted_text;
         has str $.substituted_text;
         
-        submethod BUILD(:$!source, :$!squash, :$!complement) { }
+        submethod BUILD(:$!source, :$!squash) { }
 
         method add_substitution($key, $value) {
             push @!substitutions, $key => $value;
@@ -1190,16 +1188,6 @@ my class Str does Stringy { # declared in BOOTSTRAP
                     self.increment_index($!next_substitution.key);
                 }
             }
-            else {
-                $!unsubstituted_text # = nqp::substr(nqp::unbox_s($!source), $!index, 
-                    = $!source.substr($!index, $!next_match - $!index);
-                if defined $!next_substitution {
-                    $!substituted_text = self.get_next_substitution_result;
-                    self.increment_index($!next_substitution.key);
-                }
-            }
-
-            $!prev_substitution = $!next_substitution;
 
             return $!next_match < $!source.chars && @!substitutions;
         }

--- a/src/core/Str.pm
+++ b/src/core/Str.pm
@@ -1165,7 +1165,7 @@ my class Str does Stringy { # declared in BOOTSTRAP
             $!first_substitution //= @!substitutions[0];
 
             # triage_substitution has a side effect!
-            @!substitutions = @!substitutions.grep: {self.triage_substitution($_) }
+            @!substitutions = @!substitutions.grep: { self.triage_substitution($_) }
 
             $!unsubstituted_text # = nqp::substr(nqp::unbox_s($!source), $!index,
                 = $!source.substr($!index, $!next_match - $!index);

--- a/src/core/Str.pm
+++ b/src/core/Str.pm
@@ -1082,16 +1082,22 @@ my class Str does Stringy { # declared in BOOTSTRAP
     my class LSM {
         has Str $!source;
         has @!substitutions;
+        has $!squash;
+        has $!complement;
 
         has int $!index;
         has int $!next_match;
+        has $!prev_substitution;
         has $!next_substitution;
         has $!substitution_length;
+        has $!prev_result;
+        has $!match_obj;
+        has $!last_match_obj;
 
         has str $.unsubstituted_text;
         has str $.substituted_text;
-
-        submethod BUILD(:$!source) { }
+        
+        submethod BUILD(:$!source, :$!squash, :$!complement) { }
 
         method add_substitution($key, $value) {
             push @!substitutions, $key => $value;
@@ -1104,6 +1110,7 @@ my class Str does Stringy { # declared in BOOTSTRAP
                 $!next_match = $pos;
                 $!substitution_length = $length;
                 $!next_substitution = $substitution;
+                $!match_obj = $!last_match_obj;
             }
         }
 
@@ -1111,6 +1118,7 @@ my class Str does Stringy { # declared in BOOTSTRAP
         multi method triage_substitution($_ where { nqp::istype(.key,Regex) }) {
             my $m := $!source.match(.key, :continue($!index));
             return unless $m;
+            $!last_match_obj = $/;
             self.compare_substitution($_, $m.from, $m.to - $m.from);
             True
         }
@@ -1129,11 +1137,27 @@ my class Str does Stringy { # declared in BOOTSTRAP
         proto method increment_index(|) {*}
         multi method increment_index(Regex $s) {
             $!source.substr($!index) ~~ $s;
+            $!last_match_obj = $/;
             $!index = $!next_match + $/.chars;
         }
 
         multi method increment_index(Cool $s) {
             $!index = $!next_match + nqp::chars($s.Str);
+        }
+
+        method get_next_substitution_result {
+            my $result = $!complement ?? @!substitutions[0].value !! $!next_substitution.value;
+            my $cds := nqp::getlexcaller('$CALLER_DOLLAR_SLASH');
+            try $cds = $!match_obj;
+            my $orig-result = $result = ($result ~~ Callable ?? $result() !! $result).Str;
+            if $!prev_result
+                && $!prev_result eq $result
+                && $!unsubstituted_text eq ''
+                && $!squash {
+                $result = '';
+            }
+            $!prev_result = $orig-result;
+            nqp::unbox_s($result)
         }
 
         method next_substitution() {
@@ -1145,17 +1169,43 @@ my class Str does Stringy { # declared in BOOTSTRAP
             $!unsubstituted_text # = nqp::substr(nqp::unbox_s($!source), $!index,
                 = $!source.substr($!index, $!next_match - $!index);
             if defined $!next_substitution {
-                my $result = $!next_substitution.value;
-                $!substituted_text
-                    = nqp::unbox_s((nqp::istype($result,Callable) ?? $result() !! $result).Str);
-                self.increment_index($!next_substitution.key);
+                if $!complement {
+                    my $oldidx = $!index;
+                    my $result = self.get_next_substitution_result;
+                    if $!unsubstituted_text {
+                        self.increment_index($!next_substitution.key);
+                        $!substituted_text = $!source.substr($oldidx + $!unsubstituted_text.chars, 
+                            $!index - $oldidx - $!unsubstituted_text.chars);
+                        $!unsubstituted_text = $!squash ?? $result
+                            !! $result x $!unsubstituted_text.chars;
+                    }
+                    else {
+                        self.increment_index($!next_substitution.key);
+                        $!substituted_text = '';
+                        $!unsubstituted_text = $!source.substr($oldidx, $!index - $oldidx);
+                    }
+                }
+                else {
+                    $!substituted_text = self.get_next_substitution_result;
+                    self.increment_index($!next_substitution.key);
+                }
             }
+            else {
+                $!unsubstituted_text # = nqp::substr(nqp::unbox_s($!source), $!index, 
+                    = $!source.substr($!index, $!next_match - $!index);
+                if defined $!next_substitution {
+                    $!substituted_text = self.get_next_substitution_result;
+                    self.increment_index($!next_substitution.key);
+                }
+            }
+
+            $!prev_substitution = $!next_substitution;
 
             return $!next_match < $!source.chars && @!substitutions;
         }
     }
 
-    method trans(Str:D: *@changes) {
+    method trans(Str:D: *@changes, :complement(:$c), :squash(:$s), :delete(:$d)) {
         my sub expand($s) {
             return $s.list
               if nqp::istype($s,Iterable) || nqp::istype($s,Positional);
@@ -1164,7 +1214,8 @@ my class Str does Stringy { # declared in BOOTSTRAP
             };
         }
 
-        my $lsm = LSM.new(:source(self));
+        my $CALLER_DOLLAR_SLASH := nqp::getlexcaller('$/');
+        my $lsm = LSM.new(:source(self), :squash($s), :complement($c));
         for (@changes) -> $p {
             X::Str::Trans::InvalidArg.new(got => $p).throw
               unless nqp::istype($p,Pair);
@@ -1180,7 +1231,14 @@ my class Str does Stringy { # declared in BOOTSTRAP
             else {
                 my @from = expand $p.key;
                 my @to = expand $p.value;
-                for @from Z (@to ?? @to xx ceiling(@from / @to) !! '' xx @from) -> $f, $t {
+                if @to {
+                    my $padding = $d ?? '' !! @to[@to - 1];
+                    @to = @to, $padding xx @from - @to;
+                }
+                else {
+                    @to = '' xx @from
+                }
+                for @from Z @to -> $f, $t {
                     $lsm.add_substitution($f, $t);
                 }
             }

--- a/src/core/StrDistance.pm
+++ b/src/core/StrDistance.pm
@@ -3,8 +3,17 @@ my class StrDistance is Cool {
     has Str $.after;
     has Int $!distance;
 
-    multi method Bool(StrDistance:D:)    { $.before ne $.after }
-    multi method Numeric(StrDistance:D:) { self.Int }
+    method BUILD(:$before, :$after) {
+        $!before = $before.Str
+    }
+
+    method Bool() {
+        $.before ne $.after
+    }
+
+    method Numeric() {
+        self.Int
+    }
 
     multi method Int(StrDistance:D:) {
         $!distance //= do {


### PR DESCRIPTION
...ok rather, implement a few more features that tr/// and .trans should have.
Those are adverbs for tr/// and .trans as well as closures as replacement. Additionally I have fixed the bug discovered/discussed around [here](http://irclog.perlgeek.de/perl6/2014-09-29#i_9424693).

Remaining TODO in t/spec/S05-transliteration/trans.t is `not ok 23 - ambiguous ranges combined# TODO disambiguate ranges`, which I hereby defer judgement over. 