### PR TITLE
Remove diag() from subtest()

### DIFF
--- a/lib/Test.pm6
+++ b/lib/Test.pm6
@@ -293,7 +293,6 @@ sub skip-rest($reason = '<unknown>') is export {
 multi sub subtest(Pair $what)            is export { subtest($what.value,$what.key) }
 multi sub subtest($desc, &subtests)      is export { subtest(&subtests,$desc)       }
 multi sub subtest(&subtests, $desc = '') is export {
-    diag($desc) if $desc;
     _push_vars();
     _init_vars();
     $indents ~= "    ";


### PR DESCRIPTION
It does not parse correctly and the default verbosity of prove() already includes the name of the subtest, even if at the end of its run. Relevant IRC conversation: http://irclog.perlgeek.de/perl6/2016-05-18#i_12502193