### PR TITLE
Fix Mu handling in REPL

### DIFF
--- a/src/core/REPL.pm
+++ b/src/core/REPL.pm
@@ -382,11 +382,11 @@ do {
             $*CTXSAVE := 0;
         }
 
-        method input-incomplete($value) {
+        method input-incomplete(Mu $value) {
             $value.WHERE == $more-code-sentinel.WHERE
         }
 
-        method repl-print($value) {
+        method repl-print(Mu $value) {
             say $value unless $value.gist eq '';
         }
 


### PR DESCRIPTION
Avoid crashing with
===SORRY!===
Type check failed in binding $value; expected Any but got ...
For Junction, Mu, etc.