### PR TITLE
Implement alternate ways to call `subtest` from Test.pm6

### DIFF
--- a/lib/Test.pm6
+++ b/lib/Test.pm6
@@ -289,7 +289,9 @@ sub skip-rest($reason = '<unknown>') is export {
     $time_before = nqp::time_n;
 }
 
-sub subtest(&subtests, $desc = '') is export {
+multi sub subtest(Pair $what)            is export { subtest($what.value,$what.key) }
+multi sub subtest($desc, &subtests)      is export { subtest(&subtests,$desc)       }
+multi sub subtest(&subtests, $desc = '') is export {
     _push_vars();
     _init_vars();
     $indents ~= "    ";

--- a/lib/Test.pm6
+++ b/lib/Test.pm6
@@ -292,6 +292,7 @@ sub skip-rest($reason = '<unknown>') is export {
 multi sub subtest(Pair $what)            is export { subtest($what.value,$what.key) }
 multi sub subtest($desc, &subtests)      is export { subtest(&subtests,$desc)       }
 multi sub subtest(&subtests, $desc = '') is export {
+    diag($desc) if $desc;
     _push_vars();
     _init_vars();
     $indents ~= "    ";

--- a/t/02-rakudo/02-new-is_approx.t
+++ b/t/02-rakudo/02-new-is_approx.t
@@ -21,8 +21,8 @@ subtest {
     nok($ok, $message);
 }, "check behaviour of 'large' numbers";
 
-# "normal" numbers
-subtest {
+# "normal" numbers; also test subtest(Desc, Code) multi
+subtest "check behaviour of 'normal' numbers", {
     my $eulers_constant = 2.71828182;
     my $not_quite_ec = 2.71828;
 
@@ -36,10 +36,10 @@ subtest {
     todo $message;
     my $ok = is-approx($not_quite_ec, $eulers_constant, $message);
     nok($ok, $message);
-}, "check behaviour of 'normal' numbers";
+};
 
-# "small" numbers
-subtest {
+# "small" numbers; also test subtest(Pair[desc,code]) multi
+subtest "check behaviour of 'small' numbers" => {
     my $plancks_constant = 6.62609657e-34;
     my $not_quite_pc = 6.62609e-34;
 
@@ -72,7 +72,7 @@ subtest {
     todo $message;
     $ok = is-approx($not_quite_pc, $plancks_constant, 1e-7, $message);
     nok($ok, $message);
-}, "check behaviour of 'small' numbers";
+};
 
 # check tolerance input
 subtest {

--- a/t/02-rakudo/02-new-is_approx.t
+++ b/t/02-rakudo/02-new-is_approx.t
@@ -77,10 +77,10 @@ subtest "check behaviour of 'small' numbers" => {
 # check tolerance input
 subtest {
     my $message = "should fail; cannot use negative tolerance values";
-    dies_ok { is-approx(1, 1, -1, $message) }, $message;
+    dies-ok { is-approx(1, 1, -1, $message) }, $message;
 
     $message = "should fail; cannot use a zero tolerance value";
-    dies_ok { is-approx(1, 1, 0, $message) }, $message;
+    dies-ok { is-approx(1, 1, 0, $message) }, $message;
 }, "check tolerance input";
 
 # expected value is zero


### PR DESCRIPTION
This implements the proposal in [RT #127890](https://rt.perl.org/Ticket/Display.html?id=127890) (both `desc, code` and `desc => code` forms)

In addition, it adds a `diag $desc` at the start of the subtest, to make it easier to see it in the output.

I also piggy-backed on already-existing tests to test out the functionality. They also had an old name for `dies-ok`, which I fixed.