### PR TITLE
Half-fix regression where somehow we now get a Backtrace of (Any)

### DIFF
--- a/src/core/Exception.pm
+++ b/src/core/Exception.pm
@@ -256,7 +256,7 @@ do {
             my Mu $err := nqp::getstderr();
 
             $e.backtrace;  # This is where most backtraces actually happen
-            if $e.is-compile-time || $e.backtrace.is-runtime {
+            if $e.is-compile-time || $e.backtrace && $e.backtrace.is-runtime {
                 nqp::printfh($err, $e.gist);
                 nqp::printfh($err, "\n");
                 if $v {


### PR DESCRIPTION
  This just improves the printer to handle that gracefully and
  still output the error message.  Why the backtrace is (Any) in the
  first place still needs to be figured out.