### PR TITLE
Escape spaces and quotes in MAIN() usage message

### DIFF
--- a/src/core/Main.pm
+++ b/src/core/Main.pm
@@ -141,8 +141,10 @@ my sub MAIN_HELPER($retval = 0) {
                                 $simple-const ??       $constraints                !!
                                                  '<' ~ $param.type.^name     ~ '>' ;
 
-                    $argument = "[$argument ...]" if $param.slurpy;
-                    $argument = "[$argument]"     if $param.optional;
+                    $argument  = "[$argument ...]"          if $param.slurpy;
+                    $argument  = "[$argument]"              if $param.optional;
+                    $argument .= trans(["'"] => [q|'"'"'|]) if $argument.contains("'");
+                    $argument  = "'$argument'"              if $argument.contains(' ' | '"');
                     @positional.push($argument);
                 }
                 @arg-help.push($argument => $param.WHY.contents) if $param.WHY and (@arg-help.grep:{ .key eq $argument}) == Empty;  # Use first defined


### PR DESCRIPTION
Before, if you had a literal parameter in a MAIN() with a space or
quote (single or double) the parameter wouldn't get quoted when a
usage message was printed. This means you couldn't just copy what
was suggested. Now, quote if needed.

Fixes RT #113954

Passes `make m-spectest`.