### PR TITLE
Set the default encoding for IO::Handle to 'utf8'

### DIFF
--- a/src/core/IO/Handle.pm
+++ b/src/core/IO/Handle.pm
@@ -8,7 +8,7 @@ my class IO::Handle does IO {
     has $.chomp is rw = Bool::True;
     has $.nl-in = ["\x0A", "\r\n"];
     has Str:D $.nl-out is rw = "\n";
-    has str $!encoding;
+    has str $!encoding = 'utf8';
 
     method open(IO::Handle:D:
       :$r, :$w, :$x, :$a, :$update,


### PR DESCRIPTION
When an IO::Handle (or IO::Pipe in the case that prompted the RT) is
created the default encoding isn't set. The default is set when .open()
is called, but not .new(), this commit fixes that.

Fixes RT #129296

Passes `make spectest`