### PR TITLE
Add git reference option into Configure.pl

### DIFF
--- a/Configure.pl
+++ b/Configure.pl
@@ -39,7 +39,7 @@ MAIN: {
                'gen-parrot:s', 'parrot-option=s@',
                'parrot-make-option=s@',
                'make-install!', 'makefile-timing!',
-               'git-depth=s',
+               'git-depth=s', 'git-reference=s',
     ) or do {
         print_help();
         exit(1);
@@ -371,7 +371,11 @@ General Options:
     --git-protocol={ssh,https,git}
                        Protocol used for cloning git repos
     --git-depth=<number>
-                       Use the --depth option for git clone with parameter number
+                       Use the --git-depth option for git clone with parameter number
+    --git-reference=<path>
+                       Use --git-reference option to identify local path where git repositories are stored
+                       For example: --git-reference=/home/user/repo/for_perl6
+                       Folders 'nqp', 'moar', 'parrot' with corresponding git repos should be in for_perl6 folder
     --makefile-timing  Enable timing of individual makefile commands
 
 Configure.pl also reads options from 'config.default' in the current directory.

--- a/tools/lib/NQP/Configure.pm
+++ b/tools/lib/NQP/Configure.pm
@@ -213,14 +213,17 @@ sub git_checkout {
     my $dir  = shift;
     my $checkout = shift;
     my $pushurl = shift;
-    my $git_depth = shift;
-    my $depth = $git_depth ? '--depth=' . $git_depth : '';
+    my $depth = shift;
+    my $reference = shift;
     my $pwd = cwd();
 
     # get an up-to-date repository
     if (! -d $dir) {
-    	my @args = ('git', 'clone', $repo, $dir);
-    	push @args, $depth if $depth;
+    	my @args = ('git', 'clone');
+    	push @args, $reference if $reference ne '';
+    	push @args, $depth if $depth ne '';
+    	push @args, $repo;
+    	push @args, $dir;
         system_or_die(@args);
         chdir($dir);
         system('git', 'config', 'remote.origin.pushurl', $pushurl)
@@ -327,7 +330,8 @@ sub gen_nqp {
             github_url($git_protocol, 'perl6', 'nqp'),
             'nqp', $gen_nqp || $nqp_want,
             github_url('ssh', 'perl6', 'nqp'),
-            $options{'git-depth'},
+            $options{'git-depth'} ? "--depth=$options{'git-depth'}" : '',
+            $options{'git-reference'} ? "--reference=$options{'git-reference'}/nqp" : '',
         );
     }
 
@@ -348,6 +352,8 @@ sub gen_nqp {
                "--git-protocol=$git_protocol",
               );
     push @cmd, "--git-depth=" . $options{'git-depth'} if $options{'git-depth'};
+    push @cmd, "--git-reference=" . $options{'git-reference'} if $options{'git-reference'};
+
 
     if (defined $gen_moar) {
         push @cmd, $gen_moar ? "--gen-moar=$gen_moar" : '--gen-moar';
@@ -394,7 +400,8 @@ sub gen_parrot {
             github_url($git_protocol, 'parrot', 'parrot'),
             'parrot', $gen_parrot,
             github_url('ssh', 'parrot', 'parrot'),
-            $options{'git-depth'},
+            $options{'git-depth'} ? "--depth=$options{'git-depth'}" : '',
+            $options{'git-reference'} ? "--reference=$options{'git-reference'}/parrot" : '',
         );
         $par_ok = $par_have eq $par_repo;
     }
@@ -403,7 +410,8 @@ sub gen_parrot {
             github_url($git_protocol, 'parrot', 'parrot'),
             'parrot', $par_want,
             github_url('ssh', 'parrot', 'parrot'),
-            $options{'git-depth'},
+            $options{'git-depth'} ? "--depth=$options{'git-depth'}" : '',
+            $options{'git-reference'} ? "--reference=$options{'git-reference'}/parrot" : '',
         );
     }
 
@@ -477,7 +485,8 @@ sub gen_moar {
         github_url($git_protocol, 'MoarVM', 'MoarVM'),
         'MoarVM', $gen_moar || $moar_want,
         github_url('ssh', 'MoarVM', 'MoarVM'),
-        $options{'git-depth'},
+        $options{'git-depth'} ? "--depth=$options{'git-depth'}" : '',
+        $options{'git-reference'} ? "--reference=$options{'git-reference'}/MoarVM" : '',
     );
 
     unless (cmp_rev($moar_repo, $moar_want) >= 0) {


### PR DESCRIPTION
Now we can use --git-reference=<path> option to tell Configure.pl do not clone corresponding repo from the web but use the reference to existing local repo. It reduces time for configuring and increases disk space.

This pull request depends on that https://github.com/perl6/nqp/pull/220