### PR TITLE
Revert "Make .ver and .auth MetaModel methods available on Packages"

### DIFF
--- a/src/Perl6/Metamodel/PackageHOW.nqp
+++ b/src/Perl6/Metamodel/PackageHOW.nqp
@@ -1,7 +1,6 @@
 class Perl6::Metamodel::PackageHOW
     does Perl6::Metamodel::Naming
     does Perl6::Metamodel::Documenting
-    does Perl6::Metamodel::Versioning
     does Perl6::Metamodel::Stashing
     does Perl6::Metamodel::TypePretense
     does Perl6::Metamodel::MethodDelegation
@@ -22,8 +21,6 @@ class Perl6::Metamodel::PackageHOW
         my $metaclass := nqp::create(self);
         my $obj := nqp::settypehll(nqp::newtype($metaclass, 'Uninstantiable'), 'perl6');
         $metaclass.set_name($obj, $name);
-        $metaclass.set_ver( $obj, $ver ) if $ver;
-        $metaclass.set_auth($obj, $auth) if $auth;
         self.add_stash($obj);
     }
 


### PR DESCRIPTION
This reverts commit 26817b3e355c663bd12a9e0c3e1b0728befb3934.

As per discussion on https://github.com/rakudo/rakudo/pull/818#issuecomment-231468771
packages are stubs and must not have .ver/auth identifiers