### PR TITLE
use no longer new (but still shiny) open mode :x for spurt(:createonly)

### DIFF
--- a/src/core/IO/Path.pm
+++ b/src/core/IO/Path.pm
@@ -484,10 +484,7 @@ my class IO::Path is Cool {
     }
 
     method !spurt($contents, :$enc, :$append, :$createonly, :$bin, |c) {
-        if $createonly and $.e {
-            fail("File '$!path' already exists, and :createonly was specified");
-        }
-        my $mode = $append ?? :a !! :w;
+        my $mode = $createonly ?? :x !! $append ?? :a !! :w;
         my $handle = self.open(:enc($enc // 'utf8'), :$bin, |$mode, |c);
         $handle // $handle.throw;
 


### PR DESCRIPTION
That's what it's there for.

It might also be worth to consider if `:createonly` should be the default so files only get overwritten if some explicit flag (`:truncate`?) gets passed in...