### PR TITLE
Multi-line REPL: Detect grammar's failed goals.

### DIFF
--- a/src/Perl6/Compiler.nqp
+++ b/src/Perl6/Compiler.nqp
@@ -342,7 +342,9 @@ class Perl6::Compiler is HLL::Compiler {
 
                     if $inner {
                         my $ex-type := nqp::what($inner).HOW.name(nqp::what($inner));
-                        if $ex-type eq 'X::Syntax::Missing' {
+                        if $ex-type eq 'X::Syntax::Missing' ||
+                           $ex-type eq 'X::Comp::AdHoc' && $inner.message ~~ /find/
+                        {
                             if $inner.pos() == nqp::chars($code) {
                                 return self.needs-more-input();
                             }


### PR DESCRIPTION
That allows the following REPL session (hoelzro++ for the infrastructure):
```
> my $a = <
* a b c d e f g h
* >;
(a b c d e f g h)
> my $long = «
* this is a very long
* and multi-line quoted list
* »
(this is a very long and multi-line quoted list)
> my @a = [
* 1,2,3,4,5
* ];
[1 2 3 4 5]
> q〈A large
* multi-line
* quoted
* string
* 〉.say
A large
multi-line
quoted
string
```