### PR TITLE
Make Seq:D eqv List:D return False even when all elements are same

### DIFF
--- a/src/core/Mu.pm
+++ b/src/core/Mu.pm
@@ -878,19 +878,19 @@ multi sub infix:<eqv>(Any:D \a, Any:D \b) {
     )
 }
 
-multi sub infix:<eqv>(@a, @b) {
+multi sub infix:<eqv>(Iterable:D \a, Iterable:D \b) {
     nqp::p6bool(
       nqp::unless(
-        nqp::eqaddr(@a,@b),                                    # identity
+        nqp::eqaddr(a,b),                                    # identity
         nqp::if(
-          nqp::eqaddr(@a.WHAT,@b.WHAT),                        # same type
+          nqp::eqaddr(a.WHAT,b.WHAT),                        # same type
           nqp::if(
-            nqp::iseq_i((my int $elems = @a.elems),@b.elems),  # same # elems
+            nqp::iseq_i((my int $elems = a.elems),b.elems),  # same # elems
             nqp::stmts(
               (my int $i = -1),
               nqp::while(
                 nqp::islt_i(($i = nqp::add_i($i,1)),$elems)    # not exhausted
-                  && @a.AT-POS($i) eqv @b.AT-POS($i),          # still same
+                  && a.AT-POS($i) eqv b.AT-POS($i),          # still same
                 nqp::null
               ),
               nqp::iseq_i($i,$elems)                      # exhausted = success!


### PR DESCRIPTION
This makes `say ().Seq eqv ()` return False due to their being of different types.

This passes the stresstest but I have [seconds thoughts](https://irclog.perlgeek.de/perl6/2017-03-01#i_14186702) on whether it was *intended* for a Seq to be `eqv` to a List when elements match, due to the PositionalBindFailover thing.

The only other Iterable we have in core are Maps and those have their own `infix:<eqv>` candidate