### PR TITLE
Add .gist, .perl, and .Str to BOOTSTRAPATTR

### DIFF
--- a/src/Perl6/Metamodel/BOOTSTRAP.nqp
+++ b/src/Perl6/Metamodel/BOOTSTRAP.nqp
@@ -37,6 +37,9 @@ my class BOOTSTRAPATTR {
         self.new(:name($!name), :box_target($!box_target), :type($ins))
     }
     method compose($obj, :$compiler_services) { }
+    method gist() { $!type.HOW.name($!type) ~ ' ' ~ $!name }
+    method perl() { 'BOOTSTRAPATTR.new' }
+    method Str()  { $!name }
 }
 
 # Stub all types.


### PR DESCRIPTION
Fixes RT77070, https://rt.perl.org/Ticket/Display.html?id=77070

Passes `make m-spectest`