### PR TITLE
decent infix:<**> for Complex

### DIFF
--- a/src/core/Complex.pm
+++ b/src/core/Complex.pm
@@ -81,9 +81,9 @@ my class Complex is Cool does Numeric {
 
     method sqrt(Complex:D:) {
         my Num $abs = self.abs;
-        my Num $re = (($abs + self.re)/2).sqrt;
-        my Num $im = (($abs - self.re)/2).sqrt;
-        Complex.new($re, self.im < 0 ?? -$im !! $im);
+        my Num $re = (($abs + $!re)/2).sqrt;
+        my Num $im = (($abs - $!re)/2).sqrt;
+        Complex.new($re, $!im < 0 ?? -$im !! $im);
     }
 
     multi method exp(Complex:D:) {
@@ -429,7 +429,23 @@ multi sub infix:<**>(Num(Real) \a, Complex:D \b) returns Complex:D {
     a == 0e0 ?? Complex.new(0e0, 0e0) !! (b * a.log).exp
 }
 multi sub infix:<**>(Complex:D \a, Num(Real) \b) returns Complex:D {
-    (b * a.log).exp
+    return a if b == 0e0;
+    my $ib = b.Int;
+    return a ** $ib if $ib == b;
+    my $fb = b - $ib;
+    return $fb * 2 == 1e0 ?? a ** $ib * a.sqrt
+    !!    -$fb * 2 == 1e0 ?? a ** $ib / a.sqrt
+    !!    (b * a.log).exp
+}
+multi sub infix:<**>(Complex:D \a, Int:D \b) returns Complex:D {
+    my $r = Complex.new(1e0, 0e0);
+    my $u = b.abs;
+    my $t = a;
+    while $u > 0 {
+        $r *= $t if $u +& 1 == 1;
+        $u +>= 1; $t *= $t;
+    }
+    b < 0 ?? 1e0 / $r !! $r;
 }
 
 multi sub infix:<==>(Complex:D \a, Complex:D \b) returns Bool:D { a.re == b.re && a.im == b.im }


### PR DESCRIPTION
By switching to integer arithmetics and `sqrt()` when appropriate, `$z ** $int` and `$z ** ($int/2)` are more accurate, or as accurate as other platforms.   The following is how I noticed:

% perl6
````shell
> my $z = 8+6i
8+6i
> sin($z)**2+cos($z)**2
0.999999999978172+2.00088834390044e-11i
> sin($z)*sin($z)+cos($z)*cos($z)
1.00000000001455+0i
````
% irb
````shell
irb(main):001:0> require 'cmath'
=> true
irb(main):002:0> include CMath
=> Object
irb(main):003:0> z=8+6.i
=> (8+6i)
irb(main):004:0> sin(z)**2+cos(z)**2
=> (1.000000000014552+0.0i)
irb(main):005:0> sin(z)*sin(z)+cos(z)*cos(z)
=> (1.000000000014552+0.0i)
````

% python
````
Python 2.7.10 (default, Oct 23 2015, 18:05:06) 
[GCC 4.2.1 Compatible Apple LLVM 7.0.0 (clang-700.0.59.5)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from cmath import *
>>> z=8+6j
>>> sin(z)**2+cos(z)**2
(1.000000000014552+0j)
>>> sin(z)*sin(z)+cos(z)*cos(z)
(1.000000000014552+0j)
````

%./perl6-m # after the patch
````shell
> my $z = 8+6i
8+6i
> sin($z)**2+cos($z)**2
1.00000000001455+0i
````

Dan the Complex Perl Monger
