### PR TITLE
Add shortname() method to CurriedRoleHOW

### DIFF
--- a/src/Perl6/Metamodel/CurriedRoleHOW.nqp
+++ b/src/Perl6/Metamodel/CurriedRoleHOW.nqp
@@ -150,4 +150,11 @@ class Perl6::Metamodel::CurriedRoleHOW
         
         0;
     }
+
+    method shortname($curried_role) {
+        $curried_role.HOW.name($curried_role);
+    }
+
 }
+
+# vim: expandtab sw=4


### PR DESCRIPTION
Fixes RT #129830

Passes `make spectest`