### PR TITLE
Fix undeclared variable error

### DIFF
--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -310,7 +310,7 @@ role STD {
 
                             CATCH {}
                         }
-                        $*W.throw($var, ['X', 'Undeclared'], symbol => $name, suggestions => @suggestions);
+                        $*W.throw($var, ['X', 'Undeclared'], symbol => $name, suggestions => @suggestions, precursor => '1');
                     }
                 }
                 else {


### PR DESCRIPTION
Previously it would show the cursor in a wrong (later) position and give inappropriate "expecting any of" suggestions based on that position. I'm a bit unclear on the details of this precursor thing, so please do review carefully before merging in case this is the wrong way to fix it, but what I saw seemed to suggest that precursor may be intended for these kinds of cases.