### PR TITLE
CompUnit::DependencySpecification::Str doesn't have to add the :ver, :api, and :auth if it's True anyway

### DIFF
--- a/src/core/CompUnit/DependencySpecification.pm
+++ b/src/core/CompUnit/DependencySpecification.pm
@@ -6,7 +6,10 @@ class CompUnit::DependencySpecification {
     has $.api-matcher = True;
 
     method Str(CompUnit::DependencySpecification:D:) {
-        return "{$.short-name}:ver<{$.version-matcher // 'True'}>:auth<{$.auth-matcher // 'True'}>:api<{$.api-matcher // 'True'}>";
+        return join '', $.short-name,
+          ($.version-matcher//True) ~~ Bool ?? '' !! ":ver<$.version-matcher>",
+          ($.auth-matcher   //True) ~~ Bool ?? '' !! ":auth<$.auth-matcher>",
+          ($.api-matcher    //True) ~~ Bool ?? '' !! ":api<$.api-matcher>";
     }
 }
 


### PR DESCRIPTION
As per http://irclog.perlgeek.de/perl6/2015-12-15#i_11722156