### PR TITLE
begin_time_lexical_fixup for constants

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -2212,11 +2212,13 @@ class Perl6::Actions is HLL::Actions does STDActions {
     }
 
     method statement_prefix:sym<BEGIN>($/) {
-        begin_time_lexical_fixup($<blorst>.ast.ann('past_block'));
+        my $block := $<blorst>.ast.ann('past_block');
+        begin_time_lexical_fixup($block) if has_nested_blocks($block);
         make $*W.add_phaser($/, 'BEGIN', wanted($<blorst>.ast,'BEGIN').ann('code_object'));
     }
     method statement_prefix:sym<CHECK>($/) {
-        begin_time_lexical_fixup($<blorst>.ast.ann('past_block'));
+        my $block := $<blorst>.ast.ann('past_block');
+        begin_time_lexical_fixup($block) if has_nested_blocks($block);
         make $*W.add_phaser($/, 'CHECK', wanted($<blorst>.ast,'CHECK').ann('code_object'));
     }
     method statement_prefix:sym<COMPOSE>($/) { make $*W.add_phaser($/, 'COMPOSE', unwanted($<blorst>.ast,'COMPOSE').ann('code_object')); }
@@ -2952,7 +2954,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
             $block.blocktype('declaration_static');
 
             # Role bodies run at BEGIN time, so need fixup.
-            begin_time_lexical_fixup($block);
+            begin_time_lexical_fixup($block) if has_nested_blocks($block);
 
             # As its last act, it should grab the current lexpad so that
             # we have the type environment, and also return the parametric
@@ -3027,15 +3029,6 @@ class Perl6::Actions is HLL::Actions does STDActions {
     # context. These survive serialization and thus point at what
     # has to be fixed up.
     sub begin_time_lexical_fixup($block) {
-        my $has_nested_blocks := 0;
-        for @($block[0]) {
-            if nqp::istype($_, QAST::Block) {
-                $has_nested_blocks := 1;
-                last;
-            }
-        }
-        return 0 unless $has_nested_blocks;
-
         my $throwaway_block_past := QAST::Block.new(
             :blocktype('declaration'), :name('!LEXICAL_FIXUP'),
             WANTED(QAST::Var.new( :name('$_'), :scope('lexical'), :decl('var') ),'btlf')
@@ -3052,6 +3045,17 @@ class Perl6::Actions is HLL::Actions does STDActions {
                     QAST::WVal.new( :value($throwaway_block) )
                 )));
         $block[0].push($fixup);
+    }
+
+    sub has_nested_blocks($block) {
+        my $has_nested_blocks := 0;
+        for @($block[0]) {
+            if nqp::istype($_, QAST::Block) {
+                $has_nested_blocks := 1;
+                last;
+            }
+        }
+        return $has_nested_blocks;
     }
 
     method scope_declarator:sym<my>($/)      { make $<scoped>.ast; }
@@ -4816,6 +4820,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
         }
         else {
             $con_block.push($value_ast);
+            begin_time_lexical_fixup($con_block);
             my $value_thunk := $*W.create_simple_code_object($con_block, 'Block');
             $value := $*W.handle-begin-time-exceptions($/, 'evaluating a constant', $value_thunk);
             $*W.add_constant_folded_result($value);


### PR DESCRIPTION
This patch applies the fix that jnthn created for BEGIN and CHECK
blocks to constant assignments (which are also run at compile
time). The problem is constant values may have inner blocks that get
serialized and used at runtime. This fix needs to be applied for them
to work, otherwise these explode when exported and used:

constant $const is export = sub { uc "win" };
constant @const is export  = map { uc $_ }, <foo bar baz>;
constant $regex is export  = /{ say "win"} ./;

With something like: Cannot invoke this object (REPR: Null; VMNull)

Fixes RT #127858, #131705 

Tests: https://github.com/LLFourn/roast/commit/725dc7a89f0a6d644cd12fd8d5d2faa3788b4365