### PR TITLE
fix Numeric eqv

### DIFF
--- a/src/core/Numeric.pm
+++ b/src/core/Numeric.pm
@@ -30,7 +30,7 @@ my role Numeric {
 }
 
 multi sub infix:<eqv>(Numeric:D $a, Numeric:D $b) {
-    $a.WHAT === $b.WHAT && ($a cmp $b) == 0
+    $a.WHAT === $b.WHAT && $a == $b
 }
 
 ## arithmetic operators


### PR DESCRIPTION
This fixes an [issue](http://irclog.perlgeek.de/perl6/2016-03-15#i_12186016) with `eqv` on Rat and FatRat, .e.g:

```perl6
my FatRat $f = FatRat(989898988898989898980909090939838302233848473393040383234234509484.3489523478234723847238432423); say $f eqv FatRat(989898988898989898980909090939838302233848473393040383234234509484.3489523478234723847238432423); say $f == FatRat(989898988898989940247844191134641988224436627880004840480824357399.83933482381524942767485346932);
# True False
my FatRat $f = FatRat(989898988898989898980909090939838302233848473393040383234234509484.3489523478234723847238432423); say $f eqv FatRat(989898988898989898980909090939838302233848473393040383234234509484.3489523478234723847238432423); say $f eqv FatRat(989898988898989940247844191134641988224436627880004840480824357399.83933482381524942767485346932);
# True True

my Rat $f = Rat(989898988898989898980909090939838302233848473393040383234234509484.3489523478234723847238432423); say $f eqv Rat(989898988898989898980909090939838302233848473393040383234234509484.3489523478234723847238432423); say $f == Rat(989898988898989940247844191134641988224436627880004840480824357399.83933482381524942767485346932);
# True False
my Rat $f = Rat(989898988898989898980909090939838302233848473393040383234234509484.3489523478234723847238432423); say $f eqv Rat(989898988898989898980909090939838302233848473393040383234234509484.3489523478234723847238432423); say $f eqv Rat(989898988898989940247844191134641988224436627880004840480824357399.83933482381524942767485346932);
# True True
```

All spectests are passing on Arch x86_64.