### PR TITLE
fix https://github.com/rakudo/rakudo/pull/679

### DIFF
--- a/src/core/Complex.pm
+++ b/src/core/Complex.pm
@@ -429,7 +429,26 @@ multi sub infix:<**>(Num(Real) \a, Complex:D \b) returns Complex:D {
     a == 0e0 ?? Complex.new(0e0, 0e0) !! (b * a.log).exp
 }
 multi sub infix:<**>(Complex:D \a, Num(Real) \b) returns Complex:D {
-    (b * a.log).exp
+    return Complex.new(NaN, NaN) if b.isNaN || b.abs == Inf;
+    my $ib = b.Int;
+    return a ** $ib if $ib == b;
+    my $fb = b - $ib;
+    return $fb * 2 == 1e0 ?? a ** $ib * a.sqrt
+    !!    -$fb * 2 == 1e0 ?? a ** $ib / a.sqrt
+    !!    (b * a.log).exp
+}
+multi sub infix:<**>(Complex:D \a, Int:D \b) returns Complex:D {
+    my $r = Complex.new(1e0, 0e0);
+    return $r if b == 0;
+    return  a if a == $r;
+    return  a if b == 1;
+    my $u = b.abs;
+    my $t = a;
+    while $u > 0 {
+        $r *= $t if $u +& 1 == 1;
+        $u +>= 1; $t *= $t;
+    }
+    b < 0 ?? 1e0 / $r !! $r;
 }
 
 multi sub infix:<==>(Complex:D \a, Complex:D \b) returns Bool:D { a.re == b.re && a.im == b.im }


### PR DESCRIPTION
Essentially the same as https://github.com/rakudo/rakudo/pull/679 but this time `make spectest` succeeds.

``` shell
% make TEST_JOBS=8 spectest
git clone git://github.com/perl6/roast.git t/spec
Cloning into 't/spec'...
remote: Counting objects: 62449, done.
remote: Compressing objects: 100% (20/20), done.
remote: Total 62449 (delta 7), reused 0 (delta 0), pack-reused 62429
Receiving objects: 100% (62449/62449), 20.45 MiB | 3.75 MiB/s, done.
Resolving deltas: 100% (37516/37516), done.
Checking connectivity... done.
cd t/spec/ && git config remote.origin.pushurl git@github.com:perl6/roast.git
cd t/spec && git pull --ff-only
Already up-to-date.
/usr/local/bin/perl t/harness --fudge --moar --keep-exit-code --tests-from-file=t/spectest.data
Inline::Perl5 not installed: not running Perl 5 integration tests
t/spec/S02-lexical-conventions/begin_end_pod.t ................ ok      
[...]
All tests successful.
Files=1092, Tests=51518, 220 wallclock secs (11.75 usr  4.16 sys + 1209.05 cusr 130.53 csys = 1355.49 CPU)
Result: PASS
```

The reason https://github.com/rakudo/rakudo/pull/679 broke `t/spec/S32-num/power.t` was it didn't checks if `b` is  `NaN` or `Inf` before invoking `b.Int`.  This PR fixes that.

Dan the Complex Perl Monger
