### PR TITLE
Suggest enum values as types

### DIFF
--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -3656,7 +3656,7 @@ class Perl6::World is HLL::World {
             # only care about type objects
             my $first := nqp::substr($name, 0, 1);
             return 1 if $first eq '$' || $first eq '%' || $first eq '@' || $first eq '&' || $first eq ':';
-            return 1 if !$has_object || nqp::isconcrete($object);
+            return 1 if !$has_object || (nqp::isconcrete($object) && !($object.HOW.HOW.name($object.HOW) eq 'Perl6::Metamodel::EnumHOW'));
             return 1 if nqp::existskey(%seen, $name);
 
             %seen{$name} := 1;


### PR DESCRIPTION
Implements RT #123926, e.g., `enum E <Foo Bar>; sub x(Floo) {}` now says
`Invalid typename 'Floo' in parameter declaration. Did you mean 'Foo'?`

Rakudo builds ok and passes `make m-test m-spectest`.