### PR TITLE
remove mass-chars.t from spectest.data

### DIFF
--- a/t/spectest.data
+++ b/t/spectest.data
@@ -696,7 +696,6 @@ S15-nfg/from-file.t             # moar
 S15-nfg/grapheme-break.t        # moar
 S15-nfg/GraphemeBreakTest.t     # moar
 S15-nfg/long-uni.t              # moar
-S15-nfg/mass-chars.t            # moar
 S15-nfg/many-combiners.t        # moar
 S15-nfg/many-threads.t          # moar
 S15-nfg/mass-equality.t         # moar


### PR DESCRIPTION
To see why this was removed see:
https://github.com/perl6/roast/commit/3baa4db85abfe21d4df1eb9fc1149fd1f30dda15
    
 This test has been superceeded by the recently added GraphemeBreakTest.t