### PR TITLE
Hook up windows-1252 charset support.

### DIFF
--- a/src/core/Str.pm
+++ b/src/core/Str.pm
@@ -17,6 +17,7 @@ sub NORMALIZE_ENCODING(Str:D $s) {
         'utf32'             => 'utf32',
         'ascii'             => 'ascii',
         'iso-8859-1'        => 'iso-8859-1',
+        'windows-1252'      => 'windows-1252',
         # with dash
         'utf-8'             => 'utf8',
         'utf-16'            => 'utf16',


### PR DESCRIPTION
This requires https://github.com/MoarVM/MoarVM/pull/210 and then https://github.com/perl6/nqp/pull/236

There is one crevace.  Java's stream support for Windows-1252 is strict.  If asked to decode three particular characters (0x81, 0x8d or 0x8f) from a file, it will raise an unmappable character exception, whereas the MoarVM code is more tolerant.

$ ./perl6-m -e 'slurp("/tmp/awful3.txt", enc=>"windows-1252").say'
¢€‚ƒ„…†‡ˆ‰Š
$ ./perl6-j -e 'slurp("/tmp/awful3.txt", enc=>"windows-1252").say'
java.nio.charset.UnmappableCharacterException: Input length = 1
  in method slurp at gen/jvm/CORE.setting:18757
  in sub slurp at gen/jvm/CORE.setting:19072
  in block <unit> at -e:1

... and for nonstreaming there is also a difference:

$ ./perl6-m -e "Buf.new(0x81).decode('windows-1252').say"

$ ./perl6-j -e "Buf.new(0x81).decode('windows-1252').say"
�

That probably needs attention from a java guy.


