### PR TITLE
Improve X::Syntax::Adverb error message

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -5824,7 +5824,7 @@ Compilation unit '$file' contained the following violations:
                         $/.CURSOR.typed_panic('X::Syntax::Adverb', what => $target.name);
                     }
                     else {
-                        $/.CURSOR.typed_panic('X::Syntax::Adverb')
+                        $/.CURSOR.typed_panic('X::Syntax::Adverb', what => ~$/[0]);
                     }
                 }
                 my $cpast := $<colonpair>.ast;

--- a/src/core/Exception.pm
+++ b/src/core/Exception.pm
@@ -1400,7 +1400,7 @@ my class X::Syntax::CannotMeta does X::Syntax {
 my class X::Syntax::Adverb does X::Syntax {
     has $.what;
 
-    method message() { "You can't adverb " ~ ($.what // "that")  }
+    method message() { "You can't adverb " ~ $.what }
 }
 
 my class X::Syntax::Regex::Adverb does X::Syntax {


### PR DESCRIPTION
Previously strings would just get a `You cannot adverb that` which could be seen as implying that the actual name of the adverb `:foo` could not be "adverbed".

If you now have an adverb following a string (or anything that doesn't have a `name`), it will print the string e.g., `You cannot adverb 'foo'`.

I think this could probably remove [Exception.pm#L1403](https://github.com/rakudo/rakudo/blob/nom/src/core/Exception.pm#L1403)'s `// "that"` too, right?