### PR TITLE
Report correct line numbers for failing tests

### DIFF
--- a/lib/Test.pm
+++ b/lib/Test.pm
@@ -461,9 +461,12 @@ sub proclaim($cond, $desc) {
       ~ "\n"
         if $perl6_test_times;
 
-    my $caller = callframe(3); # due to a bug in MoarVM, this callframe has to occur outside of the
-                               # unless block (see https://github.com/MoarVM/MoarVM/issues/120)
     unless $cond {
+        my $caller;
+        my $level = 3; # sub proclaim is not called directly, so 3 is minimum level
+        repeat until $caller.file ne $?FILE {
+            $caller = callframe($level++);
+        }
         if $desc ne '' {
             diag "\nFailed test '$desc'\nat {$caller.file} line {$caller.line}";
         } else {


### PR DESCRIPTION
The hard coded level for callframe we had before did only match in some cases.
Now we're looking outwards until we leave Test.pm

Additionally we can grab the call frame from within conditional,
since the bug which prevented that seems to be gone (cmp. commit 4111fa43ca).