### PR TITLE
Resolve "Missing serialize function for REPR ContextRef on JVM

### DIFF
--- a/src/core/CompUnit/Repository/Locally.pm
+++ b/src/core/CompUnit/Repository/Locally.pm
@@ -3,12 +3,11 @@ role CompUnit::Repository::Locally {
     has IO::Path $.prefix is required;
     has Str      $.WHICH;
 
-    my %instances;
-
     method new(CompUnit::Repository::Locally: Str:D :$prefix, CompUnit::Repository :$next-repo) {
         my $abspath := $*SPEC.rel2abs($prefix);
         my $IO      := IO::Path.new-from-absolute-path($abspath);
 
+        state %instances;
         %instances{$abspath} //=
           self.bless(:prefix($IO), :lock(Lock.new), :WHICH(self.^name ~ '|' ~ $abspath), :$next-repo);
     }


### PR DESCRIPTION
Assigning to "my %instances" in the CompUnit::Repository::Locally role causes a repossession of that hash into the compiling CompUnit's SC. So that pulls a bunch of CompUnit::* objects into the compiling  CompUnit's SC.

This patch resolves the issue on JVM and causes no regression on Moar. There may be an underlying JVM bug with "my" declared variables in a role body.