### PR TITLE
Revert handling of 'No' chars in Str.Int

### DIFF
--- a/src/core/Str.pm
+++ b/src/core/Str.pm
@@ -39,17 +39,11 @@ my class Str does Stringy { # declared in BOOTSTRAP
     method Int(Str:D:) {
         my str $s     = self;
         my int $chars = nqp::chars($s);
-        nqp::isge_i(nqp::findnotcclass(
-          nqp::const::CCLASS_NUMERIC,$s,0,$chars),$chars)
-            ?? nqp::atpos(nqp::radix_I(10,$s,0,0,Int),0)
-#?if moar
-            !! nqp::iseq_i($chars,1)
-              ?? (unival(nqp::ord($s)) // self.Numeric).Int
-              !! self.Numeric.Int
-#?endif
-#?if !moar
-            !! self.Numeric.Int
-#?endif
+        nqp::isge_i(
+          nqp::findnotcclass(nqp::const::CCLASS_NUMERIC,$s,0,$chars),
+          $chars
+        ) ?? nqp::atpos(nqp::radix_I(10,$s,0,0,Int),0)
+          !! self.Numeric.Int;
     }
     method Num(Str:D:) { self.Numeric.Num; }
 


### PR DESCRIPTION
The feature was added as a fix for RT#127866, however, Str.Numeric and
especially val() remained unable to handle 'No' characters.

After conversation with TimToady
(http://irclog.perlgeek.de/perl6/2016-07-04#i_12782986), it was ruled
that handling of 'No' characters should be explicitly requested
by the programmer with unival() and so this commit undoes such handling
in Str.Int case to maintain consistency.