### PR TITLE
Add .shortname to DefiniteHOW

### DIFF
--- a/src/Perl6/Metamodel/DefiniteHOW.nqp
+++ b/src/Perl6/Metamodel/DefiniteHOW.nqp
@@ -46,6 +46,17 @@ class Perl6::Metamodel::DefiniteHOW
         }
     }
 
+    method shortname($definite_type) {
+	if nqp::isnull(nqp::typeparameterized($definite_type)) {
+            '?:?'
+        }
+        else {
+            my $base_type := nqp::typeparameterat($definite_type, 0);
+            my $definite  := nqp::typeparameterat($definite_type, 1);
+            $base_type.HOW.shortname($base_type) ~ ':' ~ ($definite ?? 'D' !! 'U')
+        }
+    }
+
     sub check_instantiated($definite_type) {
         nqp::die('Cannot perform this operation on an uninstantiated definite type')
             if nqp::isnull(nqp::typeparameterized($definite_type));


### PR DESCRIPTION
Since DefiniteNOW don't "does" Metamodel::Naming. it needs a shortname
method, unconditionally used by Mu.gist

See http://irclog.perlgeek.de/perl6/2016-02-01#i_11970457
Test:
<sortiz> m: Int:D.gist
<camelia> rakudo-moar a5fe34: OUTPUT«Method 'shortname' not found for invocant of class 'Perl6::Metamodel::DefiniteHOW'␤  in block <unit> at /tmp/3vJXmqV_i_ line 1␤␤»