### PR TITLE
&[=:=] in &[eqv] for Match objects should be an optimization

### DIFF
--- a/src/core/Match.pm
+++ b/src/core/Match.pm
@@ -97,8 +97,9 @@ my class Match is Capture is Cool {
 }
 
 multi sub infix:<eqv>(Match:D $a, Match:D $b) {
+    $a =:= $b
+    ||
     [&&] (
-	$a 	=:= $b,
         $a.to   eqv $b.to,
         $a.from eqv $b.from,
         $a.orig eqv $b.orig,


### PR DESCRIPTION
Currently it requires `=:=` to return true for `eqv` to return `True`, and then also does unnecessary work by checking attributes on the same object for equivalence with its own attributes. ( is "my arm" equivalent to "my arm" )

Based on this I expect that `=:=` was meant to be an optimization, as changing it to do so makes the rest of the code actually useful. ( The discussion in the PR bears that out )

The operator candidate was added with [PR#739](https://github.com/rakudo/rakudo/pull/739)