### PR TITLE
Use '+=' and '-=' instead of postfix ops

### DIFF
--- a/lib/Test.pm6
+++ b/lib/Test.pm6
@@ -339,9 +339,11 @@ multi sub subtest(&subtests, $desc = '') is export {
     _push_vars();
     _init_vars();
     $indents ~= "    ";
-    $subtest_level++;
+    ## TODO: remove workaround for rakudo-j RT #128123 when postfix:<++> does not die here
+    $subtest_level += 1;
     subtests();
-    $subtest_level--;
+    ## TODO: remove workaround for rakudo-j RT #128123 when postfix:<--> does not die here
+    $subtest_level -= 1;
     done-testing() if nqp::iseq_i($done_testing_has_been_run,0);
     my $status =
       $num_of_tests_failed == 0 && $num_of_tests_planned == $num_of_tests_run;


### PR DESCRIPTION
This is a workaround for rakudo-j, because postfix:<++>
and postfix:<--> are dying here:
https://rt.perl.org/Ticket/Display.html?id=128123#txn-1422445