### PR TITLE
Reject signatures with both slurpy parameters and default values.

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -4665,7 +4665,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
         my $quant := $<quant>;
         if $<default_value> {
             my $name := %*PARAM_INFO<variable_name> // '';
-            if $quant eq '*' {
+            if $quant eq '*' || $quant eq '|' {
                 $/.CURSOR.typed_sorry('X::Parameter::Default', how => 'slurpy',
                             parameter => $name);
             }


### PR DESCRIPTION
Closes MoarVM's [145 ticket](https://github.com/MoarVM/MoarVM/issues/145).
Comes with [roasted tests](https://github.com/perl6/roast/pull/144).