### PR TITLE
Fix permutations(1) with early IterationEnd

### DIFF
--- a/src/core/operators.pm
+++ b/src/core/operators.pm
@@ -672,6 +672,11 @@ sub permutations(Int() $n) {
             #method is-lazy { True }
             method pull-one {
                 return (@!a = ^$!n).List unless @!a;
+
+                # stop if there is only one value
+                # ( only needed because $k starts as 0 in this case )
+                return IterationEnd if $!n == 1;
+
                 # Find the largest index k such that a[k] < a[k + 1].
                 # If no such index exists, the permutation is the last permutation.
                 my int $k = @!a.end - 1;


### PR DESCRIPTION
If the loop is run it produces an error when it tries to access @!a[-1]

There is a [ROAST pull request](https://github.com/perl6/roast/pull/98) that tests this.