### PR TITLE
Fix IO::Path.absolute/.relative to return IO::Path

### DIFF
--- a/src/core/IO/Path.pm
+++ b/src/core/IO/Path.pm
@@ -116,7 +116,7 @@ my class IO::Path is Cool {
     }
 #?endif
 
-    proto method absolute(|) { * }
+    proto method absolute(|) { {*}.IO }
     multi method absolute (IO::Path:D:) { $.abspath }
     multi method absolute (IO::Path:D: $CWD) {
         self.is-absolute
@@ -125,7 +125,7 @@ my class IO::Path is Cool {
     }
 
     method relative (IO::Path:D: $CWD = $*CWD) {
-        $!SPEC.abs2rel($.abspath, $CWD);
+        $!SPEC.abs2rel($.abspath, $CWD).IO;
     }
 
     method cleanup (IO::Path:D:) {


### PR DESCRIPTION
http://doc.perl6.org/type/IO::Path technically says `a new IO::Path`, so someone more familiar with the path caching may want to take it one step further.
