### PR TITLE
Proposal for new `is_approx()` behaviour

### DIFF
--- a/lib/Test.pm
+++ b/lib/Test.pm
@@ -151,11 +151,11 @@ multi sub cmp_ok(Mu $got, $op, Mu $expected, $desc = '') is export {
     return $ok;
 }
 
-multi sub is_approx(Mu $got, Mu $expected, $desc = '') is export {
+multi sub is_approx(Numeric $got, Numeric $expected, $desc = '') is export {
     return is_approx($got, $expected, 1e-6, $desc);
 }
 
-multi sub is_approx(Mu $got, Mu $expected, Num $tol, $desc = '') is export {
+multi sub is_approx(Numeric $got, Numeric $expected, Numeric $tol, $desc = '') is export {
     $time_after = nqp::p6box_n(nqp::time_n);
     my $abs-diff = ($got - $expected).abs;
     my $abs-max = max($got.abs, $expected.abs);

--- a/lib/Test.pm
+++ b/lib/Test.pm
@@ -153,8 +153,18 @@ multi sub cmp_ok(Mu $got, $op, Mu $expected, $desc = '') is export {
 
 multi sub is_approx(Mu $got, Mu $expected, $desc = '') is export {
     $time_after = nqp::p6box_n(nqp::time_n);
-    my $tol = $expected.abs < 1e-6 ?? 1e-5 !! $expected.abs * 1e-6;
-    my $test = ($got - $expected).abs <= $tol;
+    my $abs-diff = ($got - $expected).abs;
+    my $abs-max = max($got.abs, $expected.abs);
+    my $tol = 1e-6;
+    my $test = $abs-diff/$abs-max <= $tol;
+    my $ok = proclaim(?$test, $desc);
+    unless $test {
+	diag("expected: $expected");
+	diag("got:      $got");
+    }
+    $time_before = nqp::p6box_n(nqp::time_n);
+    return $ok;
+}
     my $ok = proclaim(?$test, $desc);
     unless $test {
         diag("expected: $expected");

--- a/lib/Test.pm
+++ b/lib/Test.pm
@@ -152,19 +152,14 @@ multi sub cmp_ok(Mu $got, $op, Mu $expected, $desc = '') is export {
 }
 
 multi sub is_approx(Mu $got, Mu $expected, $desc = '') is export {
+    return is_approx($got, $expected, 1e-6, $desc);
+}
+
+multi sub is_approx(Mu $got, Mu $expected, Num $tol, $desc = '') is export {
     $time_after = nqp::p6box_n(nqp::time_n);
     my $abs-diff = ($got - $expected).abs;
     my $abs-max = max($got.abs, $expected.abs);
-    my $tol = 1e-6;
     my $test = $abs-diff/$abs-max <= $tol;
-    my $ok = proclaim(?$test, $desc);
-    unless $test {
-	diag("expected: $expected");
-	diag("got:      $got");
-    }
-    $time_before = nqp::p6box_n(nqp::time_n);
-    return $ok;
-}
     my $ok = proclaim(?$test, $desc);
     unless $test {
         diag("expected: $expected");

--- a/lib/Test.pm
+++ b/lib/Test.pm
@@ -171,6 +171,25 @@ multi sub is_approx(Numeric $got, Numeric $expected, Numeric $tol, $desc = '') i
     return $ok;
 }
 
+multi sub is_approx(Numeric $got, Numeric $expected,
+                    Numeric :$rel_tol = 1e-6, Numeric :$abs_tol = 0,
+		    :$desc = '') is export {
+    $time_after = nqp::p6box_n(nqp::time_n);
+    die "Relative tolerance must be a positive number greater than zero" unless $rel_tol > 0;
+    die "Absolute tolerance must be a positive number greater than zero" unless $abs_tol > 0;
+    my $abs-diff = ($got - $expected).abs;
+    my $test = (($abs-diff <= ($rel_tol * $expected).abs) &&
+	       ($abs-diff <= ($rel_tol * $got).abs) ||
+	       ($abs-diff <= $abs_tol));
+    my $ok = proclaim(?$test, $desc);
+    unless $test {
+        diag("expected: $expected");
+        diag("got:      $got");
+    }
+    $time_before = nqp::p6box_n(nqp::time_n);
+    return $ok;
+}
+
 multi sub todo($reason, $count = 1) is export {
     $time_after = nqp::p6box_n(nqp::time_n);
     $todo_upto_test_num = $num_of_tests_run + $count;

--- a/lib/Test.pm
+++ b/lib/Test.pm
@@ -157,6 +157,7 @@ multi sub is_approx(Numeric $got, Numeric $expected, $desc = '') is export {
 
 multi sub is_approx(Numeric $got, Numeric $expected, Numeric $tol, $desc = '') is export {
     $time_after = nqp::p6box_n(nqp::time_n);
+    die "Tolerance must be a positive number greater than zero" unless $tol > 0;
     my $abs-diff = ($got - $expected).abs;
     my $abs-max = max($got.abs, $expected.abs);
     my $test = $abs-diff/$abs-max <= $tol;

--- a/lib/Test.pm
+++ b/lib/Test.pm
@@ -160,7 +160,8 @@ multi sub is_approx(Numeric $got, Numeric $expected, Numeric $tol, $desc = '') i
     die "Tolerance must be a positive number greater than zero" unless $tol > 0;
     my $abs-diff = ($got - $expected).abs;
     my $abs-max = max($got.abs, $expected.abs);
-    my $test = $abs-diff/$abs-max <= $tol;
+    my $rel-diff = $abs-max == 0 ?? 0 !! $abs-diff/$abs-max;
+    my $test = $rel-diff <= $tol;
     my $ok = proclaim(?$test, $desc);
     unless $test {
         diag("expected: $expected");

--- a/t/02-rakudo/01-is_approx.t
+++ b/t/02-rakudo/01-is_approx.t
@@ -2,6 +2,7 @@ use v6;
 use lib 'lib';
 use Test;
 
+plan 11;
 
 # "large" numbers
 {
@@ -15,9 +16,11 @@ use Test;
 
     # expect to fail with current implementation
     $not_quite_sol = 2.99793e8;
-    is_approx($not_quite_sol, $speed_of_light,
-        "should fail; approx *not* within 1e-5");
+    my $message = "should fail; approx *not* within 1e-5";
+    todo $message;
+    my $ok = is_approx($not_quite_sol, $speed_of_light, $message);
     # however is not "within" 1e-5 but differ by 542
+    nok($ok);
 }
 
 # "normal" numbers
@@ -31,8 +34,10 @@ use Test;
 
     # expect to fail with current implementation
     $not_quite_ec = 2.71829;
-    is_approx($not_quite_ec, $eulers_constant,
-        "should fail; approx *not* within 1e-5");
+    my $message = "should fail; approx *not* within 1e-5";
+    todo $message;
+    my $ok = is_approx($not_quite_ec, $eulers_constant, $message);
+    nok($ok, $message);
 }
 
 # "small" numbers
@@ -46,18 +51,19 @@ use Test;
 
     # expect to fail with current implementation
     $not_quite_pc = 6.62608e-34;
-    is_approx($not_quite_pc, $plancks_constant,
-        "should fail; approx *not* within 1e-5");
+    my $message = "should fail; approx *not* within 1e-5";
+    todo $message;
+    my $ok = is_approx($not_quite_pc, $plancks_constant, $message);
+    nok($ok, $message);
     # however passes, since numbers themselves are smaller than 1e-5
 
     # *really* expect to fail with current implementation
     $not_quite_pc = 16.62608e-34;
-    is_approx($not_quite_pc, $plancks_constant,
-        "should fail; approx *not* within 1e-5");
+    $message = "should fail; approx *not* within 1e-5";
+    todo $message;
+    $ok = is_approx($not_quite_pc, $plancks_constant, $message);
+    nok($ok, $message);
     # however passes, since numbers themselves are smaller than 1e-5
 }
-
-done;
-
 
 # vim: expandtab shiftwidth=4 ft=perl6

--- a/t/02-rakudo/01-is_approx.t
+++ b/t/02-rakudo/01-is_approx.t
@@ -1,0 +1,63 @@
+use v6;
+use lib 'lib';
+use Test;
+
+
+# "large" numbers
+{
+    my $speed_of_light = 2.99792458e8;
+    my $not_quite_sol = 2.997925e8;
+
+    # expect to pass with current implementation
+    is_approx($not_quite_sol, $speed_of_light,
+        "approx within 1e-5");
+    # however is not "within" 1e-5 but differ by 42
+
+    # expect to fail with current implementation
+    $not_quite_sol = 2.99793e8;
+    is_approx($not_quite_sol, $speed_of_light,
+        "should fail; approx *not* within 1e-5");
+    # however is not "within" 1e-5 but differ by 542
+}
+
+# "normal" numbers
+{
+    my $eulers_constant = 2.71828182;
+    my $not_quite_ec = 2.71828;
+
+    # expect to pass with current implementation
+    is_approx($not_quite_ec, $eulers_constant,
+        "approx within 1e-5");
+
+    # expect to fail with current implementation
+    $not_quite_ec = 2.71829;
+    is_approx($not_quite_ec, $eulers_constant,
+        "should fail; approx *not* within 1e-5");
+}
+
+# "small" numbers
+{
+    my $plancks_constant = 6.62609657e-34;
+    my $not_quite_pc = 6.62609e-34;
+
+    # expect to pass with current implementation
+    is_approx($not_quite_pc, $plancks_constant,
+        "should pass; approx within 1e-5");
+
+    # expect to fail with current implementation
+    $not_quite_pc = 6.62608e-34;
+    is_approx($not_quite_pc, $plancks_constant,
+        "should fail; approx *not* within 1e-5");
+    # however passes, since numbers themselves are smaller than 1e-5
+
+    # *really* expect to fail with current implementation
+    $not_quite_pc = 16.62608e-34;
+    is_approx($not_quite_pc, $plancks_constant,
+        "should fail; approx *not* within 1e-5");
+    # however passes, since numbers themselves are smaller than 1e-5
+}
+
+done;
+
+
+# vim: expandtab shiftwidth=4 ft=perl6

--- a/t/02-rakudo/02-new-is_approx.t
+++ b/t/02-rakudo/02-new-is_approx.t
@@ -2,10 +2,10 @@ use v6;
 use lib 'lib';
 use Test;
 
-plan 19;
+plan 5;
 
 # "large" numbers
-{
+subtest {
     my $speed_of_light = 2.99792458e8;
     my $not_quite_sol = 2.997925e8;
 
@@ -19,10 +19,10 @@ plan 19;
     todo $message;
     my $ok = is_approx($not_quite_sol, $speed_of_light, $message);
     nok($ok, $message);
-}
+}, "check behaviour of 'large' numbers";
 
 # "normal" numbers
-{
+subtest {
     my $eulers_constant = 2.71828182;
     my $not_quite_ec = 2.71828;
 
@@ -36,10 +36,10 @@ plan 19;
     todo $message;
     my $ok = is_approx($not_quite_ec, $eulers_constant, $message);
     nok($ok, $message);
-}
+}, "check behaviour of 'normal' numbers";
 
 # "small" numbers
-{
+subtest {
     my $plancks_constant = 6.62609657e-34;
     my $not_quite_pc = 6.62609e-34;
 
@@ -72,24 +72,24 @@ plan 19;
     todo $message;
     $ok = is_approx($not_quite_pc, $plancks_constant, 1e-7, $message);
     nok($ok, $message);
-}
+}, "check behaviour of 'small' numbers";
 
 # check tolerance input
-{
+subtest {
     my $message = "should fail; cannot use negative tolerance values";
     dies_ok { is_approx(1, 1, -1, $message) }, $message;
 
     $message = "should fail; cannot use a zero tolerance value";
     dies_ok { is_approx(1, 1, 0, $message) }, $message;
-}
+}, "check tolerance input";
 
 # symmetry
-{
+subtest {
     my $pi = 3.14159265358979;
     my $almost_pi = 3.141592;
     my $ok_p_ap = is_approx($pi, $almost_pi, "pi is approximately almost_pi");
     my $ok_ap_p = is_approx($almost_pi, $pi, "almost_pi is approximately pi");
     ok($ok_p_ap && $ok_ap_p, "is_approx is symmetric under argument change");
-}
+}, "check symmetry with respect to argument swapping";
 
 # vim: expandtab shiftwidth=4 ft=perl6

--- a/t/02-rakudo/02-new-is_approx.t
+++ b/t/02-rakudo/02-new-is_approx.t
@@ -2,6 +2,8 @@ use v6;
 use lib 'lib';
 use Test;
 
+plan 14;
+
 # "large" numbers
 {
     my $speed_of_light = 2.99792458e8;
@@ -13,8 +15,10 @@ use Test;
 
     # expect to fail: *not* within precision tolerance
     $not_quite_sol = 2.99793e8;
-    is_approx($not_quite_sol, $speed_of_light,
-        "should fail; approx *not* within precision");
+    my $message = "should fail; approx *not* within precision";
+    todo $message;
+    my $ok = is_approx($not_quite_sol, $speed_of_light, $message);
+    nok($ok, $message);
 }
 
 # "normal" numbers
@@ -28,8 +32,10 @@ use Test;
 
     # expect to fail: *not* within precision tolerance
     $not_quite_ec = 2.71829;
-    is_approx($not_quite_ec, $eulers_constant,
-        "should fail; approx *not* within precision");
+    my $message = "should fail; approx *not* within precision";
+    todo $message;
+    my $ok = is_approx($not_quite_ec, $eulers_constant, $message);
+    nok($ok, $message);
 }
 
 # "small" numbers
@@ -43,13 +49,17 @@ use Test;
 
     # expect to fail: *not* within precision tolerance
     $not_quite_pc = 6.62608e-34;
-    is_approx($not_quite_pc, $plancks_constant,
-        "should fail; approx *not* within precision");
+    my $message = "should fail; approx *not* within precision";
+    todo $message;
+    my $ok = is_approx($not_quite_pc, $plancks_constant, $message);
+    nok($ok, $message);
 
     # *really* expect to fail: *not* within precision tolerance
+    $message = "should fail; approx *really* *not* within precision";
     $not_quite_pc = 16.62608e-34;
-    is_approx($not_quite_pc, $plancks_constant,
-        "should fail; approx *really* *not* within precision");
+    todo $message;
+    $ok = is_approx($not_quite_pc, $plancks_constant, $message);
+    nok($ok, $message);
 
     # expect to pass within specified precision
     $not_quite_pc = 6.62608e-34;
@@ -57,12 +67,11 @@ use Test;
         "should pass; approx within explicit precision");
 
     # expect to fail; *not* within specified precision
+    $message = "should fail; approx *not* within explicit precision";
     $not_quite_pc = 6.62608e-34;
-    is_approx($not_quite_pc, $plancks_constant, 1e-7,
-        "should fail; approx *not* within explicit precision");
+    todo $message;
+    $ok = is_approx($not_quite_pc, $plancks_constant, 1e-7, $message);
+    nok($ok, $message);
 }
-
-done;
-
 
 # vim: expandtab shiftwidth=4 ft=perl6

--- a/t/02-rakudo/02-new-is_approx.t
+++ b/t/02-rakudo/02-new-is_approx.t
@@ -1,0 +1,68 @@
+use v6;
+use lib 'lib';
+use Test;
+
+# "large" numbers
+{
+    my $speed_of_light = 2.99792458e8;
+    my $not_quite_sol = 2.997925e8;
+
+    # expect to pass: within precision tolerance
+    is_approx($not_quite_sol, $speed_of_light,
+        "approx within precision");
+
+    # expect to fail: *not* within precision tolerance
+    $not_quite_sol = 2.99793e8;
+    is_approx($not_quite_sol, $speed_of_light,
+        "should fail; approx *not* within precision");
+}
+
+# "normal" numbers
+{
+    my $eulers_constant = 2.71828182;
+    my $not_quite_ec = 2.71828;
+
+    # expect to pass: within precision tolerance
+    is_approx($not_quite_ec, $eulers_constant,
+        "approx within precision");
+
+    # expect to fail: *not* within precision tolerance
+    $not_quite_ec = 2.71829;
+    is_approx($not_quite_ec, $eulers_constant,
+        "should fail; approx *not* within precision");
+}
+
+# "small" numbers
+{
+    my $plancks_constant = 6.62609657e-34;
+    my $not_quite_pc = 6.62609e-34;
+
+    # expect to pass: within precision tolerance
+    is_approx($not_quite_pc, $plancks_constant,
+        "should pass; within precision");
+
+    # expect to fail: *not* within precision tolerance
+    $not_quite_pc = 6.62608e-34;
+    is_approx($not_quite_pc, $plancks_constant,
+        "should fail; approx *not* within precision");
+
+    # *really* expect to fail: *not* within precision tolerance
+    $not_quite_pc = 16.62608e-34;
+    is_approx($not_quite_pc, $plancks_constant,
+        "should fail; approx *really* *not* within precision");
+
+    # expect to pass within specified precision
+    $not_quite_pc = 6.62608e-34;
+    is_approx($not_quite_pc, $plancks_constant, 1e-5,
+        "should pass; approx within explicit precision");
+
+    # expect to fail; *not* within specified precision
+    $not_quite_pc = 6.62608e-34;
+    is_approx($not_quite_pc, $plancks_constant, 1e-7,
+        "should fail; approx *not* within explicit precision");
+}
+
+done;
+
+
+# vim: expandtab shiftwidth=4 ft=perl6

--- a/t/02-rakudo/02-new-is_approx.t
+++ b/t/02-rakudo/02-new-is_approx.t
@@ -2,7 +2,7 @@ use v6;
 use lib 'lib';
 use Test;
 
-plan 5;
+plan 6;
 
 # "large" numbers
 subtest {
@@ -82,6 +82,18 @@ subtest {
     $message = "should fail; cannot use a zero tolerance value";
     dies_ok { is_approx(1, 1, 0, $message) }, $message;
 }, "check tolerance input";
+
+# expected value is zero
+subtest {
+    is_approx(0.000001, 0, abs_tol => 1e-6, desc => "approximately zero");
+    is_approx(0.000001, 0, rel_tol => 1e-6, abs_tol => 1e-6,
+              desc => "approximately zero");
+
+    my $message = "should fail; not approximately zero";
+    todo $message;
+    my $ok = is_approx(0.00001, 0, abs_tol => 1e-6, desc => $message);
+    nok($ok, $message);
+}, "check behaviour when input values are around zero";
 
 # symmetry
 subtest {

--- a/t/02-rakudo/02-new-is_approx.t
+++ b/t/02-rakudo/02-new-is_approx.t
@@ -2,7 +2,7 @@ use v6;
 use lib 'lib';
 use Test;
 
-plan 14;
+plan 16;
 
 # "large" numbers
 {
@@ -72,6 +72,15 @@ plan 14;
     todo $message;
     $ok = is_approx($not_quite_pc, $plancks_constant, 1e-7, $message);
     nok($ok, $message);
+}
+
+# check tolerance input
+{
+    my $message = "should fail; cannot use negative tolerance values";
+    dies_ok { is_approx(1, 1, -1, $message) }, $message;
+
+    $message = "should fail; cannot use a zero tolerance value";
+    dies_ok { is_approx(1, 1, 0, $message) }, $message;
 }
 
 # vim: expandtab shiftwidth=4 ft=perl6

--- a/t/02-rakudo/02-new-is_approx.t
+++ b/t/02-rakudo/02-new-is_approx.t
@@ -2,7 +2,7 @@ use v6;
 use lib 'lib';
 use Test;
 
-plan 6;
+plan 7;
 
 # "large" numbers
 subtest {
@@ -103,5 +103,11 @@ subtest {
     my $ok_ap_p = is_approx($almost_pi, $pi, "almost_pi is approximately pi");
     ok($ok_p_ap && $ok_ap_p, "is_approx is symmetric under argument change");
 }, "check symmetry with respect to argument swapping";
+
+# check behaviour of equal values
+subtest {
+    my $pi = 3.14159265358979;
+    is_approx($pi, 3.14159265358979, "equal values around one order of magnitude");
+}, "check behaviour of equal values";
 
 # vim: expandtab shiftwidth=4 ft=perl6

--- a/t/02-rakudo/02-new-is_approx.t
+++ b/t/02-rakudo/02-new-is_approx.t
@@ -2,7 +2,7 @@ use v6;
 use lib 'lib';
 use Test;
 
-plan 16;
+plan 19;
 
 # "large" numbers
 {
@@ -81,6 +81,15 @@ plan 16;
 
     $message = "should fail; cannot use a zero tolerance value";
     dies_ok { is_approx(1, 1, 0, $message) }, $message;
+}
+
+# symmetry
+{
+    my $pi = 3.14159265358979;
+    my $almost_pi = 3.141592;
+    my $ok_p_ap = is_approx($pi, $almost_pi, "pi is approximately almost_pi");
+    my $ok_ap_p = is_approx($almost_pi, $pi, "almost_pi is approximately pi");
+    ok($ok_p_ap && $ok_ap_p, "is_approx is symmetric under argument change");
 }
 
 # vim: expandtab shiftwidth=4 ft=perl6


### PR DESCRIPTION
While documenting the `is_approx()` test function behaviour I was confused by a (potentially only perceived by me) difference between the specs and the actual behaviour.  Namely, the specs say that `is_approx` will return True when two numbers are within 1e-5 of one another.  This implies to me something like this:

    return ($got - $expected).abs <= 1e-5;

However, the implementation allows large numbers to be "approximately equal" if 6 significant digits (i.e. not "within 1e-5") are the same.  In other words:

    my $speed_of_light = 2.99792458e8;
    my $not_quite_sol = 2.997925e8;
    is_approx($not_quite_sol, $speed_of_light);   # returns True, however differ by 42

On the other hand, small numbers (e.g. smaller than 1e-6) are always "approximately equal" even if the values are wildly different:

    my $plancks_constant = 6.62609657e-34;
    my $not_quite_pc = 16.62608e-34;
    is_approx($not_quite_pc, $plancks_constant);  # returns True, but *really* shouldn't

The reason that this returns True is that both numbers are smaller than 1e-5.

Due to this confusion, and after comparing this behaviour with other testing frameworks (e.g. http://docs.scipy.org/doc/numpy/reference/generated/numpy.testing.assert_approx_equal.html#numpy.testing.assert_approx_equal), I propose changing the current behaviour of `is_approx()` to consider two numbers to be approximately equal if they are equal up to a given number of significant digits.  This allows `is_approx()` to behave the same for the "large" and "small" numbers mentioned above and is thus a more general solution.

The proposed changes given in this PR are based upon http://en.wikipedia.org/wiki/Relative_change_and_difference#Formulas and http://c-faq.com/fp/fpequal.html.

The PR includes "tests", which are *not* intended to be merged, but merely programmatically to show in a more detailed manner what I mean here; both the current and proposed behaviour.

By making this change in behaviour, it was also possible to make `is_approx()` accept a variable tolerance.  Thus it is now possible to write code like this:

    is_approx($got, $expected, $tol = 1e-7, $description = "");

I realise this is a large change and could break a lot of code, thus I'd appreciate feedback as to how sensible this change is and whether or not it is appropriate.  It would, however, be very good to remove the ambiguity in the current behaviour.