### PR TITLE
Fix needless buffering when running prove with -j

### DIFF
--- a/lib/Test.pm6
+++ b/lib/Test.pm6
@@ -39,6 +39,8 @@ my int $done_testing_has_been_run = 0;
 _init_vars();
 
 sub _init_io {
+    nqp::setbuffersizefh(nqp::getstdin(),  0);
+    nqp::setbuffersizefh(nqp::getstdout(), 0);
     $output         = $PROCESS::OUT;
     $failure_output = $PROCESS::ERR;
     $todo_output    = $PROCESS::OUT;

--- a/lib/Test.pm6
+++ b/lib/Test.pm6
@@ -39,8 +39,8 @@ my int $done_testing_has_been_run = 0;
 _init_vars();
 
 sub _init_io {
-    nqp::setbuffersizefh(nqp::getstdin(),  0);
     nqp::setbuffersizefh(nqp::getstdout(), 0);
+    nqp::setbuffersizefh(nqp::getstderr(), 0);
     $output         = $PROCESS::OUT;
     $failure_output = $PROCESS::ERR;
     $todo_output    = $PROCESS::OUT;


### PR DESCRIPTION
See [RT #132108](https://rt.perl.org/Ticket/Display.html?id=132108).

Submitting this pull request just to get more eyes on it. I'm pretty sure that we can come up with a better solution.