### PR TITLE
Fix RT#128284: warnings on failing Test::cmp-ok

### DIFF
--- a/lib/Test.pm6
+++ b/lib/Test.pm6
@@ -198,7 +198,7 @@ multi sub cmp-ok(Mu $got, $op, Mu $expected, $desc = '') is export {
         $ok = proclaim(?$matcher($got,$expected), $desc);
         if !$ok {
             diag "expected: '{$expected // $expected.^name}'";
-            diag " matcher: '$matcher'";
+            diag " matcher: '{$matcher.?name || $matcher.^name}'";
             diag "     got: '$got'";
         }
     }


### PR DESCRIPTION
Instead of attempting to stringify the matcher, we try to call .name (that will give us name for named subs) or call ^.name, which will give us the name of the thing, such as Block, Whatever, etc.

https://rt.perl.org/Ticket/Display.html?id=128284