### PR TITLE
Disable grammar errors when running under -e

### DIFF
--- a/src/Perl6/Compiler.nqp
+++ b/src/Perl6/Compiler.nqp
@@ -84,6 +84,7 @@ class Perl6::Compiler is HLL::Compiler {
       -v, --version        display version information
       --stagestats         display time spent in the compilation stages
       --ll-exception       display a low level backtrace on errors
+      --grammar-errors     display grammar errors when running under -e
       --profile[=kind]     write profile information to an HTML file (MoarVM)
                              instrumented - performance measurements (default)
                              heap - record heap snapshots after every

--- a/src/core/Exception.pm
+++ b/src/core/Exception.pm
@@ -570,7 +570,7 @@ my role X::Comp is Exception {
                 !! "$.message\nat line $.line"
               !! "$.message\nat $.filename():$.line";
             $r ~= "\n------> $green$.pre$yellow$eject$red$.post$clear" if defined $.pre;
-            if $expect && @.highexpect {
+            if $expect && @.highexpect && !($*PROGRAM-NAME eq '-e' and !Rakudo::Internals.GRAMMAR-ERRORS) {
                 $r ~= "\n    expecting any of:";
                 for @.highexpect {
                     $r ~= "\n        $_";

--- a/src/core/Rakudo/Internals.pm
+++ b/src/core/Rakudo/Internals.pm
@@ -811,6 +811,11 @@ my class Rakudo::Internals {
              }
           !! nqp::list()
     }
+    method GRAMMAR-ERRORS() {
+        nqp::existskey($compiling-options, 'grammar-errors')
+          ?? '--grammar-errors'
+          !! Empty
+    }
 
 #?if moar
     method PRECOMP-EXT()    { "moarvm" }

--- a/src/main.nqp
+++ b/src/main.nqp
@@ -26,6 +26,7 @@ my @clo := $comp.commandline_options();
 @clo.push('c');
 @clo.push('I=s');
 @clo.push('M=s');
+@clo.push('grammar-errors');
 
 # Set up END block list, which we'll run at exit.
 nqp::bindhllsym('perl6', '@END_PHASERS', []);


### PR DESCRIPTION
This disables the 'expecting any of' error message when running under
-e. E.g., running 'p6 -e "/sadf\/"' usually produces this error:
===SORRY!===
Regex not terminated.
at -e:1
------> /sadf\/⏏<EOL>
Unable to parse regex; couldn't find final '/'
at -e:1
------> /sadf\/⏏<EOL>
    expecting any of:
        infix stopper
    term

With this patch the error is instead just:
===SORRY!===
Regex not terminated.
at -e:1
------> /sadf\/⏏<EOL>
Unable to parse regex; couldn't find final '/'
at -e:1
------> /sadf\/⏏<EOL>

However, it also adds a command line switch '--grammar-errors' which
can be used to turn them back on. Behavior when running a file, e.g.,
'perl6 script.p6' is unchanged.

Implements RT #128969
