### PR TITLE
Fix usage message for boolean flags

### DIFF
--- a/src/core/Main.pm
+++ b/src/core/Main.pm
@@ -115,12 +115,14 @@ my sub MAIN_HELPER($retval = 0) {
                     else {
                         my @names  = $param.named_names.reverse;
                         $argument  = @names.map({($^n.chars == 1 ?? '-' !! '--') ~ $^n}).join('|');
-                        $argument ~= "=<{$param.type.^name}>" unless $param.type === Bool;
-                        if Metamodel::EnumHOW.ACCEPTS($param.type.HOW) {
-                            my $options = $param.type.^enum_values.keys.sort.Str;
-                            $argument ~= $options.chars > 50
-                              ?? ' (' ~ substr($options,0,50) ~ '...'
-                              !! " ($options)"
+                        if $param.type !=== Bool {
+                            $argument ~= "=<{$param.type.^name}>";
+                            if Metamodel::EnumHOW.ACCEPTS($param.type.HOW) {
+                                my $options = $param.type.^enum_values.keys.sort.Str;
+                                $argument ~= $options.chars > 50
+                                  ?? ' (' ~ substr($options,0,50) ~ '...'
+                                  !! " ($options)"
+                            }
                         }
                         if $param.optional {
                             @optional-named.push("[$argument]");


### PR DESCRIPTION
They may be enums, but should not list their values