### PR TITLE
Add :!ext and $suffix options to IO::Path.basename

### DIFF
--- a/src/core/IO/Path.pm
+++ b/src/core/IO/Path.pm
@@ -64,8 +64,19 @@ my class IO::Path is Cool {
     }
     method volume(IO::Path:D:)   { %.parts<volume>   }
     method dirname(IO::Path:D:)  { %.parts<dirname>  }
-    method basename(IO::Path:D:) { %.parts<basename> }
     method extension(IO::Path:D:) { Rakudo::Internals.MAKE-EXT(self.basename) }
+
+    proto method basename(|) {*}
+    multi method basename(IO::Path:D:) { %.parts<basename> }
+    multi method basename(IO::Path:D: :$ext!) {
+        $ext ?? self.basename
+             !! self.basename.substr(0, * - self.extension.chars - 1);
+    }
+    multi method basename(IO::Path:D: Str $suffix) {
+        $suffix eq self.basename.substr(* - $suffix.chars)
+            ?? self.basename.substr(0, * - $suffix.chars)
+            !! self.basename;
+    }
 
     # core can't do 'basename handles <Numeric Bridge Int>'
     method Numeric(IO::Path:D:) { self.basename.Numeric }


### PR DESCRIPTION
This PR introduces additional functiolity to IO::Path's `.basename` method. I'm unsure whether or not this type of stuff can be merged directly to master or if we have some sort of protocol for new features.

### Original Behaviour

The original `.basename` does not take any arguments and returns the full filename:

```perl6
"/foo/bar/ber.zor.meow".IO.basename.say # ber.zor.meow
```

### Added Behaviour

This PR adds two more multis to `.basename`. Both of them let the user strip extension from the
filename. Rationale for adding: there's no easy, non-cryptic method to get just the filename without extension, even though operations on filenames sans-extension are pretty common; for example sanitizing or normalizing the filename and then re-attaching the extension to it.

##### Strip Current Extension

```perl6
"/foo/bar/ber.zor.meow".IO.basename(:!ext).say # ber.zor
```

By specifying the `:ext` named argument, the user can control whether the extension
should be stripped from the filename. It's kept when the argument is `True` and is
stripped when it's `False`. The stripped suffix is a `.` followed by the value of `.extension` method. Rationale for naming `.basename(:!ext)` reads as `basename(not ext)`


##### Strip Any Suffix

```perl6
"/foo/bar/ber.zor.meow".IO.basename(".zor.meow").say # ber
```

The other multi lets a user specify a custom suffix to strip. If the filename does not end with such a suffix, nothing is stripped. Rationale for adding: replicating the behaviour of *nix `basename` command as well as Perl 5's [File::Basename module](https://metacpan.org/pod/File::Basename)
```bash
basename /foo/bar/ber.zor.meow .zor.meow
ber
```

Note that no extra dots are prepended to the suffix, replicating the behaviour of aforementioned tools. This means that 
```perl6
my $p = "/foo/bar/.meow".IO;
$p.basename(".meow"); # gives `ber.zor`
$p.basename($p.extension); # gives `ber.zor.` (note the trailing dot)


