### PR TITLE
Use p6box_s for version when setting home repo

### DIFF
--- a/src/core/CompUnit/RepositoryRegistry.pm
+++ b/src/core/CompUnit/RepositoryRegistry.pm
@@ -91,7 +91,7 @@ class CompUnit::RepositoryRegistry {
                        (nqp::existskey($ENV,'HOMEPATH')
                          ?? nqp::atkey($ENV,'HOMEPATH') !! '')
                      ) -> $home {
-                    my $ver := nqp::atkey($compiler,'version');
+                    my $ver := nqp::p6box_s(nqp::atkey($compiler,'version'));
                     my str $path = "inst#$home/.perl6/$ver";
                     nqp::bindkey($custom-lib,'home',$path);
                     nqp::push($raw-specs,$path);


### PR DESCRIPTION
'home' repository is missing from the repo-chain.

Latest commit:
```
$ perl6 -e'say $*PERL.compiler.version; say CompUnit::RepositoryRegistry.repository-for-name(<home>)'
v2015.12.155.g.4.f.2.bfcf
Nil
```

Works before fbe0a66:
```
$ perl6 -e'say $*PERL.compiler.version; say CompUnit::RepositoryRegistry.repository-for-name(<home>)'
v2015.12.142.gfbe.0.a.66
Nil

$ perl6 -e'say $*PERL.compiler.version; say CompUnit::RepositoryRegistry.repository-for-name(<home>)'
v2015.12.141.g.4.ac.7.e.2
inst#/Users/panu/.perl6/2015.12-141-g04ac7e2
```

This commit:
```
$ install/bin/perl6 -e'say $*PERL.compiler.version; say CompUnit::RepositoryRegistry.repository-for-name(<home>)'
v2015.12.156.ga.540.b.79
inst#/Users/panu/.perl6/2015.12-156-ga540b79
```
