### PR TITLE
Temp fix for say (require IO::Socket::SSL)

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -1767,6 +1767,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
         my $compunit_past;
         my $target_package;
         my $has_file;
+        my $longname;
         if $<module_name> {
             for $<module_name><longname><colonpair> -> $colonpair {
                 if ~$colonpair<identifier> eq 'file' {
@@ -1774,6 +1775,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
                     last;
                 }
             }
+            $longname := $*W.dissect_longname($<module_name><longname>);
             $target_package := $*W.dissect_longname($<module_name><longname>).name_past;
         }
         if $<module_name> && nqp::defined($has_file) == 0 {
@@ -1811,11 +1813,6 @@ class Perl6::Actions is HLL::Actions does STDActions {
                                         :name<&REQUIRE_IMPORT>,
                                         $compunit_past,
                                         );
-        if $target_package {
-            $target_package.named('target-package');
-            $require_past.push($target_package);
-        }
-
         if $<EXPR> {
             my $p6_argiter   := $*W.compile_time_evaluate($/, $<EXPR>.ast).eager.iterator;
             my $IterationEnd := $*W.find_symbol(['IterationEnd']);
@@ -1833,7 +1830,9 @@ class Perl6::Actions is HLL::Actions does STDActions {
             }
         }
         $past.push($require_past);
-
+        $past.push($<module_name>
+                   ?? self.make_indirect_lookup($longname.components())
+                   !! $<file>.ast);
         make $past;
     }
 

--- a/src/core/operators.pm
+++ b/src/core/operators.pm
@@ -566,7 +566,7 @@ sub INDIRECT_NAME_LOOKUP($root, *@chunks) is raw {
     $thing;
 }
 
-sub REQUIRE_IMPORT($compunit, *@syms,:$target-package) {
+sub REQUIRE_IMPORT($compunit, *@syms) {
     my $handle := $compunit.handle;
     my $DEFAULT := $handle.export-package()<DEFAULT>.WHO;
     my $GLOBALish := $handle.globalish-package.WHO;
@@ -582,13 +582,9 @@ sub REQUIRE_IMPORT($compunit, *@syms,:$target-package) {
     if @missing {
         X::Import::MissingSymbols.new(:from($compunit.short-name), :@missing).throw;
     }
-    # Merge GLOBALish from compunit.
-    # XXX: should probably use CALLER::UNIT:: but RT #127536
+    # Merge GLOBAL from compunit.
     GLOBAL::.merge-symbols($GLOBALish);
-
-    $target-package.defined ??
-        INDIRECT_NAME_LOOKUP($GLOBALish,$target-package) !!
-        $compunit.short-name; # roast says if requiring file return its path
+    Nil;
 }
 
 sub infix:<andthen>(+a) {


### PR DESCRIPTION
restoring how require's return value used to be calculated before
f565f80a4 while investigating.