### PR TITLE
Avoid mistaking two enumeration elements with the same value

### DIFF
--- a/src/core/Enumeration.pm
+++ b/src/core/Enumeration.pm
@@ -46,12 +46,12 @@ my role Enumeration {
 
     method pred(::?CLASS:D:) {
         my @values := self.^enum_value_list;
-        my $index   = @values.first( self, :k );
+        my $index   = @values.first: { nqp::eqaddr( self, $_ ) }, :k;
         return $index <= 0 ?? self !! @values[ $index - 1 ];
     }
     method succ(::?CLASS:D:) {
         my @values := self.^enum_value_list;
-        my $index   = @values.first( self, :k );
+        my $index   = @values.first: { nqp::eqaddr( self, $_ ) }, :k;
         return $index >= @values.end ?? self !! @values[ $index + 1 ];
     }
 }


### PR DESCRIPTION
This is a fix for this issue (shown in #1156):

    enum Animal (Cat => 0, Dog => 0, Human => 42);
    say Dog.succ; # OUTPUT: «Dog␤»

With this change, the behaviour becomes:

    say Dog.succ; # OUTPUT: «Human␤»