### PR TITLE
Fix for RT #131075

### DIFF
--- a/t/harness6
+++ b/t/harness6
@@ -57,7 +57,7 @@ multi sub MAIN(
 
     if (@slow) {
         @slow.=flatmap(&all-in);
-        @tfiles = (@slow Z batch(@tfiles / @slow, @tfiles)).flatmap({ .map(|*) })
+        @tfiles = (roundrobin @slow, batch(@tfiles / @slow, @tfiles)).flat;
     }
 
     if $fudge {


### PR DESCRIPTION
It was noted by Zoffix++ that the number of tests run by harness6
differed from the number run by harness5 when spec- or stresstesting.
The problem turned out to be the piece of code combining the normal
test files in spectest.data with the ones marked as being 'slow'.
That code used the Z operator on lists that were not the same size,
changing to roundrobin instead solves the problem. Zoffix++ for help.