### PR TITLE
RFC: make v5 pluggable

### DIFF
--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -1499,9 +1499,16 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         [
         | <version> [
                     ||  <?{ $<version><vnum>[0] == 5 }> {
-                            my $module := $*W.load_module($/, 'Perl5', {}, $*GLOBALish);
-                            $*W.do_import($/, $module, 'Perl5');
-                            $*W.import_EXPORTHOW($/, $module);
+                            my $loader;
+                            {
+                                $loader := $*W.find_symbol(['&LOAD-V5']);
+                                CATCH {
+                                    $/.CURSOR.typed_panic:
+                                        'X::Language::Unsupported',
+                                        version => ~$<version>;
+                                }
+                            }
+                            $loader($<version>.ast.compile_time_value);
                         }
                     ||  <?{ $<version><vnum>[0] == 6 }> {
                             my $version_parts := $<version><vnum>;


### PR DESCRIPTION
For the foreseeable future, there will not be an official Perl5 re-implementation on top of Rakudo. Therefore, it's probably a good idea to add some hooks to let users decide what should happen on `use v5` instead of hardcoding loading the `Perl5` module.

The new system would be used like this:

```
use Slang::Perl5; # exports sub LOAD-V5(Version $) { ... }
say $*DISTRO.name; # still perl6

{
    use v5.42; # calls LOAD-V5(v5.42) which installs a Perl5 slang
    print $^O, "\n";
}
```
