### PR TITLE
Fix initial value for index variable

### DIFF
--- a/src/core/Any-iterable-methods.pm
+++ b/src/core/Any-iterable-methods.pm
@@ -917,7 +917,7 @@ augment class Any {
         # a slice into self. The JVM implementation uses a Java
         # collection sort. MoarVM has its sort algorithm implemented
         # in NQP.
-        my int $i = 0;
+        my int $i = -1;
         my int $n = sort-buffer.elems;
         my $indices := nqp::list;
         nqp::setelems($indices,$n);


### PR DESCRIPTION
This index variable was wrongly initialized to 0 with commit 019a7ff7.

Said commit reverted commit f0c6a02c, but in this specific case some
related code was changed in the meantime with commit 3bbc9222. That
lead to a situation where the corresponding change to the 'while'
clause 4 lines below was not reverted -- only the initialization of $i.

This lead to some fallout on rakudo.jvm: Even '1.sort' resulted in
a Null Pointer Exception. On rakudo.moar there seemed to be no
spectest fallout.