### PR TITLE
Better diagnostics in Test::is for strings differing only in whitespace

### DIFF
--- a/lib/Test.pm
+++ b/lib/Test.pm
@@ -134,8 +134,15 @@ multi sub is(Mu $got, Mu:D $expected, $desc = '') is export {
         my $test = $got eq $expected;
         $ok = proclaim(?$test, $desc);
         if !$test {
-            diag "expected: '$expected'";
-            diag "     got: '$got'";
+            if [eq] ($got, $expected)>>.subst(/\s/, '', :g) {
+                # only white space differs, so better show it to the user
+                diag "expected: {$expected.perl}";
+                diag "     got: {$got.perl}";
+            }
+            else {
+                diag "expected: '$expected'";
+                diag "     got: '$got'";
+            }
         }
     }
     else {


### PR DESCRIPTION
If the expected value differs from the got value only by whitespace at
the end of a line, it's very hard to find this difference. Using .perl
for the diag output on the other hand makes it trivial to find
whitespace differences.

With this patch is("foo \nbar baz", "foo\nbar baz"); gives:
expected: "foo\nbar baz"
     got: "foo \nbar baz"