### PR TITLE
Fix several issues with List.squish

### DIFF
--- a/src/core/Supply.pm
+++ b/src/core/Supply.pm
@@ -743,20 +743,20 @@ my class Supply {
             if &as {
                 whenever self -> \val {
                     $target = &as(val);
-                    if $first || !&with($target,$last) {
+                    if $first || !&with($last,$target) {
                         $first = 0;
-                        $last  = $target;
                         emit(val);
                     }
+                    $last  = $target;
                 }
             }
             else {
                 whenever self -> \val {
-                    if $first || !&with(val,$last) {
+                    if $first || !&with($last, val) {
                         $first = 0;
-                        $last = val;
                         emit(val);
                     }
+                    $last = val;
                 }
             }
         }


### PR DESCRIPTION
  Only evaluate :&as and :&with the minimum number of times
  Prevent IterationEnd from leaking into :&as and :&with calls
  Use intuitive ordering of :&with args for non-commutative :with
  Always pass :&with consecutive elements of the original list
  Once committed to doing a push-all, no need to mutate anymore
  Might possibly fix r-j RT#126527 -- needs someone to test
  Will commit roast tests for these behaviors after merge