### PR TITLE
Add two typed exceptions (X::Syntax::Regex::SolitaryQuantifier and X::Syntax::Term::MissingInitializer)

### DIFF
--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -2400,7 +2400,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         # STD.pm6 uses <defterm> here, but we need different 
         # action methods
         | '\\' <identifier> <.ws>
-            [ <term_init=initializer> || <.panic("Term definition requires an initializer")> ]
+            [ <term_init=initializer> || <.typed_panic: "X::Syntax::Term::MissingInitializer"> ]
         | <variable_declarator>
           [
           || <?{ $*SCOPE eq 'has' }> <.newpad> <initializer>? { $*ATTR_INIT_BLOCK := $*W.pop_lexpad() }

--- a/src/core/Exception.pm
+++ b/src/core/Exception.pm
@@ -1079,6 +1079,10 @@ my class X::Syntax::Regex::SolitaryQuantifier does X::Syntax {
     method message { 'Quantifier quantifies nothing' }
 }
 
+my class X::Syntax::Term::MissingInitializer does X::Syntax {
+    method message { 'Term definition requires an initializer' }
+}
+
 my class X::Syntax::Signature::InvocantMarker does X::Syntax {
     method message() {
         "Can only use : as invocant marker in a signature after the first parameter"


### PR DESCRIPTION
Should be used in nqp for something like the following (cmp. RT #111956):

> / \* /
