### PR TITLE
Fix for RT #130760 - print perl6 usage msg to stderr when an invalid …

### DIFF
--- a/src/Perl6/Compiler.nqp
+++ b/src/Perl6/Compiler.nqp
@@ -77,8 +77,9 @@ class Perl6::Compiler is HLL::Compiler {
         $p6repl.repl-loop(:interactive(1), |%adverbs)
     }
 
-    method usage($name?) {
-        say(($name ?? $name !! "") ~ " [switches] [--] [programfile] [arguments]
+    method usage($name?, :$use-stderr = False) {
+	my $print-func := $use-stderr ?? &note !! &say; # RT #130760
+        $print-func(($name ?? $name !! "") ~ " [switches] [--] [programfile] [arguments]
 
 With no arguments, enters a REPL. With a \"[programfile]\" or the \"-e\"
 option, compiles the given program and, by default, also executes the


### PR DESCRIPTION
…cmd line option is used

Entering an invalid option when invoking nqp or perl6 leads to an
error message being printed followed by usage instructions. In both
cases this information is written to stdout when it should have been
written to stderr. This fix solves the problem for perl6 by introducing
a flag which tells the code doing the writing which fd to use.
This fix will be dependent on nqp commit 745c61d in order to solve the
problem described above. In the absence of the nqp commit nothing will
break however, it will just continue to work the way it does today.