### PR TITLE
detect win32 absolute paths in World.current_file

### DIFF
--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -847,7 +847,7 @@ class Perl6::World is HLL::World {
         if nqp::isnull($file) {
             $file := '<unknown file>';
         }
-        elsif !nqp::eqat($file,'/',0) && !nqp::eqat($file,'-',0) {
+        elsif !nqp::eqat($file,'/',0) && !nqp::eqat($file,'-',0) && !nqp::eqat($file,':',1) {
             $file := nqp::cwd ~ '/' ~ $file;
         }
         $file;


### PR DESCRIPTION
The whole check is a bit of a hack, so  someone might want to think about a more robust test for absolute paths.

For now, this should be good enough to fix the issue of `$?FILE` containing bogus values on Windows in case of absolute script paths.

Note that in principle, this could result in a false positive if `:` is used in a filename on systems that support such things, but I do not believe that's much of an issue in practice.