### PR TITLE
C++mangling additions

### DIFF
--- a/lib/NativeCall/Compiler/GNU.pm6
+++ b/lib/NativeCall/Compiler/GNU.pm6
@@ -36,17 +36,38 @@ sub cpp_param_letter($type, :$R = '', :$P = '', :$K = '') {
         when int8 {
             $R ~ $P ~ $K ~ 'c'
         }
+        when uint8 {
+            $R ~ $P ~ $K ~ 'h'
+        }
         when int16 {
             $R ~ $P ~ $K ~ 's'
+        }
+        when uint16 {
+            $R ~ $P ~ $K ~ 't'
         }
         when int32 {
             $R ~ $P ~ $K ~ 'i'
         }
+        when uint32 {
+            $R ~ $P ~ $K ~ 'j'
+        }
         when NativeCall::Types::long {
             $R ~ $P ~ $K ~ 'l'
         }
+        when NativeCall::Types::ulong {
+            $R ~ $P ~ $K ~ 'm'
+        }
+        when int64 {
+            $R ~ $P ~ $K ~ 'x'
+        }
         when NativeCall::Types::longlong {
             $R ~ $P ~ $K ~ 'x'
+        }
+        when uint64 {
+            $R ~ $P ~ $K ~ 'y'
+        }
+        when NativeCall::Types::ulonglong {
+            $R ~ $P ~ $K ~ 'y'
         }
         when num32 {
             $R ~ $P ~ $K ~ 'f'

--- a/lib/NativeCall/Compiler/MSVC.pm6
+++ b/lib/NativeCall/Compiler/MSVC.pm6
@@ -58,17 +58,38 @@ sub cpp_param_letter($type, :$R = '', :$P = '', :$K = '') {
         when int8 {
             $R ~ $K ~ 'D'
         }
+        when uint8 {
+            $R ~ $K ~ 'E'
+        }
         when int16 {
             $R ~ $K ~ 'F'
+        }
+        when uint16 {
+            $R ~ $K ~ 'G'
         }
         when int32 {
             $P ~ $K ~ 'H'
         }
+        when uint32 {
+            $P ~ $K ~ 'I'
+        }
         when NativeCall::Types::long {
             $R ~ $K ~ 'J'
         }
+        when NativeCall::Types::ulong {
+            $R ~ $K ~ 'K'
+        }
+        when int64 {
+            $R ~ '_J'
+        }
         when NativeCall::Types::longlong {
             $R ~ '_J'
+        }
+        when uint64 {
+            $R ~ '_K'
+        }
+        when NativeCall::Types::ulonglong {
+            $R ~ '_K'
         }
         when num32 {
             $R ~ $K ~ 'M'

--- a/t/04-nativecall/13-cpp-mangling.cpp
+++ b/t/04-nativecall/13-cpp-mangling.cpp
@@ -30,8 +30,8 @@ public:
     virtual int TakeALongLongPointer(long long *i);
     virtual int TakeAFloatPointer(float *i);
     virtual int TakeADoublePointer(double *i);
-    virtual int TakeAUInt(uint i);
-    virtual int TakeAUShort(ushort i);
+    virtual int TakeAUInt(unsigned int i);
+    virtual int TakeAUShort(unsigned short i);
     virtual int TakeAUChar(unsigned char i);
     virtual int TakeAInt64(long long i);
     virtual int TakeAULongLong(unsigned long long i);
@@ -61,8 +61,8 @@ int Foo::TakeALongPointer(long *i)          { return 16; }
 int Foo::TakeALongLongPointer(long long *i) { return 17; }
 int Foo::TakeAFloatPointer(float *i)        { return 18; }
 int Foo::TakeADoublePointer(double *i)      { return 19; }
-int Foo::TakeAUInt(uint i)                  { return 20; }
-int Foo::TakeAUShort(ushort i)              { return 21; }
+int Foo::TakeAUInt(unsigned int i)          { return 20; }
+int Foo::TakeAUShort(unsigned short i)      { return 21; }
 int Foo::TakeAUChar(unsigned char i)        { return 22; }
 int Foo::TakeAInt64(long long i)            { return 23; }
 int Foo::TakeAULongLong(unsigned long long i) { return 24; }

--- a/t/04-nativecall/13-cpp-mangling.cpp
+++ b/t/04-nativecall/13-cpp-mangling.cpp
@@ -30,6 +30,12 @@ public:
     virtual int TakeALongLongPointer(long long *i);
     virtual int TakeAFloatPointer(float *i);
     virtual int TakeADoublePointer(double *i);
+    virtual int TakeAUInt(uint i);
+    virtual int TakeAUShort(ushort i);
+    virtual int TakeAUChar(unsigned char i);
+    virtual int TakeAInt64(long long i);
+    virtual int TakeAULongLong(unsigned long long i);
+    virtual int TakeAUInt64(unsigned long long i);
 };
 
 Foo::Foo()  { };
@@ -55,3 +61,9 @@ int Foo::TakeALongPointer(long *i)          { return 16; }
 int Foo::TakeALongLongPointer(long long *i) { return 17; }
 int Foo::TakeAFloatPointer(float *i)        { return 18; }
 int Foo::TakeADoublePointer(double *i)      { return 19; }
+int Foo::TakeAUInt(uint i)                  { return 20; }
+int Foo::TakeAUShort(ushort i)              { return 21; }
+int Foo::TakeAUChar(unsigned char i)        { return 22; }
+int Foo::TakeAInt64(long long i)            { return 23; }
+int Foo::TakeAULongLong(unsigned long long i) { return 24; }
+int Foo::TakeAUInt64(unsigned long long i)    { return 25; }

--- a/t/04-nativecall/13-cpp-mangling.t
+++ b/t/04-nativecall/13-cpp-mangling.t
@@ -16,7 +16,7 @@ try {
     }
 }
 
-plan 20;
+plan 26;
 
 # shell 'dumpbin /exports 13-cpp-mangling.dll';
 
@@ -44,6 +44,14 @@ class Foo is repr<CPPStruct> {
     method TakeALongLongPointer(Pointer[longlong]) returns int32 is native("./13-cpp-mangling") { * }
     method TakeAFloatPointer(Pointer[num32])       returns int32 is native("./13-cpp-mangling") { * }
     method TakeADoublePointer(Pointer[num64])      returns int32 is native("./13-cpp-mangling") { * }
+    method TakeAUInt(uint32)                       returns int32 is native("./13-cpp-mangling") { * }
+    method TakeAUShort(uint16)                     returns int32 is native("./13-cpp-mangling") { * }
+    method TakeAUChar(uint8)                       returns int32 is native("./13-cpp-mangling") { * }
+    method TakeAInt64(int64)                       returns int32 is native("./13-cpp-mangling") { * }
+    method TakeAULongLong(ulonglong)               returns int32 is native("./13-cpp-mangling") { * }
+    method TakeAUInt64(uint64)                     returns int32 is native("./13-cpp-mangling") { * }
+
+
 }
 
 my $foo = Foo.new;
@@ -68,3 +76,9 @@ is $foo.TakeALongPointer(Pointer[long].new),         16, 'long* mangling';
 is $foo.TakeALongLongPointer(Pointer[longlong].new), 17, 'long long* mangling';
 is $foo.TakeAFloatPointer(Pointer[num32].new),       18, 'float* mangling';
 is $foo.TakeADoublePointer(Pointer[num64].new),      19, 'double* mangling';
+is $foo.TakeAUInt(1),                                20, 'uint mangling';
+is $foo.TakeAUShort(1),                              21, 'ushort mangling';
+is $foo.TakeAUChar(1),                               22, 'uchar mangling';
+is $foo.TakeAInt64(1),                               23, 'int64 mangling';
+is $foo.TakeAULongLong(1),                           24, 'unsigned long long mangling';
+is $foo.TakeAUInt64(1),                              25, 'uint64 mangling';


### PR DESCRIPTION
Hi,
I've added mangling for unsigned integer types (and int64,) I guessed for the MSVC (based on the table nine in http://www.agner.org/optimize/calling_conventions.pdf) but it isn't tested on MSVC so someone may need to adjust that.

All good.