### PR TITLE
Improve LTA octal message

### DIFF
--- a/src/core/Exception.pm
+++ b/src/core/Exception.pm
@@ -2292,7 +2292,7 @@ my class X::PhaserExceptions is Exception {
 }
 
 nqp::bindcurhllsym('P6EX', nqp::hash(
-  'X::TypeCheck::Binding', 
+  'X::TypeCheck::Binding',
   sub (Mu $got, Mu $expected, $symbol?) {
       X::TypeCheck::Binding.new(:$got, :$expected, :$symbol).throw;
   },

--- a/src/core/Exception.pm
+++ b/src/core/Exception.pm
@@ -724,8 +724,14 @@ Parenthesize as \\(...) if you intended a capture of a single numeric value./
 my class X::Worry::P5::LeadingZero is X::Worry::P5 {
     has $.value;
     method message {
-qq/Leading 0 does not indicate octal in Perl 6.
-Please use 0o$!value if you mean that./
+        if $!value ~~ /<[89]>/ {
+            "Leading 0 is not allowed. For octals, use '0o' prefix,"
+            ~ " but note that $!value is not a valid octal number";
+        }
+        else {
+            'Leading 0 does not indicate octal in Perl 6.'
+                ~ " Please use 0o$!value if you mean that.";
+        }
     }
 }
 


### PR DESCRIPTION
The old message had suggestion to the user that used invalid octals.

```
<Zoffix> m: say 09
<camelia> rakudo-moar 55c359: OUTPUT«Potential difficulties:␤    Leading 0 does not indicate octal in Perl 6.␤    Please use 0o9 if you mean that.␤    at <tmp>:1␤    ------> say 09⏏<EOL>␤9␤»
<Zoffix> m: say 08
<camelia> rakudo-moar 55c359: OUTPUT«Potential difficulties:␤    Leading 0 does not indicate octal in Perl 6.␤    Please use 0o8 if you mean that.␤    at <tmp>:1␤    ------> say 08⏏<EOL>␤8␤»
```