### PR TITLE
unbust warning for type objects as Range endpoint for JVM

### DIFF
--- a/src/core/control.pm
+++ b/src/core/control.pm
@@ -190,7 +190,12 @@ multi sub warn(*@msg) {
     my $msg = @msg.join || "Warning: something's wrong";
     my $i = 1;
     my %anno := callframe($i).annotations;
+#?if jvm
+    %anno := callframe(++$i).annotations while nqp::isconcrete(%anno<file>) && %anno<file> ~~ /\.setting$/;
+#?endif
+#?if !jvm
     %anno := callframe(++$i).annotations while !nqp::isnull_s(%anno<file>) && %anno<file> ~~ /\.setting$/;
+#?endif
     $msg ~= ' at ' ~ %anno<file> ~ ' line ' ~ %anno<line> unless $msg ~~ /\n$/ or !%anno or !%anno<line> or nqp::isnull_s(%anno<file>);
 
     my $ex := nqp::newexception();


### PR DESCRIPTION
At the moment something like ```1..Any``` fails with "Cannot unbox a type object" on JVM.