### PR TITLE
Improve Version smart match with different lengths

### DIFF
--- a/src/core/Version.pm
+++ b/src/core/Version.pm
@@ -80,22 +80,20 @@ class Version {
         }
     }
     multi method ACCEPTS(Version:D: Version:D $other) {
-        my $oparts := nqp::getattr(nqp::decont($other),Version,'$!parts');
-        my $oelems  = nqp::isnull($oparts) ?? 0 !! nqp::elems($oparts);
+        my $oparts       := nqp::getattr(nqp::decont($other),Version,'$!parts');
+        my int $oelems    = nqp::isnull($oparts) ?? 0 !! nqp::elems($oparts);
+        my int $elems     = nqp::elems($!parts);
+        my int $max-elems = nqp::if(nqp::isge_i($oelems,$elems), $oelems, $elems);
 
-        my int $elems = nqp::elems($!parts);
-        my int $i     = -1;
-        while nqp::islt_i(++$i,$elems) {
-            my $v := nqp::atpos($!parts,$i);
+        my int $i = -1;
+        while nqp::islt_i(++$i,$max-elems) {
+            my $v := nqp::if(nqp::isge_i($i,$elems), Whatever, nqp::atpos($!parts,$i));
 
             # if whatever here, no more check this iteration
             unless nqp::istype($v,Whatever) {
-
-                # nothing left to check, so ok
-                return True if nqp::isge_i($i,$oelems);
+                my $o := nqp::if(nqp::isge_i($i,$oelems), 0, nqp::atpos($oparts,$i));
 
                 # if whatever there, no more to check this iteration
-                my $o := nqp::atpos($oparts,$i);
                 unless nqp::istype($o,Whatever) {
                     return nqp::p6bool($!plus) if $o after  $v;
                     return False               if $o before $v;


### PR DESCRIPTION
Passes spectest, but changes the behavior of the following to pass:
```
# Not in roast
use Test;
nok v6 ~~ v6c;
nok v6 ~~ v6.d;
nok v6 ~~ v6.c+;
nok v6 ~~ v6.d+';
done-testing;
```