### PR TITLE
Don't mention *CORE.setting in error message

### DIFF
--- a/src/core/Backtrace.pm
+++ b/src/core/Backtrace.pm
@@ -61,6 +61,7 @@ my class Backtrace::Frame {
     method is-setting(Backtrace::Frame:D:) {
         $!file.starts-with("SETTING::")
           || $!file.ends-with("CORE.setting." ~ Rakudo::Internals.PRECOMP-EXT)
+          || $!file.ends-with("CORE.setting")
     }
 }
 


### PR DESCRIPTION
References to CORE.setting.moarvm where removed with 4ae08e0b24,
but rakudo-j points to gen/jvm/CORE.setting (no .jar there).

Fixes RT #130509 and RT #124767 on JVM