### PR TITLE
Fix IO.l throws exception for broken symlink

### DIFF
--- a/src/core/IO/Path.pm
+++ b/src/core/IO/Path.pm
@@ -555,7 +555,7 @@ my class IO::Path is Cool {
     }
 
     method l(--> Bool) {
-        $.e
+        ?Rakudo::Internals.FILETEST-LE($.abspath)
           ?? ?Rakudo::Internals.FILETEST-L($!abspath)
           !! Failure.new(X::IO::DoesNotExist.new(:path(~self),:trying<l>))
     }

--- a/src/core/Rakudo/Internals.pm
+++ b/src/core/Rakudo/Internals.pm
@@ -1252,6 +1252,9 @@ my class Rakudo::Internals {
     method FILETEST-E(Str:D \abspath) {
         nqp::stat(nqp::unbox_s(abspath),nqp::const::STAT_EXISTS)
     }
+    method FILETEST-LE(Str:D \abspath) {
+        nqp::lstat(nqp::unbox_s(abspath),nqp::const::STAT_EXISTS)
+    }
     method FILETEST-D(Str:D \abspath) {
         my int $d = nqp::stat(nqp::unbox_s(abspath),nqp::const::STAT_ISDIR);
         nqp::isge_i($d,0)


### PR DESCRIPTION
Fixes RT#129162