### PR TITLE
Untwine Pod

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -834,26 +834,26 @@ class Perl6::Actions is HLL::Actions does STDActions {
     method pod_block:sym<delimited_code>($/) {
         my $config  := $<pod_configuration>.ast;
         my @contents := $<delimited_code_content>.ast;
-        my $twine   := Perl6::Pod::serialize_array(@contents).compile_time_value;
-        make Perl6::Pod::serialize_object(
-            'Pod::Block::Code', :contents($twine),
-            :config($config),
-        ).compile_time_value
+        @contents  := Perl6::Pod::serialize_array(@contents).compile_time_value;
+        make Perl6::Pod::serialize_object('Pod::Block::Code',
+                                          :@contents,:$config).compile_time_value
     }
 
     method delimited_code_content($/) {
-        my @t := [];
+        my @contents := [];
         for $/[0] {
             if $_<pod_string> {
-                nqp::splice(@t, Perl6::Pod::merge_twines($_<pod_string>), +@t, 0);
-                nqp::push(@t, $*W.add_constant(
+                nqp::splice(@contents,
+                            Perl6::Pod::pod_strings_from_matches($_<pod_string>),
+                            +@contents, 0);
+                nqp::push(@contents, $*W.add_constant(
                     'Str', 'str', ~$_<pod_newline>
                 ).compile_time_value);
             } else {
-                @t.push($*W.add_constant('Str', 'str', "\n").compile_time_value);
+                @contents.push($*W.add_constant('Str', 'str', "\n").compile_time_value);
             }
         }
-        make @t;
+        make @contents;
     }
 
     method pod_block:sym<paragraph>($/) {
@@ -870,15 +870,13 @@ class Perl6::Actions is HLL::Actions does STDActions {
 
     method pod_block:sym<paragraph_code>($/) {
         my $config := $<pod_configuration>.ast;
-        my @t := [];
+        my @contents := [];
         for $<pod_line> {
-            nqp::splice(@t, $_.ast, +@t, 0);
+            nqp::splice(@contents, $_.ast, +@contents, 0);
         }
-        my $twine  := Perl6::Pod::serialize_array(@t).compile_time_value;
-        make Perl6::Pod::serialize_object(
-            'Pod::Block::Code', :contents($twine),
-            :config($config),
-        ).compile_time_value
+        @contents  := Perl6::Pod::serialize_array(@contents).compile_time_value;
+        make Perl6::Pod::serialize_object('Pod::Block::Code',
+                                          :@contents,:$config).compile_time_value;
     }
 
     method pod_block:sym<abbreviated>($/) {
@@ -894,22 +892,22 @@ class Perl6::Actions is HLL::Actions does STDActions {
     }
 
     method pod_block:sym<abbreviated_code>($/) {
-        my @t := [];
+        my @contents := [];
         for $<pod_line> {
-            nqp::splice(@t, $_.ast, +@t, 0);
+            nqp::splice(@contents, $_.ast, +@contents, 0);
         }
-        my $twine := Perl6::Pod::serialize_array(@t).compile_time_value;
+        @contents := Perl6::Pod::serialize_array(@contents).compile_time_value;
         make Perl6::Pod::serialize_object(
-            'Pod::Block::Code', :contents($twine)
+            'Pod::Block::Code', :@contents
         ).compile_time_value
     }
 
     method pod_line ($/) {
-        my @t := Perl6::Pod::merge_twines($<pod_string>);
-        @t.push($*W.add_constant(
+        my @contents := Perl6::Pod::pod_strings_from_matches($<pod_string>);
+        @contents.push($*W.add_constant(
             'Str', 'str', ~$<pod_newline>
         ).compile_time_value);
-        make @t;
+        make @contents;
     }
 
     method pod_block:sym<finish>($/) {
@@ -931,11 +929,9 @@ class Perl6::Actions is HLL::Actions does STDActions {
     }
 
     method pod_textcontent:sym<regular>($/) {
-        my @t     := Perl6::Pod::merge_twines($<pod_string>);
-        my $twine := Perl6::Pod::serialize_array(@t).compile_time_value;
-        make Perl6::Pod::serialize_object(
-            'Pod::Block::Para', :contents($twine)
-        ).compile_time_value
+        my @contents := Perl6::Pod::pod_strings_from_matches($<pod_string>);
+        @contents    := Perl6::Pod::serialize_array(@contents).compile_time_value;
+        make Perl6::Pod::serialize_object('Pod::Block::Para', :@contents).compile_time_value
     }
 
     method pod_textcontent:sym<code>($/) {
@@ -983,10 +979,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
                 :@meta,
             ).compile_time_value;
         } else {
-            my @contents := [];
-            for $<pod_string_character> {
-                @contents.push($_.ast)
-            }
+            my @chars := Perl6::Pod::build_pod_chars($<pod_string_character>);
             my @meta := [];
             if $<code> eq 'X' {
                 for $/[0] {
@@ -1003,15 +996,12 @@ class Perl6::Actions is HLL::Actions does STDActions {
                 }
                 @meta := Perl6::Pod::serialize_aos(@meta).compile_time_value;
             }
-            my @t    := Perl6::Pod::build_pod_string(@contents);
+            my @contents  := Perl6::Pod::build_pod_strings([@chars]);
+            @contents := Perl6::Pod::serialize_array(@contents).compile_time_value;
             my $past := Perl6::Pod::serialize_object(
                 'Pod::FormattingCode',
-                :type(
-                    $*W.add_string_constant(~$<code>).compile_time_value
-                ),
-                :contents(
-                    Perl6::Pod::serialize_array(@t).compile_time_value
-                ),
+                :type($*W.add_string_constant(~$<code>).compile_time_value),
+                :@contents,
                 :meta(@meta),
             );
             make $past.compile_time_value;
@@ -1019,36 +1009,15 @@ class Perl6::Actions is HLL::Actions does STDActions {
     }
 
     method pod_string($/) {
-        my @contents := [];
-        for $<pod_string_character> {
-            @contents.push($_.ast)
-        }
-        make Perl6::Pod::build_pod_string(@contents);
+        make Perl6::Pod::build_pod_chars($<pod_string_character>);
     }
 
     method pod_balanced_braces($/) {
         if $<endtag> {
-            my @contents := [];
-            my @stringparts := [];
-            @stringparts.push(~$<start>);
-            if $<pod_string_character> {
-                for $<pod_string_character> {
-                    if nqp::isstr($_.ast) {
-                        @stringparts.push($_.ast);
-                    } else {
-                        @contents.push(nqp::join("", @stringparts));
-                        @stringparts := nqp::list();
-                        @contents.push($_.ast);
-                    }
-                }
-            }
-            @stringparts.push(~$<endtag>);
-            @contents.push(nqp::join("", @stringparts));
-            if +@contents == 1 {
-                make @contents[0];
-            } else {
-                make Perl6::Pod::build_pod_string(@contents);
-            }
+            my @chars := Perl6::Pod::build_pod_chars($<pod_string_character>);
+            @chars.unshift(~$<start>);
+            @chars.push(~$<endtag>);
+            make @chars;
         } else {
             make ~$<braces>
         }

--- a/src/Perl6/Pod.nqp
+++ b/src/Perl6/Pod.nqp
@@ -323,81 +323,80 @@ class Perl6::Pod {
         return @result;
     }
 
-    our sub merge_twines(@twines) {
-        my @ret := @twines.shift.ast;
-        for @twines {
-            my @cur   := $_.ast;
-            @ret.push(
-                $*W.add_constant(
-                    'Str', 'str',
-                    nqp::unbox_s(@ret.pop) ~ ' ' ~ nqp::unbox_s(@cur.shift)
-                ).compile_time_value,
-            );
-            nqp::splice(@ret, @cur, +@ret, 0);
+    our sub pod_strings_from_matches(@string_matches) {
+        my @strings := [];
+        for @string_matches {
+            @strings.push($_.ast);
         }
-        return @ret;
+        return build_pod_strings(@strings);
     }
 
-    our sub build_pod_string(@content) {
-        return $*POD_IN_CODE_BLOCK
-            ?? build_pod_code_string(@content)
-            !! build_pod_regular_string(@content)
-    }
+    # Takes an array of arrays of pod characters (normal character or formatting code)
+    # returns an array of strings and formatting codes,
+    our sub build_pod_strings(@strings) {
+        my $in_code := $*POD_IN_CODE_BLOCK;
 
-    our sub build_pod_regular_string(@content) {
-        sub push_strings(@strings, @where) {
-            my $s := subst(nqp::join('', @strings), /\s+/, ' ', :global);
-            my $t := $*W.add_constant(
-                'Str', 'str', $s
-            ).compile_time_value;
-            @where.push($t);
-        }
-
-        my @res  := [];
-        my @strs := [];
-        for @content -> $elem {
-            if nqp::isstr($elem) {
-                # don't push the leading whitespace
-                if +@res + @strs == 0 && $elem eq ' ' {
-
-                } else {
-                    @strs.push($elem);
+        sub push_chars(@chars, @where) {
+            if @chars {
+                my $s := nqp::join('', @chars);
+                if ! $in_code {
+                    $s := subst($s, /\s+/, ' ', :global);
                 }
-            } else {
-                push_strings(@strs, @res);
-                @strs := [];
-                @res.push($elem);
+                $s := $*W.add_constant('Str', 'str', $s).compile_time_value;
+                @where.push($s);
             }
-        }
-        push_strings(@strs, @res);
-
-        return @res;
-    }
-
-    # Code strings need to be handled differently:
-    # Formatting codes need to be saved, but everything
-    # else should be verbatim
-    our sub build_pod_code_string(@content) {
-        sub push_strings(@strings, @where) {
-            my $s := nqp::join('', @strings);
-            my $t := $*W.add_constant('Str', 'str', $s).compile_time_value;
-            @where.push($t);
         }
 
         my @res  := [];
-        my @strs := [];
-        for @content -> $elem {
-            if nqp::isstr($elem) {
-                @strs.push($elem);
-            } else {
-                push_strings(@strs, @res);
-                @strs := [];
-                @res.push($elem);
+        my @chars := [];
+        my int $i := 0;
+        my int $last := nqp::elems(@strings) - 1;
+        while $i <= $last {
+            my @string := @strings[$i];
+            for @string -> $char {
+                if nqp::isstr($char) {
+                    # don't push the leading whitespace unless code block
+                    if $in_code || +@res + @chars != 0 || $char ne ' ' {
+                        @chars.push($char);
+                    }
+                }
+                else {
+                    # formatting code - join the preceeding characters
+                    # to the result, then add the formatting code
+                    push_chars(@chars, @res);
+                    @chars := [];
+                    @res.push($char);
+                }
+            }
+
+            if $i != $last {
+                # space inbetween each string
+                @chars.push(' ');
+            }
+            $i := $i + 1;
+        }
+
+        push_chars(@chars, @res);
+        return @res;
+    }
+
+    our sub build_pod_chars($pod_string_characters) {
+        my @chars := [];
+        if $pod_string_characters {
+            for $pod_string_characters {
+                my $char := $_.ast;
+                # $char can sometimes be an array because of the way
+                # pod_balanced_braces works
+                if nqp::istype($char,VMArray) {
+                    for $char {
+                        @chars.push($_);
+                    }
+                } else {
+                    @chars.push($_.ast);
+                }
             }
         }
-        push_strings(@strs, @res);
-
-        return @res;
+        return @chars;
     }
 
     # takes an array of strings (rows of a table)


### PR DESCRIPTION
tl;dr `=pod C<foo>` now becomes `[ FormattingCode ]` instead of `["",FormattingCode,""]`

After merge, merge:
1. https://github.com/perl6/roast/pull/90 (tests)
2. https://github.com/perl6/doc/pull/261

long story
I started out trying to fix stray empty strings being everywhere: 

https://rt.perl.org/Public/Bug/Display.html?id=126966

Turns out empty strings were a symptom of a _twine_ algorithm (every FormattingCode has to be _intertwined_ with a string). This implementation detail side effect then leaked out everywhere:
- In the tests: https://github.com/perl6/roast/pull/90 (depends on odd array indexes because of empty strings)
- in Pod::To::HTML: https://github.com/perl6/Pod-To-HTML/pull/9 (caused by empty strings)
- in the htmlifying code: https://github.com/perl6/doc/blob/master/htmlify.p6#L379
- it sorta meant it had to serialize strings that never got used

The purpose of this commit is to expunge this algorithm. Because it is a relatively large commit I did some due diligence and tested it on a pod file containing the concatenation of all the .pod in docs and then putting `$=pod.perl.say` at the end.

```
bash-3.2$ /usr/bin/time -l perl6 test.pod  | wc -c
       58.72 real        58.26 user         0.35 sys
 705699840  maximum resident set size
...
 3672024
bash-3.2$ /usr/bin/time -l p6 test.pod  | wc -c #patched
       59.07 real        58.29 user         0.54 sys
1181294592  maximum resident set size
...
 3663120
```

I also did a precompile with `--target=mbc` to see the difference:

```
1.5M 24 Dec 13:59 test.pod
6.8M 24 Dec 23:08 test.pod.moarvm
6.1M 24 Dec 23:03 test.patched.pod.moarvm
```

This shows:
1. This commit increases the amount of memory used during compilation from 700Mb => 1200Mb
2. that there are less characters in the output (due to less "" everywhere)
3. The patched one has a smaller image size due to less unnecessary serialization
4. They are roughly the same speed

Despite 1. I suggest merging this. It's not caused by my code (I think) but my code exacerbates whatever issue is causing rakudo to need 700Mb to compile a 1.5Mb pod file in the first place. I made a RT:
https://rt.perl.org/Public/Bug/Display.html?id=127020

Given we have precomp now :tada:  this patch only benefits real world non-compiling-large-amounts of pod-code-at-runtime stuff. Also from here it's easier to implement NYI tags like S<> T<> etc.

Oh and `=pod B< < B<foo> > >` will work instead of dying with LTA error now

Merry christmas!
:santa: :santa: 
