### PR TITLE
Add the S32-list/cross.t to the spectest.data

### DIFF
--- a/t/spectest.data
+++ b/t/spectest.data
@@ -973,6 +973,7 @@ S32-list/categorize-list.t
 S32-list/classify.t
 S32-list/classify-list.t
 S32-list/create.t
+S32-list/cross.t
 S32-list/combinations.t
 S32-list/duckmap.t
 S32-list/end.t


### PR DESCRIPTION
Re https://github.com/perl6/roast/issues/165