### PR TITLE
Change the orders of arguments documentation for MAIN display. 

### DIFF
--- a/src/core/Main.pm
+++ b/src/core/Main.pm
@@ -43,7 +43,7 @@ my sub MAIN_HELPER($retval = 0) {
     # Generate $?USAGE string (default usage info for MAIN)
     my sub gen-usage() {
         my @help-msgs;
-        my %arg-help;
+        my Pair @arg-help;
 
         my sub strip_path_prefix($name) {
             my $SPEC := $*SPEC;
@@ -96,7 +96,7 @@ my sub MAIN_HELPER($retval = 0) {
                     $argument = "[$argument]"     if $param.optional;
                     @positional.push($argument);
                 }
-                %arg-help{$argument} //= $param.WHY.contents if $param.WHY;  # Use first defined
+                @arg-help.push($argument => $param.WHY.contents) if $param.WHY and (@arg-help.grep:{ .key eq $argument}) == Empty;  # Use first defined
             }
             if $sub.WHY {
                 $docs = '-- ' ~ $sub.WHY.contents
@@ -105,10 +105,10 @@ my sub MAIN_HELPER($retval = 0) {
             @help-msgs.push($msg);
         }
 
-        if %arg-help {
+        if @arg-help {
             @help-msgs.push('');
-            my $offset = max(%arg-help.map: { .key.chars }) + 4;
-            @help-msgs.append(%arg-help.map: { '  ' ~ .key ~ ' ' x ($offset - .key.chars) ~ .value });
+            my $offset = max(@arg-help.map: { .key.chars }) + 4;
+            @help-msgs.append(@arg-help.map: { '  ' ~ .key ~ ' ' x ($offset - .key.chars) ~ .value });
         }
 
         my $usage = "Usage:\n" ~ @help-msgs.map('  ' ~ *).join("\n");


### PR DESCRIPTION
Previously it was "random" (hash key order) now it the order on wich they are written

Before this commit for
```perl
sub MAIN(
          $header-file #= The header file
         , Bool :$all #= Generate everything
         , Str :$define-enum #= Try to generate enumeration from #define using the given starting pattern
         , Str :$ooc #= Do nothing
         , Bool :$enums #= Generate enumerations
         , Bool :$functions #= Generate functions
         , Bool :$structs #= Generate structures and unions
         , Bool :$externs #= Generate extern declaration
         , Bool :$list-types #= Mostly for debug purpose, list all the C type found
         , Bool :$list-files #= List all the files involved
         , Str :$files #= WIP Allow you to pick from which files you want to generate stuff. eg --files=myheader.h,mysubheader.h.
                       #=
                       #= You can also use file 'id' given by --list-types like   @f1,@f2
                       #=
                       #= You can also exclude file by putting - in front of the file
         , Bool :$merge-stypedef #= Merge a typedef pointing to a struct type to the struct name
         , *@gccoptions #= remaining options are passed to gccxml. eg -I /path/needed/by/header
         ) {
}
```

`
root@testperl6:~/piko/cpp/gptrixie# perl6 -I lib bin/gptrixie 
Usage:
  bin/gptrixie [--all] [--define-enum=<Str>] [--ooc=<Str>] [--enums] [--functions] [--structs] [--externs] [--list-types] [--list-files] [--files=<Str>] [--merge-stypedef] <header-file> [<gccoptions> ...] 
  
    [<gccoptions> ...]     remaining options are passed to gccxml. eg -I /path/needed/by/header
    --structs              Generate structures and unions
    --functions            Generate functions
    --enums                Generate enumerations
    <header-file>          The header file
    --list-types           Mostly for debug purpose, list all the C type found
    --merge-stypedef       Merge a typedef pointing to a struct type to the struct name
    --files=<Str>          WIP Allow you to pick from which files you want to generate stuff. eg --files=myheader.h,mysubheader.h. You can also use file 'id' given by --list-types like @f1,@f2 You can also exclude file by putting - in front of the file
    --define-enum=<Str>    Try to generate enumeration from #define using the given starting pattern
    --list-files           List all the files involved
    --externs              Generate extern declaration
    --ooc=<Str>            Do nothing
    --all                  Generate everything
`

After this change

`
Usage:
  testmain.p6 [--all] [--define-enum=<Str>] [--ooc=<Str>] [--enums] [--functions] [--structs] [--externs] [--list-types] [--list-files] [--files=<Str>] [--merge-stypedef] <header-file> [<gccoptions> ...] 
  
    <header-file>          The header file
    --all                  Generate everything
    --define-enum=<Str>    Try to generate enumeration from #define using the given starting pattern
    --ooc=<Str>            Do nothing
    --enums                Generate enumerations
    --functions            Generate functions
    --structs              Generate structures and unions
    --externs              Generate extern declaration
    --list-types           Mostly for debug purpose, list all the C type found
    --list-files           List all the files involved
    --files=<Str>          WIP Allow you to pick from which files you want to generate stuff. eg --files=myheader.h,mysubheader.h. You can also use file 'id' given by --list-types like @f1,@f2 You can also exclude file by putting - in front of the file
    --merge-stypedef       Merge a typedef pointing to a struct type to the struct name
    [<gccoptions> ...]     remaining options are passed to gccxml. eg -I /path/needed/by/header
`