### PR TITLE
Allow postfix operator called as method after unary postfix hyper operator

### DIFF
--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -3695,7 +3695,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         [ ['.' <.unsp>?]? <postfix_prefix_meta_operator> <.unsp>?]**0..1
         [
         | <OPER=postfix>
-        | '.' <![i]> <OPER=postfix>  ## postfix operator called as method, but not postfix:<i>
+        | '.' <?before \W> <OPER=postfix>  ## dotted form of postfix operator (non-wordy only)
         | <OPER=postcircumfix>
         | <OPER=dotty>
         | <OPER=privop>


### PR DESCRIPTION
currently something like '(my @a = 1)>>.++' fails, since METAOP_HYPER_CALL is called
instead of METAOP_HYPER_POSTFIX. Fixes RT #122342.
