### PR TITLE
handling nul real part in narrow method

### DIFF
--- a/src/core/Complex.pm
+++ b/src/core/Complex.pm
@@ -218,6 +218,7 @@ my class Complex is Cool does Numeric {
     }
 
     method narrow(Complex:D:) {
+        self == 0e0 ?? 0 !!
         $!re == 0e0 ?? self !!
         $!im / $!re ≅ 0e0
             ?? $!re.narrow

--- a/src/core/Complex.pm
+++ b/src/core/Complex.pm
@@ -218,6 +218,7 @@ my class Complex is Cool does Numeric {
     }
 
     method narrow(Complex:D:) {
+        $!re == 0e0 ?? self !!
         $!im / $!re ≅ 0e0
             ?? $!re.narrow
             !! self;


### PR DESCRIPTION
you don't want to divide by $!re unless you've dealt with the case $!re == 0e0