### PR TITLE
Fix CLONE-HASH-DECONTAINERIZED(%(:a(Any))

### DIFF
--- a/src/core/control.pm
+++ b/src/core/control.pm
@@ -263,7 +263,7 @@ sub CLONE-HASH-DECONTAINERIZED(\hash) {
     my $e;
     while $iter {
         $e := nqp::shift($iter);
-        nqp::bindkey($clone,nqp::iterkey_s($e),nqp::decont(~nqp::iterval($e)));
+        nqp::bindkey($clone,nqp::iterkey_s($e),~(nqp::decont(nqp::iterval($e)) // ''));
     }
     $clone;
 }


### PR DESCRIPTION
Removes warning messages for `my %x = :a(Any); CLONE-HASH-DECONTAINERIZED(%x)` which is called anytime `run`, `shell`, or `QX` is used

`CLONE-HASH-DECONTAINERIZED` is currently only used on `%*ENV` to be passed to `nqp::spawn`, so stringifying `Any` to `Str.new` should be safe