### PR TITLE
Add candidates method as CURI recommendation manager

### DIFF
--- a/src/core/CompUnit/Repository/Installation.pm
+++ b/src/core/CompUnit/Repository/Installation.pm
@@ -503,7 +503,7 @@ sub MAIN(:$name, :$auth, :$ver, *@, *%) {
         CompUnit::DependencySpecification $spec,
         --> CompUnit:D)
     {
-        with self.candidates($spec).head {
+        with self!matching-dist($spec) {
             return CompUnit.new(
                 :handle(CompUnit::Handle),
                 :short-name($spec.short-name),
@@ -530,7 +530,7 @@ sub MAIN(:$name, :$auth, :$ver, *@, *%) {
         CompUnit::PrecompilationStore :@precomp-stores = self!precomp-stores(),
         --> CompUnit:D)
     {
-        with self.candidates($spec).head {
+        with self!matching-dist($spec) {
             my $source-file-name = .meta<source>;
             X::CompUnit::UnsatisfiedDependency.new(:specification($spec)).throw
                 unless $source-file-name;

--- a/src/core/CompUnit/Repository/Installation.pm
+++ b/src/core/CompUnit/Repository/Installation.pm
@@ -1,6 +1,7 @@
 class CompUnit::Repository::Installation does CompUnit::Repository::Locally does CompUnit::Repository::Installable {
     has $!cver = nqp::hllize(nqp::atkey(nqp::gethllsym('perl6', '$COMPILER_CONFIG'), 'version'));
-    has %!loaded;
+    has %!loaded; # cache compunit lookup for self.need(...)
+    has %!seen;   # cache distribution lookup for self!matching-dist(...)
     has $!precomp;
     has $!id;
     has Int $!version;
@@ -52,38 +53,18 @@ __END__
 ';
     my $perl_wrapper = '#!/usr/bin/env #perl#
 sub MAIN(:$name is copy, :$auth, :$ver, *@, *%) {
-    CompUnit::RepositoryRegistry.run-script("#name#", :dist-name<#dist-name#>, :$name, :$auth, :$ver);
+    CompUnit::RepositoryRegistry.run-script("#name#", :$name, :$auth, :$ver);
 }';
 
-    method !sources-dir() {
-        my $sources = $.prefix.add('sources');
-        $sources.mkdir unless $sources.e;
-        $sources
-    }
-
-    method !resources-dir() {
-        my $resources = $.prefix.add('resources');
-        $resources.mkdir unless $resources.e;
-        $resources
-    }
-
-    method !dist-dir() {
-        my $dist = $.prefix.add('dist');
-        $dist.mkdir unless $dist.e;
-        $dist
-    }
-
-    method !bin-dir() {
-        my $bin = $.prefix.add('bin');
-        $bin.mkdir unless $bin.e;
-        $bin
-    }
+    method !sources-dir   { with $.prefix.add('sources')   { once { .mkdir unless .e }; $_ } }
+    method !resources-dir { with $.prefix.add('resources') { once { .mkdir unless .e }; $_ } }
+    method !dist-dir      { with $.prefix.add('dist')      { once { .mkdir unless .e }; $_ } }
+    method !bin-dir       { with $.prefix.add('bin')       { once { .mkdir unless .e }; $_ } }
+    method !short-dir     { with $.prefix.add('short')     { once { .mkdir unless .e }; $_ } }
 
     method !add-short-name($name, $dist, $source?, $checksum?) {
-        my $short-dir = $.prefix.add('short');
         my $id = nqp::sha1($name);
-        my $lookup = $short-dir.add($id);
-        $lookup.mkdir;
+        my $lookup = self!short-dir.add($id) andthen { .mkdir unless .e }
         $lookup.add($dist.id).spurt(
                 "{$dist.meta<ver>  // ''}\n"
             ~   "{$dist.meta<auth> // ''}\n"
@@ -94,7 +75,7 @@ sub MAIN(:$name is copy, :$auth, :$ver, *@, *%) {
     }
 
     method !remove-dist-from-short-name-lookup-files($dist --> Nil) {
-        my $short-dir = $.prefix.add('short');
+        my $short-dir = self!short-dir;
         return unless $short-dir.e;
 
         my $id = $dist.id;
@@ -106,8 +87,7 @@ sub MAIN(:$name is copy, :$auth, :$ver, *@, *%) {
     }
 
     method !file-id(Str $name, Str $dist-id) {
-        my $id = $name ~ $dist-id;
-        nqp::sha1($id)
+        nqp::sha1($name ~ $dist-id)
     }
 
     method name(--> Str:D) {
@@ -115,13 +95,11 @@ sub MAIN(:$name is copy, :$auth, :$ver, *@, *%) {
     }
 
     method !repo-prefix() {
-        my $repo-prefix = self.name // '';
-        $repo-prefix ~= '#' if $repo-prefix;
-        $repo-prefix
+        self.name ?? (self.name ~ '#') !! ''
     }
 
     method !read-dist($id) {
-        my $dist = Rakudo::Internals::JSON.from-json($.prefix.add('dist').add($id).slurp);
+        my $dist = Rakudo::Internals::JSON.from-json(self!dist-dir.add($id).slurp);
         $dist<ver> = $dist<ver> ?? Version.new( ~$dist<ver> ) !! Version.new('0');
         $dist
     }
@@ -135,7 +113,7 @@ sub MAIN(:$name is copy, :$auth, :$ver, *@, *%) {
 
     method upgrade-repository() {
         my $version = self!repository-version;
-        my $short-dir = $.prefix.add('short');
+        my $short-dir = self!short-dir;
         mkdir $short-dir unless $short-dir.e;
         my $precomp-dir = $.prefix.add('precomp');
         mkdir $precomp-dir unless $precomp-dir.e;
@@ -250,7 +228,7 @@ sub MAIN(:$name is copy, :$auth, :$ver, *@, *%) {
             my $withoutext  = $name-path.subst(/\.[exe|bat]$/, '');
             for '', '-j', '-m' -> $be {
                 $.prefix.add("$withoutext$be").IO.spurt:
-                    $perl_wrapper.subst('#name#', $name-path.IO.basename, :g).subst('#perl#', "perl6$be").subst('#dist-name#', $dist.meta<name>);
+                    $perl_wrapper.subst('#name#', $name-path, :g).subst('#perl#', "perl6$be");
                 if $is-win {
                     $.prefix.add("$withoutext$be.bat").IO.spurt:
                         $windows_wrapper.subst('#perl#', "perl6$be", :g);
@@ -371,100 +349,151 @@ sub MAIN(:$name is copy, :$auth, :$ver, *@, *%) {
         unlink( $dist-dir.add($dist.id) )
     }
 
-    method script($file, :$name!, :$auth, :$ver) {
-        my $prefix = self.prefix;
-        my $lookup = $prefix.add('short').add(nqp::sha1($file));
-        return unless $lookup.e;
+    proto method files(|) {*}
+    multi method files($file, Str:D :$name!, :$auth, :$ver, :$api) {
+        my $spec = CompUnit::DependencySpecification.new(
+            short-name      => $name,
+            auth-matcher    => $auth // True,
+            version-matcher => $ver  // True,
+            api-matcher     => $api  // True,
+        );
 
-        # Scripts using this interface could only have been installed long after the introduction of
-        # repo version 1, so we don't have to care about very old repos in this method.
-        my @dists = $lookup.dir.map({
-                my ($ver, $auth, $api, $resource-id) = $_.slurp.split("\n");
-                $resource-id ||= self!read-dist($_.basename)<files>{$file};
-                (id => $_.basename, ver => Version.new( $ver || 0 ), :$auth, :$api, :$resource-id).hash
-            }).grep({
-                $_.<auth> ~~ $auth
-                and $_.<ver> ~~ $ver
-            });
-        for @dists.sort(*.<ver>).reverse {
-            return self!resources-dir.add($_<resource-id>);
+        with self.candidates($spec) {
+            my $matches := $_.grep: { .meta<files>{$file}:exists }
+
+            return $matches.map: {
+                .meta<source> = self!resources-dir.add(.meta<source>);
+                .meta;
+            }
+        }
+    }
+    multi method files($file, :$auth, :$ver, :$api) {
+        # avoid parsing json if we don't need to know the short-name
+
+        my $spec = CompUnit::DependencySpecification.new(
+            short-name      => $file,
+            auth-matcher    => $auth // True,
+            version-matcher => $ver  // True,
+            api-matcher     => $api  // True,
+        );
+
+        return self.candidates($spec).grep: {
+            .meta<source> = self!resources-dir.add(.meta<source>)
         }
     }
 
-    method files($file, :$name!, :$auth, :$ver) {
-        my @candi;
-        my $prefix = self.prefix;
-        my $lookup = $prefix.add('short').add(nqp::sha1($name));
-        if $lookup.e {
-            my $repo-version = self!repository-version;
-            my @dists = $repo-version < 1
+    # Allows the introspection match candidates from a specific repository (unlike resolve)
+    # as well as returning them in a Distribution instead of our internal dist-id/dist pair.
+    # Essentially the CURI recommendation manager api.
+    proto method candidates(|) {*}
+    multi method candidates(Str:D $name, :$auth, :$ver, :$api) {
+        return samewith(CompUnit::DependencySpecification.new(
+            short-name      => $name,
+            auth-matcher    => $auth // True,
+            version-matcher => $ver  // True,
+            api-matcher     => $api  // True,
+        ));
+    }
+    multi method candidates(CompUnit::DependencySpecification $spec) {
+        return Empty unless $spec.from eq 'Perl6';
+
+        my $lookup = self!short-dir.add(nqp::sha1($spec.short-name));
+        return Empty unless $lookup.e;
+
+        my @dists = (
+                self!repository-version < 1
                 ?? $lookup.lines.unique.map({
-                        self!read-dist($_)
+                        $_ => self!read-dist($_)
                     })
                 !! $lookup.dir.map({
-                        my ($ver, $auth, $api) = $_.slurp.split("\n");
-                        (id => $_.basename, ver => Version.new( $ver || 0 ), auth => $auth, api => $api).hash
-                    });
-            for @dists.grep({$_<auth> ~~ $auth and $_<ver> ~~ $ver}) -> $dist is copy {
-                $dist = self!read-dist($dist<id>) if $repo-version >= 1;
-                with $dist<files>{$file} {
-                    my $candi = %$dist;
-                    $candi<files>{$file} = self!resources-dir.add($candi<files>{$file});
-                    @candi.push: $candi;
-                }
-            }
+                        my ($ver, $auth, $api, $source, $checksum) = $_.slurp.split("\n");
+                        $_.basename => {
+                            name     => $spec.short-name,
+                            ver      => Version.new( $ver || 0 ),
+                            auth     => $auth,
+                            api      => Version.new( $api || 0 ),
+                            source   => $source || Any,
+                            checksum => $checksum || Str,
+                        }
+                    })
+            );
+
+        my $version-matcher = ($spec.version-matcher ~~ Bool)
+            ?? $spec.version-matcher # fast path for matching Version.new(*)
+            !! Version.new($spec.version-matcher);
+        my $api-matcher = ($spec.api-matcher ~~ Bool)
+            ?? $spec.api-matcher
+            !! Version.new($spec.api-matcher);
+
+        my $matching-dists := @dists.grep: {
+            $_.value<auth> ~~ $spec.auth-matcher
+            and $_.value<ver> ~~ $version-matcher
+            and $_.value<api> ~~ $api-matcher
         }
-        @candi
+
+        my $sorted-dists := $matching-dists.sort(*.value<ver>).reverse;
+
+        return $sorted-dists.map(*.kv).map: -> ($dist-id, $meta) {
+            self!lazy-distribution($dist-id, :$meta)
+        }
     }
 
+    # An equivalent of self.candidates($spec).head that caches the best match
     method !matching-dist(CompUnit::DependencySpecification $spec) {
-        if $spec.from eq 'Perl6' {
-            my $repo-version = self!repository-version;
-            my $lookup = $.prefix.add('short').add(nqp::sha1($spec.short-name));
-            if $lookup.e {
-                my @dists = (
-                        $repo-version < 1
-                        ?? $lookup.lines.unique.map({
-                                $_ => self!read-dist($_)
-                            })
-                        !! $lookup.dir.map({
-                                my ($ver, $auth, $api, $source, $checksum) = $_.slurp.split("\n");
-                                $_.basename => {
-                                    ver      => Version.new( $ver || 0 ),
-                                    auth     => $auth,
-                                    api      => $api,
-                                    source   => $source || Any,
-                                    checksum => $checksum || Str,
-                                }
-                            })
-                    ).grep({
-                        $_.value<auth> ~~ $spec.auth-matcher
-                        and $_.value<ver> ~~ (($spec.version-matcher ~~ Bool)
-                            ?? $spec.version-matcher # fast path for matching Version.new(*)
-                            !! Version.new($spec.version-matcher))
-                    });
-                for @dists.sort(*.value<ver>).reverse.map(*.kv) -> ($dist-id, $dist) {
-                    return ($dist-id, $dist);
-                }
-            }
+        return %!seen{~$spec} if %!seen{~$spec}:exists;
+
+        my $dist = self.candidates($spec).head;
+
+        $!lock.protect: {
+            return %!seen{~$spec} //= $dist;
         }
-        Nil
     }
 
-    method !lazy-distribution($dist-id) {
-        class :: does Distribution::Locally {
-            has $.dist-id;
-            has $.read-dist;
-            has $!installed-dist;
-            method !dist {
-                $!installed-dist //= InstalledDistribution.new($.read-dist()(), :$.prefix)
+    # Allows a distribution to re-populate its meta data
+    # if a $key that doesn't exist is used. This is so we
+    # can supply *some* meta data on creation, and only
+    # obtaining the rest as a last resort (via IO).
+    my role LazyMetaReader {
+        has $.meta-reader;
+        method AT-KEY($key)     { $!meta-reader($key) }
+        method EXISTS-KEY($key) { $!meta-reader($key).defined }
+    }
+    my role MetaAssigner {
+        has $.meta-writer;
+        method ASSIGN-KEY($key, $value) { $!meta-writer($key, $value) }
+    }
+    my class LazyDistribution does Distribution::Locally {
+        has $.dist-id;
+        has $.read-dist;
+        has $!installed-dist;
+        has $.meta;
+        method !dist {
+            unless $!installed-dist.defined {
+                $!installed-dist = InstalledDistribution.new($.read-dist()(), :$.prefix);
+                my %hash = $!installed-dist.meta.hash;
+                %hash{$_} //= $!meta{$_} for $!meta.hash.keys;
+                $!meta = %hash;
             }
-            method meta(--> Hash:D)                      { self!dist.meta }
-            method content($content-id --> IO::Handle:D) { self!dist.content($content-id) }
-            method Str()                               { self!dist.Str }
-        }.new(
+            $!installed-dist;
+        }
+        method meta(--> Hash:D) {
+            my %hash = $!meta.hash;
+            unless $!installed-dist.defined {
+                %hash does LazyMetaReader({ $!meta.hash{$^a} // self!dist.meta.{$^a} });
+                %hash does MetaAssigner({ $!meta.ASSIGN-KEY($^a, $^b) });
+            }
+            return %hash;
+        }
+        method content($content-id --> IO::Handle:D) { self!dist.content($content-id) }
+        method Str { CompUnit::Repository::Distribution.new(self).Str }
+        method id { $.dist-id }
+    }
+
+    method !lazy-distribution($dist-id, :$meta) {
+        LazyDistribution.new(
             :$dist-id,
-            :read-dist(-> { self!read-dist($dist-id) })
+            :read-dist(-> { self!read-dist($dist-id) }),
+            :$meta,
             :$.prefix,
         )
     }
@@ -473,17 +502,15 @@ sub MAIN(:$name is copy, :$auth, :$ver, *@, *%) {
         CompUnit::DependencySpecification $spec,
         --> CompUnit:D)
     {
-        my ($dist-id, $dist) = self!matching-dist($spec);
-        if $dist-id {
-            # xxx: replace :distribution with meta6
+        with self.candidates($spec).head {
             return CompUnit.new(
                 :handle(CompUnit::Handle),
                 :short-name($spec.short-name),
-                :version($dist<ver>),
-                :auth($dist<auth> // Str),
+                :version(.meta<ver>),
+                :auth(.meta<auth> // Str),
                 :repo(self),
-                :repo-id($dist<source> // self!read-dist($dist-id)<provides>{$spec.short-name}.values[0]<file>),
-                :distribution(self!lazy-distribution($dist-id)),
+                :repo-id(.meta<source>),
+                :distribution($_),
             );
         }
         return self.next-repo.resolve($spec) if self.next-repo;
@@ -502,45 +529,44 @@ sub MAIN(:$name is copy, :$auth, :$ver, *@, *%) {
         CompUnit::PrecompilationStore :@precomp-stores = self!precomp-stores(),
         --> CompUnit:D)
     {
-        my ($dist-id, $dist) = self!matching-dist($spec);
-        if $dist-id {
-            return %!loaded{~$spec} if %!loaded{~$spec}:exists;
-            my $source-file-name = $dist<source>
-                // do {
-                    my $provides = self!read-dist($dist-id)<provides>;
-                    X::CompUnit::UnsatisfiedDependency.new(:specification($spec)).throw
-                        unless $provides{$spec.short-name}:exists;
-                    $provides{$spec.short-name}.values[0]<file>
-                };
+        with self.candidates($spec).head {
+            my $source-file-name = .meta<source>;
+            X::CompUnit::UnsatisfiedDependency.new(:specification($spec)).throw
+                unless $source-file-name;
             my $loader = $.prefix.add('sources').add($source-file-name);
-            my $*RESOURCES = Distribution::Resources.new(:repo(self), :$dist-id);
-            my $id = $loader.basename;
+            my $id     = $loader.basename;
+            return %!loaded{$id} if %!loaded{$id}:exists;
+
+            my $*RESOURCES  = Distribution::Resources.new(:repo(self), :dist-id(.dist-id));
             my $repo-prefix = self!repo-prefix;
-            my $handle = $precomp.try-load(
+            my $handle      = $precomp.try-load(
                 CompUnit::PrecompilationDependency::File.new(
                     :id(CompUnit::PrecompilationId.new($id)),
                     :src($repo-prefix ?? $repo-prefix ~ $loader.relative($.prefix) !! $loader.absolute),
-                    :checksum($dist<checksum>:exists ?? $dist<checksum> !! Str),
+                    :checksum(.meta<checksum> // Str),
                     :$spec,
                 ),
                 :source($loader),
                 :@precomp-stores,
             );
+
             my $precompiled = defined $handle;
             $handle //= CompUnit::Loader.load-source-file($loader);
 
-            # xxx: replace :distribution with meta6
             my $compunit = CompUnit.new(
                 :$handle,
-                :short-name($spec.short-name),
-                :version($dist<ver>),
-                :auth($dist<auth> // Str),
+                :short-name(.meta<name>),
+                :version(.meta<ver>),
+                :auth(.meta<auth> // Str),
                 :repo(self),
                 :repo-id($id),
                 :$precompiled,
-                :distribution(self!lazy-distribution($dist-id)),
+                :distribution($_),
             );
-            return %!loaded{~$spec} = $compunit;
+
+            $!lock.protect: {
+                return %!loaded{$id} //= $compunit;
+            }
         }
         return self.next-repo.need($spec, $precomp, :@precomp-stores) if self.next-repo;
         X::CompUnit::UnsatisfiedDependency.new(:specification($spec)).throw;

--- a/src/core/CompUnit/Repository/Installation.pm
+++ b/src/core/CompUnit/Repository/Installation.pm
@@ -52,7 +52,7 @@ __END__
 :endofperl
 ';
     my $perl_wrapper = '#!/usr/bin/env #perl#
-sub MAIN(:$name is copy, :$auth, :$ver, *@, *%) {
+sub MAIN(:$name, :$auth, :$ver, *@, *%) {
     CompUnit::RepositoryRegistry.run-script("#name#", :$name, :$auth, :$ver);
 }';
 
@@ -223,12 +223,13 @@ sub MAIN(:$name is copy, :$auth, :$ver, *@, *%) {
         # bin/ scripts
         for %files.kv -> $name-path, $file is copy {
             next unless $name-path.starts-with('bin/');
+            my $name        = $name-path.subst(/^bin\//, '');
             my $id          = self!file-id(~$file, $dist-id);
             my $destination = $resources-dir.add($id); # wrappers are put in bin/; originals in resources/
             my $withoutext  = $name-path.subst(/\.[exe|bat]$/, '');
             for '', '-j', '-m' -> $be {
                 $.prefix.add("$withoutext$be").IO.spurt:
-                    $perl_wrapper.subst('#name#', $name-path, :g).subst('#perl#', "perl6$be");
+                    $perl_wrapper.subst('#name#', $name, :g).subst('#perl#', "perl6$be");
                 if $is-win {
                     $.prefix.add("$withoutext$be.bat").IO.spurt:
                         $windows_wrapper.subst('#perl#', "perl6$be", :g);

--- a/src/core/CompUnit/Repository/Installation.pm
+++ b/src/core/CompUnit/Repository/Installation.pm
@@ -366,9 +366,9 @@ sub MAIN(:$name, :$auth, :$ver, *@, *%) {
             my $matches := $_.grep: { .meta<files>{$file}:exists }
 
             my $absolutified-metas := $matches.map: {
-                my %meta      = $_.meta;
-                %meta<source> = self!resources-dir.add(%meta<files>{$file});
-                %meta;
+                my $meta      = $_.meta;
+                $meta<source> = self!resources-dir.add($meta<files>{$file});
+                $meta;
             }
 
             return $absolutified-metas.grep(*.<source>.e);
@@ -386,9 +386,9 @@ sub MAIN(:$name, :$auth, :$ver, *@, *%) {
 
         with self.candidates($spec) {
             my $absolutified-metas := $_.map: {
-                my %meta = $_.meta;
-                %meta<source> = self!resources-dir.add(%meta<source> || %meta<files>{$file});
-                %meta;
+                my $meta      = $_.meta;
+                $meta<source> = self!resources-dir.add($meta<source> || $meta<files>{$file});
+                $meta;
             }
 
             return $absolutified-metas.grep(*.<source>.e);

--- a/src/core/CompUnit/Repository/Installation.pm
+++ b/src/core/CompUnit/Repository/Installation.pm
@@ -455,11 +455,11 @@ sub MAIN(:$name, :$auth, :$ver, *@, *%) {
     method !matching-dist(CompUnit::DependencySpecification $spec) {
         return %!seen{~$spec} if %!seen{~$spec}:exists;
 
-        my $dist = self.candidates($spec).head;
-
-        $!lock.protect: {
-            return %!seen{~$spec} //= $dist;
+        with self.candidates($spec).head {
+            $!lock.protect: { return %!seen{~$spec} //= $_ }
         }
+
+        Nil
     }
 
     # Allows a distribution to re-populate its meta data

--- a/src/core/CompUnit/RepositoryRegistry.pm
+++ b/src/core/CompUnit/RepositoryRegistry.pm
@@ -217,9 +217,9 @@ class CompUnit::RepositoryRegistry {
         shift @*ARGS if $ver;
 
         my @installations = $*REPO.repo-chain.grep(CompUnit::Repository::Installation);
-        my @candidates = @installations.map({ .files($script, :$name, :$auth, :$ver).head }).grep(*.defined);
+        my @candidates = @installations.map({ .files("bin/$script", :$name, :$auth, :$ver).head }).grep(*.defined);
         unless +@candidates {
-            @candidates = flat @installations.map({ .files($script).Slip }).grep(*.defined);
+            @candidates = flat @installations.map({ .files("bin/$script").Slip }).grep(*.defined);
             if +@candidates {
                 note "===SORRY!===\n"
                     ~ "No candidate found for '$script' that match your criteria.\n"

--- a/src/core/CompUnit/RepositoryRegistry.pm
+++ b/src/core/CompUnit/RepositoryRegistry.pm
@@ -217,22 +217,22 @@ class CompUnit::RepositoryRegistry {
         shift @*ARGS if $ver;
 
         my @installations = $*REPO.repo-chain.grep(CompUnit::Repository::Installation);
-        my @candidates = @installations.map({ .files("bin/$script", :$name, :$auth, :$ver).head }).grep(*.defined);
-        unless +@candidates {
-            @candidates = flat @installations.map({ .files("bin/$script").Slip }).grep(*.defined);
-            if +@candidates {
+        my @metas = @installations.map({ .files("bin/$script", :$name, :$auth, :$ver).head }).grep(*.defined);
+        unless +@metas {
+            @metas = flat @installations.map({ .files("bin/$script").Slip }).grep(*.defined);
+            if +@metas {
                 note "===SORRY!===\n"
                     ~ "No candidate found for '$script' that match your criteria.\n"
                     ~ "Did you perhaps mean one of these?";
                 my %caps = :name(['Distribution', 12]), :auth(['Author(ity)', 11]), :ver(['Version', 7]);
-                for @candidates -> $dist {
+                for @metas -> $meta {
                     for %caps.kv -> $caption, @opts {
-                        @opts[1] = max @opts[1], ($dist.meta{$caption} // '').Str.chars
+                        @opts[1] = max @opts[1], ($meta{$caption} // '').Str.chars
                     }
                 }
                 note '  ' ~ %caps.values.map({ sprintf('%-*s', .[1], .[0]) }).join(' | ');
-                for @candidates -> $dist {
-                    note '  ' ~ %caps.kv.map( -> $k, $v { sprintf('%-*s', $v.[1], $dist.meta{$k} // '') } ).join(' | ')
+                for @metas -> $meta {
+                    note '  ' ~ %caps.kv.map( -> $k, $v { sprintf('%-*s', $v.[1], $meta{$k} // '') } ).join(' | ')
                 }
             }
             else {
@@ -241,8 +241,8 @@ class CompUnit::RepositoryRegistry {
             exit 1;
         }
 
-        my $candi = @candidates.sort(*.meta<ver>).reverse.head;
-        my $bin   = $candi.meta<source>;
+        my $meta = @metas.sort(*.<ver>).reverse.head;
+        my $bin  = $meta<source>;
         require "$bin";
     }
 


### PR DESCRIPTION
Add `method candidates` - All distribution searching/resolving go
through this new method. This gives developers insight into how a
CURI resolves a module request, which was not possible with .resolve
(since it would chain to the next CUR, and only returned a single
result). Many NYI s22 features will require something like this, and
.candidates is indeed mentioned in s22
https://design.perl6.org/S22.html#candidates

!matching-dist is now backed by .candidates, but also caches a single
'best match' so it acts similar to before.

.candidates (i.e. !matching-dist) now returns a Distribution object
and not ($dist-id, $dist-data). This is possible because of a role
that allows our lazy distribution to avoid yet additional costly IO
calls to obtain meta data. Previously this was done by passing around
a hash internally, but now we dogfood our Distribution interface
throughout CURI.

Avoid io after setting up various directories once.

Removes .script, and reverts to using just .files - .script was just
a fast path of .files under certain conditions and lacked the ability
to filter by name. Now .files can provide the faster path for other
files automatically. Additionally this fixes an issue where .script
would invoke older version bin/ scripts from ~/.perl6

Adds :$api field wherever it was missing for consistency.