### PR TITLE
Correcting IO::Notification.watch-path event paths for individual files

### DIFF
--- a/src/core/IO/Notification.pm
+++ b/src/core/IO/Notification.pm
@@ -16,6 +16,7 @@ my class IO::Notification {
     }
 
     method watch-path(Str() $path, :$scheduler = $*SCHEDULER) {
+        my $is-dir = $path.IO.d;
         my $s = Supplier.new;
         nqp::watchfile(
             $scheduler.queue,
@@ -25,7 +26,8 @@ my class IO::Notification {
                 }
                 else {
                     my $event = rename ?? FileRenamed !! FileChanged;
-                    $s.emit(Change.new(:path($*SPEC.catdir($path, path)), :$event));
+                    my $full-path = $is-dir ?? $*SPEC.catdir($path, path) !! $path;
+                    $s.emit(Change.new(:path($full-path), :$event));
                 }
             },
             $path, FileWatchCancellation);


### PR DESCRIPTION
Handle watching individual files for file system events. The
IO::Notification::Change.path should correctly point to the file path of the file.

For https://rt.perl.org/Public/Bug/Display.html?id=132043