### PR TITLE
Simplify some Cool methods on IO::Path

### DIFF
--- a/src/core/IO/Path.pm
+++ b/src/core/IO/Path.pm
@@ -509,37 +509,30 @@ my class IO::Path is Cool {
 
     proto method lines(|) { * }
     multi method lines(IO::Path:D: |c) {
-        my $handle = self.open(|c);
-        $handle && $handle.lines(:close);
+        self.open(|c).lines(:close);
     }
 
     proto method comb(|) { * }
     multi method comb(IO::Path:D: Cool:D $comber = "", |c) {
-        my $handle = self.open(|c);
-        $handle && $handle.comb($comber, :close);
+        self.open(|c).comb($comber, :close);
     }
     multi method comb(IO::Path:D: Int:D $size, |c) {
-        my $handle = self.open(|c);
-        $handle && $handle.comb($size, :close);
+        self.open(|c).comb($size, :close);
     }
     multi method comb(IO::Path:D: Regex:D $comber, |c) {
-        my $handle = self.open(|c);
-        $handle && $handle.comb($comber, :close);
+        self.open(|c).comb($comber, :close);
     }
 
     multi method split(IO::Path:D: Str:D $splitter = "", |c) {
-        my $handle = self.open(|c);
-        $handle && $handle.split($splitter, :close);
+        self.open(|c).split($splitter, :close);
     }
     multi method split(IO::Path:D: Regex:D $splitter, |c) {
-        my $handle = self.open(|c);
-        $handle && $handle.split($splitter, :close);
+        self.open(|c).split($splitter, :close);
     }
 
     proto method words(|) { * }
     multi method words(IO::Path:D: |c) {
-        my $handle = self.open(|c);
-        $handle && $handle.words(:close);
+        self.open(|c).words(:close);
     }
 
     my %t =


### PR DESCRIPTION
Let's them throw on failed .open instead of returning a handled failure as they formerly did