### PR TITLE
Optimize Regex multi for INTERPOLATE

### DIFF
--- a/src/core/Match.pm
+++ b/src/core/Match.pm
@@ -513,20 +513,20 @@ my class Match is Capture is Cool does NQPMatchRole {
     multi method INTERPOLATE(Regex \var, int $im, int $monkey, int $s, int $a, $context) {
         my $maxmatch;
         my $cur    := self.'!cursor_start_cur'();
-        my str $tgt = $cur.target;
-        my int $eos = nqp::chars($tgt);
 
         my int $maxlen = -1;
         my int $pos    = nqp::getattr_i($cur, $?CLASS, '$!from');
         my Mu $topic := var;
         my $match := self.$topic;
-        my int $len = $match.pos - $match.from;
 
-        if $match
-          && nqp::isgt_i($len,$maxlen)
-          && nqp::isle_i(nqp::add_i($pos,$len),$eos) {
-            $maxlen    = $len;
-            $maxmatch := $match;
+        if $match {
+            my int $len = $match.pos - $match.from;
+
+            if nqp::isgt_i($len,$maxlen)
+               && nqp::isle_i(nqp::add_i($pos,$len),nqp::chars($cur.target)) {
+                $maxlen    = $len;
+                $maxmatch := $match;
+            }
         }
 
         nqp::istype($maxmatch, Match)


### PR DESCRIPTION
Move some code into a conditional and don't allocate some variables if
not needed.

`perl6 -e 'my $a = rx/aaaaaab/; "a" x 999999 ~ "b" ~~ /$a/; say now - INIT now'` used to report ~14.3s, now reports ~9.5s. This helps the performance regression spotted in https://rt.perl.org/Ticket/Display.html?id=132294, but still doesn't fix it completely.

Rakudo builds ok and passes `make m-test m-spectest`.
