### PR TITLE
Changes needed to support line directives

### DIFF
--- a/src/core/Backtrace.pm
+++ b/src/core/Backtrace.pm
@@ -59,7 +59,7 @@ my class Backtrace::Frame {
         nqp::p6bool(nqp::istype($!code,Routine))
     }
     method is-setting(Backtrace::Frame:D:) {
-        $!file.ends-with("CORE.setting")
+        $!file.contains("src/core")
     }
 }
 

--- a/src/core/Backtrace.pm
+++ b/src/core/Backtrace.pm
@@ -59,7 +59,7 @@ my class Backtrace::Frame {
         nqp::p6bool(nqp::istype($!code,Routine))
     }
     method is-setting(Backtrace::Frame:D:) {
-        $!file.contains("src/core")
+        $!file.starts-with("SETTING::")
     }
 }
 

--- a/tools/build/gen-cat.nqp
+++ b/tools/build/gen-cat.nqp
@@ -20,7 +20,7 @@ sub MAIN(*@ARGS) {
     }
     my $stderr := nqp::getstderr();
     for @ARGS -> $file {
-        say("#line 1 $file\n");
+        say("#line 1 $file");
         my $fh := open($file, :r);
         my int $in_cond := 0;
         my int $in_omit := 0;

--- a/tools/build/gen-cat.nqp
+++ b/tools/build/gen-cat.nqp
@@ -20,7 +20,7 @@ sub MAIN(*@ARGS) {
     }
     my $stderr := nqp::getstderr();
     for @ARGS -> $file {
-        say("#line 1 $file");
+        say("#line 1 SETTING::$file");
         my $fh := open($file, :r);
         my int $in_cond := 0;
         my int $in_omit := 0;


### PR DESCRIPTION
An extra blank line after a directive throws off the numbering.

The m-CORE.setting file is no longer seen in a backtrace, so we need
another way of determining if we are in the settings. This isn't a
great solution, but should work for now.

Requires https://github.com/perl6/nqp/pull/319

With the NQP PR, passes `make spectest`