### PR TITLE
Remove $.pid from Proc

### DIFF
--- a/src/core/Proc.pm
+++ b/src/core/Proc.pm
@@ -3,7 +3,6 @@ my class Proc {
     has IO::Pipe $.out;
     has IO::Pipe $.err;
     has $.exitcode = -1;  # distinguish uninitialized from 0 status
-    has $.pid;
     has $.signal;
     has @.command;
 


### PR DESCRIPTION
Not that we should not have it, but as of today it does nothing at
all (making users assume that there is something wrong with their
code).

See https://irclog.perlgeek.de/perl6/2017-03-25#i_14323473

Spectest clean.