### PR TITLE
Make `my @a = ^10; my @b = @a[0..*]` 50-80x faster

### DIFF
--- a/src/core/array_slice.pm
+++ b/src/core/array_slice.pm
@@ -211,7 +211,9 @@ multi sub postcircumfix:<[ ]>( \SELF, Any:D \pos, :$v!, *%other ) is raw {
 multi sub postcircumfix:<[ ]>( \SELF, Iterable:D \pos ) is raw {
     nqp::iscont(pos)
       ?? SELF.AT-POS(pos.Int)
-      !! POSITIONS(SELF, pos).map({ SELF[$_] }).eager.list;
+      !! nqp::istype(pos, Range) && pos.min == 0 && pos.max == Inf
+        ?? SELF.ZEN-POS()
+        !! POSITIONS(SELF, pos).map({ SELF[$_] }).eager.list;
 }
 multi sub postcircumfix:<[ ]>(\SELF, Iterable:D \pos, Mu \val ) is raw {
     # MMD is not behaving itself so we do this by hand.


### PR DESCRIPTION
By just reusing the zen-slice (`my @a = ^10; my @b = @a[]`)
implementation when we know we have a `Range` with a `.min == 0` and
a `.max == Inf`.

Passes `make m-spectest`.