### PR TITLE
add .absolutify() to CUR::Locally

### DIFF
--- a/src/core/CompUnitRepo/Local/Installation.pm
+++ b/src/core/CompUnitRepo/Local/Installation.pm
@@ -68,7 +68,7 @@ sub MAIN(:$name, :$auth, :$ver, *@, *%) {
     exit run($*EXECUTABLE-NAME, @binaries[0].hash.<files><bin/#name#>, @*ARGS).exitcode
 }';
 
-    method install(:$dist!, *@files) {
+    method install(:$dist!, :$from, *@files) {
         $!lock.protect( {
         my $path     = self.writeable-path or die "No writeable path found";
         my $repo     = %!dists{$path};
@@ -104,11 +104,12 @@ sub MAIN(:$name, :$auth, :$ver, *@, *%) {
         my $has-provides;
         for @files -> $file is copy {
             $file = $is-win ?? ~$file.subst('\\', '/', :g) !! ~$file;
+
             if [||] @provides>>.ACCEPTS($file) -> $/ {
                 $has-provides = True;
                 $d.provides{ $/.ast }{ $<ext> } = {
                     :file($file-id),
-                    :time(try $file.IO.modified.Num),
+                    :time(try self.absolutify($file, $from).IO.modified.Num),
                     :$!cver
                 }
             }
@@ -132,7 +133,7 @@ sub MAIN(:$name, :$auth, :$ver, *@, *%) {
                 }
                 $d.files{$file} = $file-id
             }
-            copy($file, $path ~ '/' ~ $file-id);
+            copy(self.absolutify($file, $from), $path ~ '/' ~ $file-id);
             $file-id++;
         }
 

--- a/src/core/CompUnitRepo/Locally.pm
+++ b/src/core/CompUnitRepo/Locally.pm
@@ -32,6 +32,10 @@ role CompUnitRepo::Locally {
         self.short-id ~ '#' ~ $!IO.abspath;
     }
 
+    method absolutify(CompUnitRepo::Locally:_: |c) {
+        $*SPEC.rel2abs(|c);
+    }
+
     # stubs
     method files(CompUnitRepo::Locally:D: $file, :$name, :$auth, :$ver)   {...}
     method candidates(CompUnitRepo::Locally:D: $name,:$file,:$auth,:$ver) {...}

--- a/src/core/CompUnitRepo/Locally.pm
+++ b/src/core/CompUnitRepo/Locally.pm
@@ -32,7 +32,7 @@ role CompUnitRepo::Locally {
         self.short-id ~ '#' ~ $!IO.abspath;
     }
 
-    method absolutify(CompUnitRepo::Locally:_: |c) {
+    method absolutify(CompUnitRepo::Locally: |c) {
         $*SPEC.rel2abs(|c);
     }
 


### PR DESCRIPTION
A first crack at lizmats reponse in #468 

Allows CUR::Installation to install from non-$*CWD directories (related to copying files, and getting the proper file modification time for the MANIFEST).

It seems like the base path (in this case, :$from added to CURLI.install) might be better off as an attribute of Distribution. If such a solution is better, a proper name for the attribute will be needed (it may contain a file path, a url, or not exist at all)