### PR TITLE
Throw X::NYI when trying to subset a native type

### DIFF
--- a/src/Perl6/Metamodel/SubsetHOW.nqp
+++ b/src/Perl6/Metamodel/SubsetHOW.nqp
@@ -38,6 +38,15 @@ class Perl6::Metamodel::SubsetHOW
                 "type or a type that can provide one");
         }
         $!refinee := nqp::decont($refinee);
+        if nqp::objprimspec($!refinee) {
+            my %ex := nqp::gethllsym('perl6', 'P6EX');
+            if nqp::existskey(%ex, 'X::NYI') {
+                %ex{'X::NYI'}('Subsets of native types');
+            }
+            else {
+                nqp::die("Subsets of native types NYI");
+            }
+        }
     }
     
     method refinee($obj) {

--- a/src/core/Exception.pm
+++ b/src/core/Exception.pm
@@ -2557,6 +2557,10 @@ nqp::bindcurhllsym('P6EX', BEGIN nqp::hash(
   -> $expected, $got, $routine, $param, Bool() $should-be-concrete, Bool() $param-is-invocant {
       X::Parameter::InvalidConcreteness.new(:$expected, :$got, :$routine, :$param, :$should-be-concrete, :$param-is-invocant).throw;
   },
+  'X::NYI',
+  -> $feature {
+      X::NYI.new(:$feature).throw;
+  },
 ));
 
 my class X::HyperWhatever::Multiple is Exception {


### PR DESCRIPTION
Native type subsets can be created currently, but don't work, always
saying the type check failed (see RT #131310).

Passes `make m-spectest`.