### PR TITLE
Make short-id2class accessible

### DIFF
--- a/src/core/CompUnit/RepositoryRegistry.pm
+++ b/src/core/CompUnit/RepositoryRegistry.pm
@@ -207,7 +207,7 @@ class CompUnit::RepositoryRegistry {
         }
     }
 
-    sub short-id2class(Str:D $short-id) {
+    our sub short-id2class(Str:D $short-id) {
         state %short-id2class;
         state $lock = Lock.new;
 


### PR DESCRIPTION
Previously it was impossible to add a custom CUR but with this change, you can add your CUR to the registry of short-ids.

I know that the plan is to change how CURs are loaded so this is a stopgap until that implementation.
