### PR TITLE
Fix forward-slash vs back-slash confusion in Win32

### DIFF
--- a/src/core/Process.pm
+++ b/src/core/Process.pm
@@ -134,7 +134,7 @@ multi sub INITIALIZE_DYNAMIC('$*REPO') {
     };
     %repos{$_} = $next-repo := CompUnitRepo.new($_, :$next-repo) for @INC>>.&canon.unique.reverse;
 
-    $_ = %repos{$_} for %CUSTOM_LIB.values;
+    $_ = %repos{$_.&canon} for %CUSTOM_LIB.values;
     PROCESS::<$REPO> := $next-repo;
 }
 

--- a/src/core/Process.pm
+++ b/src/core/Process.pm
@@ -127,7 +127,12 @@ multi sub INITIALIZE_DYNAMIC('$*REPO') {
 
     my CompUnit::Repository $next-repo;
     my %repos;
-    %repos{$_} = $next-repo := CompUnitRepo.new($_, :$next-repo) for @INC.unique.reverse;
+    my $SPEC := $*SPEC;
+    my &canon = -> $repo {
+        my @parts = $repo.split('#');
+        join '#', @parts[0], $SPEC.canonpath(@parts[1]);
+    };
+    %repos{$_} = $next-repo := CompUnitRepo.new($_, :$next-repo) for @INC>>.&canon.unique.reverse;
 
     $_ = %repos{$_} for %CUSTOM_LIB.values;
     PROCESS::<$REPO> := $next-repo;


### PR DESCRIPTION
In windows C:\a\b and C:/a/b refer to the same location, but @INC.unique thinks
they are different, so we canonicalize all paths to C:\a\b on windows.

Fixes the issue in https://gist.github.com/retupmoca/01d09301ac7fc3fd2013