### PR TITLE
allow Proc::Async to be started in any directory

### DIFF
--- a/src/core/Proc/Async.pm
+++ b/src/core/Proc/Async.pm
@@ -163,7 +163,7 @@ my class Proc::Async {
         $promise;
     }
 
-    method start(Proc::Async:D: :$scheduler = $*SCHEDULER, :$ENV) {
+    method start(Proc::Async:D: :$scheduler = $*SCHEDULER, :$ENV, :$CWD = $*CWD) {
         X::Proc::Async::AlreadyStarted.new(proc => self).throw if $!started;
         $!started = True;
 
@@ -191,7 +191,7 @@ my class Proc::Async {
 
         $!process_handle := nqp::spawnprocasync($scheduler.queue,
             CLONE-LIST-DECONTAINERIZED($!path,@!args),
-            $*CWD.Str,
+            $CWD.Str,
             CLONE-HASH-DECONTAINERIZED(%ENV),
             $callbacks,
         );


### PR DESCRIPTION
Allows the use of relative file path arguments to whatever `$!path` executes to work.

This allows avoiding CWD related boilerplate like:

    my $cwd-bak = $*CWD;
    chdir("/home/foo");
    # execute some process that expects CWD to be /home/foo
    chdir($cwd-bak);