### PR TITLE
Check configuration file's existence before opening

### DIFF
--- a/tools/lib/NQP/Configure.pm
+++ b/tools/lib/NQP/Configure.pm
@@ -97,6 +97,9 @@ sub read_config {
     local $_;
     for my $file (@config_src) {
         no warnings;
+        if (! -f $file) {
+            next;
+        }
         if (open my $CONFIG, '-|', "\"$file\" --show-config") {
             while (<$CONFIG>) {
                 if (/^([^\s=]+)=(.*)/) { $config{$1} = $2 }

--- a/tools/lib/NQP/Configure.pm
+++ b/tools/lib/NQP/Configure.pm
@@ -98,6 +98,7 @@ sub read_config {
     for my $file (@config_src) {
         no warnings;
         if (! -f $file) {
+            print "No pre-existing installed file found at $file\n";
             next;
         }
         if (open my $CONFIG, '-|', "\"$file\" --show-config") {


### PR DESCRIPTION
This will silence the `sh: 1: /home/tyil/projects/rakudo/install/bin/nqp-m: not found` warning when building Rakudo.