### PR TITLE
Suggest methods when missing method in optimizer

### DIFF
--- a/src/Perl6/Optimizer.nqp
+++ b/src/Perl6/Optimizer.nqp
@@ -1712,7 +1712,7 @@ class Perl6::Optimizer {
             else {
                 $!problems.add_exception(['X', 'Method', 'NotFound'], $op, 
                     :private(nqp::p6bool(1)), :method($name),
-                    :typename($pkg.HOW.name($pkg)));
+                    :typename($pkg.HOW.name($pkg)), :invocant($pkg));
             }
         }
     }

--- a/src/core/Exception.pm
+++ b/src/core/Exception.pm
@@ -154,7 +154,7 @@ my class X::Method::NotFound is Exception {
     has Bool $.private = False;
     method message() {
         my $message = $.private
-          ?? "No such private method '$.method' for invocant of type '$.typename'"
+          ?? "No such private method '!$.method' for invocant of type '$.typename'"
           !! "No such method '$.method' for invocant of type '$.typename'";
 
         my %suggestions;


### PR DESCRIPTION
Pass the right thing as the invocant so it can be introspected for
possible suggestions.

Also add a '!' to the beginning of the name of private methods in the
message saying it doesn't exist to be consistent with names in
suggestions.

Should finish up resolving
https://rt.perl.org/Ticket/Display.html?id=123078

Passes `make m-test` and `make m-spectest`.