### PR TITLE
Don't constant fold x op when the result is big

### DIFF
--- a/src/Perl6/Optimizer.nqp
+++ b/src/Perl6/Optimizer.nqp
@@ -1415,7 +1415,20 @@ class Perl6::Optimizer {
                         last;
                     }
                 }
-                
+
+                # Don't constant fold the 'x' operator if the resulting string would be too big.
+                # 1024 is just a heuristic, measuring might show a bigger value would be fine.
+                if $all_args_known && $op.name eq '&infix:<x>' && $!symbols.is_from_core('&infix:<x>') {
+                    my int $survived := 0;
+                    my int $size;
+                    try {
+                        $size := @args[0].chars * @args[1];
+                        $survived := 1;
+                    }
+
+                    return $op if $survived && $size > 1024;
+                }
+
                 # If so, attempt to constant fold.
                 if $all_args_known {
                     my int $survived := 0;


### PR DESCRIPTION
If the resulting string is very large, it can take a long time to encode
it on the string heap and then decode it when needed.

Some discussions:
https://irclog.perlgeek.de/perl6/2017-02-04#i_14040978
https://irclog.perlgeek.de/perl6/2017-02-04#i_14042387

Fixes RT #127972, https://rt.perl.org/Public/Bug/Display.html?id=127972

Passes `make m-spectest`.