### PR TITLE
Correctly explain why couldn't instantiate a role

### DIFF
--- a/src/Perl6/Metamodel/ParametricRoleHOW.nqp
+++ b/src/Perl6/Metamodel/ParametricRoleHOW.nqp
@@ -150,7 +150,8 @@ class Perl6::Metamodel::ParametricRoleHOW
                 }
             }
             if $error {
-                nqp::die("Could not instantiate role '" ~ self.name($obj) ~ "':\n$error")
+                nqp::die("Could not instantiate role '" ~ self.name($obj)
+                         ~ "':\n" ~ nqp::getpayload($error))
             }
 
             # Use it to build concrete role.


### PR DESCRIPTION
This broke when Exceptions were changed to not create their message
unless .gist'ed.

Fixes RT #132285.

Rakudo builds ok and passes `make m-test m-spectest`.