### PR TITLE
Initial implementation of non-blocking await for 6.d.PREVIEW

### DIFF
--- a/Configure.pl
+++ b/Configure.pl
@@ -163,7 +163,7 @@ MAIN: {
         }
     }
 
-    for my $target (qw/common_bootstrap_sources moar_core_sources jvm_core_sources/) {
+    for my $target (qw/common_bootstrap_sources moar_core_sources moar_core_d_sources jvm_core_sources jvm_core_d_sources/) {
         open my $FILELIST, '<', "tools/build/$target"
             or die "Cannot read 'tools/build/$target': $!";
         my @lines;

--- a/src/Perl6/Compiler.nqp
+++ b/src/Perl6/Compiler.nqp
@@ -3,6 +3,8 @@ use QRegex;
 use Perl6::Optimizer;
 
 class Perl6::Compiler is HLL::Compiler {
+    has $!language_version;
+
     method compilation-id() {
         my class IDHolder { }
         BEGIN { (IDHolder.WHO)<$ID> := $*W.handle }
@@ -11,7 +13,20 @@ class Perl6::Compiler is HLL::Compiler {
 
     method implementation()   { self.config<implementation> }
     method language_name()    { 'Perl' }
-    method language_version() { self.config<language_version> }
+    method reset_language_version() {
+        $!language_version := NQPMu;
+    }
+    method set_language_version($version) {
+        $!language_version := $version;
+    }
+    method language_version() {
+        if nqp::defined($!language_version) {
+            $!language_version
+        }
+        else {
+            $!language_version := self.config<language_version>
+        }
+    }
 
     method command_eval(*@args, *%options) {
         if nqp::existskey(%options, 'doc') && !%options<doc> {

--- a/src/Perl6/ModuleLoader.nqp
+++ b/src/Perl6/ModuleLoader.nqp
@@ -49,6 +49,11 @@ class Perl6::ModuleLoader does Perl6::ModuleLoaderVMConfig {
             my $file := 'Perl6/BOOTSTRAP' ~ self.file-extension;
             my $include := nqp::getcomp('perl6').cli-options<nqp-lib>;
             $file := ($include ?? $include ~ '/' !! nqp::getcomp('perl6').config<prefix> ~ '/share/nqp/lib/') ~ $file;
+
+            if nqp::existskey(%modules_loaded, $file) {
+                return nqp::ctxlexpad(%modules_loaded{$file});
+            }
+
             nqp::loadbytecode($file);
             %modules_loaded{$file} := my $module_ctx := $*MAIN_CTX;
             nqp::bindhllsym('perl6', 'GLOBAL', $preserve_global);

--- a/src/core.d/await.pm
+++ b/src/core.d/await.pm
@@ -1,0 +1,13 @@
+proto sub await(|) { * }
+multi sub await() {
+    die "Must specify an Awaitable to await (got an empty list)";
+}
+multi sub await(Any:U $x) {
+    die "Must specify a defined Awaitable to await (got an undefined $x.^name())";
+}
+multi sub await(Any:D $x) {
+    die "Must specify an Awaitable to await (got a $x.^name())";
+}
+multi sub await(Awaitable:D \a) { $*AWAITER.await(a) }
+multi sub await(Iterable:D \i)  { $*AWAITER.await-all(i) }
+multi sub await(*@awaitables)   { $*AWAITER.await-all(@awaitables) }

--- a/src/core.d/core_prologue.pm
+++ b/src/core.d/core_prologue.pm
@@ -1,0 +1,4 @@
+use MONKEY-TYPING;
+use nqp;
+
+# vim: ft=perl6 expandtab sw=4

--- a/src/core/Awaitable.pm
+++ b/src/core/Awaitable.pm
@@ -1,2 +1,48 @@
+# An Awaitable is something we can use the `await` operator on. To support
+# this, it requires a `get-await-handle` method be implemented, which returns
+# an `Awaitable::AwaitHandle`.
 my role Awaitable {
+    method get-await-handle() { ... }
+}
+
+# An Awaitable::Handle implementation is an immutable object that conveys the
+# status of the requested asynchronous result at the point we obtain the
+# handle. If the `.already` property is `True`, then there is no need to block
+# or suspend execution; the `.result` or `.cause` of failure can be used right
+# away (depending on the value of `.success). Otherwise, the consumer of the
+# handle should call the `subscribe-awaiter` method with its unblock/resume
+# handler, and then proceed to block/suspend. In this case, the handler will
+# be passed two arguments: a `Bool` success, and a result/cause (result if
+# success is `True`, cause if it's `False`). The `Awaitable::Handle` will
+# *not* have its success/result/cause updated; this would open the door to
+# data races (including subtle ones related to read/write ordering), when
+# the point of the fast-path is to test if we've got a result already with
+# minimal overhead (and thus minimal concurrency control).
+my role Awaitable::Handle {
+    has Bool $.already;
+    has Bool $.success;
+    has Mu $.result;
+    has Exception $.cause;
+
+    method already-success(\result) {
+        self.CREATE!already-success(result)
+    }
+    method !already-success(\result) {
+        $!already := True;
+        $!success := True;
+        $!result := result;
+        self
+    }
+
+    method already-failure(\cause) {
+        self.CREATE!already-failure(cause)
+    }
+    method !already-failure(\cause) {
+        $!already := True;
+        $!success := False;
+        $!cause := cause;
+        self
+    }
+
+    method subscribe-awaiter(&subscriber) { ... }
 }

--- a/src/core/Awaitable.pm
+++ b/src/core/Awaitable.pm
@@ -1,0 +1,2 @@
+my role Awaitable {
+}

--- a/src/core/Awaiter.pm
+++ b/src/core/Awaiter.pm
@@ -71,7 +71,7 @@ my class Awaiter::Blocking does Awaiter {
                 my int $insert = nqp::atpos_i(indices, $i);
                 $handle.subscribe-awaiter(-> \success, \result {
                     $l.protect: {
-                        if success {
+                        if success && $remaining {
                             nqp::bindpos(results, $insert, result);
                             --$remaining;
                             $ready.signal unless $remaining;

--- a/src/core/Awaiter.pm
+++ b/src/core/Awaiter.pm
@@ -1,0 +1,35 @@
+my role Awaiter {
+    method await(Awaitable:D $a) { ... }
+    method await-all(Iterable:D $i) { ... }
+}
+
+my class Awaiter::Blocking does Awaiter {
+    method await(Awaitable:D $a) {
+        my $handle := $a.get-await-handle;
+        if $handle.already {
+            $handle.success
+                ?? $handle.result
+                !! $handle.cause.rethrow
+        }
+        else {
+            my $s = Semaphore.new(0);
+            my $success;
+            my $result;
+            $handle.subscribe-awaiter(-> \success, \result {
+                $success := success;
+                $result := result;
+                $s.release;
+            });
+            $s.acquire;
+            $success
+                ?? $result
+                !! $result.rethrow
+        }
+    }
+
+    method await-all(Iterable:D $i) {
+        die "await-all NYI";
+    }
+}
+
+PROCESS::<$AWAITER> := Awaiter::Blocking;

--- a/src/core/Awaiter.pm
+++ b/src/core/Awaiter.pm
@@ -27,8 +27,78 @@ my class Awaiter::Blocking does Awaiter {
         }
     }
 
-    method await-all(Iterable:D $i) {
-        die "await-all NYI";
+    method await-all(Iterable:D \i) {
+        # Collect results that are already available, and handles where the
+        # results are not yet available together with the matching insertion
+        # indices.
+        my \results = nqp::list();
+        my \handles = nqp::list();
+        my \indices = nqp::list_i();
+        my int $insert = 0;
+        for i -> $awaitable {
+            unless nqp::istype($awaitable, Awaitable) {
+                die "Can only specify Awaitable objects to await (got a $awaitable.^name())";
+            }
+            unless nqp::isconcrete($awaitable) {
+                die "Must specify a defined Awaitable to await (got an undefined $awaitable.^name())";
+            }
+
+            my $handle := $awaitable.get-await-handle;
+            if $handle.already {
+                $handle.success
+                    ?? nqp::bindpos(results, $insert, $handle.result)
+                    !! $handle.cause.rethrow
+            }
+            else {
+                nqp::push(handles, $handle);
+                nqp::push_i(indices, $insert);
+            }
+
+            $insert++;
+        }
+
+        # See if we have anything that we need to really block on. If so, we
+        # use a lock and condition variable to handle the blocking. The lock
+        # protects writes into the array.
+        my int $num-handles = nqp::elems(handles);
+        if $num-handles {
+            my $exception = Mu;
+            my $l = Lock.new;
+            my $ready = $l.condition();
+            my int $remaining = $num-handles;
+            loop (my int $i = 0; $i < $num-handles; $i++) {
+                my $handle := nqp::atpos(handles, $i);
+                my int $insert = nqp::atpos_i(indices, $i);
+                $handle.subscribe-awaiter(-> \success, \result {
+                    $l.protect: {
+                        if success {
+                            nqp::bindpos(results, $insert, result);
+                            --$remaining;
+                            $ready.signal unless $remaining;
+                        }
+                        elsif !nqp::isconcrete($exception) {
+                            $exception := result;
+                            $remaining = 0;
+                            $ready.signal;
+                        }
+                    }
+                });
+            }
+
+            # Block until remaining is 0 (need the loop to cope with suprious
+            # wakeups).
+            loop {
+                $l.protect: {
+                    last if $remaining == 0;
+                    $ready.wait;
+                }
+            }
+
+            # If we got an exception, throw it.
+            $exception.rethrow if nqp::isconcrete($exception);
+        }
+
+        nqp::p6bindattrinvres(nqp::create(List), List, '$!reified', results);
     }
 }
 

--- a/src/core/Channel.pm
+++ b/src/core/Channel.pm
@@ -157,8 +157,75 @@ my class Channel does Awaitable {
     method Seq(Channel:D:)  { Seq.new(self.iterator) }
     method list(Channel:D:) { self.Seq.list }
 
+    my class ChannelAwaitableHandle does Awaitable::Handle {
+        has $!channel;
+        has $!closed_promise;
+        has $!async-notify;
+
+        method not-ready(Channel:D $channel, Promise:D $closed_promise, Supplier:D $async-notify) {
+            self.CREATE!not-ready($channel, $closed_promise, $async-notify)
+        }
+        method !not-ready($channel, $closed_promise, $async-notify) {
+            $!already = False;
+            $!channel := $channel;
+            $!closed_promise := $closed_promise;
+            $!async-notify := $async-notify;
+            self
+        }
+
+        method subscribe-awaiter(&subscriber --> Nil) {
+            # Need some care here to avoid a race. We must tap the notification
+            # supply first, and then do an immediate poll after it, just to be
+            # sure we won't miss notifications between the two. Also, we need
+            # to take some care that we never call subscriber twice; a lock is
+            # a tad heavy-weight for it, in the future we can just CAS an int.
+            my $notified := False;
+            my $l := Lock.new;
+            my $t := $!async-notify.unsanitized-supply.tap: &poll-now;
+            poll-now();
+
+            sub poll-now($discard?) {
+                $l.protect: {
+                    unless $notified {
+                        my \maybe = $!channel.poll;
+                        if maybe === Nil {
+                            if $!closed_promise.status == Kept {
+                                $notified := True;
+                                subscriber(False, X::Channel::ReceiveOnClosed.new(:$!channel))
+                            }
+                            elsif $!closed_promise.status == Broken {
+                                $notified := True;
+                                subscriber(False, $!closed_promise.cause)
+                            }
+                        }
+                        else {
+                            $notified := True;
+                            subscriber(True, maybe);
+                        }
+                        $t.close if $notified;
+                    }
+                }
+            }
+        }
+    }
+
     method get-await-handle(--> Awaitable::Handle) {
-        !!! "get-await-handle NYI"
+        my \maybe = self.poll;
+        if maybe === Nil {
+            if $!closed_promise {
+                ChannelAwaitableHandle.already-failure(
+                    $!closed_promise.status == Kept
+                        ?? X::Channel::ReceiveOnClosed.new(channel => self)
+                        !! $!closed_promise.cause
+                )
+            }
+            else {
+                ChannelAwaitableHandle.not-ready(self, $!closed_promise, $!async-notify)
+            }
+        }
+        else {
+            ChannelAwaitableHandle.already-success(maybe)
+        }
     }
 
     method close() {

--- a/src/core/Channel.pm
+++ b/src/core/Channel.pm
@@ -8,7 +8,7 @@ my class X::Channel::ReceiveOnClosed is Exception {
     has $.channel;
     method message() { "Cannot receive a message on a closed channel" }
 }
-my class Channel {
+my class Channel does Awaitable {
     # The queue of events moving through the channel.
     my class Queue is repr('ConcBlockingQueue') { }
     has $!queue;

--- a/src/core/Channel.pm
+++ b/src/core/Channel.pm
@@ -157,6 +157,10 @@ my class Channel does Awaitable {
     method Seq(Channel:D:)  { Seq.new(self.iterator) }
     method list(Channel:D:) { self.Seq.list }
 
+    method get-await-handle(--> Awaitable::Handle) {
+        !!! "get-await-handle NYI"
+    }
+
     method close() {
         $!closed = 1;
         nqp::push($!queue, CHANNEL_CLOSE);

--- a/src/core/Promise.pm
+++ b/src/core/Promise.pm
@@ -24,7 +24,7 @@ my role X::Promise::Broken {
             callsame().indent(4)
     }
 }
-my class Promise {
+my class Promise does Awaitable {
     has $.scheduler;
     has $.status;
     has $!result is default(Nil);

--- a/src/core/Promise.pm
+++ b/src/core/Promise.pm
@@ -200,9 +200,10 @@ my class Promise does Awaitable {
                     on-ready($!status == Kept, $!result)
                 }
                 else {
-                    # Push 2 entries to @!thens: one for success, one for failure.
-                    @!thens.push({ on-ready(True, $!result) });
-                    @!thens.push(-> \ex { on-ready(False, ex) });
+                    # Push 2 entries to @!thens (only need the first one in
+                    # this case; second we push 'cus .then uses it).
+                    @!thens.push({ on-ready($!status == Kept, $!result) });
+                    @!thens.push(Callable);
                     nqp::unlock($!lock);
                 }
             }

--- a/src/core/Supply.pm
+++ b/src/core/Supply.pm
@@ -620,6 +620,10 @@ my class Supply does Awaitable {
 
     method wait(Supply:D:) { await self.Promise }
 
+    method get-await-handle(--> Awaitable::Handle) {
+        !!! "get-await-handle NYI"
+    }
+
     method unique(Supply:D $self: :&as, :&with, :$expires) {
         supply {
             if $expires {

--- a/src/core/Supply.pm
+++ b/src/core/Supply.pm
@@ -621,7 +621,7 @@ my class Supply does Awaitable {
     method wait(Supply:D:) { await self.Promise }
 
     my class SupplyAwaitableHandle does Awaitable::Handle {
-        has $.supply;
+        has $!supply;
 
         method not-ready(Supply:D \supply) {
             self.CREATE!not-ready(supply)

--- a/src/core/Supply.pm
+++ b/src/core/Supply.pm
@@ -56,7 +56,7 @@ my class X::Supply::New is Exception {
 # a Supply go in here.
 my class Supplier { ... }
 my class Supplier::Preserving { ... }
-my class Supply {
+my class Supply does Awaitable {
     has Tappable $!tappable;
 
     proto method new(|) { * }

--- a/src/core/ThreadPoolScheduler.pm
+++ b/src/core/ThreadPoolScheduler.pm
@@ -3,6 +3,127 @@
 # using them.
 
 my class ThreadPoolScheduler does Scheduler {
+    constant THREAD_POOL_PROMPT = Mu.new;
+
+    class ThreadPoolAwaiter does Awaiter {
+        has $!queue;
+
+        submethod BUILD(:$queue!) {
+            $!queue := nqp::decont($queue);
+        }
+
+        method await(Awaitable:D $a) {
+            my $handle := $a.get-await-handle;
+            if $handle.already {
+                $handle.success
+                    ?? $handle.result
+                    !! $handle.cause.rethrow
+            }
+            else {
+                my $success;
+                my $result;
+                nqp::continuationcontrol(0, THREAD_POOL_PROMPT, -> Mu \c {
+                    $handle.subscribe-awaiter(-> \success, \result {
+                        $success := success;
+                        $result := result;
+                        nqp::push($!queue, { nqp::continuationinvoke(c, nqp::null()) });
+                        Nil
+                    });
+                });
+                $success
+                    ?? $result
+                    !! $result.rethrow
+            }
+        }
+
+        method await-all(Iterable:D \i) {
+            # Collect results that are already available, and handles where the
+            # results are not yet available together with the matching insertion
+            # indices.
+            my \results = nqp::list();
+            my \handles = nqp::list();
+            my \indices = nqp::list_i();
+            my int $insert = 0;
+            for i -> $awaitable {
+                unless nqp::istype($awaitable, Awaitable) {
+                    die "Can only specify Awaitable objects to await (got a $awaitable.^name())";
+                }
+                unless nqp::isconcrete($awaitable) {
+                    die "Must specify a defined Awaitable to await (got an undefined $awaitable.^name())";
+                }
+
+                my $handle := $awaitable.get-await-handle;
+                if $handle.already {
+                    $handle.success
+                        ?? nqp::bindpos(results, $insert, $handle.result)
+                        !! $handle.cause.rethrow
+                }
+                else {
+                    nqp::push(handles, $handle);
+                    nqp::push_i(indices, $insert);
+                }
+
+                $insert++;
+            }
+
+            # See if we have anything that we really need to suspend for. If
+            # so, we need to take great care that the continuation taking is
+            # complete before we try to resume it (completions can happen on
+            # different threads, and so concurrent with us subscribing, not
+            # to mention concurrent with each other wanting to resume). We
+            # use a lock to take care of this, holding the lock until the
+            # continuation has been taken.
+            my int $num-handles = nqp::elems(handles);
+            if $num-handles {
+                my $continuation;
+                my $exception;
+                my $l = Lock.new;
+                $l.lock;
+                {
+                    my int $remaining = $num-handles;
+                    loop (my int $i = 0; $i < $num-handles; $i++) {
+                        my $handle := nqp::atpos(handles, $i);
+                        my int $insert = nqp::atpos_i(indices, $i);
+                        $handle.subscribe-awaiter(-> \success, \result {
+                            my int $resume;
+                            $l.protect: {
+                                if success {
+                                    nqp::bindpos(results, $insert, result);
+                                    --$remaining;
+                                    $resume = 1 unless $remaining;
+                                }
+                                elsif !nqp::isconcrete($exception) {
+                                    $exception := result;
+                                    $remaining = 0;
+                                    $resume = 1;
+                                }
+                            }
+                            if $resume {
+                                nqp::push($!queue, {
+                                    nqp::continuationinvoke($continuation, nqp::null())
+                                });
+                            }
+                        });
+                    }
+                    CATCH {
+                        # Unlock if we fail here, and let the exception
+                        # propagate outwards.
+                        $l.unlock();
+                    }
+                }
+                nqp::continuationcontrol(0, THREAD_POOL_PROMPT, -> Mu \c {
+                    $continuation := c;
+                    $l.unlock;
+                });
+
+                # If we got an exception, throw it.
+                $exception.rethrow if nqp::isconcrete($exception);
+            }
+
+            nqp::p6bindattrinvres(nqp::create(List), List, '$!reified', results);
+        }
+    }
+
     # A concurrent work queue that blocks any worker threads that poll it
     # when empty until some work arrives.
     my class Queue is repr('ConcBlockingQueue') { }
@@ -38,10 +159,11 @@ my class ThreadPoolScheduler does Scheduler {
             $!started_any = 1;
             $!counts_lock.protect: { $!threads_started = $!threads_started + 1 };
             Thread.start(:app_lifetime, {
+                my $*AWAITER := ThreadPoolAwaiter.new(:$!queue);
                 loop {
                     my Mu $task := nqp::shift($!queue);
                     $!counts_lock.protect: { $!loads = $!loads + 1 };
-                    try {
+                    nqp::continuationreset(THREAD_POOL_PROMPT, {
                         if nqp::islist($task) {
                             my Mu $code := nqp::shift($task);
                             my \args = nqp::p6bindattrinvres(nqp::create(List), List, '$!reified', $task);
@@ -61,7 +183,7 @@ my class ThreadPoolScheduler does Scheduler {
                                 self.handle_uncaught($_)
                             }
                         }
-                    }
+                    });
                     $!counts_lock.protect: { $!loads = $!loads - 1 };
                 }
             });

--- a/src/core/ThreadPoolScheduler.pm
+++ b/src/core/ThreadPoolScheduler.pm
@@ -87,7 +87,7 @@ my class ThreadPoolScheduler does Scheduler {
                         $handle.subscribe-awaiter(-> \success, \result {
                             my int $resume;
                             $l.protect: {
-                                if success {
+                                if success && $remaining {
                                     nqp::bindpos(results, $insert, result);
                                     --$remaining;
                                     $resume = 1 unless $remaining;

--- a/src/core/Version.pm
+++ b/src/core/Version.pm
@@ -109,7 +109,7 @@ class Version {
         nqp::box_s(nqp::unbox_s(self.^name ~ '|' ~ $!string), ObjAt);
     }
 
-    method parts() { $!parts }
+    method parts() { nqp::hllize($!parts) }
     method plus()  { nqp::p6bool($!plus) }
 }
 

--- a/t/spectest.data
+++ b/t/spectest.data
@@ -838,6 +838,7 @@ S17-supply/merge.t
 S17-supply/migrate.t
 S17-supply/min.t
 S17-supply/minmax.t
+S17-promise/nonblocking-await.t
 S17-supply/on-demand.t
 S17-supply/Promise.t
 S17-supply/produce.t

--- a/tools/build/Makefile-JVM.in
+++ b/tools/build/Makefile-JVM.in
@@ -37,6 +37,7 @@ PERL6_C_JAR   = blib/Perl6/Compiler.jar
 PERL6_M_JAR   = blib/Perl6/Metamodel.jar
 PERL6_B_JAR   = blib/Perl6/BOOTSTRAP.jar
 SETTING_JAR   = CORE.setting.jar
+SETTING_D_JAR = CORE.d.setting.jar
 
 PERL6_LANG_JARS = $(PERL6_ML_JAR) $(PERL6_W_JAR) $(PERL6_G_JAR) $(PERL6_OPS_JAR) $(PERL6_A_JAR) \
   $(PERL6_O_JAR) $(PERL6_P_JAR) $(PERL6_C_JAR) $(PERL6_M_JAR) $(PERL6_B_JAR) $(PERL6_DP_JAR)
@@ -55,6 +56,9 @@ J_METAMODEL_SOURCES = $(COMMON_BOOTSTRAP_SOURCES) \
 J_CORE_SOURCES = \
   @jvm_core_sources@
 
+J_CORE_D_SOURCES = \
+  @jvm_core_d_sources@
+
 PERL6_DEBUG_JAR = perl6-debug.jar
 J_DEBUG_RUNNER = perl6-debug-j@runner_suffix@
 
@@ -62,6 +66,7 @@ J_CLEANUPS = \
   *.manifest \
   blib/Perl6/*.jar \
   $(SETTING_JAR) \
+  $(SETTING_D_JAR) \
   $(PERL6_JAR) \
   j-rakudo_test_run.tar.gz \
   $(J_BUILD_DIR)/* \
@@ -78,7 +83,7 @@ HARNESS_TYPE =
 J_HARNESS5 = $(PERL5) t/harness5 --jvm
 J_HARNESS5_WITH_FUDGE = $(J_HARNESS5) --fudge --keep-exit-code
 
-j-all: $(PERL6_JAR) $(SETTING_JAR) $(J_RUNNER) eval-client.pl  $(PERL6_DEBUG_JAR) $(J_DEBUG_RUNNER)
+j-all: $(PERL6_JAR) $(SETTING_JAR) $(SETTING_D_JAR) $(J_RUNNER) eval-client.pl  $(PERL6_DEBUG_JAR) $(J_DEBUG_RUNNER)
 
 $(RUNTIME_JAR): $(RUNTIME_JAVAS)
 	$(MKPATH) bin
@@ -143,6 +148,11 @@ $(SETTING_JAR): $(PERL6_JAR) $(PERL6_B_JAR) $(J_CORE_SOURCES)
 	$(J_NQP) $(J_GEN_CAT) -f tools/build/jvm_core_sources > $(J_BUILD_DIR)/CORE.setting
 	@echo "The following step can take a long time, please be patient."
 	NQP_LIB=blib $(J_RUN_PERL6) --setting=NULL --ll-exception --optimize=3 --target=jar --stagestats --output=$(SETTING_JAR) --nqp-lib=blib $(J_BUILD_DIR)/CORE.setting
+
+$(SETTING_D_JAR): $(PERL6_JAR) $(PERL6_B_JAR) $(SETTING_JAR) $(J_CORE_SOURCES)
+	$(J_NQP) $(J_GEN_CAT) $(J_CORE_D_SOURCES) > $(J_BUILD_DIR)/CORE.d.setting
+	@echo "The following step can take a long time, please be patient."
+	$(J_RUN_PERL6) --ll-exception --optimize=3 --target=jar --stagestats --output=$(SETTING_D_JAR) $(J_BUILD_DIR)/CORE.d.setting
 
 $(J_RUNNER):    tools/build/create-jvm-runner.pl
 	$(PERL5) tools/build/create-jvm-runner.pl dev . . $(NQP_PREFIX) --nqp-lib=blib $(NQP_JARS)
@@ -210,7 +220,7 @@ j-install: j-all tools/build/create-jvm-runner.pl tools/build/install-core-dist.
 	$(MKPATH) $(DESTDIR)$(J_LIBPATH)/Perl6
 	$(MKPATH) $(DESTDIR)$(PERL6_LANG_DIR)/runtime
 	$(CP) $(PERL6_LANG_JARS) $(DESTDIR)$(J_LIBPATH)/Perl6
-	$(CP) $(SETTING_JAR) $(DESTDIR)$(PERL6_LANG_DIR)/runtime
+	$(CP) $(SETTING_JAR) $(SETTING_D_JAR) $(DESTDIR)$(PERL6_LANG_DIR)/runtime
 	$(CP) $(PERL6_JAR) $(DESTDIR)$(PERL6_LANG_DIR)/runtime
 	$(CP) $(PERL6_DEBUG_JAR) $(DESTDIR)$(PERL6_LANG_DIR)/runtime
 	$(CP) $(RUNTIME_JAR) $(DESTDIR)$(PERL6_LANG_DIR)/runtime

--- a/tools/build/Makefile-Moar.in
+++ b/tools/build/Makefile-Moar.in
@@ -33,6 +33,7 @@ PERL6_C_MOAR   = blib/Perl6/Compiler.moarvm
 PERL6_M_MOAR   = blib/Perl6/Metamodel.moarvm
 PERL6_B_MOAR   = blib/Perl6/BOOTSTRAP.moarvm
 SETTING_MOAR   = CORE.setting.moarvm
+SETTING_D_MOAR = CORE.d.setting.moarvm
 R_SETTING_MOAR = RESTRICTED.setting.moarvm
 
 M_PERL6_OPS_DIR  = dynext
@@ -59,6 +60,8 @@ M_METAMODEL_SOURCES = $(COMMON_BOOTSTRAP_SOURCES)
 # setting - basically anything that feels MOP-ish.
 M_CORE_SOURCES = \
 	@moar_core_sources@
+M_CORE_D_SOURCES = \
+	@moar_core_d_sources@
 
 PERL6_DEBUG_MOAR = perl6-debug.moarvm
 M_DEBUG_RUNNER = perl6-debug-m@runner_suffix@
@@ -69,6 +72,7 @@ M_CLEANUPS = \
   *.manifest \
   blib/Perl6/*.moarvm \
   $(SETTING_MOAR) \
+  $(SETTING_D_MOAR) \
   $(R_SETTING_MOAR) \
   $(PERL6_MOAR) \
   rakudo_test_run.tar.gz \
@@ -90,7 +94,7 @@ M_HARNESS5_WITH_FUDGE = $(M_HARNESS5) --fudge --moar --keep-exit-code
 M_HARNESS6 = .@slash@$(M_RUNNER) -Ilib t/harness6
 M_HARNESS6_WITH_FUDGE = $(M_HARNESS6) --fudge
 
-m-all: $(PERL6_MOAR) $(SETTING_MOAR) $(R_SETTING_MOAR) $(M_RUNNER) $(PERL6_DEBUG_MOAR) $(M_DEBUG_RUNNER) @m_all@
+m-all: $(PERL6_MOAR) $(SETTING_MOAR) $(SETTING_D_MOAR) $(R_SETTING_MOAR) $(M_RUNNER) $(PERL6_DEBUG_MOAR) $(M_DEBUG_RUNNER) @m_all@
 
 $(M_PERL6_OPS_DLL): $(M_PERL6_OPS_SRC) $(M_PERL6_CONT_SRC) 
 	$(M_CC) @moar::ccswitch@ @moar::ccshared@ $(M_CFLAGS) -I$(M_INCPATH)/libatomic_ops \
@@ -162,6 +166,11 @@ $(SETTING_MOAR): $(PERL6_MOAR) $(PERL6_B_MOAR) $(M_CORE_SOURCES)
 	$(M_NQP) $(M_GEN_CAT) -f tools/build/moar_core_sources > $(M_BUILD_DIR)/CORE.setting
 	@echo "The following step can take a long time, please be patient."
 	$(M_RUN_PERL6) --setting=NULL --ll-exception --optimize=3 --target=mbc --stagestats --output=$(SETTING_MOAR) $(M_BUILD_DIR)/CORE.setting
+
+$(SETTING_D_MOAR): $(PERL6_MOAR) $(PERL6_B_MOAR) $(SETTING_MOAR) $(M_CORE_D_SOURCES)
+	$(M_NQP) $(M_GEN_CAT) -f tools/build/moar_core_d_sources > $(M_BUILD_DIR)/m-CORE.d.setting
+	@echo "The following step can take a long time, please be patient."
+	$(M_RUN_PERL6) --ll-exception --optimize=3 --target=mbc --stagestats --output=$(SETTING_D_MOAR) $(M_BUILD_DIR)/m-CORE.d.setting
 
 $(R_SETTING_MOAR): $(PERL6_MOAR) $(SETTING_MOAR) $(R_SETTING_SRC) $(SETTING_MOAR)
 	$(M_RUN_PERL6) --target=mbc --ll-exception --output=$(R_SETTING_MOAR) $(R_SETTING_SRC)
@@ -270,7 +279,7 @@ m-install: m-all tools/build/create-moar-runner.pl tools/build/install-core-dist
 	$(CP) $(M_PERL6_LANG_OUTPUT) $(DESTDIR)$(M_LIBPATH)/Perl6
 	$(MKPATH) $(DESTDIR)$(PERL6_LANG_DIR)/lib
 	$(MKPATH) $(DESTDIR)$(PERL6_LANG_DIR)/runtime
-	$(CP) $(SETTING_MOAR) $(R_SETTING_MOAR) $(DESTDIR)$(PERL6_LANG_DIR)/runtime
+	$(CP) $(SETTING_MOAR) $(SETTING_D_MOAR) $(R_SETTING_MOAR) $(DESTDIR)$(PERL6_LANG_DIR)/runtime
 	$(CP) $(PERL6_MOAR) $(PERL6_DEBUG_MOAR) $(DESTDIR)$(PERL6_LANG_DIR)/runtime
 	$(MKPATH) $(DESTDIR)$(PERL6_LANG_DIR)/runtime/dynext
 	$(CP) $(M_PERL6_OPS_DLL) $(DESTDIR)$(PERL6_LANG_DIR)/runtime/dynext

--- a/tools/build/jvm_core_d_sources
+++ b/tools/build/jvm_core_d_sources
@@ -1,0 +1,1 @@
+src/core.d/core_prologue.pm

--- a/tools/build/jvm_core_d_sources
+++ b/tools/build/jvm_core_d_sources
@@ -1,1 +1,2 @@
 src/core.d/core_prologue.pm
+src/core.d/await.pm

--- a/tools/build/jvm_core_sources
+++ b/tools/build/jvm_core_sources
@@ -129,6 +129,7 @@ src/core/Thread.pm
 src/core/Lock.pm
 src/core/Semaphore.pm
 src/core/Cancellation.pm
+src/core/Awaitable.pm
 src/core/Scheduler.pm
 src/core/Env.pm
 src/core/ThreadPoolScheduler.pm

--- a/tools/build/jvm_core_sources
+++ b/tools/build/jvm_core_sources
@@ -130,6 +130,7 @@ src/core/Lock.pm
 src/core/Semaphore.pm
 src/core/Cancellation.pm
 src/core/Awaitable.pm
+src/core/Awaiter.pm
 src/core/Scheduler.pm
 src/core/Env.pm
 src/core/ThreadPoolScheduler.pm

--- a/tools/build/moar_core_d_sources
+++ b/tools/build/moar_core_d_sources
@@ -1,0 +1,1 @@
+src/core.d/core_prologue.pm

--- a/tools/build/moar_core_d_sources
+++ b/tools/build/moar_core_d_sources
@@ -1,1 +1,2 @@
 src/core.d/core_prologue.pm
+src/core.d/await.pm

--- a/tools/build/moar_core_sources
+++ b/tools/build/moar_core_sources
@@ -130,6 +130,7 @@ src/core/Thread.pm
 src/core/Lock.pm
 src/core/Semaphore.pm
 src/core/Cancellation.pm
+src/core/Awaitable.pm
 src/core/Scheduler.pm
 src/core/Env.pm
 src/core/ThreadPoolScheduler.pm

--- a/tools/build/moar_core_sources
+++ b/tools/build/moar_core_sources
@@ -131,6 +131,7 @@ src/core/Lock.pm
 src/core/Semaphore.pm
 src/core/Cancellation.pm
 src/core/Awaitable.pm
+src/core/Awaiter.pm
 src/core/Scheduler.pm
 src/core/Env.pm
 src/core/ThreadPoolScheduler.pm


### PR DESCRIPTION
So far, when you `await` in code running on a thread in the thread pool, it would block a real OS thread. This meant that certain patterns had to be expressed in unnatural ways (using `.then` and a callback), or that the scheduler had to have its maximum number of threads raised really high. For example, sleepsort on a hundred or a thousand values would run into issues there if you wrote it with `await`.

My original intention for `await`, when used on a thread pool thread, was that it would instead hand control back to the scheduler so the thread could be used for other work. This would mean we could have thousands of tasks awaiting stuff, and just a handful of threads required for progress.

This PR implements exactly that. As a bonus, it also makes `await` in the case of an already available result not require concurrency control in the `Promise` case, which should be a speed-up. Furthermore, there's now an interface for things that wish to participate in the `await` system to implement, so while we just use it for `Promise`, `Supply`, and `Channel` today, module space will also be able to create their own things that we can `await`.

Unless you `use v6.d.PREVIEW`, nothing changes as of merging this PR. You have to opt in to get this new behavior of `await`. Once Perl 6.d is released, then Rakudo will switch to 6.d being the default and - unless code has explicitly declared itself as wanting 6.c - this will become the default behavior for all `await`s on thread pool threads. (And `await` in the mainline, or in a bare `Thread`, will continue to have the same blocking behavior as today, just implemented through the new `Awaitable` interface.)