### PR TITLE
Fix RT #124204 in squish: Do not .Str the return value of &as, in order ...

### DIFF
--- a/src/core/List.pm
+++ b/src/core/List.pm
@@ -503,11 +503,11 @@ my class List does Positional { # declared in BOOTSTRAP
     proto method squish(|) {*}
     multi method squish( :&as!, :&with = &[===] ) {
         my $last = @secret;
-        my str $which;
+        my $as;
         gather for @.list {
-            $which = &as($_).Str;
-            unless with($which,$last) {
-                $last = $which;
+            $as = &as($_);
+            unless with($as,$last) {
+                $last = $as;
                 take $_;
             }
         }


### PR DESCRIPTION
...to

keep objects distinguishable for the comparison operator used (=== by default).
