### PR TITLE
The -K flag to uname wasn't introduced until FreeBSD 10.0

### DIFF
--- a/src/core/Kernel.pm
+++ b/src/core/Kernel.pm
@@ -33,7 +33,7 @@ class Kernel does Systemic {
         $!version //= Version.new( do {
             given $*DISTRO.name {
                 when 'freebsd' {
-                    uname '-K';
+                    uname '-r'; # -K -U not introduced until 10.0
                 }
                 when 'macosx' {
                     my $unamev = uname '-v';


### PR DESCRIPTION
use -r as next best thing

Found while testing on FreeBSD 8.4 and 9.1