### PR TITLE
Fixed test broken by 7f3032685

### DIFF
--- a/t/01-sanity/55-use-trace.t
+++ b/t/01-sanity/55-use-trace.t
@@ -25,9 +25,9 @@ my $p = run($*EXECUTABLE, $filename, :out, :err);
 ok $p ~~ Proc,                    "did we get a Proc?";
 is $p.out.lines.join, "42",       "is the program output ok?";
 is $p.err.lines.join("\n"), qq:to/STDERR/.chomp, "is the trace ok?";
-4 ($filename:4)
+4 ($filename line 4)
 \$a++
-10 ($filename:10)
+10 ($filename line 10)
 \$a -= 1
 STDERR
 


### PR DESCRIPTION
Line numbers in errors/trace are now "line $number" rather than
":$number"