### PR TITLE
Fix ModuleLoader.nqp so RAKUDO_MODULE_DEBUG works the same as elsewhere

### DIFF
--- a/src/Perl6/ModuleLoader.nqp
+++ b/src/Perl6/ModuleLoader.nqp
@@ -1,4 +1,8 @@
-my $DEBUG := +nqp::ifnull(nqp::atkey(nqp::getenvhash(), 'RAKUDO_MODULE_DEBUG'), 0);
+# $DEBUG is set to 1 for Truey numeric values of ENV 'RAKUDO_MODULE_DEBUG'
+# or for non-numeric strings. All other cases $DEBUG is set to 0
+my $rakudo-module-debug := nqp::atkey(nqp::getenvhash(), 'RAKUDO_MODULE_DEBUG');
+my $DEBUG := nqp::stmts((my $debug-radix := nqp::radix(10, $rakudo-module-debug, 0, 0)),($debug-radix[2] != -1))
+?? ?$debug-radix[0] !! ?nqp::chars($rakudo-module-debug);
 sub DEBUG(*@strs) {
     my $err := stderr();
     $err.print("     " ~ nqp::getpid() ~ " RMD: ");


### PR DESCRIPTION
This code emulates the whitespace ignoring code written in Perl 6
in which beginning and trailing whitespace in %*ENV<RAKUDO_MODULE_DEBUG>
are ignored.
Here, the str number is converted to an int. Examples:
    'yes' => 1, '' => 0, null => 0, ' 9 ' => 9, 'no' => 1, 'camelia' => 1 etc.

Additionally it also fixes a bug that would cause Rakudo to die during compilation
if RAKUDO_MODULE_DEBUG were set to anything other than a number. This was
discovered by the Rakudo AppImage builder here:
https://travis-ci.org/samcv/rakudo-appimage-module-test-automation/jobs/242732276#L1204

When given a non-number during normal operation the debugging code in
ModuleLoader.nqp would not be activated, even though other debugging
code in Rakudo codebase would. The original code was added a long time ago,
on 2013-04-21.

This fix only applies to MoarVM, and this bug could still exist on the JVM.
This commit harmonizes the ModuleLoader.nqp code with the Perl 6 based code.