### PR TITLE
Make anonymous enums follow Synopsis 2

### DIFF
--- a/src/core/Enumeration.pm
+++ b/src/core/Enumeration.pm
@@ -64,7 +64,7 @@ sub ANON_ENUM(*@args) {
     my %res;
     for @args {
         if .^isa(Enum) {
-            %res{.key} = .value;
+            %res{.key} = $prev = .value;
         }
         else {
             %res{$_} = $prev.=succ;


### PR DESCRIPTION
Adding a pair to an enum is supposed to change the value the next key would get.

Before:

```
enum ( a => 1, 'b' ).perl.say; # EnumMap.new("a", 1, "b", 0, )
```

Now:

```
enum ( a => 1, 'b' ).perl.say; # EnumMap.new("a", 1, "b", 2, )
```
