### PR TITLE
Site wide config: working --prefix option

### DIFF
--- a/Configure.pl
+++ b/Configure.pl
@@ -283,9 +283,9 @@ MAIN: {
         unless ($win) {
             $config{'m_cleanups'} = "  \$(M_GDB_RUNNER) \\\n  \$(M_LLDB_RUNNER) \\\n  \$(M_VALGRIND_RUNNER)";
             $config{'m_all'}      = '$(M_GDB_RUNNER) $(M_LLDB_RUNNER) $(M_VALGRIND_RUNNER)';
-            $config{'m_install'}  = "\t" . '$(M_RUN_PERL6) tools/build/create-moar-runner.pl "$(MOAR)" perl6.moarvm $(DESTDIR)$(PREFIX)/bin/perl6-gdb-m "$(PERL6_LANG_DIR)/runtime" "gdb" "" "$(M_LIBPATH)" "$(PERL6_LANG_DIR)/lib" "$(PERL6_LANG_DIR)/runtime"' . "\n"
-                                  . "\t" . '$(M_RUN_PERL6) tools/build/create-moar-runner.pl "$(MOAR)" perl6.moarvm $(DESTDIR)$(PREFIX)/bin/perl6-lldb-m "$(PERL6_LANG_DIR)/runtime" "lldb" "" "$(M_LIBPATH)" "$(PERL6_LANG_DIR)/lib" "$(PERL6_LANG_DIR)/runtime"' . "\n"
-                                  . "\t" . '$(M_RUN_PERL6) tools/build/create-moar-runner.pl "$(MOAR)" perl6.moarvm $(DESTDIR)$(PREFIX)/bin/perl6-valgrind-m "$(PERL6_LANG_DIR)/runtime" "valgrind" "" "$(M_LIBPATH)" "$(PERL6_LANG_DIR)/lib" "$(PERL6_LANG_DIR)/runtime"';
+            $config{'m_install'}  = "\t" . '$(M_RUN_PERL6) tools/build/create-moar-runner.pl "$(MOAR)" perl6.moarvm $(PREFIX)/bin/perl6-gdb-m "$(PERL6_LANG_DIR)/runtime" "gdb" "" "$(M_LIBPATH)" "$(PERL6_LANG_DIR)/lib" "$(PERL6_LANG_DIR)/runtime"' . "\n"
+                                  . "\t" . '$(M_RUN_PERL6) tools/build/create-moar-runner.pl "$(MOAR)" perl6.moarvm $(PREFIX)/bin/perl6-lldb-m "$(PERL6_LANG_DIR)/runtime" "lldb" "" "$(M_LIBPATH)" "$(PERL6_LANG_DIR)/lib" "$(PERL6_LANG_DIR)/runtime"' . "\n"
+                                  . "\t" . '$(M_RUN_PERL6) tools/build/create-moar-runner.pl "$(MOAR)" perl6.moarvm $(PREFIX)/bin/perl6-valgrind-m "$(PERL6_LANG_DIR)/runtime" "valgrind" "" "$(M_LIBPATH)" "$(PERL6_LANG_DIR)/lib" "$(PERL6_LANG_DIR)/runtime"';
         }
 
         unless (@errors) {

--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -74,11 +74,11 @@
     into local "nqp/" and "moar/" subdirectories, install NQP and MoarVM
     into the "install/" subdirectory, and use them for building Rakudo.
     It's okay to use the "--gen-moar" option on later invocations of
-    Configure.pl; the configure system will re-build NQP and/or MoarVM 
-    only if a newer version is needed for whatever version of Rakudo 
+    Configure.pl; the configure system will re-build NQP and/or MoarVM
+    only if a newer version is needed for whatever version of Rakudo
     you're working with.
 
-    If you already have MoarVM installed, you can use 
+    If you already have MoarVM installed, you can use
     "--with-moar=/path/to/bin/moar" to use it instead of
     building a new one.  This installed MoarVM must include its
     development environment.  Similarly, if you already have NQP
@@ -89,7 +89,7 @@
     The versions of any already installed NQP or MoarVM binaries must
     satify a minimum specified by the Rakudo being built -- Configure.pl
     and "make" will verify this for you.  Released versions of Rakudo
-    generally build against the latest release of MoarVM; checkouts of 
+    generally build against the latest release of MoarVM; checkouts of
     Rakudo's HEAD revision from Github often require a version of MoarVM
     that is newer than the most recent MoarVM monthly release.
 
@@ -161,9 +161,9 @@
     recent version of the Perl 5 module Test::Harness (3.16 works for sure).
 
   Spectest smolder requirements (Windows)
-    You need recent version of either Strawberry Perl or ActiveState Perl.
+    You need a recent version of either Strawberry Perl or ActiveState Perl.
 
-    If you are working with ActiveState Perl you need the Mingw gcc compiler.
+    If you are working with ActiveState Perl, you need the Mingw gcc compiler.
 
     You need msys git installed and you need "\Program Files\Git\cmd" on your
     execution path and NOT "\Program Files\Git\bin".

--- a/tools/build/Makefile-JVM.in
+++ b/tools/build/Makefile-JVM.in
@@ -216,27 +216,27 @@ sometests: j-all
 	@$(J_HARNESS5_WITH_FUDGE) $(TESTFILES)
 
 j-install: j-all tools/build/create-jvm-runner.pl tools/build/install-core-dist.pl
-	$(MKPATH) $(DESTDIR)$(PREFIX)/bin
-	$(MKPATH) $(DESTDIR)$(J_LIBPATH)/Perl6
-	$(MKPATH) $(DESTDIR)$(PERL6_LANG_DIR)/runtime
-	$(CP) $(PERL6_LANG_JARS) $(DESTDIR)$(J_LIBPATH)/Perl6
-	$(CP) $(SETTING_JAR) $(SETTING_D_JAR) $(DESTDIR)$(PERL6_LANG_DIR)/runtime
-	$(CP) $(PERL6_JAR) $(DESTDIR)$(PERL6_LANG_DIR)/runtime
-	$(CP) $(PERL6_DEBUG_JAR) $(DESTDIR)$(PERL6_LANG_DIR)/runtime
-	$(CP) $(RUNTIME_JAR) $(DESTDIR)$(PERL6_LANG_DIR)/runtime
-	.@slash@$(J_RUNNER) tools/build/upgrade-repository.pl $(DESTDIR)$(PERL6_LANG_DIR)
-	$(MKPATH) $(DESTDIR)$(PERL6_LANG_DIR)/vendor
-	.@slash@$(J_RUNNER) tools/build/upgrade-repository.pl $(DESTDIR)$(PERL6_LANG_DIR)/vendor
-	$(MKPATH) $(DESTDIR)$(PERL6_LANG_DIR)/site
-	.@slash@$(J_RUNNER) tools/build/upgrade-repository.pl $(DESTDIR)$(PERL6_LANG_DIR)/site
-	.@slash@$(J_RUNNER) tools/build/install-core-dist.pl $(DESTDIR)$(PERL6_LANG_DIR)
-	$(PERL5) tools/build/create-jvm-runner.pl install "$(DESTDIR)" $(PREFIX) $(NQP_PREFIX) --nqp-lib=blib $(NQP_JARS)
-	$(PERL5) tools/build/create-jvm-runner.pl install-debug "$(DESTDIR)" $(PREFIX) $(NQP_PREFIX) --nqp-lib=blib $(NQP_JARS)
+	$(MKPATH) $(PREFIX)/bin
+	$(MKPATH) $(J_LIBPATH)/Perl6
+	$(MKPATH) $(PERL6_LANG_DIR)/runtime
+	$(CP) $(PERL6_LANG_JARS) $(J_LIBPATH)/Perl6
+	$(CP) $(SETTING_JAR) $(SETTING_D_JAR) $(PERL6_LANG_DIR)/runtime
+	$(CP) $(PERL6_JAR) $(PERL6_LANG_DIR)/runtime
+	$(CP) $(PERL6_DEBUG_JAR) $(PERL6_LANG_DIR)/runtime
+	$(CP) $(RUNTIME_JAR) $(PERL6_LANG_DIR)/runtime
+	.@slash@$(J_RUNNER) tools/build/upgrade-repository.pl $(PERL6_LANG_DIR)
+	$(MKPATH) $(PERL6_LANG_DIR)/vendor
+	.@slash@$(J_RUNNER) tools/build/upgrade-repository.pl $(PERL6_LANG_DIR)/vendor
+	$(MKPATH) $(PERL6_LANG_DIR)/site
+	.@slash@$(J_RUNNER) tools/build/upgrade-repository.pl $(PERL6_LANG_DIR)/site
+	.@slash@$(J_RUNNER) tools/build/install-core-dist.pl $(PERL6_LANG_DIR)
+	$(PERL5) tools/build/create-jvm-runner.pl install "" $(PREFIX) $(NQP_PREFIX) --nqp-lib=blib $(NQP_JARS)
+	$(PERL5) tools/build/create-jvm-runner.pl install-debug "" $(PREFIX) $(NQP_PREFIX) --nqp-lib=blib $(NQP_JARS)
 
 j-runner-default-install: j-install
-	$(PERL5) tools/build/create-jvm-runner.pl install "$(DESTDIR)" $(PREFIX) $(NQP_PREFIX) --nqp-lib=blib $(NQP_JARS)
-	$(CP) $(DESTDIR)$(PREFIX)/bin/perl6-j$(J_BAT) $(DESTDIR)$(PREFIX)/bin/perl6$(J_BAT)
-	$(CHMOD) 755 $(DESTDIR)$(PREFIX)/bin/perl6$(J_BAT)
+	$(PERL5) tools/build/create-jvm-runner.pl install "" $(PREFIX) $(NQP_PREFIX) --nqp-lib=blib $(NQP_JARS)
+	$(CP) $(PREFIX)/bin/perl6-j$(J_BAT) $(PREFIX)/bin/perl6$(J_BAT)
+	$(CHMOD) 755 $(PREFIX)/bin/perl6$(J_BAT)
 
 ##  cleaning
 j-clean:

--- a/tools/build/Makefile-Moar.in
+++ b/tools/build/Makefile-Moar.in
@@ -280,6 +280,7 @@ m-sometests: m-all
 	@$(M_HARNESS6_WITH_FUDGE) $(TESTFILES)
 
 m-install: m-all tools/build/create-moar-runner.pl tools/build/install-core-dist.pl $(SETTING_MOAR)
+	touch $(PREFIX)/m-install-timestamp
 	$(MKPATH) $(PREFIX)/bin
 	$(MKPATH) $(M_LIBPATH)/Perl6
 	$(CP) $(M_PERL6_LANG_OUTPUT) $(M_LIBPATH)/Perl6
@@ -299,6 +300,7 @@ m-install: m-all tools/build/create-moar-runner.pl tools/build/install-core-dist
 @m_install@
 
 m-runner-default-install: m-install
+	touch $(PREFIX)/m-runner-default-install-timestamp
 	$(M_RUN_PERL6) tools/build/create-moar-runner.pl "$(MOAR)" perl6.moarvm $(PREFIX)/bin/perl6-m "$(PERL6_LANG_DIR)/runtime" "" "" "$(M_LIBPATH)" "$(NQP_LIBPATH)" "$(PERL6_LANG_DIR)/lib" "$(PERL6_LANG_DIR)/runtime"
 	$(CP) $(PREFIX)/bin/perl6-m$(M_BAT) $(PREFIX)/bin/perl6$(M_BAT)
 	$(CHMOD) 755 $(PREFIX)/bin/perl6$(M_BAT)

--- a/tools/build/Makefile-Moar.in
+++ b/tools/build/Makefile-Moar.in
@@ -280,28 +280,28 @@ m-sometests: m-all
 	@$(M_HARNESS6_WITH_FUDGE) $(TESTFILES)
 
 m-install: m-all tools/build/create-moar-runner.pl tools/build/install-core-dist.pl $(SETTING_MOAR)
-	$(MKPATH) $(DESTDIR)$(PREFIX)/bin
-	$(MKPATH) $(DESTDIR)$(M_LIBPATH)/Perl6
-	$(CP) $(M_PERL6_LANG_OUTPUT) $(DESTDIR)$(M_LIBPATH)/Perl6
-	$(MKPATH) $(DESTDIR)$(PERL6_LANG_DIR)/lib
-	$(MKPATH) $(DESTDIR)$(PERL6_LANG_DIR)/runtime
-	$(CP) $(SETTING_MOAR) $(SETTING_D_MOAR) $(R_SETTING_MOAR) $(DESTDIR)$(PERL6_LANG_DIR)/runtime
-	$(CP) $(PERL6_MOAR) $(PERL6_DEBUG_MOAR) $(DESTDIR)$(PERL6_LANG_DIR)/runtime
-	$(MKPATH) $(DESTDIR)$(PERL6_LANG_DIR)/runtime/dynext
-	$(CP) $(M_PERL6_OPS_DLL) $(DESTDIR)$(PERL6_LANG_DIR)/runtime/dynext
-	.@slash@$(M_RUNNER) tools/build/upgrade-repository.pl $(DESTDIR)$(PERL6_LANG_DIR)
-	.@slash@$(M_RUNNER) tools/build/upgrade-repository.pl $(DESTDIR)$(PERL6_LANG_DIR)/vendor
-	.@slash@$(M_RUNNER) tools/build/upgrade-repository.pl $(DESTDIR)$(PERL6_LANG_DIR)/site
-	.@slash@$(M_RUNNER) tools/build/install-core-dist.pl $(DESTDIR)$(PERL6_LANG_DIR)
-	$(M_RUN_PERL6) tools/build/create-moar-runner.pl "$(MOAR)" perl6.moarvm $(DESTDIR)$(PREFIX)/bin/perl6-m "$(PERL6_LANG_DIR)/runtime" "" "" "$(M_LIBPATH)" "$(NQP_LIBPATH)" "$(PERL6_LANG_DIR)/lib" "$(PERL6_LANG_DIR)/runtime"
-	$(M_RUN_PERL6) tools/build/create-moar-runner.pl "$(MOAR)" perl6-debug.moarvm $(DESTDIR)$(PREFIX)/bin/perl6-debug-m "$(PERL6_LANG_DIR)/runtime" "" "" "$(M_LIBPATH)" "$(NQP_LIBPATH)" "$(PERL6_LANG_DIR)/lib" "$(PERL6_LANG_DIR)/runtime"
-	$(CHMOD) 755 $(DESTDIR)$(PREFIX)/bin/perl6-m$(M_BAT)
+	$(MKPATH) $(PREFIX)/bin
+	$(MKPATH) $(M_LIBPATH)/Perl6
+	$(CP) $(M_PERL6_LANG_OUTPUT) $(M_LIBPATH)/Perl6
+	$(MKPATH) $(PERL6_LANG_DIR)/lib
+	$(MKPATH) $(PERL6_LANG_DIR)/runtime
+	$(CP) $(SETTING_MOAR) $(SETTING_D_MOAR) $(R_SETTING_MOAR) $(PERL6_LANG_DIR)/runtime
+	$(CP) $(PERL6_MOAR) $(PERL6_DEBUG_MOAR) $(PERL6_LANG_DIR)/runtime
+	$(MKPATH) $(PERL6_LANG_DIR)/runtime/dynext
+	$(CP) $(M_PERL6_OPS_DLL) $(PERL6_LANG_DIR)/runtime/dynext
+	.@slash@$(M_RUNNER) tools/build/upgrade-repository.pl $(PERL6_LANG_DIR)
+	.@slash@$(M_RUNNER) tools/build/upgrade-repository.pl $(PERL6_LANG_DIR)/vendor
+	.@slash@$(M_RUNNER) tools/build/upgrade-repository.pl $(PERL6_LANG_DIR)/site
+	.@slash@$(M_RUNNER) tools/build/install-core-dist.pl $(PERL6_LANG_DIR)
+	$(M_RUN_PERL6) tools/build/create-moar-runner.pl "$(MOAR)" perl6.moarvm $(PREFIX)/bin/perl6-m "$(PERL6_LANG_DIR)/runtime" "" "" "$(M_LIBPATH)" "$(NQP_LIBPATH)" "$(PERL6_LANG_DIR)/lib" "$(PERL6_LANG_DIR)/runtime"
+	$(M_RUN_PERL6) tools/build/create-moar-runner.pl "$(MOAR)" perl6-debug.moarvm $(PREFIX)/bin/perl6-debug-m "$(PERL6_LANG_DIR)/runtime" "" "" "$(M_LIBPATH)" "$(NQP_LIBPATH)" "$(PERL6_LANG_DIR)/lib" "$(PERL6_LANG_DIR)/runtime"
+	$(CHMOD) 755 $(PREFIX)/bin/perl6-m$(M_BAT)
 @m_install@
 
 m-runner-default-install: m-install
-	$(M_RUN_PERL6) tools/build/create-moar-runner.pl "$(MOAR)" perl6.moarvm $(DESTDIR)$(PREFIX)/bin/perl6-m "$(PERL6_LANG_DIR)/runtime" "" "" "$(M_LIBPATH)" "$(NQP_LIBPATH)" "$(PERL6_LANG_DIR)/lib" "$(PERL6_LANG_DIR)/runtime"
-	$(CP) $(DESTDIR)$(PREFIX)/bin/perl6-m$(M_BAT) $(DESTDIR)$(PREFIX)/bin/perl6$(M_BAT)
-	$(CHMOD) 755 $(DESTDIR)$(PREFIX)/bin/perl6$(M_BAT)
+	$(M_RUN_PERL6) tools/build/create-moar-runner.pl "$(MOAR)" perl6.moarvm $(PREFIX)/bin/perl6-m "$(PERL6_LANG_DIR)/runtime" "" "" "$(M_LIBPATH)" "$(NQP_LIBPATH)" "$(PERL6_LANG_DIR)/lib" "$(PERL6_LANG_DIR)/runtime"
+	$(CP) $(PREFIX)/bin/perl6-m$(M_BAT) $(PREFIX)/bin/perl6$(M_BAT)
+	$(CHMOD) 755 $(PREFIX)/bin/perl6$(M_BAT)
 
 manifest:
 	echo MANIFEST >MANIFEST

--- a/tools/build/Makefile-common-macros.in
+++ b/tools/build/Makefile-common-macros.in
@@ -9,9 +9,10 @@ RM_RF   = @rm_rf@
 TEST_F  = @test_f@
 SHELL   = @shell@
 
-SYSROOT= @sysroot@
-SDKROOT= @sdkroot@
-PREFIX = @prefix@
+SYSROOT = @sysroot@
+SDKROOT = @sdkroot@
+PREFIX  = @prefix@
+INSTDIR = @instdir@
 PERL6_LANG_DIR = $(PREFIX)/share/perl6
 
 BOOTSTRAP_SOURCES = \


### PR DESCRIPTION
This branch enables, with the --prefix option:

1. configure, make, make test, etc. as user
2. install as root into the --prefix dir

The installation is portable (see notes in the Configure.pl file). Note the original installation used absolute file names which hampered portability.

Still to do:

1. correct and improve documentation
2. rename Perl 6 build files with .pl file name extensions to .p6
3. add a timestamp capability to minimize rebuilds when not necessary
4. remove some PR comments and dead code
5. make it work for other OSs