### PR TITLE
Throw when attempting to use .contains() on Lists

### DIFF
--- a/src/core/List.pm
+++ b/src/core/List.pm
@@ -1,4 +1,5 @@
 # for our tantrums
+my class X::Obsolete { ... }
 my class X::TypeCheck::Splice { ... }
 my class Supplier { ... }
 
@@ -475,6 +476,14 @@ my class List does Iterable does Positional { # declared in BOOTSTRAP
           # no args, an empty list suffices
           nqp::create(self)
         )
+    }
+
+    method contains (|) {
+        fail X::Obsolete.new(
+            :old('.contains()'),
+            :when('to find whether a list contains an element'),
+            :replacement('.first() or create and smartmatch with an any() Junction'),
+        );
     }
 
     method new(**@things) {


### PR DESCRIPTION
Due to Lists being Cool, the .contains() method is available on them. However, it's of dubious utility, considering the List will be stringified.

IMO, this is a source of bugs, as it may be natural for a programmer to try a trivial example to see if the method "works" and just assume that .contains() on lists checks element membership. Consider:

    say [^100].contains: 42;           # True
    say <foo bar ber>.contains: "foo"; # True

What actually happens is the list gets stringified and the resultant string is searched
for the given argument, which is also stringified:

    say ("a"…"z").contains: "nop".comb; # True
    say [1..100].contains("98 99");     # True

Moreover, some languages (e.g. Swift), do provide a `.contains()` method that *does* check membership of an element in a list, making people used to such languages even more prone to introducing bugs into their code by incorrectly using Perl 6's `.contains()`

Due to non-obvious actual behaviour of this method on Lists, I propose we throw when
such usage is attempted. Example of throwage this PR provides:

```
cpan@perlbuild2~/CPANPRC/rakudo (throw-list-contains)$ ./perl6 -e '[].contains: 42'
Unsupported use of .contains(); to find whether a list contains an element please use .first() or create and smartmatch with an any() Junction
  in block <unit> at -e line 1

Actually thrown at:
  in block <unit> at -e line 1

cpan@perlbuild2~/CPANPRC/rakudo (throw-list-contains)$ 
```