### PR TITLE
[Test] Add default description.

### DIFF
--- a/lib/Test.pm6
+++ b/lib/Test.pm6
@@ -435,30 +435,30 @@ multi sub flunk($reason) is export {
     $ok or ($die_on_fail and die-on-fail) or $ok;
 }
 
-multi sub isa-ok(Mu $var, Mu $type, $msg = ("The object is-a '" ~ $type.perl ~ "'")) is export {
+multi sub isa-ok(Mu $var, Mu $type, $desc = ("The object is-a '" ~ $type.perl ~ "'")) is export {
     $time_after = nqp::time_n;
-    my $ok = proclaim($var.isa($type), $msg)
+    my $ok = proclaim($var.isa($type), $desc)
         or _diag('Actual type: ' ~ $var.^name);
     $time_before = nqp::time_n;
     $ok or ($die_on_fail and die-on-fail) or $ok;
 }
 
-multi sub does-ok(Mu $var, Mu $type, $msg = ("The object does role '" ~ $type.perl ~ "'")) is export {
+multi sub does-ok(Mu $var, Mu $type, $desc = ("The object does role '" ~ $type.perl ~ "'")) is export {
     $time_after = nqp::time_n;
-    my $ok = proclaim($var.does($type), $msg)
+    my $ok = proclaim($var.does($type), $desc)
         or _diag([~] 'Type: ',  $var.^name, " doesn't do role ", $type.perl);
     $time_before = nqp::time_n;
     $ok or ($die_on_fail and die-on-fail) or $ok;
 }
 
-multi sub can-ok(Mu $var, Str $meth, $msg = ( ($var.defined ?? "An object of type '" !! "The type '" ) ~ $var.WHAT.perl ~ "' can do the method '$meth'") ) is export {
+multi sub can-ok(Mu $var, Str $meth, $desc = ( ($var.defined ?? "An object of type '" !! "The type '" ) ~ $var.WHAT.perl ~ "' can do the method '$meth'") ) is export {
     $time_after = nqp::time_n;
-    my $ok = proclaim($var.^can($meth), $msg);
+    my $ok = proclaim($var.^can($meth), $desc);
     $time_before = nqp::time_n;
     $ok or ($die_on_fail and die-on-fail) or $ok;
 }
 
-multi sub like(Str $got, Regex $expected, $desc = '') is export {
+multi sub like(Str $got, Regex $expected, $desc = ("'$got' matches '$expected.perl()'")) is export {
     $time_after = nqp::time_n;
     $got.defined; # Hack to deal with Failures
     my $test = $got ~~ $expected;
@@ -471,7 +471,7 @@ multi sub like(Str $got, Regex $expected, $desc = '') is export {
     $ok or ($die_on_fail and die-on-fail) or $ok;
 }
 
-multi sub unlike(Str $got, Regex $expected, $desc = '') is export {
+multi sub unlike(Str $got, Regex $expected, $desc = ($got ~ ' does not matches \'' ~ $expected.perl ~ "'")) is export {
     $time_after = nqp::time_n;
     $got.defined; # Hack to deal with Failures
     my $test = !($got ~~ $expected);
@@ -484,12 +484,12 @@ multi sub unlike(Str $got, Regex $expected, $desc = '') is export {
     $ok or ($die_on_fail and die-on-fail) or $ok;
 }
 
-multi sub use-ok(Str $code, $msg = ("The module can be use-d ok")) is export {
+multi sub use-ok(Str $code, $desc = ($code ~ ' module can be use-d ok')) is export {
     $time_after = nqp::time_n;
     try {
         EVAL ( "use $code" );
     }
-    my $ok = proclaim((not defined $!), $msg) or _diag($!);
+    my $ok = proclaim((not defined $!), $desc) or _diag($!);
     $time_before = nqp::time_n;
     $ok or ($die_on_fail and die-on-fail) or $ok;
 }


### PR DESCRIPTION
Some methods already have default description (can-ok for example).

Add description for like, unlike, use-ok methods.
Rename some parameters for a more standardised naming (desc vs msg) for
isa-ok, does-ok, can-ok and use-ok.