### PR TITLE
Fix add history for readline, since the method is called add-history,…

### DIFF
--- a/src/core/REPL.pm
+++ b/src/core/REPL.pm
@@ -64,7 +64,7 @@ do {
             my $line = $read.readline(prompt);
 
             if $line.defined {
-                $read.add_history($line);
+                $read.add-history($line);
             }
 
             $line


### PR DESCRIPTION
… it's the function that's called add_history