### PR TITLE
Make INTERPOLATE's parameters non-optional

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -10059,23 +10059,25 @@ class Perl6::P5RegexActions is QRegex::P5Regex::Actions does STDActions {
                     QAST::Op.new( :op<callmethod>, :name<new>,
                         QAST::WVal.new( :value($*W.find_symbol(['PseudoStash']))),
                     ),
-                ),
+                 ),
                  :rxtype<subrule>, :subtype<method>, :node($/));
     }
 
     method p5metachar:sym<var>($/) {
-        make QAST::Regex.new( QAST::NodeList.new(
-                                    QAST::SVal.new( :value('INTERPOLATE') ),
-                                    wanted($<var>.ast, 'p5var'),
-                                    QAST::IVal.new( :value(%*RX<i> ?? 1 !! 0) ),
-                                    QAST::IVal.new( :value(0) ),
-                                    QAST::IVal.new( :value(monkey_see_no_eval($/)) ),
-                                    QAST::IVal.new( :value($*SEQ ?? 1 !! 0) ),
-                                    QAST::IVal.new( :value($*INTERPOLATION) ),
-                                    QAST::Op.new( :op<callmethod>, :name<new>,
-                                        QAST::WVal.new( :value($*W.find_symbol(['PseudoStash']))),
-                                    ), ),
-                              :rxtype<subrule>, :subtype<method>, :node($/));
+        make QAST::Regex.new(
+                 QAST::NodeList.new(
+                    QAST::SVal.new( :value('INTERPOLATE') ),
+                    wanted($<var>.ast, 'p5var'),
+                    QAST::IVal.new( :value(%*RX<i> ?? 1 !! 0) ),
+                    QAST::IVal.new( :value(0) ),
+                    QAST::IVal.new( :value(monkey_see_no_eval($/)) ),
+                    QAST::IVal.new( :value($*SEQ ?? 1 !! 0) ),
+                    QAST::IVal.new( :value($*INTERPOLATION) ),
+                    QAST::Op.new( :op<callmethod>, :name<new>,
+                        QAST::WVal.new( :value($*W.find_symbol(['PseudoStash']))),
+                    ),
+                 ),
+                 :rxtype<subrule>, :subtype<method>, :node($/));
     }
 
     method codeblock($/) {

--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -10071,7 +10071,10 @@ class Perl6::P5RegexActions is QRegex::P5Regex::Actions does STDActions {
                                     QAST::IVal.new( :value(0) ),
                                     QAST::IVal.new( :value(monkey_see_no_eval($/)) ),
                                     QAST::IVal.new( :value($*SEQ ?? 1 !! 0) ),
-                                    QAST::IVal.new( :value($*INTERPOLATION) ) ),
+                                    QAST::IVal.new( :value($*INTERPOLATION) ),
+                                    QAST::Op.new( :op<callmethod>, :name<new>,
+                                        QAST::WVal.new( :value($*W.find_symbol(['PseudoStash']))),
+                                    ), ),
                               :rxtype<subrule>, :subtype<method>, :node($/));
     }
 

--- a/src/core/Match.pm
+++ b/src/core/Match.pm
@@ -198,7 +198,7 @@ my class Match is Capture is Cool does NQPMatchRole {
     # $m is ignore accent marks flag
     # $s is for sequential matching instead of junctive
     # $a is true if we are in an assertion
-    method INTERPOLATE(\var, int $i, int $m, int $monkey, int $s, int $a = 0, $context = PseudoStash) {
+    method INTERPOLATE(\var, int $i, int $m, int $monkey, int $s, int $a, $context) {
         if nqp::isconcrete(var) {
             # Call it if it is a routine. This will capture if requested.
             return (var)(self) if nqp::istype(var,Callable);


### PR DESCRIPTION
Since the ops for optional params aren't currently JITted.

Passes `make m-test m-spectest`.