### PR TITLE
%*LANG modifications go through World.mixin_LANG

### DIFF
--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -4576,7 +4576,6 @@ if $*COMPILING_CORE_SETTING {
 
         # This also becomes the current MAIN. Also place it in %?LANG.
         %*LANG<MAIN> := self.WHAT;
-        $*W.install_lexical_symbol($*W.cur_lexpad(), '%?LANG', $*W.p6ize_recursive(%*LANG));
 
         # Declarand should get precedence traits.
         if $is_oper && nqp::isconcrete($declarand) {
@@ -4629,6 +4628,7 @@ if $*COMPILING_CORE_SETTING {
                     !! TermAction.HOW.curry(TermAction, $canname, $subname));
         }
 
+        $*W.install_lexical_symbol($*W.cur_lexpad(), '%?LANG', $*W.p6ize_recursive(%*LANG));
         return 1;
     }
 

--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -609,7 +609,6 @@ class Perl6::World is HLL::World {
 
             # This also becomes the current MAIN. Also place it in %?LANG.
             %*LANG<MAIN> := $cursor.WHAT;
-            self.install_lexical_symbol(self.cur_lexpad(), '%?LANG', self.p6ize_recursive(%*LANG));
         }
 
         # Add action method if needed.
@@ -622,6 +621,7 @@ class Perl6::World is HLL::World {
             %*LANG<MAIN-actions> := $*ACTIONS.HOW.mixin($*ACTIONS,
                 PackageDeclaratorAction.HOW.curry(PackageDeclaratorAction, $canname));
         }
+        self.install_lexical_symbol(self.cur_lexpad(), '%?LANG', self.p6ize_recursive(%*LANG));
     }
 
     method do_import($/, $module, $package_source_name, $arglist?) {


### PR DESCRIPTION
This is something I've had to do for my local build in order to `EXPORT` infixes etc along with manual modifications to `%*LANG<MAIN>`. Check commit msg for details. Let me know if I didn't do anything right.