### PR TITLE
Avoid NPE when parameter has no coerce_type

### DIFF
--- a/src/core/Parameter.pm
+++ b/src/core/Parameter.pm
@@ -389,21 +389,23 @@ multi sub infix:<eqv>(Parameter \a, Parameter \b) {
     return True if a =:= b;
 
     # different nominal or coerce type
+    my $acoerce := nqp::getattr(a,Parameter,'$!coerce_type');
+    my $bcoerce := nqp::getattr(b,Parameter,'$!coerce_type');
     return False
       unless nqp::iseq_s(
           nqp::getattr(a,Parameter,'$!nominal_type').^name,
           nqp::getattr(b,Parameter,'$!nominal_type').^name
         )
       && nqp::iseq_s(
-          nqp::getattr(a,Parameter,'$!coerce_type').^name,
-          nqp::getattr(b,Parameter,'$!coerce_type').^name
+          nqp::isnull($acoerce) ?? "" !! $acoerce.^name,
+          nqp::isnull($bcoerce) ?? "" !! $bcoerce.^name
         );
 
     # different flags
     return False
       if nqp::isne_i(
-        nqp::getattr(a,Parameter,'$!flags'),
-        nqp::getattr(b,Parameter,'$!flags')
+        nqp::getattr_i(a,Parameter,'$!flags'),
+        nqp::getattr_i(b,Parameter,'$!flags')
       );
 
     # first is named

--- a/src/core/Parameter.pm
+++ b/src/core/Parameter.pm
@@ -404,8 +404,8 @@ multi sub infix:<eqv>(Parameter \a, Parameter \b) {
     # different flags
     return False
       if nqp::isne_i(
-        nqp::getattr_i(a,Parameter,'$!flags'),
-        nqp::getattr_i(b,Parameter,'$!flags')
+        nqp::getattr(a,Parameter,'$!flags'),
+        nqp::getattr(b,Parameter,'$!flags')
       );
 
     # first is named


### PR DESCRIPTION
This lead to NPE in some files under S32-trig/
One golfed example for dying code:

  class Foo is Real { }