### PR TITLE
CURI.files :$name is required

### DIFF
--- a/src/core/CompUnit/Repository/Installation.pm
+++ b/src/core/CompUnit/Repository/Installation.pm
@@ -307,7 +307,7 @@ sub MAIN(:$name is copy, :$auth, :$ver, *@, *%) {
         $dist-dir.child($dist.id).unlink;
     }
 
-    method files($file, :$name, :$auth, :$ver) {
+    method files($file, :$name!, :$auth, :$ver) {
         my @candi;
         my $prefix = self.prefix;
         my $lookup = $prefix.child('short').child(nqp::sha1($name));


### PR DESCRIPTION
perl6 -e '$*REPO.repo-chain[1].files("libssl.so").say'
    Cannot unbox a type object
      in block <unit> at -e line 1
    
https://github.com/rakudo/rakudo/blob/e8fd55bbe6bcdcd10f5c4ca1888ef0ed42dd5f07/src/core/CompUnit/Repository/Installation.pm#L313