### PR TITLE
RFC: Allow subcommands in MAIN

### DIFF
--- a/src/core/Main.pm
+++ b/src/core/Main.pm
@@ -16,11 +16,12 @@ my sub MAIN_HELPER($retval = 0) {
     # Convert raw command line args into positional and named args for MAIN
     my sub process-cmd-args(@args is copy) {
         my (@positional-arguments, %named-arguments);
-        my $stopped = False;
         while +@args {
             my $passed-value = @args.shift;
-            $stopped = $passed-value eq '--';
-            if !$stopped && $passed-value ~~ /^ ( '--' | '-' | ':' ) ('/'?) (<-[0..9\.]> .*) $/ {
+	    if $passed-value eq '--' {
+                @positional-arguments.append: @args.map: &val;
+                last;
+            } elsif $passed-value ~~ /^ ( '--' | '-' | ':' ) ('/'?) (<-[0..9\.]> .*) $/ {
                 my ($switch, $negate, $arg) = (~$0, ?((~$1).chars), ~$2);
 
                 with $arg.index('=') {
@@ -32,9 +33,7 @@ my sub MAIN_HELPER($retval = 0) {
                     %named-arguments.push: $arg => !$negate;
                 }
             } else {
-                @args.unshift($passed-value) unless $passed-value eq '--';
-                @positional-arguments.append: @args.map: &val;
-                last;
+                @positional-arguments.append: val $passed-value;
             }
         }
         @positional-arguments, %named-arguments;


### PR DESCRIPTION
The combination of these two patches will allow subcommands like in "git" or "apt".

Note that f8227bb deliberately goes against spec (S06), which says:

> As usual, switches are assumed to be first, and everything after the first non-switch, or any switches after a --, are treated as positionals or go into the slurpy array (even if they look like switches)

S06 is demonstrably wrong in that this would be the usual thing, since all these standard tools apparently take switches after positionals:

1;0 juerd@cxie:~$ wc $(ls $(which perl6 -a) -1) --chars
26876 /home/juerd/.rakudobrew/bin/perl6

Requiring switches at the beginning is common with BSD-style command line parsing, but that style doesn't have --long-names or --, both of which are already supported by Perl 6.

This patch set has not yet been thoroughly tested. Please discuss and test :-)
