### PR TITLE
Alternative to peppering the filesystem with .precomp dirs

### DIFF
--- a/src/core/CompUnit/Repository/FileSystem.pm
+++ b/src/core/CompUnit/Repository/FileSystem.pm
@@ -110,7 +110,10 @@ class CompUnit::Repository::FileSystem does CompUnit::Repository::Locally does C
         $!precomp := CompUnit::PrecompilationRepository::Default.new(
             :store(
                 CompUnit::PrecompilationStore::File.new(
-                    :prefix(self.prefix.child('.precomp')),
+                    :prefix(
+                        $*DISTRO.cache-dir.?child('precomp')
+                            // self.prefix.child('.precomp')
+                    )
                 )
             ),
         ) unless $!precomp;

--- a/src/core/Distro.pm
+++ b/src/core/Distro.pm
@@ -7,6 +7,7 @@ class Distro does Systemic {
     has Str $.release;
     has Bool $.is-win;
     has Str $.path-sep;
+    has $.cache-dir;
 
     submethod BUILD (
       :$name,
@@ -16,6 +17,7 @@ class Distro does Systemic {
       :$!path-sep,
       :$!signature  = Blob,
       :$!desc = Str,
+      :$!cache-dir,
     ) {
         $!name = $name.lc;    # lowercase
         $!name ~~ s:g/" "//;  # spaceless
@@ -42,6 +44,14 @@ sub INITIALIZE-A-DISTRO-NOW() {
 #?endif
     my Str $release := "unknown";
     my Str $auth    := "unknown";
+    my $cache-dir   := do if $name eq 'linux' {
+        with (%*ENV<XDG_CACHE_DIR>, "%*ENV<HOME>/.cache").first(*.?IO.d) {
+            given .IO.child('perl6') {
+                try .mkdir(0o755) unless .e;
+                $_ when .d;
+            }
+        }
+    }
 
     # darwin specific info
     if $name eq 'darwin' {
@@ -81,7 +91,7 @@ sub INITIALIZE-A-DISTRO-NOW() {
         }
     }
     my $desc := DateTime.now.Str;
-    Distro.new(:$name, :$version, :$release, :$auth, :$path-sep, :$desc);
+    Distro.new(:$name, :$version, :$release, :$auth, :$path-sep, :$desc, :$cache-dir);
 }
 
 # set up $*DISTRO


### PR DESCRIPTION
This'll hopefully solve the problem @ugexe had earlier today (http://irclog.perlgeek.de/perl6/2015-12-02#i_11644081). I admit it's not pretty code by any means, but it seems like an improvement over "not working at all" in that one case.

There are some issues with the locking in `CompUnit::PrecompilationStore::File` being too coarse-grained; this change exacerbates them pretty badly. Only one perl6-m process can be compiling at a time _on the entire OS_ (sorry), and if one of them deadlocks (that's a pre-existing problem, try `panda install Hinges`) they all get wedged. That's probably fixable but I don't have enough tuits to go poking around in low-level locking code.

I've left a safety valve in, in case it needs to be disabled for any reason: put a plain file where it expects the "perl6" cache dir to be and it'll fall back to the existing .precomp behaviour.