### PR TITLE
Ensure uniqueness of precomp dependencies.

### DIFF
--- a/src/core/CompUnit/PrecompilationRepository.pm
+++ b/src/core/CompUnit/PrecompilationRepository.pm
@@ -123,7 +123,7 @@ class CompUnit::PrecompilationRepository::Default does CompUnit::PrecompilationR
         %ENV.DELETE-KEY(<RAKUDO_PRECOMP_LOADING>);
         %ENV<RAKUDO_PRECOMP_DIST> = $current_dist;
 
-        my @result = $proc.out.lines;
+        my @result = $proc.out.lines.unique;
         if not $proc.out.close or $proc.status {  # something wrong
             self.store.unlock;
             push @result, "Return status { $proc.status }\n";


### PR DESCRIPTION
Some background:
I noticed duplicate entries appearing in some of the `lib/.precomp/*.rev-deps` when doing the following:
```
$ panda installdeps PDF
$ panda look PDF
.panda-work/1452532671_1$ time perl6 -I lib -e'use PDF::DAO::Doc'
.panda-work/1452532671_1$ time perl6 -I lib -e'use PDF::DAO::Doc'
```
With this patch, duplicates are removed from `*.rev-deps` and the second `use PDF::DAO::Doc` only takes about half the time.