### PR TITLE
Allow whitespace between named parameter and closing parenthesis

### DIFF
--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -2964,8 +2964,8 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         :dba('named parameter')
         ':'
         [
-        | <name=.identifier> '(' <.ws>
-            [ <named_param> | <param_var> <.ws> ]
+        | <name=.identifier> '(' 
+            <.ws> [ <named_param> | <param_var> ] <.ws>
             [ ')' || <.panic: 'Unable to parse named parameter; couldnt find right parenthesis'> ]
         | <param_var>
         ]


### PR DESCRIPTION
for multi-name argument parsing

fixes RT #123956