### PR TITLE
Configure ends up requiring perl v5.10.0 for // op

### DIFF
--- a/Configure.pl
+++ b/Configure.pl
@@ -1,7 +1,7 @@
 #! perl
 # Copyright (C) 2009 The Perl Foundation
 
-use 5.008;
+use 5.010;
 use strict;
 use warnings;
 use Text::ParseWords;


### PR DESCRIPTION
code in tools/lib/NQP/Configure.pm uses the // operator from perl v5.10

without requiring it, you end up with nasty crazy syntax errors; this makes the error clearer