### PR TITLE
Remove section "How the compiler works"

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,10 +138,6 @@ Linenoise is via [panda](https://github.com/tadzik/panda):
 
 An alternative is to use a third-party program such as [rlwrap](http://utopia.knoware.nl/~hlub/uck/rlwrap/#rlwrap).
 
-## How the compiler works
-
-See `docs/compiler_overview.pod`.
-
 ## AUTHOR
 
 Jonathan Worthington is the current pumpking for Rakudo Perl 6.

--- a/docs/compiler_overview.pod
+++ b/docs/compiler_overview.pod
@@ -2,6 +2,9 @@
 
 =head1 RAKUDO COMPILER OVERVIEW
 
+F<Please note: Parts of this overview are outdated since Rakudo does
+no longer run on the Parrot Virtual Machine.>
+
 =head2 How the Rakudo Perl 6 compiler works
 
 This document describes the architecture and operation of the Rakudo


### PR DESCRIPTION
As noted in https://rt.perl.org/Ticket/Display.html?id=127580 the information in 'docs/compiler_overview.pod' is outdated. The README should not reference that file (at least until it's updated).