### PR TITLE
Fix calling lines() after exhausting input

### DIFF
--- a/src/core/IO/ArgFiles.pm
+++ b/src/core/IO/ArgFiles.pm
@@ -101,6 +101,7 @@ my class IO::ArgFiles is IO::Handle {
 
             method pull-one() {
                 nqp::stmts(
+                  (nqp::unless(nqp::defined($!iter), return IterationEnd)),
                   (my \value = $!iter.pull-one),
                   nqp::if(nqp::eqaddr(value, IterationEnd),
                     nqp::stmts(


### PR DESCRIPTION
Passes `make m-spectest`

If doing something like `say lines.elems; say lines[0]`, a recent change to IO::ArgFiles.lines caused a regression, so the output would be `<some number>\nNo such method 'pull-one' for invocant of type 'Any'`. The output is now `<some number>\nNil`, like it was before 73797b759.