### PR TITLE
Type check when creating Failure object with '.new'

### DIFF
--- a/src/core/Failure.pm
+++ b/src/core/Failure.pm
@@ -3,7 +3,7 @@ my class Failure {
     has $.backtrace;
     has $!handled;
 
-    method new($exception) {
+    method new(Exception $exception) {
          self.bless(:$exception);
     }
 


### PR DESCRIPTION
fixes RT #115436