### PR TITLE
Add :close flag to IO::Handle.slurp-rest

### DIFF
--- a/src/core/IO/Handle.pm
+++ b/src/core/IO/Handle.pm
@@ -698,7 +698,8 @@ my class IO::Handle does IO {
     }
 
     proto method slurp-rest(|) { * }
-    multi method slurp-rest(IO::Handle:D: :$bin! where *.so) returns Buf {
+    multi method slurp-rest(IO::Handle:D: :$bin! where *.so, :$close) returns Buf {
+        LEAVE self.close if $close;
         my $res := buf8.new;
         loop {
             my $buf := nqp::readfh($!PIO,buf8.new,0x100000);
@@ -707,7 +708,8 @@ my class IO::Handle does IO {
               !! return $res
         }
     }
-    multi method slurp-rest(IO::Handle:D: :$enc, :$bin) returns Str {
+    multi method slurp-rest(IO::Handle:D: :$enc, :$bin, :$close) returns Str {
+        LEAVE self.close if $close;
         self.encoding($enc) if $enc.defined;
         nqp::p6box_s(nqp::readallfh($!PIO));
     }


### PR DESCRIPTION
`slurp` closes files automatically, whereas various other methods (`lines`, `words`, `comb`, ...) require a `:close` flag. I went with the flag to maintain backwards compatibility.