### PR TITLE
Support positional skipping in .assuming

### DIFF
--- a/src/core/Routine.pm
+++ b/src/core/Routine.pm
@@ -26,6 +26,17 @@ my class Routine { # declared in BOOTSTRAP
     method onlystar() { nqp::p6bool($!onlystar) }
 
     method assuming($r: |curried) {
+        if my @holes := (^curried).grep: { curried[$_] ~~ Whatever } {
+            my $last-hole = @holes[*-1];
+            my @mixed;
+            @mixed[$_] := curried[$_] for 0 .. $last-hole;
+            my @curried := curried[$last-hole ^.. *];
+            return sub CURRIED (|direct) {
+                @mixed[@holes[$_]] := direct[$_] for ^@holes;
+                $r(|@mixed, |@curried, |@(direct[+@holes .. *]), |%(curried), |%(direct));
+            }
+        }
+
         return sub CURRIED (|direct) {
             $r(|curried, |direct)
         }


### PR DESCRIPTION
This is slow and clumsy-looking, but it works with no new spectest failures.

Much of the awkwardness is trying to avoid triggering things like flattening and unboxing.

I don't know much about Rakudo's idea of standards and code quality, so please let me know if there is anything I can do better here, or if another approach entirely might make more sense.