### PR TITLE
Remove needless check

### DIFF
--- a/src/core/Str.pm
+++ b/src/core/Str.pm
@@ -761,8 +761,8 @@ my class Str does Stringy { # declared in BOOTSTRAP
         }
 
         # nothing to do
-        elsif $limit < 2 {
-            return $limit <= 0 ?? () !! self.list;
+        elsif $limit == 1 {
+            return self.list;
         }
 
         # want them all


### PR DESCRIPTION
$limit is already checked for <= 0 condition [at the start of the method](https://github.com/zoffixznet/rakudo/blob/b5136cf3d4f03602f82965111df58b84e296b72b/src/core/Str.pm#L755) so we can avoid performing another check for a condition that'll never occur.