### PR TITLE
Fix RT#127252: missing compliance with latest JSON spec

### DIFF
--- a/src/core/JSON/Pretty.pm
+++ b/src/core/JSON/Pretty.pm
@@ -1,6 +1,6 @@
 my class JSONPrettyActions {
     method TOP($/) {
-        make $/.values.[0].ast;
+        make $<value>.ast;
     };
     method object($/) {
         make $<pairlist>.ast.hash.item;
@@ -53,7 +53,7 @@ my class JSONPrettyActions {
 }
 
 my grammar JSONPrettyGrammar {
-    token TOP       { ^ \s* [ <object> | <array> ] \s* $ }
+    token TOP       { \s* <value> \s*          }
     rule object     { '{' ~ '}' <pairlist>     }
     rule pairlist   { <pair> * % \,            }
     rule pair       { <string> ':' <value>     }


### PR DESCRIPTION
Newer JSON spec (RFC7159) does not restrict top level items to just objects/arrays and any valid value is acceptable. See:  http://rfc7159.net/rfc7159#rfc.section.2