### PR TITLE
Check for concreteness in p6scalarfromdesc on JVM

### DIFF
--- a/src/vm/jvm/runtime/org/perl6/rakudo/RakOps.java
+++ b/src/vm/jvm/runtime/org/perl6/rakudo/RakOps.java
@@ -370,7 +370,7 @@ public final class RakOps {
     public static SixModelObject p6scalarfromdesc(SixModelObject desc, ThreadContext tc) {
         GlobalExt gcx = key.getGC(tc);
 
-        if (desc == null || desc instanceof TypeObject)
+        if ( Ops.isconcrete(desc, tc) == 0 )
             desc = gcx.defaultContainerDescriptor;
         SixModelObject defVal = desc.get_attribute_boxed(tc, gcx.ContainerDescriptor,
             "$!default", HINT_CD_DEFAULT);


### PR DESCRIPTION
That method looks whether the decontainerized value of desc is
a type object. It handles the 'null' case as well.

Fixes RT #128341 and newly failing tests in S09-multidim/assign.t.