### PR TITLE
IO::Handle - Fix warning on .gist method on empty path name

### DIFF
--- a/src/core/IO/Handle.pm
+++ b/src/core/IO/Handle.pm
@@ -774,8 +774,8 @@ my class IO::Handle does IO {
 
     multi method gist(IO::Handle:D:) {
         self.opened
-            ?? self.^name ~ "<$!path>(opened, at octet {$.tell})"
-            !! self.^name ~ "<$!path>(closed)"
+            ?? self.^name ~ "<$!path.gist>(opened, at octet {$.tell})"
+            !! self.^name ~ "<$!path.gist>(closed)"
     }
 
     multi method perl(IO::Handle:D:) {


### PR DESCRIPTION
Currently, "say IO::Handle.new.gist;" warns :

Use of uninitialized value $!path of type Any in string context
Any of .^name, .perl, .gist, or .say can stringify undefined things, if needed. in block at -e line 1
IO::Handle<>(closed)

This commit should correct it =)