### PR TITLE
Support DESTDIR in CompUnit::Repository::Installation

### DIFF
--- a/src/core/CompUnit/Repository/Installation.pm
+++ b/src/core/CompUnit/Repository/Installation.pm
@@ -6,6 +6,10 @@ class CompUnit::Repository::Installation does CompUnit::Repository::Locally does
 
     submethod BUILD(:$!prefix, :$!lock, :$!WHICH, :$!next-repo) { }
 
+    method prefix {
+	IO::Path.new(%*ENV<DESTDIR> ~ $!prefix)
+    }
+
     method writeable-path {
         $.prefix.w ?? $.prefix !! IO::Path;
     }


### PR DESCRIPTION
When installing the 2015.12 release of Rakudo within NetBSD pkgsrc, installing fails with the following messages:

```
/opt/pkg/bin/perl -MExtUtils::Command -e mkpath /opt/pkgsrc/wip/rakudo/work/.destdir/opt/pkg/share/perl6/site/bin
/opt/pkg/bin/perl -MExtUtils::Command -e mkpath /opt/pkgsrc/wip/rakudo/work/.destdir/opt/pkg/share/perl6/site/short
./perl6-m tools/build/install-core-dist.pl
No writeable path found
  in block <unit> at tools/build/install-core-dist.pl line 12

gnumake: *** [m-install] Error 1
*** Error code 2
```

This is because ${PREFIX}/share/perl6 (which it tries to write to) is not writeable, but ${DESTDIR}${PREFIX}/share/perl6 is. Interestingly, the part of Rakudo's build system that uses the old EU::MM does respect destdir.

**I do not think this is actually the right fix.** But I would be glad for any suggestions for improvement :)