### PR TITLE
Terminate sequence when values do not match signature of generator function

### DIFF
--- a/src/core/operators.pm
+++ b/src/core/operators.pm
@@ -187,8 +187,13 @@ sub SEQUENCE($left, Mu $right, :$exclude_end) {
                 my $count = $code.count;
                 while 1 {
                     $tail.munch($tail.elems - $count);
-                    $value := Nil; ## don't return previous value when 'last' is called from $code
-                    $value := $code(|$tail);
+                    $value := Nil; ## don't return previous value when 'last' is called in next block
+                    try {
+                        $value := $code(|$tail);
+                        CATCH {
+                            when X::TypeCheck::Binding { last };
+                        }
+                    };
                     if $end_code_arity != 0 {
                         $end_tail.push($value);
                         if $end_tail.elems >= $end_code_arity {


### PR DESCRIPTION
S03 states: "A sequence generated from an explicit function places no type constraints on the sequence other than those constraints implied by the signature of the function. If the signature of the function does not match the existing values, the sequence terminates."

Currently the exception X::TypeCheck::Binding (from the violation of type constraint of the generator function) is not handled. The following example dies: ```sub f (Int $n) { $n > 3 ?? "liftoff!" !! $n + 1 }; say 1, &f ... *```