### PR TITLE
Make Cursor's $!name a str and speed up Cursor.MATCH() by 10-15%

### DIFF
--- a/src/core/Cursor.pm
+++ b/src/core/Cursor.pm
@@ -45,7 +45,7 @@ my class Cursor does NQPCursorRole {
             # For captures with lists, initialize the lists.
             my $caplist := $NO_CAPS;
             my $rxsub   := nqp::getattr(self, Cursor, '$!regexsub');
-            my Mu $onlyname := '';
+            my str $onlyname  = '';
             my int $namecount = 0;
 
             if !nqp::isnull($rxsub) && nqp::defined($rxsub) {
@@ -64,7 +64,7 @@ my class Cursor does NQPCursorRole {
                         if nqp::iterval($curcap) >= 2 {
 #?endif
                             my str $name = nqp::iterkey_s($curcap);
-                            $onlyname := $name if $namecount == 1;
+                            $onlyname = $name if $namecount == 1;
                             nqp::iscclass(nqp::const::CCLASS_NUMERIC, $name, 0)
                                 ?? nqp::bindpos(
                                         nqp::if(nqp::isconcrete($list), $list, ($list := nqp::list())),
@@ -93,19 +93,19 @@ my class Cursor does NQPCursorRole {
                   !! nqp::atkey($hash, $onlyname);
 
                 while nqp::islt_i(++$csi,$cselems) {
-                    my $subcur := nqp::atpos($cs, $csi);
-                    my $name   := nqp::getattr($subcur, $?CLASS, '$!name');
+                    my $subcur  := nqp::atpos($cs, $csi);
+                    my str $name = nqp::getattr_s($subcur, $?CLASS, '$!name');
                     nqp::push($dest,$subcur.MATCH())
-                      if !nqp::isnull($name) && nqp::defined($name);
+                      if !nqp::isnull_s($name) && nqp::defined($name);
                 }
             }
             else {
                 my int $cselems = nqp::elems($cs);
                 my int $csi     = -1;
                 while nqp::islt_i(++$csi,$cselems) {
-                    my Mu $subcur   := nqp::atpos($cs, $csi);
-                    my Mu $name     := nqp::getattr($subcur, $?CLASS, '$!name');
-                    if !nqp::isnull($name) && nqp::defined($name) && $name ne '' {
+                    my Mu $subcur := nqp::atpos($cs, $csi);
+                    my str $name   = nqp::getattr_s($subcur, $?CLASS, '$!name');
+                    if !nqp::isnull_s($name) && nqp::defined($name) && $name ne '' {
                         my Mu $submatch := $subcur.MATCH;
                         if nqp::eqat($name, '$', 0) && ($name eq '$!from' || $name eq '$!to') {
                             nqp::bindattr_i($match, Match, $name, $submatch.from);
@@ -123,8 +123,8 @@ my class Cursor does NQPCursorRole {
                             if nqp::iscclass(nqp::const::CCLASS_NUMERIC, $name, 0) {
                                 $list := nqp::list() unless nqp::isconcrete($list);
                                 $needs_list
-                                    ?? nqp::atpos($list, nqp::fromstr_I(nqp::unbox_s($name), Int)).append($submatch)
-                                    !! nqp::bindpos($list, nqp::fromstr_I(nqp::unbox_s($name), Int), $submatch);
+                                    ?? nqp::atpos($list, nqp::fromstr_I($name, Int)).append($submatch)
+                                    !! nqp::bindpos($list, nqp::fromstr_I($name, Int), $submatch);
                             }
                             else {
                                 $needs_list
@@ -133,10 +133,10 @@ my class Cursor does NQPCursorRole {
                             }
                         }
                         else {
-                            my Mu $names := nqp::split('=', $name);
-                            my $iter     := nqp::iterator($names);
+                            my $names := nqp::split('=', $name);
+                            my $iter  := nqp::iterator($names);
                             while $iter {
-                                my str $name   = nqp::unbox_s(nqp::shift($iter));
+                                my str $name   = nqp::shift($iter);
                                 my Mu $capval := nqp::atkey($caplist, $name);
 #?if jvm
                                 my int $needs_list = nqp::isconcrete($capval) &&

--- a/src/core/Cursor.pm
+++ b/src/core/Cursor.pm
@@ -41,30 +41,32 @@ my class Cursor does NQPCursorRole {
         nqp::bindattr($match, Match, '$!CURSOR', self);
         my Mu $list;
         my Mu $hash := nqp::hash();
-        if $to >= $from {
+        if nqp::isge_i($to, $from) {
             # For captures with lists, initialize the lists.
             my $caplist := $NO_CAPS;
             my $rxsub   := nqp::getattr(self, Cursor, '$!regexsub');
             my str $onlyname  = '';
             my int $namecount = 0;
 
-            if !nqp::isnull($rxsub) && nqp::defined($rxsub) {
+            if nqp::not_i(nqp::isnull($rxsub)) {
                 $caplist := nqp::can($rxsub, 'CAPS') ?? nqp::findmethod($rxsub, 'CAPS')($rxsub) !! nqp::null();
-                if !nqp::isnull($caplist) && nqp::istrue($caplist) {
+                if nqp::not_i(nqp::isnull($caplist)) && nqp::istrue($caplist) {
                     my $iter := nqp::iterator($caplist);
+                    my $curcap;
+                    my str $name;
                     while $iter {
-                        my $curcap := nqp::shift($iter);
-                        $namecount = $namecount + 1;
+                        $curcap := nqp::shift($iter);
+                        $namecount = nqp::add_i($namecount, 1);
 #?if jvm
                         my Mu $curval := nqp::iterval($curcap);
                         if (nqp::isint($curval) && nqp::isge_i($curval, 2))
-                        || (nqp::isnum($curval) && nqp::p6box_n($curval) >= 2) {
+                        || (nqp::isnum($curval) && nqp::isge_n($curval, 2)) {
 #?endif
 #?if !jvm
                         if nqp::iterval($curcap) >= 2 {
 #?endif
-                            my str $name = nqp::iterkey_s($curcap);
-                            $onlyname = $name if $namecount == 1;
+                            $name = nqp::iterkey_s($curcap);
+                            $onlyname = $name if nqp::iseq_i($namecount, 1);
                             nqp::iscclass(nqp::const::CCLASS_NUMERIC, $name, 0)
                                 ?? nqp::bindpos(
                                         nqp::if(nqp::isconcrete($list), $list, ($list := nqp::list())),
@@ -77,11 +79,11 @@ my class Cursor does NQPCursorRole {
 
             # Walk the Cursor stack and populate the Cursor.
             my Mu $cs := nqp::getattr(self, Cursor, '$!cstack');
-            if nqp::isnull($cs) || !nqp::istrue($cs) {}
+            if nqp::isnull($cs) || nqp::not_i(nqp::istrue($cs)) {}
 #?if !jvm
-            elsif !$caplist {}
+            elsif nqp::not_i(nqp::istrue($caplist)) {}
 #?endif
-            elsif $namecount == 1 && $onlyname ne '' && nqp::eqat($onlyname,'$!',0) {
+            elsif nqp::iseq_i($namecount, 1) && nqp::isgt_i(nqp::chars($onlyname), 0) && nqp::eqat($onlyname, '$!', 0) {
                 # If there's only one destination, avoid repeated hash lookups
                 my int $cselems = nqp::elems($cs);
                 my int $csi = -1;
@@ -92,30 +94,34 @@ my class Cursor does NQPCursorRole {
                   ?? nqp::atpos($list, $onlyname)
                   !! nqp::atkey($hash, $onlyname);
 
+                my $subcur;
+                my str $name;
                 while nqp::islt_i(++$csi,$cselems) {
-                    my $subcur  := nqp::atpos($cs, $csi);
-                    my str $name = nqp::getattr_s($subcur, $?CLASS, '$!name');
+                    $subcur := nqp::atpos($cs, $csi);
+                    $name    = nqp::getattr_s($subcur, $?CLASS, '$!name');
                     nqp::push($dest,$subcur.MATCH())
-                      if !nqp::isnull_s($name) && nqp::defined($name);
+                      if nqp::not_i(nqp::isnull_s($name));
                 }
             }
             else {
                 my int $cselems = nqp::elems($cs);
                 my int $csi     = -1;
+                my $subcur;
+                my str $name;
                 while nqp::islt_i(++$csi,$cselems) {
-                    my Mu $subcur := nqp::atpos($cs, $csi);
-                    my str $name   = nqp::getattr_s($subcur, $?CLASS, '$!name');
-                    if !nqp::isnull_s($name) && nqp::defined($name) && $name ne '' {
+                    $subcur := nqp::atpos($cs, $csi);
+                    $name    = nqp::getattr_s($subcur, $?CLASS, '$!name');
+                    if nqp::not_i(nqp::isnull_s($name)) && nqp::isgt_i(nqp::chars($name), 0) {
                         my Mu $submatch := $subcur.MATCH;
-                        if nqp::eqat($name, '$', 0) && ($name eq '$!from' || $name eq '$!to') {
+                        if nqp::eqat($name, '$', 0) && (nqp::iseq_s($name, '$!from') || nqp::iseq_s($name, '$!to')) {
                             nqp::bindattr_i($match, Match, $name, $submatch.from);
                         }
-                        elsif nqp::index($name, '=') < 0 {
+                        elsif nqp::islt_i(nqp::index($name, '='), 0) {
                             my Mu $capval     := nqp::atkey($caplist, $name);
 #?if jvm
                             my int $needs_list = nqp::isconcrete($capval) &&
                                 ((nqp::isint($capval) && nqp::isge_i($capval, 2)) ||
-                                (nqp::isnum($capval) && nqp::p6box_n($capval) >= 2));
+                                 (nqp::isnum($capval) && nqp::isge_n($capval, 2)));
 #?endif
 #?if !jvm
                             my int $needs_list = nqp::isconcrete($capval) && $capval >= 2;
@@ -135,16 +141,18 @@ my class Cursor does NQPCursorRole {
                         else {
                             my $names := nqp::split('=', $name);
                             my $iter  := nqp::iterator($names);
+                            my Mu $capval;
+                            my int $needs_list;
                             while $iter {
-                                my str $name   = nqp::shift($iter);
-                                my Mu $capval := nqp::atkey($caplist, $name);
+                                $name    = nqp::shift($iter);
+                                $capval := nqp::atkey($caplist, $name);
 #?if jvm
-                                my int $needs_list = nqp::isconcrete($capval) &&
+                                $needs_list = nqp::isconcrete($capval) &&
                                     ((nqp::isint($capval) && nqp::isge_i($capval, 2)) ||
-                                    (nqp::isnum($capval) && nqp::p6box_n($capval) >= 2));
+                                     (nqp::isnum($capval) && nqp::isge_n($capval, 2)));
 #?endif
 #?if !jvm
-                                my int $needs_list = nqp::isconcrete($capval) && $capval >= 2;
+                                $needs_list = nqp::isconcrete($capval) && $capval >= 2;
 #?endif
                                 if nqp::iscclass(nqp::const::CCLASS_NUMERIC, $name, 0) {
                                     $list := nqp::list() unless nqp::isconcrete($list);


### PR DESCRIPTION
Hopefully turning into a native will be more efficient.

Passes `make m-spectest`

Requires https://github.com/perl6/nqp/pull/334