### PR TITLE
RT#129363: duckmap preserve structure types

### DIFF
--- a/src/core/metaops.pm
+++ b/src/core/metaops.pm
@@ -514,7 +514,7 @@ proto sub coremap(|) { * }
 
 multi sub coremap(\op, Associative \h, Bool :$deep) {
     my @keys = h.keys;
-    hash @keys Z coremap(op, h{@keys}, deep => $deep)
+    hash @keys Z coremap(op, h{@keys}, :$deep)
 }
 
 multi sub coremap(\op, \obj, Bool :$deep) {
@@ -559,10 +559,8 @@ multi sub coremap(\op, \obj, Bool :$deep) {
                                     $deep,
                                     nqp::if(
                                         nqp::istype($value, Iterable),
-                                        nqp::stmts(
-                                            ($result := coremap(&!block, $value, deep => $deep).item),
-                                        ),
-                                        ($result := &!block($value)),
+                                        ($result := coremap(&!block, $value, :$deep).item),
+                                        ($result := &!block($value))
                                     ),
                                     ($result := &!block($value))
                                 ),

--- a/tools/build/jvm_core_sources
+++ b/tools/build/jvm_core_sources
@@ -11,8 +11,8 @@ src/core/Stringy.pm
 src/core/Any.pm
 src/core/Attribute.pm
 src/core/Iterator.pm
-src/core/Rakudo/Internals.pm
 src/core/SlippyIterator.pm
+src/core/Rakudo/Internals.pm
 src/core/HyperIterator.pm
 src/core/Iterable.pm
 src/core/HyperIterable.pm

--- a/tools/build/moar_core_sources
+++ b/tools/build/moar_core_sources
@@ -11,8 +11,8 @@ src/core/Stringy.pm
 src/core/Any.pm
 src/core/Attribute.pm
 src/core/Iterator.pm
-src/core/Rakudo/Internals.pm
 src/core/SlippyIterator.pm
+src/core/Rakudo/Internals.pm
 src/core/HyperIterator.pm
 src/core/Iterable.pm
 src/core/HyperIterable.pm


### PR DESCRIPTION
Implements `deepmap` and `duckmap` in terms of slight modification to the existing `deepmap` code.

Corresponding changes to perl6/roast made in that repo (perl6/roast#180)

Comments welcome!