### PR TITLE
fix Blob/precomp SHA-1 check-sums

### DIFF
--- a/src/core/Buf.pm
+++ b/src/core/Buf.pm
@@ -13,7 +13,7 @@ my role Blob[::T = uint8] does Positional[T] does Stringy is repr('VMArray') is 
       unless nqp::istype(T,Int);
 
     multi method WHICH(Blob:D:) {
-        self.^name ~ '|' ~ nqp::sha1(self.join(","))
+        self.^name ~ '|' ~ nqp::sha1(self.decode("latin-1"))
     }
 
     multi method new(Blob:) { nqp::create(self) }

--- a/src/core/CompUnit/PrecompilationStore/File.pm
+++ b/src/core/CompUnit/PrecompilationStore/File.pm
@@ -11,7 +11,7 @@ class CompUnit::PrecompilationStore::File does CompUnit::PrecompilationStore {
         submethod BUILD(CompUnit::PrecompilationId :$!id, IO::Path :$!path, :@!dependencies, :$!bytecode --> Nil) {
             if $!bytecode {
                 $!initialized = True;
-                $!checksum = nqp::sha1($!bytecode.join(','));
+                $!checksum = nqp::sha1($!bytecode.decode("latin-1"));
             }
         }
 


### PR DESCRIPTION
With this fix, SHA-1 check-sums agree with the sha1sum Unix utility.
```
%  echo "abc" |sha1sum
03cfd743661f07975fa2f1220c5194cbaff48451  -
% perl6 -e'my $b = Blob.new("abc\n".encode("latin-1")); say $b.WHICH'
Blob|03CFD743661F07975FA2F1220C5194CBAFF48451
```