### PR TITLE
Add IO::Spec::Any

### DIFF
--- a/src/core/IO/Spec/Any.pm
+++ b/src/core/IO/Spec/Any.pm
@@ -1,0 +1,81 @@
+my role IO::Spec::Any {
+
+    method canonpath { ... }
+
+    method dir-sep  { ... }
+    method curdir   { '.'  }
+    method updir    { '..' }
+    method curupdir { none('.','..') }
+    method rootdir  { ... }
+    method devnull  { ... }
+
+    method basename { ... }
+
+    method extension(\path) {
+        my str $str = nqp::unbox_s(path);
+        my int $index = nqp::rindex($str,'.');
+        nqp::p6bool($index == -1)
+          ?? ''
+          !! substr(path,nqp::box_i($index + 1,Int) );
+    }
+
+    method is-absolute { ... }
+    method path { ... }
+    method splitpath { ... }
+    method splitdir { ... }
+    method split { ... }
+    method join { ... }
+    method catpath { ... }
+    method catfile { ... }
+
+    method abs2rel($path is copy, $base is copy = Str ) {
+        $base = $*CWD unless $base.defined && $base.chars;
+
+        if self.is-absolute($path) || self.is-absolute($base) {
+            $path = self.rel2abs( $path );
+            $base = self.rel2abs( $base );
+        }
+        else {
+            # save a couple of cwd()s if both paths are relative
+            $path = self.catdir( self.rootdir, $path );
+            $base = self.catdir( self.rootdir, $base );
+        }
+
+        my ($path_volume, $path_directories) = self.splitpath( $path, :nofile );
+        my ($base_volume, $base_directories) = self.splitpath( $base, :nofile );
+
+        # Can't relativize across volumes
+        return $path unless $path_volume eq $base_volume;
+
+        # For UNC paths, the user might give a volume like //foo/bar that
+        # strictly speaking has no directory portion.  Treat it as if it
+        # had the root directory for that volume.
+        if !$base_directories.chars && self.is-absolute( $base ) {
+            $base_directories = self.rootdir;
+        }
+
+        # Now, remove all leading components that are the same
+        my @pathchunks = self.splitdir( $path_directories );
+        my @basechunks = self.splitdir( $base_directories );
+
+        if $base_directories eq self.rootdir {
+            @pathchunks.shift;
+            return self.canonpath( self.catpath('', self.catdir( @pathchunks ), '') );
+        }
+
+        while @pathchunks && @basechunks && @pathchunks[0] eq @basechunks[0] {
+            @pathchunks.shift;
+            @basechunks.shift;
+        }
+        return self.curdir unless @pathchunks || @basechunks;
+
+        # $base now contains the directories the resulting relative path
+        # must ascend out of before it can descend to $path_directory.
+        my $result_dirs = self.catdir( self.updir() xx @basechunks.elems, @pathchunks );
+        return self.canonpath( self.catpath('', $result_dirs, '') );
+    }
+
+    method rel2abs { ... }
+}
+
+

--- a/src/core/IO/Spec/Unix.pm
+++ b/src/core/IO/Spec/Unix.pm
@@ -1,4 +1,4 @@
-my class IO::Spec::Unix is IO::Spec {
+my class IO::Spec::Unix is IO::Spec does IO::Spec::Any {
 
     method canonpath( $patharg, :$parent --> Str) {
         my $path = $patharg.Str;
@@ -19,9 +19,6 @@ my class IO::Spec::Unix is IO::Spec {
     }
 
     method dir-sep  {  '/' }
-    method curdir   {  '.' }
-    method updir    { '..' }
-    method curupdir { none('.','..') }
     method rootdir  { '/' }
     method devnull  { '/dev/null' }
 
@@ -30,14 +27,6 @@ my class IO::Spec::Unix is IO::Spec {
         my int $index = nqp::rindex($str,'/');
         nqp::p6bool($index == -1)
           ?? path
-          !! substr(path,nqp::box_i($index + 1,Int) );
-    }
-
-    method extension(\path) {
-        my str $str = nqp::unbox_s(path);
-        my int $index = nqp::rindex($str,'.');
-        nqp::p6bool($index == -1)
-          ?? ''
           !! substr(path,nqp::box_i($index + 1,Int) );
     }
 
@@ -120,53 +109,6 @@ my class IO::Spec::Unix is IO::Spec {
     method catdir( *@parts ) { self.canonpath( (flat @parts, '').join('/') ) }
     method splitdir( $path ) { $path.split( '/' )  }
     method catfile( |c )     { self.catdir(|c) }
-
-    method abs2rel( $path is copy, $base is copy = Str ) {
-        $base = $*CWD unless $base.defined && $base.chars;
-
-        if self.is-absolute($path) || self.is-absolute($base) {
-            $path = self.rel2abs( $path );
-            $base = self.rel2abs( $base );
-        }
-        else {
-            # save a couple of cwd()s if both paths are relative
-            $path = self.catdir( self.rootdir, $path );
-            $base = self.catdir( self.rootdir, $base );
-        }
-
-        my ($path_volume, $path_directories) = self.splitpath( $path, :nofile );
-        my ($base_volume, $base_directories) = self.splitpath( $base, :nofile );
-
-        # Can't relativize across volumes
-        return $path unless $path_volume eq $base_volume;
-
-        # For UNC paths, the user might give a volume like //foo/bar that
-        # strictly speaking has no directory portion.  Treat it as if it
-        # had the root directory for that volume.
-        if !$base_directories.chars && self.is-absolute( $base ) {
-            $base_directories = self.rootdir;
-        }
-
-        # Now, remove all leading components that are the same
-        my @pathchunks = self.splitdir( $path_directories );
-        my @basechunks = self.splitdir( $base_directories );
-
-        if $base_directories eq self.rootdir {
-            @pathchunks.shift;
-            return self.canonpath( self.catpath('', self.catdir( @pathchunks ), '') );
-        }
-
-        while @pathchunks && @basechunks && @pathchunks[0] eq @basechunks[0] {
-            @pathchunks.shift;
-            @basechunks.shift;
-        }
-        return self.curdir unless @pathchunks || @basechunks;
-
-        # $base now contains the directories the resulting relative path
-        # must ascend out of before it can descend to $path_directory.
-        my $result_dirs = self.catdir( self.updir() xx @basechunks.elems, @pathchunks );
-        return self.canonpath( self.catpath('', $result_dirs, '') );
-    }
 
     method rel2abs( $path, $base? is copy) {
         return self.canonpath($path) if self.is-absolute($path);

--- a/src/core/IO/Spec/Win32.pm
+++ b/src/core/IO/Spec/Win32.pm
@@ -1,4 +1,4 @@
-my class IO::Spec::Win32 is IO::Spec::Unix {
+my class IO::Spec::Win32 is IO::Spec does IO::Spec::Any {
 
     # Some regexes we use for path splitting
     my $slash       = regex {  <[\/ \\]> }

--- a/tools/build/Makefile-JVM.in
+++ b/tools/build/Makefile-JVM.in
@@ -133,6 +133,7 @@ J_CORE_SOURCES = \
   src/core/IO/File.pm \
   src/core/IO/Huh.pm \
   src/core/IO/Spec.pm \
+  src/core/IO/Spec/Any.pm \
   src/core/IO/Spec/Unix.pm \
   src/core/IO/Spec/Win32.pm \
   src/core/IO/Spec/Cygwin.pm \

--- a/tools/build/moar_core_sources
+++ b/tools/build/moar_core_sources
@@ -82,6 +82,7 @@ src/core/IO/Dir.pm
 src/core/IO/File.pm
 src/core/IO/Huh.pm
 src/core/IO/Spec.pm
+src/core/IO/Spec/Any.pm
 src/core/IO/Spec/Unix.pm
 src/core/IO/Spec/Win32.pm
 src/core/IO/Spec/Cygwin.pm


### PR DESCRIPTION
In the old design an IO::Spec::Win32 isa IO::Spec::Unix, this violation of the Liskov substitution principple causes various issues. This patch adds a IO::Spec::Any role containing the shared interface, as well as shared implementations. I would have preferred to add this to IO::Spec itself, but that is not possible while it's exposing a (documented) class method (select).
