### PR TITLE
Make Instant.perl to produce eval-able code

### DIFF
--- a/src/core/Instant.pm
+++ b/src/core/Instant.pm
@@ -45,7 +45,7 @@ my class Instant is Cool does Real {
         'Instant:' ~ $.x
     }
     multi method perl(Instant:D:) {
-        "Instant.new(x => $.x.perl())";
+        "Instant.new($.x.perl())";
     }
     method Bridge(Instant:D:) { $.x.Bridge }
     method Num   (Instant:D:) { $.x.Num    }


### PR DESCRIPTION
Instant.new takes one positional argument, not a argument named x
