### PR TITLE
$*VM.platform-library-name: only return IO::Path

### DIFF
--- a/lib/NativeCall.pm6
+++ b/lib/NativeCall.pm6
@@ -202,8 +202,7 @@ sub guess_library_name($lib) is export(:TEST) {
     return '' unless $libname.DEFINITE;
     #Already a full name?
     return $libname if ($libname ~~ /\.<.alpha>+$/ or $libname ~~ /\.so(\.<.digit>+)+$/);
-    my $pln = $*VM.platform-library-name($libname.IO, :version($apiversion || Version));
-    return $libname.IO.is-absolute ?? $pln.absolute !! $pln.relative;
+    $*VM.platform-library-name($libname.IO, :version($apiversion || Version));
 }
 
 sub check_routine_sanity(Routine $r) is export(:TEST) {

--- a/lib/NativeCall.pm6
+++ b/lib/NativeCall.pm6
@@ -184,25 +184,12 @@ my role NativeCallSymbol[Str $name] {
 }
 
 sub guess_library_name($lib) is export(:TEST) {
-    my $libname;
-    my $apiversion = '';
-    my Str $ext = '';
-    given $lib {
-        when Callable {
-           return $lib();
-        }
-        when List {
-           $libname = $lib[0];
-           $apiversion = $lib[1];
-        }
-        when Str {
-           $libname = $lib;
-        }
-    }
-    return '' unless $libname.DEFINITE;
-    #Already a full name?
-    return $libname if ($libname ~~ /\.<.alpha>+$/ or $libname ~~ /\.so(\.<.digit>+)+$/);
-    $*VM.platform-library-name($libname.IO, :version($apiversion || Version));
+    return $lib() if $lib ~~ Callable;
+    return '' unless $lib[0].DEFINITE;
+    my $name-path = $lib[0].IO;
+    $name-path.extension
+        ?? $name-path
+        !! $*VM.platform-library-name($name-path, :version($lib.end ?? $lib[1] !! Version));
 }
 
 sub check_routine_sanity(Routine $r) is export(:TEST) {
@@ -271,12 +258,13 @@ my role Native[Routine $r, $libname where Str|Callable|List] {
     has Pointer $!entry-point;
 
     method !setup() {
-        my $guessed_libname = guess_library_name($libname);
-        $!cpp-name-mangler = %lib{$guessed_libname} //= guess-name-mangler($r, $guessed_libname);
+        my $guess = guess_library_name($libname);
+        my $guessed_libname = $guess.?chars ?? $guess.IO.absolute !! $guess;
+        $!cpp-name-mangler  = %lib{$guessed_libname} //= guess-name-mangler($r, $guessed_libname);
         my Mu $arg_info := param_list_for($r.signature, $r);
         my $conv = self.?native_call_convention || '';
         nqp::buildnativecall(self,
-            nqp::unbox_s($guessed_libname.?chars ?? $guessed_libname.IO.absolute !! $guessed_libname), # library name
+            nqp::unbox_s($guessed_libname),                           # library name
             nqp::unbox_s(gen_native_symbol($r, :$!cpp-name-mangler)), # symbol to call
             nqp::unbox_s($conv),        # calling convention
             $arg_info,

--- a/src/core/VM.pm
+++ b/src/core/VM.pm
@@ -50,14 +50,12 @@ class VM does Systemic {
 #?if jvm
         my int $is-darwin = $*VM.config<os.name> eq 'darwin';
 #?endif
-
-        my $basename  = $library.basename;
-        my int $full-path = $library ne $basename;
-        my $dirname   = $library.dirname;
+        my $abslib   = $library.absolute.IO;
+        my $basename = $abslib.basename;
+        my $root     = $abslib.parent;
 
         # OS X needs version before extension
         $basename ~= ".$version" if $is-darwin && $version.defined;
-
 #?if moar
         my $dll = self.config<dll>;
         my $platform-name = sprintf($dll, $basename);
@@ -66,13 +64,11 @@ class VM does Systemic {
         my $prefix = $is-win ?? '' !! 'lib';
         my $platform-name = "$prefix$basename.{self.config<nativecall.so>}";
 #?endif
-
         $platform-name ~= '.' ~ $version
             if $version.defined and nqp::iseq_i(nqp::add_i($is-darwin,$is-win),0);
 
-        $full-path
-          ?? $dirname.IO.child($platform-name).abspath
-          !! $platform-name.IO
+        my $path = IO::Path.new($platform-name, :CWD($root));
+        ?$library.is-absolute ?? $path.absolute.IO !! $path;
     }
 }
 

--- a/src/core/VM.pm
+++ b/src/core/VM.pm
@@ -68,7 +68,7 @@ class VM does Systemic {
             if $version.defined and nqp::iseq_i(nqp::add_i($is-darwin,$is-win),0);
 
         my $path = IO::Path.new($platform-name, :CWD($root));
-        ?$library.is-absolute ?? $path.absolute.IO !! $path;
+        ?$library.is-absolute ?? $path.absolute !! $path.relative;
     }
 }
 

--- a/t/04-nativecall/17-libnames.t
+++ b/t/04-nativecall/17-libnames.t
@@ -11,7 +11,7 @@ if $*KERNEL ~~ 'linux' {
 	is guess_library_name(("foo", Version.new(1))), "libfoo.so.1", "foo , 1  is libfoo.so.1";
 	is guess_library_name(("foo", v1.2.3)), "libfoo.so.1.2.3", "foo , v1.2.3  is libfoo.so.1.2.3";
 	is guess_library_name("libfoo.so"), "libfoo.so", "libfoo.so is libfoo.so";
-	is guess_library_name("./foo"), "$*CWD/libfoo.so", "./foo is ./libfoo.so";
+	is guess_library_name("./foo"), "libfoo.so", "./foo is ./libfoo.so";
 	is guess_library_name("./libfoo.so"), "./libfoo.so", "./libfoo.so is ./libfoo.so";
 	is guess_library_name("/libfoo.so"), "/libfoo.so", "/libfoo.so is /libfoo.so";
 } else {


### PR DESCRIPTION
Previously this would return a `Str` or `IO::Path` depending on if the passed in `IO::Path` was absolute or relative:

```
perl6 -e 'say $*VM.platform-library-name($*CWD.child("xxx").relative.IO)'
"/home/nickl/perl6/rakudo/libxxx.so".IO

perl6 -e 'say $*VM.platform-library-name($*CWD.child("xxx").absolute.IO)'
/home/nickl/perl6/rakudo/libxxx.so
```

Both now return an IO::Path. A few further changes were required for areas that used $*VM.platform-library-name
