### PR TITLE
Fix rotate on empty list

### DIFF
--- a/src/core/Rakudo/Internals.pm
+++ b/src/core/Rakudo/Internals.pm
@@ -21,17 +21,20 @@ my class Rakudo::Internals {
     method RotateListToList(\from,\n,\to) {
         nqp::stmts(
           (my $from := nqp::getattr(from,List,'$!reified')),
-          (my int $elems = nqp::elems($from)),
-          (my $to := nqp::getattr(to,List,'$!reified')),
-          (my int $i = -1),
-          (my int $j = nqp::mod_i(nqp::sub_i(nqp::sub_i($elems,1),n),$elems)),
-          nqp::if(nqp::islt_i($j,0),($j = nqp::add_i($j,$elems))),
-          nqp::while(
-            nqp::islt_i(($i = nqp::add_i($i,1)),$elems),
-            nqp::bindpos(
-              $to,
-              ($j = nqp::mod_i(nqp::add_i($j,1),$elems)),
-              nqp::atpos($from,$i)
+          nqp::if((my int $elems = nqp::elems($from)),
+            nqp::stmts(
+              (my $to := nqp::getattr(to,List,'$!reified')),
+              (my int $i = -1),
+              (my int $j = nqp::mod_i(nqp::sub_i(nqp::sub_i($elems,1),n),$elems)),
+              nqp::if(nqp::islt_i($j,0),($j = nqp::add_i($j,$elems))),
+              nqp::while(
+                nqp::islt_i(($i = nqp::add_i($i,1)),$elems),
+                nqp::bindpos(
+                  $to,
+                  ($j = nqp::mod_i(nqp::add_i($j,1),$elems)),
+                  nqp::atpos($from,$i)
+                ),
+              ),
             ),
           ),
           to


### PR DESCRIPTION
`my @a = (); @a.rotate(1)` used to error with `Modulation by zero`
before, but now does nothing.

Passes `make m-spectest`.