### PR TITLE
Fix module loading on rakudo-j

### DIFF
--- a/src/core/CompUnit/RepositoryRegistry.pm
+++ b/src/core/CompUnit/RepositoryRegistry.pm
@@ -121,7 +121,7 @@ class CompUnit::RepositoryRegistry {
         sub normalize(\spec){
             my $parts := nqp::split('#', spec);
             my $path := nqp::elems($parts) - 1;
-            nqp::bindpos($parts, $path, $SPEC.canonpath(nqp::atpos($parts, $path)));
+            nqp::bindpos($parts, $path, nqp::unbox_s($SPEC.canonpath(nqp::atpos($parts, $path))));
             nqp::join('#', $parts)
         };
 


### PR DESCRIPTION
Trying to load a module on rakudo-j failed with
'This type cannot unbox to a native string'

Adding a 'nqp::unbox_s' fixes this and works for
rakudo-m as well.