### PR TITLE
Improved behavior for symmetric difference

### DIFF
--- a/src/core/set_operators.pm
+++ b/src/core/set_operators.pm
@@ -1,4 +1,3 @@
-use nqp;
 
 proto sub infix:<(elem)>($, $ --> Bool) is pure {*}
 multi sub infix:<(elem)>($a, Any $b --> Bool) {
@@ -138,12 +137,37 @@ only sub infix:<∖>(|p) is pure {
     infix:<(-)>(|p);
 }
 
-proto sub infix:<(^)>(|c) is pure {*}
-multi sub infix:<(^)>($a, $b) is pure {
-    ($a (-) $b) (+) ($b (-) $a)
-}
-multi sub infix:<(^)>(**@p) is pure {
-    Set.new(BagHash.new(@p.map(*.Set(:view).keys.Slip)).pairs.map({.key if .value == 1}));
+only sub infix:<(^)>(**@p) is pure {
+    return set() unless my $chain = @p.elems;
+
+    if $chain == 1 {
+        return @p[0];
+    } elsif $chain == 2 {
+        my ($a, $b) = @p;
+        if nqp::istype($a, Mixy) || nqp::istype($b, Mixy) {
+            ($a, $b) = $a.MixHash, $b.MixHash;
+        } elsif nqp::istype($a, Baggy) || nqp::istype($b, Baggy) {
+            ($a, $b) = $a.BagHash, $b.BagHash;
+        }
+        return  ($a (|) $b) (-) ($b (&) $a);
+    } else {
+        my $head;
+        while (@p) {
+            my ($a, $b);
+            if $head.defined {
+                ($a, $b) = $head, @p.shift;
+            } else {
+                ($a, $b) = @p.shift, @p.shift;
+            }
+            if nqp::istype($a, Mixy) || nqp::istype($b, Mixy) {
+                ($a, $b) = $a.MixHash, $b.MixHash;
+            } elsif nqp::istype($a, Baggy) || nqp::istype($b, Baggy) {
+                ($a, $b) = $a.BagHash, $b.BagHash;
+            }
+            $head = ($a (|) $b) (-) ($b (&) $a);
+        }
+        return $head;
+    }
 }
 # U+2296 CIRCLED MINUS
 only sub infix:<⊖>($a, $b --> Setty) is pure {

--- a/src/core/set_operators.pm
+++ b/src/core/set_operators.pm
@@ -1,3 +1,4 @@
+use nqp;
 
 proto sub infix:<(elem)>($, $ --> Bool) is pure {*}
 multi sub infix:<(elem)>($a, Any $b --> Bool) {
@@ -136,7 +137,12 @@ only sub infix:<(-)>(**@p) is pure {
 only sub infix:<∖>(|p) is pure {
     infix:<(-)>(|p);
 }
-only sub infix:<(^)>(**@p) is pure {
+
+proto sub infix:<(^)>(|c) is pure {*}
+multi sub infix:<(^)>($a, $b) is pure {
+    ($a (-) $b) (+) ($b (-) $a)
+}
+multi sub infix:<(^)>(**@p) is pure {
     Set.new(BagHash.new(@p.map(*.Set(:view).keys.Slip)).pairs.map({.key if .value == 1}));
 }
 # U+2296 CIRCLED MINUS

--- a/src/core/set_operators.pm
+++ b/src/core/set_operators.pm
@@ -170,7 +170,7 @@ only sub infix:<(^)>(**@p) is pure {
     }
 }
 # U+2296 CIRCLED MINUS
-only sub infix:<⊖>($a, $b --> Setty) is pure {
+only sub infix:<⊖>($a, $b) is pure {
     $a (^) $b;
 }
 


### PR DESCRIPTION
Previously the symmetric difference operator would only return a `Set`. This is in contrast to some fudged tests and (likely) against expectations of DWIMiness by the user.

This patch changes the behavior such that chained symmetric difference invocations will evaluate one pair at a time. This changes the expectations found in the `S03-operators/set.t` tests, which appeared to be doing some form of conjoined evaluation.

Instead, the results look like:

````````
$s (^) $s (^) $s == $s; # returns True
````````

Step by step:

````````
$s (^) $s; # returns set(), there were zero items appearing in only one of the two sets
set() (^) $s; # returns $s, because all items in $s are missing from the empty set
````````

This also means that `Mix` and `Bag` symmetric difference operations can be sensibly chained:

```````
my $m = ( :x(4.4), :y(5.5), :z(6.6) ).Mix;
my $b = ( :x(4), :y(5), :z(6) ).Bag;
$m (^) $b; # returns mix( :x(0.4), :y(0.5), :z(0.6) )
$m (^) $b (^) $b;  # returns mix( :x(3.6), :y(4.5), :z(5.4) )

my $s = ( :x, :y, :z ).Set;
$m (^) $b (^) $b (^) $s;  # returns mix( :x(2.6), :y(3.5), :z(4.4) )
```````

Symmetric difference is not actually symmetric when chained (order matters). This patch takes a "higher orders of complexity have priority" approach. You could also argue that it is `Set` which should have precedence over `Mix` or `Bag`, such that:

```````
$m (^) $b (^) $b (^) $s;  # returns set()
```````

All the keys in `$s` are present in the symmetric difference of `$m (^) $b (^) $b`, so the result is an empty set.

In my opinion we lose a lot of the utility of `(^)` if we take this set-centric approach, but I felt it worth mentioning in case someone has strong opinions in the other direction.