### PR TITLE
changed underscore to dash

### DIFF
--- a/src/core/Metamodel/Primitives.pm
+++ b/src/core/Metamodel/Primitives.pm
@@ -1,14 +1,14 @@
 my class Metamodel::Primitives {
-    method create_type(Mu $how, $repr) {
+    method create-type(Mu $how, $repr) {
         nqp::newtype($how, $repr.Str)
     }
 
-    method set_package(Mu $type, $package) {
+    method set-package(Mu $type, $package) {
         nqp::setwho(nqp::decont($type), nqp::decont($package));
         $type
     }
 
-    method install_method_cache(Mu $type, %cache, :$authoritative = True) {
+    method install-method-cache(Mu $type, %cache, :$authoritative = True) {
         my Mu $cache := nqp::hash();
         for %cache.kv -> $name, $meth {
             nqp::bindkey($cache, $name, nqp::decont($meth));
@@ -18,41 +18,41 @@ my class Metamodel::Primitives {
         $type
     }
 
-    method configure_type_checking(Mu $type, @cache, :$authoritative = True, :$call_accepts = False) {
+    method configure-type-checking(Mu $type, @cache, :$authoritative = True, :$call-accepts = False) {
         my Mu $cache := nqp::list();
         for @cache {
             nqp::push($cache, nqp::decont($_));
         }
         nqp::settypecache($type, $cache);
         nqp::settypecheckmode($type,
-            ($authoritative ?? 0 !! 1) + ($call_accepts ?? 2 !! 0));
+            ($authoritative ?? 0 !! 1) + ($call-accepts ?? 2 !! 0));
         $type
     }
 
-    method configure_destroy(Mu $type, $destroy) {
+    method configure-destroy(Mu $type, $destroy) {
         nqp::settypefinalize($type, $destroy ?? 1 !! 0);
         $type
     }
 
-    method compose_type(Mu $type, $configuration) {
-        multi sub to_vm_types(@array) {
+    method compose-type(Mu $type, $configuration) {
+        multi sub to-vm-types(@array) {
             my Mu $list := nqp::list();
             for @array {
-                nqp::push($list, to_vm_types($_));
+                nqp::push($list, to-vm-types($_));
             }
             $list
         }
-        multi sub to_vm_types(%hash) {
+        multi sub to-vm-types(%hash) {
             my Mu $hash := nqp::hash();
             for %hash.kv -> $k, $v {
-                nqp::bindkey($hash, $k, to_vm_types($v));
+                nqp::bindkey($hash, $k, to-vm-types($v));
             }
             $hash
         }
-        multi sub to_vm_types($other) {
+        multi sub to-vm-types($other) {
             nqp::decont($other)
         }
-        nqp::composetype(nqp::decont($type), to_vm_types($configuration));
+        nqp::composetype(nqp::decont($type), to-vm-types($configuration));
         $type
     }
 
@@ -60,7 +60,7 @@ my class Metamodel::Primitives {
         nqp::rebless($obj, $type)
     }
 
-    method is_type(Mu \obj, Mu \type) {
+    method is-type(Mu \obj, Mu \type) {
         nqp::p6bool(nqp::istype(obj, type))
     }
 }


### PR DESCRIPTION
There is also https://github.com/perl6/roast/pull/51

I think The API in src/Perl6/Metamodel needs to be changed to dash too, since it is exposed API. And S12-meta/primitives.t uses the API.
