### PR TITLE
Make EXPORTHOW declarators modify %*LANG rather than CURSOR

### DIFF
--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -591,12 +591,13 @@ class Perl6::World is HLL::World {
 
     method add_package_declarator($/, str $pdecl) {
         my $cursor := $/.CURSOR;
+        my $grammar := %*LANG<MAIN>;
 
         # Compute name of grammar/action entry.
         my $canname := 'package_declarator:sym<' ~ $pdecl ~ '>';
 
         # Add to grammar if needed.
-        unless nqp::can($cursor, $canname) {
+        unless nqp::can($grammar, $canname) {
             my role PackageDeclarator[$meth_name, $declarator] {
                 token ::($meth_name) {
                     :my $*OUTERPACKAGE := $*PACKAGE;
@@ -604,23 +605,28 @@ class Perl6::World is HLL::World {
                     :my $*LINE_NO := HLL::Compiler.lineof($cursor.orig(), $cursor.from(), :cache(1));
                     $<sym>=[$declarator] <.end_keyword> <package_def>
                 }
-            }
-            $cursor.HOW.mixin($cursor, PackageDeclarator.HOW.curry(PackageDeclarator, $canname, $pdecl));
+            };
 
-            # This also becomes the current MAIN. Also place it in %?LANG.
-            %*LANG<MAIN> := $cursor.WHAT;
+            # Add package declarator to current MAIN. Also place it in %?LANG
+            %*LANG<MAIN> := $grammar.HOW.mixin($grammar,
+                PackageDeclarator.HOW.curry(PackageDeclarator, $canname, $pdecl)
+            );
             self.install_lexical_symbol(self.cur_lexpad(), '%?LANG', self.p6ize_recursive(%*LANG));
         }
 
+        my $actions := %*LANG<MAIN-actions>;
+
         # Add action method if needed.
-        unless nqp::can($*ACTIONS, $canname) {
+        unless nqp::can($actions, $canname) {
             my role PackageDeclaratorAction[$meth] {
                 method ::($meth)($/) {
                     make $<package_def>.ast;
                 }
             };
-            %*LANG<MAIN-actions> := $*ACTIONS.HOW.mixin($*ACTIONS,
-                PackageDeclaratorAction.HOW.curry(PackageDeclaratorAction, $canname));
+
+            %*LANG<MAIN-actions> := $actions.HOW.mixin($actions,
+                PackageDeclaratorAction.HOW.curry(PackageDeclaratorAction, $canname)
+            );
         }
     }
 


### PR DESCRIPTION
```
14:13 jnthn        llfourn: I fear the way the slang is being applied tweaks %*LANG but EXPORTHOW works against the current cursor
14:13 llfourn      jnthn: I thought %*LANG was the current cursor
14:14 jnthn        No, it only determines the type of the cursor at the point of the next statement
14:14 llfourn      is there any better way to apply a slang so that it doesn't get wiped by EXPORTHOW?
14:16 jnthn        llfourn: Don't know; another option maybe is that we tweak EXPORTHOW to also manipulate %*LANG instead
14:16 jnthn        llfourn: You might try patching the EXPORTHOW handling in Rakudo to see if that helps
14:16 llfourn      jnthn: kk will give it a shot. thanks.
```
This patch fixes the problem where EXPORTHOW would wipe changes you make to `%*LANG` in EXPORT:
```perl6
sub EXPORT {
 #do something to %*LANG
}

package EXPORTHOW {
     package DELCARE {
         #this will wipe whatever you did before
         constant myclass = MyMetalModel::MyClass;  
     }
}
````
scrutinise carefully because I don't know much about things :)