### PR TITLE
Main single positional

### DIFF
--- a/src/core/Main.pm
+++ b/src/core/Main.pm
@@ -150,24 +150,37 @@ my sub MAIN_HELPER($retval = 0) is hidden_from_backtrace {
     @matching_candidates .=grep: {!has-unexpected-named-arguments($_.signature, $n)};
     # If there are still some candidates left, try to dispatch to MAIN
     if +@matching_candidates {
-        return $m(|@($p), |%($n));
-    }
-    # if there aren't any, try to see if we can find a candidate that wants a named array param
-    # where we only got one occurence on command line invocation
-    else {
-        my $found = False;
-        for %($n).keys -> $named_arg {
-            for $m.candidates -> $cand {
-                for $cand.signature.params -> $param {
-                    if $param.named_names eq $named_arg && $param.type ~~ Positional {
-                        $found = True;
-                        %($n){$named_arg} = [%($n){$named_arg}];
-                        last;
+        # verify that we don't dispatch multiple occurences of a command line argument
+        # to a parameter that is a Scalar
+        if %($n).grep: { .value ~~ Positional } -> @pairs {
+            for @pairs -> $pair {
+                for @matching_candidates -> $cand {
+                    my @param = $cand.signature.params.grep: { .named_names eq $pair.key };
+                    for @param {
+                        if $_.type ~~ Positional {
+                            return $cand(|@($p), |%($n));
+                        }
                     }
                 }
             }
         }
-        return $m(|@($p), |%($n)) if $found;
+        else {
+            return $m(|@($p), |%($n));
+        }
+    }
+    # if there aren't any, try to see if we can find a candidate that wants a named array param
+    # where we only got one occurence on command line invocation
+    else {
+        for %($n).keys -> $named_arg {
+            for $m.candidates -> $cand {
+                for $cand.signature.params -> $param {
+                    if $param.named_names eq $named_arg && $param.type ~~ Positional {
+                        %($n){$named_arg} = [%($n){$named_arg}];
+                        return $cand(|@($p), |%($n));
+                    }
+                }
+            }
+        }
     }
 
     # We could not find the correct MAIN to dispatch to!

--- a/src/core/Main.pm
+++ b/src/core/Main.pm
@@ -152,6 +152,23 @@ my sub MAIN_HELPER($retval = 0) is hidden_from_backtrace {
     if +@matching_candidates {
         return $m(|@($p), |%($n));
     }
+    # if there aren't any, try to see if we can find a candidate that wants a named array param
+    # where we only got one occurence on command line invocation
+    else {
+        my $found = False;
+        for %($n).keys -> $named_arg {
+            for $m.candidates -> $cand {
+                for $cand.signature.params -> $param {
+                    if $param.named_names eq $named_arg && $param.type ~~ Positional {
+                        $found = True;
+                        %($n){$named_arg} = [%($n){$named_arg}];
+                        last;
+                    }
+                }
+            }
+        }
+        return $m(|@($p), |%($n)) if $found;
+    }
 
     # We could not find the correct MAIN to dispatch to!
     # Let's try to run a user defined USAGE sub


### PR DESCRIPTION
This PR brings handling of arguments to the programm more in line with what Getopt::Long would do. I.e. a parameter that is declared as Scalar (like in «sub MAIN(:$foo) { ... }») cannot be dispatched to by multiple occurences of a command line switch of the same name.