### PR TITLE
Fix a few problems with IO::ArgFiles

### DIFF
--- a/src/core/IO/ArgFiles.pm
+++ b/src/core/IO/ArgFiles.pm
@@ -95,8 +95,8 @@ my class IO::ArgFiles is IO::Handle {
     }
     method slurp(IO::ArgFiles:D:) {
         my @chunks;
-        if $!io && $!io.opened {
-            @chunks.push: nqp::p6box_s($!io.readall);
+        if $!io.defined && $!io.opened {
+            @chunks.push: nqp::p6box_s($!io.slurp-rest);
             $!io.close;
         }
         while $!args {


### PR DESCRIPTION
I noticed that `slurp()` would complain about `$!io` not having a `.readall` method ( must have been overlooked after a name change )

I also saw that `slurp()` would do the wrong thing if it was called twice, and that `$*ARGFILES.eof` never seemed to return True.

I think there are a few edge cases where it does something slightly differently than it should ( most of them are noted in comments )
The proper way to fix all of them I can think of would be to write a lot more code ( basically both methods should probably be written in terms of `!next-io()` )
This fixes the most glaring issues though.