### PR TITLE
Make Cool.trans work the same as Str.trans

### DIFF
--- a/src/core/Cool.pm
+++ b/src/core/Cool.pm
@@ -128,7 +128,7 @@ my class Cool { # declared in BOOTSTRAP
     method flip() {
         self.Str.flip
     }
-    method trans(*@a) { self.Str.trans(@a) }
+    method trans(|c) { self.Str.trans(|c) }
 
     proto method starts-with(|) {*}
     multi method starts-with(Cool:D: Str(Cool) $needle) {


### PR DESCRIPTION
Cool.trans coerces the invovant to Str and then directly calls
Str.trans. The way this is done causes adverbs, if specified, to
be thrown away. We must ensure that the these parameters are sent
to Str.trans and not being thrown away. A couple of changes
suggested by Zoffix++ takes care of this problem.