### PR TITLE
Implement pred() and succ() for the Enumeration role

### DIFF
--- a/src/core/Enumeration.pm
+++ b/src/core/Enumeration.pm
@@ -36,16 +36,12 @@ my role Enumeration {
     method pred() {
         my @values := self.^enum_value_list;
         my $index   = @values.first( self, :k );
-        return $index <= 0
-            ?? Failure.new( X::OutOfRange.new( what => "Decrement", got => self, range => @values[0] ^.. @values[*-1] ) )
-            !! @values[ $index - 1 ];
+        return $index <= 0 ?? self !! @values[ $index - 1 ];
     }
     method succ() {
         my @values := self.^enum_value_list;
         my $index   = @values.first( self, :k );
-        return $index >= @values.end
-            ?? Failure.new( X::OutOfRange.new( what => "Increment", got => self, range => @values[0] ..^ @values[*-1] ) )
-            !! @values[ $index + 1 ];
+        return $index >= @values.end ?? self !! @values[ $index + 1 ];
     }
 }
 

--- a/src/core/Enumeration.pm
+++ b/src/core/Enumeration.pm
@@ -32,6 +32,21 @@ my role Enumeration {
             ?? $x
             !! self.^enum_from_value($x)
     }
+
+    method pred() {
+        my @values := self.^enum_value_list;
+        my $index   = @values.first( self, :k );
+        return $index <= 0
+            ?? Failure.new( X::OutOfRange.new( what => "Decrement", got => self, range => @values[0] ^.. @values[*-1] ) )
+            !! @values[ $index - 1 ];
+    }
+    method succ() {
+        my @values := self.^enum_value_list;
+        my $index   = @values.first( self, :k );
+        return $index >= @values.end
+            ?? Failure.new( X::OutOfRange.new( what => "Increment", got => self, range => @values[0] ..^ @values[*-1] ) )
+            !! @values[ $index + 1 ];
+    }
 }
 
 # Methods that we also have if the base type of an enumeration is


### PR DESCRIPTION
These method will walk the enumeration in the declaration order.

Using Order as an example:
- Order::Same.succ is Order::More,
- Order::Same.pred is Order::Less.

Calling pred or succ on the boundaries will fail with X::OutOfBound.
Using the same example, Order::Less.pred fails with this X::OutOfRange:
"Decrement out of range. Is: Less, should be in Order::Less^..Order::More".