### PR TITLE
Temporarily skip REPL completions for jvm

### DIFF
--- a/src/core/REPL.pm
+++ b/src/core/REPL.pm
@@ -115,9 +115,12 @@ do {
     }
 
     my role Completions {
-        has @!completions = CORE::.keys.flatmap({
-            /^ "&"? $<word>=[\w* <.lower> \w*] $/ ?? ~$<word> !! []
-        }).sort;
+        # RT #129092: jvm can't do CORE::.keys
+        has @!completions = $*VM.name eq 'jvm'
+            ?? ()
+            !! CORE::.keys.flatmap({
+                    /^ "&"? $<word>=[\w* <.lower> \w*] $/ ?? ~$<word> !! []
+                }).sort;
 
         method update-completions {
             my $context := self.compiler.context;


### PR DESCRIPTION
Fixes (well... works-around) RT#129020, REPL not working for jvm at all.

Per RT#129092, jvm doesn't currently handle `CORE::.keys`, so loading up completions crashes the REPL startup.