### PR TITLE
teach &dir to be recursive

### DIFF
--- a/src/core/IO/Path.pm
+++ b/src/core/IO/Path.pm
@@ -388,7 +388,8 @@ my class IO::Path is Cool {
         True;
     }
 
-    method dir(IO::Path:D:
+    proto method dir(|){ * }
+    multi method dir(IO::Path:D:
         Mu :$test = $*SPEC.curupdir,
         :$absolute,
         :$Str,
@@ -448,6 +449,16 @@ my class IO::Path is Cool {
               )
             );
             nqp::closedir($dirh);
+        }
+    }
+
+    multi method dir(IO::Path:D:
+        :$recursive,
+        |rest
+    ) {
+        gather for callwith(self, |rest) {
+            (take .dir(:recursive, |rest)) if .d;
+            take $_;
         }
     }
 


### PR DESCRIPTION
With &dir being recursive pretty much all deps on Find::File could be replaced by:
    dir('.', :recursive).grep(*.ends-with: '.html');

Also, by turning IO::Path.dir into a multi, it becomes accessable to modules that want to augment it, without replacing the base method entirely.

roast commit: https://github.com/perl6/roast/commit/ddf9ae1c0331d42845d8c099fee4da02f10d3910