### PR TITLE
Fix RT #126759

### DIFF
--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -587,6 +587,12 @@ class Perl6::World is HLL::World {
                     }
                 }
             }).eager;
+
+            # copy modified %*HOW into lexical EXPORTHOW symbol so new/superceded
+            # declarators will work inside EVAL.
+            my $lex_EXPORTHOW := nqp::knowhow().new_type(:name('EXPORTHOW'));
+            nqp::setwho($lex_EXPORTHOW,self.p6ize_recursive(%*HOW));
+            self.install_lexical_symbol(self.cur_lexpad,'EXPORTHOW',$lex_EXPORTHOW);
         }
     }
 


### PR DESCRIPTION
create a sneaky lexical EXPORTHOW package so if you do:

```
use MyDeclarator;
EVAL 'my-declarator my-class { }'
```

it will work because my-declarator is available in %*HOW in EVAL

Fixes the RT and makes the fudged tests here pass: 
https://github.com/perl6/roast/blob/master/S12-meta/exporthow.t
