### PR TITLE
Fix for WhateverCodes in sink context

### DIFF
--- a/src/Perl6/Optimizer.nqp
+++ b/src/Perl6/Optimizer.nqp
@@ -1388,13 +1388,13 @@ class Perl6::Optimizer {
                 elsif $op.node && $!void_context {
                     my str $op_txt := nqp::escape($op.node.Str);
                     my str $expr   := nqp::escape(widen($op.node));
-                    unless $op_txt eq '/' && $op[1].has_compile_time_value && $op[1].compile_time_value == 0 {
-                        # we don't want to warn in the case of un-compiled WhateverCodes
-                        unless nqp::index($expr, '*') >= 0 {
-                            my $warning := qq[Useless use of "$op_txt" in expression "$expr" in sink context];
-                            note($warning) if $!debug;
-                            $!problems.add_worry($op, $warning);
-                        }
+                    unless $op_txt eq '/'
+                                && $op[1].has_compile_time_value
+                                && $op[1].compile_time_value == 0
+                                && ! nqp::index($expr, '*') >= 0 {
+                        my $warning := qq[Useless use of "$op_txt" in expression "$expr" in sink context];
+                        note($warning) if $!debug;
+                        $!problems.add_worry($op, $warning);
                     }
                 }
                 # check if all arguments are known at compile time

--- a/src/Perl6/Optimizer.nqp
+++ b/src/Perl6/Optimizer.nqp
@@ -1389,9 +1389,12 @@ class Perl6::Optimizer {
                     my str $op_txt := nqp::escape($op.node.Str);
                     my str $expr   := nqp::escape(widen($op.node));
                     unless $op_txt eq '/' && $op[1].has_compile_time_value && $op[1].compile_time_value == 0 {
-                        my $warning := qq[Useless use of "$op_txt" in expression "$expr" in sink context];
-                        note($warning) if $!debug;
-                        $!problems.add_worry($op, $warning);
+                        # we don't want to warn in the case of un-compiled WhateverCodes
+                        unless nqp::index($expr, '*') >= 0 {
+                            my $warning := qq[Useless use of "$op_txt" in expression "$expr" in sink context];
+                            note($warning) if $!debug;
+                            $!problems.add_worry($op, $warning);
+                        }
                     }
                 }
                 # check if all arguments are known at compile time

--- a/src/Perl6/Optimizer.nqp
+++ b/src/Perl6/Optimizer.nqp
@@ -1389,8 +1389,7 @@ class Perl6::Optimizer {
                     my str $op_txt := nqp::escape($op.node.Str);
                     my str $expr   := nqp::escape(widen($op.node));
                     unless $op_txt eq '/' && $op[1].has_compile_time_value && $op[1].compile_time_value == 0 {
-                        my $whatever_index := nqp::index($expr, '*');
-                        unless $whatever_index == 0 || $whatever_index == (nqp::chars($expr)-1) {
+                        unless nqp::substr($expr, 0, 1) eq '*' || nqp::substr($expr, nqp::chars($expr)-1, 1) eq '*' {
                             my $warning := qq[Useless use of "$op_txt" in expression "$expr" in sink context];
                             note($warning) if $!debug;
                             $!problems.add_worry($op, $warning);

--- a/src/Perl6/Optimizer.nqp
+++ b/src/Perl6/Optimizer.nqp
@@ -1388,13 +1388,13 @@ class Perl6::Optimizer {
                 elsif $op.node && $!void_context {
                     my str $op_txt := nqp::escape($op.node.Str);
                     my str $expr   := nqp::escape(widen($op.node));
-                    unless $op_txt eq '/'
-                                && $op[1].has_compile_time_value
-                                && $op[1].compile_time_value == 0
-                                && ! nqp::index($expr, '*') >= 0 {
-                        my $warning := qq[Useless use of "$op_txt" in expression "$expr" in sink context];
-                        note($warning) if $!debug;
-                        $!problems.add_worry($op, $warning);
+                    unless $op_txt eq '/' && $op[1].has_compile_time_value && $op[1].compile_time_value == 0 {
+                        my $whatever_index := nqp::index($expr, '*');
+                        unless $whatever_index == 0 || $whatever_index == (nqp::chars($expr)-1) {
+                            my $warning := qq[Useless use of "$op_txt" in expression "$expr" in sink context];
+                            note($warning) if $!debug;
+                            $!problems.add_worry($op, $warning);
+                        }
                     }
                 }
                 # check if all arguments are known at compile time


### PR DESCRIPTION
This is my first NQP patch. My apologies without surprise if it turns out to be too boneheaded to merge.

The intent of the patch is to silence this warning:

```
perl6 -e 'my $f = <25 25 25>; $f ~~ s:nth(*-1)[\d+] = 42; say $f'
WARNINGS for -e:
Useless use of "-" in expression "*-1" in sink context (line 1)
25 42 25
```