### PR TITLE
Containerize only if needed when calling item() on Iterable.

### DIFF
--- a/src/core/Iterable.pm
+++ b/src/core/Iterable.pm
@@ -11,8 +11,10 @@ my class X::Invalid::Value { ... }
 my role Iterable {
     method iterator() { ... }
 
-    method item() {
-        nqp::p6bindattrinvres(nqp::create(Scalar), Scalar, '$!value', self)
+    method item(Iterable \item:) is raw {
+        nqp::iscont(item)
+            ?? item
+            !! nqp::p6bindattrinvres(nqp::create(Scalar), Scalar, '$!value', item)
     }
 
     method flat(Iterable:D:) {


### PR DESCRIPTION
**DO NOT MERGE YET**, I do see a single spectest failure in `repl.t` but am not sure if it's related to this change (and am really sleepy right now).

Keep in mind that `$.x` gets desugared into `self.x.item` by `p6store`.
As seen in the examples below once the item becomes an object implementing the `Iterable` trait any subsequent call to `$.x` is going to call `Iterable.item()` instead of `Mu.item()` which has quite a different behaviour wrt containerization (as @jnthn pointed out).

```perl6
class :: {has $.x is rw;method a{$.x.item=[];dd $.x;dd $!x}}.new.a
class :: {has $.x is rw;method a{$.x.item={};dd $.x;dd $!x}}.new.a
```

Fixes [RT#128124](https://rt.perl.org/Public/Bug/Display.html?id=128124#ticket-history)