### PR TITLE
Update localport if we made bind on port 0

### DIFF
--- a/src/core/IO/Socket/INET.pm
+++ b/src/core/IO/Socket/INET.pm
@@ -126,7 +126,7 @@ my class IO::Socket::INET does IO::Socket {
         }
 
         if $.listening {
-            $!localport = nqp::get_port($PIO) if !$!localport;
+            $!localport = nqp::getport($PIO) if !$!localport;
         }
         elsif $.type == PIO::SOCK_STREAM {
             nqp::connect($PIO, nqp::unbox_s($.host), nqp::unbox_i($.port));

--- a/src/core/IO/Socket/INET.pm
+++ b/src/core/IO/Socket/INET.pm
@@ -126,6 +126,7 @@ my class IO::Socket::INET does IO::Socket {
         }
 
         if $.listening {
+            $!localport = nqp::get_port($PIO) if !$!localport;
         }
         elsif $.type == PIO::SOCK_STREAM {
             nqp::connect($PIO, nqp::unbox_s($.host), nqp::unbox_i($.port));


### PR DESCRIPTION
This is a dependency for: https://github.com/MoarVM/MoarVM/pull/600

There is a common practice to bind on first un-used port, you have to
bind on port 0 and after that with help of getsockname call you can get
what port is in use.