### PR TITLE
Remove no longer required special case for r-j

### DIFF
--- a/src/core/Failure.pm
+++ b/src/core/Failure.pm
@@ -67,13 +67,7 @@ my class Failure is Nil {
        )
     }
 
-#?if moar
     method Int(Failure:D:)        { $!handled ?? Int !! self!throw(); }
-#?endif
-#?if jvm
-    method Int(Failure:D:)        { $!handled ?? 0   !! self!throw(); }
-#?endif
-
     method Num(Failure:D:)        { $!handled ?? NaN !! self!throw(); }
     method Numeric(Failure:D:)    { $!handled ?? NaN !! self!throw(); }
     multi method Str(Failure:D:)  { $!handled ?? $.mess !! self!throw(); }


### PR DESCRIPTION
I was unable to find out why this special case was needed back in 2015.
A spectest run looked good on rakudo-j (no new failures).