### PR TITLE
Add non slurply candidate for method new to CArray

### DIFF
--- a/lib/NativeCall/Types.pm6
+++ b/lib/NativeCall/Types.pm6
@@ -158,7 +158,7 @@ our class CArray is repr('CArray') is array_type(Pointer) {
         do for ^self.elems { self.AT-POS($_) }
     }
 
-    multi method new(*@values) {
+    multi method new(@values) {
         nextsame unless @values;
         my $result := self.new();
         my int $n = @values.elems;
@@ -169,6 +169,10 @@ our class CArray is repr('CArray') is array_type(Pointer) {
             $i = $i + 1;
         }
         $result;
+    }
+    
+    multi method new(*@values) {
+        self.new(@values);
     }
 }
 


### PR DESCRIPTION
Much faster when creating from a List, Array, Iterables, Seq, etc.

Discovered while digging a 20x regression introduced by https://github.com/rakudo/rakudo/commit/f25d41c6782a4a2f32b6f01722b475cffbe9c3be on `CArray.new($buf.list)`