### PR TITLE
Fix for RT #129321

### DIFF
--- a/src/core/metaops.pm
+++ b/src/core/metaops.pm
@@ -682,7 +682,7 @@ multi sub nodemap(\op, Associative \h) {
 
 proto sub duckmap(|) { * }
 multi sub duckmap(\op, \obj) {
-    nodemap(-> \arg { try { op.(arg) } // try { duckmap(op,arg) } }, obj);
+    nodemap(sub (\arg) { CATCH { return arg ~~ Iterable:D ?? duckmap(op,arg) !! arg }; op.(arg); }, obj);
 }
 
 multi sub duckmap(\op, Associative \h) {


### PR DESCRIPTION
Under some circumstances duckmap could recurse indefinitely. The problem
was that if the expression returned undef for an argument the code would
gladly take the same argument, which caused the problem, and call
duckmap again leading to a hang or OOM condition. After a discussion with
with TimToady++ in #perl6 he came up with a solution to the problem which
is what this commit contains.