### PR TITLE
Fix typed optional Array and Hash parameters

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -8433,15 +8433,31 @@ class Perl6::Actions is HLL::Actions does STDActions {
                 }
                 else {
                     if %info<sigil> eq '@' {
+                        my $type;
+                        if nqp::istype($nomtype, $*W.find_symbol(['Positional'])) && nqp::can($nomtype.HOW, 'role_arguments') {
+                            my @role_args := $nomtype.HOW.role_arguments($nomtype);
+                            $type := $*W.parameterize_type_with_args($/, $*W.find_symbol(['Array']), @role_args, nqp::hash);
+                        }
+                        else {
+                            $type := $*W.find_symbol(['Array']);
+                        }
                         $var.default(
                                 QAST::Op.new( :op<create>,
-                                              QAST::WVal.new( :value($*W.find_symbol(['Array'])) )
+                                              QAST::WVal.new( :value($type) )
                             ));
                     }
                     elsif %info<sigil> eq '%' {
+                        my $type;
+                        if nqp::istype($nomtype, $*W.find_symbol(['Associative'])) && nqp::can($nomtype.HOW, 'role_arguments') {
+                            my @role_args := $nomtype.HOW.role_arguments($nomtype);
+                            $type := $*W.parameterize_type_with_args($/, $*W.find_symbol(['Hash']), @role_args, nqp::hash);
+                        }
+                        else {
+                            $type := $*W.find_symbol(['Hash']);
+                        }
                         $var.default(
                                 QAST::Op.new( :op<create>,
-                                              QAST::WVal.new( :value($*W.find_symbol(['Hash'])) )
+                                              QAST::WVal.new( :value($type) )
                             ));
                     }
                     else {

--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -8432,33 +8432,19 @@ class Perl6::Actions is HLL::Actions does STDActions {
                     }
                 }
                 else {
-                    if %info<sigil> eq '@' {
-                        my $type;
-                        if nqp::istype($nomtype, $*W.find_symbol(['Positional'])) && nqp::can($nomtype.HOW, 'role_arguments') {
-                            my @role_args := $nomtype.HOW.role_arguments($nomtype);
-                            $type := $*W.parameterize_type_with_args($/, $*W.find_symbol(['Array']), @role_args, nqp::hash);
-                        }
-                        else {
-                            $type := $*W.find_symbol(['Array']);
-                        }
+                    if (my $is-array := %info<sigil> eq '@') || %info<sigil> eq '%' {
+
+                        my $role      := $is-array ?? 'Positional' !! 'Associative';
+                        my $base-type := $is-array ?? 'Array'      !! 'Hash';
+
                         $var.default(
-                                QAST::Op.new( :op<create>,
-                                              QAST::WVal.new( :value($type) )
-                            ));
-                    }
-                    elsif %info<sigil> eq '%' {
-                        my $type;
-                        if nqp::istype($nomtype, $*W.find_symbol(['Associative'])) && nqp::can($nomtype.HOW, 'role_arguments') {
-                            my @role_args := $nomtype.HOW.role_arguments($nomtype);
-                            $type := $*W.parameterize_type_with_args($/, $*W.find_symbol(['Hash']), @role_args, nqp::hash);
-                        }
-                        else {
-                            $type := $*W.find_symbol(['Hash']);
-                        }
-                        $var.default(
-                                QAST::Op.new( :op<create>,
-                                              QAST::WVal.new( :value($type) )
-                            ));
+                            QAST::Op.new(
+                                :op<create>,
+                                QAST::WVal.new(
+                                    value => nqp::istype($nomtype, $*W.find_symbol([$role])) && nqp::can($nomtype.HOW, 'role_arguments')
+                                               ?? $*W.parameterize_type_with_args($/, $*W.find_symbol([$base-type]), $nomtype.HOW.role_arguments($nomtype), nqp::hash)
+                                               !! $*W.find_symbol([$base-type])
+                            )));
                     }
                     else {
                         if $spec == 1 {


### PR DESCRIPTION
When handling typed optional Array and Hash parameters that don't
have a value passed we now nqp::create() the correct empty
parameterized type.

Before, `sub foo(Int @a?) { @a.push(42); dd @a }; foo();` would die with `Type check failed in binding to @a; expected Positional[Int] but got Array ($[])`, but now it prints `Array[Int].new(42)`

Fixes RT #118555

Passes `make m-spectest`.