### PR TITLE
Handle all Nd digits in regex backslash errors

### DIFF
--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -5208,7 +5208,7 @@ grammar Perl6::RegexGrammar is QRegex::P6Regex::Grammar does STD does CursorPack
 
     token metachar:sym<{}> { \\<[xo]>'{' <.obsbrace> }
 
-    token backslash:sym<1> { <[1..9]>\d* {} <.sorry("Unrecognized backslash sequence (did you mean \${$/ - 1}?)")> }
+    token backslash:sym<1> { <.[\d] - [0]>\d* {} <.sorry("Unrecognized backslash sequence (did you mean \${nqp::radix(10, $/, 0, 0)[0] - 1}?)")> }
 
     token assertion:sym<{ }> {
         <?[{]> <codeblock>

--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -5208,7 +5208,12 @@ grammar Perl6::RegexGrammar is QRegex::P6Regex::Grammar does STD does CursorPack
 
     token metachar:sym<{}> { \\<[xo]>'{' <.obsbrace> }
 
-    token backslash:sym<1> { <.[\d] - [0]>\d* {} <.sorry("Unrecognized backslash sequence (did you mean \${nqp::radix(10, $/, 0, 0)[0] - 1}?)")> }
+    token backslash:sym<1> {
+        <.[\d] - [0]>\d*
+        {}
+        :my int $br := nqp::radix(10, $/, 0, 0)[0];
+        <.sorry("Unrecognized backslash sequence (did you mean \${$br == 0 ?? $br !! $br - 1}?)")>
+    }
 
     token assertion:sym<{ }> {
         <?[{]> <codeblock>


### PR DESCRIPTION
/\۳/ now suggests $2, before it just didn't recognize it.

Passes `make m-spectest`