### PR TITLE
On Linux use the counterintuitive -r for $*KERNEL.version

### DIFF
--- a/src/core/Kernel.pm
+++ b/src/core/Kernel.pm
@@ -42,7 +42,16 @@ class Kernel does Systemic {
                       !! $unamev.chomp;
                 }
                 default {
-                    uname '-v';
+                    given $.name {
+                        when 'linux' {
+                            # somewhat counter-intuitively the '-r' is what
+                            # most people think of the kernel version
+                            uname '-r';
+                        }
+                        default {
+                            uname '-v';
+                        }
+                    }
                 }
             }
         } );


### PR DESCRIPTION
Hi,
on linux $*KERNEL.release and $*KERNEL.version were the same.  This uses the '-r' for version which is what I think most people thing of as the kernel 'version'.