### PR TITLE
Look for yada fullfillment in default parent type, too (RT#131676)

### DIFF
--- a/src/Perl6/Metamodel/RoleToClassApplier.nqp
+++ b/src/Perl6/Metamodel/RoleToClassApplier.nqp
@@ -7,7 +7,18 @@ my class RoleToClassApplier {
             return nqp::existskey(%mt, $name);
         }
         else {
-            for $target.HOW.mro($target) {
+
+            # In an uncomposed class we need to look for methods in
+            # the part of the mro that has not been added yet.
+            my @mro := $target.HOW.mro($target);
+            if $target.HOW.parents($target, :local(1)) == 0
+              && $target.HOW.has_default_parent_type
+              && $target.HOW.name($target) ne 'Mu' {
+                my $dt := $target.HOW.get_default_parent_type;
+                nqp::splice(@mro, $dt.HOW.mro($dt), nqp::elems(@mro), 0);
+            }
+
+            for @mro {
                 my %mt := $_.HOW.method_table($_);
                 if nqp::existskey(%mt, $name) {
                     return 1;

--- a/src/Perl6/Metamodel/RoleToClassApplier.nqp
+++ b/src/Perl6/Metamodel/RoleToClassApplier.nqp
@@ -7,18 +7,7 @@ my class RoleToClassApplier {
             return nqp::existskey(%mt, $name);
         }
         else {
-
-            # In an uncomposed class we need to look for methods in
-            # the part of the mro that has not been added yet.
-            my @mro := $target.HOW.mro($target);
-            if $target.HOW.parents($target, :local(1)) == 0
-              && $target.HOW.has_default_parent_type
-              && $target.HOW.name($target) ne 'Mu' {
-                my $dt := $target.HOW.get_default_parent_type;
-                nqp::splice(@mro, $dt.HOW.mro($dt), nqp::elems(@mro), 0);
-            }
-
-            for @mro {
+            for $target.HOW.mro($target) {
                 my %mt := $_.HOW.method_table($_);
                 if nqp::existskey(%mt, $name) {
                     return 1;


### PR DESCRIPTION
  Role interface/requirements should be satisifiable by Any/Mu,
  but at the point we check them, they have not been appended to
  the MRO yet, unless we are a subclass of an already-composed
  class that has them.  So add the default parent type from the
  class HOW to the list of classes we check for fullfillment.

  In the case of "class C is Mu" we go down a different path which
  ends up skipping Any, as it should.