### PR TITLE
Get Mixes working properly with the QuantHash ops

### DIFF
--- a/src/core/set_operators.pm
+++ b/src/core/set_operators.pm
@@ -230,7 +230,7 @@ only sub infix:<(.)>(**@p) {
               for $mixhash.keys;
         }
         $mixhash.Mix(:view);
-    } elsif @p.grep(Baggy) {
+    } else {  # go Baggy by default
         my $baghash = nqp::istype(@p[0], BagHash)
             ?? BagHash.new-from-pairs(@p.shift.pairs)
             !! @p.shift.BagHash;
@@ -259,7 +259,7 @@ only sub infix:<(+)>(**@p) {
             $mixhash{$_} += $mix{$_} for $mix.keys;
         }
         $mixhash.Mix(:view);
-    } elsif @p.grep(Baggy) {
+    } else {  # go Baggy by default
         my $baghash = nqp::istype(@p[0], BagHash)
             ?? BagHash.new-from-pairs(@p.shift.pairs)
             !! @p.shift.BagHash;

--- a/src/core/set_operators.pm
+++ b/src/core/set_operators.pm
@@ -32,7 +32,7 @@ only sub infix:<<"\x220C">>($a, $b --> Bool) {
 }
 
 only sub infix:<(|)>(**@p) {
-    if @p.grep(Mixy) {
+    if @p.first(Mixy) {
         my $mixhash = nqp::istype(@p[0], MixHash)
             ?? MixHash.new-from-pairs(@p.shift.pairs)
             !! @p.shift.MixHash;
@@ -40,7 +40,7 @@ only sub infix:<(|)>(**@p) {
             $mixhash{$_} max= $mix{$_} for $mix.keys;
         }
         $mixhash.Mix(:view);
-    } elsif @p.grep(Baggy) {
+    } elsif @p.first(Baggy) {
         my $baghash = nqp::istype(@p[0], BagHash)
             ?? BagHash.new-from-pairs(@p.shift.pairs)
             !! @p.shift.BagHash;
@@ -60,7 +60,7 @@ only sub infix:<<"\x222A">>(|p) {
 only sub infix:<(&)>(**@p) {
     return set() unless @p;
 
-    if @p.grep(Mixy) {
+    if @p.first(Mixy) {
         my $mixhash = nqp::istype(@p[0], MixHash)
             ?? MixHash.new-from-pairs(@p.shift.pairs)
             !! @p.shift.MixHash;
@@ -71,7 +71,7 @@ only sub infix:<(&)>(**@p) {
               for $mixhash.keys;
         }
         $mixhash.Mix(:view);
-    } elsif @p.grep(Baggy) {
+    } elsif @p.first(Baggy) {
         my $baghash = nqp::istype(@p[0], BagHash)
             ?? BagHash.new-from-pairs(@p.shift.pairs)
             !! @p.shift.BagHash;
@@ -100,7 +100,7 @@ only sub infix:<<"\x2229">>(|p) {
 only sub infix:<(-)>(**@p) {
     return set() unless @p;
 
-    if @p.grep(Mixy) {
+    if @p.first(Mixy) {
         my $mixhash = nqp::istype(@p[0], MixHash)
             ?? MixHash.new-from-pairs(@p.shift.pairs)
             !! @p.shift.MixHash;
@@ -111,7 +111,7 @@ only sub infix:<(-)>(**@p) {
               for $mixhash.keys;
         }
         $mixhash.Mix(:view);
-    } elsif @p.grep(Baggy) {
+    } elsif @p.first(Baggy) {
         my $baghash = nqp::istype(@p[0], BagHash)
             ?? BagHash.new-from-pairs(@p.shift.pairs)
             !! @p.shift.BagHash;
@@ -219,7 +219,7 @@ only sub infix:<<"\x2285">>($a, $b --> Bool) {
 only sub infix:<(.)>(**@p) {
     return bag() unless @p;
 
-    if @p.grep(Mixy) {
+    if @p.first(Mixy) {
         my $mixhash = nqp::istype(@p[0], MixHash)
             ?? MixHash.new-from-pairs(@p.shift.pairs)
             !! @p.shift.MixHash;
@@ -251,7 +251,7 @@ only sub infix:<<"\x228D">>(|p) {
 only sub infix:<(+)>(**@p) {
     return bag() unless @p;
 
-    if @p.grep(Mixy) {
+    if @p.first(Mixy) {
         my $mixhash = nqp::istype(@p[0], MixHash)
             ?? MixHash.new-from-pairs(@p.shift.pairs)
             !! @p.shift.MixHash;
@@ -276,7 +276,7 @@ only sub infix:<<"\x228E">>(|p) {
 
 proto sub infix:<<(<+)>>($, $ --> Bool) {*}
 multi sub infix:<<(<+)>>(Any $a, Any $b --> Bool) {
-    if $a ~~ Mixy or $b ~~ Mixy {
+    if nqp::istype($a, Mixy) or nqp::istype($b, Mixy) {
         $a.Mix(:view) (<+) $b.Mix(:view);
     } else {
         $a.Bag(:view) (<+) $b.Bag(:view);
@@ -295,7 +295,7 @@ multi sub infix:<<(>+)>>(Baggy $a, Baggy $b --> Bool) {
     so all $b.keys.map({ $b{$_} <= $a{$_} });
 }
 multi sub infix:<<(>+)>>(Any $a, Any $b --> Bool) {
-    if $a ~~ Mixy or $b ~~ Mixy {
+    if nqp::istype($a, Mixy) or nqp::istype($b, Mixy) {
         $a.Mix(:view) (>+) $b.Mix(:view);
     } else {
         $a.Bag(:view) (>+) $b.Bag(:view);

--- a/src/core/set_operators.pm
+++ b/src/core/set_operators.pm
@@ -283,7 +283,7 @@ multi sub infix:<<(<+)>>(Any $a, Any $b --> Bool) {
     }
 }
 multi sub infix:<<(<+)>>(QuantHash $a, QuantHash $b --> Bool) {
-    so all $a.keys.map({ $a{$_} <= $b{$_} })
+    [&&] $a.keys.map({ $a{$_} <= $b{$_} })
 }
 # U+227C PRECEDES OR EQUAL TO
 only sub infix:<<"\x227C">>($a, $b --> Bool) {
@@ -292,7 +292,7 @@ only sub infix:<<"\x227C">>($a, $b --> Bool) {
 
 proto sub infix:<<(>+)>>($, $ --> Bool) {*}
 multi sub infix:<<(>+)>>(Baggy $a, Baggy $b --> Bool) {
-    so all $b.keys.map({ $b{$_} <= $a{$_} });
+    [&&] $b.keys.map({ $b{$_} <= $a{$_} });
 }
 multi sub infix:<<(>+)>>(Any $a, Any $b --> Bool) {
     if nqp::istype($a, Mixy) or nqp::istype($b, Mixy) {

--- a/t/spectest.data
+++ b/t/spectest.data
@@ -190,6 +190,7 @@ S03-operators/lcm.t
 S03-operators/list-quote-junction.t
 S03-operators/minmax.t
 S03-operators/misc.t
+S03-operators/mix.t
 S03-operators/names.t
 S03-operators/nesting.t
 S03-operators/not.t


### PR DESCRIPTION
Up until now, mixes would get baggified, leading to some serious anti-DWIM.

This PR was suggested by @colomon in another of my Set-related PRs as a necessary first step: https://github.com/rakudo/rakudo/pull/335

See https://github.com/perl6/roast/pull/52 for the relevant spec tests.