### PR TITLE
improve permutations

### DIFF
--- a/src/core/native_array.pm
+++ b/src/core/native_array.pm
@@ -731,8 +731,8 @@ sub permutations(int $n where $n > 0) {
                 # Find the largest index k such that a[k] < a[k + 1].
                 # If no such index exists, the permutation is the last permutation.
                 my int $k = @!a.end - 1;
-                $k-- until $k < 0 or @!a[$k] < @!a[$k + 1];
-                return IterationEnd if $k < 0;
+                $k-- or return IterationEnd until @!a[$k] < @!a[$k + 1];
+                
                 # Find the largest index l greater than k such that a[k] < a[l].
                 my int $l = @!a.end;
                 $l-- until @!a[$k] < @!a[$l];

--- a/src/core/native_array.pm
+++ b/src/core/native_array.pm
@@ -738,17 +738,12 @@ sub permutations(int $n where $n > 0) {
                 $l-- until @!a[$k] < @!a[$l];
                 # use L<https://en.wikipedia.org/wiki/XOR_swap_algorithm>
                 # @!a[$k, $l].=reverse
-                @!a[$k] +^= @!a[$l];
-                @!a[$k] +^= @!a[$l] = @!a[$k] +^ @!a[$l];
-                
+                (@!a[$k] +^= @!a[$l]) +^= @!a[$l] +^= @!a[$k];
+
                 # @!a[$k+1 .. @!a.end].=reverse;
                 $l = $!n;
-                until ++$k >= --$l {
-                    @!a[$k] +^= @!a[$l];
-                    @!a[$k] +^= @!a[$l] = @!a[$k] +^ @!a[$l];
-                }
-                @!a.List;
-            }
+                (@!a[$k] +^= @!a[$l]) +^= @!a[$l] +^= @!a[$k] until ++$k >= --$l;
+                @!a.List;            }
             method count-only { [*] 1 .. $!n }
         }.new(:$n)
     );


### PR DESCRIPTION
implement the XOR swap algorithm in a single statement.  Not really necessary but still pretty cool.  It should also provide a small performance improvement as we can then put the `until` in the end, thus avoiding creating a lexical scope.