### PR TITLE
Fix for RT#127402: Set.hash stringifies its objects

### DIFF
--- a/src/core/Setty.pm
+++ b/src/core/Setty.pm
@@ -27,9 +27,9 @@ my role Setty does QuantHash {
     multi method Bool(Setty:D:) { %!elems.Bool }
 
     multi method hash(Setty:D: --> Hash) {
-        my %e;
-        %e{$_} = True for %!elems.values;
-        %e;
+        my \e = Hash.^parameterize(Bool, Any).new;
+        e{$_} = True for %!elems.values;
+        e;
     }
 
     multi method new(Setty: +@args) {


### PR DESCRIPTION
Reopening  as agreed in https://github.com/rakudo/rakudo/pull/698