### PR TITLE
Avoid leaking file handles during precompilation

### DIFF
--- a/src/core/CompUnit/PrecompilationStore/File.pm
+++ b/src/core/CompUnit/PrecompilationStore/File.pm
@@ -43,7 +43,10 @@ class CompUnit::PrecompilationStore::File does CompUnit::PrecompilationStore {
 
         method bytecode(--> Buf) {
             self!read-dependencies;
-            $!bytecode //= $!file.slurp-rest(:bin)
+            $!bytecode //= do {
+                LEAVE $!file.close;
+                $!file.slurp-rest(:bin);
+            }
         }
 
         method bytecode-handle(--> IO::Handle) {

--- a/src/core/CompUnit/Repository/FileSystem.pm
+++ b/src/core/CompUnit/Repository/FileSystem.pm
@@ -60,7 +60,11 @@ class CompUnit::Repository::FileSystem does CompUnit::Repository::Locally does C
                     [~]
                     map    {
                         my $handle := $_.IO.open;
-                        $handle ?? nqp::sha1($handle.slurp-rest(:enc<latin1>)) !! ''
+                        if $handle {
+                            LEAVE $handle.close;
+                            nqp::sha1($handle.slurp-rest(:enc<latin1>));
+                        }
+                        else { '' }
                     },
                     grep   {
                         try Rakudo::Internals.FILETEST-F($_)


### PR DESCRIPTION
Sadly, this does not fix an issue I'm having on win32 where `nqp::rename` fails during precompilation :(