### PR TITLE
Propagate Failure on some coercers

### DIFF
--- a/src/core/Str.pm
+++ b/src/core/Str.pm
@@ -43,9 +43,9 @@ my class Str does Stringy { # declared in BOOTSTRAP
           nqp::findnotcclass(nqp::const::CCLASS_NUMERIC,$s,0,$chars),
           $chars
         ) ?? nqp::atpos(nqp::radix_I(10,$s,0,0,Int),0)
-          !! self.Numeric.Int;
+          !! (given self.Numeric { when Failure { $_ }; .Int });
     }
-    method Num(Str:D:) { self.Numeric.Num; }
+    method Num(Str:D:) { given self.Numeric { when Failure { $_ }; .Num } }
 
     multi method ACCEPTS(Str:D: Str:D \other) {
         nqp::p6bool(nqp::iseq_s(nqp::unbox_s(other),$!value));


### PR DESCRIPTION
See a long discussion at http://irclog.perlgeek.de/perl6/2016-07-09#i_12812787
```
<sortiz> m: say "a".Numeric ~~ Failure
<camelia> rakudo-moar 959cd3: OUTPUT«True␤»
<BenGoldberg> m: "a".Numeric.WHAT.say
<camelia> rakudo-moar 959cd3: OUTPUT«(Failure)␤»
<sortiz> m: say "a".Int ~~ Failure
<camelia> rakudo-moar 959cd3: OUTPUT«Cannot convert string to number: base-10 number must begin with valid digits or '.' in '⏏a' (indicated by ⏏)␤  in block <unit> at <tmp> line 1␤␤Actually thrown at:␤  in block <unit> at <tmp> line 1␤␤»
<sortiz> That inconsistency bothers me.
<pmichaud> it bothers me also
<BenGoldberg> rakudobug it!
<pmichaud> testing for Failure should not cause it to be thrown.
```

I think that the implementation can be optimized, but this simple approach solve the problem and
prove that no specs was broken.

Some similar will follow on Cool.pm