### PR TITLE
Find proper %?RESOURCES for non-lib CURFS

### DIFF
--- a/src/core/CompUnit/Repository/FileSystem.pm
+++ b/src/core/CompUnit/Repository/FileSystem.pm
@@ -194,8 +194,8 @@ class CompUnit::Repository::FileSystem does CompUnit::Repository::Locally does C
         # but we also want to root any path request to the CUR's resources directory
 
         # When $.prefix points at a directory containing a meta file (eg. -I.)
-        return $.prefix.add( %!meta<files>.first(*<<$key>>).values[0] )
-            if %!meta<files>.first(*<<$key>>);
+        return $.prefix.add( %!meta<files><<$key>> )
+            if %!meta<files> && %!meta<files><<$key>>;
         return $.prefix.add( $key )
             if %!meta<resources>.first({ $_ eq $key.subst(/^resources\//, "") });
 

--- a/src/core/CompUnit/Repository/FileSystem.pm
+++ b/src/core/CompUnit/Repository/FileSystem.pm
@@ -192,7 +192,15 @@ class CompUnit::Repository::FileSystem does CompUnit::Repository::Locally does C
         # We now save the 'resources/' part of a resource's path in files, i.e:
         # "files" : [ "resources/libraries/xxx" => "resources/libraries/xxx.so" ]
         # but we also want to root any path request to the CUR's resources directory
-        $.prefix.parent.add('resources').add($key.subst(/^resources\//, ""));
+
+        # When $.prefix points at a directory containing a meta file (eg. -I.)
+        return $.prefix.add( %!meta<files>.first(*<<$key>>).values[0] )
+            if %!meta<files>.first(*<<$key>>);
+        return $.prefix.add( $key )
+            if %!meta<resources>.first({ $_ eq $key.subst(/^resources\//, "") });
+
+        # When $.prefix is presumably the 'lib' folder (eg. -Ilib)
+        return $.prefix.parent.add($key);
     }
 
     method precomp-store(--> CompUnit::PrecompilationStore:D) {


### PR DESCRIPTION
Fixes `perl6 -I. bin/zef --help` - in this case the failure was `%?RESOURCES<config.json>` pointing 1 directory level above what it should have.