### PR TITLE
Fix "Cannot look up attributes in a type object" in generated scripts

### DIFF
--- a/src/core/CompUnitRepo/Local/Installation.pm
+++ b/src/core/CompUnitRepo/Local/Installation.pm
@@ -34,9 +34,10 @@ __END__
 ';
     my $perl_wrapper = '#!/usr/bin/env #perl#
 sub MAIN(:$name, :$auth, :$ver, *@pos, *%named) {
-    my @binaries = CompUnitRepo::Local::Installation.files(\'bin/#name#\', :$name, :$auth, :$ver);
+    my @installations = @*INC.grep(CompUnitRepo::Local::Installation);
+    my @binaries = @installations>>.files(\'bin/#name#\', :$name, :$auth, :$ver);
     unless +@binaries {
-        @binaries = CompUnitRepo::Local::Installation.files(\'bin/#name#\');
+        @binaries = @installations>>.files(\'bin/#name#\');
         if +@binaries {
             note q:to/SORRY/;
                 ===SORRY!===


### PR DESCRIPTION
The panda script failed with "Cannot look up attributes in a type object
in method files at src/gen/m-CORE.setting:26732". Seems like files()
expects to be called on an object. CompUnitRepo objects are to be found
in @*INC.