### PR TITLE
Don't print ", or" if @.available.elems == 1

### DIFF
--- a/src/core/Exception.pm
+++ b/src/core/Exception.pm
@@ -503,7 +503,7 @@ my class X::NYI::Available is X::NYI {
     method available-str {
         my @a = @.available;
         my $a = @a.pop;
-        (@a.join(', ') || (), $a).join(" or ")
+        @a ?? (@a.join(', ') || (), $a).join(" or ") !! $a;
     }
     method message() {
         "Please install { self.available-str } for $.feature support. "


### PR DESCRIPTION
    # Corrects this: Please install  or OpenSSL::fake for openssl support.

    require OpenSSL::fake;
    CATCH {
        default { X::NYI::Available.new(:available("OpenSSL::fake"), :feature("openssl")).throw };
    }