### PR TITLE
Better error message for assigning to ro variable

### DIFF
--- a/src/vm/jvm/runtime/org/perl6/rakudo/RakudoContainerSpec.java
+++ b/src/vm/jvm/runtime/org/perl6/rakudo/RakudoContainerSpec.java
@@ -41,8 +41,15 @@ public class RakudoContainerSpec extends ContainerSpec {
             rw = tc.native_i;
         }
         if (rw == 0)
-            throw ExceptionHandling.dieInternal(tc,
-                "Cannot assign to a readonly variable or a value");
+            if (desc != null) {
+                desc.get_attribute_native(tc, gcx.ContainerDescriptor, "$!name", RakOps.HINT_CD_NAME);
+                throw ExceptionHandling.dieInternal(tc,
+                    "Cannot assign to a readonly variable (" + tc.native_s  + ") or a value");
+            }
+            else {
+                throw ExceptionHandling.dieInternal(tc,
+                    "Cannot assign to a readonly variable or a value");
+            }
 
         if (value.st.WHAT == gcx.Nil) {
             value = desc.get_attribute_boxed(tc,

--- a/src/vm/moar/ops/container.c
+++ b/src/vm/moar/ops/container.c
@@ -79,7 +79,10 @@ static void rakudo_scalar_store(MVMThreadContext *tc, MVMObject *cont, MVMObject
     if (rcd && IS_CONCRETE(rcd))
         rw = rcd->rw;
     if (!rw)
-        MVM_exception_throw_adhoc(tc, "Cannot assign to a readonly variable or a value");
+        if (rcd && IS_CONCRETE(rcd) && rcd->name)
+            MVM_exception_throw_adhoc(tc, "Cannot assign to a readonly variable (%s) or a value", MVM_string_utf8_encode_C_string(tc, rcd->name));
+        else
+            MVM_exception_throw_adhoc(tc, "Cannot assign to a readonly variable or a value");
 
     /* Handle Nil and type-checking. */
     if (!obj) {


### PR DESCRIPTION
If possible, include the name of the variable that was assigned to.

Builds for MoarMV and JVM, passes `make m-spectest`.

Inspired by https://irclog.perlgeek.de/perl6/2016-11-29#i_13645399