### PR TITLE
remove Str.path leftovers in IO::Path.ACCEPTS

### DIFF
--- a/src/core/IO/Path.pm
+++ b/src/core/IO/Path.pm
@@ -10,7 +10,7 @@ my class IO::Path is Cool {
     has %!parts;
 
     multi method ACCEPTS(IO::Path:D: IO::Path:D \other) {
-        nqp::p6bool(nqp::iseq_s($.abspath, nqp::unbox_s(other.path.abspath)));
+        nqp::p6bool(nqp::iseq_s($.abspath, nqp::unbox_s(other.abspath)));
     }
 
     multi method ACCEPTS(IO::Path:D: Mu \that) {


### PR DESCRIPTION
    ./perl6 -e 'say $*CWD.ACCEPTS($*CWD)'
    Method 'abspath' not found for invocant of class 'Str'
      in block <unit> at -e:1