### PR TITLE
Duration Improvements

### DIFF
--- a/src/core/Duration.pm
+++ b/src/core/Duration.pm
@@ -10,17 +10,38 @@ my class Duration is Cool does Real {
     method narrow(Duration:D:) { $!tai.narrow }
 
     multi method Str(Duration:D:) { ~$.tai }
-    multi method Numeric() { $!tai }
+    multi method Numeric() { $!tai } # (Unary plus)
 
     multi method WHICH(Duration:D:) { self.^name ~ '|' ~ $!tai.WHICH }
 
     multi method perl(Duration:D:) { "Duration.new({$.tai.perl})" }
 }
 
+# For Addition and Subtraction operations, dimensionless number operands are
+# assumed to represent durations in units of seconds; once this promotion is
+# done, all operations are dimensionally consistent and return Duration objects.
+#
+# For the rest of the operations, I define three categories:
+#   - Perfect:  Dimensionally consistent operations that naturally return
+#               Duration objects.
+#   - Dimensional:  Dimensionally consistent operations that do *not* return
+#                   Duration objects.
+#   - Non-Dimensional:  Operations that are non-sensical or would naturally return
+#                       values in units we don't have types for.  For these, we
+#                       auto-promote dimensionless operands to duration, and
+#                       we *always* return values of type Duration.
+#
+# (Rationale for 'Non-Dimensional' behavior: anyone performing such operations
+#  most likely wishes to simply treat Durations and numbers both as durations in
+#  units of seconds.)
+
+
+# Unary minus
 multi sub prefix:<->(Duration:D $a) {
     Duration.new: -$a.tai;
 }
 
+# Addition
 multi sub infix:<+>(Duration:D $a, Real $b) {
     Duration.new: $a.tai + $b;
 }
@@ -31,15 +52,61 @@ multi sub infix:<+>(Duration:D $a, Duration:D $b) {
     Duration.new: $a.tai + $b.tai;
 }
 
+# Subtraction
 multi sub infix:<->(Duration:D $a, Real $b) {
     Duration.new: $a.tai - $b;
+}
+multi sub infix:<->(Real $a, Duration:D $b) {
+    Duration.new: $a - $b.tai;
 }
 multi sub infix:<->(Duration:D $a, Duration:D $b) {
     Duration.new: $a.tai - $b.tai;
 }
 
+# Perfect:  Dur * Real --> Dur,  Real * Dur --> Dur
+# Non-Dimensional:  Dur * Dur --> Dur
+multi sub infix:<*>(Duration:D $a, Real $b) {
+    Duration.new: $a.tai * $b
+}
+multi sub infix:<*>(Real $a, Duration:D $b) {
+    Duration.new: $a * $b.tai
+}
+multi sub infix:<*>(Duration:D $a, Duration:D $b) {
+    Duration.new: $a.tai * $b.tai
+}
+
+# Dimension examples for division and modulo operations:
+#
+# 119 seconds / 2  =  59.5 seconds  =  59 seconds, remainder 1 second
+# 1 minute / 28 seconds  =  apx. 2.143  ==  2, remainder 4 seconds
+# 451 / 42 seconds is non-dimensional.. redefine it as:
+#     451 seconds / 42 seconds  =  apx. 10.738  ==  10, remainder 31 seconds
+#
+# (Remember: in non-dimensional cases, we *always* return a Duration.)
+
+# Perfect:  Dur / Real --> Dur
+# Dimensional:  Dur / Dur --> Real
+# Non-Dimensional:  Real / Dur --> Dur
+multi sub infix:</>(Duration:D $a, Real $b) {
+    Duration.new: $a.tai / $b
+}
+multi sub infix:</>(Real $a, Duration:D $b) {
+    Duration.new: $a / $b.tai
+}
+multi sub infix:</>(Duration:D $a, Duration:D $b) {
+    $a.tai / $b.tai
+}
+
+# Perfect:  Dur % Real --> Dur,  Dur % Dur --> Dur
+# Non-Dimensional:  Real % Dur --> Dur
 multi sub infix:<%>(Duration:D $a, Real $b) {
     Duration.new: $a.tai % $b
+}
+multi sub infix:<%>(Real $a, Duration:D $b) {
+    Duration.new: $a % $b.tai
+}
+multi sub infix:<%>(Duration:D $a, Duration:D $b) {
+    Duration.new: $a.tai % $b.tai
 }
 
 # vim: ft=perl6 expandtab sw=4

--- a/src/core/Duration.pm
+++ b/src/core/Duration.pm
@@ -4,12 +4,15 @@ my class Duration is Cool does Real {
 
     method new($tai) { self.bless: tai => $tai.Rat }
 
-    method Bridge(Duration:D:) { $!tai.Num }
-    method Rat(Duration:D:)    { $!tai     }
+    method Bridge(Duration:D:) { $!tai.Bridge }
+    method Rat(Duration:D:)    { $!tai }
     method Num(Duration:D:)    { $!tai.Num }
     method narrow(Duration:D:) { $!tai.narrow }
 
     multi method Str(Duration:D:) { ~$.tai }
+    multi method Numeric() { $!tai }
+
+    multi method WHICH(Duration:D:) { self.^name ~ '|' ~ $!tai.WHICH }
 
     multi method perl(Duration:D:) { "Duration.new({$.tai.perl})" }
 }

--- a/src/core/Instant.pm
+++ b/src/core/Instant.pm
@@ -103,6 +103,9 @@ multi sub infix:<->(Instant:D $a, Instant:D $b) {
 multi sub infix:<->(Instant:D $a, Real:D $b) {
     nqp::create(Instant).SET-SELF($a.tai - $b.Rat)
 }
+multi sub infix:<->(Instant:D $a, Duration:D $b) {
+    nqp::create(Instant).SET-SELF($a.tai - $b.Rat)
+}
 
 sub term:<time>() { nqp::p6box_i(nqp::time_i()) }
 sub term:<now>() {

--- a/src/core/Instant.pm
+++ b/src/core/Instant.pm
@@ -28,6 +28,10 @@ my class Instant is Cool does Real {
         Rakudo::Internals.posix-from-tai($!tai)
     }
 
+    multi method WHICH (Instant:D:) {
+        self.^name ~ '|' ~ $!tai.WHICH
+    }
+
     multi method Str(Instant:D:) {
         'Instant:' ~ $!tai
     }


### PR DESCRIPTION
This is my first attempt to contribute something to p6; feel free to point out any errors/misunderstandings on my part, or further improvements; I am happy to incorporate suggestions and re-submit.


Description:
---
    Add missing ops * / for Duration; fixes RT #127339
    
    Also see corresponding PR/commits against perl6/roast.
    
    Has tests to cover new functionality, and all tests pass.
    
    Still, I am new to Perl6, and look forward to one or more
    rounds of requested changes before this gets into Perl6.
---
    Move Duration and Instant closer to S02 spec.
    
    Duration and Instant now behave (more?) like value types.
    
    Also, Duration now becomes a Rat in explicit numeric context.
    i.e., +$dur will return a Rat, however $dur1/$dur2 still performs
    Num/Num artithmetic, even when it loses precision :(
---
