### PR TITLE
Fix RT #128214

### DIFF
--- a/src/core/IO/Path.pm
+++ b/src/core/IO/Path.pm
@@ -161,14 +161,13 @@ my class IO::Path is Cool {
             # Normal part, set as next path to test
             my str $next = nqp::concat($resolved, nqp::concat($sep, $part));
 
-            # Path part doesn't exist; handle rest in non-resolving mode
+            # Path part doesn't exist, so bail out
             if !nqp::stat($next, nqp::const::STAT_EXISTS) {
-                $resolved = $next;
-                while $parts {
-                    $part = nqp::shift($parts);
-                    next if nqp::iseq_s($part, $empty) || nqp::iseq_s($part, $cur);
-                    $resolved = nqp::concat($resolved, nqp::concat($sep, $part));
-                }
+                fail X::IO::DoesNotExist.new(
+                    :path($next),
+                    :trying('resolve'),
+                    :os-error("path part doesn't exist"),
+                );
             }
             # Symlink; read it and act on absolute or relative link
             elsif nqp::fileislink($next) {


### PR DESCRIPTION
While the docs could be read to imply that finding a non-existent part during IO::Path.resolve isn't an error, it is an error in regular Bash directory traversal.
