### PR TITLE
Make require use CompUnit interface for importing

### DIFF
--- a/src/core/operators.pm
+++ b/src/core/operators.pm
@@ -566,26 +566,31 @@ sub INDIRECT_NAME_LOOKUP($root, *@chunks) is raw {
     $thing;
 }
 
-sub REQUIRE_IMPORT($package-name, *@syms) {
-    my $package = CALLER::OUR::($package-name);
-    my $who     = $package.WHO;
-    unless $who.EXISTS-KEY('EXPORT') {
-        die "Trying to import symbols @syms.join(', ') from '$package-name', but it does not export anything";
-    }
-    $who := $who<EXPORT>.WHO<DEFAULT>.WHO;
+sub REQUIRE_IMPORT($compunit, *@syms,:$target-package) {
+    my $handle := $compunit.handle;
+    my $DEFAULT := $handle.export-package()<DEFAULT>.WHO;
+    my $GLOBALish := $handle.globalish-package.WHO;
     my @missing;
+    # Set the runtime values for compile time stub symbols
     for @syms {
-        unless $who.EXISTS-KEY($_) {
+        unless $DEFAULT.EXISTS-KEY($_) {
             @missing.push: $_;
             next;
         }
-        OUTER::CALLER::{$_} := $who{$_};
+        OUTER::CALLER::{$_} := $DEFAULT{$_};
     }
     if @missing {
-        X::Import::MissingSymbols.new(:from($package-name), :@missing).throw;
+        X::Import::MissingSymbols.new(:from($compunit.short-name), :@missing).throw;
     }
-    $package
+    # Merge GLOBALish from compunit.
+    # XXX: should probably use CALLER::UNIT:: but RT #127536
+    CALLER::LEXICAL::GLOBALish::.merge-symbols($GLOBALish);
+
+    $target-package.defined ??
+        INDIRECT_NAME_LOOKUP($GLOBALish,$target-package) !!
+        $compunit.short-name; # roast says if requiring file return its path
 }
+
 sub infix:<andthen>(+a) {
     my $ai := a.iterator;
     my Mu $current := $ai.pull-one;


### PR DESCRIPTION
Uses the `CompUnit` object to do the importing of symbols and merging of globalish in `&REQUIRE_IMPORT` instead of some haphazard `CALLER::OUR::` thing. This makes things a bit less brittle and fixes a few bugs. 

The following now works:
`my $name = "/lib/Module.pm"; require $name <sym>;`
`require Module <sym>; # where <sym> isn't inside a module/package`

bonus: no more "useless use of blah in sink context"
Fixes: 
* [#127147](https://rt.perl.org/Public/Bug/Display.html?id=127147)
* [#125951](https://rt.perl.org/Public/Bug/Display.html?id=125951)
* [#127233](https://rt.perl.org/Public/Bug/Display.html?id=127233)
* [#125084](https://rt.perl.org/Public/Bug/Display.html?id=125084)
* [#126658](https://rt.perl.org/Public/Bug/Display.html?id=126658)
* [#118407](https://rt.perl.org/Public/Bug/Display.html?id=118407)

**note** the first chunk removed in actions is just because it's dead code that can't be reached.