### PR TITLE
Fix {List,Seq,Range}.is-lazy method for type objects invocants

### DIFF
--- a/src/core/List.pm
+++ b/src/core/List.pm
@@ -998,7 +998,7 @@ my class List does Iterable does Positional { # declared in BOOTSTRAP
         self.new(|c);
     }
 
-    method is-lazy() {
+    multi method is-lazy(List:D:) {
         nqp::if(
           $!todo.DEFINITE,
           nqp::stmts(

--- a/src/core/Range.pm
+++ b/src/core/Range.pm
@@ -16,7 +16,7 @@ my class Range is Cool does Iterable does Positional {
         $!is-int   = nqp::istype($!min,Int) && nqp::istype($!max,Int);
         self
     }
-    method is-lazy { self.infinite }
+    multi method is-lazy(Range:D:) { self.infinite }
 
     # The order of "method new" declarations matters here, to ensure
     # appropriate candidate tiebreaking when mixed type arguments

--- a/src/core/Seq.pm
+++ b/src/core/Seq.pm
@@ -60,7 +60,7 @@ my class Seq is Cool does Iterable does PositionalBindFailover {
         )
     }
 
-    method is-lazy(Seq:D:) {
+    multi method is-lazy(Seq:D:) {
         nqp::if(
           $!iter.DEFINITE,
           $!iter.is-lazy,


### PR DESCRIPTION
Before:

```
> List.is-lazy
Cannot look up attributes in a List type object

> Range.is-lazy
Cannot look up attributes in a Range type object

> Seq.is-lazy
Invocant requires an instance of type Seq, but a type object was passed.  Did you forget a .new?
```

After:

```
> say List.is-lazy
False

> say Range.is-lazy
False

> say Seq.is-lazy
False
```
