### PR TITLE
Implement Str.parse-names / &parse-names

### DIFF
--- a/src/core/Exception.pm
+++ b/src/core/Exception.pm
@@ -1810,6 +1810,14 @@ my class X::Phaser::PrePost is Exception {
     }
 }
 
+my class X::Str::InvalidCharName is Exception {
+    has $.name;
+    method message() {
+        $!name.chars ?? "Unrecognized character name [{$!name}]"
+                     !! "Cannot use empty name as character name"
+    }
+}
+
 my class X::Str::Numeric is Exception {
     has $.source;
     has $.pos;

--- a/src/core/Str.pm
+++ b/src/core/Str.pm
@@ -1,6 +1,7 @@
 my class Cursor {... }
 my class Range  {... }
 my class Match  {... }
+my class X::Str::InvalidCharName { ... }
 my class X::Str::Numeric  { ... }
 my class X::Str::Match::x { ... }
 my class X::Str::Subst::Adverb { ... }
@@ -1351,6 +1352,24 @@ my class Str does Stringy { # declared in BOOTSTRAP
 
             $sign * $parsed[0];
         }
+    }
+
+    method parse-names(Str:D:) {
+        my     \names := nqp::split(',', self);
+        my int $elems  = nqp::elems(names);
+        my int $i      = -1;
+        my str $res    = '';
+        nqp::while(
+            nqp::islt_i( ($i = nqp::add_i($i,1)), $elems ),
+            ($res = nqp::concat($res,
+                nqp::unless(
+                    nqp::getstrfromname(nqp::atpos(names, $i).trim),
+                    X::Str::InvalidCharName.new(
+                        :name(nqp::atpos(names, $i).trim)
+                    ).fail
+            ))),
+        );
+        $res
     }
 
     multi method split(Str:D: Regex:D $pat, $limit is copy = Inf;;
@@ -2971,6 +2990,8 @@ sub chrs(*@c) returns Str:D {
 
 proto sub parse-base(|) { * }
 multi sub parse-base(Str:D $str, Int:D $radix) { $str.parse-base($radix) }
+
+sub parse-names(Str:D $str) { $str.parse-names }
 
 proto sub substr(|) { * }
 multi sub substr(Str:D \what, Int:D \start) {

--- a/t/spectest.data
+++ b/t/spectest.data
@@ -1089,6 +1089,7 @@ S32-str/numeric.t
 S32-str/ords.t
 S32-str/pack.t
 S32-str/parse-base.t
+S32-str/parse-names.t
 S32-str/pos.t
 S32-str/rindex.t
 S32-str/samemark.t


### PR DESCRIPTION
Functionality:
- similar to `"\c[BELL, BLACK HEART SUIT]"`, except can be used by
    users at runtime, without requiring `EVAL`/`nqp` in user's code
- Unlike `\c[…]` does not allow comments or anything similarly esoteric.
    The idea is this will process some sort of user input, so we want
    it just as liberal as necessary (whitespace around char names is allowed).

Naming:
- the name follows `Str.parse-base` that parses a string containing numerals
    in some base; whereas `Str.parse-names` parses a string of character names

------

Sample usage:

```perl6
    say parse-names('BELL, BLACK HEART SUIT'); # output: 🔔♥
    say 'BELL, BLACK HEART SUIT'.parse-names; # output: 🔔♥
```
