### PR TITLE
optimize recently added AT-POS for typed pointers

### DIFF
--- a/lib/NativeCall/Types.pm6
+++ b/lib/NativeCall/Types.pm6
@@ -68,7 +68,12 @@ our class Pointer                               is repr('CPointer') {
             self.add(-1);
         }
         method AT-POS(Int $pos) {
-            self.add($pos).deref;
+            nqp::nativecallcast(
+                TValue,
+                nqp::istype(TValue, Int) ?? Int
+                                         !! nqp::istype(TValue, Num) ?? Num !! TValue,
+                nqp::box_i(nqp::unbox_i(nqp::decont(self)) + nqp::nativecallsizeof(TValue) * $pos, Pointer)
+            )
         }
     }
     method ^parameterize(Mu:U \p, Mu:U \t) {


### PR DESCRIPTION
Inline the add method and subsequent calls to nativecast and Int and add
methods. Improves performance by 4-5x.