### PR TITLE
Add fast .elems to .combinations

### DIFF
--- a/src/core/List.pm
+++ b/src/core/List.pm
@@ -41,6 +41,10 @@ my sub combinations(\n, \k) {
             }
             IterationEnd
         }
+
+        method count-only {
+            (  ([*] 1..$!n) / (([*] 1..$!k) * ([*] 1..$!n-$!k))  ).Int
+        }
     }.new(n, k))
 }
 


### PR DESCRIPTION
This PR lets us evaluate the total number of `.combinations` without actualy calculating them all. This mirrors doing so with `.permutations`.

I believe we can get rid of `( ).Int` if we change `    return ((),) if k < 1;` on line 10 to `    return ((),) if k < 1 or k > n`, but that's for another PR ATM :)

Relevant IRC discussion: http://irclog.perlgeek.de/perl6/2015-12-16#i_11730331