### PR TITLE
[JVM] Complete adaptation to findmethod changes

### DIFF
--- a/src/vm/jvm/runtime/org/perl6/rakudo/Binder.java
+++ b/src/vm/jvm/runtime/org/perl6/rakudo/Binder.java
@@ -488,7 +488,7 @@ public final class Binder {
             if (Ops.istype(decontValue, coerceType, tc) == 0) {
                 param.get_attribute_native(tc, gcx.Parameter, "$!coerce_method", HINT_coerce_method);
                 String methName = tc.native_s;
-                SixModelObject coerceMeth = Ops.findmethod(decontValue, methName, tc);
+                SixModelObject coerceMeth = Ops.findmethodNonFatal(decontValue, methName, tc);
                 if (coerceMeth != null) {
                     Ops.invokeDirect(tc, coerceMeth,
                         Ops.invocantCallSite,
@@ -660,7 +660,7 @@ public final class Binder {
                 capture = decontValue;
             }
             else {
-                SixModelObject meth = Ops.findmethod(decontValue, "Capture", tc);
+                SixModelObject meth = Ops.findmethodNonFatal(decontValue, "Capture", tc);
                 if (meth == null) {
                     if (error != null)
                         error[0] = "Could not turn argument into capture";

--- a/src/vm/jvm/runtime/org/perl6/rakudo/RakOps.java
+++ b/src/vm/jvm/runtime/org/perl6/rakudo/RakOps.java
@@ -327,7 +327,7 @@ public final class RakOps {
             spec.store(tc, cont, Ops.decont(value, tc));
         }
         else {
-            SixModelObject meth = Ops.findmethod(cont, "STORE", tc);
+            SixModelObject meth = Ops.findmethodNonFatal(cont, "STORE", tc);
             if (meth != null) {
                 Ops.invokeDirect(tc, meth,
                     STORE, new Object[] { cont, value });


### PR DESCRIPTION
With https://github.com/rakudo/rakudo/pull/967 a few occurences
of 'findmethod' were changed to unbust the JVM build. It turned
out that some other tweaks were necessary, because 'findmethod'
throws an exception now if it can't find the method. Where the
return value from 'findmethod' is checked manually, the code
now uses the new method 'findmethodNonFatal'.