### PR TITLE
More Proc::Status.exit -> .exitcode conversions

### DIFF
--- a/src/core/OS.pm
+++ b/src/core/OS.pm
@@ -12,7 +12,7 @@ my class Proc::Status {
     #~ method signal()   { $!signal }
 
     method exit {
-        DEPRECATED('Proc::Status.exit', |<2015.03 2015.09>);
+        DEPRECATED('Proc::Status.exitcode', |<2015.03 2015.09>);
         $!exitcode;
     }
 

--- a/src/core/Proc/Async.pm
+++ b/src/core/Proc/Async.pm
@@ -173,7 +173,7 @@ my class Proc::Async {
 
         my Mu $callbacks := nqp::hash();
         nqp::bindkey($callbacks, 'done', -> Mu \status {
-            $!exit_promise.keep(Proc::Status.new(:exit(status)))
+            $!exit_promise.keep(Proc::Status.new(:exitcode(status)))
         });
         nqp::bindkey($callbacks, 'error', -> Mu \err {
             $!exit_promise.break(X::OS.new(os-error => err));

--- a/src/core/control.pm
+++ b/src/core/control.pm
@@ -240,7 +240,7 @@ sub THE_END {
 my class Proc::Status { ... }
 
 sub run(*@args ($, *@)) {
-    my $status = Proc::Status.new( :exit(255) );
+    my $status = Proc::Status.new( :exitcode(255) );
     try {
         $status.status(nqp::p6box_i(nqp::spawn(
           CLONE-LIST-DECONTAINERIZED(@args),
@@ -252,7 +252,7 @@ sub run(*@args ($, *@)) {
 }
 
 sub shell($cmd) {
-    my $status = Proc::Status.new( :exit(255) );
+    my $status = Proc::Status.new( :exitcode(255) );
     try {
         $status.status(nqp::p6box_i(nqp::shell(
           $cmd,


### PR DESCRIPTION
Fixes the S17-procasync/basic.t failures mentioned at http://irclog.perlgeek.de/perl6/2015-04-23#i_10486443