### PR TITLE
Better align the --help output of the perl6 cmd

### DIFF
--- a/src/Perl6/Compiler.nqp
+++ b/src/Perl6/Compiler.nqp
@@ -101,14 +101,14 @@ compiled code.
   --ll-exception       display a low level backtrace on errors
   --profile[=kind]     write profile information to an HTML file (MoarVM)
                          instrumented - performance measurements (default)
-                         heap - record heap snapshots after every
-                                garbage collector run
+                         heap - record heap snapshots after every garbage
+                         collector run
   --profile-filename=name
-                       provide a different filename for profile. Extension
-                       controls format:
-                            .json outputs in JSON
-                            .sql  outputs in SQL
-                            any other extension outputs in HTML
+                       provide a different filename for profile.
+                       Extension controls format:
+                         .json outputs in JSON
+                         .sql  outputs in SQL
+                         any other extension outputs in HTML
   --doc=module         use Pod::To::[module] to render inline documentation
 
 


### PR DESCRIPTION
Make some changes to make the indentation a little more
consistent.