### PR TITLE
Bypass path attribute caching in CompUnit

### DIFF
--- a/src/core/CompUnit/Repository/Installation.pm
+++ b/src/core/CompUnit/Repository/Installation.pm
@@ -4,16 +4,18 @@ class CompUnit::Repository::Installation does CompUnit::Repository::Locally does
     has $!precomp;
     has $!id;
 
-    submethod BUILD(:$!prefix, :$!lock, :$!WHICH, :$!next-repo) {
-        $!prefix.mkdir;
-    }
+    submethod BUILD(:$!prefix, :$!lock, :$!WHICH, :$!next-repo) { }
 
     method writeable-path {
         $.prefix.w ?? $.prefix !! IO::Path;
     }
 
+    method !writeable-path {
+        self.can-install ?? $.prefix !! IO::Path;
+    }
+
     method can-install() {
-        $.prefix.w
+        $.prefix.w || ?(!$.prefix.e && try { $.prefix.mkdir } && $.prefix.e);
     }
 
     my $windows_wrapper = '@rem = \'--*-Perl-*--
@@ -109,7 +111,7 @@ sub MAIN(:$name is copy, :$auth, :$ver, *@, *%) {
     method install(Distribution $dist, %sources, %scripts?, %resources?, :$force) {
         $!lock.protect( {
         my @*MODULES;
-        my $path   = self.writeable-path or die "No writeable path found, $.prefix not writeable";
+        my $path   = self!writeable-path or die "No writeable path found, $.prefix not writeable";
         my $lock //= $.prefix.child('repo.lock').open(:create, :w);
         $lock.lock(2);
 

--- a/src/core/CompUnit/Repository/Installation.pm
+++ b/src/core/CompUnit/Repository/Installation.pm
@@ -4,7 +4,9 @@ class CompUnit::Repository::Installation does CompUnit::Repository::Locally does
     has $!precomp;
     has $!id;
 
-    submethod BUILD(:$!prefix, :$!lock, :$!WHICH, :$!next-repo) { }
+    submethod BUILD(:$!prefix, :$!lock, :$!WHICH, :$!next-repo) {
+        $!prefix.mkdir;
+    }
 
     method writeable-path {
         $.prefix.w ?? $.prefix !! IO::Path;

--- a/src/core/CompUnit/Repository/Locally.pm
+++ b/src/core/CompUnit/Repository/Locally.pm
@@ -27,6 +27,8 @@ role CompUnit::Repository::Locally {
         self.short-id ~ '#' ~ $!prefix.abspath;
     }
 
+    method prefix { "{$!prefix}".IO }
+
     method id() {
         my $name = self.path-spec;
         $name ~= ',' ~ self.next-repo.id if self.next-repo;


### PR DESCRIPTION
* Fixes issues where installation of modules fails on the
first run but works on subsequent tries.
* Allows `rm -rf /path/to/repo` uninstallation of modules
while still being able to recreate the path structure with-
out "No writeable path found" errors.

`method prefix` fixes instances of `$path.mkdir unless $path.e`
that pass around an IO::Path where `!$path.e` or `!$path.w`
erroneously (`perl6 -e 'my $path = "non-existent".IO; say $path.e; $path.mkdir; say $path.e'` -> `False False`). This avoids adding stringification code throughout
the rest of the codebase (or adding .IO all over)

`.mkdir` in BUILD mimicks prior art in PrecompilationStore::File

Alternatively mkdir could (and probably should) break the cache