### PR TITLE
Add support for USAGE arg help.

### DIFF
--- a/src/core/Main.pm
+++ b/src/core/Main.pm
@@ -91,7 +91,7 @@ my sub MAIN_HELPER($retval = 0) {
                     $argument = "[$argument]"     if $param.optional;
                     @positional.push($argument);
                 }
-                %arg-help{$argument} = $param.WHY if $param.WHY;
+                %arg-help{$argument} //= $param.WHY.contents if $param.WHY;  # Use first defined
             }
             if $sub.WHY {
                 $docs = '-- ' ~ $sub.WHY.contents

--- a/src/core/Main.pm
+++ b/src/core/Main.pm
@@ -44,6 +44,7 @@ my sub MAIN_HELPER($retval = 0) {
     # Generate $?USAGE string (default usage info for MAIN)
     my sub gen-usage() {
         my @help-msgs;
+        my %arg-help;
 
         my sub strip_path_prefix($name) {
             my $SPEC := $*SPEC;
@@ -90,6 +91,7 @@ my sub MAIN_HELPER($retval = 0) {
                     $argument = "[$argument]"     if $param.optional;
                     @positional.push($argument);
                 }
+                %arg-help{$argument} = $param.WHY if $param.WHY;
             }
             if $sub.WHY {
                 $docs = '-- ' ~ $sub.WHY.contents
@@ -97,6 +99,13 @@ my sub MAIN_HELPER($retval = 0) {
             my $msg = join(' ', $prog-name, @required-named, @optional-named, @positional, $docs // '');
             @help-msgs.push($msg);
         }
+
+        if %arg-help {
+            @help-msgs.push('');
+            my $offset = max(%arg-help.map: { .key.chars }) + 4;
+            @help-msgs.append(%arg-help.map: { '  ' ~ .key ~ ' ' x ($offset - .key.chars) ~ .value });
+        }
+
         my $usage = "Usage:\n" ~ @help-msgs.map('  ' ~ *).join("\n");
         $usage;
     }


### PR DESCRIPTION
Example USAGE with arg help here:

https://gist.github.com/donaldh/478814e68ab9d674eab9
```
Usage:
  ./panda-help [--notests] [--nodeps] [--prefix=<Str>] install [<modules> ...] -- Install the specified modules
  ./panda-help [--notests] [--prefix=<Str>] installdeps [<modules> ...] -- Install dependencies, but don't build the modules themselves
  ./panda-help [--installed] [--verbose] [--prefix=<Str>] list -- List all available modules
  ./panda-help [--prefix=<Str>] update -- Update the module database
  ./panda-help [--prefix=<Str>] info [<modules> ...] -- Display information about specified modules
  ./panda-help [--prefix=<Str>] search [<pattern>] -- Search the name/description
  ./panda-help [--notests] [--name=<Str>] [--auth=<Str>] [--ver=<Str>] [--desc=<Str>] [--prefix=<Str>] gen-meta -- Autogenerate META.info
  ./panda-help [--exclude=<Any>] [--prefix=<Str>] smoke -- Test and install all known distributions
  ./panda-help [--prefix=<Str>] look [<modules> ...] -- Download and unpack the distribution and then open the directory with your shell.
  ./panda-help [--notests] [--nodeps] [--prefix=<Str>] [<modules> ...] 
  
    --auth=<Str>       Author for META.info
    --desc=<Str>       Module description for META.info
    --exclude=<Any>    Modules to exclude from smoke - defaults to panda
    --installed        Only list installed modules
    --name=<Str>       Name for module for META.info
    --nodeps           Install without module dependencies
    --notests          Do not run the module tests
    --prefix=<Str>     Override the installation prefix
    --ver=<Str>        Version info for META.info
    --verbose          Provide more module detais
```