### PR TITLE
Fix Bags to allow values larger than a native int

### DIFF
--- a/src/core/Baggy.pm
+++ b/src/core/Baggy.pm
@@ -41,14 +41,14 @@ my role Baggy does QuantHash {
           nqp::while(
             $iter,
             nqp::if(
-              nqp::isle_i(
-                nqp::getattr(nqp::iterval(nqp::shift($iter)),Pair,'$!value'),
+              nqp::isle_I(
+                nqp::decont(nqp::getattr(nqp::iterval(nqp::shift($iter)),Pair,'$!value')),
                 0
               ),
               nqp::stmts(
                 nqp::if(
-                  nqp::islt_i(
-                    nqp::getattr(nqp::iterval($iter),Pair,'$!value'),
+                  nqp::islt_I(
+                    nqp::decont(nqp::getattr(nqp::iterval($iter),Pair,'$!value')),
                     0
                   ),
                   nqp::push($low,nqp::getattr(nqp::iterval($iter),Pair,'$!key'))


### PR DESCRIPTION
I believe this broke in e7e97c7b.

Passes `make m-spectest`.

Before the fix:
`perl6-m -e 'my $bag = {"red" => 200000000000000000019, "blue" => 100000000000000000000}.Bag; dd $bag'`
gave
`Cannot unbox 68 bit wide bigint into native integer`
after the fix:
`Bag $bag = ("red"=>200000000000000000019,"blue"=>100000000000000000000).Bag`
