### PR TITLE
Fix RT #127883: Missing line/column number information when using a missing module

### DIFF
--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -980,7 +980,7 @@ class Perl6::World is HLL::World {
             :from(%opts<from> // 'Perl6'),
             :auth-matcher(%opts<auth> // $true),
             :version-matcher(%opts<ver> // $true),
-            :line($line)
+            :source-line-number($line)
         );
         self.add_object($spec);
         my $registry := self.find_symbol(['CompUnit', 'RepositoryRegistry']);

--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -980,6 +980,7 @@ class Perl6::World is HLL::World {
             :from(%opts<from> // 'Perl6'),
             :auth-matcher(%opts<auth> // $true),
             :version-matcher(%opts<ver> // $true),
+            :line($line)
         );
         self.add_object($spec);
         my $registry := self.find_symbol(['CompUnit', 'RepositoryRegistry']);

--- a/src/core/CompUnit/DependencySpecification.pm
+++ b/src/core/CompUnit/DependencySpecification.pm
@@ -1,5 +1,6 @@
 class CompUnit::DependencySpecification {
     has Str:D $.short-name is required;
+    has Int:D $.line       is required;
     has Str:D $.from = 'Perl6';
     has $.version-matcher = True;
     has $.auth-matcher = True;

--- a/src/core/CompUnit/DependencySpecification.pm
+++ b/src/core/CompUnit/DependencySpecification.pm
@@ -1,6 +1,6 @@
 class CompUnit::DependencySpecification {
-    has Str:D $.short-name is required;
-    has Int:D $.line       is required;
+    has Str:D $.short-name         is required;
+    has Int:D $.source-line-number is required;
     has Str:D $.from = 'Perl6';
     has $.version-matcher = True;
     has $.auth-matcher = True;

--- a/src/core/Exception.pm
+++ b/src/core/Exception.pm
@@ -2496,7 +2496,7 @@ my class X::CompUnit::UnsatisfiedDependency is Exception {
 
     method message() {
         my $name = $.specification.short-name;
-        my $line = $.specification.line;
+        my $line = $.specification.source-line-number;
         is-core($name)
             ?? "{$name} is a builtin type. You can use it without loading a module."
             !! "Could not find $.specification at line $line in:\n" ~ $*REPO.repo-chain.map(*.Str).join("\n").indent(4)

--- a/src/core/Exception.pm
+++ b/src/core/Exception.pm
@@ -2496,9 +2496,10 @@ my class X::CompUnit::UnsatisfiedDependency is Exception {
 
     method message() {
         my $name = $.specification.short-name;
+        my $line = $.specification.line;
         is-core($name)
             ?? "{$name} is a builtin type. You can use it without loading a module."
-            !! "Could not find $.specification in:\n" ~ $*REPO.repo-chain.map(*.Str).join("\n").indent(4)
+            !! "Could not find $.specification at line $line in:\n" ~ $*REPO.repo-chain.map(*.Str).join("\n").indent(4)
     }
 }
 


### PR DESCRIPTION
For more information, please see https://rt.perl.org/Public/Bug/Display.html?id=127883