### PR TITLE
Add missing role to ::TranslateNewlineWrapper

### DIFF
--- a/src/core/Encoding/Encoder/TranslateNewlineWrapper.pm
+++ b/src/core/Encoding/Encoder/TranslateNewlineWrapper.pm
@@ -1,4 +1,4 @@
-my class Encoding::Encoder::TranslateNewlineWrapper {
+my class Encoding::Encoder::TranslateNewlineWrapper does Encoding::Encoder {
     has Encoding::Encoder $!delegate;
 
     method new(Encoding::Encoder $delegate) {


### PR DESCRIPTION
`Encoding::Encoder::TranslateNewlineWrapper` was missing `does Encoding::Encoder`

This broke the build on my Windows computer