### PR TITLE
IO::Proc: store command line and use it in X::Proc::Unsuccessful

### DIFF
--- a/src/core/Exception.pm
+++ b/src/core/Exception.pm
@@ -2426,7 +2426,8 @@ my class X::Language::Unsupported is Exception {
 my class X::Proc::Unsuccessful is Exception {
     has $.proc;
     method message() {
-        "The spawned process exited unsuccessfully (exit code: $.proc.exitcode())"
+        "The spawned process exited unsuccessfully " ~
+        "(exit code: $.proc.exitcode(), command line: $.proc.args())"
     }
 }
 

--- a/src/core/Proc.pm
+++ b/src/core/Proc.pm
@@ -5,6 +5,7 @@ my class Proc {
     has $.exitcode = -1;  # distinguish uninitialized from 0 status
     has $.pid;
     has $.signal;
+    has @.args;
 
     has $!in_fh;
     has $!out_fh;
@@ -95,6 +96,7 @@ my class Proc {
 
     method spawn(*@args ($, *@), :$cwd = $*CWD, :$env) {
         my %env := $env ?? $env.hash !! %*ENV;
+        self.args = @args;
         self.status(nqp::p6box_i(nqp::spawn(
             CLONE-LIST-DECONTAINERIZED(@args),
             nqp::unbox_s($cwd.Str),
@@ -107,6 +109,7 @@ my class Proc {
 
     method shell($cmd, :$cwd = $*CWD, :$env) {
         my %env := $env ?? $env.hash !! %*ENV;
+        self.args = [$cmd];
         self.status(nqp::p6box_i(nqp::shell(
             nqp::unbox_s($cmd),
             nqp::unbox_s($cwd.Str),


### PR DESCRIPTION
This allows the user of a program which doesn't catch the exception to
debug the problem or provide a good bug report.

There was some discussion in #perl6 if dumping the whole command line arguments is a good idea or not, but to help debugging unknown programs I'd really like to see the full output so I know exactly what's going on. Also helps with spurious errors.