### PR TITLE
Pass correct exitstatus and signal values from Proc::Async to Proc

### DIFF
--- a/src/core/Proc.pm
+++ b/src/core/Proc.pm
@@ -13,7 +13,7 @@ my class Proc {
 
     submethod BUILD(:$in = '-', :$out = '-', :$err = '-', :$exitcode,
                     Bool :$bin, Bool :$chomp = True, Bool :$merge,
-                    Str:D :$enc = 'utf8', Str:D :$nl = "\n") {
+                    Str:D :$enc = 'utf8', Str:D :$nl = "\n", :$signal) {
         if nqp::istype($in, IO::Handle) && $in.DEFINITE {
             $!in_fh := nqp::getattr(nqp::decont($in), IO::Handle, '$!PIO');
             $!flags += nqp::const::PIPE_INHERIT_IN;
@@ -84,6 +84,9 @@ my class Proc {
 
         if nqp::istype($exitcode, Int) && $exitcode.DEFINITE {
             $!exitcode = $exitcode;
+        }
+        if nqp::istype($signal, Int) && $signal.DEFINITE {
+            $!signal = $signal;
         }
     }
 

--- a/src/core/Proc/Async.pm
+++ b/src/core/Proc/Async.pm
@@ -172,7 +172,7 @@ my class Proc::Async {
 
         my Mu $callbacks := nqp::hash();
         nqp::bindkey($callbacks, 'done', -> Mu \status {
-            $!exit_promise.keep(Proc.new(:exitcode(status)))
+            $!exit_promise.keep(Proc.new(:exitcode(status +> 8), :signal(status +& 0xFF)))
         });
         nqp::bindkey($callbacks, 'error', -> Mu \err {
             $!exit_promise.break(X::OS.new(os-error => err));


### PR DESCRIPTION
Proc::Async is confusing exit-code with status.

The code
~~~~
Proc::Async.new("perl6", "-e", "exit 2").start.result.perl.say
~~~~

is currently returning something like
~~~~
Proc.new(in => IO::Pipe, out => IO::Pipe, err => IO::Pipe, exitcode => 512, pid => Any, signal => Any)
~~~~

This is incorrect, it should return something like
~~~~
Proc.new(in => IO::Pipe, out => IO::Pipe, err => IO::Pipe, exitcode => 2, pid => Any, signal => 0)
~~~~

(and possibly set the pid too, but that'd be subject of a different patch).

An alternative to this patch would be to make it accept a :status argument, and let that sort out the unpacking into exitcode and signal. Wouldn't be much harder to implement that, but this felt like the more compatible way to do it.