### PR TITLE
Make errors in BOOTSTRAP more awesome

### DIFF
--- a/src/Perl6/Metamodel/BOOTSTRAP.nqp
+++ b/src/Perl6/Metamodel/BOOTSTRAP.nqp
@@ -1529,19 +1529,19 @@ BEGIN {
             my $SIG_ELEM_IS_RW       := 256;
             my $SIG_ELEM_IS_OPTIONAL := 2048;
             my $dcself := nqp::decont($self);
-            my int $flags := nqp::getattr_i($dcself, Parameter, '$!flags');
-            if $flags +& $SIG_ELEM_IS_OPTIONAL {
-                nqp::die("Cannot use 'is rw' on an optional parameter");
-            }
             my str $varname := nqp::getattr_s($dcself, Parameter, '$!variable_name');
             unless nqp::isnull_s($varname) || nqp::eqat($varname, '$', 0) {
                 my $error;
                 if nqp::eqat($varname, '%', 0) || nqp::eqat($varname, '@', 0)  {
                     my $sig := nqp::substr($varname, 0, 1);
-                    $error := "'$sig' sigil containers don't need 'is rw' to be writable\n";
+                    $error := "For parameter '$varname', '$sig' sigil containers don't need 'is rw' to be writable\n";
                 }
-                $error := $error ~ "Can only use 'is rw' on a scalar ('\$' sigil) parameter";
+                $error := $error ~ "Can only use 'is rw' on a scalar ('\$' sigil) parameter, not '$varname'";
                 nqp::die($error);
+            }
+            my int $flags := nqp::getattr_i($dcself, Parameter, '$!flags');
+            if $flags +& $SIG_ELEM_IS_OPTIONAL {
+                nqp::die("Cannot use 'is rw' on optional parameter '$varname'");
             }
             my $cd := nqp::getattr($dcself, Parameter, '$!container_descriptor');
             if nqp::defined($cd) { $cd.set_rw(1) }
@@ -1813,7 +1813,8 @@ BEGIN {
                 $dc_self
             }
             else {
-                nqp::die("Cannot add a dispatchee to a non-dispatcher code object");
+                nqp::die("Cannot add dispatchee '" ~ $dispatchee.name() ~
+                         "' to non-dispatcher code object '" ~ $self.name() ~ "'");
             }
         }));
     Routine.HOW.add_method(Routine, 'derive_dispatcher', nqp::getstaticcode(sub ($self) {

--- a/src/Perl6/Metamodel/BOOTSTRAP.nqp
+++ b/src/Perl6/Metamodel/BOOTSTRAP.nqp
@@ -1541,7 +1541,13 @@ BEGIN {
             }
             my int $flags := nqp::getattr_i($dcself, Parameter, '$!flags');
             if $flags +& $SIG_ELEM_IS_OPTIONAL {
-                nqp::die("Cannot use 'is rw' on optional parameter '$varname'");
+                my %ex := nqp::gethllsym('perl6', 'P6EX');
+                if nqp::isnull(%ex) || !nqp::existskey(%ex, 'X::Trait::Invalid') {
+                    nqp::die("Cannot use 'is rw' on optional parameter '$varname'");
+                }
+                else {
+                    nqp::atkey(%ex, 'X::Trait::Invalid')('is', 'rw', 'optional parameter', $varname);
+                }
             }
             my $cd := nqp::getattr($dcself, Parameter, '$!container_descriptor');
             if nqp::defined($cd) { $cd.set_rw(1) }

--- a/src/core/Exception.pm
+++ b/src/core/Exception.pm
@@ -781,6 +781,16 @@ my class X::Worry::P5::LeadingZero is X::Worry::P5 {
     }
 }
 
+my class X::Trait::Invalid is Exception {
+    has $.type;       # is, will, of etc.
+    has $.subtype;    # wrong subtype being tried
+    has $.declaring;  # variable, sub, parameter, etc.
+    has $.name;       # '$foo', '@bar', etc.
+    method message () {
+        "Cannot use '$.type $.subtype' on $.declaring '$.name'."
+    }
+}
+
 my class X::Trait::Unknown is Exception {
     has $.type;       # is, will, of etc.
     has $.subtype;    # wrong subtype being tried
@@ -2496,6 +2506,10 @@ nqp::bindcurhllsym('P6EX', nqp::hash(
   sub (@exceptions) {
       X::PhaserExceptions.new(exceptions =>
         @exceptions.map(-> Mu \e { EXCEPTION(e) })).throw;
+  },
+  'X::Trait::Invalid',
+  sub ($type, $subtype, $declaring, $name) {
+      X::Trait::Invalid.new(:$type, :$subtype, :$declaring, :$name).throw;
   },
 ));
 

--- a/t/05-messages/01-errors.t
+++ b/t/05-messages/01-errors.t
@@ -49,4 +49,17 @@ throws-like ｢m: my @a = for 1..3 <-> { $_ }｣, Exception,
     :message(/«'do for'»/),
     '<-> does not prevent an error suggesting to use `do for`';
 
+# https://irclog.perlgeek.de/perl6-dev/2017-04-13#i_14425133
+# RT #79288
+{
+    my $param = '$bar';
+    throws-like { EVAL q[ sub foo(\qq{$param}? is rw) {} ] }, Exception,
+        message => "Cannot use 'is rw' on optional parameter '$param'",
+        'making an "is rw" parameter optional dies with adequate error message and mentions the parameter name';
+
+    throws-like { EVAL q[ sub foo(\qq{$param} is rw = 42) {} ] }, Exception,
+        message => "Cannot use 'is rw' on optional parameter '$param'",
+        'making an "is rw" parameter optional dies with adequate error message and mentions the parameter name';
+}
+
 done-testing;


### PR DESCRIPTION
Include relevant information where possible.

Passes `make m-spectest` except for two tests in t/spec/S06-signature/optional.t, which expect the exact text of one of the changed error messages, but have as their description "making an "is rw" parameter optional dies with adequate error message". I would argue that my changes to the error message are improvements, so the tests should be altered to pass. 