### PR TITLE
implement typed pointer increment and array dereference salortiz++

### DIFF
--- a/lib/NativeCall/Types.pm6
+++ b/lib/NativeCall/Types.pm6
@@ -56,6 +56,20 @@ our class Pointer                               is repr('CPointer') {
     my role TypedPointer[::TValue] {
         method of() { TValue }
         method deref(::?CLASS:D \ptr:) { self ?? nativecast(TValue, ptr) !! fail("Can't dereference a Null Pointer"); }
+        method add(UInt $off) returns Pointer {
+            die "Can't do arithmetic with a void pointer"
+                if TValue.isa(void);
+            nqp::box_i(self.Int + nqp::nativecallsizeof(TValue) * $off, self.WHAT);
+        }
+        method succ {
+            self.add(1);
+        }
+        method pred {
+            self.add(-1);
+        }
+        method AT-POS(Int $pos) {
+            self.add($pos).deref;
+        }
     }
     method ^parameterize(Mu:U \p, Mu:U \t) {
         die "A typed pointer can only hold:\n" ~

--- a/t/04-nativecall/04-pointers.c
+++ b/t/04-nativecall/04-pointers.c
@@ -33,3 +33,9 @@ DLLEXPORT void * TakeTwoPointersToInt(int *ptr1, int *ptr2)
 DLLEXPORT void * TakeCArrayToInt8(int array[]) {
     return NULL;
 }
+
+static int array[3] = {10, 20, 30};
+DLLEXPORT int * ReturnPointerToIntArray()
+{
+    return array;
+}

--- a/t/04-nativecall/04-pointers.t
+++ b/t/04-nativecall/04-pointers.t
@@ -6,13 +6,14 @@ use NativeCall;
 use NativeCall::Types;
 use Test;
 
-plan 12;
+plan 17;
 
 compile_test_lib('04-pointers');
 
 sub ReturnSomePointer()         returns Pointer is native("./04-pointers") { * }
 sub CompareSomePointer(Pointer) returns int32   is native("./04-pointers") { * }
 sub ReturnNullPointer()         returns Pointer is native("./04-pointers") { * }
+sub ReturnPointerToIntArray()   returns Pointer[int32] is native("./04-pointers") { * }
 
 my $x     = ReturnSomePointer();
 my int $a = 4321;
@@ -27,6 +28,13 @@ is +Pointer.new(0),       0, 'Pointer.new(0) has 0 numerical value';
 is +Pointer.new(1234), 1234, 'Pointer.new(1234) has numerical value 1234';
 is +Pointer.new($a),     $a, 'Pointer.new accepts a native int too';
 ok ReturnNullPointer() === Pointer,           'A returned NULL pointer is the Pointer type object itself';
+
+my $p = ReturnPointerToIntArray();
+is $p.deref, 10, 'typed pointer deref method';
+is $p[1], 20, 'typed pointer array dereference';
+is (++$p).deref, 20, 'typed pointer increment';
+is $p[0], 20, 'typed pointer incremented';
+is $p[1], 30, 'typed pointer incremented';
 
 {
     eval-lives-ok q:to 'CODE', 'Signature matching with Pointer[int32] works (RT #124321)';


### PR DESCRIPTION
The following now works.

    use NativeCall;
    my CArray[uint16] $a .= new: 10, 20 ... 100;
    my $p = nativecast(Pointer[uint16], $a);
    
    # pointer increment
    ++$p;
    say $p.deref; # 20
    # array dereferencing
    say $p[2];  ; # 40

Addresses RT #128000. Based on NativeHelpers::Pointer implementation salortiz++