### PR TITLE
Fix right shift op; make it 55% faster

### DIFF
--- a/src/core/Int.pm
+++ b/src/core/Int.pm
@@ -410,11 +410,7 @@ multi sub infix:«+<»(Int:D \a, Int:D \b --> Int:D) {
 #}
 
 multi sub infix:«+>»(Int:D \a, Int:D \b --> Int:D) {
-    nqp::isbig_I(nqp::decont(b))
-      ?? Failure.new(X::NYI::BigInt.new(:op('+>'),:big(b)))
-      !! a < 0 && b > 31
-        ?? -1 # temp fix for RT#126942, remove if fixed otherwise
-        !! nqp::bitshiftr_I(nqp::decont(a), nqp::unbox_i(b), Int)
+    nqp::bitshiftr_I(nqp::decont(a), nqp::unbox_i(b), Int)
 }
 #multi sub infix:«+>»(int $a, int $b) { RT#128655
 #    nqp::bitshiftr_i($a, $b)


### PR DESCRIPTION
- Fix underlying MoarVM problem:
    https://github.com/MoarVM/MoarVM/pull/593
- Remove the kludge and bigI check, making the op 55% faster
- Fixes RT#126942: https://rt.perl.org/Ticket/Display.html?id=126942
- Fixes RT#13278: https://rt.perl.org/Ticket/Display.html?id=131278