### PR TITLE
Restore bare Whatever candidate to map method.

### DIFF
--- a/src/core/Any-iterable-methods.pm
+++ b/src/core/Any-iterable-methods.pm
@@ -19,6 +19,11 @@ augment class Any {
 
     proto method map(|) { * }
 
+    multi method map(\SELF: Whatever, |c) {
+        # XXX nextwith/callwith would not work here
+        SELF.map(-> $star is parcel { $star }, |c)
+    }
+
     multi method map(\SELF: &block, :$label, :$item) {
         sequential-map(as-iterable($item ?? (SELF,) !! SELF).iterator, &block, :$label);
     }


### PR DESCRIPTION
Seems to have gotten removed during GLR.