### PR TITLE
Failure bugfixes, enhancements, and error awsomization, take 2

### DIFF
--- a/src/core/Backtrace.pm
+++ b/src/core/Backtrace.pm
@@ -80,11 +80,11 @@ my class Backtrace {
         return nqp::atpos($!frames,$pos) if nqp::existspos($!frames,$pos);
 
         my int $elems = $!bt.elems;
-        return Nil if $!bt-next == $elems;
+        return Nil if $!bt-next >= $elems; # bt-next can init > elems
 
         my int $todo = $pos - nqp::elems($!frames) + 1;
+        return Nil if $todo < 1; # in case absurd $pos passed
         while $!bt-next < $elems {
-
             my $frame := $!bt.AT-POS($!bt-next++);
             my $sub := $frame<sub>;
             next unless defined $sub;
@@ -102,13 +102,19 @@ my class Backtrace {
             next if $file.ends-with('BOOTSTRAP.nqp')
                  || $file.ends-with('QRegex.nqp')
                  || $file.ends-with('Perl6/Ops.nqp');
-            last if $file.ends-with('NQPHLL.nqp');
+            if $file.ends-with('NQPHLL.nqp') {
+                $!bt-next = $elems;
+                last;
+            }
 
             my $line := $annotations<line>;
             next unless $line;
 
             my $name := nqp::p6box_s(nqp::getcodename($do));
-            last if $name eq 'handle-begin-time-exceptions';
+            if $name eq 'handle-begin-time-exceptions' {
+                $!bt-next = $elems;
+                last;
+            }
 
             my $code;
             try {

--- a/src/core/Exception.pm
+++ b/src/core/Exception.pm
@@ -12,7 +12,14 @@ my class Exception {
     }
 
     multi method Str(Exception:D:) {
-        self.?message.Str // 'Something went wrong in ' ~ self.WHAT.gist;
+        my $str;
+        if nqp::isconcrete($!ex) {
+            my str $message = nqp::getmessage($!ex);
+            $str = nqp::isnull_s($message) ?? '' !! nqp::p6box_s($message);
+        }
+        $str ||= (try self.?message);
+        $str = ~$str if defined $str;
+        $str // "Something went wrong in {self.WHAT.gist}";
     }
 
     multi method gist(Exception:D:) {

--- a/src/core/Exception.pm
+++ b/src/core/Exception.pm
@@ -5,9 +5,11 @@ my class Exception {
     has $!ex;
     has $!bt;
 
-    method backtrace() {
+    method backtrace(Exception:D is rw:) {
         if $!bt { $!bt }
-        elsif nqp::isconcrete($!ex) { Backtrace.new($!ex); }
+        elsif nqp::isconcrete($!ex) {
+            nqp::bindattr(self, Exception, '$!bt', Backtrace.new($!ex));
+        }
         else { '' }
     }
 

--- a/src/core/Exception.pm
+++ b/src/core/Exception.pm
@@ -78,7 +78,7 @@ my class Exception {
 }
 
 my class X::AdHoc is Exception {
-    has $.payload;
+    has $.payload = "Unexplained error";
     method message() { $.payload.Str     }
     method Numeric() { $.payload.Numeric }
 }

--- a/src/core/Exception.pm
+++ b/src/core/Exception.pm
@@ -5,7 +5,7 @@ my class Exception {
     has $!ex;
     has $!bt;
 
-    method backtrace(Exception:D is rw:) {
+    method backtrace(Exception:D:) {
         if $!bt { $!bt }
         elsif nqp::isconcrete($!ex) {
             nqp::bindattr(self, Exception, '$!bt', Backtrace.new($!ex));
@@ -17,7 +17,7 @@ my class Exception {
     method vault-backtrace(Exception:D:) {
 	nqp::isconcrete($!ex) && $!bt ?? Backtrace.new($!ex) !! ''
     }
-    method reset-backtrace(Exception:D is rw:) {
+    method reset-backtrace(Exception:D:) {
         nqp::bindattr(self, Exception, '$!ex', Nil)
     }
 
@@ -50,7 +50,7 @@ my class Exception {
         $str;
     }
 
-    method throw($bt?) {
+    method throw(Exception:D: $bt?) {
         nqp::bindattr(self, Exception, '$!ex', nqp::newexception())
             unless nqp::isconcrete($!ex) and $bt;
         nqp::bindattr(self, Exception, '$!bt', $bt); # Even if !$bt
@@ -61,16 +61,16 @@ my class Exception {
         nqp::setmessage($!ex, nqp::unbox_s($msg));
         nqp::throw($!ex)
     }
-    method rethrow() {
+    method rethrow(Exception:D:) {
         nqp::setpayload($!ex, nqp::decont(self));
         nqp::rethrow($!ex)
     }
 
-    method resumable() {
+    method resumable(Exception:D:) {
         nqp::p6bool(nqp::istrue(nqp::atkey($!ex, 'resume')));
     }
 
-    method resume() {
+    method resume(Exception:D:) {
         nqp::resume($!ex);
         True
     }

--- a/src/core/Exception.pm
+++ b/src/core/Exception.pm
@@ -79,8 +79,24 @@ my class Exception {
 
 my class X::AdHoc is Exception {
     has $.payload = "Unexplained error";
-    method message() { $.payload.Str     }
+
+    my role SlurpySentry { }
+
+    method message() {
+        # Remove spaces for die(*@msg)/fail(*@msg) forms
+        given $.payload {
+            when SlurpySentry {
+                $_.list.join;
+            }
+            default {
+                .Str;
+            }
+        }
+    }
     method Numeric() { $.payload.Numeric }
+    method from-slurpy (|cap) {
+        self.new(:payload(cap does SlurpySentry))
+    }
 }
 
 my class X::Dynamic::NotFound is Exception {

--- a/src/core/Failure.pm
+++ b/src/core/Failure.pm
@@ -93,12 +93,25 @@ multi sub fail(|cap (*@msg)) {
     $return($fail) unless nqp::isnull($return);
     $fail
 }
-
-multi sub die(Failure:D $failure) {
-    $failure.exception.throw
+multi sub fail(Failure:U $f) {
+    my $fail := Failure.new(
+        X::AdHoc.new(:payload("Failed with undefined " ~ $f.^name))
+    );
+    my Mu $return := nqp::getlexcaller('RETURN');
+    $return($fail) unless nqp::isnull($return);
+    $fail
 }
-multi sub die(Failure:U) {
-    X::AdHoc('Failure').throw
+multi sub fail(Failure:D $fail) {
+    my Mu $return := nqp::getlexcaller('RETURN');
+    $return($fail) unless nqp::isnull($return);
+    $fail
+}
+
+multi sub die(Failure:D $f) {
+    $f.exception.throw
+}
+multi sub die(Failure:U $f) {
+    X::AdHoc.new(:payload("Died with undefined " ~ $f.^name)).throw;
 }
 
 # vim: ft=perl6 expandtab sw=4

--- a/src/core/Failure.pm
+++ b/src/core/Failure.pm
@@ -3,8 +3,21 @@ my class Failure {
     has $.backtrace;
     has $!handled;
 
-    method new(Exception $exception) {
-         self.bless(:$exception);
+    multi method new(Exception $exception) {
+        self.bless(:$exception);
+    }
+    multi method new($payload =
+        (CALLER::CALLER::.EXISTS-KEY('$!') and CALLER::CALLER::('$!').DEFINITE)
+         ?? CALLER::CALLER::('$!') !! 'Failed') {
+        if ($payload ~~ Exception) {
+            self.bless(:exception($payload));
+        }
+        else {
+            self.bless(:exception(X::AdHoc.new(:$payload)));
+        }
+    }
+    multi method new(|cap (*@msg)) {
+         self.bless(:exception(X::AdHoc.from-slurpy(|cap)));
     }
 
     submethod BUILD (:$!exception) {

--- a/src/core/Failure.pm
+++ b/src/core/Failure.pm
@@ -61,7 +61,7 @@ multi sub fail(Exception $e) {
     $return($fail) unless nqp::isnull($return);
     $fail
 }
-multi sub fail($payload) {
+multi sub fail($payload = 'Failed') {
     my $fail := Failure.new(X::AdHoc.new(:$payload));
     my Mu $return := nqp::getlexcaller('RETURN');
     $return($fail) unless nqp::isnull($return);

--- a/src/core/Failure.pm
+++ b/src/core/Failure.pm
@@ -67,9 +67,8 @@ multi sub fail($payload = 'Failed') {
     $return($fail) unless nqp::isnull($return);
     $fail
 }
-multi sub fail(*@msg) {
-    my $payload = @msg == 1 ?? @msg[0] !! @msg.join;
-    my $fail := Failure.new(X::AdHoc.new(:$payload));
+multi sub fail(|cap (*@msg)) {
+    my $fail := Failure.new(X::AdHoc.from-slurpy(|cap));
     my Mu $return := nqp::getlexcaller('RETURN');
     $return($fail) unless nqp::isnull($return);
     $fail

--- a/src/core/Failure.pm
+++ b/src/core/Failure.pm
@@ -9,6 +9,7 @@ my class Failure {
 
     submethod BUILD (:$!exception) {
         $!backtrace = $!exception.backtrace() || Backtrace.new(9);
+        $!exception.reset-backtrace;
     }
 
     # "Shouldn't happen."  We use note here because the dynamic scope in GC is likely meaningless.

--- a/src/core/control.pm
+++ b/src/core/control.pm
@@ -149,9 +149,15 @@ sub samewith(|c) {
 }
 
 proto sub die(|) {*};
-multi sub die(Exception $e) { $e.throw }
-multi sub die($payload = "Died") {
-    X::AdHoc.new(:$payload).throw
+multi sub die($payload =
+    (CALLER::CALLER::.EXISTS-KEY('$!') and CALLER::CALLER::('$!').DEFINITE)
+     ?? CALLER::CALLER::('$!') !! "Died") {
+    if $payload ~~ Exception {
+        $payload.throw;
+    }
+    else {
+        X::AdHoc.new(:$payload).throw
+    }
 }
 multi sub die(|cap ( *@msg )) {
     X::AdHoc.from-slurpy(|cap).throw

--- a/src/core/control.pm
+++ b/src/core/control.pm
@@ -149,6 +149,9 @@ sub samewith(|c) {
 }
 
 proto sub die(|) {*};
+multi sub die(Exception:U $e) {
+    X::AdHoc.new(:payload("Died with undefined " ~ $e.^name)).throw;
+}
 multi sub die($payload =
     (CALLER::CALLER::.EXISTS-KEY('$!') and CALLER::CALLER::('$!').DEFINITE)
      ?? CALLER::CALLER::('$!') !! "Died") {

--- a/src/core/control.pm
+++ b/src/core/control.pm
@@ -153,8 +153,8 @@ multi sub die(Exception $e) { $e.throw }
 multi sub die($payload = "Died") {
     X::AdHoc.new(:$payload).throw
 }
-multi sub die(*@msg) {
-    X::AdHoc.new(payload => @msg.join).throw
+multi sub die(|cap ( *@msg )) {
+    X::AdHoc.from-slurpy(|cap).throw
 }
 
 multi sub warn(*@msg) {


### PR DESCRIPTION
This replaces PR#470.

I moved all the bugfixes mostly to the front of the queue.

The only feedback I got was not liking the word "Inchoate" so I removed that.

In addition, a new feature whereby Failures produce two backtraces (from their point of origin and from their point of throw)

Fixes to Exception.Str are more robust in this PR following jnthn's example when he fixed .gist.