### PR TITLE
Perl -e is strict by default

### DIFF
--- a/docs/running.pod
+++ b/docs/running.pod
@@ -14,7 +14,7 @@ compiled code.
 
   -c                   check syntax only (runs BEGIN and CHECK blocks)
   --doc                extract documentation and print it as text
-  -e program           one line of program, strict is disabled by default
+  -e program           one line of program, strict is enabled by default
   -h, --help           display this help text
   -n                   run program once for each line of input
   -p                   same as -n, but also print $_ at the end of lines

--- a/src/Perl6/Compiler.nqp
+++ b/src/Perl6/Compiler.nqp
@@ -171,7 +171,7 @@ class Perl6::Compiler is HLL::Compiler {
  
           -c                   check syntax only (runs BEGIN and CHECK blocks)
           --doc                extract documentation and print it as text
-          -e program           one line of program, strict is disabled by default
+          -e program           one line of program, strict is enabled by default
           -h, --help           display this help text
           -n                   run program once for each line of input
           -p                   same as -n, but also print \$_ at the end of lines


### PR DESCRIPTION
According to perl6-users (http://www.nntp.perl.org/group/perl.perl6.users/2015/08/msg2220.html), perl6 oneliners are strict by default so documentation and help screen requires aligning