### PR TITLE
Implement Rakudo::Internals.DIR-RECURSE

### DIFF
--- a/src/core/Distribution.pm
+++ b/src/core/Distribution.pm
@@ -124,21 +124,9 @@ class Distribution::Path does Distribution::Locally {
         die "No meta file located at {$path.abspath}" unless $path.e;
         my $meta = Rakudo::Internals::JSON.from-json(slurp($path));
 
-        my sub ls-files($prefix, $subdir) {
-            my $dir   = $prefix.child($subdir);
-            my @stack = dir($dir) if $dir.e;
-            my @files = eager gather while ( @stack ) {
-                my IO::Path $current = @stack.pop;
-                my Str      $relpath = $current.relative($prefix);
-                take $relpath and next if $current.f;
-                next if $current.basename eq '.precomp';
-                @stack.append( |dir($current.absolute) ) if $current.d;
-            }
-        }
-
         # generate `files` (special directories) directly from the file system
-        my @bins      = ls-files($prefix, 'bin');
-        my @resources = ls-files($prefix, 'resources');
+        my @bins      = grep *.IO.f, Rakudo::Internals.DIR-RECURSE( $prefix.child('bin').absolute );
+        my @resources = grep *.IO.f, Rakudo::Internals.DIR-RECURSE( $prefix.child('resources').absolute );
         my @files     = grep *.defined, unique(|$meta<files>, |@bins, |@resources);
         $meta<files>  = @files;
 

--- a/src/core/Rakudo/Internals.pm
+++ b/src/core/Rakudo/Internals.pm
@@ -1157,6 +1157,16 @@ my class Rakudo::Internals {
           !! path;
     }
 
+    method DIR-RECURSE(Str(Cool) \abspath, Mu :$test = none(<. .. .precomp>)) {
+        my @paths = Rakudo::Internals.FILETEST-E(abspath)
+            ?? dir(abspath, :$test)
+            !! ();
+        gather while ( @paths.pop ) -> Str(Cool) $path {
+            @paths.append( dir($path, :$test) ) if Rakudo::Internals.FILETEST-D($path);
+            take $path;
+        }
+    }
+
     method FILETEST-E(Str:D \abspath) {
         nqp::stat(nqp::unbox_s(abspath),nqp::const::STAT_EXISTS)
     }


### PR DESCRIPTION
Directory recursion is used in at least 2 internal locations, and this aims to consolidate that behavior