### PR TITLE
s/index/eqat/g in INTERPOLATE literal handling

### DIFF
--- a/src/core/Match.pm
+++ b/src/core/Match.pm
@@ -325,22 +325,22 @@ my class Match is Capture is Cool does NQPMatchRole {
 
                 # no modifier, match literally
                 elsif $nomod {
-                    $match = nqp::eqat($tgt, $topic_str, $pos)
+                    $match = nqp::eqat($tgt, $topic_str, $pos);
                 }
 
                 # ignoremark+ignorecase
                 elsif $m && $i {
-                    $match = nqp::indexicim($tgt, $topic_str, $pos) >= 0;
+                    $match = nqp::eqaticim($tgt, $topic_str, $pos);
                 }
 
                 # ignoremark
                 elsif $m {
-                    $match = nqp::indexim($tgt, $topic_str, $pos) >= 0;
+                    $match = nqp::eqatim($tgt, $topic_str, $pos);
                 }
 
                 # ignorecase
                 elsif $i {
-                    $match = nqp::indexic($tgt, $topic_str, $pos) >= 0;
+                    $match = nqp::eqatic($tgt, $topic_str, $pos);
                 }
 
                 if $match


### PR DESCRIPTION
The simplification in 215a5fa731 used `nqp::index*` for the ignore* cases,
but if that change is made to the regular case some spectests break.
Both 215a5fa731 and this change pass all spectests, which I think
indicates that there probably aren't enough (any?) tests for
regex interpolation with ingnore* modifiers.

Using `nqp::index*` is more efficient, since it doesn't require walking
through the haystack and checking at each position, but it somehow needs
to be done more correctly.