### PR TITLE
Die in skip_rest if no plan is set

### DIFF
--- a/lib/Test.pm
+++ b/lib/Test.pm
@@ -186,6 +186,7 @@ multi sub skip($reason, $count = 1) is export {
 
 sub skip_rest($reason = '<unknown>') is export {
     $time_after = nqp::p6box_n(nqp::time_n);
+    die "A plan is required in order to use skip_rest" if $no_plan;
     skip($reason, $num_of_tests_planned - $num_of_tests_run);
     $time_before = nqp::p6box_n(nqp::time_n);
 }


### PR DESCRIPTION
Current behaviour dies with "use of uninitialized value of type Any in
numeric context", which is confusing to the user of the Test module.  This
change tells the user what is required in order to use skip_rest correctly.