### PR TITLE
Fix the introspection of attributes with explicitly typed keys

### DIFF
--- a/src/core/Associative.pm
+++ b/src/core/Associative.pm
@@ -1,5 +1,6 @@
-my role Associative[::T = Mu] {
-    method of() { T }
+my role Associative[::TValue = Mu, ::TKey = Str(Any)] {
+    method of() { TValue }
+    method keyof() { TKey }
 }
 
 # vim: ft=perl6 expandtab sw=4


### PR DESCRIPTION
This was reported as https://github.com/jonathanstowe/JSON-Class/issues/3

It appears that when the "BOOTSTRAP" Associative is made for the
attributes type it has two parameters but when it is materialised
to call 'of' on it, it fails because the Associative only has one
parameter:

```
class C {
    has Str %.bla{subset :: of Str where any("ble", "blob")};
    has Str %.foo{Int};
};

for C.^attributes -> $attr {
    say $attr.type;
    say $attr.type.of;

}
```
Gives
```
(Associative[Str,<anon>])
No appropriate parametric role variant available for 'Associative'
  in block <unit> at tt line 13
```
This fixes that by providing the extra parameter.

Also took the opportunity to match Hash with a .keyof()