### PR TITLE
Enhancements to Failure/Exception/fail/die

### DIFF
--- a/src/core/Backtrace.pm
+++ b/src/core/Backtrace.pm
@@ -80,11 +80,11 @@ my class Backtrace {
         return nqp::atpos($!frames,$pos) if nqp::existspos($!frames,$pos);
 
         my int $elems = $!bt.elems;
-        return Nil if $!bt-next == $elems;
+        return Nil if $!bt-next >= $elems; # bt-next can init > elems
 
         my int $todo = $pos - nqp::elems($!frames) + 1;
+        return Nil if $todo < 1; # in case absurd $pos passed
         while $!bt-next < $elems {
-
             my $frame := $!bt.AT-POS($!bt-next++);
             my $sub := $frame<sub>;
             next unless defined $sub;
@@ -102,13 +102,19 @@ my class Backtrace {
             next if $file.ends-with('BOOTSTRAP.nqp')
                  || $file.ends-with('QRegex.nqp')
                  || $file.ends-with('Perl6/Ops.nqp');
-            last if $file.ends-with('NQPHLL.nqp');
+            if $file.ends-with('NQPHLL.nqp') {
+                $!bt-next = $elems;
+                last;
+            }
 
             my $line := $annotations<line>;
             next unless $line;
 
             my $name := nqp::p6box_s(nqp::getcodename($do));
-            last if $name eq 'handle-begin-time-exceptions';
+            if $name eq 'handle-begin-time-exceptions' {
+                $!bt-next = $elems;
+                last;
+            }
 
             my $code;
             try {

--- a/src/core/Exception.pm
+++ b/src/core/Exception.pm
@@ -69,7 +69,17 @@ my class Exception {
 
 my class X::AdHoc is Exception {
     has $.payload = "Unexplained error";
-    method message() { $.payload.Str     }
+    method message() {
+        # Remove spaces for die(*@msg)/fail(*@msg) forms
+        given $.payload {
+            when Parcel {
+                $_.join;
+            }
+            default {
+                .Str;
+            }
+        }
+    }
     method Numeric() { $.payload.Numeric }
 }
 

--- a/src/core/Exception.pm
+++ b/src/core/Exception.pm
@@ -69,11 +69,14 @@ my class Exception {
 
 my class X::AdHoc is Exception {
     has $.payload = "Unexplained error";
+
+    my role SlurpySentry { }
+
     method message() {
         # Remove spaces for die(*@msg)/fail(*@msg) forms
         given $.payload {
-            when Parcel {
-                $_.join;
+            when SlurpySentry {
+                $_.list.join;
             }
             default {
                 .Str;
@@ -81,6 +84,9 @@ my class X::AdHoc is Exception {
         }
     }
     method Numeric() { $.payload.Numeric }
+    method from-slurpy (|cap) {
+        self.new(:payload(cap does SlurpySentry))
+    }
 }
 
 my class X::Dynamic::NotFound is Exception {

--- a/src/core/Exception.pm
+++ b/src/core/Exception.pm
@@ -12,7 +12,8 @@ my class Exception {
     }
 
     multi method Str(Exception:D:) {
-        self.?message.Str // 'Something went wrong in ' ~ self.WHAT.gist;
+        my $msg = self.?message // '';
+        $msg.Str || 'Something went wrong in ' ~ self.WHAT.gist;
     }
 
     multi method gist(Exception:D:) {
@@ -36,8 +37,8 @@ my class Exception {
             unless nqp::isconcrete($!ex);
         nqp::setpayload($!ex, nqp::decont(self));
         my $msg := self.?message;
-        nqp::setmessage($!ex, nqp::unbox_s($msg.Str))
-            if $msg.defined;
+        $msg := $msg // self.WHAT.gist;
+        nqp::setmessage($!ex, nqp::unbox_s($msg.Str));
         nqp::throw($!ex)
     }
     method rethrow() {

--- a/src/core/Exception.pm
+++ b/src/core/Exception.pm
@@ -5,7 +5,7 @@ my class Exception {
     has $!ex;
     has $!bt;
 
-    method backtrace() {
+    method backtrace(Exception:D:) {
         if $!bt { $!bt }
         elsif nqp::isconcrete($!ex) { Backtrace.new($!ex); }
         else { '' }
@@ -31,7 +31,7 @@ my class Exception {
         $str;
     }
 
-    method throw($bt?) {
+    method throw(Exception:D: $bt?) {
         nqp::bindattr(self, Exception, '$!bt', $bt) if $bt;
         nqp::bindattr(self, Exception, '$!ex', nqp::newexception())
             unless nqp::isconcrete($!ex);
@@ -41,16 +41,16 @@ my class Exception {
         nqp::setmessage($!ex, nqp::unbox_s($msg.Str));
         nqp::throw($!ex)
     }
-    method rethrow() {
+    method rethrow(Exception:D:) {
         nqp::setpayload($!ex, nqp::decont(self));
         nqp::rethrow($!ex)
     }
 
-    method resumable() {
+    method resumable(Exception:D:) {
         nqp::p6bool(nqp::istrue(nqp::atkey($!ex, 'resume')));
     }
 
-    method resume() {
+    method resume(Exception:D:) {
         nqp::resume($!ex);
         True
     }

--- a/src/core/Exception.pm
+++ b/src/core/Exception.pm
@@ -13,14 +13,14 @@ my class Exception {
 
     multi method Str(Exception:D:) {
         my $msg = self.?message // '';
-        $msg.Str || 'Something went wrong in ' ~ self.WHAT.gist;
+        $msg.Str || 'Inchoate error of class ' ~ self.WHAT.^name;
     }
 
     multi method gist(Exception:D:) {
         my $str = nqp::isconcrete($!ex)
           ?? nqp::p6box_s(nqp::getmessage($!ex))
           !! try self.?message;
-        $str //= "Internal error";
+        $str //= "Unspecified error " ~ self.WHAT.gist;
 
         if nqp::isconcrete($!ex) {
             $str ~= "\n";
@@ -68,7 +68,7 @@ my class Exception {
 }
 
 my class X::AdHoc is Exception {
-    has $.payload;
+    has $.payload = "Unexplained error";
     method message() { $.payload.Str     }
     method Numeric() { $.payload.Numeric }
 }

--- a/src/core/Failure.pm
+++ b/src/core/Failure.pm
@@ -56,6 +56,14 @@ my class Failure {
 
 proto sub fail(|) {*};
 # Why do we need two levels of CALLER:: here?  Is this stable?
+multi sub fail(Exception:U $e) {
+    my $fail := Failure.new(
+        X::AdHoc.new(:payload("Failed with undefined " ~ $e.^name))
+    );
+    my Mu $return := nqp::getlexcaller('RETURN');
+    $return($fail) unless nqp::isnull($return);
+    $fail
+}
 multi sub fail($payload =
     (CALLER::CALLER::.EXISTS-KEY('$!') and CALLER::CALLER::('$!').DEFINITE)
      ?? CALLER::CALLER::('$!') !! 'Failed') {

--- a/src/core/Failure.pm
+++ b/src/core/Failure.pm
@@ -67,8 +67,8 @@ multi sub fail($payload = 'Failed') {
     $return($fail) unless nqp::isnull($return);
     $fail
 }
-multi sub fail(*@msg) {
-    my $fail := Failure.new(X::AdHoc.new(:payload(@msg.Parcel)));
+multi sub fail(|cap (*@msg)) {
+    my $fail := Failure.new(X::AdHoc.from-slurpy(|cap));
     my Mu $return := nqp::getlexcaller('RETURN');
     $return($fail) unless nqp::isnull($return);
     $fail

--- a/src/core/Failure.pm
+++ b/src/core/Failure.pm
@@ -3,8 +3,21 @@ my class Failure {
     has $.backtrace;
     has $!handled;
 
-    method new(Exception $exception) {
+    multi method new(Exception $exception) {
         self.bless(:$exception);
+    }
+    multi method new($payload =
+        (CALLER::CALLER::.EXISTS-KEY('$!') and CALLER::CALLER::('$!').DEFINITE)
+         ?? CALLER::CALLER::('$!') !! 'Failed') {
+        if ($payload ~~ Exception) {
+            self.bless(:exception($payload));
+        }
+        else {
+            self.bless(:exception(X::AdHoc.new(:$payload)));
+        }
+    }
+    multi method new(|cap (*@msg)) {
+         self.bless(:exception(X::AdHoc.from-slurpy(|cap)));
     }
 
     submethod BUILD (:$!exception) {

--- a/src/core/Failure.pm
+++ b/src/core/Failure.pm
@@ -93,12 +93,25 @@ multi sub fail(|cap (*@msg)) {
     $return($fail) unless nqp::isnull($return);
     $fail
 }
-
-multi sub die(Failure:D $failure) {
-    $failure.exception.throw
+multi sub fail(Failure:U $f) {
+    my $fail := Failure.new(
+        X::AdHoc.new(:payload("Failed with undefined " ~ $f.^name))
+    );
+    my Mu $return := nqp::getlexcaller('RETURN');
+    $return($fail) unless nqp::isnull($return);
+    $fail
 }
-multi sub die(Failure:U) {
-    X::AdHoc('Failure').throw
+multi sub fail(Failure:D $fail) {
+    my Mu $return := nqp::getlexcaller('RETURN');
+    $return($fail) unless nqp::isnull($return);
+    $fail
+}
+
+multi sub die(Failure:D $f) {
+    $f.exception.throw
+}
+multi sub die(Failure:U $f) {
+    X::AdHoc.new(:payload("Died with undefined " ~ $f.^name)).throw;
 }
 
 # vim: ft=perl6 expandtab sw=4

--- a/src/core/Failure.pm
+++ b/src/core/Failure.pm
@@ -68,8 +68,7 @@ multi sub fail($payload = 'Failed') {
     $fail
 }
 multi sub fail(*@msg) {
-    my $payload = @msg == 1 ?? @msg[0] !! @msg.join;
-    my $fail := Failure.new(X::AdHoc.new(:$payload));
+    my $fail := Failure.new(X::AdHoc.new(:payload(@msg.Parcel)));
     my Mu $return := nqp::getlexcaller('RETURN');
     $return($fail) unless nqp::isnull($return);
     $fail

--- a/src/core/Failure.pm
+++ b/src/core/Failure.pm
@@ -61,7 +61,7 @@ multi sub fail(Exception $e) {
     $return($fail) unless nqp::isnull($return);
     $fail
 }
-multi sub fail($payload) {
+multi sub fail($payload = 'Failed') {
     my $fail := Failure.new(X::AdHoc.new(:$payload));
     my Mu $return := nqp::getlexcaller('RETURN');
     $return($fail) unless nqp::isnull($return);

--- a/src/core/Failure.pm
+++ b/src/core/Failure.pm
@@ -4,7 +4,7 @@ my class Failure {
     has $!handled;
 
     method new(Exception $exception) {
-         self.bless(:$exception);
+        self.bless(:$exception);
     }
 
     submethod BUILD (:$!exception) {
@@ -55,17 +55,29 @@ my class Failure {
 }
 
 proto sub fail(|) {*};
-multi sub fail(Exception $e) {
-    my $fail := Failure.new($e);
+# Why do we need two levels of CALLER:: here?  Is this stable?
+multi sub fail($payload =
+    (CALLER::CALLER::.EXISTS-KEY('$!') and CALLER::CALLER::('$!').DEFINITE)
+     ?? CALLER::CALLER::('$!') !! 'Failed') {
+
     my Mu $return := nqp::getlexcaller('RETURN');
-    $return($fail) unless nqp::isnull($return);
-    $fail
-}
-multi sub fail($payload = 'Failed') {
-    my $fail := Failure.new(X::AdHoc.new(:$payload));
-    my Mu $return := nqp::getlexcaller('RETURN');
-    $return($fail) unless nqp::isnull($return);
-    $fail
+
+    # Strange behavior alert:
+    # If you try to if(...) { $fail := ... } else { $fail := ... }
+    # here it behaves sort of as if "use fatal" were in effect even
+    # when it is not, except that's not what is going on because
+    # "die" does not get hit AFAICT.  That took me 4 hours of
+    # fumbling around to figure out what was wrong.
+    if ($payload ~~ Exception) {
+        my $fail := Failure.new($payload);
+        $return($fail) unless nqp::isnull($return);
+        $fail
+    }
+    else {
+        my $fail := Failure.new(X::AdHoc.new(:$payload));
+        $return($fail) unless nqp::isnull($return);
+        $fail
+    }
 }
 multi sub fail(|cap (*@msg)) {
     my $fail := Failure.new(X::AdHoc.from-slurpy(|cap));

--- a/src/core/control.pm
+++ b/src/core/control.pm
@@ -154,7 +154,7 @@ multi sub die($payload = "Died") {
     X::AdHoc.new(:$payload).throw
 }
 multi sub die(*@msg) {
-    X::AdHoc.new(payload => @msg.join).throw
+    X::AdHoc.new(:payload(@msg.Parcel)).throw
 }
 
 multi sub warn(*@msg) {

--- a/src/core/control.pm
+++ b/src/core/control.pm
@@ -153,8 +153,8 @@ multi sub die(Exception $e) { $e.throw }
 multi sub die($payload = "Died") {
     X::AdHoc.new(:$payload).throw
 }
-multi sub die(*@msg) {
-    X::AdHoc.new(:payload(@msg.Parcel)).throw
+multi sub die(|cap ( *@msg )) {
+    X::AdHoc.from-slurpy(|cap).throw
 }
 
 multi sub warn(*@msg) {

--- a/src/core/control.pm
+++ b/src/core/control.pm
@@ -149,9 +149,16 @@ sub samewith(|c) {
 }
 
 proto sub die(|) {*};
-multi sub die(Exception $e) { $e.throw }
-multi sub die($payload = "Died") {
-    X::AdHoc.new(:$payload).throw
+# Why two levels of CALLER:: here?  Is this stable?
+multi sub die($payload = 
+    (CALLER::CALLER::.EXISTS-KEY('$!') and CALLER::CALLER::('$!').DEFINITE)
+     ?? CALLER::CALLER::('$!') !! "Died") {
+    if $payload ~~ Exception {
+        $payload.throw;
+    }
+    else {
+        X::AdHoc.new(:$payload).throw
+    }
 }
 multi sub die(|cap ( *@msg )) {
     X::AdHoc.from-slurpy(|cap).throw

--- a/src/core/control.pm
+++ b/src/core/control.pm
@@ -150,6 +150,9 @@ sub samewith(|c) {
 
 proto sub die(|) {*};
 # Why two levels of CALLER:: here?  Is this stable?
+multi sub die(Exception:U $e) {
+    X::AdHoc.new(:payload("Died with undefined " ~ $e.^name)).throw;
+}
 multi sub die($payload = 
     (CALLER::CALLER::.EXISTS-KEY('$!') and CALLER::CALLER::('$!').DEFINITE)
      ?? CALLER::CALLER::('$!') !! "Died") {


### PR DESCRIPTION
This branch contains various enhancements to failure/exception code.  Some of them are minor spec changes and some may merit a bit of bikeshedding over exact text.  Some may be cherry-pickable.

Most of the improvements give better messages and/or increase the leniency of constructors and
fail/die.  One implements behavior defined in S04 but which rakudo either never implemented or was bitrotted out.  One RT is fixed.  Two tests break, one of which should be tweaked as its expectations are off, and the other is an RT test which hits one of the spec changes.

A script that shows the expected behaviors after the changes is at
https://gist.github.com/skids/2639325b87d5d55840fd

I may add some more commit to this set, but the issues that remain may be more formidable given exception throwing goes layers deep.  The remaining issues I see are:

1) Backtraces are not consistently shown sometimes, and sometimes show a lot of cruft from inside the failure throwing code and stop before getting to useful information.
2) A tweak of "use fatal" that causes Failures created with unthrown exceptions or adhoc text to take a backtrace at the failure creation time and emit two backtraces -- one from that point and one from the actual throw -- is needed.
3) Since 2) may be useful during debugging an additional non-lexical control to cause that behavior may be needed.
