### PR TITLE
Fail with typed errors if nqp::open dies in IO::Handle.open.

### DIFF
--- a/src/core/Exception.pm
+++ b/src/core/Exception.pm
@@ -467,6 +467,14 @@ my class X::IO::DoesNotExist does X::IO {
     }
 }
 
+my class X::IO::DoesExist does X::IO {
+    has $.path;
+    has $.trying;
+    method message() {
+        "Found preexisting file '$.path' while trying to do '.$.trying'"
+    }
+}
+
 my class X::IO::NotAFile does X::IO {
     has $.path;
     has $.trying;

--- a/src/core/IO/Handle.pm
+++ b/src/core/IO/Handle.pm
@@ -94,7 +94,9 @@ my class IO::Handle does IO {
         {
             CATCH {
                 fail X::IO::DoesNotExist.new(:$!path, :trying<open>)
-                    unless $!path.e;
+                    unless $create || $!path.e;
+                fail X::IO::DoesExist.new(:$!path, :trying<open>)
+                    if $exclusive && $!path.e;
                 fail X::IO::Directory.new(:$!path, :trying<open>)
                     if $!path.d;
                 fail X::IO.new(:os-error(.message));


### PR DESCRIPTION
Also removes an expensive check necessary to avoid opening directories:
This is now handled at the VM level, which still needs to happen on the JVM (cf https://github.com/perl6/nqp/issues/310).

It could be made even nicer if there was a way to communicate error types to the HLL, eg via error codes provided in addition to the error message. Currently, we're forced to (non-atomically) repeat checks that already have been performed at the VM level (or parse error messages).
