### PR TITLE
QX deprecated, runout and shellout

### DIFF
--- a/src/core/Proc.pm
+++ b/src/core/Proc.pm
@@ -140,7 +140,16 @@ sub shell($cmd, :$in = '-', :$out = '-', :$err = '-',
     $proc
 }
 
+sub runout(|c) {
+    run(|c, :out).out.slurp-rest
+}
+
+sub shellout(|c) {
+    shell(|c, :out).out.slurp-rest
+}
+
 sub QX($cmd, :$cwd = $*CWD, :$env) {
+    DEPRECATED("'runout' or 'shellout'", '2015.10');
     my %env := $env ?? $env.hash !! %*ENV;
     my Mu $pio := nqp::syncpipe();
     my $status := nqp::shell(


### PR DESCRIPTION
Description of this pull request was moved to https://github.com/perl6/specs/pull/102.
