### PR TITLE
Preserve $.timezone in DateTime.later()

### DIFF
--- a/src/core/Temporal.pm
+++ b/src/core/Temporal.pm
@@ -341,7 +341,7 @@ my class DateTime does Dateish {
 
         given $unit {
             when 'second' | 'seconds' {
-                return self.new(self.Instant + $amount, :$.timezone);
+                return self.new(self.Instant + $amount, :$.timezone, :&.formatter);
             }
 
             when 'minute' | 'minutes' { $minute += $amount; proceed }

--- a/src/core/Temporal.pm
+++ b/src/core/Temporal.pm
@@ -341,7 +341,7 @@ my class DateTime does Dateish {
 
         given $unit {
             when 'second' | 'seconds' {
-                return self.new(self.Instant + $amount);
+                return self.new(self.Instant + $amount, :timezone($.timezone));
             }
 
             when 'minute' | 'minutes' { $minute += $amount; proceed }
@@ -390,7 +390,7 @@ my class DateTime does Dateish {
                 }
             }
         }
-        self.new(:$date, :$hour, :$minute, :$second);
+        self.new(:$date, :$hour, :$minute, :$second, :timezone($.timezone));
     }
 
     method earlier(*%unit) {

--- a/src/core/Temporal.pm
+++ b/src/core/Temporal.pm
@@ -441,10 +441,12 @@ my class DateTime does Dateish {
     }
 
     method utc() {
-        self.in-timezone(0)
+	$.timezone.WHAT.say;
+	$.timezone.perl.say;
+        self.in-timezone($.timezone.new(0))
     }
     method local() {
-        self.in-timezone($*TZ)
+        self.in-timezone($.timezone.new(+$*TZ))
     }
 
     method Date() {

--- a/src/core/Temporal.pm
+++ b/src/core/Temporal.pm
@@ -390,7 +390,7 @@ my class DateTime does Dateish {
                 }
             }
         }
-        self.new(:$date, :$hour, :$minute, :$second, :$.timezone);
+        self.new(:$date, :$hour, :$minute, :$second, :$.timezone, :&.formatter);
     }
 
     method earlier(*%unit) {

--- a/src/core/Temporal.pm
+++ b/src/core/Temporal.pm
@@ -341,7 +341,7 @@ my class DateTime does Dateish {
 
         given $unit {
             when 'second' | 'seconds' {
-                return self.new(self.Instant + $amount, :timezone($.timezone));
+                return self.new(self.Instant + $amount, :$.timezone);
             }
 
             when 'minute' | 'minutes' { $minute += $amount; proceed }
@@ -390,7 +390,7 @@ my class DateTime does Dateish {
                 }
             }
         }
-        self.new(:$date, :$hour, :$minute, :$second, :timezone($.timezone));
+        self.new(:$date, :$hour, :$minute, :$second, :$.timezone);
     }
 
     method earlier(*%unit) {


### PR DESCRIPTION
These changes make the tests in roast/date-time-slices-tz pass.

My weekend time to work on this is about up, so I won't be coding again until next Saturday.

This fix is pretty straightforward, but there could be other "timezone gets sliced" fixes coming.  I dunno whether it makes sense to apply this one now, or wait to see if there are others.

