### PR TITLE
Make port an Int if extracted from host:port in host

### DIFF
--- a/src/core/IO/Socket/INET.pm
+++ b/src/core/IO/Socket/INET.pm
@@ -45,7 +45,7 @@ my class IO::Socket::INET does IO::Socket {
                 ?? v6-split(%args<host>)
                 !! v4-split(%args<host>);
             if $port {
-                %args<port> //= $port;
+                %args<port> //= $port.Int;
                 %args<host> = $host;
             }
         }
@@ -54,7 +54,7 @@ my class IO::Socket::INET does IO::Socket {
                 ?? v6-split(%args<localhost>)
                 !! v4-split(%args<localhost>);
             if $port {
-                %args<localport> //= $port;
+                %args<localport> //= $port.Int;
                 %args<localhost> = $peer;
             }
         }


### PR DESCRIPTION
Was failing with "Type check failed in assignment to '$!port'; expected 'Int' but got 'Str'" if doing for example:

   IO::Socket::INET.new(host => '127.0.0.1:80')

