### PR TITLE
Use #!/usr/bin/env perl instead of #! perl

### DIFF
--- a/Configure.pl
+++ b/Configure.pl
@@ -1,4 +1,4 @@
-#! perl
+#!/usr/bin/env perl
 # Copyright (C) 2009 The Perl Foundation
 
 use 5.10.1;


### PR DESCRIPTION
Unless there is a good reason to keep this, it would be nice
if this was changed for better compatibility.