### PR TITLE
Support smartmatching char Ranges

### DIFF
--- a/src/core/Range.pm
+++ b/src/core/Range.pm
@@ -426,13 +426,23 @@ my class Range is Cool does Iterable does Positional {
         nqp::istype(($_ := got.Real), Failure) ?? False !! nextwith $_
     }
     multi method ACCEPTS(Range:D: Range \topic) {
-        (topic.min > $!min
-         || topic.min == $!min
-            && !(!topic.excludes-min && $!excludes-min))
-        &&
-        (topic.max < $!max
-         || topic.max == $!max
-            && !(!topic.excludes-max && $!excludes-max))
+        $!is-int && topic.is-int
+          ??
+            (topic.min > $!min
+             || topic.min == $!min
+                && !(!topic.excludes-min && $!excludes-min))
+            &&
+            (topic.max < $!max
+             || topic.max == $!max
+                && !(!topic.excludes-max && $!excludes-max))
+          !!
+            (topic.min after $!min
+             || topic.min eq $!min
+                && !(!topic.excludes-min && $!excludes-min))
+            &&
+            (topic.max before $!max
+             || topic.max eq $!max
+                && !(!topic.excludes-max && $!excludes-max))
     }
 
     multi method AT-POS(Range:D: int \pos) {


### PR DESCRIPTION
Before `say ("a" .. "c") ~~ ("a" .. "c")` would give the error:

`Cannot convert string to number: base-10 number must begin with
valid digits or '.' in '⏏a' (indicated by ⏏)`

Passes `make m-spectest`.

Inspired by https://irclog.perlgeek.de/perl6/2017-02-08#i_14061478