### PR TITLE
Support additional arguments to IO::Handle.open

### DIFF
--- a/src/core/IO/Handle.pm
+++ b/src/core/IO/Handle.pm
@@ -36,17 +36,17 @@ my class IO::Handle does IO {
 
         my $m = do given $mode {
             when '<'  { 'r' }
-            when '>'  { '-ct' }
-            when '>>' { '-ca' }
+            when '>'  { 'w' }
+            when '>>' { 'wa' }
 
             when '+<'  { '+' }
             when '+>'  { '+ct' }
             when '+>>' { '+ca' }
 
             when 'r'  { 'r' }
-            when 'w'  { '-ct' }
-            when 'a'  { '-ca' }
-            when 'wx' { '-cx' }
+            when 'w'  { 'w' }
+            when 'a'  { 'wa' }
+            when 'wx' { 'wx' }
 
             when 'r+'  { '+' }
             when 'w+'  { '+ct' }
@@ -54,9 +54,9 @@ my class IO::Handle does IO {
             when 'w+x' { '+cx' }
 
             when 'rb'  { $bin = True; 'r' }
-            when 'wb'  { $bin = True; '-ct' }
-            when 'ab'  { $bin = True; '-ca' }
-            when 'wbx' { $bin = True; '-cx' }
+            when 'wb'  { $bin = True; 'w' }
+            when 'ab'  { $bin = True; 'wa' }
+            when 'wbx' { $bin = True; 'wx' }
 
             when 'r+b' |'rb+'  { $bin = True; '+' }
             when 'w+b' |'wb+'  { $bin = True; '+ct' }
@@ -70,7 +70,7 @@ my class IO::Handle does IO {
             $!path = IO::Special.new:
                 what => do given $m.substr(0, 1) {
                     when 'r' { '<STDIN>'  }
-                    when '-' { '<STDOUT>' }
+                    when 'w' { '<STDOUT>' }
                     default {
                         die "Cannot open standard stream in mode '$mode'";
                     }


### PR DESCRIPTION
In addition to the (fixed) `:rw`, there's now also `:wr`. The former updates the file, the latter truncates it first.

The method now takes an optional mode descriptor as first argument. Supported values are Perl 5's `<`, `>`, `>>`, `+<`, `+>`, `+>>` as well as the arguments to `fopen()` according to the C11 spec.

There's a corresponding PR for MoarVM.

On the JVM, unsupported modes will blow up, but everything that used to work should continue to work (with the caveat that `:rw` now blows up instead of silently getting adjusted to `:w`).

On Parrot, unsupported modes will lead to undefined behaviour as unknown characters get silently dropped from mode strings.