### PR TITLE
A worry for RT #126732

### DIFF
--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -3506,6 +3506,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         | 'Inf' >>
         | $<uinf>='∞'
         | <?{ nqp::existskey(nqp::backendconfig(), 'moarlib') }> <unum=:No+:Nl>
+          [ <.after <[⁰¹²³⁴⁵⁶⁷⁸⁹]>> <.before <[⁰¹²³⁴⁵⁶⁷⁸⁹]>> {$/.worry: "$<unum> is parsed as a separate numeric literal. Did you forget a term?"} ]?
         ]
     }
 


### PR DESCRIPTION
I blinked my eyes and the ticket got closed. In any case, here is a
fix.

For those who think that this might cause some kind of breakage, this
is just a worry, so don't worry.

This whole discussion was basically about adding or not adding this
one line of code. I don't see any problem with it. Curious users will
try to use superscripts alone, maybe just for fun, but a “potential
difficulty” will give them a lesser WTF-ish feeling. So let's just
take it.

Example:

Code:
```
say ³²
```

Result:
```
Potential difficulties:
    ³ is parsed as a separate numeric literal. Did you forget a term?
    at -e:1
    ------> say ³⏏²
9
```