### PR TITLE
Ability to mark nativecall import symbol to be mangled or not

### DIFF
--- a/lib/NativeCall.pm6
+++ b/lib/NativeCall.pm6
@@ -18,6 +18,22 @@ my constant CArray        is export(:types, :DEFAULT) = NativeCall::Types::CArra
 my constant Pointer       is export(:types, :DEFAULT) = NativeCall::Types::Pointer;
 my constant OpaquePointer is export(:types, :DEFAULT) = NativeCall::Types::Pointer;
 
+
+# Role for carrying extra calling convention information.
+my role NativeCallingConvention[$name] {
+    method native_call_convention() { $name };
+}
+
+# Role for carrying extra string encoding information.
+my role NativeCallEncoded[$name] {
+    method native_call_encoded() { $name };
+}
+
+my role NativeCallMangled[$name] {
+    method native_call_mangled() { $name }
+}
+
+
 # Throwaway type just to get us some way to get at the NativeCall
 # representation.
 my class native_callsite is repr('NativeCall') { }
@@ -302,20 +318,6 @@ my role Native[Routine $r, $libname where Str|Callable|List] {
 
         nqp::nativecall($!rettype, self, $args)
     }
-}
-
-# Role for carrying extra calling convention information.
-my role NativeCallingConvention[$name] {
-    method native_call_convention() { $name };
-}
-
-# Role for carrying extra string encoding information.
-my role NativeCallEncoded[$name] {
-    method native_call_encoded() { $name };
-}
-
-my role NativeCallMangled[$name] {
-    method native_call_mangled() { $name }
 }
 
 multi sub postcircumfix:<[ ]>(CArray:D \array, $pos) is export(:DEFAULT, :types) {


### PR DESCRIPTION
Hi,

In order to play with perl I wanted to do a gui. I decided to try to
bind qt libraries via nativecall[1]. Nativecall contains logic for g++
or msvc which tries to guess mangled name. I found that it does not work
that well for qt libraries. Especially on windows the actual symbols are
far from nativecall guess. So I decided I'll compile the shim library
exporting qt functionality into 'extern "C"' to make the symbols
predictable. Sadly I can't force nativecall to not mangle symbols at
all. I'm using the attached patch and in the perl itself

```
class QString is repr<CPPStruct> is QObject {
    has Pointer $.vtable;

        my sub qt_QString(Str) returns QString is native('./p6', v1) is
        mangled(False) { * };
...

```
Important is the 'is mangled(False)'.

Could something like this be included into nativecall?

[1] https://bitbucket.org/vlmarek/perl6-qt (beware, only proof of
concept)

Thank you
        Vlad
