### PR TITLE
Add an env var to override precompilation paths wholesale

### DIFF
--- a/docs/running.pod
+++ b/docs/running.pod
@@ -44,39 +44,90 @@ The supported values for C<--target> are:
 For C<--profile-filename>, specifying a name ending in C<.json> will write a raw JSON profile dump.
 The default if this is omitted is C<profile-I<[timestamp]>.html>.
 
-=head1 List of env vars used in Rakudo
+=head1 ENVIRONMENT VARIABLES
+
+Rakudo's behavior can be tweaked by a (growing) number of environment variables; this section
+attempts to document all those currently in use.
+
+=head2 Module Loading
 
 =over
 
-=item C<RAKUDOLIB>, C<PERL6LIB> (src/core/Inc.pm)
+=item C<RAKUDOLIB>, C<PERL6LIB> (I<Str>; F<src/core/Inc.pm>)
 
-Appends a delimited list of paths to C<@INC>. C<RAKUDOLIB> is evaluated first.
+Appends a comma-delimited list of paths to C<@INC>. C<RAKUDOLIB> is evaluated first.
 
-=item C<RAKUDO_MODULE_DEBUG> (src/Perl6/ModuleLoader.pm)
+=item C<RAKUDO_MODULE_DEBUG> (I<Bool>; F<src/Perl6/ModuleLoader.pm>)
 
-If set to a non-false value, causes the module loader to print debugging information to standard
-error.
+Causes the module loader to print debugging information to standard error.
 
-=item C<RAKUDO_ERROR_COLOR> (src/core/Exception.pm)
+=back
+
+=head2 Error Message Verbosity and Strictness
+
+=over
+
+=item C<RAKUDO_NO_DEPRECATIONS> (I<Bool>; F<src/core/Deprecations.pm>)
+
+If true, suppresses deprecation warnings triggered by the C<is DEPRECATED> trait.
+
+=item C<RAKUDO_DEPRECATIONS_FATAL> (I<Bool>; F<src/core/Deprecations.pm>)
+
+If true, deprecation warnings become thrown exceptions.
+
+=item C<RAKUDO_VERBOSE_STACKFRAME> (I<UInt>; F<src/core/Backtrace.pm>)
+
+Displays source code in stack frames surrounded by the specified number of lines of context.
+
+=item C<RAKUDO_BACKTRACE_SETTING> (I<Bool>; F<src/core/Backtrace.pm>)
+
+Controls whether .setting files are included in backtraces.
+
+=back
+
+=head2 Affecting Precompilation
+
+=over
+
+=item C<RAKUDO_PRECOMP_DIST> (F<src/core/CompUnit/PrecompilationRepository.pm>)
+
+=item C<RAKUDO_PRECOMP_LOADING> (F<src/core/CompUnit/PrecompilationRepository.pm>)
+
+=item C<RAKUDO_PRECOMP_WITH> (F<src/core/CompUnit/PrecompilationRepository.pm>)
+
+These are internal variables for passing serialized state to precompilation jobs in child processes.
+Please do not set them manually.
+
+=back
+
+=head2 Other
+
+=over
+
+=item C<RAKUDO_ERROR_COLOR> (I<Bool>; F<src/core/Exception.pm>)
 
 Controls whether to emit ANSI codes for error highlighting. Defaults to true if unset, except on
 Win32.
 
-=item C<RAKUDO_MAX_THREADS> (src/core/ThreadPoolScheduler.pm)
+=item C<RAKUDO_MAX_THREADS> (I<UInt>; F<src/core/ThreadPoolScheduler.pm>)
 
-Controls the maximum number of threads used by a thread pool.
+Override the default maximum number of threads used by a thread pool.
 
-=item C<RAKUDO_NO_DEPRECATIONS> (src/core/Deprecations.pm)
+=item C<TMPDIR>, C<TEMP>, C<TMP> (I<Str>; F<src/core/IO/Spec/>)
 
-If set, suppresses deprecation warnings.
+The C<IO::Spec::Unix.tmpdir> method will return C<$TMPDIR> if it points to a directory with full
+access permissions for the current user, with a fallback default of C<'/tmp'>.
 
-=item C<RAKUDO_VERBOSE_STACKFRAME> (src/core/Backtrace.pm)
+C<IO::Spec::Cygwin> and C<IO::Spec::Win32> use more Win32-appropriate lists which also include the
+C<%TEMP%> and C<%TMP%> environment variables.
 
-Controls stack frame verbosity.
+=item C<PATH>, C<Path> (I<Str>; F<src/core/IO/Spec/>)
 
-=item C<RAKUDO_BACKTRACE_SETTING> (src/core/Backtrace.pm)
+The C<IO::Spec::Unix.path> method splits C<$PATH> as a shell would; i.e. as a colon-separated list.
+C<IO::Spec::Cygwin> inherits this from C<IO::Spec::Unix>.
 
-Controls whether .setting files are included in backtraces.
+C<IO::Spec::Win32.path> will read the first defined of either C<%PATH%> or C<%Path%> as a
+semicolon-delimited list.
 
 =back
 

--- a/docs/running.pod
+++ b/docs/running.pod
@@ -89,6 +89,12 @@ Controls whether .setting files are included in backtraces.
 
 =over
 
+=item C<RAKUDO_PRECOMP_PREFIX> (I<Str>; F<src/core/CompUnit/RepositoryRegistry.pm>)
+
+When this is set, Rakudo will perform all normal precompilation actions in the specified directory.
+This is intended as an escape hatch for build-time bootstrapping issues, where Rakudo may be built
+as an unprivileged user without write access to the runtime paths in NQP's config.
+
 =item C<RAKUDO_PRECOMP_DIST> (F<src/core/CompUnit/PrecompilationRepository.pm>)
 
 =item C<RAKUDO_PRECOMP_LOADING> (F<src/core/CompUnit/PrecompilationRepository.pm>)

--- a/src/core/CompUnit/RepositoryRegistry.pm
+++ b/src/core/CompUnit/RepositoryRegistry.pm
@@ -75,7 +75,7 @@ class CompUnit::RepositoryRegistry {
             }
 #?endif
 
-            my $prefix := nqp::p6box_s(
+            my $prefix := %*ENV<RAKUDO_PRECOMP_PREFIX> // nqp::p6box_s(
               nqp::concat(nqp::atkey(nqp::backendconfig,'prefix'),'/share/perl6')
             );
 


### PR DESCRIPTION
This is an alternate approach to PR #654. Setting `RAKUDO_PRECOMP_PREFIX` to a directory will do any precomp-related stuff there (provided it isn't affected by a `use lib` pragma — those still go into `$CWD/.precomp/`).

Both approaches can fix the initial problem I had (being unable to build distro packages for rakudo 2015.12): mst's approach makes the configure/make/install cycle Just Work, while this one takes some manual configuration but may be useful when it comes to packaging modules too.

(This pull request is a superset of #653, and is more or less independent of #654)