### PR TITLE
Fix RT #126566

### DIFF
--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -615,14 +615,15 @@ class Perl6::World is HLL::World {
             %*LANG<MAIN> := $cursor.WHAT;
         }
 
+        my $actions := %*LANG<MAIN-actions>;
         # Add action method if needed.
-        unless nqp::can($*ACTIONS, $canname) {
+        unless nqp::can($actions, $canname) {
             my role PackageDeclaratorAction[$meth] {
                 method ::($meth)($/) {
                     make $<package_def>.ast;
                 }
             };
-            %*LANG<MAIN-actions> := $*ACTIONS.HOW.mixin($*ACTIONS,
+            %*LANG<MAIN-actions> := $actions.HOW.mixin($actions,
                 PackageDeclaratorAction.HOW.curry(PackageDeclaratorAction, $canname));
         }
         self.install_lexical_symbol(self.cur_lexpad(), '%?LANG', self.p6ize_recursive(%*LANG));


### PR DESCRIPTION
Exporting multiple custom declarators made them clobber their changes to
`$*ACTIONS`. Now use `%*LANG<MAIN-actions>` to chain the changes.

Test: https://github.com/perl6/roast/pull/93
RT: https://rt.perl.org/Public/Bug/Display.html?id=126566

I have a module that I would like to release that depends on multiple custom declarators so I would be happy if this got merged. 

PS I have a wholistic patch that cleans up a lot of the mixing into LANG stuff but it seems that the less ambitious my PRs are the more likely they are to be merged :P