### PR TITLE
Handle new if statement definition

### DIFF
--- a/src/perl6-debug.nqp
+++ b/src/perl6-debug.nqp
@@ -198,7 +198,7 @@ class Perl6::HookActions is Perl6::Actions {
     
     method statement_control:sym<if>($/) {
         if $*DEBUG_HOOKS.has_hook('statement_cond') {
-            my $from := $<sym>.from;
+            my $from := $<sym>[0].from;
             for $<xblock> {
                 my $ast := $_.ast;
                 $ast[0] := QAST::Stmts.new(


### PR DESCRIPTION
This updates the debugger to deal with the syntax tree as it is created
after 1c76b58e5.

Without this commit, the debugger will die if your code contains any if
statements.