### PR TITLE
Add candidates method as CURFS recommendation manager

### DIFF
--- a/src/core/CompUnit/Repository/FileSystem.pm
+++ b/src/core/CompUnit/Repository/FileSystem.pm
@@ -18,12 +18,14 @@ class CompUnit::Repository::FileSystem does CompUnit::Repository::Locally does C
         )
     }
 
-    method !matching-dist($spec) {
+    method !matching-dist(CompUnit::DependencySpecification $spec) {
         return %!seen{~$spec} if %!seen{~$spec}:exists;
 
-        my $dist = self.candidates($spec).head;
+        with self.candidates($spec).head {
+            return %!seen{~$spec} //= $_;
+        }
 
-        return %!seen{~$spec} //= $dist;
+        Nil
     }
 
     method id() {


### PR DESCRIPTION
See #1125 for .candidates details/concept

Creates full Distribution for both -I. and -Ilib, where the later will use the directory recursion it was already doing (to determine id) to automatically populate meta data for provides and files (bin/, resources/).

Gives bin scripts a way to more robustly know their own version:
```
# bin/zef
use Zef::Client;

sub MAIN("version") {
    my $spec = CompUnit::DependencySpecification.new(:short-name<Zef::Client>);
    say $*REPO.need($spec).distribution.meta<ver version>.first
}
```
The above currently only works for `perl6 bin/zef` (See: https://github.com/ugexe/zef/issues/122#issuecomment-280796779), and would blow up on `perl6 -I. bin/zef` and `perl6 -Ilib bin/zef`. This PR works for all 3; -I. (which we assume is pointing at a directory with a META file) will pull its version from the meta file, and -Ilib (a directory without a META file) is version 0.

Note this does look at `../` to build the meta data for -Ilib, but this is already the case for CURFS.resources.