### PR TITLE
New fancier fudgeandrun

### DIFF
--- a/t/fudgeandrun
+++ b/t/fudgeandrun
@@ -2,8 +2,6 @@
 use strict;
 use warnings;
 
-use List::Util qw(first);
-
 ######################################################################
 # Fudge a test and run the fudged result.
 #
@@ -13,6 +11,9 @@ use List::Util qw(first);
 ######################################################################
 
 use Getopt::Long;
+use List::Util qw(first);
+use File::Spec::Functions qw(canonpath catfile splitpath);
+use Cwd 'cwd';
 
 GetOptions(
     'backend=s' => \my $backend,
@@ -47,7 +48,8 @@ if ($backend) {
     }
 }
 else {
-    my $p6 = -x './perl6' ? './perl6' : 'perl6';
+    my $p6 = catfile('.', 'perl6');
+    $p6 = 'perl6' unless -x $p6;
     my $version = `$p6 --version`;
     $backend = ($version =~ /jvm/i) ? "jvm" : 'moar';
 }
@@ -59,7 +61,7 @@ my @already_fudged; # test directories may also have already fudged files
 
 for (my $i = 0; $i < @ARGV; $i++) {
     if (! -e $ARGV[ $i ]) {
-        my $spec = "t/spec/$ARGV[ $i ]";
+        my $spec = canonpath("t/spec/$ARGV[ $i ]");
         $ARGV[ $i ] = $spec if -e $spec;
     }
     die "fudging does not handle directories like $ARGV[ $i ]\n",
@@ -75,17 +77,18 @@ for (my $i = 0; $i < @ARGV; $i++) {
 } @already_fudged;
 
 # look for fudge in spec checkout, then root of roast repo, then PATH
-my ($fudger) = first { -e } ('t/spec/fudgeall', './fudgeall');
+my ($fudger) = first { -e }
+    canonpath('t/spec/fudgeall'), catfile('.', 'fudgeall');
 $fudger //= 'fudgeall';
-my $nt = `$fudger @OPTS @ARGV`;
+my $nt = `$^X $fudger @OPTS @ARGV`;
 die "$fudger failed return code: $?\n" if $?;
 
 # uninstalled rakudo doesn't know how to find Test.pm
 # ... or any other modules
-my $pwd = `pwd`; chomp $pwd;
+my $pwd = cwd();
 $ENV{PERL6LIB}="$pwd/lib";
-my $p6 = './perl6-' . substr($backend, 0, 1);
-$p6 = substr($p6, 2) unless -x $p6;
+my $p6 = catfile('.', 'perl6-' . substr($backend, 0, 1));
+$p6 = (splitpath $p6)[ -1 ] unless -x $p6;
 
 if ($opt_6) {
     system($p6, split(' ', $nt), @already_fudged);

--- a/t/fudgeandrun
+++ b/t/fudgeandrun
@@ -2,11 +2,41 @@
 use strict;
 use warnings;
 
+use List::Util qw(first);
+
+######################################################################
+# Fudge a test and run the fudged result.
+#
+# Historically, this was part of the Rakudo development repository
+# and it will check for local perl6 and fudge(all?) executables first
+# and give them priority over executables on path.
+######################################################################
+
 use Getopt::Long;
 
 GetOptions(
     'backend=s' => \my $backend,
+    'quiet' => \my $opt_q,
+    'six|6' => \my $opt_6,
 );
+
+unless (@ARGV) {
+    die <<"USAGE";
+Usage: $0 [options] testfilename ...
+
+    Options:
+    --backend=(moar|jvm)
+        specify backend for fudge
+
+    --quiet
+        By default fudged tests are run with "prove -v". This option
+        turns off the "-v"
+
+    --six|6
+        Runs fudged tests with perl6 instead of prove.
+
+USAGE
+}
 
 if ($backend) {
     if ($backend =~ /^(jvm|moar)/i) {
@@ -17,28 +47,56 @@ if ($backend) {
     }
 }
 else {
-    my $version = `./perl6 --version`;
+    my $p6 = -x './perl6' ? './perl6' : 'perl6';
+    my $version = `$p6 --version`;
     $backend = ($version =~ /jvm/i) ? "jvm" : 'moar';
 }
 
 my $impl = "rakudo.$backend";
 
 my @OPTS = ('--keep-exit-code', $impl);
+my @already_fudged; # test directories may also have already fudged files
 
-if (@ARGV) {
-    my $file = $ARGV[0];
-    if (! -e $file) {
-        my $spec = "t/spec/$file";
-        if (-e $spec) {
-            $ARGV[0] = $spec;
-        }
+for (my $i = 0; $i < @ARGV; $i++) {
+    if (! -e $ARGV[ $i ]) {
+        my $spec = "t/spec/$ARGV[ $i ]";
+        $ARGV[ $i ] = $spec if -e $spec;
+    }
+    die "fudging does not handle directories like $ARGV[ $i ]\n",
+        "    try shell glob ('*')\n" if -d $ARGV[ $i ];
+    if ($ARGV[$i] =~ /(?:\.(?:rakudo|jvm|moar))+$/) {
+        push @already_fudged, splice @ARGV, $i--, 1;
     }
 }
 
-my $nt = `t/spec/fudge @OPTS @ARGV`;
+@already_fudged = grep { # ignore files we will generate with fudge
+    my $pre_fudged = s/\Q.$impl\E$/.t/r;
+    not first { $_ eq $pre_fudged } @ARGV
+} @already_fudged;
+
+# look for fudge in spec checkout, then root of roast repo, then PATH
+my ($fudger) = first { -e } ('t/spec/fudgeall', './fudgeall');
+$fudger //= 'fudgeall';
+my $nt = `$fudger @OPTS @ARGV`;
+die "$fudger failed return code: $?\n" if $?;
+
 # uninstalled rakudo doesn't know how to find Test.pm
 # ... or any other modules
 my $pwd = `pwd`; chomp $pwd;
 $ENV{PERL6LIB}="$pwd/lib";
-my $first = substr($backend, 0, 1);
-system("./perl6-$first", split ' ', $nt);
+my $p6 = './perl6-' . substr($backend, 0, 1);
+$p6 = substr($p6, 2) unless -x $p6;
+
+if ($opt_6) {
+    system($p6, split(' ', $nt), @already_fudged);
+}
+else {
+    system( 'prove', ($opt_q ? () : '-v'), "-e$p6",
+            split(' ', $nt), @already_fudged
+    );
+}
+
+my $already_fudge_warn = "Some files were already fudged" if @already_fudged;
+$already_fudge_warn .= " and were run after other tests"
+    if @already_fudged and @ARGV;
+warn "\n$already_fudge_warn\n\n" if $already_fudge_warn;


### PR DESCRIPTION
Built for [roast issue #226](https://github.com/perl6/roast/issues/226).  New fudgeandrun is backwards compatible but can also be used to run tests for roast repository without rest of rakudo repository.  This fudgeandrun runs under Windows.  Defaults to running fudged tests with "prove -v -e(./?)perl6 ..." but has a -6|--six option for backwards compatibility.  Also has a -q|--quiet option to turn off '-v' with prove.  Trying to run with no files dumps usage including options.  Handles multiple test files consistently.