### PR TITLE
fix subset isa method on a subset.

### DIFF
--- a/src/Perl6/Metamodel/SubsetHOW.nqp
+++ b/src/Perl6/Metamodel/SubsetHOW.nqp
@@ -58,7 +58,8 @@ class Perl6::Metamodel::SubsetHOW
     }
 
     method isa($obj, $type) {
-        $!refinee.isa($type);
+        $!refinee.isa($type)
+            || nqp::p6bool(nqp::istrue($type.HOW =:= self))
     }
     
     method nominalize($obj) {


### PR DESCRIPTION
perl6 -e'subset S of Int; subset S2 of S; say S2.isa(S)'

now returns True. fully resolves RT #132073