### PR TITLE
Proposed IO::Path slash operator

### DIFF
--- a/src/core/IO/Path.pm
+++ b/src/core/IO/Path.pm
@@ -635,4 +635,8 @@ my class IO::Path::Win32 is IO::Path {
     method new(|c) { IO::Path.new(|c, :SPEC(IO::Spec::Win32) ) }
 }
 
+multi sub infix:</> (IO::Path:D $base, Str:D $child) is assoc<left> returns IO::Path:D {
+    $base.child($child);
+}
+
 # vim: ft=perl6 expandtab sw=4


### PR DESCRIPTION
I've seen this operator defined in Ruby code someplace. It seems pretty slick to me to say something like:

    my $homedir = %*ENV<HOME>.IO;
    my $bindir = $homedir/"bin";