### PR TITLE
Crude implementation of $*HOME

### DIFF
--- a/src/core/Process.pm
+++ b/src/core/Process.pm
@@ -36,6 +36,22 @@ multi sub INITIALIZE_DYNAMIC('$*TMPDIR') {
     PROCESS::<$TMPDIR> = $*SPEC.tmpdir;
 }
 
+multi sub INITIALIZE_DYNAMIC('$*HOME') {
+    my $HOME;
+
+    if %*ENV<HOME>.defined {
+        $HOME = %*ENV<HOME>;
+    }
+    else {
+        given $*DISTRO.name {
+            when 'MSWin32' {
+                $HOME = %*ENV<HOMEDRIVE> ~ %*ENV<HOMEPATH>;
+            }
+        }
+    }
+    PROCESS::<$HOME> = $HOME.defined ?? IO::Path.new($HOME) !! Nil;
+}
+
 {
     class IdName {
         has Int $!id;

--- a/src/core/Process.pm
+++ b/src/core/Process.pm
@@ -39,15 +39,11 @@ multi sub INITIALIZE_DYNAMIC('$*TMPDIR') {
 multi sub INITIALIZE_DYNAMIC('$*HOME') {
     my $HOME;
 
-    if %*ENV<HOME>.defined {
-        $HOME = %*ENV<HOME>;
+    if %*ENV<HOME> -> $home {
+        $HOME = $home;
     }
-    else {
-        given $*DISTRO.name {
-            when 'MSWin32' {
-                $HOME = %*ENV<HOMEDRIVE> ~ %*ENV<HOMEPATH>;
-            }
-        }
+    elsif $*DISTRO.is-win {
+        $HOME = %*ENV<HOMEDRIVE> ~ %*ENV<HOMEPATH>;
     }
     PROCESS::<$HOME> = $HOME.defined ?? IO::Path.new($HOME) !! Nil;
 }


### PR DESCRIPTION
Currently we get:

> say $*HOME;
Dynamic variable $*HOME not found
  in method gist at src/gen/m-CORE.setting:15985
  in sub say at src/gen/m-CORE.setting:18823
  in block <unit> at <unknown file>:1

> homedir("/tmp");
Dynamic variable $*HOME not found
  in method <anon> at src/gen/m-CORE.setting:15989
  in any find_method_fallback at src/gen/m-Metamodel.nqp:2908
  in any find_method at src/gen/m-Metamodel.nqp:1052
  in sub homedir at src/gen/m-CORE.setting:18988
  in block <unit> at <unknown file>:1

This fixes that in a somewhat naive way.

I'm aware that there is some code in newio that does this, but this is
just to get it working somewhat :)