### PR TITLE
Add tests to cover a common NC usage

### DIFF
--- a/t/04-nativecall/22-method.c
+++ b/t/04-nativecall/22-method.c
@@ -1,0 +1,25 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef _WIN32
+#define DLLEXPORT __declspec(dllexport)
+#else
+#define DLLEXPORT extern
+#endif
+
+typedef struct {
+    long intval;
+} MyStruct;
+
+DLLEXPORT MyStruct *ReturnAStruct(long intval)
+{
+    MyStruct *obj = (MyStruct *) malloc(sizeof(MyStruct));
+    obj->intval = intval;
+    return obj;
+}
+
+DLLEXPORT long Add(MyStruct *obj, long intval)
+{
+	return obj->intval + intval;
+}

--- a/t/04-nativecall/22-method.t
+++ b/t/04-nativecall/22-method.t
@@ -1,0 +1,29 @@
+use v6;
+
+use lib <lib t/04-nativecall>;
+use CompileTestLib;
+use NativeCall;
+use Test;
+
+plan 2;
+
+compile_test_lib('22-method');
+
+class MyStruct is repr('CStruct') {
+    has long   $.long;
+
+    sub ReturnAStruct(long $intval --> MyStruct) is native('./22-method') { * }
+    method new(Int :$intval) {
+        ReturnAStruct($intval)
+    }
+    method Add(long $intval --> long) is native('./22-method') { * }
+}
+
+my $a = MyStruct.new(intval => 42);
+
+my $res;
+
+lives-ok { $res = $a.Add(2) }, "native sub as method";
+is $res, 44, "and got the result we expected";
+
+# vim:ft=perl6


### PR DESCRIPTION
C functions that consistently take some struct or pointer
as the first argument are declared as methods of that
CStruct or CPointer