### PR TITLE
Show all roles that have missing method in error message

### DIFF
--- a/src/Perl6/Metamodel/RoleToClassApplier.nqp
+++ b/src/Perl6/Metamodel/RoleToClassApplier.nqp
@@ -108,16 +108,18 @@ my class RoleToClassApplier {
                 if $yada {
                     unless has_method($target, $name, 0)
                             || has_public_attribute($target, $name) {
+                        my @needed;
                         for @roles {
                             for $_.HOW.method_table($_) -> $m {
                                 if $m.key eq $name {
-                                    nqp::die("Method '$name' must be implemented by " ~
-                                             $target.HOW.name($target) ~
-                                             " because it is required by role " ~
-                                             $_.HOW.name($_));
+                                    nqp::push(@needed, $_.HOW.name($_));
                                 }
                             }
                         }
+                        nqp::die("Method '$name' must be implemented by " ~
+                                 $target.HOW.name($target) ~
+                                 " because it is required by roles: " ~
+                                 nqp::join(", ", @needed) ~ ".");
                     }
                 }
                 elsif !has_method($target, $name, 1) {


### PR DESCRIPTION
```
> EVAL 'role R { method overload-this(){...} }; role C { method overload-this(){...} }; class A does R does C {};'; CATCH { default { say .^name, .Str } };
X::Comp::AdHocMethod 'overload-this' must be implemented by A because it is required by roles: C, R.
```
See https://irclog.perlgeek.de/perl6/2016-12-13#i_13732692 for discussion.
cast @zoffixznet.

Tests for https://rt.perl.org/Public/Bug/Display.html?id=130211 depend on approve or reject of this PR, so I'll write one after this PR.