### PR TITLE
Remove superfluous diag() in subtest

### DIFF
--- a/lib/Test.pm6
+++ b/lib/Test.pm6
@@ -293,7 +293,6 @@ sub skip-rest($reason = '<unknown>') is export {
 multi sub subtest(Pair $what)            is export { subtest($what.value,$what.key) }
 multi sub subtest($desc, &subtests)      is export { subtest(&subtests,$desc)       }
 multi sub subtest(&subtests, $desc = '') is export {
-    diag($desc) if $desc;
     _push_vars();
     _init_vars();
     $indents ~= "    ";


### PR DESCRIPTION
Test.pm `diag()` is used for displaying errors everywhere else

See:
https://gist.github.com/ugexe/0fd759225aefbeac9c08d1cc87603206
