### PR TITLE
A few small tweaks for Test.pm6

### DIFF
--- a/lib/Test.pm6
+++ b/lib/Test.pm6
@@ -289,7 +289,11 @@ sub skip-rest($reason = '<unknown>') is export {
     $time_before = nqp::time_n;
 }
 
-sub subtest(&subtests, $desc = '') is export {
+multi sub subtest($desc, &subtests) is export {
+    subtest(&subtests, $desc);
+}
+
+multi sub subtest(&subtests, $desc = '') is export {
     _push_vars();
     _init_vars();
     $indents ~= "    ";

--- a/lib/Test.pm6
+++ b/lib/Test.pm6
@@ -294,6 +294,7 @@ multi sub subtest($desc, &subtests) is export {
 }
 
 multi sub subtest(&subtests, $desc = '') is export {
+    diag($desc) if $desc;
     _push_vars();
     _init_vars();
     $indents ~= "    ";


### PR DESCRIPTION
I wish this module had tests, but that's a much bigger PR.

This PR makes two changes:

Adds a `multi sub subtest($desc, &subtests) is export` so you can pass the name first, which I think read _much_ better for any sub longer than a couple lines.

Adds a `diag()` with the subtest name before running the subtest block, if a name was provided. This makes scanning through test output a little easier.