### PR TITLE
Test.pm's is_approx isn't being removed until 6.d

### DIFF
--- a/lib/Test.pm6
+++ b/lib/Test.pm6
@@ -239,7 +239,7 @@ sub bail-out ($desc?) is export {
 }
 
 multi sub is_approx(Mu $got, Mu $expected, $desc = '') is export {
-    DEPRECATED('is-approx'); # Remove at 20161217 release (6 months from today)
+    DEPRECATED('is-approx'); # Remove for 6.d release
 
     $time_after = nqp::time_n;
     my $tol = $expected.abs < 1e-6 ?? 1e-5 !! $expected.abs * 1e-6;


### PR DESCRIPTION
See https://irclog.perlgeek.de/perl6-dev/2017-01-05#i_13860967

Un-spectested, YMMV