### PR TITLE
Add ≤ ≥ ≠ unicode ops

### DIFF
--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -4343,8 +4343,11 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
     token infix:sym«≅»    { <sym>  <O(|%chaining)> }
     token infix:sym«==»   { <sym>  <O(|%chaining)> }
     token infix:sym«!=»   { <sym> <?before \s|']'> <O(|%chaining)> }
+    token infix:sym«≠»    { <sym>  <O(|%chaining)> }
     token infix:sym«<=»   { <sym>  <O(|%chaining)> }
+    token infix:sym«≤»    { <sym>  <O(|%chaining)> }
     token infix:sym«>=»   { <sym>  <O(|%chaining)> }
+    token infix:sym«≥»    { <sym>  <O(|%chaining)> }
     token infix:sym«<»    { <sym>  <O(|%chaining)> }
     token infix:sym«>»    { <sym>  <O(|%chaining)> }
     token infix:sym«eq»   { <sym> >> <O(|%chaining)> }

--- a/src/core/Numeric.pm
+++ b/src/core/Numeric.pm
@@ -287,6 +287,7 @@ sub infix:<=~=>(|c) { infix:<≅>(|c) }
 proto sub infix:<!=>(Mu $?, Mu $?) is pure  { * }
 multi sub infix:<!=>($?)        { Bool::True }
 multi sub infix:<!=>(Mu \a, Mu \b)   { not a == b }
+sub infix:<≠>(|c) is pure { infix:<!=>(|c) }
 
 proto sub infix:«<»(Mu $?, Mu $?) is pure   { * }
 multi sub infix:«<»($?)         { Bool::True }
@@ -295,6 +296,7 @@ multi sub infix:«<»(\a, \b)    { a.Real < b.Real }
 proto sub infix:«<=»(Mu $?, Mu $?) is pure  { * }
 multi sub infix:«<=»($?)        { Bool::True }
 multi sub infix:«<=»(\a, \b)   { a.Real <= b.Real }
+sub infix:«≤»(|c) is pure { infix:«<=»(|c) }
 
 proto sub infix:«>»(Mu $?, Mu $?) is pure   { * }
 multi sub infix:«>»($?)         { Bool::True }
@@ -303,6 +305,7 @@ multi sub infix:«>»(\a, \b)    { a.Real > b.Real }
 proto sub infix:«>=»(Mu $?, Mu $?) is pure  { * }
 multi sub infix:«>=»($?)        { Bool::True }
 multi sub infix:«>=»(\a, \b)   { a.Real >= b.Real }
+sub infix:«≥»(|c) is pure { infix:«>=»(|c) }
 
 ## bitwise operators
 


### PR DESCRIPTION
🙌

Tiny IRC discussion:
https://irclog.perlgeek.de/perl6/2017-03-01#i_14183585

⩵ (and especially ⩶) were left out intentionally. For now, let's focus
on operators that were actually requested many times.

Spectest clean.