### PR TITLE
Centralize CURI search logic

### DIFF
--- a/src/core/CompUnit/Repository/Installation.pm
+++ b/src/core/CompUnit/Repository/Installation.pm
@@ -1,7 +1,7 @@
 class CompUnit::Repository::Installation does CompUnit::Repository::Locally does CompUnit::Repository::Installable {
     has $!cver = nqp::hllize(nqp::atkey(nqp::gethllsym('perl6', '$COMPILER_CONFIG'), 'version'));
-    has %!loaded; # cache compunit lookup
-    has %!seen;   # cache distribution lookup
+    has %!loaded; # cache compunit lookup for self.need(...)
+    has %!seen;   # cache distribution lookup for self!matching-dist(...)
     has $!precomp;
     has $!id;
     has Int $!version;
@@ -56,35 +56,15 @@ sub MAIN(:$name is copy, :$auth, :$ver, *@, *%) {
     CompUnit::RepositoryRegistry.run-script("#name#", :dist-name<#dist-name#>, :$name, :$auth, :$ver);
 }';
 
-    method !sources-dir() {
-        my $sources = $.prefix.add('sources');
-        $sources.mkdir unless $sources.e;
-        $sources
-    }
-
-    method !resources-dir() {
-        my $resources = $.prefix.add('resources');
-        $resources.mkdir unless $resources.e;
-        $resources
-    }
-
-    method !dist-dir() {
-        my $dist = $.prefix.add('dist');
-        $dist.mkdir unless $dist.e;
-        $dist
-    }
-
-    method !bin-dir() {
-        my $bin = $.prefix.add('bin');
-        $bin.mkdir unless $bin.e;
-        $bin
-    }
+    method !sources-dir   { with $.prefix.add('sources')   { once { .mkdir unless .e }; $_ } }
+    method !resources-dir { with $.prefix.add('resources') { once { .mkdir unless .e }; $_ } }
+    method !dist-dir      { with $.prefix.add('dist')      { once { .mkdir unless .e }; $_ } }
+    method !bin-dir       { with $.prefix.add('bin')       { once { .mkdir unless .e }; $_ } }
+    method !short-dir     { with $.prefix.add('short')     { once { .mkdir unless .e }; $_ } }
 
     method !add-short-name($name, $dist, $source?, $checksum?) {
-        my $short-dir = $.prefix.add('short');
         my $id = nqp::sha1($name);
-        my $lookup = $short-dir.add($id);
-        $lookup.mkdir;
+        my $lookup = self!short-dir.add($id) andthen { .mkdir unless .e }
         $lookup.add($dist.id).spurt(
                 "{$dist.meta<ver>  // ''}\n"
             ~   "{$dist.meta<auth> // ''}\n"
@@ -95,7 +75,7 @@ sub MAIN(:$name is copy, :$auth, :$ver, *@, *%) {
     }
 
     method !remove-dist-from-short-name-lookup-files($dist --> Nil) {
-        my $short-dir = $.prefix.add('short');
+        my $short-dir = self!short-dir;
         return unless $short-dir.e;
 
         my $id = $dist.id;
@@ -107,8 +87,7 @@ sub MAIN(:$name is copy, :$auth, :$ver, *@, *%) {
     }
 
     method !file-id(Str $name, Str $dist-id) {
-        my $id = $name ~ $dist-id;
-        nqp::sha1($id)
+        nqp::sha1($name ~ $dist-id)
     }
 
     method name(--> Str:D) {
@@ -116,13 +95,11 @@ sub MAIN(:$name is copy, :$auth, :$ver, *@, *%) {
     }
 
     method !repo-prefix() {
-        my $repo-prefix = self.name // '';
-        $repo-prefix ~= '#' if $repo-prefix;
-        $repo-prefix
+        self.name ?? (self.name ~ '#') !! ''
     }
 
     method !read-dist($id) {
-        my $dist = Rakudo::Internals::JSON.from-json($.prefix.add('dist').add($id).slurp);
+        my $dist = Rakudo::Internals::JSON.from-json(self!dist-dir.add($id).slurp);
         $dist<ver> = $dist<ver> ?? Version.new( ~$dist<ver> ) !! Version.new('0');
         $dist
     }
@@ -136,7 +113,7 @@ sub MAIN(:$name is copy, :$auth, :$ver, *@, *%) {
 
     method upgrade-repository() {
         my $version = self!repository-version;
-        my $short-dir = $.prefix.add('short');
+        my $short-dir = self!short-dir;
         mkdir $short-dir unless $short-dir.e;
         my $precomp-dir = $.prefix.add('precomp');
         mkdir $precomp-dir unless $precomp-dir.e;
@@ -298,7 +275,6 @@ sub MAIN(:$name is copy, :$auth, :$ver, *@, *%) {
             my $repo-prefix = self!repo-prefix;
             my $*RESOURCES = Distribution::Resources.new(:repo(self), :$dist-id);
             my %done;
-
             my $compiler-id = CompUnit::PrecompilationId.new($*PERL.compiler.id);
             for %provides.kv -> $source-name, $source-meta {
                 my $id = CompUnit::PrecompilationId.new($source-meta.values[0]<file>);
@@ -309,7 +285,6 @@ sub MAIN(:$name is copy, :$auth, :$ver, *@, *%) {
                 my $id = $source-meta.values[0]<file>;
                 my $source = $sources-dir.add($id);
                 my $source-file = $repo-prefix ?? $repo-prefix ~ $source.relative($.prefix) !! $source;
-
                 if %done{$id} {
                     note "(Already did $id)" if $verbose;
                     next;
@@ -372,58 +347,59 @@ sub MAIN(:$name is copy, :$auth, :$ver, *@, *%) {
         unlink( $dist-dir.add($dist.id) )
     }
 
-    method script($file, :$name!, :$auth, :$ver) {
+    method script($file, :$name, :$auth, :$ver, :$api) {
         my $spec = CompUnit::DependencySpecification.new(
-            :short-name($file),
-            :auth-matcher($auth || True),
-            :version-matcher($ver // '*'),
+            short-name      => $file,
+            auth-matcher    => $auth // True,
+            version-matcher => $ver  // True,
+            api-matcher     => $api  // True,
         );
 
-        with self!matching-dists($spec) {
-            my $matches-file := $_.map: { self!resources-dir.add(.hash.values[0]<source>) }
+        with self.candidates($spec) {
+            my $matches-file := $_.map: {
+                my $basename = .meta.<source>;
+                self!resources-dir.add($basename);
+            }
             return $matches-file.head;
         }
     }
 
-    method files($file, :$name!, :$auth, :$ver) {
+    method files($file, :$name!, :$auth, :$ver, :$api) {
         my $spec = CompUnit::DependencySpecification.new(
-            :short-name($name),
-            :auth-matcher($auth || True),
-            :version-matcher($ver // '*'),
+            short-name      => $name,
+            auth-matcher    => $auth // True,
+            version-matcher => $ver  // True,
+            api-matcher     => $api  // True,
         );
 
-        with self!matching-dists($spec) {
-            my $dist-ids       := $_.map: { .hash.keys[0] }
-            my $matches-spec   := $dist-ids.map: { self!read-dist($_) }
-            my $matches-file   := $matches-spec.grep: { .<files>{$file} }
+        with self.candidates($spec) {
+            my $matches-file := $_.grep: { .meta<files>{$file} }
 
-            return $matches-file.map: -> $candi is copy {
+            return $matches-file.map: -> $dist {
+                my %meta = $dist.meta.hash;
                 # absolutify paths
-                $candi<files>{$_} = self!resources-dir.add($candi<files>{$_}) for $candi<files>.hash.keys;
-                $candi;
+                %meta<files>{$_} = self!resources-dir.add(%meta<files>{$_}) for %meta<files>.hash.keys;
+                %meta;
             }
         }
     }
 
-    # If we're only interestested in matching a single item then we can use a cache...
-    method !matching-dist(CompUnit::DependencySpecification $spec) {
-        $!lock.protect: {
-            return %!seen{~$spec} if %!seen{~$spec}:exists;
-        }
-
-        my ($dist-id, $dist) = self!matching-dists($spec).head;
-
-        $!lock.protect: {
-            return %!seen{~$spec} = ($dist-id, $dist);
-        }
+    # Allows the introspection match candidates from a specific repository (unlike resolve)
+    # as well as returning them in a Distribution instead of our internal dist-id/dist pair.
+    # Essentially the CURI recommendation manager api.
+    proto method candidates(|) {*}
+    multi method candidates(Str:D $name, :$auth, :$ver, :$api) {
+        return samewith(CompUnit::DependencySpecification.new(
+            short-name      => $name,
+            auth-matcher    => $auth // True,
+            version-matcher => $ver  // True,
+            api-matcher     => $api  // True,
+        ));
     }
-
-    # ...but otherwise lets not cache every single match.
-    # (This method exists to support future methods that need *all* the matches)
-    method !matching-dists(CompUnit::DependencySpecification $spec) {
+    multi method candidates(CompUnit::DependencySpecification $spec) {
         return Empty unless $spec.from eq 'Perl6';
 
-        my $lookup = $.prefix.add('short').add(nqp::sha1($spec.short-name));
+        my $lookup = self!short-dir.add(nqp::sha1($spec.short-name));
         return Empty unless $lookup.e;
 
         my @dists = (
@@ -434,6 +410,7 @@ sub MAIN(:$name is copy, :$auth, :$ver, *@, *%) {
                 !! $lookup.dir.map({
                         my ($ver, $auth, $api, $source, $checksum) = $_.slurp.split("\n");
                         $_.basename => {
+                            name     => $spec.short-name,
                             ver      => Version.new( $ver || 0 ),
                             auth     => $auth,
                             api      => Version.new( $api || 0 ),
@@ -456,23 +433,60 @@ sub MAIN(:$name is copy, :$auth, :$ver, *@, *%) {
             and $_.value<api> ~~ $api-matcher
         }
 
-        return $matching-dists.sort(-*.value<ver>).map(*.kv);
+        return $matching-dists.sort(-*.value<ver>).map(*.kv).map: -> ($dist-id, $meta) {
+            self!lazy-distribution($dist-id, :$meta)
+        }
     }
 
-    method !lazy-distribution($dist-id) {
-        class :: does Distribution::Locally {
-            has $.dist-id;
-            has $.read-dist;
-            has $!installed-dist;
-            method !dist {
-                $!installed-dist //= InstalledDistribution.new($.read-dist()(), :$.prefix)
+    # An equivalent of self.candidates($spec).head that caches the best match
+    method !matching-dist(CompUnit::DependencySpecification $spec) {
+        return %!seen{~$spec} if %!seen{~$spec}:exists;
+
+        my $dist = self.candidates($spec).head;
+
+        $!lock.protect: {
+            return %!seen{~$spec} //= $dist;
+        }
+    }
+
+    # Allows a distribution to re-populate its meta data
+    # if a $key that doesn't exist is used. This is so we
+    # can supply *some* meta data on creation, and only
+    # obtaining the rest as a last resort (via IO).
+    my role LazyMetaReader {
+        has $.meta-reader;
+        method AT-KEY($key)     { $!meta-reader($key) }
+        method EXISTS-KEY($key) { $!meta-reader($key).defined }
+    }
+    my class LazyDistribution does Distribution::Locally {
+        has $.dist-id;
+        has $.read-dist;
+        has $!installed-dist;
+        has $.meta;
+        method !dist {
+            unless $!installed-dist.defined {
+                $!installed-dist = InstalledDistribution.new($.read-dist()(), :$.prefix);
+                my %hash = $!installed-dist.meta.hash;
+                $!meta{$_} //= %hash{$_} for %hash.keys;
             }
-            method meta(--> Hash:D)                      { self!dist.meta }
-            method content($content-id --> IO::Handle:D) { self!dist.content($content-id) }
-            method Str()                               { self!dist.Str }
-        }.new(
+            $!installed-dist;
+        }
+        method meta(--> Hash:D) {
+            my %hash = $!meta.hash;
+            %hash does LazyMetaReader(-> $key {
+                $!meta.hash{$key} // self!dist.meta.{$key}
+            });
+            return %hash;
+        }
+        method content($content-id --> IO::Handle:D) { self!dist.content($content-id) }
+        method Str()                                 { self!dist.Str }
+    }
+
+    method !lazy-distribution($dist-id, :$meta) {
+        LazyDistribution.new(
             :$dist-id,
-            :read-dist(-> { self!read-dist($dist-id) })
+            :read-dist(-> { self!read-dist($dist-id) }),
+            :$meta,
             :$.prefix,
         )
     }
@@ -481,17 +495,15 @@ sub MAIN(:$name is copy, :$auth, :$ver, *@, *%) {
         CompUnit::DependencySpecification $spec,
         --> CompUnit:D)
     {
-        my ($dist-id, $dist) = self!matching-dist($spec);
-        if $dist-id {
-            # xxx: replace :distribution with meta6
+        with self.candidates($spec).head {
             return CompUnit.new(
                 :handle(CompUnit::Handle),
                 :short-name($spec.short-name),
-                :version($dist<ver>),
-                :auth($dist<auth> // Str),
+                :version(.meta<ver>),
+                :auth(.meta<auth> // Str),
                 :repo(self),
-                :repo-id($dist<source> // self!read-dist($dist-id)<provides>{$spec.short-name}.values[0]<file>),
-                :distribution(self!lazy-distribution($dist-id)),
+                :repo-id(.meta<source>),
+                :distribution($_),
             );
         }
         return self.next-repo.resolve($spec) if self.next-repo;
@@ -510,45 +522,44 @@ sub MAIN(:$name is copy, :$auth, :$ver, *@, *%) {
         CompUnit::PrecompilationStore :@precomp-stores = self!precomp-stores(),
         --> CompUnit:D)
     {
-        my ($dist-id, $dist) = self!matching-dist($spec);
-        if $dist-id {
-            return %!loaded{~$spec} if %!loaded{~$spec}:exists;
-            my $source-file-name = $dist<source>
-                // do {
-                    my $provides = self!read-dist($dist-id)<provides>;
-                    X::CompUnit::UnsatisfiedDependency.new(:specification($spec)).throw
-                        unless $provides{$spec.short-name}:exists;
-                    $provides{$spec.short-name}.values[0]<file>
-                };
+        with self.candidates($spec).head {
+            my $source-file-name = .meta<source>;
+            X::CompUnit::UnsatisfiedDependency.new(:specification($spec)).throw
+                unless $source-file-name;
             my $loader = $.prefix.add('sources').add($source-file-name);
-            my $*RESOURCES = Distribution::Resources.new(:repo(self), :$dist-id);
-            my $id = $loader.basename;
+            my $id     = $loader.basename;
+            return %!loaded{$id} if %!loaded{$id}:exists;
+
+            my $*RESOURCES  = Distribution::Resources.new(:repo(self), :dist-id(.dist-id));
             my $repo-prefix = self!repo-prefix;
-            my $handle = $precomp.try-load(
+            my $handle      = $precomp.try-load(
                 CompUnit::PrecompilationDependency::File.new(
                     :id(CompUnit::PrecompilationId.new($id)),
                     :src($repo-prefix ?? $repo-prefix ~ $loader.relative($.prefix) !! $loader.absolute),
-                    :checksum($dist<checksum>:exists ?? $dist<checksum> !! Str),
+                    :checksum(.meta<checksum> // Str),
                     :$spec,
                 ),
                 :source($loader),
                 :@precomp-stores,
             );
+
             my $precompiled = defined $handle;
             $handle //= CompUnit::Loader.load-source-file($loader);
 
-            # xxx: replace :distribution with meta6
             my $compunit = CompUnit.new(
                 :$handle,
-                :short-name($spec.short-name),
-                :version($dist<ver>),
-                :auth($dist<auth> // Str),
+                :short-name(.meta<name>),
+                :version(.meta<ver>),
+                :auth(.meta<auth> // Str),
                 :repo(self),
                 :repo-id($id),
                 :$precompiled,
-                :distribution(self!lazy-distribution($dist-id)),
+                :distribution($_),
             );
-            return %!loaded{~$spec} = $compunit;
+
+            $!lock.protect: {
+                return %!loaded{$id} //= $compunit;
+            }
         }
         return self.next-repo.need($spec, $precomp, :@precomp-stores) if self.next-repo;
         X::CompUnit::UnsatisfiedDependency.new(:specification($spec)).throw;


### PR DESCRIPTION
* Use !matching-dist to do any dist searches to remove duplicated
search logic.

* !matching-dist returns a list of matching dists so that it
can serve a wider range of functions. A thin wrapper method
could use this to provide a list of "candidate" distributions
from a specific CUR.

* Take $api into account when searching dists.

* Set all meta<files>.values to absolute paths, not just the one
being searched for.