### PR TITLE
Optimize Actions.(dec|hex|oct|bin)int()

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -631,10 +631,17 @@ class Perl6::Actions is HLL::Actions does STDActions {
         }
     }
 
-    sub string_to_bigint($src, $base) {
+    sub string_to_int($src, int $base, int $chars) {
+        my $res := nqp::radix($base, ~$src, 0, 2);
+        $src.CURSOR.panic("'$src' is not a valid number")
+            unless nqp::iseq_i(nqp::atpos($res, 2), $chars);
+        nqp::box_i(nqp::atpos($res, 0), $*W.find_symbol(['Int']));
+    }
+
+    sub string_to_bigint($src, int $base, int $chars) {
         my $res := nqp::radix_I($base, ~$src, 0, 2, $*W.find_symbol(['Int']));
         $src.CURSOR.panic("'$src' is not a valid number")
-            unless nqp::iseq_i(nqp::unbox_i(nqp::atpos($res, 2)), nqp::chars($src));
+            unless nqp::iseq_i(nqp::unbox_i(nqp::atpos($res, 2)), $chars);
         nqp::atpos($res, 0);
     }
 
@@ -7258,10 +7265,30 @@ class Perl6::Actions is HLL::Actions does STDActions {
         make QAST::WVal.new( :value($v) );
     }
 
-    method decint($/) { make string_to_bigint( $/, 10); }
-    method hexint($/) { make string_to_bigint( $/, 16); }
-    method octint($/) { make string_to_bigint( $/, 8 ); }
-    method binint($/) { make string_to_bigint( $/, 2 ); }
+    method decint($/) {
+        my int $chars := nqp::chars($/);
+        make $chars > 9
+          ?? string_to_bigint($/, 10, $chars)
+          !! string_to_int($/, 10, $chars);
+    }
+    method hexint($/) {
+        my int $chars := nqp::chars($/);
+        make $chars > 8
+          ?? string_to_bigint($/, 16, $chars)
+          !! string_to_int($/, 16, $chars);
+    }
+    method octint($/) {
+        my int $chars := nqp::chars($/);
+        make $chars > 10
+          ?? string_to_bigint($/, 8, $chars)
+          !! string_to_int($/, 8, $chars);
+    }
+    method binint($/) {
+        my int $chars := nqp::chars($/);
+        make $chars > 30
+          ?? string_to_bigint($/, 2, $chars)
+          !! string_to_int($/, 2, $chars);
+    }
 
     method number:sym<numish>($/) {
         make $<numish>.ast;

--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -7,6 +7,8 @@ use QAST;
 
 my $wantwant := Mu;
 
+my int $?BITS := nqp::iseq_i(0x1ffffffff,8589934591) ?? 64 !! 32;
+
 sub block_closure($code) {
     my $closure := QAST::Op.new(
         :op('callmethod'), :name('clone'),
@@ -7267,25 +7269,25 @@ class Perl6::Actions is HLL::Actions does STDActions {
 
     method decint($/) {
         my int $chars := nqp::chars($/);
-        make $chars > 9
+        make $chars > ($?BITS == 64 ?? 16 !! 9)
           ?? string_to_bigint($/, 10, $chars)
           !! string_to_int($/, 10, $chars);
     }
     method hexint($/) {
         my int $chars := nqp::chars($/);
-        make $chars > 8
+        make $chars > ($?BITS == 64 ?? 14 !! 8)
           ?? string_to_bigint($/, 16, $chars)
           !! string_to_int($/, 16, $chars);
     }
     method octint($/) {
         my int $chars := nqp::chars($/);
-        make $chars > 10
+        make $chars > ($?BITS == 64 ?? 20 !! 10)
           ?? string_to_bigint($/, 8, $chars)
           !! string_to_int($/, 8, $chars);
     }
     method binint($/) {
         my int $chars := nqp::chars($/);
-        make $chars > 30
+        make $chars > ($?BITS == 64 ?? 62 !! 30)
           ?? string_to_bigint($/, 2, $chars)
           !! string_to_int($/, 2, $chars);
     }


### PR DESCRIPTION
Create a string_to_int that uses nqp::radix instead of nqp::radix_I.
Then call that from Actions.(dec|hex|oct|bin)int() instead of
string_to_bigint when the number of chars in the string to be converted
is small enough that it couldn't cause overflow.

Passes `make m-spectest`.

If there was a way to tell whether we're on a 32 or 64 bit system in
Actions.nqp the number of chars at which we switch to nqp::radix_I
could be increased.