### PR TITLE
Add narrower candidates for infix min and max

### DIFF
--- a/src/core/Any-iterable-methods.pm
+++ b/src/core/Any-iterable-methods.pm
@@ -1934,9 +1934,9 @@ multi sub infix:<min>(Mu:D \a, Mu:U) { a }
 multi sub infix:<min>(Mu:U, Mu:D \b) { b }
 multi sub infix:<min>(Mu:D \a, Mu:D \b) { (a cmp b) < 0 ?? a !! b }
 multi sub infix:<min>(Int:D \a, Int:D \b) { nqp::if(nqp::islt_i(nqp::cmp_I(nqp::decont(a), nqp::decont(b)), 0), a, b) }
-multi sub infix:<min>(int:D \a, int:D \b) { nqp::if(nqp::islt_i(nqp::cmp_i(a, b), 0), a, b) }
+multi sub infix:<min>(int   \a, int   \b) { nqp::if(nqp::islt_i(nqp::cmp_i(a, b), 0), a, b) }
 multi sub infix:<min>(Num:D \a, Num:D \b) { nqp::if(nqp::islt_i(nqp::cmp_n(a, b), 0), a, b) }
-multi sub infix:<min>(num:D \a, num:D \b) { nqp::if(nqp::islt_i(nqp::cmp_n(a, b), 0), a, b) }
+multi sub infix:<min>(num   \a, num   \b) { nqp::if(nqp::islt_i(nqp::cmp_n(a, b), 0), a, b) }
 multi sub infix:<min>(+args is raw) { args.min }
 sub min(+args, :&by = &infix:<cmp>) { args.min(&by) }
 
@@ -1945,9 +1945,9 @@ multi sub infix:<max>(Mu:D \a, Mu:U) { a }
 multi sub infix:<max>(Mu:U, Mu:D \b) { b }
 multi sub infix:<max>(Mu:D \a, Mu:D \b) { (a cmp b) > 0 ?? a !! b }
 multi sub infix:<max>(Int:D \a, Int:D \b) { nqp::if(nqp::isgt_i(nqp::cmp_I(nqp::decont(a), nqp::decont(b)), 0), a, b) }
-multi sub infix:<max>(int:D \a, int:D \b) { nqp::if(nqp::isgt_i(nqp::cmp_i(a, b), 0), a, b) }
+multi sub infix:<max>(int   \a, int   \b) { nqp::if(nqp::isgt_i(nqp::cmp_i(a, b), 0), a, b) }
 multi sub infix:<max>(Num:D \a, Num:D \b) { nqp::if(nqp::isgt_i(nqp::cmp_n(a, b), 0), a, b) }
-multi sub infix:<max>(num:D \a, num:D \b) { nqp::if(nqp::isgt_i(nqp::cmp_n(a, b), 0), a, b) }
+multi sub infix:<max>(num   \a, num   \b) { nqp::if(nqp::isgt_i(nqp::cmp_n(a, b), 0), a, b) }
 multi sub infix:<max>(+args) { args.max }
 sub max(+args, :&by = &infix:<cmp>) { args.max(&by) }
 

--- a/src/core/Any-iterable-methods.pm
+++ b/src/core/Any-iterable-methods.pm
@@ -1933,6 +1933,10 @@ proto sub infix:<min>(|) is pure { * }
 multi sub infix:<min>(Mu:D \a, Mu:U) { a }
 multi sub infix:<min>(Mu:U, Mu:D \b) { b }
 multi sub infix:<min>(Mu:D \a, Mu:D \b) { (a cmp b) < 0 ?? a !! b }
+multi sub infix:<min>(Int:D \a, Int:D \b) { nqp::if(nqp::islt_i(nqp::cmp_I(nqp::decont(a), nqp::decont(b)), 0), a, b) }
+multi sub infix:<min>(int:D \a, int:D \b) { nqp::if(nqp::islt_i(nqp::cmp_i(a, b), 0), a, b) }
+multi sub infix:<min>(Num:D \a, Num:D \b) { nqp::if(nqp::islt_i(nqp::cmp_n(a, b), 0), a, b) }
+multi sub infix:<min>(num:D \a, num:D \b) { nqp::if(nqp::islt_i(nqp::cmp_n(a, b), 0), a, b) }
 multi sub infix:<min>(+args is raw) { args.min }
 sub min(+args, :&by = &infix:<cmp>) { args.min(&by) }
 
@@ -1940,6 +1944,10 @@ proto sub infix:<max>(|) is pure { * }
 multi sub infix:<max>(Mu:D \a, Mu:U) { a }
 multi sub infix:<max>(Mu:U, Mu:D \b) { b }
 multi sub infix:<max>(Mu:D \a, Mu:D \b) { (a cmp b) > 0 ?? a !! b }
+multi sub infix:<max>(Int:D \a, Int:D \b) { nqp::if(nqp::isgt_i(nqp::cmp_I(nqp::decont(a), nqp::decont(b)), 0), a, b) }
+multi sub infix:<max>(int:D \a, int:D \b) { nqp::if(nqp::isgt_i(nqp::cmp_i(a, b), 0), a, b) }
+multi sub infix:<max>(Num:D \a, Num:D \b) { nqp::if(nqp::isgt_i(nqp::cmp_n(a, b), 0), a, b) }
+multi sub infix:<max>(num:D \a, num:D \b) { nqp::if(nqp::isgt_i(nqp::cmp_n(a, b), 0), a, b) }
 multi sub infix:<max>(+args) { args.max }
 sub max(+args, :&by = &infix:<cmp>) { args.max(&by) }
 


### PR DESCRIPTION
Add :D candidate for Int, int, Num, and num and implement them in nqp.
Makes `Int:D max Int:D` about 3x faster.

Passes `make m-spectest`.