### PR TITLE
Add S15-nfg/GraphemeBreakPropertyTest.t to spectest.data

### DIFF
--- a/t/spectest.data
+++ b/t/spectest.data
@@ -693,6 +693,7 @@ S15-nfg/crlf-encoding.t         # moar
 S15-nfg/from-buf.t              # moar
 S15-nfg/from-file.t             # moar
 S15-nfg/grapheme-break.t        # moar
+S15-nfg/GraphemeBreakPropertyTest.t # moar
 S15-nfg/long-uni.t              # moar
 S15-nfg/mass-chars.t            # moar
 S15-nfg/many-combiners.t        # moar


### PR DESCRIPTION
I just added this to roast, so let's add it to the spectest.data file.