### PR TITLE
Make sure to always ACCEPT the enum elements.

### DIFF
--- a/src/core/Enumeration.pm
+++ b/src/core/Enumeration.pm
@@ -21,6 +21,9 @@ my role Enumeration {
     multi method Numeric(::?CLASS:D:) { $!value.Numeric }
     multi method Int(::?CLASS:D:)     { $!value.Int }
 
+    # Make sure we always accept any element of the enumeration
+    multi method ACCEPTS(::?CLASS:D: ::?CLASS:U) { True }
+
     method CALL-ME(|) {
         my $x := nqp::atpos(nqp::p6argvmarray(), 1).AT-POS(0);
         nqp::istype($x, ::?CLASS)


### PR DESCRIPTION
As shown in RT#129160 if we try to use an enumeration element as a type
for an optional parameter like in the following example we end up with a
type mismatch between Int:D and Foo.
To actually understand what goes wrong we simply have to look at the
backtrace: the ACCEPT method that the binder calls is the one from the
Numeric role (since enums have Int as base type by default) which in
turn calls the infix:<==> operator which in turn calls Bridge.
This is where things go south as we actually fail to bind a (Option)
type object to a Int:D, causing the error shown in the bug report.
The solution is to simply catch this edge case and let the base type
handle all the other ones in a similar manner to what we already do for
Bool.

```perl6
enum Options(<Foo Bar>); (sub f(Foo $o?){ ... })()
```

Some additional tests to show how the enum behave, compared with Bool

```perl6
use Test;
ok Bool.ACCEPTS(True);
ok True.ACCEPTS(Bool);
enum En(<Foo>);
ok En.ACCEPTS(Foo);
ok Foo.ACCEPTS(En);
```