### PR TITLE
Fix RT#127958 on moarvm... :D smiley containers assigned from Nil

### DIFF
--- a/src/core/Exception.pm
+++ b/src/core/Exception.pm
@@ -1937,30 +1937,36 @@ my class X::TypeCheck::Binding is X::TypeCheck {
     has $.symbol;
     method operation { 'binding' }
     method message() {
-        if $.symbol {
-            self.priors() ~
-            "Type check failed in $.operation $.symbol; expected $.expectedn but got $.gotn";
-        } else {
-            self.priors() ~
-            "Type check failed in $.operation; expected $.expectedn but got $.gotn";
-        }
+        my $to = $.symbol.defined && $.symbol ne '$'
+            ?? " to $.symbol" !! "";
+        my $expected = $.expected =:= $.got
+            ?? "expected type $.expectedn cannot be itself"
+            !! "expected $.expectedn but got $.gotn";
+        self.priors() ~ "Type check failed in $.operation$to; $expected";
     }
 }
 my class X::TypeCheck::Return is X::TypeCheck {
     method operation { 'returning' }
     method message() {
+        my $expected = $.expected =:= $.got
+            ?? "expected return type $.expectedn cannot be itself " ~
+               "(perhaps $.operation a :D type object?)"
+            !! "expected $.expectedn but got $.gotn";
         self.priors() ~
-        "Type check failed for return value; expected $.expectedn but got $.gotn";
+        "Type check failed for return value; $expected";
     }
 }
 my class X::TypeCheck::Assignment is X::TypeCheck {
     has $.symbol;
     method operation { 'assignment' }
     method message {
-        self.priors() ~ do
-            $.symbol.defined && $.symbol ne '$'
-            ?? "Type check failed in assignment to $.symbol; expected $.expectedn but got $.gotn"
-            !! "Type check failed in assignment; expected $.expectedn but got $.gotn";
+        my $to = $.symbol.defined && $.symbol ne '$'
+            ?? " to $.symbol" !! "";
+        my $expected = $.expected =:= $.got
+            ?? "expected type $.expectedn cannot be itself " ~
+               "(perhaps Nil was assigned to a :D which had no default?)"
+            !! "expected $.expectedn but got $.gotn";
+        self.priors() ~ "Type check failed in assignment$to; $expected";
     }
 }
 my class X::TypeCheck::Argument is X::TypeCheck {

--- a/src/vm/moar/ops/container.c
+++ b/src/vm/moar/ops/container.c
@@ -85,13 +85,15 @@ static void rakudo_scalar_store(MVMThreadContext *tc, MVMObject *cont, MVMObject
     if (!obj) {
         MVM_exception_throw_adhoc(tc, "Cannot assign a null value to a Perl 6 scalar");
     }
-    else if (STABLE(obj)->WHAT == get_nil()) {
-        obj = rcd->the_default;
-    }
     else {
+        MVMint64 mode;
+        if (STABLE(obj)->WHAT == get_nil()) {
+            obj = rcd->the_default;
+            /* We still have to check the_default, for :D types */
+        }
         /* Check against the type-check cache first (common, fast-path
          * case). */
-        MVMint64 mode = STABLE(rcd->of)->mode_flags & MVM_TYPE_CHECK_CACHE_FLAG_MASK;
+        mode = STABLE(rcd->of)->mode_flags & MVM_TYPE_CHECK_CACHE_FLAG_MASK;
         if (rcd->of != get_mu() && !MVM_6model_istype_cache_only(tc, obj, rcd->of)) {
             /* Failed. If the cache is definitive, we certainly have an error. */
             if (STABLE(obj)->type_check_cache &&


### PR DESCRIPTION
  There is no sensible default default for :D types, blame Kurt Gödel.
  This breaks the assumption that a type's default is a legal value.
  So, check the assigned type even when assigning from the_default.