### PR TITLE
Checking uname as executable instead of file size

### DIFF
--- a/src/core/Kernel.pm
+++ b/src/core/Kernel.pm
@@ -10,7 +10,7 @@ class Kernel does Systemic {
     has Int $!bits;
 
     sub uname($opt) {
-        state $has_uname = "/bin/uname".IO.s || "/usr/bin/uname".IO.s;
+        state $has_uname = "/bin/uname".IO.x || "/usr/bin/uname".IO.x;
         $has_uname ?? qqx/uname $opt/.chomp !! 'unknown';
     }
 


### PR DESCRIPTION
Finding executable file should be done with .x instead of .s method,
otherwise, we should run in case where the file is existed but can not
executable.

Some thing like:
```sh
root@18694b54d55f:/root# chmod -x /bin/uname
root@18694b54d55f:/root# perl6
> $*KERNEL
/bin/sh: 1: uname: Permission denied
/bin/sh: 1: uname: Permission denied
Start argument to substr out of range. Is: -1, should be in 0..0
```