### PR TITLE
min/max on Failure must fail, not return ±Inf

### DIFF
--- a/src/core/Any-iterable-methods.pm
+++ b/src/core/Any-iterable-methods.pm
@@ -902,7 +902,7 @@ Did you mean to add a stub (\{...\}) or did you mean to .classify?"
         todo = $elems;
         my $value;
 
-        return $value
+        return nqp::istype($value, Failure) ?? $value.exception.throw !! $value
           if nqp::isconcrete($value := self.AT-POS(i))
             while nqp::islt_i(++i,todo);
 


### PR DESCRIPTION
Fixes [RT#128573](https://rt.perl.org/Ticket/Display.html?id=128573), namely:

```
<Zoffix> m: say Failure.new.min: &infix:<cmp>
<camelia> rakudo-moar 29a110: OUTPUT«Inf␤»
<Zoffix> m: say Failure.new.max: &infix:<cmp>
<camelia> rakudo-moar 29a110: OUTPUT«-Inf␤»
<Zoffix> m: say Failure.new.max
<camelia> rakudo-moar 29a110: OUTPUT«-Inf␤»
<Zoffix> m: say Failure.new.min
<camelia> rakudo-moar 29a110: OUTPUT«Inf␤»
<Zoffix> m: say min +'a'
<camelia> rakudo-moar 29a110: OUTPUT«Inf␤»
<Zoffix> m: say max +'a'
<camelia> rakudo-moar 29a110: OUTPUT«-Inf␤»
```