### PR TITLE
Better handling of generator function for sequence

### DIFF
--- a/src/core/operators.pm
+++ b/src/core/operators.pm
@@ -187,6 +187,7 @@ sub SEQUENCE($left, Mu $right, :$exclude_end) {
                 my $count = $code.count;
                 while 1 {
                     $tail.munch($tail.elems - $count);
+                    $value := Nil;  ## reset; $code can end loop via 'last'
                     $value := $code(|$tail);
                     if $end_code_arity != 0 {
                         $end_tail.push($value);

--- a/src/core/operators.pm
+++ b/src/core/operators.pm
@@ -188,7 +188,12 @@ sub SEQUENCE($left, Mu $right, :$exclude_end) {
                 while 1 {
                     $tail.munch($tail.elems - $count);
                     $value := Nil;  ## reset; $code can end loop via 'last'
-                    $value := $code(|$tail);
+                    try {
+                        $value := $code(|$tail);
+                        CATCH {
+                            when X::TypeCheck::Binding { last };
+                        }
+                    };
                     if $end_code_arity != 0 {
                         $end_tail.push($value);
                         if $end_tail.elems >= $end_code_arity {


### PR DESCRIPTION
fixes example ```'10,9,8, { $_ - 1 || last } ... *'``` from S03

also implement the following from S03: "If the signature of the [generator] function does not match the existing values, the sequence terminates."