### PR TITLE
In slurp, don't call nqp::join if not needed

### DIFF
--- a/src/core/IO/Path.pm
+++ b/src/core/IO/Path.pm
@@ -609,9 +609,12 @@ my class IO::Path is Cool does IO {
             $handle,
             nqp::stmts(
                 (my $blob := $handle.slurp(:close)),
-                nqp::if($bin, $blob, nqp::join("\n",
-                  nqp::split("\r\n", $blob.decode: $enc || 'utf-8')))
-            ))
+                nqp::if($bin, $blob,
+                    nqp::if(
+                        nqp::isne_i(nqp::elems(my $l := nqp::split("\r\n", $blob.decode: $enc || 'utf-8')), 1),
+                        nqp::join("\n", $l),
+                        nqp::atpos($l, 0)
+            ))))
     }
 
     method spurt(IO::Path:D: $data, :$enc, :$append, :$createonly) {


### PR DESCRIPTION
nqp::join creates a copy of the string(s) during processing and then
creates another copy to return. For slurping large files this can be
very wasteful if there weren't any "\r\n"s to split on.

For a 50mb file of 1million lines, the time to slurp it dropped from
2.3s to 1.8s, and ~230mb of memory didn't need to be allocated.

Rakudo builds fine and passes `make m-test m-spectest`.