### PR TITLE
Revert "Error if No/Nl chars are used in colon pairs/radix"

### DIFF
--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -3410,11 +3410,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
     }
 
     token rad_number {
-        ':' $<radix> =
-        [
-        || [\d+] <.unsp>?
-        || <:No+:Nl>+ {$/.CURSOR.typed_panic('X::Comp::AdHoc', payload => "Only 'Nd' digits are allowed, not 'No' or 'Nl' numbers", expected => ["colon pair", "radix base"])}
-        ]
+        ':' $<radix> = [\d+] <.unsp>?
         :my $r := nqp::radix(10, $<radix>, 0, 0)[0];
         {}           # don't recurse in lexer
         :dba('number in radix notation')


### PR DESCRIPTION
Reverts rakudo/rakudo#883

See the conversation with @TimToady starting [here](http://irclog.perlgeek.de/perl6-dev/2016-09-26#i_13280449)

tl;dr We don't need to teach people how Unicode works, but if a lot more similar tickets to [RT #129319](https://rt.perl.org/Ticket/Display.html?id=129319) show up we can revisit