### PR TITLE
Add routine name to 'Too many positionals error'

### DIFF
--- a/src/Perl6/Metamodel/BOOTSTRAP.nqp
+++ b/src/Perl6/Metamodel/BOOTSTRAP.nqp
@@ -137,7 +137,7 @@ my class Binder {
     my $PositionalBindFailover;
 
 #?if moar
-    sub arity_fail($params, int $num_params, int $num_pos_args, int $too_many) {
+    sub arity_fail($params, int $num_params, int $num_pos_args, int $too_many, $lexpad) {
         my str $error_prefix := $too_many ?? "Too many" !! "Too few";
         my int $count;
         my int $arity;
@@ -165,14 +165,15 @@ my class Binder {
             $param_i++;
         }
         my str $s := $arity == 1 ?? "" !! "s";
+        my str $routine := nqp::getcodeobj(nqp::ctxcode($lexpad)).name;
 
         if $arity == $count {
-            return "$error_prefix positionals passed; expected $arity argument$s but got $num_pos_args";
+            return "$error_prefix positionals passed to '$routine'; expected $arity argument$s but got $num_pos_args";
         } elsif $count < 0 {
-            return "$error_prefix positionals passed; expected at least $arity argument$s but got only $num_pos_args";
+            return "$error_prefix positionals passed to '$routine'; expected at least $arity argument$s but got only $num_pos_args";
         } else {
             my str $conj := $count == $arity+1 ?? "or" !! "to";
-            return "$error_prefix positionals passed; expected $arity $conj $count arguments but got $num_pos_args";
+            return "$error_prefix positionals passed to '$routine'; expected $arity $conj $count arguments but got $num_pos_args";
         }
     }
 
@@ -812,7 +813,7 @@ my class Binder {
                         }
                         else {
                             if nqp::defined($error) {
-                                $error[0] := arity_fail(@params, $num_params, $num_pos_args, 0);
+                                $error[0] := arity_fail(@params, $num_params, $num_pos_args, 0, $lexpad);
                             }
                             return $BIND_RESULT_FAIL;
                         }
@@ -868,7 +869,7 @@ my class Binder {
         if $cur_pos_arg < $num_pos_args && !$suppress_arity_fail {
             # Oh noes, too many positionals passed.
             if nqp::defined($error) {
-                $error[0] := arity_fail(@params, $num_params, $num_pos_args, 1);
+                $error[0] := arity_fail(@params, $num_params, $num_pos_args, 1, $lexpad);
             }
             return $BIND_RESULT_FAIL;
         }

--- a/t/05-messages/01-errors.t
+++ b/t/05-messages/01-errors.t
@@ -155,6 +155,18 @@ subtest 'non-ASCII digits > 7 in leading-zero-octal warning' => {
         'wrong arity in a sub-signature with a named parameter has correct values in error message';
 }
 
+# RT #131408
+{
+    throws-like { sub foo([$head, $tail]) {}; foo([3, 4], [3]) },
+        Exception,
+        message => /<<'foo'>>/,
+        'wrong arity in a signature mentions the name of the sub';
+    throws-like { class A { foo([$head, $tail]) {} }; A.foo([3, 4], [3]) },
+        Exception,
+        message => /<<'foo'>>/,
+        'wrong arity in a signature mentions the name of the method';
+}
+
 { # https://irclog.perlgeek.de/perl6-dev/2017-05-31#i_14666102
     throws-like '42.length      ', Exception, '.length on non-List Cool',
         :message{ .contains: <chars codes>.all & none <elems graphs> };


### PR DESCRIPTION
Also add some tests.

Fixes https://rt.perl.org/Ticket/Display.html?id=131408

Passes `make m-spectest`