### PR TITLE
Access packages in their CUR::FS $base

### DIFF
--- a/src/core/CompUnit/Repository/FileSystem.pm
+++ b/src/core/CompUnit/Repository/FileSystem.pm
@@ -37,11 +37,14 @@ class CompUnit::Repository::FileSystem does CompUnit::Repository::Locally does C
                     }
                 }
             }
-            # deduce path to compilation unit from package name
-            elsif %extensions<Perl6> -> @extensions {
-                for @extensions -> $extension {
-                    my $path = $base ~ $extension;
-                    $found = $path.IO if IO::Path.new-from-absolute-path($path).f;
+
+            unless ?$found {
+                # deduce path to compilation unit from package name
+                if %extensions<Perl6> -> @extensions {
+                    for @extensions -> $extension {
+                        my $path = $base ~ $extension;
+                        $found = $path.IO if IO::Path.new-from-absolute-path($path).f;
+                    }
                 }
             }
 


### PR DESCRIPTION
Makes `META6.json` and `META.info` follow the same behavior in regards to access modules in a package $base
See: http://irclog.perlgeek.de/perl6-toolchain/2016-06-02#i_12593703