### PR TITLE
Allow users to send Nil through Channel

### DIFF
--- a/src/core/Channel.pm
+++ b/src/core/Channel.pm
@@ -121,12 +121,10 @@ my class Channel {
             }
             whenever $!async-notify.unsanitized-supply.schedule-on($*SCHEDULER) {
                 my Mu \got = self.poll;
-                if nqp::eqaddr(got, Nil) {
-                    if $!closed_promise {
-                        $!closed_promise.status == Kept
-                            ?? done()
-                            !! die $!closed_promise.cause
-                    }
+                if nqp::eqaddr(got, Nil) and $!closed_promise {
+                    $!closed_promise.status == Kept
+                        ?? done()
+                        !! die $!closed_promise.cause
                 }
                 else {
                     emit got;


### PR DESCRIPTION
Fixes [RT#127648](https://rt.perl.org/Ticket/Display.html?id=127648#ticket-history)

It fixes the issue in the ticket and passes all the spectests, but I'm not sure what [this `loop {}`](https://github.com/zoffixznet/rakudo/blob/0ee25be71cd4d9d4fa14b3044fe13baa75ea0d26/src/core/Channel.pm#L111) is for and what happens when it gets a `Nil`. Adding a `and $!closed_promise` to that `last` caused a bunch of spectest failures.