### PR TITLE
Make push and unshift iterate on single arguments in containers.

### DIFF
--- a/lib/Test.pm
+++ b/lib/Test.pm
@@ -604,7 +604,7 @@ sub _init_vars {
 }
 
 sub _push_vars {
-    @vars.push: item [
+    @vars.push: ([
       $num_of_tests_run,
       $num_of_tests_failed,
       $todo_upto_test_num,
@@ -615,7 +615,7 @@ sub _push_vars {
       $time_before,
       $time_after,
       $done_testing_has_been_run,
-    ];
+    ],);
 }
 
 sub _pop_vars {

--- a/src/core/Any-iterable-methods.pm
+++ b/src/core/Any-iterable-methods.pm
@@ -555,7 +555,7 @@ augment class Any {
                 return if $val =:= IterationEnd;
                 my @args = $val;
                 while (my \current = iter.pull-one) !=:= IterationEnd {
-                    @args.unshift: current;
+                    @args.unshift: (current,);
                     if @args.elems == $count {
                         $val := with(|@args);
                         @args = $val;
@@ -571,7 +571,7 @@ augment class Any {
                 return if $val =:= IterationEnd;
                 my @args = $val;
                 while (my \current = iter.pull-one) !=:= IterationEnd {
-                    @args.push: current;
+                    @args.push: (current,);
                     if @args.elems == $count {
                         $val := with(|@args);
                         @args = $val;
@@ -602,7 +602,7 @@ augment class Any {
         gather self.map: {
             $target = &as($_);
             if first( { with($target,$_) }, @seen ) =:= Nil {
-                @seen.push($target);
+                @seen.push(($target,));
                 take $_;
             }
         };
@@ -626,7 +626,7 @@ augment class Any {
         gather self.map: {
             $target := $_;
             if first( { with($target,$_) }, @seen ) =:= Nil {
-                @seen.push($target.item);
+                @seen.push(($target,));
                 take $_;
             }
         }

--- a/src/core/Array.pm
+++ b/src/core/Array.pm
@@ -218,7 +218,7 @@ my class Array { # declared in BOOTSTRAP
 
     multi method push(Array:D: \value) {
         self!ensure-allocated();
-        if nqp::iscont(value) || nqp::not_i(nqp::istype(value, Iterable)) {
+        if nqp::not_i(nqp::istype(value, Iterable)) {
             fail X::Cannot::Lazy.new(action => 'push to') if self.is-lazy;
 
             nqp::push(
@@ -249,7 +249,7 @@ my class Array { # declared in BOOTSTRAP
     }
 
     multi method unshift(Array:D: \value) {
-        if nqp::iscont(value) || nqp::not_i(nqp::istype(value, Iterable)) {
+        if nqp::not_i(nqp::istype(value, Iterable)) {
             self!ensure-allocated();
 
             nqp::unshift(

--- a/src/core/List.pm
+++ b/src/core/List.pm
@@ -18,7 +18,7 @@ my sub combinations($n, $k) {
 
         while $value < $n {
             @result[$index++] = $value++;
-            @stack.push($value);
+            @stack.push(($value,));
             if $index == $k {
                 take infix:<,>(|@result);
                 $value = $n;  # fake a last
@@ -994,7 +994,7 @@ sub roundrobin(**@lol) {
             for @iters -> $i {
                 my \v = $i.pull-one;
                 if v !=:= IterationEnd {
-                    @values.push: v;
+                    @values.push: (v,);
                     @new-iters.push: $i;
                 }
             }

--- a/src/core/Supply.pm
+++ b/src/core/Supply.pm
@@ -63,7 +63,7 @@ my role Supply {
             .emit().(msg) for tappers;
         }
         elsif !$!been_tapped {
-            $!tappers_lock.protect({ @!paused.push: msg });
+            $!tappers_lock.protect({ @!paused.push: (msg,) });
         }
         Nil;
     }
@@ -229,7 +229,7 @@ my role Supply {
                                   }
                               }
                               else {
-                                  @seen.push: $[$target, $now+$expires];
+                                  @seen.push: ([$target, $now+$expires],);
                                   $res.emit(val);
                               }
                           }
@@ -244,7 +244,7 @@ my role Supply {
                                   }
                               }
                               else {
-                                  @seen.push: $[val, $now+$expires];
+                                  @seen.push: ([val, $now+$expires],);
                                   $res.emit(val);
                               }
                           };
@@ -281,14 +281,14 @@ my role Supply {
                           ?? -> \val {
                               $target = &as(val);
                               if @seen.first({ &with($target,$_) } ) =:= Nil {
-                                  @seen.push($target);
+                                  @seen.push(($target,));
                                   $res.emit(val);
                               }
                           }
                           !! -> \val {
                               if @seen.first({ &with(val,$_) } ) =:= Nil {
-                                  @seen.push(val);
-                                  $res.emit(val);
+                                  @seen.push((val,));
+                                  $res.emit(val,);
                               }
                           };
                     }
@@ -380,7 +380,7 @@ my role Supply {
 
                 {
                     emit => -> \val {
-                        @batched.push: val unless $skip && $skip--;
+                        @batched.push: (val,) unless $skip && $skip--;
                         if @batched.elems == $elems {
                             flush;
                             next-batch;
@@ -419,10 +419,10 @@ my role Supply {
                                   if $this_time != $last_time {
                                       flush if @batched;
                                       $last_time = $this_time;
-                                      @batched.push: val;
+                                      @batched.push: (val,);
                                   }
                                   else {
-                                      @batched.push: val;
+                                      @batched.push: (val,);
                                       flush if @batched.elems == $elems;
                                   }
                               }
@@ -432,12 +432,12 @@ my role Supply {
                                       flush if @batched;
                                       $last_time = $this_time;
                                   }
-                                  @batched.push: val;
+                                  @batched.push: (val,);
                               }
                         }
                         else { # just $elems
                             -> \val {
-                                @batched.push: val;
+                                @batched.push: (val,);
                                 flush if @batched.elems == $elems;
                             }
                         }
@@ -614,7 +614,7 @@ my role Supply {
                       ?? -> \val { @seen[0] = val }
                       !! -> \val {
                           @seen.shift if +@seen == $number;
-                          @seen.push: val;
+                          @seen.push: (val,);
                       },
                     done => {
                         $res.emit($_) for @seen;
@@ -707,7 +707,7 @@ my role Supply {
             $self => do {
                 my @seen;
                 {
-                    emit => -> \val { @seen.push: val },
+                    emit => -> \val { @seen.push: (val,) },
                     done => {
                         $res.emit($_) for when_done(@seen);
                         $res.done;
@@ -752,7 +752,7 @@ my role Supply {
         my @values = ( [] xx +@s );
         on -> $res {
             @s => -> $val, $index {
-                @values[$index].push($val);
+                @values[$index].push(($val,));
                 if all(@values) {
                     $res.emit( [[&with]] @values>>.shift );
                 }
@@ -895,10 +895,10 @@ sub on(&setup) {
                 }
                 given $what {
                     when EnumMap {
-                        @to_close.push(self!add_source($source, $lock, $index, |$what));
+                        @to_close.push((self!add_source($source, $lock, $index, |$what),));
                     }
                     when Callable {
-                        @to_close.push(self!add_source($source, $lock, $index, emit => $what));
+                        @to_close.push((self!add_source($source, $lock, $index, emit => $what),));
                     }
                     default {
                         X::Supply::On::BadSetup.new.throw;

--- a/src/core/asyncops.pm
+++ b/src/core/asyncops.pm
@@ -73,8 +73,7 @@ sub EARLIEST(@earliest,*@other,:$wild_done,:$wild_more,:$wait,:$wait_time) {
 
         for @contestant {
             %channels-by-kind{$kind}{$_.WHICH} = $_;
-            # XXX GLR .item necessary ??
-            @todo.push: [ +@todo, $kind, $_, &block ].item;
+            @todo.push: ([ +@todo, $kind, $_, &block ],);
         }
     }
 
@@ -89,15 +88,13 @@ sub EARLIEST(@earliest,*@other,:$wild_done,:$wild_more,:$wait,:$wait_time) {
 
             if $wild_more.defined {
                 if not %channels-by-kind{$EARLIEST_KIND_MORE}{$n}:exists {
-                    # XXX GLR .item necessary ??
-                    @todo.push: [ +@todo, $EARLIEST_KIND_MORE, $_, $wild_more ].item;
+                    @todo.push: ([ +@todo, $EARLIEST_KIND_MORE, $_, $wild_more ],);
                     %distinct-channels{$n} = $_;
                 }
             }
             if $wild_done.defined {
                 if not %channels-by-kind{$EARLIEST_KIND_DONE}{$n}:exists {
-                    # XXX GLR .item necessary ??
-                    @todo.push: [ +@todo, $EARLIEST_KIND_DONE, $_, $wild_done ].item;
+                    @todo.push: ([ +@todo, $EARLIEST_KIND_DONE, $_, $wild_done ],);
                     %distinct-channels{$n} = $_;
                 }
             }


### PR DESCRIPTION
Per http://irclog.perlgeek.de/perl6/2015-08-24#i_11106557
itemization only protects against flattening, not single-arg-rule.

When push and unshift were implemented they assumed the opposite.

This brings their behavior in line and fixes as much of the
fallout from that in rakudo.  Even with those fixes we lose
progress on the test suite -- 7 files and some more tests in
already failing files need adjustment because they relied on
the previous behavior.

Some of the internal fixes may be superstitious, but can be
cleaned up later (you must be able to know you will not get any
Iterables to determine what is safe, and that is time consuming.)