### PR TITLE
Only create Exception messages when gisting

### DIFF
--- a/src/core/Exception.pm
+++ b/src/core/Exception.pm
@@ -37,7 +37,7 @@ my class Exception {
         if nqp::isconcrete($!ex) {
             my str $message = nqp::getmessage($!ex);
             $str = nqp::isnull_s($message)
-                ?? "Died with {self.^name}"
+                ?? (try self.?message) // "Died with {self.^name}"
                 !! nqp::p6box_s($message);
             $str ~= "\n";
             try $str ~= self.backtrace
@@ -54,12 +54,6 @@ my class Exception {
         $!ex := nqp::newexception() unless nqp::isconcrete($!ex) and $bt;
         $!bt := $bt; # Even if !$bt
         nqp::setpayload($!ex, nqp::decont(self));
-        my $msg := try self.?message;
-        if defined($msg) {
-            $msg := try ~$msg;
-        }
-        $msg := $msg // "{self.^name} exception produced no message";
-        nqp::setmessage($!ex, nqp::unbox_s($msg));
         nqp::throw($!ex)
     }
     method rethrow(Exception:D:) {


### PR DESCRIPTION
With the recent change to suggest similar method names when throwing
X::Method::NotFound, it got a lot slower to try possible methods (e.g.,
`try Int.sin`) even if you didn't care about the exception message. This
commit removes the .message call from .throw and puts it in both
branches of .gist.

Passes `make m-test` and `make m-spectest`.

Before this, `for ^100 { try Int.son }; say now - INIT now` took 20s, after 0.003s.

@LLFourn++, @skaji++