### PR TITLE
Fix rotor for some Positionals

### DIFF
--- a/src/core/List.pm
+++ b/src/core/List.pm
@@ -773,6 +773,7 @@ my class List does Iterable does Positional { # declared in BOOTSTRAP
     }
 
     method rotor(List:D: *@cycle, :$partial) is nodal {
+        self!ensure-allocated;
         die "Must specify *how* to rotor a List"
           unless @cycle.is-lazy || @cycle;
 


### PR DESCRIPTION
Assure $!reified is set for method .rotor

Fixes Buf/Blob.new().rotor(1) error "This type does not support elems"