### PR TITLE
Fix the behaviour of require WRT to global symbols

### DIFF
--- a/src/core/operators.pm
+++ b/src/core/operators.pm
@@ -584,7 +584,7 @@ sub REQUIRE_IMPORT($compunit, *@syms,:$target-package) {
     }
     # Merge GLOBALish from compunit.
     # XXX: should probably use CALLER::UNIT:: but RT #127536
-    CALLER::LEXICAL::GLOBALish::.merge-symbols($GLOBALish);
+    GLOBAL::.merge-symbols($GLOBALish);
 
     $target-package.defined ??
         INDIRECT_NAME_LOOKUP($GLOBALish,$target-package) !!


### PR DESCRIPTION
Recent changes in require meant that code that did a require in an inner lexical scope were not having the symbols merged in such a way that they could be found by an indirect lookup, this broke for instance, the way that Panda dealt with the Build.pm files