### PR TITLE
teach EVAL about nqp

### DIFF
--- a/src/core/control.pm
+++ b/src/core/control.pm
@@ -216,7 +216,7 @@ proto sub EVAL(Cool $code, Str() :$lang = 'perl6', PseudoStash :$context, *%n) {
     $compiled();
 }
 multi sub EVAL(Cool $code, Str() :$lang! where 'nqp' | 'NQP', *%_) {
-    nqp::loadbytecode("nqp.{ $*VM.precomp-ext }");
+    once nqp::loadbytecode("nqp.{ $*VM.precomp-ext }");
     EVAL($code, :lang<nqp>, |%_);
 }
 multi sub EVAL(Cool $code, Str :$lang where { ($lang // '') eq 'Perl5' }, PseudoStash :$context) {

--- a/src/core/control.pm
+++ b/src/core/control.pm
@@ -215,6 +215,10 @@ proto sub EVAL(Cool $code, Str() :$lang = 'perl6', PseudoStash :$context, *%n) {
     nqp::forceouterctx(nqp::getattr($compiled, ForeignCode, '$!do'), $eval_ctx);
     $compiled();
 }
+multi sub EVAL(Cool $code, Str() :$lang! where 'nqp', *%_) {
+    nqp::loadbytecode('nqp.moarvm');
+    EVAL($code, :$lang, |%_);
+}
 multi sub EVAL(Cool $code, Str :$lang where { ($lang // '') eq 'Perl5' }, PseudoStash :$context) {
     my $eval_ctx := nqp::getattr(nqp::decont($context // CALLER::), PseudoStash, '$!ctx');
     my $?FILES   := 'EVAL_' ~ (state $no)++;

--- a/src/core/control.pm
+++ b/src/core/control.pm
@@ -216,7 +216,7 @@ proto sub EVAL(Cool $code, Str() :$lang = 'perl6', PseudoStash :$context, *%n) {
     $compiled();
 }
 multi sub EVAL(Cool $code, Str() :$lang! where 'nqp' | 'NQP', *%_) {
-    nqp::loadbytecode('nqp.moarvm');
+    nqp::loadbytecode("nqp.{ $*VM.precomp-ext }");
     EVAL($code, :lang<nqp>, |%_);
 }
 multi sub EVAL(Cool $code, Str :$lang where { ($lang // '') eq 'Perl5' }, PseudoStash :$context) {

--- a/src/core/control.pm
+++ b/src/core/control.pm
@@ -215,9 +215,9 @@ proto sub EVAL(Cool $code, Str() :$lang = 'perl6', PseudoStash :$context, *%n) {
     nqp::forceouterctx(nqp::getattr($compiled, ForeignCode, '$!do'), $eval_ctx);
     $compiled();
 }
-multi sub EVAL(Cool $code, Str() :$lang! where 'nqp', *%_) {
+multi sub EVAL(Cool $code, Str() :$lang! where 'nqp' | 'NQP', *%_) {
     nqp::loadbytecode('nqp.moarvm');
-    EVAL($code, :$lang, |%_);
+    EVAL($code, :lang<nqp>, |%_);
 }
 multi sub EVAL(Cool $code, Str :$lang where { ($lang // '') eq 'Perl5' }, PseudoStash :$context) {
     my $eval_ctx := nqp::getattr(nqp::decont($context // CALLER::), PseudoStash, '$!ctx');


### PR DESCRIPTION
The language is called lower-case `nqp` as that's what `nqp::getcomp` expects.

~~It might be a good idea to add another candidate that dispatches on `:lang<NQP>` for consistency with with `use :from<NQP>`...~~

For consistency, the spelling `NQP` is also allowed
