### PR TITLE
deprecation fix: CompUnit.precomp s/pipe/shell/

### DIFF
--- a/src/core/CompUnit.pm
+++ b/src/core/CompUnit.pm
@@ -125,12 +125,12 @@ RAKUDO_MODULE_DEBUG("Precomping with %*ENV<RAKUDO_PRECOMP_WITH>")
   if $?RAKUDO_MODULE_DEBUG;
 
         my $cmd = "$*EXECUTABLE$lle --target={$*VM.precomp-target} --output=$out $!path";
-        my $handle = pipe("$cmd 2>&1", :r, :!chomp);
+        my $proc = shell("$cmd 2>&1", :out, :!chomp);
         %*ENV<RAKUDO_PRECOMP_WITH>:delete;
 
         my $result = '';
-        $result ~= $_ for $handle.lines;
-        if $handle.close.status -> $status {  # something wrong
+        $result ~= $_ for $proc.out.lines;
+        if $proc.status -> $status {  # something wrong
             $result ~= "Return status $status\n";
             fail $result if $result;
         }


### PR DESCRIPTION
This may be better expressed as something like `my $proc = run($*EXECUTABLE, @args, :merge); my $result = $proc.out.lines.join` once the `:merge` implementation works.