### PR TITLE
Adding test demonstrating structs with nested structs are not working

### DIFF
--- a/lib/NativeCall.pm
+++ b/lib/NativeCall.pm
@@ -155,6 +155,7 @@ my %repr_map =
     'CStruct'   => 'cstruct',
     'CPointer'  => 'cpointer',
     'CArray'    => 'carray',
+    'CUnion'    => 'cunion',
     'VMArray'   => 'vmarray',
     ;
 sub type_code_for(Mu ::T) {
@@ -411,6 +412,10 @@ multi trait_mod:<is>(Parameter $p, :$encoded!) is export(:DEFAULT, :traits) {
 }
 multi trait_mod:<is>(Routine $p, :$encoded!) is export(:DEFAULT, :traits) {
     $p does NativeCallEncoded[$encoded];
+}
+
+multi trait_mod:<is>(Attribute $a, :$inlined!) is export(:DEFAULT, :traits) {
+    nqp::bindattr_i(nqp::decont($a), $a.WHAT, '$!inlined', 1);
 }
 
 role ExplicitlyManagedString {

--- a/src/Perl6/Metamodel/BOOTSTRAP.nqp
+++ b/src/Perl6/Metamodel/BOOTSTRAP.nqp
@@ -21,10 +21,12 @@ my class BOOTSTRAPATTR {
     has $!type;
     has $!box_target;
     has $!package;
+    has $!inlined;
     method name() { $!name }
     method type() { $!type }
     method box_target() { $!box_target }
     method package() { $!package }
+    method inlined() { $!inlined }
     method has_accessor() { 0 }
     method has-accessor() { 0 }
     method positional_delegate() { 0 }
@@ -1081,6 +1083,7 @@ BEGIN {
     Attribute.HOW.add_attribute(Attribute, BOOTSTRAPATTR.new(:name<$!auto_viv_container>, :type(Mu), :package(Attribute)));
     Attribute.HOW.add_attribute(Attribute, BOOTSTRAPATTR.new(:name<$!build_closure>, :type(Mu), :package(Attribute)));
     Attribute.HOW.add_attribute(Attribute, BOOTSTRAPATTR.new(:name<$!package>, :type(Mu), :package(Attribute)));
+    Attribute.HOW.add_attribute(Attribute, BOOTSTRAPATTR.new(:name<$!inlined>, :type(int), :package(Attribute)));
     Attribute.HOW.add_attribute(Attribute, BOOTSTRAPATTR.new(:name<$!box_target>, :type(int), :package(Attribute)));
     Attribute.HOW.add_attribute(Attribute, BOOTSTRAPATTR.new(:name<$!positional_delegate>, :type(int), :package(Attribute)));
     Attribute.HOW.add_attribute(Attribute, BOOTSTRAPATTR.new(:name<$!associative_delegate>, :type(int), :package(Attribute)));
@@ -1088,13 +1091,14 @@ BEGIN {
 
     # Need new and accessor methods for Attribute in here for now.
     Attribute.HOW.add_method(Attribute, 'new',
-        nqp::getstaticcode(sub ($self, :$name!, :$type!, :$package!, :$has_accessor,
+        nqp::getstaticcode(sub ($self, :$name!, :$type!, :$package!, :$inlined = 0, :$has_accessor,
                 :$positional_delegate = 0, :$associative_delegate = 0, *%other) {
             my $attr := nqp::create($self);
             nqp::bindattr_s($attr, Attribute, '$!name', $name);
             nqp::bindattr($attr, Attribute, '$!type', nqp::decont($type));
             nqp::bindattr_i($attr, Attribute, '$!has_accessor', $has_accessor);
             nqp::bindattr($attr, Attribute, '$!package', $package);
+            nqp::bindattr_i($attr, Attribute, '$!inlined', $inlined);
             if nqp::existskey(%other, 'container_descriptor') {
                 nqp::bindattr($attr, Attribute, '$!container_descriptor', %other<container_descriptor>);
                 if nqp::existskey(%other, 'auto_viv_container') {

--- a/src/Perl6/Metamodel/REPRComposeProtocol.nqp
+++ b/src/Perl6/Metamodel/REPRComposeProtocol.nqp
@@ -46,6 +46,9 @@ role Perl6::Metamodel::REPRComposeProtocol {
                         if $attr.associative_delegate {
                             %attr_info<associative_delegate> := 1;
                         }
+                        if nqp::can($attr, 'inlined') {
+                            %attr_info<inlined> := $attr.inlined;
+                        }
                         nqp::push(@attrs, %attr_info);
                     }
                 

--- a/src/core/Attribute.pm
+++ b/src/core/Attribute.pm
@@ -8,6 +8,7 @@ my class Attribute { # declared in BOOTSTRAP
     #     has Mu $!auto_viv_container;
     #     has Mu $!build_closure;
     #     has Mu $!package;
+    #     has int $!inlined;
     #     has int $!positional_delegate;
     #     has int $!associative_delegate;
     #     has Mu $!why;
@@ -110,6 +111,7 @@ my class Attribute { # declared in BOOTSTRAP
     method has-accessor() { ?$!has_accessor }
     method readonly() { !self.rw }
     method package() { $!package }
+    method inlined() { $!inlined }
     multi method Str(Attribute:D:) { self.name }
     multi method gist(Attribute:D:) { self.type.^name ~ " " ~ self.name }
 

--- a/t/04-nativecall/06-struct.c
+++ b/t/04-nativecall/06-struct.c
@@ -32,6 +32,11 @@ typedef struct {
     char *second;
 } StringStruct;
 
+typedef struct {
+    IntStruct a;
+    int i;
+} StructIntStruct;
+
 DLLEXPORT MyStruct *ReturnAStruct()
 {
     MyStruct *obj = (MyStruct *) malloc(sizeof(MyStruct));
@@ -101,4 +106,13 @@ DLLEXPORT int TakeAStringStruct(StringStruct *obj) {
 
 DLLEXPORT long _deref(long *ptr) {
     return *ptr;
+}
+
+DLLEXPORT StructIntStruct *ReturnAStructIntStruct() {
+    StructIntStruct *sis = (StructIntStruct *) malloc(sizeof(StructIntStruct));
+    sis->a.first = 101;
+    sis->a.second = 77;
+    sis->i = 42;
+
+    return sis;
 }

--- a/t/04-nativecall/06-struct.t
+++ b/t/04-nativecall/06-struct.t
@@ -4,7 +4,7 @@ use lib 'lib';
 use NativeCall;
 use Test;
 
-plan 22;
+plan 25;
 
 compile_test_lib('06-struct');
 
@@ -91,6 +91,11 @@ class PointerStruct is repr('CStruct') {
     has PointerThing $.p;
 }
 
+class StructIntStruct is repr('CStruct') {
+    has IntStruct $.a;
+    has int $.i;
+}
+
 sub ReturnAStruct()            returns MyStruct2 is native('./06-struct') { * }
 sub TakeAStruct(MyStruct $arg) returns int32     is native('./06-struct') { * }
 
@@ -101,6 +106,8 @@ sub ReturnAPointerStruct() returns PointerStruct is native('./06-struct') { * }
 
 sub ReturnAStringStruct()                returns StringStruct is native('./06-struct') { * }
 sub TakeAStringStruct(StringStruct $arg) returns int32        is native('./06-struct') { * }
+
+sub ReturnAStructIntStruct() returns StructIntStruct is native('./06-struct') { * }
 
 # Perl-side tests:
 my MyStruct $obj .= new;
@@ -149,5 +156,10 @@ $strstr2.init;
 #$strstr2.first  := "Lorem";
 #$strstr2.second := "ipsum";
 is TakeAStringStruct($strstr2), 33, 'C-side strict values in struct';
+
+my StructIntStruct $sis = ReturnAStructIntStruct();
+is $sis.i, 42, 'and the int after is 42';
+is $sis.a.first, 101, 'nested first is 101';
+is $sis.a.second, 77, 'nested second is 77';
 
 # vim:ft=perl6

--- a/t/04-nativecall/13-union.c
+++ b/t/04-nativecall/13-union.c
@@ -18,13 +18,29 @@ typedef union {
 typedef struct {
     long intval;
     double numval;
-    char byteval;
+    signed char byteval;
     onion vegval;
     float floatval;
 } MyStruct;
 
+typedef struct {
+    long intval;
+    float numval1;
+    float numval2;
+    signed char byteval;
+} YourStruct;
+
+typedef union {
+    MyStruct   a;
+    YourStruct b;
+} UnionOfStructs;
+
 DLLEXPORT int SizeofMyStruct() {
     return sizeof(MyStruct);
+}
+
+DLLEXPORT int SizeofUnionOfStructs() {
+    return sizeof(UnionOfStructs);
 }
 
 DLLEXPORT void SetLongMyStruct(MyStruct *obj) {
@@ -96,6 +112,13 @@ DLLEXPORT MyStruct2 *ReturnMyStruct2() {
     obj->vegval->c = 1 << 6;
 
     obj->floatval  = -6.28;
+
+    return obj;
+}
+
+DLLEXPORT UnionOfStructs *ReturnUnionOfStructs() {
+    UnionOfStructs *obj = (UnionOfStructs *)malloc(sizeof(UnionOfStructs));
+    obj->b.byteval      = 42;
 
     return obj;
 }

--- a/t/04-nativecall/13-union.c
+++ b/t/04-nativecall/13-union.c
@@ -1,0 +1,101 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+#ifdef WIN32
+#define DLLEXPORT __declspec(dllexport)
+#else
+#define DLLEXPORT extern
+#endif
+
+typedef union {
+    unsigned long  l;
+    unsigned int   i;
+    unsigned short s;
+    unsigned char  c;
+} onion;
+
+/* Test for inlined union. */
+typedef struct {
+    long intval;
+    double numval;
+    char byteval;
+    onion vegval;
+    float floatval;
+} MyStruct;
+
+DLLEXPORT int SizeofMyStruct() {
+    return sizeof(MyStruct);
+}
+
+DLLEXPORT void SetLongMyStruct(MyStruct *obj) {
+    obj->vegval.l = 1 << 30;
+}
+
+DLLEXPORT void SetIntMyStruct(MyStruct *obj) {
+    obj->vegval.i = 1 << 27;
+}
+
+DLLEXPORT void SetShortMyStruct(MyStruct *obj) {
+    obj->vegval.s = 1 << 13;
+}
+
+DLLEXPORT void SetCharMyStruct(MyStruct *obj) {
+    obj->vegval.c = 1 << 6;
+}
+
+DLLEXPORT MyStruct *ReturnMyStruct() {
+    MyStruct *obj = (MyStruct *)malloc(sizeof(MyStruct));
+    obj->intval   = 17;
+    obj->numval   = 4.2;
+    obj->byteval  = 13;
+    obj->vegval.l = 0;
+    obj->floatval = -6.28;
+
+    return obj;
+}
+
+/* Test for referenced union. */
+typedef struct {
+    long intval;
+    double numval;
+    char byteval;
+    onion* vegval;
+    float floatval;
+} MyStruct2;
+
+DLLEXPORT int SizeofMyStruct2() {
+    return sizeof(MyStruct2);
+}
+
+DLLEXPORT void SetLongMyUnion(onion *obj) {
+    obj->l = 1 << 30;
+}
+
+DLLEXPORT void SetIntMyUnion(onion *obj) {
+    obj->i = 1 << 27;
+}
+
+DLLEXPORT void SetShortMyUnion(onion *obj) {
+    obj->s = 1 << 13;
+}
+
+DLLEXPORT void SetCharMyUnion(onion *obj) {
+    obj->c = 1 << 6;
+}
+
+DLLEXPORT MyStruct2 *ReturnMyStruct2() {
+    MyStruct2 *obj = (MyStruct2 *)malloc(sizeof(MyStruct2));
+    obj->intval    = 17;
+    obj->numval    = 4.2;
+    obj->byteval   = 13;
+
+    obj->vegval    = (onion *)malloc(sizeof(onion));
+    obj->vegval->l = 0;
+    obj->vegval->i = 1 << 30;
+    obj->vegval->s = 1 << 14;
+    obj->vegval->c = 1 << 6;
+
+    obj->floatval  = -6.28;
+
+    return obj;
+}

--- a/t/04-nativecall/13-union.t
+++ b/t/04-nativecall/13-union.t
@@ -4,7 +4,7 @@ use lib 'lib';
 use NativeCall;
 use Test;
 
-plan 23;
+plan 28;
 
 compile_test_lib('13-union');
 
@@ -115,5 +115,27 @@ is $onion.s, 1 +< 13, 'short in union*';
 
 SetCharMyUnion($onion);
 is $onion.c, 1 +< 6,  'char in union*';
+
+class YourStruct is repr('CStruct') {
+    has long  $.long;
+    has num32 $.num1;
+    has num32 $.num2;
+    has int8  $.byte;
+}
+
+class UnionOfStructs is repr('CUnion') {
+    has MyStruct   $.a is inlined;
+    has YourStruct $.b is inlined;
+}
+
+sub ReturnUnionOfStructs() returns UnionOfStructs is native('./13-union') { * }
+sub SizeofUnionOfStructs() returns int32          is native('./13-union') { * }
+
+is nativesizeof(UnionOfStructs), SizeofUnionOfStructs(), 'sizeof(UnionOfStructs)';
+my $uos = ReturnUnionOfStructs;
+isa-ok $uos.a, MyStruct,   'member a of union is-a MyStruct';
+isa-ok $uos.b, YourStruct, 'member b of union is-a YourStruct';
+is $uos.a.byte, 42, 'a.byte was set to 42 by C';
+is $uos.b.byte, 42, 'b.byte must be the same';
 
 # vim:ft=perl6

--- a/t/04-nativecall/13-union.t
+++ b/t/04-nativecall/13-union.t
@@ -1,0 +1,119 @@
+use lib 't/04-nativecall';
+use CompileTestLib;
+use lib 'lib';
+use NativeCall;
+use Test;
+
+plan 23;
+
+compile_test_lib('13-union');
+
+class Onion is repr('CUnion') {
+    has long   $.l;
+    has uint32 $.i;
+    has uint16 $.s;
+    has uint8  $.c;
+}
+
+is nativesizeof(Onion), nativesizeof(long), 'sizeof union is sizeof biggest member';
+
+class MyStruct is repr('CStruct') {
+    has long  $.long;
+    has num64 $.num;
+    has int8  $.byte;
+    has Onion $.onion is inlined;
+    has num32 $.float;
+
+    method init() {
+        $!long = 42;
+        $!byte = 7;
+        $!num = -3.7e0;
+        $!float = 3.14e0;
+    }
+}
+
+sub ReturnMyStruct()   returns MyStruct is native('./13-union') { * }
+sub SizeofMyStruct()   returns int32    is native('./13-union') { * }
+sub SetLongMyStruct(MyStruct)           is native('./13-union') { * }
+sub SetIntMyStruct(MyStruct)            is native('./13-union') { * }
+sub SetShortMyStruct(MyStruct)          is native('./13-union') { * }
+sub SetCharMyStruct(MyStruct)           is native('./13-union') { * }
+
+is nativesizeof(MyStruct), SizeofMyStruct(), 'sizeof(MyStruct)';
+
+# Perl-side tests:
+my MyStruct $obj .= new;
+$obj.init;
+
+is $obj.long,         42,     'getting long';
+is_approx $obj.num,  -3.7e0,  'getting num';
+is $obj.byte,         7,      'getting int8';
+is_approx $obj.float, 3.14e0, 'getting num32';
+
+# C-side tests:
+my $cobj = ReturnMyStruct;
+
+is $cobj.long,          17,     'getting long from C-created struct';
+is_approx $cobj.num,    4.2e0,  'getting num from C-created struct';
+is $cobj.byte,          13,     'getting int8 from C-created struct';
+is_approx $cobj.float, -6.28e0, 'getting num32 from C-created struct';
+
+SetLongMyStruct($cobj);
+is $cobj.onion.l, 1 +< 30, 'long in union';
+
+SetIntMyStruct($cobj);
+is $cobj.onion.i, 1 +< 27, 'int in union';
+
+SetShortMyStruct($cobj);
+is $cobj.onion.s, 1 +< 13, 'short in union';
+
+SetCharMyStruct($cobj);
+is $cobj.onion.c, 1 +< 6,  'char in union';
+
+class MyStruct2 is repr('CStruct') {
+    has long  $.long;
+    has num64 $.num;
+    has int8  $.byte;
+    has Onion $.onion;
+    has num32 $.float;
+
+    method init() {
+        $!long = 42;
+        $!byte = 7;
+        $!num = -3.7e0;
+        $!float = 3.14e0;
+    }
+}
+
+sub ReturnMyStruct2() returns MyStruct2 is native('./13-union') { * }
+sub SizeofMyStruct2() returns int32     is native('./13-union') { * }
+sub SetLongMyUnion(Onion)               is native('./13-union') { * }
+sub SetIntMyUnion(Onion)                is native('./13-union') { * }
+sub SetShortMyUnion(Onion)              is native('./13-union') { * }
+sub SetCharMyUnion(Onion)               is native('./13-union') { * }
+
+is nativesizeof(MyStruct2), SizeofMyStruct2(), 'sizeof(MyStruct2)';
+
+# C-side tests:
+my $cobj2 = ReturnMyStruct2;
+
+is $cobj2.long,          17,     'getting long from C-created struct';
+is_approx $cobj2.num,    4.2e0,  'getting num from C-created struct';
+is $cobj2.byte,          13,     'getting int8 from C-created struct';
+is_approx $cobj2.float, -6.28e0, 'getting num32 from C-created struct';
+
+my $onion = $cobj2.onion;
+
+SetLongMyUnion($onion);
+is $onion.l, 1 +< 30, 'long in union*';
+
+SetIntMyUnion($onion);
+is $onion.i, 1 +< 27, 'int in union*';
+
+SetShortMyUnion($onion);
+is $onion.s, 1 +< 13, 'short in union*';
+
+SetCharMyUnion($onion);
+is $onion.c, 1 +< 6,  'char in union*';
+
+# vim:ft=perl6


### PR DESCRIPTION
For @FROGGS: I've added a test to highlight the kind of issues I'm having with the CStruct repr. At this point CUnion is not the problem. 

Working with the Gumbo library, it has some structs like this with nested structs that are allocated with the parent, mixed with primitive variables. It would appear that moar is basically ignoring the nested struct when calculating address lookups for later values stored within the struct.

I've been reading the C code in MoarVM to see if I can figure it out, but I need to learn a lot moar vocabulary yet before I understand what it's doing well enough to consider fixing it.

I think I might be able to fake it out and make it work by adding the primitives from the nested struct directly into the parent, but I haven't tried it. Even if I do, I don't think that's the right solution.