### PR TITLE
Add a :&where parameter to control how where clauses are gistperled

### DIFF
--- a/src/core/Parameter.pm
+++ b/src/core/Parameter.pm
@@ -199,7 +199,7 @@ my class Parameter { # declared in BOOTSTRAP
         True;
     }
 
-    multi method perl(Parameter:D: Mu:U :$elide-type = Any) {
+    multi method perl(Parameter:D: Mu:U :$elide-type = Any, :&where = -> $ { 'where { ... }' }) {
         my $perl = '';
         my $rest = '';
         my $type = $!nominal_type.^name;
@@ -279,7 +279,11 @@ my class Parameter { # declared in BOOTSTRAP
             $sig ~~ s/^^ ':'//;
             $rest ~= ' ' ~ $sig;
         }
-        $rest ~= ' where { ... }' if !nqp::isnull($!post_constraints);
+        unless nqp::isnull($!post_constraints) {
+            my $where = &where(self);
+            return Nil without $where;
+            $rest ~= " $where";
+        }
         $rest ~= ' = { ... }' if $default;
         if $name or $rest {
             $perl ~= ($perl ?? ' ' !! '') ~ $name;


### PR DESCRIPTION
  If this returns Nil, the whole gistperl returns Nil, which can be
  used to detect where clauses when you want them to matter, such as
  in the metamodel Signature comparator to prevent false conflicts.
  Do so, fixing RT#127024 and RT#127025.

  Whether Signature eqv Signature should be changed to do this as
  well is TBD.