### PR TITLE
Prevent a segfault on deref of null typed pointer

### DIFF
--- a/lib/NativeCall/Types.pm6
+++ b/lib/NativeCall/Types.pm6
@@ -33,7 +33,12 @@ our class Pointer                               is repr('CPointer') {
         nqp::p6box_i(nqp::unbox_i(nqp::decont(self)))
     }
 
-    method deref(::?CLASS:D \ptr:) { nativecast(void, ptr) }
+    proto method Bool() {*}
+    multi method Bool(::?CLASS:U: --> False) { }
+    multi method Bool(::?CLASS:D:) { so self.Int }
+
+
+    method deref(::?CLASS:D \ptr:) { self ?? nativecast(void, ptr) !! fail("Can't dereference a Null Pointer") }
 
     multi method gist(::?CLASS:U:) { '(' ~ self.^name ~ ')' }
     multi method gist(::?CLASS:D:) {
@@ -50,7 +55,7 @@ our class Pointer                               is repr('CPointer') {
 
     my role TypedPointer[::TValue] {
         method of() { TValue }
-        method deref(::?CLASS:D \ptr:) { nativecast(TValue, ptr) }
+        method deref(::?CLASS:D \ptr:) { self ?? nativecast(TValue, ptr) !! fail("Can't dereference a Null Pointer"); }
     }
     method ^parameterize(Mu:U \p, Mu:U \t) {
         die "A typed pointer can only hold integers, numbers, strings, CStructs, CPointers or CArrays (not {t.^name})"


### PR DESCRIPTION
fail rather than return a type object for null deref

Stops

perl6 -e 'use NativeCall; my $a = Pointer[int32].new; say $a.deref'
Segmentation fault (core dumped)

Also add a better Bool coercion for Pointer

This is a rework of #769