### PR TITLE
Flatten return values from SEQUENCE

### DIFF
--- a/src/core/operators.pm
+++ b/src/core/operators.pm
@@ -198,7 +198,12 @@ sub SEQUENCE($left, Mu $right, :$exclude_end) {
                         last if $value ~~ $endpoint;
                     }
                     $tail.push($value);
-                    take $value;
+                    if $value {
+                        take $value.flat
+                    }
+                    else { ## special case for returning ()
+                        take $value;
+                    }
                 }
             }
             elsif $badseq {


### PR DESCRIPTION
-- except when returning the empty list '()'

Fixes RT #80574 and makes 3 fudged tests in S03-sequence/misc.t pass