### PR TITLE
Use distribution's name to find binary resources

### DIFF
--- a/src/core/CompUnit/Repository/Installation.pm
+++ b/src/core/CompUnit/Repository/Installation.pm
@@ -34,7 +34,7 @@ sub MAIN(:$name is copy, :$auth, :$ver, *@, *%) {
     shift @*ARGS if $name;
     shift @*ARGS if $auth;
     shift @*ARGS if $ver;
-    $name //= \'#name#\';
+    $name //= \'#dist-name#\';
     my @installations = $*REPO.repo-chain.grep(CompUnit::Repository::Installable);
     my @binaries = flat @installations.map: { .files(\'bin/#name#\', :$name, :$auth, :$ver) };
     unless +@binaries {
@@ -146,7 +146,7 @@ sub MAIN(:$name is copy, :$auth, :$ver, *@, *%) {
             my $withoutext  = $basename.subst(/\.[exe|bat]$/, '');
             for '', '-j', '-m' -> $be {
                 "$path/bin/$withoutext$be".IO.spurt:
-                    $perl_wrapper.subst('#name#', $basename, :g).subst('#perl#', "perl6$be");
+                    $perl_wrapper.subst('#name#', $basename, :g).subst('#perl#', "perl6$be").subst('#dist-name#', $dist.name);
                 if $is-win {
                     "$path/bin/$withoutext$be.bat".IO.spurt:
                         $windows_wrapper.subst('#perl#', "perl6$be", :g);


### PR DESCRIPTION
Currently, when a distribution has binary/script files, we install them
as resources owned by the distribution, as well as wrapper scripts that
the shell can find via PATH that use the CompUnit API to dispatch to
the corresponding resource.

Some distributions install multiple binaries; for example, panda
installs panda, panda-build, panda-test, etc.  The wrapper scripts
currently use the basename of the wrapper script to locate the
distribution that contains the corresponding binary resource, rather
than the name of the distribution that binary is a part of.

This change makes wrapper scripts use the distribution name to find dist
metadata, which will then be used to locate the resource for the actual
binary.