### PR TITLE
Fix RT#128421

### DIFF
--- a/src/core/Numeric.pm
+++ b/src/core/Numeric.pm
@@ -255,9 +255,7 @@ multi sub infix:<≅>(\a, \b, :$tolerance = $*TOLERANCE)    {
     # If operands are non-0, scale the tolerance to the larger of the abs values.
     # We test b first since $value ≅ 0 is the usual idiom and falsifies faster.
     if b && a && $tolerance {
-        my $a = a.abs;
-        my $b = b.abs;
-        abs($a - $b) < ($a max $b) * $tolerance;
+        abs(a - b) < (a.abs max b.abs) * $tolerance;
     }
     else {  # interpret tolerance as absolute
         abs(a.Num - b.Num) < $tolerance;


### PR DESCRIPTION
Fix ≅ incorrectly handling negative numbers, e.g. producing True for 100 ≅ -100