### PR TITLE
Add kv adverb to first

### DIFF
--- a/src/core/Any-iterable-methods.pm
+++ b/src/core/Any-iterable-methods.pm
@@ -507,9 +507,12 @@ Did you mean to add a stub (\{...\}) or did you mean to .classify?"
                 elsif %a<v> {
                     value
                 }
+                elsif %a<kv> {
+                    (index,value).Seq
+                }
                 else {
                     my $k = %a.keys[0];
-                    if $k eq 'k' || $k eq 'p' {
+                    if $k eq 'k' || $k eq 'p' || $k eq 'kv' {
                         value
                     }
                     elsif $k eq 'v' {


### PR DESCRIPTION
This was first noticed [here](http://irclog.perlgeek.de/perl6/2016-03-31#i_12267194)

The docs define first as
````
multi sub    first(Mu $matcher, *@elems, :k, :kv, :p, :end)
multi method first(List:D:  Mu $matcher, :k, :kv, :p, :end)
```
However there is no `:kv` adverb implemented. Although [S32](http://design.perl6.org/S32/Containers.html) does not mention a `first-kv`, there's a reasonable user expectation that `first` would have same adverbs as `grep`.

This patch adds an additional conditional check for `%a<kv>` to the private worker method `first-result` and returns `(index,value).Seq`.

A Seq is return for 2 reasons. One being that `grep :kv` returns a Seq, so this is consistent. The second reason is, as [jnthn pointed out](http://irclog.perlgeek.de/perl6/2016-04-01#i_12271679), most things that produce values you can iterate return a Seq. 

Tests `first-kv.t` and `first-end-kv.t` have been written and will be submitted to roast accordingly.