### PR TITLE
Fix unimatch so it checks canonical short/alternate unicode properties

### DIFF
--- a/src/core/Cool.pm
+++ b/src/core/Cool.pm
@@ -509,6 +509,10 @@ multi sub univals(Str:D $str) { $str.ords.map: { unival($_) } }
 
 proto sub unimatch(|) {*}
 multi sub unimatch(Str:D $str, |c) { $str ?? unimatch($str.ord, |c) !! Nil }
+# This multi below can be removed when MoarVM bug #448 is fixed
+multi sub unimatch(Int:D $code, Stringy:D $pvalname, Stringy:D $propname) {
+    so uniprop($code, $propname) eq $pvalname;
+}
 multi sub unimatch(Int:D $code, Stringy:D $pvalname, Stringy:D $propname = $pvalname) {
     my $prop := Rakudo::Internals.PROPCODE($propname);
     so nqp::matchuniprop($code,$prop,Rakudo::Internals.PVALCODE($prop,$pvalname));


### PR DESCRIPTION
If we don't specify a property name to check against unimatch
will still work the same, but if we do supply a property
to check against, call uniprop where the issue is fixed
to resolve the name.

Passes S15-unicode-information/unimatch-general.t