### PR TITLE
Add can-ok subroutine

### DIFF
--- a/lib/Test.pm
+++ b/lib/Test.pm
@@ -342,6 +342,13 @@ multi sub isa-ok(Mu $var, Mu $type, $msg = ("The object is-a '" ~ $type.perl ~ "
     $ok;
 }
 
+multi sub can-ok(Mu $var, Str $meth, $msg = ( ($var.defined ?? "An object of type '" !! "The type '" ) ~ $var.WHAT.perl ~ "' can do the method '$meth'") ) is export {
+    $time_after = nqp::p6box_n(nqp::time_n);
+    my $ok = proclaim($var.^can($meth), $msg);
+    $time_before = nqp::time_n;
+    $ok;
+}
+
 multi sub like(Str $got, Regex $expected, $desc = '') is export {
     $time_after = nqp::time_n;
     $got.defined; # Hack to deal with Failures


### PR DESCRIPTION
Hi,
this seems like a no-brainer to me.  It's comforting to Test::More users and saves quite a bit of typing over ok($obj.^can ...) with a sensible default description.  If nothing else it gets people started porting perl 5 tests by s/_ok/-ok/g ;-)

