### PR TITLE
Update Makefile-common.in to work with mingw

### DIFF
--- a/tools/build/Makefile-common-macros.in
+++ b/tools/build/Makefile-common-macros.in
@@ -7,6 +7,7 @@ CHMOD   = $(PERL) -MExtUtils::Command -e chmod
 CP      = $(PERL) -MExtUtils::Command -e cp
 RM_F    = $(PERL) -MExtUtils::Command -e rm_f
 RM_RF   = $(PERL) -MExtUtils::Command -e rm_rf
+SHELL   = @shell@
 
 SYSROOT= @sysroot@
 SDKROOT= @sdkroot@


### PR DESCRIPTION
Fix "/usr/bin/sh: C:Strawberryperlbinperl.exe: command not found" type errors under windows the same way we did for nqp about a week ago by effectively setting the SHELL to cmd under windows and 'sh' for posix environments.