### PR TITLE
Remove .precomp dirs in realclean target

### DIFF
--- a/tools/build/Makefile-common-rules.in
+++ b/tools/build/Makefile-common-rules.in
@@ -13,5 +13,6 @@ t/localtest.data:
 
 realclean: clean
 	$(RM_F) Makefile config.status MANIFEST
+	$(RM_RF) lib/.precomp/ t/04-nativecall/.precomp/
 
 distclean: realclean


### PR DESCRIPTION
These directories are created as part of a `make test` run and should be
removed when cleaning up.

... one wonders if they should be cleaned up during a `make clean` rather than `make realclean`, however this will ensure a working directory without untracked files at the most thorough level of the "clean" targets.