### PR TITLE
add the option --libdir to rakudo Configuration

### DIFF
--- a/Configure.pl
+++ b/Configure.pl
@@ -58,7 +58,7 @@ MAIN: {
     }
     $options{prefix} = File::Spec->rel2abs($options{prefix});
     unless (defined $options{libdir}) {
-        my $default = File::Spec->catdir($options{prefix}, 'lib');
+        my $default = File::Spec->catdir($options{prefix}, 'share');
         # print "ATTENTION: no --libdir supplied, building and installing architecture specific files to $default\n";
         $options{libdir} = $default;
     }

--- a/Configure.pl
+++ b/Configure.pl
@@ -53,11 +53,13 @@ MAIN: {
 
     unless (defined $options{prefix}) {
         my $default = defined($options{sysroot}) ? '/usr' : File::Spec->catdir(getcwd, 'install');
+        print "ATTENTION: no --prefix supplied, building and installing to $default\n";
         $options{prefix} = $default;
     }
     $options{prefix} = File::Spec->rel2abs($options{prefix});
     unless (defined $options{libdir}) {
         my $default = File::Spec->catdir($options{prefix}, 'share');
+        
         $options{libdir} = $default;
     }
     my $prefix         = $options{'prefix'};

--- a/Configure.pl
+++ b/Configure.pl
@@ -59,7 +59,6 @@ MAIN: {
     $options{prefix} = File::Spec->rel2abs($options{prefix});
     unless (defined $options{libdir}) {
         my $default = File::Spec->catdir($options{prefix}, 'share');
-        
         $options{libdir} = $default;
     }
     my $prefix         = $options{'prefix'};

--- a/Configure.pl
+++ b/Configure.pl
@@ -53,13 +53,11 @@ MAIN: {
 
     unless (defined $options{prefix}) {
         my $default = defined($options{sysroot}) ? '/usr' : File::Spec->catdir(getcwd, 'install');
-        # print "ATTENTION: no --prefix supplied, building and installing to $default\n";
         $options{prefix} = $default;
     }
     $options{prefix} = File::Spec->rel2abs($options{prefix});
     unless (defined $options{libdir}) {
         my $default = File::Spec->catdir($options{prefix}, 'share');
-        # print "ATTENTION: no --libdir supplied, building and installing architecture specific files to $default\n";
         $options{libdir} = $default;
     }
     my $prefix         = $options{'prefix'};

--- a/Configure.pl
+++ b/Configure.pl
@@ -58,7 +58,7 @@ MAIN: {
     }
     $options{prefix} = File::Spec->rel2abs($options{prefix});
     unless (defined $options{libdir}) {
-        my $default = File::Spec->catdir($options{prefix}, 'lib');
+        my $default = File::Spec->catdir($options{prefix}, 'share');
         $options{libdir} = $default;
     }
     my $prefix         = $options{'prefix'};

--- a/Configure.pl
+++ b/Configure.pl
@@ -32,7 +32,7 @@ MAIN: {
     my $exe = $NQP::Configure::exe;
 
     my %options;
-    GetOptions(\%options, 'help!', 'prefix=s',
+    GetOptions(\%options, 'help!', 'prefix=s', 'libdir=s',
                'sysroot=s', 'sdkroot=s',
                'backends=s', 'no-clean!',
                'with-nqp=s', 'gen-nqp:s',
@@ -53,10 +53,15 @@ MAIN: {
 
     unless (defined $options{prefix}) {
         my $default = defined($options{sysroot}) ? '/usr' : File::Spec->catdir(getcwd, 'install');
-        print "ATTENTION: no --prefix supplied, building and installing to $default\n";
+        # print "ATTENTION: no --prefix supplied, building and installing to $default\n";
         $options{prefix} = $default;
     }
     $options{prefix} = File::Spec->rel2abs($options{prefix});
+    unless (defined $options{libdir}) {
+        my $default = File::Spec->catdir($options{prefix}, 'lib');
+        # print "ATTENTION: no --libdir supplied, building and installing architecture specific files to $default\n";
+        $options{libdir} = $default;
+    }
     my $prefix         = $options{'prefix'};
     my @known_backends = qw/moar jvm/;
     my %known_backends = map { $_, 1; } @known_backends;
@@ -129,6 +134,7 @@ MAIN: {
     }
 
     $config{prefix} = $prefix;
+    $config{libdir} = $options{libdir};
     $config{sdkroot} = $options{sdkroot} || '';
     $config{sysroot} = $options{sysroot} || '';
     $config{slash}  = $slash;
@@ -374,6 +380,7 @@ Configure.pl - $lang Configure
 General Options:
     --help             Show this text
     --prefix=dir       Install files in dir; also look for executables there
+    --libdir=dir       Install architecture-specific files in dir; Perl6 modules included
     --sdkroot=dir      When given, use for searching build tools here, e.g.
                        nqp, java etc.
     --sysroot=dir      When given, use for searching runtime components here

--- a/Configure.pl
+++ b/Configure.pl
@@ -58,7 +58,7 @@ MAIN: {
     }
     $options{prefix} = File::Spec->rel2abs($options{prefix});
     unless (defined $options{libdir}) {
-        my $default = File::Spec->catdir($options{prefix}, 'share');
+        my $default = File::Spec->catdir($options{prefix}, 'lib');
         $options{libdir} = $default;
     }
     my $prefix         = $options{'prefix'};

--- a/src/Perl6/ModuleLoader.nqp
+++ b/src/Perl6/ModuleLoader.nqp
@@ -52,7 +52,7 @@ class Perl6::ModuleLoader does Perl6::ModuleLoaderVMConfig {
             my $*MAIN_CTX;
             my $file := 'Perl6/BOOTSTRAP' ~ self.file-extension;
             my $include := nqp::getcomp('perl6').cli-options<nqp-lib>;
-            $file := ($include ?? $include ~ '/' !! nqp::getcomp('perl6').config<prefix> ~ '/share/nqp/lib/') ~ $file;
+            $file := ($include ?? $include ~ '/' !! nqp::getcomp('perl6').config<libdir> ~ '/nqp/lib/') ~ $file;
 
             if nqp::existskey(%modules_loaded, $file) {
                 return nqp::ctxlexpad(%modules_loaded{$file});

--- a/src/core/CompUnit/RepositoryRegistry.pm
+++ b/src/core/CompUnit/RepositoryRegistry.pm
@@ -67,8 +67,8 @@ class CompUnit::RepositoryRegistry {
         my $prefix := nqp::existskey($ENV,'RAKUDO_PREFIX')
           ?? nqp::atkey($ENV,'RAKUDO_PREFIX')
           !! nqp::concat(
-               nqp::atkey(nqp::getcomp('perl6').config,'prefix'),
-               '/share/perl6'
+               nqp::atkey(nqp::getcomp('perl6').config,'libdir'),
+               '/perl6'
              );
 
         # XXX Various issues with this stuff on JVM , TEMPORARY

--- a/src/vm/moar/ModuleLoaderVMConfig.nqp
+++ b/src/vm/moar/ModuleLoaderVMConfig.nqp
@@ -1,8 +1,10 @@
 role Perl6::ModuleLoaderVMConfig {
     method vm_search_paths() {
         my @search_paths;
-        @search_paths.push(nqp::backendconfig<prefix> ~ '/share/perl6/lib');
+        @search_paths.push(nqp::backendconfig<libdir> ~ '/perl6/lib');
         # XXX CHEAT: Goes away when we implement :from<nqp>.
+        @search_paths.push(nqp::backendconfig<libdir> ~ '/nqp/lib');
+        # Keep share dir, moarvm has some files there
         @search_paths.push(nqp::backendconfig<prefix> ~ '/share/nqp/lib');
         @search_paths
     }

--- a/tools/build/Makefile-Moar.in
+++ b/tools/build/Makefile-Moar.in
@@ -10,6 +10,7 @@ M_BUILD_DIR = gen/moar
 MOAR_PREFIX = @moar::prefix@
 MOAR   = @moar::bindir@@slash@moar@exe@
 M_NQP  = @m_nqp@
+M_LIBDEFPATH = $(PREFIX)@slash@share@slash@nqp@slash@lib
 M_LIBPATH = $(LIBDIR)@slash@nqp@slash@lib
 M_INCPATH = $(MOAR_PREFIX)@slash@include
 NQP_LIBPATH = @nqp::libdir@
@@ -195,7 +196,7 @@ $(M_DEBUG_RUNNER): tools/build/create-moar-runner.pl $(PERL6_DEBUG_MOAR) $(SETTI
 
 $(M_GDB_RUNNER): tools/build/create-moar-runner.pl $(PERL6_MOAR) $(SETTING_MOAR)
 	$(RM_F) $(M_GDB_RUNNER)
-	$(M_RUN_PERL6) tools/build/create-moar-runner.pl "$(MOAR)" perl6.moarvm perl6-gdb-m . "gdb" --nqp-lib=blib "$(M_LIBPATH)" "$(NQP_LIBPATH)" .
+	$(M_RUN_PERL6) tools/build/create-moar-runner.pl "$(MOAR)" perl6.moarvm perl6-gdb-m . "gdb" --nqp-lib=blib "$(M_LIBDEFPATH)" "$(M_LIBPATH)" "$(NQP_LIBPATH)" .
 	-$(CHMOD) 755 $(M_GDB_RUNNER)
 
 $(M_VALGRIND_RUNNER): tools/build/create-moar-runner.pl $(PERL6_MOAR) $(SETTING_MOAR)

--- a/tools/build/Makefile-Moar.in
+++ b/tools/build/Makefile-Moar.in
@@ -10,7 +10,7 @@ M_BUILD_DIR = gen/moar
 MOAR_PREFIX = @moar::prefix@
 MOAR   = @moar::bindir@@slash@moar@exe@
 M_NQP  = @m_nqp@
-M_LIBPATH = $(PREFIX)@slash@share@slash@nqp@slash@lib
+M_LIBPATH = $(LIBDIR)@slash@nqp@slash@lib
 M_INCPATH = $(MOAR_PREFIX)@slash@include
 NQP_LIBPATH = @nqp::libdir@
 
@@ -147,7 +147,7 @@ $(PERL6_C_MOAR): src/Perl6/Compiler.nqp $(PERL6_O_MOAR)
 	    src/Perl6/Compiler.nqp
 
 $(PERL6_MOAR): src/main.nqp $(PERL6_G_MOAR) $(PERL6_A_MOAR) $(PERL6_C_MOAR) $(PERL6_P_MOAR) $(PERL6_DP_MOAR)
-	$(PERL5) tools/build/gen-version.pl $(PREFIX) > $(M_BUILD_DIR)/main-version.nqp
+	$(PERL5) tools/build/gen-version.pl $(PREFIX) $(LIBDIR) > $(M_BUILD_DIR)/main-version.nqp
 	$(M_NQP) $(M_GEN_CAT) src/main.nqp $(M_BUILD_DIR)/main-version.nqp > $(M_BUILD_DIR)/main.nqp
 	$(M_NQP) --target=mbc --output=$(PERL6_MOAR) \
 	    --vmlibs=$(M_PERL6_OPS_DLL)=Rakudo_ops_init $(M_BUILD_DIR)/main.nqp

--- a/tools/build/Makefile-common-macros.in
+++ b/tools/build/Makefile-common-macros.in
@@ -12,7 +12,8 @@ SHELL   = @shell@
 SYSROOT= @sysroot@
 SDKROOT= @sdkroot@
 PREFIX = @prefix@
-PERL6_LANG_DIR = $(PREFIX)/share/perl6
+LIBDIR = @libdir@
+PERL6_LANG_DIR = $(LIBDIR)/perl6
 
 BOOTSTRAP_SOURCES = \
   src/Perl6/Metamodel/BOOTSTRAP.nqp \

--- a/tools/build/gen-version.pl
+++ b/tools/build/gen-version.pl
@@ -9,6 +9,7 @@ gen-version.pl -- script to generate version information for HLL compilers
 use POSIX 'strftime';
 
 my $prefix = shift;
+my $libdir = shift;
 
 open(my $fh, '<', 'VERSION') or die $!;
 my $VERSION = <$fh>;
@@ -34,6 +35,7 @@ sub hll-config(\$config) {
     \$config<build-date>       := '$builddate';
     \$config<language_version> := '6.c';
     \$config<prefix>           := '$prefix';
+    \$config<libdir>           := '$libdir';
 }
 END_VERSION
 


### PR DESCRIPTION
This patch is used for packaging rakudo at Fedora. It would be nice if it could go to the rakudo sources.