### PR TITLE
Micro-optimize Grammar.nqp

### DIFF
--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -64,7 +64,7 @@ role STD {
     my %quote_lang_cache := nqp::hash();
     method quote_lang($l, $start, $stop, @base_tweaks?, @extra_tweaks?) {
         sub lang_key() {
-            my $stopstr := nqp::istype($stop,VMArray) ?? nqp::join(' ',$stop) !! $stop;
+            my str $stopstr := nqp::istype($stop,VMArray) ?? nqp::join(' ',$stop) !! $stop;
             my @keybits := [$l.HOW.name($l), $start, $stopstr];
             for @base_tweaks {
                 @keybits.push($_);
@@ -84,7 +84,7 @@ role STD {
             }
 
             for @extra_tweaks {
-                my $t := $_[0];
+                my str $t := $_[0];
                 if nqp::can($lang, "tweak_$t") {
                     $lang := $lang."tweak_$t"($_[1]);
                 }
@@ -98,7 +98,7 @@ role STD {
         }
 
         # Get language from cache or derive it.
-        my $key := lang_key();
+        my str $key := lang_key();
         nqp::existskey(%quote_lang_cache, $key) && $key ne 'NOCACHE'
             ?? %quote_lang_cache{$key}
             !! (%quote_lang_cache{$key} := con_lang());
@@ -198,8 +198,8 @@ role STD {
 
     token quibble($l, *@base_tweaks) {
         :my $lang;
-        :my $start;
-        :my $stop;
+        :my str $start;
+        :my str $stop;
         <babble($l, @base_tweaks)>
         { my $B := $<babble><B>.ast; $lang := $B[0]; $start := $B[1]; $stop := $B[2]; }
 
@@ -274,7 +274,7 @@ role STD {
     }
     method missing_block($borg, $has_mystery) {
         my $marked := self.MARKED('ws');
-        my $pos := $marked ?? $marked.from !! self.pos;
+        my int $pos := $marked ?? $marked.from !! self.pos;
 
         if $borg<block> {
             self.'!clear_highwater'();
@@ -362,7 +362,7 @@ role STD {
             $varast := $varast[0];
         }
         if !$*IN_DECL && nqp::istype($varast, QAST::Var) && $varast.scope eq 'lexical' {
-            my $name := $varast.name;
+            my str $name := $varast.name;
 
             if $name ne '%_' && $name ne '@_' && !$*W.is_lexical($name) {
                 my $sigil := $var<sigil> || nqp::substr($name,0,1);
@@ -374,12 +374,11 @@ role STD {
                         my @suggestions := $*W.suggest_lexicals($name);
 
                         if nqp::can($*PACKAGE.HOW, 'get_attribute_for_usage') {
-                            my $sigil    := nqp::substr($name, 0, 1);
-                            my $twigil   := nqp::concat($sigil, '!');
-                            my $basename := nqp::substr($name, 1, nqp::chars($name) - 1);
-                            my $attrname := nqp::concat($twigil, $basename);
+                            my str $sigil    := nqp::substr($name, 0, 1);
+                            my str $twigil   := nqp::concat($sigil, '!');
+                            my str $basename := nqp::substr($name, 1, nqp::chars($name) - 1);
+                            my str $attrname := nqp::concat($twigil, $basename);
 
-                            my $attribute := $*PACKAGE.HOW.get_attribute_for_usage($*PACKAGE, $attrname);
                             nqp::push(@suggestions, $attrname);
 
                             CATCH {}
@@ -413,7 +412,7 @@ role STD {
 }
 
 grammar Perl6::Grammar is HLL::Grammar does STD {
-    my $sc_id := 0;
+    my int $sc_id := 0;
     method TOP() {
         # Language braid.
         my %*LANG;
@@ -442,8 +441,8 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         # Symbol table and serialization context builder - keeps track of
         # objects that cross the compile-time/run-time boundary that are
         # associated with this compilation unit.
-        my $file := nqp::getlexdyn('$?FILES');
-        my $source_id := nqp::sha1(
+        my str $file := nqp::getlexdyn('$?FILES');
+        my str $source_id := nqp::sha1(
             nqp::defined(%*COMPILING<%?OPTIONS><outer_ctx>)
                 ?? self.target() ~ $sc_id++
                 !! self.target());
@@ -491,18 +490,18 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         :my $*QSIGIL := '';
         '::'
         [
-        ||  <?before '(' | <alpha> >
+        ||  <?before '(' | <.alpha> >
             [
             | <identifier>
             | :dba('indirect name') '(' ~ ')' [ <.ws> <EXPR> ]
             ]
         || <?before '::'> <.typed_panic: "X::Syntax::Name::Null">
-        || $<bad>=[<.sigil><.identifier>] { my $b := $<bad>; self.malformed("lookup of ::$b; please use ::('$b'), ::\{'$b'\}, or ::<$b>") }
+        || $<bad>=[<.sigil><.identifier>] { my str $b := $<bad>; self.malformed("lookup of ::$b; please use ::('$b'), ::\{'$b'\}, or ::<$b>") }
         ]?
     }
 
     token longname {
-        <name> {} [ <?before ':' <+alpha+[\< \[ \« ]>> <!RESTRICTED> <colonpair> ]*
+        <name> {} [ <?before ':' <.+alpha+[\< \[ \« ]>> <!RESTRICTED> <colonpair> ]*
     }
 
     token deflongname {
@@ -527,12 +526,12 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         | <colonpair>+
             {
                 if $<colonpair>[0]<coloncircumfix> -> $cf {
-                    my $category := $<identifier>.Str;
-                    my $opname := $cf<circumfix>
+                    my str $category := $<identifier>.Str;
+                    my str $opname := $cf<circumfix>
                         ?? $*W.colonpair_nibble_to_str($/, $cf<circumfix><nibble>)
                         !! '';
-                    my $canname  := $category ~ $*W.canonicalize_pair('sym', $opname);
-                    my $termname := $category ~ $*W.canonicalize_pair('', $opname);
+                    my str $canname  := $category ~ $*W.canonicalize_pair('sym', $opname);
+                    my str $termname := $category ~ $*W.canonicalize_pair('', $opname);
                     $/.CURSOR.add_categorical($category, $opname, $canname, $termname, :defterm);
                 }
             }
@@ -546,7 +545,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
     }
 
     token end_keyword {
-        » <!before <[ \( \\ ' \- ]> || \h* '=>'>
+        » <!before <.[ \( \\ ' \- ]> || \h* '=>'>
     }
     token end_prefix {
         <.end_keyword> \s*
@@ -556,9 +555,9 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
     token kok {
         <.end_keyword>
         [
-        || <?before <[ \s \# ]> > <.ws>
+        || <?before <.[ \s \# ]> > <.ws>
         || <?{
-                my $n := nqp::substr(self.orig, self.from, self.pos - self.from);
+                my str $n := nqp::substr(self.orig, self.from, self.pos - self.from);
                 $*W.is_name([$n]) || $*W.is_name(['&' ~ $n])
                     ?? False
                     !! self.sorry("Whitespace required after keyword '$n'")
@@ -569,7 +568,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
     token tok {
         <.end_keyword>
         <!{
-                my $n := nqp::substr(self.orig, self.from, self.pos - self.from);
+                my str $n := nqp::substr(self.orig, self.from, self.pos - self.from);
                 $*W.is_name([$n]) || $*W.is_name(['&' ~ $n])
         }>
     }
@@ -780,11 +779,11 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         :my $*POD_ANGLE_COUNT := nqp::getlexdyn('$*POD_ANGLE_COUNT');
         <?{ $*POD_ALLOW_FCODES }>
 
-        :my $endtag;
+        :my str $endtag;
         <code=[A..Z]>
         $<begin-tag>=['<'+ <![<]> | '«'] { $*POD_IN_FORMATTINGCODE := 1 }
         <?{
-            my $codenum := nqp::ord($<code>.Str) - nqp::ord("A");
+            my int $codenum := nqp::ord($<code>.Str) - nqp::ord("A");
             if !($*POD_ALLOW_FCODES +& (2 ** $codenum)) {
                 0
             } elsif ~$<begin-tag> eq '«' {
@@ -794,7 +793,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
             } else {
               my int $ct := nqp::chars($<begin-tag>);
               $endtag := nqp::x(">", $ct);
-              my $rv := $*POD_ANGLE_COUNT <= 0 || $*POD_ANGLE_COUNT >= $ct;
+              my int $rv := $*POD_ANGLE_COUNT <= 0 || $*POD_ANGLE_COUNT >= $ct;
               $*POD_ANGLE_COUNT := $ct;
               $rv;
             }
@@ -822,7 +821,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
 
     token pod_balanced_braces {
         <?{ $*POD_IN_FORMATTINGCODE }>
-        :my $endtag;
+        :my str $endtag;
         [
             $<braces>=[
                       || '<'+ <![<]>
@@ -1186,7 +1185,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         ''
         [
         | $
-        | <?before <[\)\]\}]>>
+        | <?before <.[\)\]\}]>>
         | [ <statement> <.eat_terminator> ]*
         ]
     }
@@ -1203,7 +1202,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         :dba('list composer')
         ''
         [
-        | <?before <[)\]}]> >
+        | <?before <.[)\]}]> >
         | [<statement><.eat_terminator> ]*
         ]
     }
@@ -1212,7 +1211,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         :dba('sequence of statements')
         ''
         [
-        | <?before <[)\]}]> >
+        | <?before <.[)\]}]> >
         | [<statement><.eat_terminator> ]*
         ]
     }
@@ -1244,7 +1243,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         :my $*STATEMENT_ID := $*NEXT_STATEMENT_ID++;
         :my $*IN_STMT_MOD := 0;
         :my $*ESCAPEBLOCK := 0;
-        <!before <[\])}]> | $ >
+        <!before <.[\])}]> | $ >
         <!stopper>
         <!!{ nqp::rebless($/.CURSOR, %*LANG<MAIN>) }>
         [
@@ -1258,7 +1257,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
                 {
                     my $sp := $<EXPR><statement_prefix>;
                     if $sp && $sp<sym> eq 'do' {
-                        my $s := $<statement_mod_loop><sym>;
+                        my str $s := $<statement_mod_loop><sym>;
                         $/.CURSOR.obs("do..." ~ $s, "repeat...while or repeat...until");
                     }
                 }
@@ -1304,7 +1303,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         <.attach_leading_docs>
         :dba('block or pointy block')
         :my $borg := $*BORG;
-        :my $has_mystery := $*MYSTERY ?? 1 !! 0;
+        :my int $has_mystery := $*MYSTERY ?? 1 !! 0;
         { $*BORG := {} }
         [
         | <lambda>
@@ -1331,7 +1330,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         :my $*CODE_OBJECT := $*DECLARAND;
         :dba('scoped block')
         :my $borg := $*BORG;
-        :my $has_mystery := $*MYSTERY ?? 1 !! 0;
+        :my int $has_mystery := $*MYSTERY ?? 1 !! 0;
         { $*BORG := {} }
         [ <?[{]> || <.missing_block($borg, $has_mystery)>]
         <.newpad>
@@ -1344,7 +1343,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         :my %*PRAGMAS := self.shallow_copy(nqp::getlexdyn('%*PRAGMAS'));
         <.finishpad>
         :my $borg := $*BORG;
-        :my $has_mystery := $*MYSTERY ?? 1 !! 0;
+        :my int $has_mystery := $*MYSTERY ?? 1 !! 0;
         { $*BORG := {} }
         [
         | '{YOU_ARE_HERE}' <you_are_here>
@@ -1496,7 +1495,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         {
             for $<module_name> {
                 my $lnd  := $*W.dissect_longname($_<longname>);
-                my $name := $lnd.name;
+                my str $name := $lnd.name;
                 my %cp   := $lnd.colonpairs_hash('need');
                 $*W.load_module($/, $name, %cp, $*W.cur_lexpad);
             }
@@ -1511,7 +1510,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         {
             my $longname := $*W.dissect_longname($<module_name><longname>);
             my $module;
-            my $found := 0;
+            my int $found := 0;
             try {
                 $module := $*W.find_symbol($longname.components());
                 $found := 1;
@@ -1529,7 +1528,6 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
 
     token statement_control:sym<no> {
         :my $*IN_DECL := 'no';
-        :my $longname;
         <sym> <.ws>
         [
         | <module_name> [ <.spacey> <arglist> ]? <.explain_mystery> <.cry_sorrows>
@@ -1539,11 +1537,10 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
     }
 
     token statement_control:sym<use> {
-        :my $longname;
         :my $*IN_DECL := 'use';
         :my $*HAS_SELF := '';
         :my $*SCOPE   := 'use';
-        :my $OLD_MAIN := ~$*MAIN;
+        :my str $OLD_MAIN := ~$*MAIN;
         :my %*MYSTERY;
         $<doc>=[ 'DOC' \h+ ]**0..1
         <sym> <.ws>
@@ -1555,7 +1552,6 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
                             $*W.import_EXPORTHOW($/, $module);
                         }
                     ||  <?{ $<version><vnum>[0] == 6 }> {
-                            my $version_parts := $<version><vnum>;
                             my $vwant := $<version>.ast.compile_time_value;
                             my $vhave := $*W.find_symbol(['Version']).new(
                                 nqp::getcomp('perl6').language_version());
@@ -1743,16 +1739,16 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
 
     token infix:sym<lambda> {
         <?before '{' | '->' > <!{ $*IN_META }> {
-            my $needparens := 0;
-            my $pos := $/.from;
-            my $line := HLL::Compiler.lineof($/.orig, $/.from, :cache(1));
+            my int $needparens := 0;
+            my int $pos := $/.from;
+            my int $line := HLL::Compiler.lineof($/.orig, $/.from, :cache(1));
             my $lex := $*W.cur_lexpad();
             for 'if', 'unless', 'while', 'until', 'for', 'given', 'when', 'loop', 'sub', 'method', 'with', 'without', 'supply', 'whenever', 'react' {
-                $needparens++ if $_ eq 'loop';
+                ++$needparens if $_ eq 'loop';
                 my $m := %*MYSTERY{$_ ~ '-' ~ $lex.cuid};
                 next unless $m;
-                my $m_pos  := $m<pos>[nqp::elems($m<pos>) - 1];
-                my $m_line := HLL::Compiler.lineof($/.orig, $m_pos, :cache(1));
+                my int $m_pos  := $m<pos>[nqp::elems($m<pos>) - 1];
+                my int $m_line := HLL::Compiler.lineof($/.orig, $m_pos, :cache(1));
                 if $line - $m_line < 5 {
                     if $m<ctx> eq '(' {
                         $/.CURSOR.'!clear_highwater'();
@@ -1788,7 +1784,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
             <.obs('$/ variable as input record separator',
                  "the filehandle's .slurp method")>
         ]?
-        [ <?before [ '(' || \h*<sigil><twigil>?\w ] >
+        [ <?before [ '(' || \h*<.sigil><.twigil>?\w ] >
             <.obs('undef as a verb', 'undefine() or assignment of Nil')>
         ]?
         <.obs('undef as a value', "something more specific:\n\tan undefined type object such as Any or Int,\n\t:!defined as a matcher,\n\tAny:U as a type constraint,\n\tNil as the absence of an expected value\n\tor fail() as a failure return\n\t   ")>
@@ -1820,13 +1816,13 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
             [ <[ \[ \( \< \{ ]> {
             $/.CURSOR.typed_panic('X::Syntax::NegatedPair', key => ~$<identifier>) } ]?
             { $*key := $<identifier>.Str; $*value := 0; }
-        | $<num> = [\d+] <identifier> [ <?before <[ \[ \( \< \{ ]>> {} <.sorry("Extra argument not allowed; pair already has argument of " ~ $<num>.Str)> <.circumfix> ]?
+        | $<num> = [\d+] <identifier> [ <?before <.[ \[ \( \< \{ ]>> {} <.sorry("Extra argument not allowed; pair already has argument of " ~ $<num>.Str)> <.circumfix> ]?
             <?{
                 # Here we go over each character in the numeral and check $ch.chr eq $ch.ord.chr
                 # to fail any matches that have synthetics, such as 7\x[308]
-                my $num       := ~$<num>;
-                my $chars-num := nqp::chars($num);
-                my $pos       := -1;
+                my str $num       := ~$<num>;
+                my int $chars-num := nqp::chars($num);
+                my int $pos       := -1;
                 nqp::while(
                     nqp::islt_i( ($pos := nqp::add_i($pos, 1)), $chars-num )
                     && nqp::eqat(
@@ -1874,7 +1870,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
     }
 
     token special_variable:sym<$`> {
-        <sym>  <?before \s | ',' | <terminator> >
+        <sym>  <?before \s | ',' | <.terminator> >
         <.obsvar('$`')>
     }
 
@@ -1906,7 +1902,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
     }
 
     token special_variable:sym<$&> {
-        <sym> <?before \s | ',' | <terminator> >
+        <sym> <?before \s | ',' | <.terminator> >
         <.obsvar('$&')>
     }
 
@@ -1921,12 +1917,12 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
     }
 
     token special_variable:sym<@+> {
-        <sym> <?before \s | ',' | <terminator> >
+        <sym> <?before \s | ',' | <.terminator> >
         <.obsvar('@+')>
     }
 
     token special_variable:sym<%+> {
-        <sym> <?before \s | ',' | <terminator> >
+        <sym> <?before \s | ',' | <.terminator> >
         <.obsvar('%+')>
     }
 
@@ -1946,12 +1942,12 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
     }
 
     token special_variable:sym<@-> {
-        <sym> <?before \s | ',' | <terminator> >
+        <sym> <?before \s | ',' | <.terminator> >
         <.obsvar('@-')>
     }
 
     token special_variable:sym<%-> {
-        <sym> <?before \s | ',' | <terminator> >
+        <sym> <?before \s | ',' | <.terminator> >
         <.obsvar('%-')>
     }
 
@@ -1971,12 +1967,12 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
     }
 
     token special_variable:sym<$/> {
-        <sym> <?before \h* '=' \h* <[ ' " ]> >
+        <sym> <?before \h* '=' \h* <.[ ' " ]> >
         <.obsvar('$/')>
     }
 
     token special_variable:sym<$\\> {
-        '$\\' <?before \s | ',' | '=' | <terminator> >
+        '$\\' <?before \s | ',' | '=' | <.terminator> >
         <.obsvar('$\\')>
     }
 
@@ -1996,7 +1992,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
     }
 
     token special_variable:sym<$'> { #'
-        <sym> <?before \s | ',' | <terminator> >
+        <sym> <?before \s | ',' | <.terminator> >
         <.obsvar('$' ~ "'")>
     }
 
@@ -2072,7 +2068,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         | <special_variable>
         | <sigil> $<index>=[\d+]                              [<?{ $*IN_DECL }> <.typed_panic: "X::Syntax::Variable::Numeric">]?
         | <sigil> <?[<]> <postcircumfix>                      [<?{ $*IN_DECL }> <.typed_panic('X::Syntax::Variable::Match')>]?
-        | <?before <sigil> <?[ ( [ { ]>> <!RESTRICTED> <?{ !$*IN_DECL }> <contextualizer>
+        | <?before <.sigil> <.?[ ( [ { ]>> <!RESTRICTED> <?{ !$*IN_DECL }> <contextualizer>
         | $<sigil>=['$'] $<desigilname>=[<[/_!¢]>]
         | {} <sigil> <!{ $*QSIGIL }> <?MARKER('baresigil')>   # try last, to allow sublanguages to redefine sigils (like & in regex)
         ]
@@ -2225,7 +2221,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
 
                     # Locate any existing symbol. Note that it's only a match
                     # with "my" if we already have a declaration in this scope.
-                    my $exists := 0;
+                    my int $exists := 0;
                     my @name := $longname ??
                         $longname.type_name_parts('package name', :decl(1)) !!
                         [];
@@ -2235,7 +2231,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
                             $exists := 1;
                         }
                     }
-                    my $fullname;
+                    my str $fullname;
                     if @name {
                         $fullname := $longname.fully_qualified_with($target_package);
                     }
@@ -2522,7 +2518,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
 
     token variable_declarator {
         :my $*IN_DECL := 'variable';
-        :my $sigil;
+        :my str $sigil;
         <variable>
         {
             $*VARIABLE := $<variable>.ast.name;
@@ -2612,11 +2608,11 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
             if $<deflongname> && $<deflongname><colonpair>[0]<coloncircumfix> -> $cf {
                 # It's an (potentially new) operator, circumfix, etc. that we
                 # need to tweak into the grammar.
-                my $category := $<deflongname><name>.Str;
-                my $opname := $cf<circumfix>
+                my str $category := $<deflongname><name>.Str;
+                my str $opname := $cf<circumfix>
                     ?? $*W.colonpair_nibble_to_str($/, $cf<circumfix><nibble> // $cf<circumfix><semilist>)
                     !! '';
-                my $canname := $category ~ $*W.canonicalize_pair('sym', $opname);
+                my str $canname := $category ~ $*W.canonicalize_pair('sym', $opname);
                 $/.CURSOR.add_categorical($category, $opname, $canname, $<deflongname>.ast, $*DECLARAND);
             }
         }
@@ -2693,7 +2689,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
             {
                 $*IN_DECL := '';
 
-                my $meta := $<specials> && ~$<specials> eq '^';
+                my int $meta := $<specials> && ~$<specials> eq '^';
                 my $invocant_type := $*W.find_symbol([
                     $<longname> && $*W.is_lexical('$?CLASS') && !$meta
                         ?? '$?CLASS'
@@ -2740,11 +2736,11 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
             if $<deflongname> && $<deflongname><colonpair>[0]<coloncircumfix> -> $cf {
                 # It's an (potentially new) operator, circumfix, etc. that we
                 # need to tweak into the grammar.
-                my $category := $<deflongname><name>.Str;
-                my $opname := $cf<circumfix>
+                my str $category := $<deflongname><name>.Str;
+                my str $opname := $cf<circumfix>
                     ?? $*W.colonpair_nibble_to_str($/, $cf<circumfix><nibble>)
                     !! '';
-                my $canname := $category ~ $*W.canonicalize_pair('sym', $opname);
+                my str $canname := $category ~ $*W.canonicalize_pair('sym', $opname);
                 $/.CURSOR.add_categorical($category, $opname, $canname, $<deflongname>.ast, $*DECLARAND);
             }
         }
@@ -2869,13 +2865,13 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
 
         # enforce zone constraints
         {
-            my $kind :=
+            my str $kind :=
                 $<named_param>                      ?? '*' !!
                 $<quant> eq '?' || $<default_value> ?? '?' !!
                 $<quant> eq '!'                     ?? '!' !!
                 $<quant> ne '' && $<quant> ne '\\'  ?? '*' !!
                                                        '!';
-            my $name := %*PARAM_INFO<variable_name> // '';
+            my str $name := %*PARAM_INFO<variable_name> // '';
             if $kind eq '!' {
                 if $*zone eq 'posopt' {
                     $/.CURSOR.typed_panic('X::Parameter::WrongOrder', misplaced => 'required', after => 'optional', parameter => $name);
@@ -2908,7 +2904,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         :my $*SURROUNDING_DECL := nqp::getlexdyn('$*IN_DECL');
         <.attach_leading_docs>
         {
-            my $line_no := HLL::Compiler.lineof(self.orig(), self.from(), :cache(1));
+            my int $line_no := HLL::Compiler.lineof(self.orig(), self.from(), :cache(1));
             if $*PRECEDING_DECL_LINE < $line_no {
                 $*PRECEDING_DECL_LINE := $line_no;
                 my $par_type := $*W.find_symbol(['Parameter'], :setting-only);
@@ -2933,7 +2929,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
           | <?before ':('>  ':'  # XXX allow fakesig parsed as subsig for the moment
           | <?before '('>         <.sorry: "Shape declaration with () is reserved;\n  please use whitespace if you meant a subsignature for unpacking,\n  or use the :() form if you meant to add signature info to the function's type">
           | <?before '['> <arrayshape=.postcircumfix>
-          | <?before <[ { < « ]>> <.sorry: 'Shape declaration is not yet implemented; please use whitespace if you meant something else'>
+          | <?before <.[ { < « ]>> <.sorry: 'Shape declaration is not yet implemented; please use whitespace if you meant something else'>
                <postcircumfix>
           ]?
         ]
@@ -3058,7 +3054,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         :my $*POD_BLOCK;
         :my $*DECLARAND;
         {
-            my $line_no := HLL::Compiler.lineof(self.orig(), self.from(), :cache(1));
+            my int $line_no := HLL::Compiler.lineof(self.orig(), self.from(), :cache(1));
             if $*PRECEDING_DECL_LINE < $line_no {
                 $*PRECEDING_DECL_LINE := $line_no;
                 $*PRECEDING_DECL      := Mu; # actual declarand comes later, in Actions::type_declarator:sym<enum>
@@ -3094,7 +3090,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         :my $*POD_BLOCK;
         :my $*DECLARAND;
         {
-            my $line_no := HLL::Compiler.lineof(self.orig(), self.from(), :cache(1));
+            my int $line_no := HLL::Compiler.lineof(self.orig(), self.from(), :cache(1));
             if $*PRECEDING_DECL_LINE < $line_no {
                 $*PRECEDING_DECL_LINE := $line_no;
                 $*PRECEDING_DECL      := Mu; # actual declarand comes later, in Actions::type_declarator:sym<subset>
@@ -3217,7 +3213,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
 
     token term:sym<time> { <sym> <.tok> }
 
-    token term:sym<empty_set> { "∅" <!before <[ \( \\ ' \- ]> || \h* '=>'> }
+    token term:sym<empty_set> { "∅" <!before <.[ \( \\ ' \- ]> || \h* '=>'> }
 
     token term:sym<rand> {
         <sym> »
@@ -3228,15 +3224,15 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
 
     token term:sym<...> {
         [<sym>|'…']
-        [ <?after ','\h*<[ . … ]>+> { self.worry("Comma found before apparent sequence operator; please remove comma (or put parens around the ... call, or use 'fail' instead of ...)") } ]?
-        [ <?{ $*GOAL eq 'endargs' && !$*COMPILING_CORE_SETTING }> <?after <:L + [\]]>\h*<[ . … ]>+> { self.worry("Apparent sequence operator parsed as stubbed function argument; please supply any missing argument to the function or the sequence (or parenthesize the ... call, or use 'fail' instead of ...)") } ]?
+        [ <?after ','\h*<.[ . … ]>+> { self.worry("Comma found before apparent sequence operator; please remove comma (or put parens around the ... call, or use 'fail' instead of ...)") } ]?
+        [ <?{ $*GOAL eq 'endargs' && !$*COMPILING_CORE_SETTING }> <?after <.:L + [\]]>\h*<[ . … ]>+> { self.worry("Apparent sequence operator parsed as stubbed function argument; please supply any missing argument to the function or the sequence (or parenthesize the ... call, or use 'fail' instead of ...)") } ]?
         <args>
     }
     token term:sym<???> { <sym> <args> }
     token term:sym<!!!> { <sym> <args> }
 
     token term:sym<identifier> {
-        :my $pos;
+        :my int $pos;
         <identifier> <!{ $*W.is_type([~$<identifier>]) }> <?before <.unsp>|'('> <![:]>
         { $pos := $/.CURSOR.pos }
         <args(1)>
@@ -3272,7 +3268,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         <longname>
         :my %colonpairs;
         :my $*longname;
-        :my $pos;
+        :my int $pos;
         :my $*IN_RETURN;
         :my $is_type := 0;
         {
@@ -3304,7 +3300,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
             {
                 for $<longname><colonpair> {
                     if $_<identifier> {
-                        my $name := $_<identifier>.Str;
+                        my str $name := $_<identifier>.Str;
                         if $name eq 'D' || $name eq 'U' || $name eq '_' {
                             %colonpairs{$name} := 1;
                         }
@@ -3318,20 +3314,19 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         || <args(1)>
             {
                 if !$<args><invocant> {
-                    my $name := ~$<longname>;
+                    my str $name := ~$<longname>;
                     if $*BORG<block> {
                         unless $*BORG<name> {
                             $*BORG<name> := $*BORG<name> // $name;
                         }
                     }
-                    my $nextch := nqp::substr($/.CURSOR.orig, $/.CURSOR.pos, 1) || ' ';
+                    my str $nextch := nqp::substr($/.CURSOR.orig, $/.CURSOR.pos, 1) || ' ';
                     if %deftrap{$name} {
                         my $al := $<args><arglist>;
                         my int $ok := 0;
                         $ok := 1 unless $al<EXPR> eq '';
                         $ok := 1 if $<args><semiarglist>;
                         unless $ok {
-                            my $trap := %deftrap{$name};
                             if nqp::index('<[{', $nextch) >= 0 {
                                 $/.CURSOR.typed_panic('X::Syntax::Confused', reason => "Use of non-subscript brackets after \"$name\" where postfix is expected; please use whitespace before any arguments")
                             }
@@ -3339,9 +3334,10 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
                                 $/.CURSOR.typed_panic('X::Syntax::Confused', reason => "A list operator such as \"$name\" must have whitespace before its arguments (or use parens)")
                             }
                             else {
-                                my $missing := $/.CURSOR.terminator() || $/.CURSOR.infixish();
                                 $/.CURSOR.'!clear_highwater'();  # don't have suppose
-                                my $orry := $missing ?? "sorry" !! "worry";
+                                my $missing := $/.CURSOR.terminator() || $/.CURSOR.infixish();
+                                my str $orry := $missing ?? "sorry" !! "worry";
+                                my int $trap := %deftrap{$name};
                                 if $trap == 1 {        # probably misused P5ism
                                     $<longname>.CURSOR."{$orry}obs"("bare \"$name\"", ".$name if you meant \$_, or use an explicit invocant or argument, or use &$name to refer to the function as a noun");
                                 }
@@ -3443,13 +3439,13 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
             ]
         | <VALUE=decint>
         ]
-        <!!before ['.' <?before \s | ',' | '=' | ':' | <terminator> | $ > <.typed_sorry: 'X::Syntax::Number::IllegalDecimal'>]? >
+        <!!before ['.' <?before \s | ',' | '=' | ':' | <.terminator> | $ > <.typed_sorry: 'X::Syntax::Number::IllegalDecimal'>]? >
         [ <?before '_' '_'+\d> <.sorry: "Only isolated underscores are allowed inside numbers"> ]?
     }
 
     token rad_number {
         ':' $<radix> = [\d+] <.unsp>?
-        :my $r := nqp::radix(10, $<radix>, 0, 0)[0];
+        :my int $r := nqp::radix(10, $<radix>, 0, 0)[0];
         {}           # don't recurse in lexer
         :dba('number in radix notation')
         :my $rad_digit  := token rad_digit  { \d | <[ a..z A..Z ａ..ｚ Ａ..Ｚ ]> };
@@ -3483,10 +3479,10 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
     token sign { '+' | '-' | '−' | '' }
 
     token rat_number { '<' <bare_rat_number> '>' }
-    token bare_rat_number { <?before <[-−+0..9<>:boxd]>+? '/'> <nu=.signed-integer> '/' <de=integer> }
+    token bare_rat_number { <?before <.[-−+0..9<>:boxd]>+? '/'> <nu=.signed-integer> '/' <de=integer> }
 
     token complex_number { '<' <bare_complex_number> '>' }
-    token bare_complex_number { <?before <[-−+0..9<>:.eEboxdInfNa\\]>+? 'i'> <re=.signed-number> <?[-−+]> <im=.signed-number> \\? 'i' }
+    token bare_complex_number { <?before <.[-−+0..9<>:.eEboxdInfNa\\]>+? 'i'> <re=.signed-number> <?[-−+]> <im=.signed-number> \\? 'i' }
 
     token typename {
         :my %colonpairs;
@@ -3513,7 +3509,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         {
             for ($<longname> ?? $<longname><colonpair> !! $<colonpair>) {
                 if $_<identifier> {
-                    my $name := $_<identifier>.Str;
+                    my str $name := $_<identifier>.Str;
                     if $name eq 'D' || $name eq 'U' || $name eq '_' {
                         %colonpairs{$name} := 1;
                     }
@@ -3531,7 +3527,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         {
           my $longname := $*W.dissect_longname($<longname>);
           my @suggestions := $*W.suggest_typename($longname.name);
-          my $method := $panic ?? 'typed_panic' !! 'typed_sorry';
+          my str $method := $panic ?? 'typed_panic' !! 'typed_sorry';
           $/.CURSOR."$method"('X::Undeclared',
                     what => "Type",
                     symbol => $longname.name(),
@@ -3571,7 +3567,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
 
     token qok($x) {
         » <![(]>
-        [ <?[:]> || <!{ my $n := ~$x; $*W.is_name([$n]) || $*W.is_name(['&' ~ $n]) }> ]
+        [ <?[:]> || <!{ my str $n := ~$x; $*W.is_name([$n]) || $*W.is_name(['&' ~ $n]) }> ]
         [ \s* '#' <.panic: "# not allowed as delimiter"> ]?
         <.ws>
     }
@@ -3601,7 +3597,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
     token quote:sym<hdblq> { :dba('high curly double quotes') '”' ~ <[”“]> <nibble(self.quote_lang(%*LANG<Quote>, '”', ['”','“'], ['qq']))> }
     token quote:sym<crnr>  { :dba('corner quotes') '｢' ~ '｣' <nibble(self.quote_lang(%*LANG<Quote>, '｢', '｣'))> }
     token quote:sym<q> {
-        :my $qm;
+        :my str $qm;
         'q'
         [
         | <quote_mod> {} <.qok($/)> { $qm := $<quote_mod>.Str } <quibble(%*LANG<Quote>, 'q', $qm)>
@@ -3609,7 +3605,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         ]
     }
     token quote:sym<qq> {
-        :my $qm;
+        :my str $qm;
         'qq'
         [
         | <quote_mod> { $qm := $<quote_mod>.Str } <.qok($/)> <quibble(%*LANG<Quote>, 'qq', $qm)>
@@ -3617,7 +3613,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         ]
     }
     token quote:sym<Q> {
-        :my $qm;
+        :my str $qm;
         'Q'
         [
         | <quote_mod> { $qm := $<quote_mod>.Str } <.qok($/)> <quibble(%*LANG<Quote>, $qm)>
@@ -3738,7 +3734,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
     token old_rx_mods {
         (<[ i g s m x c e ]>)
         {
-            my $m := $/[0].Str;
+            my str $m := $/[0].Str;
             if    $m eq 'i' { $/.CURSOR.obs('/i',':i');                                   }
             elsif $m eq 'g' { $/.CURSOR.obs('/g',':g');                                   }
             elsif $m eq 'm' { $/.CURSOR.obs('/m','^^ and $$ anchors');                    }
@@ -3858,9 +3854,9 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
     }
 
     sub bracket_ending($matches) {
-        my $check     := $matches[+$matches - 1];
-        my str $str   := $check.Str;
-        my $last  := nqp::substr($str, nqp::chars($check) - 1, 1);
+        my str $check := $matches[+$matches - 1];
+        my str $str   := $check;
+        my str $last  := nqp::substr($str, nqp::chars($check) - 1, 1);
         $last eq ')' || $last eq '}' || $last eq ']' || $last eq '>'
     }
 
@@ -3919,7 +3915,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         :dba('infix stopper')
         [
         | <?before '!!'> <?{ $*GOAL eq '!!' }>
-        | <?before '{' | <lambda> > <?MARKED('ws')> <?{ $*GOAL eq '{' || $*GOAL eq 'endargs' }>
+        | <?before '{' | <.lambda> > <?MARKED('ws')> <?{ $*GOAL eq '{' || $*GOAL eq 'endargs' }>
         ]
     }
 
@@ -3982,7 +3978,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         :my $*IN_REDUCE := 1;
         :my $op;
         <?before '['\S+']'>
-        <!before '[' <[ - + ? ~ ^ ]> <[ \w $ @ ]> >  # disallow accidental prefix before termish thing
+        <!before '[' <.[ - + ? ~ ^ ]> <.[ \w $ @ ]> >  # disallow accidental prefix before termish thing
 
         '['
         [
@@ -4071,7 +4067,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         | <longname>
         | <?[$@&]> <variable> { self.check_variable($<variable>) }
         | <?['"]>
-            [ <!{$*QSIGIL}> || <!before '"' <-["]>*? [\s|$] > ] # dwim on "$foo."
+            [ <!{$*QSIGIL}> || <!before '"' <.-["]>*? [\s|$] > ] # dwim on "$foo."
             <quote>
             [ <?before '(' | '.(' | '\\'> || <.panic: "Quoted method name requires parenthesized arguments. If you meant to concatenate two strings, use '~'."> ]
         ] <.unsp>?
@@ -4108,7 +4104,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         '<'
         [
         || <nibble(self.quote_lang(%*LANG<Quote>, "<", ">", ['q', 'w', 'v']))> '>'
-        || <?before \h* [ \d | <sigil> | ':' ] >
+        || <?before \h* [ \d | <.sigil> | ':' ] >
            { $/.CURSOR.panic("Whitespace required before < operator") }
         || { $/.CURSOR.panic("Unable to parse quote-words subscript; couldn't find right angle quote") }
         ]
@@ -4179,7 +4175,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
     token prefix:sym<^^>  { <sym> <.dupprefix('^^')> <O(|%symbolic_unary)> }
     token prefix:sym<^>   {
         <sym>  <O(|%symbolic_unary)>
-        <?before \d+ <?before \. <?alpha> > <.worry: "Precedence of ^ is looser than method call; please parenthesize"> >?
+        <?before \d+ <?before \. <.?alpha> > <.worry: "Precedence of ^ is looser than method call; please parenthesize"> >?
     }
 
     token infix:sym<*>    { <sym>  <O(|%multiplicative)> }
@@ -4226,7 +4222,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         <!{ $*IN_REDUCE }>
         [<!alpha>
             {
-                my $pre := nqp::substr(self.orig, self.from - 1, 1);
+                my str $pre := nqp::substr(self.orig, self.from - 1, 1);
                 $<ws> ne ''
                 ?? $¢.obs('. to concatenate strings', '~')
                 !! $pre ~~ /^\s$/
@@ -4317,8 +4313,8 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         <.ws>
         <EXPR('i=')>
         [ '!!'
-        || <?before '::' <-[=]>> { self.typed_panic: "X::Syntax::ConditionalOperator::SecondPartInvalid", second-part => "::" }
-        || <?before ':' <-[=\w]>> { self.typed_panic: "X::Syntax::ConditionalOperator::SecondPartInvalid", second-part => ":" }
+        || <?before '::' <.-[=]>> { self.typed_panic: "X::Syntax::ConditionalOperator::SecondPartInvalid", second-part => "::" }
+        || <?before ':' <.-[=\w]>> { self.typed_panic: "X::Syntax::ConditionalOperator::SecondPartInvalid", second-part => ":" }
         || <infixish> { self.typed_panic: "X::Syntax::ConditionalOperator::PrecedenceTooLoose", operator => ~$<infixish> }
         || <?{ ~$<EXPR> ~~ / '!!' / }> { self.typed_panic: "X::Syntax::ConditionalOperator::SecondPartGobbled" }
         || <?before \N*? [\n\N*?]? '!!'> { self.typed_panic: "X::Syntax::Confused", reason => "Confused: Bogus code found before the !! of conditional operator" }
@@ -4413,8 +4409,8 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         { $*INVOCANT_OK := 0; }
     }
 
-    token infix:sym<Z>    { <!before <sym> <infixish> > <sym>  <O(|%list_infix)> }
-    token infix:sym<X>    { <!before <sym> <infixish> > <sym>  <O(|%list_infix)> }
+    token infix:sym<Z>    { <!before <.sym> <.infixish> > <sym>  <O(|%list_infix)> }
+    token infix:sym<X>    { <!before <.sym> <.infixish> > <sym>  <O(|%list_infix)> }
 
     token infix:sym<...>  { <sym> <O(|%list_infix)> }
     token infix:sym<…>    { <sym> <O(|%list_infix)> }
@@ -4422,7 +4418,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
     token infix:sym<…^>   { <sym>  <O(|%list_infix)> }
     # token term:sym<...>   { <sym> <args>**0..1 <O(|%list_prefix)> }
 
-    token infix:sym<?>    { <sym> {} <![?]> <?before <-[;]>*?':'> <.obs('? and : for the ternary conditional operator', '?? and !!')> <O(|%conditional)> }
+    token infix:sym<?>    { <sym> {} <![?]> <?before <.-[;]>*?':'> <.obs('? and : for the ternary conditional operator', '?? and !!')> <O(|%conditional)> }
 
     token infix:sym<ff> { <sym> <O(|%conditional_ff)> }
     token infix:sym<^ff> { <sym> <O(|%conditional_ff)> }
@@ -4472,15 +4468,15 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
     token infix:sym<=~> { <sym> <.obs('=~ to do pattern matching', '~~')> <O(|%chaining)> }
 
     method add_mystery($token, $pos, $ctx) {
-        my $name := ~$token;
+        my str $name := ~$token;
         $name := nqp::substr($name,1) if nqp::eqat($name,"&",0);
         my $categorical := $name ~~ /^((\w+?fix) [ ':<'\s*(\S+?)\s*'>' | ':«'\s*(\S+?)\s*'»' ])$/;
         if $categorical {    # Does it look like a metaop?
-            my $cat := ~$categorical[0][0];
-            my $op := ~$categorical[0][1];
+            my str $cat := ~$categorical[0][0];
+            my str $op := ~$categorical[0][1];
             return self if $op eq '!=';
             my $lang := self.'!cursor_init'($op, :p(0));
-            my $meth := $cat eq 'infix' || $cat eq 'prefix' || $cat eq 'postfix' ?? $cat ~ 'ish' !! $cat;
+            my str $meth := $cat eq 'infix' || $cat eq 'prefix' || $cat eq 'postfix' ?? $cat ~ 'ish' !! $cat;
             $meth := 'term:sym<reduce>' if $cat eq 'prefix' && $op ~~ /^ \[ .* \] $ /;
             # nqp::printfh(nqp::getstderr(), "$meth $op\n");
             my $cursor := $lang."$meth"();
@@ -4505,7 +4501,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         }
         unless $name eq '' || $*W.is_lexical('&' ~ $name) {
             my $lex := $*W.cur_lexpad();
-            my $key := $name ~ '-' ~ $lex.cuid;
+            my str $key := $name ~ '-' ~ $lex.cuid;
             if nqp::existskey(%*MYSTERY, $key) {
                 nqp::push(%*MYSTERY{$key}<pos>, $pos);
             }
@@ -4536,8 +4532,8 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
 
         for %*MYSTERY {
             my %sym  := $_.value;
-            my $name := %sym<name>;
-            my $decl := $*W.is_lexically_visible($name, %sym<lex>);
+            my str $name := %sym<name>;
+            my int $decl := $*W.is_lexically_visible($name, %sym<lex>);
             if $decl == 2 {
                 # types may not be post-declared
                 %post_types{$name} := [] unless %post_types{$name};
@@ -4588,7 +4584,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
 
     method add_variable($name) {
         my $categorical := $name ~~ /^'&'((\w+) [ ':<'\s*(\S+?)\s*'>' | ':«'\s*(\S+?)\s*'»' ])$/;
-        my $cat := ~$categorical[0][0];
+        my str $cat := ~$categorical[0][0];
         if $categorical && nqp::can(self,$cat) {
             self.add_categorical($cat, ~$categorical[0][1],
                 $cat ~ $*W.canonicalize_pair('sym', $categorical[0][1]),
@@ -4629,8 +4625,8 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         # Work out what default precedence we want, or if it's more special than
         # just an operator.
         my %prec;
-        my $is_oper;
-        my $is_term := 0;
+        my int $is_oper;
+        my int $is_term := 0;
         if $category eq 'infix' {
             %prec := nqp::clone(%additive);
             $is_oper := 1;
@@ -4822,7 +4818,7 @@ grammar Perl6::QGrammar is HLL::Grammar does STD {
         token backslash:sym<c> { <sym> <charspec> }
         token backslash:sym<e> { <sym> }
         token backslash:sym<f> { <sym> }
-        token backslash:sym<N> { <?before 'N{'<[A..Z]>> <.obs('\N{CHARNAME}','\c[CHARNAME]')>  }
+        token backslash:sym<N> { <?before 'N{'<.[A..Z]>> <.obs('\N{CHARNAME}','\c[CHARNAME]')>  }
         token backslash:sym<n> { <sym> }
         token backslash:sym<o> { :dba('octal character') <sym> [ <octint> | '[' ~ ']' <octints> | '{' <.obsbrace> ] }
         token backslash:sym<r> { <sym> }
@@ -4946,8 +4942,8 @@ grammar Perl6::QGrammar is HLL::Grammar does STD {
     }
 
     token do_nibbling {
-        :my $from := self.pos;
-        :my $to   := $from;
+        :my int $from := self.pos;
+        :my int $to   := $from;
         [
             <!stopper>
             [
@@ -5032,7 +5028,7 @@ grammar Perl6::QGrammar is HLL::Grammar does STD {
         token backslash:sym<e> { :i <sym> }
         token backslash:sym<f> { :i <sym> }
         token backslash:sym<h> { :i <sym> { $*CCSTATE := '' } }
-        token backslash:sym<N> { <?before 'N{'<[A..Z]>> <.obs('\N{CHARNAME}','\c[CHARNAME]')>  }
+        token backslash:sym<N> { <?before 'N{'<.[A..Z]>> <.obs('\N{CHARNAME}','\c[CHARNAME]')>  }
         token backslash:sym<n> { :i <sym> }
         token backslash:sym<o> { :i :dba('octal character') <sym> [ <octint> | '[' ~ ']' <octints> | '{' <.obsbrace> ] }
         token backslash:sym<r> { :i <sym> }
@@ -5186,14 +5182,14 @@ grammar Perl6::RegexGrammar is QRegex::P6Regex::Grammar does STD does CursorPack
     }
 
     token metachar:sym<rakvar> {
-        <?before <sigil> $<twigil>=[<alpha> | \W<alpha> | '(']>
-        <!before <sigil> <rxstopper> >
+        <?before <.sigil> $<twigil>=[<.alpha> | \W<.alpha> | '(']>
+        <!before <.sigil> <.rxstopper> >
         <var=.LANG('MAIN', 'variable')>
         [
         || $<binding> = ( \s* '=' \s* <quantified_atom> )
            { self.check_variable($<var>) unless $<twigil> eq '<' }
         || { self.check_variable($<var>) }
-           [ <?before '.'? <[ \[ \{ \< ]>> <.worry: "Apparent subscript will be treated as regex"> ]?
+           [ <?before '.'? <.[ \[ \{ \< ]>> <.worry: "Apparent subscript will be treated as regex"> ]?
         ]
         <.SIGOK>
     }


### PR DESCRIPTION
Mostly just explicitly typing (str|int) things or making groups used in
a <before> or <after> non-capturing.

Passes `make m-spectest`