### PR TITLE
fix installation path of core dist

### DIFF
--- a/tools/build/Makefile-Moar.in
+++ b/tools/build/Makefile-Moar.in
@@ -286,7 +286,7 @@ m-install: m-all tools/build/create-moar-runner.pl tools/build/install-core-dist
 	.@slash@$(M_RUNNER) tools/build/upgrade-repository.pl $(DESTDIR)$(PERL6_LANG_DIR)
 	.@slash@$(M_RUNNER) tools/build/upgrade-repository.pl $(DESTDIR)$(PERL6_LANG_DIR)/vendor
 	.@slash@$(M_RUNNER) tools/build/upgrade-repository.pl $(DESTDIR)$(PERL6_LANG_DIR)/site
-	.@slash@$(M_RUNNER) tools/build/install-core-dist.pl $(DESTDIR)$(PERL6_LANG_DIR)
+	.@slash@$(M_RUNNER) tools/build/install-core-dist.pl  $(DESTDIR)$(PERL6_LANG_DIR)/lib
 	$(M_RUN_PERL6) tools/build/create-moar-runner.pl "$(MOAR)" perl6.moarvm $(DESTDIR)$(PREFIX)/bin/perl6-m "$(PERL6_LANG_DIR)/runtime" "" "" "$(M_LIBPATH)" "$(NQP_LIBPATH)" "$(PERL6_LANG_DIR)/lib" "$(PERL6_LANG_DIR)/runtime"
 	$(M_RUN_PERL6) tools/build/create-moar-runner.pl "$(MOAR)" perl6-debug.moarvm $(DESTDIR)$(PREFIX)/bin/perl6-debug-m "$(PERL6_LANG_DIR)/runtime" "" "" "$(M_LIBPATH)" "$(NQP_LIBPATH)" "$(PERL6_LANG_DIR)/lib" "$(PERL6_LANG_DIR)/runtime"
 	$(CHMOD) 755 $(DESTDIR)$(PREFIX)/bin/perl6-m$(M_BAT)


### PR DESCRIPTION
Wihout this patch, all core files are installed in `/usr/share/perl6` (build uses `--prefix=/usr`):

```
$ ls /usr/share/perl6
bin  dist  lib  precomp  repo.lock  resources  runtime  short  site  sources  vendor  version
```

And the directory which is specified in perl6 script (with `--libpath="/usr/share/perl6/lib"` ) is empty:
```
$ ls /usr/share/perl6/lib/
[empty]
```

This patch fixes this issue. When applied, all core files are installed in `/usr/share/perl6/lib`.
This is currently applied in [Debian's rakudo_2017.02-1](https://packages.debian.org/source/experimental/rakudo):
```
$ ls /usr/share/perl6/
lib  runtime  site  vendor  version
$ ls /usr/share/perl6/lib/
dist  precomp  repo.lock  short  sources  version
```

All the best

