### PR TITLE
NC: Add code to test the sanity of routine that receive the is native trait

### DIFF
--- a/t/04-nativecall/05-arrays.t
+++ b/t/04-nativecall/05-arrays.t
@@ -9,13 +9,13 @@ plan 33;
 compile_test_lib('05-arrays');
 
 {
-    sub ReturnADoubleArray() returns CArray[num] is native("./05-arrays") { * }
+    sub ReturnADoubleArray() returns CArray[num64] is native("./05-arrays") { * }
     my @rarr := ReturnADoubleArray();
     is_approx @rarr[0], 23.45e0, 'returning double array (1)';
     is_approx @rarr[1], -99.87e0, 'returning double array (2)';
     is_approx @rarr[2], 0.25e0, 'returning double array (3)';
 
-    sub TakeADoubleArrayAndAddElements(CArray[num]) returns num is native("./05-arrays") { * }
+    sub TakeADoubleArrayAndAddElements(CArray[num64]) returns num64 is native("./05-arrays") { * }
     my @parr := CArray[num].new();
     @parr[0] = 9.5e0;
     @parr[1] = 32.5e0;

--- a/t/04-nativecall/06-struct.t
+++ b/t/04-nativecall/06-struct.t
@@ -10,7 +10,7 @@ compile_test_lib('06-struct');
 
 class MyStruct is repr('CStruct') {
     has long   $.long;
-    has num    $.num;
+    has num64  $.num;
     has int8   $.byte;
     has num32  $.float;
     has CArray $.arr;
@@ -31,7 +31,7 @@ class MyStruct is repr('CStruct') {
 # is declared as type CArray[long].
 class MyStruct2 is repr('CStruct') {
     has long         $.long;
-    has num          $.num;
+    has num64        $.num;
     has int8         $.byte;
     has num32        $.float;
     has CArray[long] $.arr;
@@ -49,8 +49,8 @@ class IntStruct is repr('CStruct') {
 }
 
 class NumStruct is repr('CStruct') {
-    has num $.first;
-    has num $.second;
+    has num64 $.first;
+    has num64 $.second;
 
     # Work around struct members not being containerized yet.
     method init {

--- a/t/04-nativecall/18-routine-sig-sanity.t
+++ b/t/04-nativecall/18-routine-sig-sanity.t
@@ -1,0 +1,109 @@
+use Test;
+use NativeCall :ALL;
+
+
+class A is repr('CStruct') {
+    has	int32 $a;
+}
+
+class B {};
+
+sub goodPointer(Pointer $a)  { * };
+
+sub goodCStruct(A $a) { * };
+
+sub goodBuf(Buf $a) { * };
+
+sub badclass(B $a) { * };
+
+sub goodCArray(CArray $a)  { * };
+
+sub badCArray(CArray[int] $a) { * };
+
+sub goodint(int32 $a)  { * };
+
+sub badint(Int $a)  { * };
+
+sub badint2(int $a)  { * };
+
+sub goodnum(num32 $a)  { * };
+
+sub badnum(Num $a)  { * };
+
+sub badnum2(num $a)  { * };
+
+sub goodstr(Str $a)  { * };
+
+sub badstr(str $a)  { * };
+
+
+sub goodretint() returns int32  { * };
+
+sub badretint() returns int  { * };
+
+sub badretint2() returns Int  { * };
+
+sub goodretnum() returns num64  { * };
+
+sub badretnum() returns num  { * };
+
+sub badretnum2() returns Num  { * };
+
+sub goodretbool() returns bool  { * };
+
+sub badretbool() returns Bool  { * };
+
+sub goodretPointer() returns Pointer  { * };
+
+sub goodretCStruct() returns A  { * };
+
+sub goodretCArray() returns CArray  { * };
+
+
+sub goodstrencoded(Str is encoded('utf8'))  { * };
+sub goodretstrencoded() returns Str is encoded('utf8')  { * };
+
+
+sub testr($r) {
+   check_routine_sanity($r);
+}
+
+lives-ok {testr(&goodPointer)}, "Taking a pointer is fine";
+lives-ok {testr(&goodCStruct)}, "Taking a CStruct is fine";
+lives-ok {testr(&goodCArray)}, "Taking a CArray is fine";
+lives-ok {testr(&goodBuf)}, "Taking a Buf is fine";
+dies-ok {testr(&badCArray)}, "Taking a CArray[int] is not fine";
+dies-ok {testr(&badclass)}, "Taking a Perl6 class is NOT fine";
+lives-ok {testr(&goodint)}, "Taking a int32 is fine";
+dies-ok {testr(&badint)}, "Taking a Int is NOT fine";
+dies-ok {testr(&badint2)}, "Taking a int is NOT fine";
+lives-ok {testr(&goodnum)}, "Taking a num32 is fine";
+dies-ok {testr(&badnum)}, "Taking a Num is NOT fine";
+dies-ok {testr(&badnum2)}, "Taking a num is NOT fine";
+lives-ok {testr(&goodstr)}, "Taking a Str is fine";
+lives-ok {testr(&badstr)}, "FIXME: Taking a str is buggy but should be fine?";
+
+
+lives-ok {testr(&goodretPointer)}, "Returning a pointer is fine";
+lives-ok {testr(&goodretCStruct)}, "Returning a CStruct is fine";
+lives-ok {testr(&goodretCArray)}, "Returning a CArray is fine";
+lives-ok {testr(&goodretint)}, "Returning a int32 is fine";
+dies-ok {testr(&badretint)}, "Returning a Int is NOT fine";
+dies-ok {testr(&badretint2)}, "Returning a int is NOT fine";
+lives-ok {testr(&goodretnum)}, "Returning a num32 is fine";
+dies-ok {testr(&badretnum)}, "Returning a Num is NOT fine";
+dies-ok {testr(&badretnum2)}, "Returning a num is NOT fine";
+lives-ok {testr(&goodretbool)}, "Returning a bool is fine";
+lives-ok {testr(&badretbool)}, "FIXME: Returning a Bool maybe be bugged";
+
+lives-ok {testr(&goodstrencoded)}, "Taking an encoded Str is fine";
+lives-ok {testr(&goodretstrencoded)}, "Returning an encoded Str is fine";
+
+eval-dies-ok 'use NativeCall; sub test(Int $a) is native("fake") {*};', "Bad trait declaration";
+eval-lives-ok 'use NativeCall; sub test2(int32 $a) is native("fake") {*};', "Good trait declaration";
+eval-lives-ok 'use NativeCall; class A is repr("CPointer") { sub foo(A $a) is native("fake") {*} }', "Embeded type";
+eval-lives-ok 'use NativeCall; sub foo() is native("fake") {*}', "Void function";
+eval-lives-ok 'use NativeCall; class Piko { method All_The_Things(int8, int16, int32, long, num32, num64) returns long is native("./11-cpp") is nativeconv("thisgnu") { * }}', "Method are silly";
+
+done-testing
+


### PR DESCRIPTION
This way, we can avoid misuse of Int or int in routine parameter/returns function.

Comments:
I did not find a way to call the check routine when given a Callable as a callback.
Bool and str are accepted but str can lead to some weird SIGSEV, but seem to work fine as a return type (but it sucks because you can call .perl or it for example).

Errors look like this https://gist.github.com/Skarsnik/4579e451ab1b6b364305 but the check is done at compile time