### PR TITLE
Remove as many uses of $no-sink as possible

### DIFF
--- a/src/core/Any-iterable-methods.pm
+++ b/src/core/Any-iterable-methods.pm
@@ -161,7 +161,6 @@ Did you mean to add a stub (\{...\}) or did you mean to .classify?"
                           );
                         ) unless $!did-init;
 
-                        my $no-sink;
                         my int $redo;
                         my int $running = 1;
                         my $value;
@@ -182,7 +181,7 @@ Did you mean to add a stub (\{...\}) or did you mean to .classify?"
                                        $redo = 0,
                                        nqp::handle(
                                          nqp::stmts(
-                                           ($no-sink := &!block($value)),
+                                           &!block($value),
                                            ($!did-iterate = 1),
                                            nqp::if($!NEXT, &!block.fire_phasers('NEXT')),
                                          ),

--- a/src/core/Any-iterable-methods.pm
+++ b/src/core/Any-iterable-methods.pm
@@ -480,12 +480,11 @@ Did you mean to add a stub (\{...\}) or did you mean to .classify?"
                 }
             }
             method push-all($target) {
-                my $no-sink;
                 until ($_ := $!iter.pull-one) =:= IterationEnd {
                     $!index = $!index + 1;
                     if $!test($_) {
                         $target.push(nqp::p6box_i($!index));
-                        $no-sink := $target.push($_);
+                        $target.push($_);
                     }
                 }
                 IterationEnd
@@ -539,8 +538,7 @@ Did you mean to add a stub (\{...\}) or did you mean to .classify?"
                 $_
             }
             method push-all($target) {
-                my $no-sink;
-                $no-sink := $target.push($_) if $_.match($!test)
+                $target.push($_) if $_.match($!test)
                   until ($_ := $!iter.pull-one) =:= IterationEnd;
                 IterationEnd
             }
@@ -557,8 +555,7 @@ Did you mean to add a stub (\{...\}) or did you mean to .classify?"
                          $_
                      }
                      method push-all($target) {
-                         my $no-sink;
-                         $no-sink := $target.push($_) if $!test($_)
+                         $target.push($_) if $!test($_)
                            until ($_ := $!iter.pull-one) =:= IterationEnd;
                          IterationEnd
                      }
@@ -601,8 +598,7 @@ Did you mean to add a stub (\{...\}) or did you mean to .classify?"
                 $_
             }
             method push-all($target) {
-                my $no-sink;
-                $no-sink := $target.push($_) if $!test.ACCEPTS($_)
+                $target.push($_) if $!test.ACCEPTS($_)
                   until ($_ := $!iter.pull-one) =:= IterationEnd;
                 IterationEnd
             }
@@ -1043,12 +1039,11 @@ Did you mean to add a stub (\{...\}) or did you mean to .classify?"
             method push-all($target) {
                 my Mu $value;
                 my str $needle;
-                my $no-sink;
                 until ($value := $!iter.pull-one) =:= IterationEnd {
                     $needle = nqp::unbox_s($value.WHICH);
                     unless nqp::existskey($!seen, $needle) {
                         nqp::bindkey($!seen, $needle, 1);
-                        $no-sink := $target.push($value);
+                        $target.push($value);
                     }
                 }
                 IterationEnd
@@ -1092,12 +1087,11 @@ Did you mean to add a stub (\{...\}) or did you mean to .classify?"
             method push-all($target) {
                 my Mu $value;
                 my str $needle;
-                my $no-sink;
                 until ($value := $!iter.pull-one) =:= IterationEnd {
                     $needle = nqp::unbox_s(&!as($value).WHICH);
                     unless nqp::existskey($!seen, $needle) {
                         nqp::bindkey($!seen, $needle, 1);
-                        $no-sink := $target.push($value);
+                        $target.push($value);
                     }
                 }
                 IterationEnd
@@ -1143,11 +1137,10 @@ Did you mean to add a stub (\{...\}) or did you mean to .classify?"
             method push-all($target) {
                 my Mu $value;
                 my str $needle;
-                my $no-sink;
                 until ($value := $!iter.pull-one) =:= IterationEnd {
                     $needle = nqp::unbox_s($value.WHICH);
                     nqp::existskey($!seen, $needle)
-                      ?? ($no-sink := $target.push($value))
+                      ?? $target.push($value)
                       !! nqp::bindkey($!seen, $needle, 1);
                 }
                 IterationEnd
@@ -1189,11 +1182,10 @@ Did you mean to add a stub (\{...\}) or did you mean to .classify?"
             method push-all($target) {
                 my Mu $value;
                 my str $needle;
-                my $no-sink;
                 until ($value := $!iter.pull-one) =:= IterationEnd {
                     $needle = nqp::unbox_s(&!as($value).WHICH);
                     nqp::existskey($!seen, $needle)
-                      ?? ($no-sink := $target.push($value))
+                      ?? $target.push($value)
                       !! nqp::bindkey($!seen, $needle, 1);
                 }
                 IterationEnd
@@ -1251,9 +1243,8 @@ Did you mean to add a stub (\{...\}) or did you mean to .classify?"
                 unless $value =:= IterationEnd {
                     my $which;
                     my $last_as := $!last_as;
-                    my $no-sink;
                     if $!first {
-                        $no-sink := $target.push($value);
+                        $target.push($value);
                         $which := &!as($value);
                         $last_as := $which;
                         $value := $!iter.pull-one;
@@ -1261,7 +1252,7 @@ Did you mean to add a stub (\{...\}) or did you mean to .classify?"
                     until IterationEnd =:= $value {
                         $which := &!as($value);
                         unless with($last_as, $which) {
-                            $no-sink := $target.push($value);
+                            $target.push($value);
                         }
                         $last_as := $which;
                         $value := $!iter.pull-one;
@@ -1305,15 +1296,14 @@ Did you mean to add a stub (\{...\}) or did you mean to .classify?"
                 my Mu $value := $!iter.pull-one;
                 unless $value =:= IterationEnd {
                     my $last_val = $!last;
-                    my $no-sink;
                     if $!first {
-                        $no-sink := $target.push($value);
+                        $target.push($value);
                         $last_val := $value;
                         $value := $!iter.pull-one;
                     }
                     until IterationEnd =:= $value {
                         unless with($last_val, $value) {
-                            $no-sink := $target.push($value);
+                            $target.push($value);
                         }
                         $last_val := $value;
                         $value := $!iter.pull-one;

--- a/src/core/Array.pm
+++ b/src/core/Array.pm
@@ -90,8 +90,7 @@ my class Array { # declared in BOOTSTRAP
                 method push-until-lazy($target) {
                     if $!todo.DEFINITE {
                         my int $elems = $!todo.reify-until-lazy;
-                        my $no-sink;
-                        $no-sink := $target.push(nqp::atpos($!reified,$!i))
+                        $target.push(nqp::atpos($!reified,$!i))
                           while nqp::islt_i($!i = nqp::add_i($!i,1),$elems);
                         $!todo.fully-reified
                           ?? self!done
@@ -99,8 +98,7 @@ my class Array { # declared in BOOTSTRAP
                     }
                     else {
                         my int $elems = nqp::elems($!reified);
-                        my $no-sink;
-                        $no-sink := $target.push(
+                        $target.push(
                           nqp::ifnull(
                             nqp::atpos($!reified,$!i),
                             nqp::p6bindattrinvres(
@@ -150,8 +148,7 @@ my class Array { # declared in BOOTSTRAP
 
                 method push-all($target) {
                     my int $elems = nqp::elems($!reified);
-                    my $no-sink;
-                    $no-sink := $target.push(nqp::ifnull(
+                    $target.push(nqp::ifnull(
                       nqp::atpos($!reified,$!i),
                       nqp::p6bindattrinvres(
                         (my \v := nqp::p6scalarfromdesc($!descriptor)),

--- a/src/core/Baggy.pm
+++ b/src/core/Baggy.pm
@@ -158,8 +158,7 @@ my role Baggy does QuantHash {
                   !! IterationEnd
             }
             method push-all($target) {
-                my $no-sink;
-                $no-sink := $target.push(nqp::iterval(nqp::shift($!iter)))
+                $target.push(nqp::iterval(nqp::shift($!iter)))
                   while $!iter;
                 IterationEnd
             }
@@ -173,9 +172,7 @@ my role Baggy does QuantHash {
                   !! IterationEnd
             }
             method push-all($target) {
-                my $no-sink;
-                $no-sink :=
-                  $target.push(nqp::iterval(nqp::shift($!iter)).key)
+                $target.push(nqp::iterval(nqp::shift($!iter)).key)
                     while $!iter;
                 IterationEnd
             }
@@ -201,12 +198,11 @@ my role Baggy does QuantHash {
                 }
             }
             method push-all($target) {
-                my $no-sink;
                 while $!iter {
                     my \tmp =
                       nqp::decont(nqp::iterval(nqp::shift($!iter)));
-                    $no-sink := $target.push(nqp::getattr(tmp,Pair,'$!key'));
-                    $no-sink := $target.push(nqp::getattr(tmp,Pair,'$!value'));
+                    $target.push(nqp::getattr(tmp,Pair,'$!key'));
+                    $target.push(nqp::getattr(tmp,Pair,'$!value'));
                 }
                 IterationEnd
             }
@@ -221,8 +217,7 @@ my role Baggy does QuantHash {
                     !! IterationEnd
             }
             method push-all($target) {
-                my $no-sink;
-                $no-sink := $target.push(nqp::getattr(nqp::decont(
+                $target.push(nqp::getattr(nqp::decont(
                   nqp::iterval(nqp::shift($!iter))),Pair,'$!value'
                 )) while $!iter;
                 IterationEnd
@@ -241,10 +236,9 @@ my role Baggy does QuantHash {
                 }
             }
             method push-all($target) {
-                my $no-sink;
                 while $!iter {
                     my \tmp = nqp::iterval(nqp::shift($!iter));
-                    $no-sink := $target.push(Pair.new(tmp.value, tmp.key));
+                    $target.push(Pair.new(tmp.value, tmp.key));
                 }
                 IterationEnd
             }
@@ -272,12 +266,11 @@ my role Baggy does QuantHash {
                 }
             }
             method push-all($target) {
-                my $no-sink;
                 while $!iter {
                     my \tmp = nqp::iterval(nqp::shift($!iter));
                     $!key  := tmp.key;
                     $!times = tmp.value + 1;
-                    $no-sink := $target.push($!key) while $!times = $!times - 1;
+                    $target.push($!key) while $!times = $!times - 1;
                 }
                 IterationEnd
             }

--- a/src/core/Iterator.pm
+++ b/src/core/Iterator.pm
@@ -19,11 +19,10 @@ my role Iterator {
     # pushed, or IterationEnd if it reached the end of the iteration.
     method push-exactly($target, int $n) {
         my $pulled;
-        my $no-sink;
         my int $i = -1;
 
         # we may not .sink $pulled here, since it can be a Seq
-        $no-sink := $target.push($pulled)
+        $target.push($pulled)
           while nqp::islt_i(++$i,$n)
             && !(IterationEnd =:= ($pulled := self.pull-one));
 
@@ -48,10 +47,9 @@ my role Iterator {
     # sufficient; you needn't override this. Returns IterationEnd.
     method push-all($target) {
         my $pulled;
-        my $no-sink;
 
         # we may not .sink $pulled here, since it can be a Seq
-        $no-sink := $target.push($pulled)
+        $target.push($pulled)
           until IterationEnd =:= ($pulled := self.pull-one);
         IterationEnd
     }

--- a/src/core/List.pm
+++ b/src/core/List.pm
@@ -297,8 +297,7 @@ my class List does Iterable does Positional { # declared in BOOTSTRAP
         my int $elems = +@things;  # reify
         my int $i     = -1;
         my $reified  := nqp::getattr(@things,List,'$!reified');
-        my $no-sink;
-        $no-sink := nqp::bindpos(iterbuffer,$i,(nqp::atpos($reified,$i)))
+        nqp::bindpos(iterbuffer,$i,(nqp::atpos($reified,$i)))
           while nqp::islt_i($i = nqp::add_i($i,1),$elems);
         list
     }
@@ -433,8 +432,7 @@ my class List does Iterable does Positional { # declared in BOOTSTRAP
                 method push-until-lazy($target) {
                     if $!todo.DEFINITE {
                         my int $elems = $!todo.reify-until-lazy;
-                        my $no-sink;
-                        $no-sink := $target.push(nqp::atpos($!reified,$!i))
+                        $target.push(nqp::atpos($!reified,$!i))
                           while nqp::islt_i($!i = nqp::add_i($!i,1),$elems);
                         $!todo.fully-reified
                           ?? self!done
@@ -442,8 +440,7 @@ my class List does Iterable does Positional { # declared in BOOTSTRAP
                     }
                     else {
                         my int $elems = nqp::elems($!reified);
-                        my $no-sink;
-                        $no-sink := $target.push(nqp::atpos($!reified,$!i))
+                        $target.push(nqp::atpos($!reified,$!i))
                           while nqp::islt_i($!i = nqp::add_i($!i,1),$elems);
                         IterationEnd
                     }
@@ -475,8 +472,7 @@ my class List does Iterable does Positional { # declared in BOOTSTRAP
                 }
                 method push-all($target) {
                     my int $elems = nqp::elems($!reified);
-                    my $no-sink;
-                    $no-sink := $target.push(nqp::atpos($!reified,$!i))
+                    $target.push(nqp::atpos($!reified,$!i))
                       while nqp::islt_i($!i = nqp::add_i($!i,1),$elems);
                     IterationEnd
                 }
@@ -790,10 +786,8 @@ my class List does Iterable does Positional { # declared in BOOTSTRAP
             }
             method push-all($target) {
                 my int $i;
-                my $no-sink;
                 while $!number {
-                    $no-sink :=
-                      $target.push(nqp::atpos($!list,$i = $!elems.rand.floor));
+                    $target.push(nqp::atpos($!list,$i = $!elems.rand.floor));
                     nqp::bindpos(
                       $!list,$i,nqp::atpos($!list,nqp::unbox_i(--$!elems)));
                     $!number = $!number - 1;

--- a/src/core/Map.pm
+++ b/src/core/Map.pm
@@ -93,10 +93,9 @@ my class Map does Iterable does Associative { # declared in BOOTSTRAP
                 }
             }
             method push-all($target) {
-                my $no-sink;
                 while $!iter {
                     my \tmp = nqp::shift($!iter);
-                    $no-sink := $target.push(
+                    $target.push(
                       Pair.new(nqp::iterkey_s(tmp), nqp::iterval(tmp)));
                 }
                 IterationEnd
@@ -111,9 +110,7 @@ my class Map does Iterable does Associative { # declared in BOOTSTRAP
                     !! IterationEnd
             }
             method push-all($target) {
-                my $no-sink;
-                $no-sink :=
-                  $target.push(nqp::iterkey_s(nqp::shift($!iter)))
+                $target.push(nqp::iterkey_s(nqp::shift($!iter)))
                     while $!iter;
                 IterationEnd
             }
@@ -133,11 +130,10 @@ my class Map does Iterable does Associative { # declared in BOOTSTRAP
                     !! IterationEnd
             }
             method push-all($target) {
-                my $no-sink;
 
                 STATEMENT_LIST(
-                  $no-sink := $target.push(nqp::iterkey_s(nqp::shift($!iter)));
-                  $no-sink := $target.push(nqp::iterval($!iter))
+                  $target.push(nqp::iterkey_s(nqp::shift($!iter)));
+                  $target.push(nqp::iterval($!iter))
                 ) while $!iter;
 
                 IterationEnd
@@ -152,8 +148,7 @@ my class Map does Iterable does Associative { # declared in BOOTSTRAP
                     !! IterationEnd
             }
             method push-all($target) {
-                my $no-sink;
-                $no-sink := $target.push(nqp::iterval(nqp::shift($!iter)))
+                $target.push(nqp::iterval(nqp::shift($!iter)))
                   while $!iter;
                 IterationEnd
             }
@@ -171,10 +166,9 @@ my class Map does Iterable does Associative { # declared in BOOTSTRAP
                 }
             }
             method push-all($target) {
-                my $no-sink;
                 while $!iter {
                     my \tmp = nqp::shift($!iter);
-                    $no-sink := $target.push(
+                    $target.push(
                       Pair.new( nqp::iterval(tmp), nqp::iterkey_s(tmp) ));
                 }
                 IterationEnd

--- a/src/core/Seq.pm
+++ b/src/core/Seq.pm
@@ -339,7 +339,7 @@ sub GATHER(&block) {
                             iter!start-slip-wanted($taken),
                             ($wanted = nqp::getattr_i(iter, self, '$!wanted'))),
                         nqp::stmts(
-                            (my $no-sink := nqp::getattr(iter, self, '$!push-target').push($taken)),
+                            nqp::getattr(iter, self, '$!push-target').push($taken),
                             ($wanted = nqp::bindattr_i(iter, self, '$!wanted',
                                 nqp::sub_i(nqp::getattr_i(iter, self, '$!wanted'), 1))))),
                     nqp::if(nqp::iseq_i($wanted, 0),
@@ -350,7 +350,7 @@ sub GATHER(&block) {
                 )
             }
             nqp::bindattr(iter, self, '&!resumption', {
-                my $no-sink := nqp::handle(&block(), 'TAKE', $taker());
+                nqp::handle(&block(), 'TAKE', $taker());
                 nqp::continuationcontrol(0, PROMPT, -> | {
                     nqp::bindattr(iter, self, '&!resumption', Callable)
                 });
@@ -394,12 +394,12 @@ sub GATHER(&block) {
         method !start-slip-wanted(\slip) {
             my $value := self.start-slip(slip);
             unless $value =:= IterationEnd {
-                my $no-sink := $!push-target.push($value);
+                $!push-target.push($value);
                 my int $i = 1;
                 my int $n = $!wanted;
                 while $i < $n {
                     last if ($value := self.slip-one()) =:= IterationEnd;
-                    $no-sink := $!push-target.push($value);
+                    $!push-target.push($value);
                     $i = $i + 1;
                 }
                 $!wanted = $!wanted - $i;
@@ -410,10 +410,9 @@ sub GATHER(&block) {
             my int $i = 0;
             my int $n = $!wanted;
             my $value;
-            my $no-sink;
             while $i < $n {
                 last if ($value := self.slip-one()) =:= IterationEnd;
-                $no-sink := $!push-target.push($value);
+                $!push-target.push($value);
                 $i = $i + 1;
             }
             $!wanted = $!wanted - $i;


### PR DESCRIPTION
This is an exploration of whether the use of $no-sink can be removed.See http://irclog.perlgeek.de/perl6-dev/2016-06-08#i_12628220 for some discussion. As the PR stands, it passes all the spec tests.

Removing the one remaining use in List.pm caused a whole bunch of failures (I'd guess about 50 different test files).

Removing the one remaining use in Any-iterable-methods.pm caused failures in three test files:
- t/spec/S04-statements/label.rakudo.moar
- t/spec/S04-statements/last.t
- t/spec/S04-statements/redo.t