### PR TITLE
Make sure Readline loads inputrc config files

### DIFF
--- a/src/core/REPL.pm
+++ b/src/core/REPL.pm
@@ -54,12 +54,15 @@ do {
     my role ReadlineBehavior[$WHO] {
         my &readline    = $WHO<&readline>;
         my &add_history = $WHO<&add_history>;
-
+        my $Readline = try { require Readline }
+        my $read = $Readline.new;
+        $read.read-init-file("/etc/inputrc");
+        $read.read-init-file("~/.inputrc");
         method repl-read(Mu \prompt) {
-            my $line = readline(prompt);
+            my $line = $read.readline(prompt);
 
             if $line.defined {
-                add_history($line);
+                $read.add_history($line);
             }
 
             $line

--- a/src/core/REPL.pm
+++ b/src/core/REPL.pm
@@ -56,8 +56,10 @@ do {
         my &add_history = $WHO<&add_history>;
         my $Readline = try { require Readline }
         my $read = $Readline.new;
-        $read.read-init-file("/etc/inputrc");
-        $read.read-init-file("~/.inputrc");
+        if ! $*DISTRO.is-win {
+            $read.read-init-file("/etc/inputrc");
+            $read.read-init-file("~/.inputrc");
+        }
         method repl-read(Mu \prompt) {
             my $line = $read.readline(prompt);
 


### PR DESCRIPTION
This fixes an issue where the Readline settings in these files are not applied in Perl 6's REPL, causing some shortcuts not to work like Ctrl + <- or Ctrl + ->
This makes sure on non-Windows platforms we tell Readline to make sure to load these files, so Perl 6 will behave as expected.