### PR TITLE
install-core-dist: Use $*PERL, not $*PERL6

### DIFF
--- a/tools/build/install-core-dist.pl
+++ b/tools/build/install-core-dist.pl
@@ -1,6 +1,6 @@
 use lib "inst#repo";
 my $v = run("git", "describe", :out).out.lines[0];
-$v //= $*PERL6.version;
+$v //= $*PERL.version;
 
 my %provides = 
     "Test"                       => "lib/Test.pm",


### PR DESCRIPTION
It seems likely nobody's tried this script where `git describe` won't
work.