### PR TITLE
Decent sqrt()

### DIFF
--- a/src/core/Complex.pm
+++ b/src/core/Complex.pm
@@ -80,8 +80,10 @@ my class Complex is Cool does Numeric {
     }
 
     method sqrt(Complex:D:) {
-        my Num ($mag, $angle) = self.polar;
-        $mag.sqrt.unpolar($angle/2);
+        my Num $abs = self.abs;
+        my Num $re = (($abs + self.re)/2).sqrt;
+        my Num $im = (($abs - self.re)/2).sqrt;
+        Complex.new($re, self.im < 0 ?? -$im !! $im);
     }
 
     multi method exp(Complex:D:) {


### PR DESCRIPTION
I am glad perl6 supports complex numbers natively.  What I am not glad is that its definition of `i` does not agree with mathematics:

% perl6
````
> sqrt(-1+0i)
6.12323399573677e-17+1i
````

Though `(-1+0i)**0.5 != 1i` for most other platforms, they still get `sqrt(-1+0i)` right:

% python
````
    Python 2.7.10 (default, Oct 23 2015, 18:05:06) 
    [GCC 4.2.1 Compatible Apple LLVM 7.0.0 (clang-700.0.59.5)] on darwin
    Type "help", "copyright", "credits" or "license" for more information.
    >>> from cmath import *
    >>> sqrt(-1+0j)
    1j
    >>> (-1+0j)**0.5
    (6.123233995736766e-17+1j)
    >>> ^D
````
% irb
````
    irb(main):001:0> require 'cmath'
    => true
    irb(main):002:0> CMath.sqrt(-1)
    => (0+1.0i)
    irb(main):003:0> ^D
````    
% perl -MMath::Complex -dE 1
````    
    Loading DB routines from perl5db.pl version 1.49
    Editor support available.
    
    Enter h or 'h h' for help, or 'man perldebug' for more help.
    
    main::(-e:1):	1
      DB<1> p sqrt(-1+0*i)
    i
      DB<2> p (-1+0*i)**0.5
    6.12323399573677e-17+i
````

So here is the patch that defines `sqrt` in `sqrt`.

Dan the Complex Perl6 Newbie
