### PR TITLE
Proc.shell/run/spawn and QX :$cwd param

### DIFF
--- a/src/core/Proc.pm
+++ b/src/core/Proc.pm
@@ -87,10 +87,10 @@ my class Proc {
         }
     }
 
-    method spawn(*@args ($, *@)) {
+    method spawn(*@args ($, *@), :$cwd = $*CWD) {
         self.status(nqp::p6box_i(nqp::spawn(
             CLONE-LIST-DECONTAINERIZED(@args),
-            nqp::unbox_s($*CWD.Str),
+            nqp::unbox_s($cwd.Str),
             CLONE-HASH-DECONTAINERIZED(%*ENV),
             $!in_fh, $!out_fh, $!err_fh,
             $!flags
@@ -98,10 +98,10 @@ my class Proc {
         self.Bool
     }
 
-    method shell($cmd) {
+    method shell($cmd, :$cwd = $*CWD) {
         self.status(nqp::p6box_i(nqp::shell(
             nqp::unbox_s($cmd),
-            nqp::unbox_s($*CWD.Str),
+            nqp::unbox_s($cwd.Str),
             CLONE-HASH-DECONTAINERIZED(%*ENV),
             $!in_fh, $!out_fh, $!err_fh,
             $!flags
@@ -121,25 +121,25 @@ my class Proc {
 
 sub run(*@args ($, *@), :$in = '-', :$out = '-', :$err = '-',
         Bool :$bin, Bool :$chomp = True, Bool :$merge,
-        Str:D :$enc = 'utf8', Str:D :$nl = "\n") {
+        Str:D :$enc = 'utf8', Str:D :$nl = "\n", :$cwd = $*CWD) {
     my $proc = Proc.new(:$in, :$out, :$err, :$bin, :$chomp, :$merge, :$enc, :$nl);
-    $proc.spawn(@args);
+    $proc.spawn(@args, :$cwd);
     $proc
 }
 
 sub shell($cmd, :$in = '-', :$out = '-', :$err = '-',
         Bool :$bin, Bool :$chomp = True, Bool :$merge,
-        Str:D :$enc = 'utf8', Str:D :$nl = "\n") {
+        Str:D :$enc = 'utf8', Str:D :$nl = "\n", :$cwd = $*CWD) {
     my $proc = Proc.new(:$in, :$out, :$err, :$bin, :$chomp, :$merge, :$enc, :$nl);
-    $proc.shell($cmd);
+    $proc.shell($cmd, :$cwd);
     $proc
 }
 
-sub QX($cmd) {
+sub QX($cmd, :$cwd = $*CWD) {
     my Mu $pio := nqp::syncpipe();
     my $status := nqp::shell(
         nqp::unbox_s($cmd),
-        nqp::unbox_s($*CWD.Str),
+        nqp::unbox_s($cwd.Str),
         CLONE-HASH-DECONTAINERIZED(%*ENV),
         nqp::null(), $pio, nqp::null(),
         nqp::const::PIPE_INHERIT_IN + nqp::const::PIPE_CAPTURE_OUT + nqp::const::PIPE_INHERIT_ERR

--- a/src/core/Proc/Async.pm
+++ b/src/core/Proc/Async.pm
@@ -163,7 +163,7 @@ my class Proc::Async {
         $promise;
     }
 
-    method start(Proc::Async:D: :$scheduler = $*SCHEDULER, :$ENV, :$CWD = $*CWD) {
+    method start(Proc::Async:D: :$scheduler = $*SCHEDULER, :$ENV, :$cwd = $*CWD) {
         X::Proc::Async::AlreadyStarted.new(proc => self).throw if $!started;
         $!started = True;
 
@@ -191,7 +191,7 @@ my class Proc::Async {
 
         $!process_handle := nqp::spawnprocasync($scheduler.queue,
             CLONE-LIST-DECONTAINERIZED($!path,@!args),
-            $CWD.Str,
+            $cwd.Str,
             CLONE-HASH-DECONTAINERIZED(%ENV),
             $callbacks,
         );


### PR DESCRIPTION
Allow setting :$cwd for both Proc and Proc::Async.
Lowercase 'cwd' per suggestion.