### PR TITLE
Fix Distribution::Path missing bin/ or resources/

### DIFF
--- a/src/core/Distribution.pm
+++ b/src/core/Distribution.pm
@@ -118,7 +118,8 @@ class Distribution::Path does Distribution::Locally {
         my $meta = Rakudo::Internals::JSON.from-json(slurp($path));
 
         my sub ls-files($prefix, $subdir) {
-            my @stack = dir($prefix.child($subdir));
+            my $dir   = $prefix.child($subdir);
+            my @stack = dir($dir) if $dir.e;
             my @files = eager gather while ( @stack ) {
                 my IO::Path $current = @stack.pop;
                 my Str      $relpath = $current.relative($prefix);


### PR DESCRIPTION
Allows `Distribution::Path` to work on distributions that have no `bin/` or `resources/` directories