### PR TITLE
Fix the x operator for large count values

### DIFF
--- a/src/core/Str.pm
+++ b/src/core/Str.pm
@@ -2093,9 +2093,16 @@ multi sub infix:<~>(str $a, str $b) returns str { nqp::concat($a, $b) }
 multi sub infix:<~>(*@args) returns Str:D { @args.join }
 
 multi sub infix:<x>(Str:D $s, Int:D $repetition) returns Str:D {
-    nqp::if(nqp::islt_i($repetition, 0),
+    my Int $max = int.Range.max;
+    nqp::if(
+        nqp::islt_I(nqp::decont($repetition), 0),
         '',
-        nqp::p6box_s(nqp::x(nqp::unbox_s($s), nqp::unbox_i($repetition))))
+        nqp::if(
+            nqp::isgt_I(nqp::decont($repetition), nqp::decont($max)),
+            nqp::p6box_s(nqp::x(nqp::unbox_s($s), nqp::unbox_i($max))),
+            nqp::p6box_s(nqp::x(nqp::unbox_s($s), nqp::unbox_i($repetition)))
+        )
+    )
 }
 multi sub infix:<x>(str $s, int $repetition) returns str {
     nqp::if(nqp::islt_i($repetition, 0), '', nqp::x($s, $repetition))


### PR DESCRIPTION
There are two changes in this commit. The first is a fix to the initial
check that the count is greater than 0. The change in 586f784 meant that
large count values could overflow the native int size and become negative
numbers, thus not correctly passing the check and instead returning an
empty string.

However, before that change large values would instead overflow when
passed to nqp::x, which actually performs the string repetition. So the
second change is to check if the value passed in is larger than an int.
If so, use the max size of an int instead. The nqp::x op has an arbitrary
limit of 1073741824 (2**30), so it will error out, but if any changes to
that limit in NQP are made later, they should get picked up automatically.

See http://irclog.perlgeek.de/perl6-dev/2016-09-04#i_13148294 and
http://irclog.perlgeek.de/perl6-dev/2016-09-04#i_13148630 for some
discussion.

Fixes RT #128035
