### PR TITLE
Ability to use a custom debugger module

### DIFF
--- a/src/perl6-debug.nqp
+++ b/src/perl6-debug.nqp
@@ -484,6 +484,7 @@ sub MAIN(*@ARGS) {
 	if @ARGS[$i] ~~ /^\-D/ {
 	    $debugger := "-M" ~ nqp::substr(@ARGS[$i], 2);
 	    nqp::splice(@ARGS, [], $i, 1);
+	    last;
 	}
 	$i++;
     }

--- a/src/perl6-debug.nqp
+++ b/src/perl6-debug.nqp
@@ -479,12 +479,19 @@ sub MAIN(*@ARGS) {
 
     # Force loading of the debugger module.
     my $debugger;
-    if @ARGS[1] ~~ /^\-D/ {
-	$debugger := "-M" ~ nqp::substr(@ARGS[1], 2);
-	@ARGS.shift();
-    } else {
+    my $i := 1;
+    while @ARGS[$i] ~~ /^\-/ {
+	if @ARGS[$i] ~~ /^\-D/ {
+	    $debugger := "-M" ~ nqp::substr(@ARGS[$i], 2);
+	    nqp::splice(@ARGS, [], $i, 1);
+	}
+	$i++;
+    }
+
+    if !(nqp::defined($debugger)) {
 	$debugger := '-MDebugger::UI::CommandLine';
     }
+
     my $pname := @ARGS.shift();
     @ARGS.unshift('-Ilib');
     @ARGS.unshift($debugger);

--- a/src/perl6-debug.nqp
+++ b/src/perl6-debug.nqp
@@ -476,13 +476,20 @@ sub MAIN(*@ARGS) {
     
     # Set up END block list, which we'll run at exit.
     nqp::bindhllsym('perl6', '@END_PHASERS', []);
-    
+
     # Force loading of the debugger module.
+    my $debugger;
+    if @ARGS[1] ~~ /^\-D/ {
+	$debugger := "-M" ~ nqp::substr(@ARGS[1], 2);
+	@ARGS.shift();
+    } else {
+	$debugger := '-MDebugger::UI::CommandLine';
+    }
     my $pname := @ARGS.shift();
     @ARGS.unshift('-Ilib');
-    @ARGS.unshift('-MDebugger::UI::CommandLine');
+    @ARGS.unshift($debugger);
     @ARGS.unshift($pname);
-    
+
     # Set up debug hooks object.
     my $*DEBUG_HOOKS := Perl6::DebugHooks.new();
 


### PR DESCRIPTION
I looked at how Perl 5 `Devel::Trace` works and saw that it uses a compiler hook for a custom debugger module. But now in Rakudo we have only `Debugger::UI::CommandLine` module hardcoded. So I decided to fix it to gain an ability to write proper `Devel::Trace` implementation for Perl 6 too.

This commit adds a support for a new command line argument: `-Dsomedebuggermodule`, like
`perl6-debug-m -DCustomDebugger file.p6`
In the case if we don't have this argument, we try to use default `Debugger::UI::CommandLine`.

Also my knowing of proper nqp style is less than awesome, so suggestions are strongly appreciated.

It passes `make spectest` and I doubt it reduces performance of perl6-debug-m.