### PR TITLE
Make cmp-ok take user-defined operators as Str b2gills++

### DIFF
--- a/t/02-rakudo/03-cmp-ok.t
+++ b/t/02-rakudo/03-cmp-ok.t
@@ -1,8 +1,9 @@
 use v6;
-use lib 'lib';
+use lib <lib  t/02-rakudo/test-packages>;
 use Test;
+use CustomOps; # test cmp-ok handling custom infixes that we imported
 
-plan 4;
+plan 6;
 
 sub check-fail (&test-to-run) {
     my $message = 'should fail due to requested comparison';
@@ -41,13 +42,59 @@ subtest '&[] comparators', {
     check-fail { cmp-ok 'foo', &[eq], 'bar', '"foo" eq "bar"' }
 }
 
-subtest 'custom operators', {
+subtest 'custom operators (in code)', {
     sub infix:<◀> { $^a < $^b };
-    cmp-ok 1, &[◀], 2, 'comparing using a fancy operator';
-    check-fail { cmp-ok 2, &[◀], 1, 'failing comparison using a fancy op' }
-    check-fail { cmp-ok 1, '◀', 2 }
+    cmp-ok 1, &[◀], 2, 'comparing using a fancy operator (Callable version)';
+    cmp-ok 1,  '◀', 2, 'comparing using a fancy operator (Str version)';
+    check-fail { cmp-ok 2, &[◀], 1, 'failing comparison custom op (Callable)' }
+    check-fail { cmp-ok 2,  '◀', 1, 'failing comparison custom op (Str)' }
+}
+
+subtest 'custom operators (in nested scope)', {
+    sub infix:<◀> { $^a < $^b };
+    {
+        {
+            cmp-ok 1, &[◀], 2, 'passing, Callable';
+            cmp-ok 1,  '◀', 2, 'passing, Str';
+            check-fail { cmp-ok 2, &[◀], 1, 'failing, Callable' }
+            check-fail { cmp-ok 2,  '◀', 1, 'failing, Str'      }
+        }
+    }
+}
+
+subtest 'custom operators (imported)', {
+    # Commented out tests fails due to some other bug regarding using
+    # &[...] notation with imported ops with `<`/`>` in them, like `<=»`
+
+    cmp-ok 1,  &[<=!], 2, 'passing <=! op, Callable';
+    cmp-ok 1,   '<=!', 2, 'passing <=! op, Str';
+    # cmp-ok 1,  &[<=»], 2, 'passing <=» op, Callable';
+    cmp-ok 1,   '<=»', 2, 'passing <=» op, Str';
+    cmp-ok 1,    &[«], 2, 'passing « op, Callable';
+    cmp-ok 1,     '«', 2, 'passing « op, Str';
+    # cmp-ok 1,   &[<«], 2, 'passing <« op, Callable';
+    cmp-ok 1,    '<«', 2, 'passing <« op, Str';
+    # cmp-ok 1,   &[>»], 2, 'passing >» op, Callable';
+    cmp-ok 1,    '>»', 2, 'passing >» op, Str';
+    # cmp-ok 1, &[<«>»], 2, 'passing <«>» op, Callable';
+    cmp-ok 1,  '<«>»', 2, 'passing <«>» op, Str';
+
+    check-fail { cmp-ok 2,  &[<=!], 1, 'failing <=! op, Callable'  }
+    check-fail { cmp-ok 2,   '<=!', 1, 'failing <=! op, Str'       }
+    # check-fail { cmp-ok 2,  &[<=»], 1, 'failing <=» op, Callable'  }
+    check-fail { cmp-ok 2,   '<=»', 1, 'failing <=» op, Str'       }
+    check-fail { cmp-ok 2,    &[«], 1, 'failing « op, Callable'    }
+    check-fail { cmp-ok 2,     '«', 1, 'failing « op, Str'         }
+    # check-fail { cmp-ok 2,   &[<«], 1, 'failing <« op, Callable'   }
+    check-fail { cmp-ok 2,    '<«', 1, 'failing <« op, Str'        }
+    # check-fail { cmp-ok 2,   &[>»], 1, 'failing >» op, Callable'   }
+    check-fail { cmp-ok 2,    '>»', 1, 'failing >» op, Str'        }
+    # check-fail { cmp-ok 2, &[<«>»], 1, 'failing <«>» op, Callable' }
+    check-fail { cmp-ok 2,  '<«>»', 1, 'failing <«>» op, Str'      }
 }
 
 subtest 'no EVAL exploit (RT#128283)', {
     check-fail { cmp-ok '', '~~>;exit; <z', '', '' };
 }
+
+done-testing;

--- a/t/02-rakudo/test-packages/CustomOps.pm6
+++ b/t/02-rakudo/test-packages/CustomOps.pm6
@@ -1,0 +1,11 @@
+unit module CustomOps;
+
+# These custom operators are for testing functionality of cmp-ok
+# in t/02-rakudo/03-cmp-ok.t
+
+sub infix:«<=!»    is export { $^a < $^b }
+sub infix:<«>      is export { $^a < $^b }
+sub infix:['<=»']  is export { $^a < $^b }
+sub infix:['<«']   is export { $^a < $^b }
+sub infix:['>»']   is export { $^a < $^b }
+sub infix:['<«>»'] is export { $^a < $^b }


### PR DESCRIPTION
This rescinds the claim made in commit 102b0eade9093a38d4bb526014d860e87c3e7797
that Str comparator for custom ops is not supported. b2gills++ shown
a way to support that, which is what this commit implements.