### PR TITLE
Typo in X::Seq::Consumed exception

### DIFF
--- a/src/core/Exception.pm
+++ b/src/core/Exception.pm
@@ -2334,7 +2334,7 @@ my class X::InvalidTypeSmiley does X::Comp {
 my class X::Seq::Consumed is Exception {
     method message() {
         "This Seq has already been iterated, and its values consumed\n" ~
-        "(you might solve this by addding .cache on usages of the Seq, or\n" ~
+        "(you might solve this by adding .cache on usages of the Seq, or\n" ~
         "by assigning the Seq into an array)"
     }
 }


### PR DESCRIPTION
I triggered the exception myself. :blush: I was presented with the following message (notice the typo of "addding"):

```text
This Seq has already been iterated, and its values consumed
(you might solve this by addding .cache on usages of the Seq, or
by assigning the Seq into an array)
```