### PR TITLE
Prevent generation of X::Cannot::Empty Failures in :nth processing.

### DIFF
--- a/src/core/Str.pm
+++ b/src/core/Str.pm
@@ -687,11 +687,11 @@ my class Str does Stringy { # declared in BOOTSTRAP
             @matches := (gather do for $matches -> $m {
                 state $i = 0;
                 state $took = 0;
-                state $n = $idxs.shift;
+                state $n = $idxs.EXISTS-POS(0) ?? $idxs.shift !! Nil;
                 last unless $n.defined;
 
                 if $i == $n {
-                    $n = $idxs.shift;
+                    $n = $idxs.EXISTS-POS(0) ?? $idxs.shift !! Nil;
                     take $m;
                     $took++;
                     last if $took >= $clip.max;


### PR DESCRIPTION
There was a case where the result of shift() could escape without
being handled.  Probably more efficient not to generate any Failure
objects in the first place, so do that.

ab[56]tract++ for unearthing with a long-running script.