### PR TITLE
add count-only method to combinations Iterator

### DIFF
--- a/src/core/List.pm
+++ b/src/core/List.pm
@@ -41,6 +41,7 @@ my sub combinations(\n, \k) {
             }
             IterationEnd
         }
+        method count-only { ([*] ($!n ... 0) Z/ 1 .. min($!n - $!k, $!k)).Int }
     }.new(n, k))
 }
 


### PR DESCRIPTION
as suggested on IRC.  Replaces https://github.com/rakudo/rakudo/pull/635