### PR TITLE
Make .ver and .auth MetaModel methods available on Packages

### DIFF
--- a/src/Perl6/Metamodel/PackageHOW.nqp
+++ b/src/Perl6/Metamodel/PackageHOW.nqp
@@ -1,6 +1,7 @@
 class Perl6::Metamodel::PackageHOW
     does Perl6::Metamodel::Naming
     does Perl6::Metamodel::Documenting
+    does Perl6::Metamodel::Versioning
     does Perl6::Metamodel::Stashing
     does Perl6::Metamodel::TypePretense
     does Perl6::Metamodel::MethodDelegation
@@ -21,6 +22,8 @@ class Perl6::Metamodel::PackageHOW
         my $metaclass := nqp::create(self);
         my $obj := nqp::settypehll(nqp::newtype($metaclass, 'Uninstantiable'), 'perl6');
         $metaclass.set_name($obj, $name);
+        $metaclass.set_ver( $obj, $ver ) if $ver;
+        $metaclass.set_auth($obj, $auth) if $auth;
         self.add_stash($obj);
     }
 


### PR DESCRIPTION
Fixes RT#128579

Tests: https://github.com/perl6/roast/pull/134

This adds .^ver and .^auth methods to packages, fixing this:
```
$ perl6 -e 'my class Z:ver<1.2.3>:auth<me> {}; say [ Z.^ver(), Z.^auth ];'
[v1.2.3 me]
$ perl6 -e 'my module Z:ver<1.2.3>:auth<me> {}; say [ Z.^ver(), Z.^auth ];'
[v1.2.3 me]
$ perl6 -e 'my package Z:ver<1.2.3>:auth<me> {}; say [ Z.^ver(), Z.^auth ];'
Method 'ver' not found for invocant of class 'Perl6::Metamodel::PackageHOW'
  in block <unit> at -e line 1

$ 
```

Relevant IRC Conversation: http://irclog.perlgeek.de/perl6/2016-07-08#i_12808945