### PR TITLE
Fix the r/w file tests

### DIFF
--- a/src/core/IO/Special.pm
+++ b/src/core/IO/Special.pm
@@ -12,8 +12,8 @@ class IO::Special {
     method f(IO::Special:D:) { False }
     method s(IO::Special:D:) { 0 }
     method l(IO::Special:D:) { False }
-    method r(IO::Special:D:) { $!what eq '<IN>' }
-    method w(IO::Special:D:) { $!what eq '<OUT>' or $!what eq '<ERR>' }
+    method r(IO::Special:D:) { $!what eq '<STDIN>' }
+    method w(IO::Special:D:) { $!what eq '<STDOUT>' or $!what eq '<STDERR>' }
     method x(IO::Special:D:) { False }
     method modified(IO::Special:D:) { Instant }
     method accessed(IO::Special:D:) { Instant }


### PR DESCRIPTION
The code expected $!what to be ```<IN>```, ```<OUT>```  or ```<ERR>``` but
the objects are initialised with ```<STDIN>```, ```<STDOUT>``` and ```<STDERR>```
in io_operators when the handles are setup. Thus the file tests
which do a string comparison to $!what were incorrect.