### PR TITLE
Delay attributive parameter binding ops until after bind will succeed

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -6932,6 +6932,7 @@ Compilation unit '$file' contained the following violations:
         my @p_objs := nqp::getattr($sig, $Sig, '$!params');
         my int $i  := 0;
         my int $n  := nqp::elems(@params);
+        my @attrs;
         while $i < $n {
             # Some things need the full binder to do.
             my %info      := @params[$i];
@@ -7336,14 +7337,14 @@ Compilation unit '$file' contained the following violations:
                 }
             }
 
-            # If it's an attributive parameter, do the bind.
+            # If it's an attributive parameter, stash some ops for binding it
             if %info<bind_attr> {
                 # If the type given for the attr_package is generic, we're
                 # dealing with a role and have to look up what type it's
                 # supposed to grab the attribute from during run-time.
                 if %info<attr_package>.HOW.archetypes.generic {
                     my $packagename := %info<attr_package>.HOW.name(%info<attr_package>);
-                    $var.push(QAST::Op.new(
+                    @attrs.push(QAST::Op.new(
                         :op('p6store'),
                         QAST::Var.new(
                             :name(%info<variable_name>), :scope('attribute'),
@@ -7356,7 +7357,7 @@ Compilation unit '$file' contained the following violations:
                         )));
                 }
                 else {
-                    $var.push(QAST::Op.new(
+                    @attrs.push(QAST::Op.new(
                         :op('p6store'),
                         QAST::Var.new(
                             :name(%info<variable_name>), :scope('attribute'),
@@ -7375,6 +7376,8 @@ Compilation unit '$file' contained the following violations:
 
             $i++;
         }
+        # Add the attributive parameter binding code.
+        for @attrs { nqp::push(@result, $_) };
         if $clear_topic_bind {
             $clear_topic_bind.shift(); $clear_topic_bind.shift();
             $clear_topic_bind.op('null');


### PR DESCRIPTION
This fixes one of the cases in [RT#125437](https://github.com/Raku/old-issue-tracker/issues/4332).  Also a flag is now provided that
could be used if we can identify certain types of bind operations
which should not implicitly alter self.

Note that $!param inside a where clause will return self's current value
after this patch, and also note that the patch does not protect against
explicit side-effect-modification of self's attributes in where
clauses during a failed bind.  If we can make a temporary lexpad shadow of
. or !-twigiled variables for the where clause lexpad, I don't know how
(and am not sure we'd want to, anyway.)
