### PR TITLE
bugfix: chdir ensure `.` is resolved to abspath

### DIFF
--- a/src/core/IO/Path.pm
+++ b/src/core/IO/Path.pm
@@ -252,7 +252,7 @@ my class IO::Path is Cool {
     }
     multi method chdir(IO::Path:D: Str() $path is copy, :$test = 'r') {
         if !$!SPEC.is-absolute($path) {
-            my ($volume,$dirs) = $!SPEC.splitpath(self, :nofile);
+            my ($volume,$dirs) = $!SPEC.splitpath(self.abspath, :nofile);
             my @dirs = $!SPEC.splitdir($dirs);
             @dirs.shift; # the first is always empty for absolute dirs
             for $!SPEC.splitdir($path) -> $dir {


### PR DESCRIPTION
Fixes:

    nickl@localhost:~/perl6$ perl6 -e 'say ".".IO.chdir("rakudo/lib").IO.perl.say'
    Failed to change the working directory to '/rakudo/lib': does not exist

This also addresses windows behavior where the volume would become lost.