### PR TITLE
Avoid magic $cwd in module search path RT #130883

### DIFF
--- a/src/core/CompUnit/RepositoryRegistry.pm
+++ b/src/core/CompUnit/RepositoryRegistry.pm
@@ -345,6 +345,7 @@ class CompUnit::RepositoryRegistry {
 
         # something we understand
         if $spec ~~ /^
+          <before .>
           [
             $<type>=[ <.ident>+ % '::' ]
             [ '#' $<n>=\w+


### PR DESCRIPTION
https://rt.perl.org/Ticket/Display.html?id=130883

Similar to the Perl dot-inc security issue, but limited to when PERL6LIB (or `use lib`) is set to an empty string:

```
$ echo 'package { say "all your base" }' > NativeCall.pm6
$ PERL6LIB="" perl6 -e 'use NativeCall;'
all your base
```

Note this PR has a LTA error when using `use lib ""`:

```
$ perl6 -e 'use lib "";'
===SORRY!===
Too few positionals passed to 'repository-for-spec'; expected 3 arguments but got 0
```