### PR TITLE
Enable extended file open modes on the JVM

### DIFF
--- a/src/core/IO/Handle.pm
+++ b/src/core/IO/Handle.pm
@@ -84,8 +84,7 @@ my class IO::Handle does IO {
             $truncate  ?? 't' !! '',
             $exclusive ?? 'x' !! '';
 
-#?if !moar
-        # don't use new modes on anything but MoarVM
+#?if parrot
         # TODO: check what else can be made to work on Parrot
         #       cf io/utilities.c, Parrot_io_parse_open_flags()
         #          platform/generic/io.c, convert_flags_to_unix()


### PR DESCRIPTION
Requires https://github.com/perl6/nqp/pull/245

Doc patches and tests still needed. For reference, see https://github.com/rakudo/rakudo/pull/430