### PR TITLE
Add typed exception X::NYI::Available

### DIFF
--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -3160,7 +3160,8 @@ my class Perl5ModuleLoaderStub {
         {
             nqp::gethllsym('perl6', 'ModuleLoader').load_module('Inline::Perl5', {}, @GLOBALish, :$line, :$file);
             CATCH {
-                nqp::die("Please install Inline::Perl5 for Perl 5 support");
+                $*W.find_symbol(nqp::list('X','NYI','Available')).new(
+                    :available('Inline::Perl5'), :feature('Perl 5')).throw;
             }
         }
 

--- a/src/core/Exception.pm
+++ b/src/core/Exception.pm
@@ -493,6 +493,18 @@ my class X::NYI is Exception {
     method message() { "$.feature not yet implemented. Sorry. " }
 }
 my class X::Comp::NYI is X::NYI does X::Comp { };
+my class X::NYI::Available is X::NYI {
+    has @.available = die("Must give :available<modules> for installation. ");
+    method available-str {
+        my @a = @.available;
+        my $a = @a.pop;
+        (@a.join(', ') || (), $a).join(" or ")
+    }
+    method message() {
+        "Please install { self.available-str } for $.feature support. "
+    }
+}
+
 
 my class X::Trait::Unknown is Exception {
     has $.type;       # is, will, of etc.


### PR DESCRIPTION

Use same for "use :from<Perl5>."

This is more for the ecosystem's use than internal, though.  A lot of
modules.perl6.org stuff has optional "dependencies" that are determined
at runtime rather than through Panda, because they are not needed
for most use-cases of the module.