### PR TITLE
Make `my @a = ^10; my @b = @a[*]` 30-40x faster

### DIFF
--- a/src/core/array_slice.pm
+++ b/src/core/array_slice.pm
@@ -398,7 +398,7 @@ multi sub postcircumfix:<[ ]>(\SELF,Callable:D $block,:$v!,*%other) is raw {
 
 # @a[*]
 multi sub postcircumfix:<[ ]>( \SELF, Whatever:D ) is raw {
-    SELF[^SELF.elems];
+    SELF.ZEN-POS();
 }
 multi sub postcircumfix:<[ ]>( \SELF, Whatever:D, Mu \assignee ) is raw {
     SELF[^SELF.elems] = assignee;


### PR DESCRIPTION
By just reusing the zen-slice (`my @a = ^10; my @b = @a[]`)
implementation.

Passes `make m-spectest`.