### PR TITLE
Revert "Fix stuck precomp on osx"

### DIFF
--- a/src/core/CompUnit/PrecompilationRepository.pm
+++ b/src/core/CompUnit/PrecompilationRepository.pm
@@ -267,17 +267,17 @@ class CompUnit::PrecompilationRepository::Default does CompUnit::PrecompilationR
           :%env
         );
 
-        my $err    = $proc.err.slurp-rest(:close);
         my @result = $proc.out.lines.unique;
         if not $proc.out.close or $proc.status {  # something wrong
             self.store.unlock;
             $RMD("Precomping $path failed: $proc.status()") if $RMD;
             Rakudo::Internals.VERBATIM-EXCEPTION(1);
-            die $err;
+            die $proc.err.slurp-rest(:close);
         }
 
-        $*ERR.print($err) if $err;
-
+        if $proc.err.slurp-rest(:close) -> $warnings {
+            $*ERR.print($warnings);
+        }
         unless $bc.e {
             $RMD("$path aborted precompilation without failure") if $RMD;
             self.store.unlock;


### PR DESCRIPTION
Reverts rakudo/rakudo#1076

This commit makes precompilation hang for my project on OSX: https://github.com/spitsh/spitsh

`zef install Spit` on HEAD should demonstrate this. Reverting it fixed it.

I have also encountered the "too much STDERR at BEGIN hangs on OSX" problem this commit was trying to fix but for me that problem wasn't as bad as this one :)