### PR TITLE
Print a newline after the message when using 'warn'

### DIFF
--- a/src/core/Exception.pm
+++ b/src/core/Exception.pm
@@ -364,6 +364,7 @@ do {
               (my Mu $err := nqp::getstderr),
               (my str $msg = nqp::getmessage($ex)),
               nqp::printfh($err,nqp::if(nqp::chars($msg),$msg,"Warning")),
+              nqp::printfh($err, "\n"),
               nqp::printfh($err, $backtrace.first-none-setting-line),
               nqp::resume($ex)
             )


### PR DESCRIPTION
Streamline the behaviour so now it's consistent across die, note and
warn.