### PR TITLE
Some IO-related cleanup and an actually useful binary mode

### DIFF
--- a/src/core/io_operators.pm
+++ b/src/core/io_operators.pm
@@ -108,13 +108,6 @@ multi sub open($path, :$chomp = True, :$enc = 'utf8', |c) {
     $handle.open(:$chomp,:$enc,|c);
 }
 
-proto sub pipe(|) { * }
-multi sub pipe($path, :$chomp = True, :$enc = 'utf8', |c) {
-    my $handle = IO::Handle.new(:path($path.IO));
-    $handle // $handle.throw;
-    $handle.pipe(:$chomp,:$enc,|c);
-}
-
 proto sub lines(|) { * }
 multi sub lines($what = $*ARGFILES, $limit = Inf, *%named) {
     nqp::istype($limit,Whatever) || $limit == Inf

--- a/src/core/io_operators.pm
+++ b/src/core/io_operators.pm
@@ -102,10 +102,10 @@ multi sub dir(Cool $path, |c) {
 }
 
 proto sub open(|) { * }
-multi sub open($path, :$chomp = True, :$enc = 'utf8', |c) {
-    my $handle = IO::Handle.new(:path($path.IO));
+multi sub open(IO() $path, |c) {
+    my $handle = IO::Handle.new(:$path);
     $handle // $handle.throw;
-    $handle.open(:$chomp,:$enc,|c);
+    $handle.open(|c);
 }
 
 proto sub lines(|) { * }


### PR DESCRIPTION
In particular, this removes `&pipe` (which was defunct as the backend method [had already been removed](https://github.com/rakudo/rakudo/commit/03b5a0abb58905f8e8e6e768186696f10e37729e)).

It also adds the ability for binary line-by-line access when opening files in mode `:bin` that previously had been [specced](http://design.perl6.org/S32/IO.html#line_114) and [documented](http://docs.perl6.org/routine/open#Encoding_options), but apparently never been implemented.