### PR TITLE
Fix bug in makeUNIPROP.p6 causing it not to generate 2 props

### DIFF
--- a/src/core/Cool.pm
+++ b/src/core/Cool.pm
@@ -446,8 +446,10 @@ multi sub uniprop(Int:D $code, Stringy:D $propname) {
       'ASCII_Hex_Digit','B','Hex_Digit','B','Bidi_Paired_Bracket_Type','S',
       'General_Category','S','Grapheme_Cluster_Break','S','Grapheme_Base','B',
       'Changes_When_Lowercased','B','Name','na','Deprecated','B',
+      'Full_Composition_Exclusion','B','Canonical_Combining_Class','S',
     );
     ## End generated code
+
     # prop-mappings can be removed when MoarVM bug #448 is fixed...
     $propname := nqp::atkey(%prop-mappings, $propname) if nqp::existskey(%prop-mappings,$propname);
     my $prop := Rakudo::Internals.PROPCODE($propname);

--- a/tools/build/makeUNIPROP.pl6
+++ b/tools/build/makeUNIPROP.pl6
@@ -273,6 +273,7 @@ sub create-Str-code {
             print-line qq['$key','{$value<type>}',];
         }
     }
+    print-line('', :flush );
     say '  );';
     say '  ## End generated code';
 }


### PR DESCRIPTION
I forgot to flush the code generator function at the end, so it
ended up missing the last two properties:
'Full_Composition_Exclusion' and 'Canonical_Combining_Class'