### PR TITLE
Add support for 1^..^10 non inclusive range quantifiers in regexs

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -8543,11 +8543,22 @@ class Perl6::RegexActions is QRegex::P6Regex::Actions does STDActions {
             );
         }
         else {
-            my $min := $<min>.ast;
+            my $min := 0;
+            if $<min> { $min := $<min>.ast; }
+
             my $max := -1;
-            if ! $<max> { $max := $min }
+            my $upto := $<upto>;
+
+            if $<from> eq '^' { $min++ }
+
+            if ! $<max> {
+                $max := $min
+            }
             elsif $<max> ne '*' {
                 $max := $<max>.ast;
+                if $<upto> eq '^' {
+                    $max--;
+                }
                 $/.CURSOR.panic("Empty range") if $min > $max;
             }
             $qast := QAST::Regex.new( :rxtype<quant>, :min($min), :max($max), :node($/) );


### PR DESCRIPTION
A recent change in NQP https://github.com/perl6/nqp/pull/249 added support for non inclusive range syntax as quantifiers in a regex. Rakudo overrides the action method that provides that functionality. As such that feature needs to be ported to rakudo as well.