### PR TITLE
Remove pod instructions specific to Perl6 pod

### DIFF
--- a/docs/running.pod
+++ b/docs/running.pod
@@ -1,5 +1,3 @@
-=begin pod
-
 =head1 NAME
 
 perl6 - Rakudo Perl 6 Compiler
@@ -147,5 +145,3 @@ Written by the Rakudo contributors, see the CREDITS file.
 
 This manual page was written by Reini Urban, Moritz Lenz and the Rakudo
 contributors.
-
-=end pod


### PR DESCRIPTION
With PR #751 , the file docs/running.pod became a Perl6 pod document (because of =begin pod).

This [breaks man page generation](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=839059) on Debian build.

According to @niner, this switch is not intentional. Hence this PR.