### PR TITLE
Implement metamethod shorthand syntax (RT#131478)

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -2706,7 +2706,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
                 setup_attr_var($/, $past);
             }
         }
-        elsif $twigil eq '.' && $*IN_DECL ne 'variable' {
+        elsif ($twigil eq '.' || $twigil eq '.^') && $*IN_DECL ne 'variable' {
             if !$*HAS_SELF {
                 $*W.throw($/, ['X', 'Syntax', 'NoSelf'], variable => $name);
             } elsif $*HAS_SELF eq 'partial' {
@@ -2714,7 +2714,12 @@ class Perl6::Actions is HLL::Actions does STDActions {
             }
             # Need to transform this to a method call.
             $past := $<arglist> ?? $<arglist>.ast !! QAST::Op.new();
-            $past.op('callmethod');
+            if $twigil eq '.^' {
+                $past.op('p6callmethodhow');
+            }
+            else {
+                $past.op('callmethod');
+            }
             $past.name($desigilname);
             $past.unshift(QAST::Var.new( :name('self'), :scope('lexical') ));
             # Contextualize based on sigil.


### PR DESCRIPTION
  Silence Perl5 warning on $.<!alpha>
  Create a faux non-multipart-name desigilname token
  Teach dissect_longname to digest said token
  Teach variable action to generate a p6callmethodhow
  Adjust parsing to handle the meta thrigil