### PR TITLE
dead code removal: `.absolutify()`

### DIFF
--- a/src/core/CompUnitRepo.pm
+++ b/src/core/CompUnitRepo.pm
@@ -111,7 +111,7 @@ sub INCLUDE-SPEC2CUR(Str:D $spec) {
     die "No class loaded for short-id '$short-id': $spec -> $path"
       if $class === Any;
 
-    my $abspath = $class.?absolutify($path) // $path;
+    my $abspath = !$path ?? $*CWD !! ?$path.IO.is-absolute ?? $path !! $path.IO.abspath;
     my $id      = "$short-id#$abspath";
     $lock.protect( {
         %INCLUDE-SPEC2CUR{$id}:exists


### PR DESCRIPTION
The extra keystrokes are to work around dying if `$path eq ''` is theoretically set from `PARSE-INCLUDE-SPEC`