### PR TITLE
Suggest misspelled method names

### DIFF
--- a/src/core/Exception.pm
+++ b/src/core/Exception.pm
@@ -176,17 +176,21 @@ my class X::Method::NotFound is Exception {
             %suggestions<encode($encoding).bytes> = 0;
         }
 
-        for $.invocant.^methods(:all)>>.name -> $method_name {
-            my $dist = StrDistance.new(:before($.method), :after($method_name));
-            if $dist <= $max_length {
-                %suggestions{$method_name} = $dist;
+        if nqp::can($!invocant.HOW, 'methods') {
+            for $!invocant.^methods(:all)>>.name -> $method_name {
+                my $dist = StrDistance.new(:before($.method), :after($method_name));
+                if $dist <= $max_length {
+                    %suggestions{$method_name} = $dist;
+                }
             }
         }
 
-        for $.invocant.^private_method_table.keys -> $method_name {
-            my $dist = StrDistance.new(:before($.method), :after($method_name));
-            if $dist <= $max_length {
-                %suggestions{"!$method_name"} = $dist;
+        if nqp::can($!invocant.HOW, 'private_method_table') {
+            for $!invocant.^private_method_table.keys -> $method_name {
+                my $dist = StrDistance.new(:before($.method), :after($method_name));
+                if $dist <= $max_length {
+                    %suggestions{"!$method_name"} = $dist;
+                }
             }
         }
 

--- a/tools/build/jvm_core_sources
+++ b/tools/build/jvm_core_sources
@@ -79,6 +79,7 @@ src/core/Rational.pm
 src/core/Rat.pm
 src/core/Complex.pm
 src/core/Backtrace.pm
+src/core/StrDistance.pm
 src/core/Exception.pm
 src/core/Failure.pm
 src/core/Match.pm
@@ -181,7 +182,6 @@ src/vm/jvm/CompUnit/Repository/Java.pm
 src/vm/jvm/CompUnit/Repository/JavaRuntime.pm
 src/core/Argfiles.pm
 src/core/Process.pm
-src/core/StrDistance.pm
 src/core/Slang.pm
 src/core/Metamodel/Primitives.pm
 src/core/REPL.pm

--- a/tools/build/moar_core_sources
+++ b/tools/build/moar_core_sources
@@ -81,6 +81,7 @@ src/core/Rational.pm
 src/core/Rat.pm
 src/core/Complex.pm
 src/core/Backtrace.pm
+src/core/StrDistance.pm
 src/core/Exception.pm
 src/core/Failure.pm
 src/core/Match.pm
@@ -180,7 +181,6 @@ src/core/CompUnit/Repository/Perl5.pm
 src/core/CompUnit/Repository/Unknown.pm
 src/core/Argfiles.pm
 src/core/Process.pm
-src/core/StrDistance.pm
 src/core/Slang.pm
 src/core/Metamodel/Primitives.pm
 src/core/REPL.pm


### PR DESCRIPTION
Like types, lexicals, and routines/phasers, suggest methods with a
similar name if the given method is not found for the invocant.

Fixes https://rt.perl.org/Ticket/Display.html?id=123078 and
https://rt.perl.org/Ticket/Display.html?id=127395.

Passes `make m-spectest`.