### PR TITLE
Implement support for auto-generating private accessors.

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -3102,6 +3102,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
             my %config := hash(
                 name => $attrname,
                 has_accessor => $twigil eq '.',
+		has_private_accessor => $twigil eq '!',
                 container_descriptor => $descriptor,
                 type => %cont_info<bind_constraint>,
                 package => $*W.find_symbol(['$?CLASS']));

--- a/src/Perl6/Metamodel/BOOTSTRAP.nqp
+++ b/src/Perl6/Metamodel/BOOTSTRAP.nqp
@@ -1104,6 +1104,7 @@ BEGIN {
     #     has str $!name;
     #     has int $!rw;
     #     has int $!has_accessor;
+    #     has int $!has_private_accessor;
     #     has Mu $!type;
     #     has Mu $!container_descriptor;
     #     has Mu $!auto_viv_container;
@@ -1119,6 +1120,7 @@ BEGIN {
     Attribute.HOW.add_attribute(Attribute, BOOTSTRAPATTR.new(:name<$!ro>, :type(int), :package(Attribute)));
     Attribute.HOW.add_attribute(Attribute, BOOTSTRAPATTR.new(:name<$!required>, :type(int), :package(Attribute)));
     Attribute.HOW.add_attribute(Attribute, BOOTSTRAPATTR.new(:name<$!has_accessor>, :type(int), :package(Attribute)));
+    Attribute.HOW.add_attribute(Attribute, BOOTSTRAPATTR.new(:name<$!has_private_accessor>, :type(int), :package(Attribute)));
     Attribute.HOW.add_attribute(Attribute, BOOTSTRAPATTR.new(:name<$!type>, :type(Mu), :package(Attribute)));
     Attribute.HOW.add_attribute(Attribute, BOOTSTRAPATTR.new(:name<$!container_descriptor>, :type(Mu), :package(Attribute)));
     Attribute.HOW.add_attribute(Attribute, BOOTSTRAPATTR.new(:name<$!auto_viv_container>, :type(Mu), :package(Attribute)));
@@ -1134,11 +1136,12 @@ BEGIN {
     # Need new and accessor methods for Attribute in here for now.
     Attribute.HOW.add_method(Attribute, 'new',
         nqp::getstaticcode(sub ($self, :$name!, :$type!, :$package!, :$inlined = 0, :$has_accessor,
-                :$positional_delegate = 0, :$associative_delegate = 0, *%other) {
+                 :$has_private_accessor, :$positional_delegate = 0, :$associative_delegate = 0, *%other) {
             my $attr := nqp::create($self);
             nqp::bindattr_s($attr, Attribute, '$!name', $name);
             nqp::bindattr($attr, Attribute, '$!type', nqp::decont($type));
             nqp::bindattr_i($attr, Attribute, '$!has_accessor', $has_accessor);
+	    nqp::bindattr_i($attr, Attribute, '$!has_private_accessor', $has_private_accessor);
             nqp::bindattr($attr, Attribute, '$!package', $package);
             nqp::bindattr_i($attr, Attribute, '$!inlined', $inlined);
             if nqp::existskey(%other, 'container_descriptor') {
@@ -1187,6 +1190,10 @@ BEGIN {
     Attribute.HOW.add_method(Attribute, 'has_accessor', nqp::getstaticcode(sub ($self) {
             nqp::p6bool(nqp::getattr_i(nqp::decont($self),
                 Attribute, '$!has_accessor'));
+        }));
+    Attribute.HOW.add_method(Attribute, 'has_private_accessor', nqp::getstaticcode(sub ($self) {
+            nqp::p6bool(nqp::getattr_i(nqp::decont($self),
+                Attribute, '$!has_private_accessor'));
         }));
     Attribute.HOW.add_method(Attribute, 'rw', nqp::getstaticcode(sub ($self) {
             nqp::p6bool(nqp::getattr_i(nqp::decont($self),

--- a/src/Perl6/Metamodel/EnumHOW.nqp
+++ b/src/Perl6/Metamodel/EnumHOW.nqp
@@ -8,6 +8,7 @@ class Perl6::Metamodel::EnumHOW
     does Perl6::Metamodel::Stashing
     does Perl6::Metamodel::AttributeContainer
     does Perl6::Metamodel::MethodContainer
+    does Perl6::Metamodel::PrivateMethodContainer
     does Perl6::Metamodel::MultiMethodContainer
     does Perl6::Metamodel::RoleContainer
     does Perl6::Metamodel::BaseType

--- a/src/Perl6/Metamodel/PrivateMethodContainer.nqp
+++ b/src/Perl6/Metamodel/PrivateMethodContainer.nqp
@@ -21,4 +21,10 @@ role Perl6::Metamodel::PrivateMethodContainer {
             %!private_methods{$name} !!
             nqp::null()
     }
+
+    # Checks if this package (not its parents) declares a given
+    # private method.
+    method declares_private_method($obj, $name) {
+	%!private_methods{$name} ?? 1 !! 0;
+    }
 }

--- a/src/core/traits.pm
+++ b/src/core/traits.pm
@@ -74,11 +74,11 @@ multi sub trait_mod:<is>(Attribute:D $attr, |c ) {
 }
 multi sub trait_mod:<is>(Attribute:D $attr, :$rw!) {
     $attr.set_rw();
-    warn "useless use of 'is rw' on $attr.name()" unless $attr.has_accessor;
+    warn "useless use of 'is rw' on $attr.name()" unless $attr.has_accessor || $attr.has_private_accessor;
 }
 multi sub trait_mod:<is>(Attribute:D $attr, :$readonly!) {
     $attr.set_readonly();
-    warn "useless use of 'is readonly' on $attr.name()" unless $attr.has_accessor;
+    warn "useless use of 'is readonly' on $attr.name()" unless $attr.has_accessor || $attr.has_private_accessor;
 }
 multi sub trait_mod:<is>(Attribute $attr, :$required!) {
     $attr.set_required();


### PR DESCRIPTION
'has $!foo' will auto-generate accessors in the same manner as 'has
$.foo' does, but the resulting accessor will be private. No accessor
is auto-generated should a privatly defined method with the same name
already exist. 'is rw' and 'is readonly' now makes sense for private
attributes as well.
