### PR TITLE
add infix:<ne>(Str,Str) subs, skip metaop for ne(Any, Any)

### DIFF
--- a/src/core/Str.pm
+++ b/src/core/Str.pm
@@ -1453,6 +1453,13 @@ multi sub infix:<eq>(str $a, str $b) returns Bool:D {
     nqp::p6bool(nqp::iseq_s($a, $b))
 }
 
+multi sub infix:<ne>(Str:D \a, Str:D \b) returns Bool:D {
+    nqp::p6bool(nqp::isne_s(nqp::unbox_s(a), nqp::unbox_s(b)))
+}
+multi sub infix:<ne>(str $a, str $b) returns Bool:D {
+    nqp::p6bool(nqp::isne_s($a, $b))
+}
+
 multi sub infix:<lt>(Str:D \a, Str:D \b) returns Bool:D {
     nqp::p6bool(nqp::islt_s(nqp::unbox_s(a), nqp::unbox_s(b)))
 }

--- a/src/core/Stringy.pm
+++ b/src/core/Stringy.pm
@@ -28,6 +28,7 @@ multi sub infix:<eq>(\a, \b)       { a.Stringy eq b.Stringy }
 proto sub infix:<ne>(Mu $?, Mu $?) is pure { * }
 multi sub infix:<ne>($x?)            { Bool::True }
 multi sub infix:<ne>(Mu \a, Mu \b)   { a !eq b }
+multi sub infix:<ne>(Any \a, Any \b) { a.Stringy ne b.Stringy }
 
 proto sub infix:<lt>(Mu $?, Mu $?) is pure { * }
 multi sub infix:<lt>($x?)          { Bool::True }


### PR DESCRIPTION
Makes string `ne` much closer in speed to `eq` by using `nqp::isne_s()`.
28-47% faster, depending on how many of the args are strings.

The reason I'm creating a PR is because I screwed this up like 2 years ago, but I think I have a better understanding of multi-dispatch now.  The key issue is that with junctions, `!eq` and string `ne` are not equivalent.  My understanding is that with Any, there is only one value to consider, so the `!eq` is equivalent to the simple comparision `a.Stringy ne b.Stringy` in this simpler subset.  If this is true, go ahead and merge.

Passes spectests.