### PR TITLE
Warn on typical precedence errors with infix:<..> (RT#127279)

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -6469,6 +6469,16 @@ class Perl6::Actions is HLL::Actions does STDActions {
         'fff^', -> $/, $sym { flipflop($/[0].ast, $/[1].ast, 0, 1, 1) },
         '^fff^',-> $/, $sym { flipflop($/[0].ast, $/[1].ast, 1, 1, 1) }
     );
+    my %worrisome := nqp::hash(
+        '..', 1,
+        '^..', 1,
+        '..^', 1,
+        '^..^', 1,
+        'R..', 1,
+        'R^..', 1,
+        'R..^', 1,
+        'R^..^', 1
+    );
     method EXPR($/, $KEY?) {
         unless $KEY { return 0; }
         my $past := $/.ast // $<OPER>.ast;
@@ -6636,6 +6646,15 @@ class Perl6::Actions is HLL::Actions does STDActions {
                     :op('hllize'), :returns($past.returns()));
             }
         }
+	if $key eq 'infix' && nqp::existskey(%worrisome, ~$/<OPER>) {
+            if ~$/[0]<prefix> eq '|' {
+                $/[0].typed_worry('X::Worry::Precedence::Range', action => "apply a Slip flattener to", precursor => 1);
+            }
+            elsif ~$/[0]<prefix> eq '~' {
+                $/[0].typed_worry('X::Worry::Precedence::Range', action => "stringify", precursor => 1);
+            }
+        }
+
         make $past;
     }
 

--- a/src/core/Exception.pm
+++ b/src/core/Exception.pm
@@ -841,6 +841,13 @@ my class X::Worry::P5::LeadingZero is X::Worry::P5 {
         ) ~ '. If you meant to create a string, please add quotation marks.'
     }
 }
+my class X::Worry::Precedence::Range is X::Worry {
+    has $.action;
+    method message {
+"To $!action a range, parenthesize the whole range.
+(Or parenthesize the whole endpoint expression, if you meant that.)"
+    }
+}
 
 my class X::Trait::Invalid is Exception {
     has $.type;       # is, will, of etc.


### PR DESCRIPTION
  Alerts user to potential accidental use of prefix:<|> or
  prefix:<~> on a range start value, when they are usually intended
  to apply to the entire range, and encourages use of parens.