### PR TITLE
bugfix: `.precomp` returning Failure erroneously

### DIFF
--- a/src/core/CompUnit.pm
+++ b/src/core/CompUnit.pm
@@ -130,6 +130,7 @@ RAKUDO_MODULE_DEBUG("Precomping with %*ENV<RAKUDO_PRECOMP_WITH>")
 
         my $result = '';
         $result ~= $_ for $proc.out.lines;
+        $proc.out.close;
         if $proc.status -> $status {  # something wrong
             $result ~= "Return status $status\n";
             fail $result if $result;


### PR DESCRIPTION
On JVM the pipe must be closed after reading but before the status is checked to get the actual exitcode for `.precomp` to return a true value.

side note: It would seem `process.waitFor()` does not close the channel, as if it never finishes reading the buffer.