### PR TITLE
Add method name and received type to type vs instance error

### DIFF
--- a/src/Perl6/Metamodel/BOOTSTRAP.nqp
+++ b/src/Perl6/Metamodel/BOOTSTRAP.nqp
@@ -316,29 +316,21 @@ my class Binder {
 
                 # Also enforce definedness constraints.
                 if $flags +& $SIG_ELEM_DEFINEDNES_CHECK {
-                    if $flags +& $SIG_ELEM_UNDEFINED_ONLY && nqp::isconcrete($oval) {
+                    if (my $should_be_undef := $flags +& $SIG_ELEM_UNDEFINED_ONLY &&  nqp::isconcrete($oval)) ||
+                                               $flags +& $SIG_ELEM_DEFINED_ONLY   && !nqp::isconcrete($oval)
+                    {
                         if nqp::defined($error) {
                             my $method := nqp::getcodeobj(nqp::ctxcode($lexpad)).name;
-                            $method    := '<anon>' if nqp::isnull_s($method);
+                            $method    := '<anon>' if nqp::isnull_s($method) || $method eq '';
                             my $class  := $nom_type.HOW.name($nom_type);
                             my $got    := $oval.HOW.name($oval);
                             $error[0]  := $flags +& $SIG_ELEM_INVOCANT
-                              ?? "Method '$method' must be called on a type object of type '$class', not an object instance of type '$got'.  Did you forget a 'multi'?"
-                              !! "Parameter '$varname' of routine '$method' must be a type object of type '$class', but an object instance of type '$got' was passed.  Did you forget a 'multi'?";
-                        }
-                        return $oval.WHAT =:= Junction && nqp::isconcrete($oval)
-                            ?? $BIND_RESULT_JUNCTION
-                            !! $BIND_RESULT_FAIL;
-                    }
-                    if $flags +& $SIG_ELEM_DEFINED_ONLY && !nqp::isconcrete($oval) {
-                        if nqp::defined($error) {
-                            my $method := nqp::getcodeobj(nqp::ctxcode($lexpad)).name;
-                            $method    := '<anon>' if nqp::isnull_s($method);
-                            my $class  := $nom_type.HOW.name($nom_type);
-                            my $got    := $oval.HOW.name($oval);
-                            $error[0]  := $flags +& $SIG_ELEM_INVOCANT
-                              ?? "Method '$method' must be called on an object instance of type '$class', not a '$got' type object.  Did you forget a '.new'?"
-                              !! "Parameter '$varname' of routine '$method' must be an object instance of type '$class', but a '$got' type object was passed.  Did you forget a '.new'?";
+                              ?? $should_be_undef
+                                   ?? "Method '$method' must be called on a type object of type '$class', not an object instance of type '$got'.  Did you forget a 'multi'?"
+                                   !! "Method '$method' must be called on an object instance of type '$class', not a '$got' type object.  Did you forget a '.new'?"
+                              !! $should_be_undef
+                                   ?? "Parameter '$varname' of routine '$method' must be a type object of type '$class', but an object instance of type '$got' was passed.  Did you forget a 'multi'?"
+                                   !! "Parameter '$varname' of routine '$method' must be an object instance of type '$class', but a '$got' type object was passed.  Did you forget a '.new'?";
                         }
                         return $oval.WHAT =:= Junction && nqp::isconcrete($oval)
                             ?? $BIND_RESULT_JUNCTION

--- a/src/Perl6/Metamodel/BOOTSTRAP.nqp
+++ b/src/Perl6/Metamodel/BOOTSTRAP.nqp
@@ -318,11 +318,12 @@ my class Binder {
                 if $flags +& $SIG_ELEM_DEFINEDNES_CHECK {
                     if $flags +& $SIG_ELEM_UNDEFINED_ONLY && nqp::isconcrete($oval) {
                         if nqp::defined($error) {
-                            my $class := $nom_type.HOW.name($nom_type);
-                            my $what  := $flags +& $SIG_ELEM_INVOCANT
-                              ?? "Invocant"
-                              !! "Parameter '$varname'";
-                            $error[0] := "$what requires a type object of type $class, but an object instance was passed.  Did you forget a 'multi'?";
+                            my $method := nqp::getcodeobj(nqp::ctxcode($lexpad)).name;
+                            my $class  := $nom_type.HOW.name($nom_type);
+                            my $got    := $oval.HOW.name($oval);
+                            $error[0]  := $flags +& $SIG_ELEM_INVOCANT
+                              ?? "Method '$method' must be called on a type object of type '$class', not an object instance of type '$got'.  Did you forget a 'multi'?"
+                              !! "Parameter '$varname' of method '$method' must be a type object of type '$class', but an object instance of type '$got' was passed.  Did you forget a 'multi'?";
                         }
                         return $oval.WHAT =:= Junction && nqp::isconcrete($oval)
                             ?? $BIND_RESULT_JUNCTION
@@ -330,11 +331,12 @@ my class Binder {
                     }
                     if $flags +& $SIG_ELEM_DEFINED_ONLY && !nqp::isconcrete($oval) {
                         if nqp::defined($error) {
-                            my $class := $nom_type.HOW.name($nom_type);
-                            my $what  := $flags +& $SIG_ELEM_INVOCANT
-                              ?? "Invocant"
-                              !! "Parameter '$varname'";
-                            $error[0] := "$what requires an instance of type $class, but a type object was passed.  Did you forget a .new?";
+                            my $method := nqp::getcodeobj(nqp::ctxcode($lexpad)).name;
+                            my $class  := $nom_type.HOW.name($nom_type);
+                            my $got    := $oval.HOW.name($oval);
+                            $error[0]  := $flags +& $SIG_ELEM_INVOCANT
+                              ?? "Method '$method' must be called on an object instance of type '$class', not a '$got' type object.  Did you forget a '.new'?"
+                              !! "Parameter '$varname' of method '$method' must be an object instance of type '$class', but a '$got' type object was passed.  Did you forget a '.new'?";
                         }
                         return $oval.WHAT =:= Junction && nqp::isconcrete($oval)
                             ?? $BIND_RESULT_JUNCTION

--- a/src/Perl6/Metamodel/BOOTSTRAP.nqp
+++ b/src/Perl6/Metamodel/BOOTSTRAP.nqp
@@ -319,6 +319,7 @@ my class Binder {
                     if $flags +& $SIG_ELEM_UNDEFINED_ONLY && nqp::isconcrete($oval) {
                         if nqp::defined($error) {
                             my $method := nqp::getcodeobj(nqp::ctxcode($lexpad)).name;
+                            $method    := '<anon>' if nqp::isnull_s($method);
                             my $class  := $nom_type.HOW.name($nom_type);
                             my $got    := $oval.HOW.name($oval);
                             $error[0]  := $flags +& $SIG_ELEM_INVOCANT
@@ -332,6 +333,7 @@ my class Binder {
                     if $flags +& $SIG_ELEM_DEFINED_ONLY && !nqp::isconcrete($oval) {
                         if nqp::defined($error) {
                             my $method := nqp::getcodeobj(nqp::ctxcode($lexpad)).name;
+                            $method    := '<anon>' if nqp::isnull_s($method);
                             my $class  := $nom_type.HOW.name($nom_type);
                             my $got    := $oval.HOW.name($oval);
                             $error[0]  := $flags +& $SIG_ELEM_INVOCANT

--- a/src/Perl6/Metamodel/BOOTSTRAP.nqp
+++ b/src/Perl6/Metamodel/BOOTSTRAP.nqp
@@ -324,7 +324,7 @@ my class Binder {
                             my $got    := $oval.HOW.name($oval);
                             $error[0]  := $flags +& $SIG_ELEM_INVOCANT
                               ?? "Method '$method' must be called on a type object of type '$class', not an object instance of type '$got'.  Did you forget a 'multi'?"
-                              !! "Parameter '$varname' of method '$method' must be a type object of type '$class', but an object instance of type '$got' was passed.  Did you forget a 'multi'?";
+                              !! "Parameter '$varname' of routine '$method' must be a type object of type '$class', but an object instance of type '$got' was passed.  Did you forget a 'multi'?";
                         }
                         return $oval.WHAT =:= Junction && nqp::isconcrete($oval)
                             ?? $BIND_RESULT_JUNCTION
@@ -338,7 +338,7 @@ my class Binder {
                             my $got    := $oval.HOW.name($oval);
                             $error[0]  := $flags +& $SIG_ELEM_INVOCANT
                               ?? "Method '$method' must be called on an object instance of type '$class', not a '$got' type object.  Did you forget a '.new'?"
-                              !! "Parameter '$varname' of method '$method' must be an object instance of type '$class', but a '$got' type object was passed.  Did you forget a '.new'?";
+                              !! "Parameter '$varname' of routine '$method' must be an object instance of type '$class', but a '$got' type object was passed.  Did you forget a '.new'?";
                         }
                         return $oval.WHAT =:= Junction && nqp::isconcrete($oval)
                             ?? $BIND_RESULT_JUNCTION

--- a/src/core/Exception.pm
+++ b/src/core/Exception.pm
@@ -1143,6 +1143,26 @@ my class X::Parameter::WrongOrder does X::Comp {
     }
 }
 
+my class X::Parameter::InvalidConcreteness is Exception {
+    has $.expected;
+    has $.got;
+    has $.routine;
+    has $.param;
+    has $.should-be-concrete;
+    has $.param-is-invocant;
+
+    method message() {
+        $!routine = '<anon>' if not $!routine.defined or $!routine eq '';
+        $!param   = '<anon>' if not $!param.defined   or $!param   eq '';
+        my $beginning  = $!param-is-invocant  ?? 'Invocant of method' !! "Parameter '$!param' of routine";
+        my $must-be    = $!should-be-concrete ?? 'an object instance' !! 'a type object';
+        my $not-a      = $!should-be-concrete ?? 'a type object'      !! 'an object instance';
+        my $suggestion = $!should-be-concrete ?? '.new'               !! 'multi';
+
+        "$beginning '$!routine' must be $must-be of type '$!expected', not $not-a of type '$!got'.  Did you forget a '$suggestion'?"
+    }
+}
+
 my class X::Parameter::InvalidType does X::Comp {
     has $.typename;
     has @.suggestions;
@@ -2457,6 +2477,7 @@ my class X::PhaserExceptions is Exception {
     }
 }
 
+
 #?if jvm
 nqp::bindcurhllsym('P6EX', nqp::hash(
 #?endif
@@ -2528,6 +2549,10 @@ nqp::bindcurhllsym('P6EX', BEGIN nqp::hash(
   'X::Trait::Invalid',
   -> $type, $subtype, $declaring, $name {
       X::Trait::Invalid.new(:$type, :$subtype, :$declaring, :$name).throw;
+  },
+  'X::Parameter::InvalidConcreteness',
+  -> $expected, $got, $routine, $param, $should-be-concrete, $param-is-invocant {
+      X::Parameter::InvalidConcreteness.new(:$expected, :$got, :$routine, :$param, :$should-be-concrete, :$param-is-invocant).throw;
   },
 ));
 

--- a/t/05-messages/01-errors.t
+++ b/t/05-messages/01-errors.t
@@ -85,4 +85,24 @@ throws-like ｢m: my @a = for 1..3 <-> { $_ }｣, Exception,
         'The message when trying to pun a role with required methods should have the names of the child, parent, required methods, and suggest "does"';
 }
 
+# RT #126124
+# adapted from S06-signature/types.t
+{
+    throws-like { sub f(Mu:D $a) {}; f(Int) },
+        Exception,
+        message => all(/'Parameter'/, /\W '$a'>>/, /<<'f'>>/, /<<'must be an object instance'>>/, /<<'not a type object'>>/, /<<'Mu'>>/,  /<<'Int'>>/, /\W '.new'>>/),
+        'types and names shown in the exception message are correct';
+    throws-like { sub f(Mu:U $a) {}; f(123) },
+        Exception,
+        message => all(/'Parameter'/, /\W '$a'>>/, /<<'f'>>/, /<<'not an object instance'>>/, /<<'must be a type object'>>/, /<<'Mu'>>/,  /<<'Int'>>/, /<<'multi'>>/),
+        'types shown in the exception message are correct';
+}
+
+# adapted from S32-exceptions/misc.t
+for <fail die throw rethrow resumable resume> -> $meth {
+    throws-like 'X::NYI.' ~ $meth,
+        Exception,
+        message => all(/'Invocant'/, /<<$meth>>/, /<<'must be an object instance'>>/, /<<'not a type object'>>/, /<<'Exception'>>/,  /<<'X::NYI'>>/, /\W '.new'>>/),
+}
+
 done-testing;


### PR DESCRIPTION
Ex.

`perl6 -e 'Int.abs'` used to say `Invocant requires an instance of type Int, but a type object was passed.  Did you forget a .new?`, but now says `Method 'abs' must be called on an object instance of type 'Int', not a 'Int' type object.  Did you forget a '.new'?`

`perl6 -e 'sub foo(Any:D $bar){}(Str)'` used to say `Parameter '$bar' requires an instance of type Any, but a type object was passed.  Did you forget a .new?`, but now says `Parameter '$bar' of routine 'foo' must be an object instance of type 'Any', but a 'Str' type object was passed.  Did you forget a '.new'?`

Breaks some tests in t/spec/S32-exceptions/misc.t and t/spec/S06-signature/types.t that are looking for specific words in a specific sequence.