### PR TITLE
Unbust warning for type objects as Range endpoint for JVM

### DIFF
--- a/src/core/Backtrace.pm
+++ b/src/core/Backtrace.pm
@@ -166,7 +166,7 @@ my class Backtrace is List {
     }
 
     method first-none-setting-line(Backtrace:D:) {
-        self.first({ !.is-hidden && !.is-setting }).Str
+        (self.first({ !.is-hidden && !.is-setting }) || "\n").Str
     }
 
     method concise(Backtrace:D:) {


### PR DESCRIPTION
For some reasons evaluating '1..Any' on rakudo.jvm ended up with 'Nil.Str' exploding in 'method first-non-setting-line'.