### PR TITLE
Fix PIO table so they are equal to the kernel values + add family packing

### DIFF
--- a/src/core/IO.pm6
+++ b/src/core/IO.pm6
@@ -9,20 +9,21 @@ enum SeekType (
   :SeekFromEnd(2),
 );
 enum ProtocolFamily (
-  :PF_LOCAL(0),
+  :PF_UNSPEC(0),
+  :PF_LOCAL(1),
   :PF_UNIX(1),
   :PF_INET(2),
-  :PF_INET6(3),
-  :PF_MAX(4),
+  :PF_INET6(10),
+  :PF_MAX(44),
 );
 enum SocketType (
-  :SOCK_PACKET(0),
   :SOCK_STREAM(1),
   :SOCK_DGRAM(2),
   :SOCK_RAW(3),
   :SOCK_RDM(4),
   :SOCK_SEQPACKET(5),
-  :SOCK_MAX(6),
+  :SOCK_PACKET(10),
+  :SOCK_MAX(11),
 );
 enum ProtocolType (
   :PROTO_TCP(6),

--- a/src/core/IO/Socket/INET.pm6
+++ b/src/core/IO/Socket/INET.pm6
@@ -55,10 +55,7 @@ my class IO::Socket::INET does IO::Socket {
 
     method !correct-family(Int:D $family) {
         if ($family == 3) {
-            note "You're using the old value (3) for IPv6 / PF_NET6, " ~
-                "please use the constant PF_INET6 to specify IPv6";
-            note Backtrace.new.Str;
-
+            DEPRECATED('PF_INET6', :what("You're using the old value (3) for IPv6 / PF_NET6"), :up(*));
             return PF_INET6;
         }
 


### PR DESCRIPTION
This will allow enforcing IPv4 and IPv6 sockets, but also allow the creation of `AF_UNIX`/`PF_UNIX` sockets

Currently this will renumber the PIO table as it's not the same as their C counterparts

Other part to fix MoarVM/MoarVM#683