### PR TITLE
Dissallow control commands (next, return, etc) in toplevel REPL

### DIFF
--- a/t/02-rakudo/repl.t
+++ b/t/02-rakudo/repl.t
@@ -166,4 +166,12 @@ my @input-lines;
         'Print-time error error gives the expected error';
 }
 
+{
+    for <return redo next last warn proceed succeed> -> $cmd {
+        @input-lines = $cmd;
+        like feed_repl_with(@input-lines), / "Control flow commands not allowed in topleve" /,
+            "Raises error when you run control flow command '$cmd'";
+    }
+}
+
 done-testing;


### PR DESCRIPTION
Addresses RT#127631

* Catch control usage and show error
* Switch to instance attributes for out-of-band control values
* Merge partial-eval and repl-eval to simplify
* Add to repl tests
