### PR TITLE
Gracefully handle .gist on unthrown exceptions

### DIFF
--- a/src/core/Exception.pm
+++ b/src/core/Exception.pm
@@ -14,6 +14,7 @@ my class Exception {
     multi method gist(Exception:D:) {
         my $str = try self.?message;
         return "Error while creating error string: $!" if $!;
+        return $str unless nqp::isconcrete($!ex);
         $str ~= "\n";
         try $str ~= self.backtrace;
         return "$str\nError while creating backtrace: $!.message()\n$!.backtrace.full();" if $!;


### PR DESCRIPTION
If an exception is created and not thrown, and gist is called on it, the backtrace op is called without a VM-level exception object, and a long backtrace about not being able to make a backtrace is produced and appended to the gist.  This patch makes .gist simply print the Exception's message if it is called before the exception is thrown.

Spectested fine.
