### PR TITLE
non-legacy travis-ci config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: "perl"
 perl:
     - "5.10"
+
+sudo: false
+
 install: "echo"
 
 script: "perl Configure.pl --backends=moar $RAKUDO_OPTIONS; make test"


### PR DESCRIPTION
Resolves the following message: `This job ran on our legacy infrastructure. Please read our docs on how to upgrade`