### PR TITLE
Check if we actually got a return value from the Java method.

### DIFF
--- a/src/vm/jvm/runtime/org/perl6/rakudo/RakudoJavaInterop.java
+++ b/src/vm/jvm/runtime/org/perl6/rakudo/RakudoJavaInterop.java
@@ -259,8 +259,12 @@ public class RakudoJavaInterop extends BootJavaInterop {
     }
 
     public static Object filterReturnValueMethod(Object in, ThreadContext tc) {
-        Class<?> what = in.getClass();
         GlobalExt gcx = RakOps.key.getGC(tc);
+        if(in == null) {
+            return gcx.Nil;
+        }
+
+        Class<?> what = in.getClass();
         Object out = null;
         if(what == void.class) {
             out = null;


### PR DESCRIPTION
This fixes shortname candidates that return void throwing a NullPointerException.