### PR TITLE
Small IO cleanup

### DIFF
--- a/src/core/io_operators.pm
+++ b/src/core/io_operators.pm
@@ -108,13 +108,6 @@ multi sub open($path, :$chomp = True, :$enc = 'utf8', |c) {
     $handle.open(:$chomp,:$enc,|c);
 }
 
-proto sub pipe(|) { * }
-multi sub pipe($path, :$chomp = True, :$enc = 'utf8', |c) {
-    my $handle = IO::Handle.new(:path($path.IO));
-    $handle // $handle.throw;
-    $handle.pipe(:$chomp,:$enc,|c);
-}
-
 proto sub lines(|) { * }
 multi sub lines($what = $*ARGFILES, $limit = Inf, *%named) {
     nqp::istype($limit,Whatever) || $limit == Inf

--- a/src/core/io_operators.pm
+++ b/src/core/io_operators.pm
@@ -102,10 +102,8 @@ multi sub dir(Cool $path, |c) {
 }
 
 proto sub open(|) { * }
-multi sub open($path, :$chomp = True, :$enc = 'utf8', |c) {
-    my $handle = IO::Handle.new(:path($path.IO));
-    $handle // $handle.throw;
-    $handle.open(:$chomp,:$enc,|c);
+multi sub open(IO() $path, |c) {
+    IO::Handle.new(:$path).open(|c);
 }
 
 proto sub lines(|) { * }


### PR DESCRIPTION
Removes defunct `&pipe`, simplifies `&open`.
