### PR TITLE
Implement Failure.fail

### DIFF
--- a/src/core/Failure.pm
+++ b/src/core/Failure.pm
@@ -83,6 +83,12 @@ my class Failure is Nil {
         "(HANDLED) " x $!handled ~ self.exception.message ~ "\n" ~ self.backtrace;
     }
 
+    method fail(Failure:D:) {
+        $!handled = 0;
+        nqp::throwpayloadlexcaller(nqp::const::CONTROL_RETURN, self);
+        CATCH { self.exception.throw }
+    }
+
     method sink(Failure:D:) {
         self!throw() unless $!handled
     }


### PR DESCRIPTION
A way to propagate a Failure further up the callstack without marking it as handled. Marks already-handled Failures as unhandled.

```perl6
sub foo { fail "meow" };
sub bar { foo() orelse .?fail }; bar
# meow
#   in sub foo at -e line 1
#   in sub bar at -e line 1
#   in block <unit> at -e line 1
#
# Actually thrown at:
#   in block <unit> at -e line 1
```

```perl6
sub foo { fail "meow" };
sub bar { foo() orelse .?fail };
bar.handled.say
# False
```

In most cases, the safe-call can be just a regular call and in many cases the stuff can be shortened to just:

```perl6
sub foo { fail "meow" };
sub bar { foo.?fail };
```

So if you got a couple of things to call and you don't wanna bother with a `try` + `fail` to return an unhandled Failure to caller, just do:

```perl6
'/tmp'.&chdir.?fail;
'meows'.&mkdir.?fail;
```
And done.

For comparison is partly equivalent to:
```perl6
try {
    chdir '/tmp';
    mkdir 'meows';
}
$! and fail;
```

The point of difference is the `.?fail` approach won't catch any Exceptions that occur, so it's more precise than letting Failures explode and then catching them for re-failuring.