### PR TITLE
Coerce set comparator operands 'up'

### DIFF
--- a/src/core/set_operators.pm
+++ b/src/core/set_operators.pm
@@ -123,13 +123,22 @@ only sub infix:<<"\x2296">>($a, $b --> Setty) {
 #     $a == $b and so $a.keys.all (elem) $b
 # }
 
-proto sub infix:<<(<=)>>($, $ --> Bool) {*}
-multi sub infix:<<(<=)>>(Any $a, Any $b --> Bool) {
-    $a.Set(:view) (<=) $b.Set(:view);
+### Set Comparison Operators
+#
+# Note that these are implemented according to subroutine signature
+# combinatorics because of the performance implications of junctions
+
+only sub infix:<<(<=)>>(Any $a, Any $b --> Bool) {
+    my ($c,$d);
+    if      $a ~~ Mix or $b ~~ Mix { $c = $a.Mix(:view); $d = $b.Mix(:view); }
+    elsif   $a ~~ Bag or $b ~~ Bag { $c = $a.Bag(:view); $d = $b.Bag(:view); }
+    else {
+        $c = $a.Set(:view); $d = $b.Set(:view);
+        return so $c <= $d and [&&] $c.keys X(elem) $d;
+    }
+    return [&&] $c.keys.map({ $c{$_} <= $d{$_} });
 }
-multi sub infix:<<(<=)>>(Setty $a, Setty $b --> Bool) {
-    $a <= $b and so $a.keys.all (elem) $b
-}
+
 # U+2286 SUBSET OF OR EQUAL TO
 only sub infix:<<"\x2286">>($a, $b --> Bool) {
     $a (<=) $b;
@@ -139,13 +148,18 @@ only sub infix:<<"\x2288">>($a, $b --> Bool) {
     $a !(<=) $b;
 }
 
-proto sub infix:<<(<)>>($, $ --> Bool) {*}
-multi sub infix:<<(<)>>(Any $a, Any $b --> Bool) {
-    $a.Set(:view) (<) $b.Set(:view);
+
+only sub infix:<<(<)>>(Any $a, Any $b --> Bool) {
+    my ($c,$d);
+    if      $a ~~ Mix or $b ~~ Mix { $c = $a.Mix(:view); $d = $b.Mix(:view); }
+    elsif   $a ~~ Bag or $b ~~ Bag { $c = $a.Bag(:view); $d = $b.Bag(:view); }
+    else {
+        $c = $a.Set(:view); $d = $b.Set(:view);
+        return so $c < $d and [&&] $c.keys X(elem) $d;
+    }
+    return [&&] $c.keys.map({ $c{$_} < $d{$_} });
 }
-multi sub infix:<<(<)>>(Setty $a, Setty $b --> Bool) {
-    $a < $b and so $a.keys.all (elem) $b;
-}
+
 # U+2282 SUBSET OF
 only sub infix:<<"\x2282">>($a, $b --> Bool) {
     $a (<) $b;
@@ -155,13 +169,17 @@ only sub infix:<<"\x2284">>($a, $b --> Bool) {
     $a !(<) $b;
 }
 
-proto sub infix:<<(>=)>>($, $ --> Bool) {*}
-multi sub infix:<<(>=)>>(Any $a, Any $b --> Bool) {
-    $a.Set(:view) (>=) $b.Set(:view);
+only sub infix:<<(>=)>>(Any $a, Any $b --> Bool) {
+    my ($c,$d);
+    if      $a ~~ Mix or $b ~~ Mix { $c = $a.Mix(:view); $d = $b.Mix(:view); }
+    elsif   $a ~~ Bag or $b ~~ Bag { $c = $a.Bag(:view); $d = $b.Bag(:view); }
+    else {
+        $c = $a.Set(:view); $d = $b.Set(:view);
+        return so $c >= $d and [&&] $d.keys X(elem) $c;
+    }
+    return [&&] $d.keys.map({ $c{$_} >= $d{$_} });
 }
-multi sub infix:<<(>=)>>(Setty $a, Setty $b --> Bool) {
-    $a >= $b and so $b.keys.all (elem) $a;
-}
+
 # U+2287 SUPERSET OF OR EQUAL TO
 only sub infix:<<"\x2287">>($a, $b --> Bool) {
     $a (>=) $b;
@@ -171,13 +189,17 @@ only sub infix:<<"\x2289">>($a, $b --> Bool) {
     $a !(>=) $b;
 }
 
-proto sub infix:<<(>)>>($, $ --> Bool) {*}
-multi sub infix:<<(>)>>(Any $a, Any $b --> Bool) {
-    $a.Set(:view) (>) $b.Set(:view);
+only sub infix:<<(>)>>(Any $a, Any $b --> Bool) {
+    my ($c,$d);
+    if      $a ~~ Mix or $b ~~ Mix { $c = $a.Mix(:view); $d = $b.Mix(:view); }
+    elsif   $a ~~ Bag or $b ~~ Bag { $c = $a.Bag(:view); $d = $b.Bag(:view); }
+    else {
+        $c = $a.Set(:view); $d = $b.Set(:view);
+        return so $c > $d and [&&] $d.keys X(elem) $c;
+    }
+    return [&&] $d.keys.map({ $c{$_} > $d{$_} });
 }
-multi sub infix:<<(>)>>(Setty $a, Setty $b --> Bool) {
-    $a > $b and so $b.keys.all (elem) $a;
-}
+
 # U+2283 SUPERSET OF
 only sub infix:<<"\x2283">>($a, $b --> Bool) {
     $a (>) $b;
@@ -227,7 +249,7 @@ multi sub infix:<<(<+)>>(Any $a, Any $b --> Bool) {
     $a.Bag(:view) (<+) $b.Bag(:view);
 }
 multi sub infix:<<(<+)>>(Baggy $a, Baggy $b --> Bool) {
-    so all $a.keys.map({ $a{$_} <= $b{$_} })
+    so all $a.keys.map({ $a{$_} <= $b{$_} });
 }
 # U+227C PRECEDES OR EQUAL TO
 only sub infix:<<"\x227C">>($a, $b --> Bool) {

--- a/src/core/set_operators.pm
+++ b/src/core/set_operators.pm
@@ -124,9 +124,6 @@ only sub infix:<<"\x2296">>($a, $b --> Setty) {
 # }
 
 ### Set Comparison Operators
-#
-# Note that these are implemented according to subroutine signature
-# combinatorics because of the performance implications of junctions
 
 only sub infix:<<(<=)>>(Any $a, Any $b --> Bool) {
     my ($c,$d);

--- a/src/core/set_operators.pm
+++ b/src/core/set_operators.pm
@@ -125,7 +125,7 @@ only sub infix:<<"\x2296">>($a, $b --> Setty) {
 
 ### Set Comparison Operators
 
-only sub infix:<<(<=)>>(Any $a, Any $b --> Bool) {
+multi sub infix:<<(<=)>>(Any $a, Any $b --> Bool) {
     my ($c,$d);
     if      $a ~~ Mix or $b ~~ Mix { $c = $a.Mix(:view); $d = $b.Mix(:view); }
     elsif   $a ~~ Bag or $b ~~ Bag { $c = $a.Bag(:view); $d = $b.Bag(:view); }
@@ -134,6 +134,14 @@ only sub infix:<<(<=)>>(Any $a, Any $b --> Bool) {
         return so $c <= $d and [&&] $c.keys X(elem) $d;
     }
     return [&&] $c.keys.map({ $c{$_} <= $d{$_} });
+}
+
+multi sub infix:<<(<=)>>(Set $a, Set $b --> Bool) {
+    return so $a <= $b and [&&] $a.keys X(elem) $b;
+}
+
+multi sub infix:<<(<=)>>(QuantHash $a, QuantHash $b --> Bool) {
+    return [&&] $a.keys.map({ $a{$_} <= $b{$_} });
 }
 
 # U+2286 SUBSET OF OR EQUAL TO
@@ -146,7 +154,7 @@ only sub infix:<<"\x2288">>($a, $b --> Bool) {
 }
 
 
-only sub infix:<<(<)>>(Any $a, Any $b --> Bool) {
+multi sub infix:<<(<)>>(Any $a, Any $b --> Bool) {
     my ($c,$d);
     if      $a ~~ Mix or $b ~~ Mix { $c = $a.Mix(:view); $d = $b.Mix(:view); }
     elsif   $a ~~ Bag or $b ~~ Bag { $c = $a.Bag(:view); $d = $b.Bag(:view); }
@@ -155,6 +163,14 @@ only sub infix:<<(<)>>(Any $a, Any $b --> Bool) {
         return so $c < $d and [&&] $c.keys X(elem) $d;
     }
     return [&&] $c.keys.map({ $c{$_} < $d{$_} });
+}
+
+multi sub infix:<<(<)>>(Set $a, Set $b --> Bool) {
+    return so $a < $b and [&&] $a.keys X(elem) $b;
+}
+
+multi sub infix:<<(<)>>(QuantHash $a, QuantHash $b --> Bool) {
+    return [&&] $a.keys.map({ $a{$_} < $b{$_} });
 }
 
 # U+2282 SUBSET OF
@@ -166,7 +182,7 @@ only sub infix:<<"\x2284">>($a, $b --> Bool) {
     $a !(<) $b;
 }
 
-only sub infix:<<(>=)>>(Any $a, Any $b --> Bool) {
+multi sub infix:<<(>=)>>(Any $a, Any $b --> Bool) {
     my ($c,$d);
     if      $a ~~ Mix or $b ~~ Mix { $c = $a.Mix(:view); $d = $b.Mix(:view); }
     elsif   $a ~~ Bag or $b ~~ Bag { $c = $a.Bag(:view); $d = $b.Bag(:view); }
@@ -175,6 +191,14 @@ only sub infix:<<(>=)>>(Any $a, Any $b --> Bool) {
         return so $c >= $d and [&&] $d.keys X(elem) $c;
     }
     return [&&] $d.keys.map({ $c{$_} >= $d{$_} });
+}
+
+multi sub infix:<<(>=)>>(Set $a, Set $b --> Bool) {
+    return so $a >= $b and [&&] $b.keys X(elem) $a;
+}
+
+multi sub infix:<<(>=)>>(QuantHash $a, QuantHash $b --> Bool) {
+    return [&&] $b.keys.map({ $a{$_} >= $b{$_} });
 }
 
 # U+2287 SUPERSET OF OR EQUAL TO
@@ -186,7 +210,7 @@ only sub infix:<<"\x2289">>($a, $b --> Bool) {
     $a !(>=) $b;
 }
 
-only sub infix:<<(>)>>(Any $a, Any $b --> Bool) {
+multi sub infix:<<(>)>>(Any $a, Any $b --> Bool) {
     my ($c,$d);
     if      $a ~~ Mix or $b ~~ Mix { $c = $a.Mix(:view); $d = $b.Mix(:view); }
     elsif   $a ~~ Bag or $b ~~ Bag { $c = $a.Bag(:view); $d = $b.Bag(:view); }
@@ -195,6 +219,14 @@ only sub infix:<<(>)>>(Any $a, Any $b --> Bool) {
         return so $c > $d and [&&] $d.keys X(elem) $c;
     }
     return [&&] $d.keys.map({ $c{$_} > $d{$_} });
+}
+
+multi sub infix:<<(>)>>(Set $a, Set $b --> Bool) {
+    return so $a >= $b and [&&] $b.keys X(elem) $a;
+}
+
+multi sub infix:<<(>)>>(QuantHash $a, QuantHash $b --> Bool) {
+    return [&&] $b.keys.map({ $a{$_} > $b{$_} });
 }
 
 # U+2283 SUPERSET OF


### PR DESCRIPTION
This patch presents the position that comparator ops could be more
DWIM-y by always coercing their arguments up the chain of complexity.

The current behavior is to coerce Setty things to Sets. This puts Bags
and Mixes in an awkward situation, as .values become True and so only
.keys comparisons matter. The approach of having (<+) and the like be
Baggy specific versions of the operator smells overcomplicated to me.

This approach preserves the original behavior by asking our dev to
be explicit about any "downgrading" of any .values inasmuch as they are
present in the operation:

```
$set (<) $bag.Set
```

This demand to a more explicit statement is the only perceived
tradeoff*, the reward of which is that one does not need to think twice
about:

```
my $reference-bag = bag <1 1 1 2 2 3>;
my $random-mix = mix <1 2 2 3 3 3>;

# Existing syntax:
# Bag --> Set (<=) Mix --> Set
> $reference-bag (<=) $random-mix
True

# Coercion of least surprise:
# Bag --> Mix (<=) Mix
> $reference-bag (<=) $random-mix
False
```

There is another option to implement this, using multi methods and
signatures. However, this implementation is way DRY-er, and thus a
better example of code (which I take it the core settings are intended
to be.. and that's judging mainly from the looks of things!).

Notes:

*Which is also arguably a better demand to make than to ask our dev to
remember a separate-but-strange (<+))
