### PR TITLE
Just call $<nu>.ast.compile_time_value in Perl6::Actions.bare_rat_number

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -7226,7 +7226,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
     method rat_number($/) { make $<bare_rat_number>.ast }
 
     method bare_rat_number($/) {
-        my $nu := @($<nu>.ast)[0].compile_time_value;
+        my $nu := $<nu>.ast.compile_time_value;
         my $de := $<de>.ast;
         my $ast := $*W.add_constant('Rat', 'type_new', $nu, $de, :nocache(1));
         $ast.node($/);


### PR DESCRIPTION
The value of $<nu>.ast can either be a QAST::Want or a QAST::WVal depending on
the value of the numerator. Any value of 2**31 or greater gives us a
QAST::WVal.

Previously the code called "@($<nu>.ast)[0].compile_time_value" - this works
fine for a QAST::Want, but a QAST::WVal does not have any children, and so
this would lead to an error of "Cannot find method 'compile_time_value'".

Internally QAST::Want.compile_time_value is implemented as
"self[0].compile_time_value()" so it seems like there's no good reason for us
to do same thing in Perl6::Actions. Yay polymorphism!