### PR TITLE
Don't return previous value when generator function of sequence calls 'last'

### DIFF
--- a/src/core/operators.pm
+++ b/src/core/operators.pm
@@ -187,6 +187,7 @@ sub SEQUENCE($left, Mu $right, :$exclude_end) {
                 my $count = $code.count;
                 while 1 {
                     $tail.munch($tail.elems - $count);
+                    $value := Nil; ## don't return previous value when 'last' is called from $code
                     $value := $code(|$tail);
                     if $end_code_arity != 0 {
                         $end_tail.push($value);


### PR DESCRIPTION

fixes things like '```say 10,9,8, { $_ - 1 || last } ... *```'