### PR TITLE
Remove bandaid for r-j, native attribute works now

### DIFF
--- a/src/core/Rakudo/Internals.pm
+++ b/src/core/Rakudo/Internals.pm
@@ -388,12 +388,7 @@ my class Rakudo::Internals {
     method IterateNextNFromIterator(\iterator,\times) {
         class :: does Iterator {
             has $!iterator;
-#?if !jvm
             has int $!times;
-#?endif
-#?if jvm
-            has Int $!times;
-#?endif
             method !SET-SELF($!iterator,$!times) { self }
             method new(\i,\t) { nqp::create(self)!SET-SELF(i,t) }
             method pull-one() is raw {


### PR DESCRIPTION
psch++ for implementing attributive parameter binding on the JVM