### PR TITLE
Fix triangle reduction with listinfix ops

### DIFF
--- a/src/core/metaops.pm
+++ b/src/core/metaops.pm
@@ -424,9 +424,8 @@ multi sub METAOP_REDUCE_LISTINFIX(\op, \triangle) {
         GATHER({
             my @list;
             while $i < p.elems {
-                @list.append(p[$i]);
-                $i = $i + 1;
-                take op.(|@list);
+                @list.push(p[$i++]);
+                take op.(|@list.map({nqp::decont($_)}));
             }
         }).lazy-if(p.is-lazy);
     }


### PR DESCRIPTION
The triangle reduction was appending the data inside of a array and applying the
op on that. It was changed to push the data and apply the op on that array with
each item deconted. RT #131009