### PR TITLE
Combinations fixes

### DIFF
--- a/src/core/List.pm
+++ b/src/core/List.pm
@@ -4,6 +4,7 @@ my class Supply { ... }
 my class Supplier { ... }
 
 my sub combinations(Int() $n, Int() $k) {
+    return () if $k < 0;
     return ((),) if $n < 1 || $k < 1;
 
     fail X::OutOfRange.new(
@@ -863,11 +864,10 @@ my class List does Iterable does Positional { # declared in BOOTSTRAP
         combinations(self.elems, $of).map: { self[@$_] }
     }
     multi method combinations( Range $ofrange = 0 .. * ) {
-        gather for $ofrange.min .. ($ofrange.max min self.elems) -> $of {
-            for combinations(self.elems, $of) {
-                take self[@$_]
-            }
-        }
+        my $over := ($ofrange.first max 0)
+                 .. (($ofrange.first(:end) // -1) min self.elems);
+
+        $over.map: { |combinations(self.elems, $_).map: { self[@$_] } }
     }
 
     proto method permutations(|) is nodal {*}


### PR DESCRIPTION
 Fix sub combinations to return () not ((),) for absurd $k
 Fix List.combinations(Range) to use right values with careted Range endpoints
 Fix List.combinations(Range) to return () on an iterably-empty range
 Ensure only one empty list appears in result, only when a k==0 is involved
 Use a map/map instead of gather/take, no discernable performance impact
 ...someone may wish to weigh in on which will optimize better in future.
 ...this may help a plan to avoid pulling during .elems on the resulting Seq