### PR TITLE
Various fixes to Signature introspection and take safety CATCH off .assuming

### DIFF
--- a/src/core/Block.pm
+++ b/src/core/Block.pm
@@ -345,7 +345,8 @@ my class Block { # declared in BOOTSTRAP
 
     multi method perl(Block:D:) {
         my $perl = '-> ';
-        $perl ~= substr(self.signature().perl,1); # lose colon prefix
+        # lose colon prefix and parens
+        $perl ~= substr(self.signature().perl,2,*-1);
         $perl ~= ' { #`(' ~ self.WHICH ~ ') ... }';
         $perl
     }

--- a/src/core/Parameter.pm
+++ b/src/core/Parameter.pm
@@ -208,7 +208,9 @@ my class Parameter { # declared in BOOTSTRAP
             $type ~~ / .*? \[ <( .* )> \] $$/;
             $perl = $/ ~ $modifier if $/;
         }
-        elsif $!nominal_type.WHICH !=== $elide-type.WHICH or $modifier {
+        elsif $modifier or !($!nominal_type.HOW.archetypes.nominal &&
+                             $elide-type.HOW.archetypes.nominal &&
+                             $!nominal_type.WHICH === $elide-type.WHICH) {
             $perl = $type ~ $modifier;
         }
         $perl ~= " ::$_" for @($.type_captures);

--- a/src/core/Parameter.pm
+++ b/src/core/Parameter.pm
@@ -201,19 +201,19 @@ my class Parameter { # declared in BOOTSTRAP
           ?? ':D' !! $!flags +& $SIG_ELEM_UNDEFINED_ONLY
             ?? ':U' !! '';
 
+        $perl ~= " ::$_" for @($.type_captures);
         # XXX Need a CODE_SIGIL too?
         if $!flags +& $SIG_ELEM_ARRAY_SIGIL or
             $!flags +& $SIG_ELEM_HASH_SIGIL or
             $type ~~ /^^ Callable >> / {
             $type ~~ / .*? \[ <( .* )> \] $$/;
-            $perl = $/ ~ $modifier if $/;
+            $perl ~= $/ ~ $modifier if $/;
         }
         elsif $modifier or !($!nominal_type.HOW.archetypes.nominal &&
                              $elide-type.HOW.archetypes.nominal &&
                              $!nominal_type.WHICH === $elide-type.WHICH) {
-            $perl = $type ~ $modifier;
+            $perl ~= $type ~ $modifier;
         }
-        $perl ~= " ::$_" for @($.type_captures);
         my $name = $.name;
         if $name {
             if $!flags +& $SIG_ELEM_IS_CAPTURE {

--- a/src/core/Parameter.pm
+++ b/src/core/Parameter.pm
@@ -240,10 +240,11 @@ my class Parameter { # declared in BOOTSTRAP
             $name = '*' ~ $name;
         } elsif self.named {
             my $name1 := substr($name,1);
-            for @(self.named_names) {
-                $name = $_ && $_ eq $name1
-                  ?? ':' ~ $name
-                  !! ':' ~ $_ ~ '(' ~ $name ~ ')';
+            if @(self.named_names).first({$_ && $_ eq $name1}) {
+                $name = ':' ~ $name;
+            }
+            for @(self.named_names).grep({$_ && $_ ne $name1}) {
+                $name = ':' ~ $_ ~ '(' ~ $name ~ ')';
             }
             $name ~= '!' unless self.optional;
         } elsif self.optional && !$default {

--- a/src/core/Parameter.pm
+++ b/src/core/Parameter.pm
@@ -201,7 +201,7 @@ my class Parameter { # declared in BOOTSTRAP
           ?? ':D' !! $!flags +& $SIG_ELEM_UNDEFINED_ONLY
             ?? ':U' !! '';
 
-        $perl ~= " ::$_" for @($.type_captures);
+        $perl ~= "::$_ " for @($.type_captures);
         # XXX Need a CODE_SIGIL too?
         if $!flags +& $SIG_ELEM_ARRAY_SIGIL or
             $!flags +& $SIG_ELEM_HASH_SIGIL or

--- a/src/core/Parameter.pm
+++ b/src/core/Parameter.pm
@@ -269,13 +269,13 @@ my class Parameter { # declared in BOOTSTRAP
                 $rest ~= ' is parcel';
             }
         }
-        $rest ~= ' where { ... }' if !nqp::isnull($!post_constraints);
-        $rest ~= ' = { ... }' if $default;
         unless nqp::isnull($!sub_signature) {
             my $sig = $!sub_signature.perl();
             $sig ~~ s/^^ ':'//;
             $rest ~= ' ' ~ $sig;
         }
+        $rest ~= ' where { ... }' if !nqp::isnull($!post_constraints);
+        $rest ~= ' = { ... }' if $default;
         if $name or $rest {
             $perl ~= ($perl ?? ' ' !! '') ~ $name;
         }


### PR DESCRIPTION
These patches are mostly fixes to problems with .perl methods noticed while/since writing
the new .assuming.  In addition since there have been no complaints with .assuming since it was 
merged, the final commit removes the nerf from the part that checks binding of primer arguments.

