### PR TITLE
equiv/tighter/looser traits with is equiv<+> syntax

### DIFF
--- a/src/core/operators.pm
+++ b/src/core/operators.pm
@@ -631,6 +631,35 @@ sub infix:<orelse>(**@a) {
     $current;
 }
 
+# next three sub would belong to traits.pm if PseudoStash were available
+# so early in the setting compunit
+multi sub trait_mod:<is>(Routine $r, Str :$equiv!) {
+    if (my $i = nqp::index($r.name, ':')) > 0 {
+        my \nm ='&' ~ nqp::substr($r.name, 0, $i+1) ~ '<' ~ $equiv ~ '>';
+        trait_mod:<is>($r, equiv => ::(nm));
+        return;
+    } 
+    die "Routine given to equiv does not appear to be an operator";;
+}
+
+multi sub trait_mod:<is>(Routine $r, Str :$tighter!) {
+    if (my $i = nqp::index($r.name, ':')) > 0 {
+        my \nm ='&' ~ nqp::substr($r.name, 0, $i+1) ~ '<' ~ $tighter ~ '>';
+        trait_mod:<is>($r, tighter => ::(nm));
+        return;
+    } 
+    die "Routine given to tighter does not appear to be an operator";;
+}
+
+multi sub trait_mod:<is>(Routine $r, Str :$looser!) {
+    if (my $i = nqp::index($r.name, ':')) > 0 {
+        my \nm ='&' ~ nqp::substr($r.name, 0, $i+1) ~ '<' ~ $looser ~ '>';
+        trait_mod:<is>($r, looser => ::(nm));
+        return;
+    } 
+    die "Routine given to looser does not appear to be an operator";;
+}
+
 proto sub infix:<∘> (&?, &?) {*}
 multi sub infix:<∘> () { *.self }
 multi sub infix:<∘> (&f) { &f }

--- a/src/core/traits.pm
+++ b/src/core/traits.pm
@@ -148,6 +148,7 @@ multi sub trait_mod:<is>(Routine:D $r, :prec(%spec)!) {
     }
     0;
 }
+# three other trait_mod sub for equiv/tighter/looser in operators.pm
 multi sub trait_mod:<is>(Routine $r, :&equiv!) {
     nqp::can(&equiv, 'prec')
         ?? trait_mod:<is>($r, :prec(&equiv.prec))


### PR DESCRIPTION
as per S06/=item C<is tighter>/C<is looser>/C<is equiv>
S06-routines.pod:2196:    sub postfix:<!> ($x) is equiv<++> {...}
