### PR TITLE
Fix noisy Configure.pl on JVM backend.

### DIFF
--- a/Configure.pl
+++ b/Configure.pl
@@ -124,8 +124,8 @@ MAIN: {
     }
 
     $config{prefix} = $prefix;
-    $config{sdkroot} = $options{sdkroot};
-    $config{sysroot} = $options{sysroot};
+    $config{sdkroot} = $options{sdkroot} || '';
+    $config{sysroot} = $options{sysroot} || '';
     $config{slash}  = $slash;
     $config{'makefile-timing'} = $options{'makefile-timing'};
     $config{'stagestats'} = '--stagestats' if $options{'makefile-timing'};


### PR DESCRIPTION
was complaining with:
    Use of uninitialized value {sysroot} in concatenation (.) or string at Configure.pl line 229.