### PR TITLE
Simplify signatures for Regex and Associative...

### DIFF
--- a/src/core/Match.pm
+++ b/src/core/Match.pm
@@ -410,7 +410,7 @@ my class Match is Capture is Cool does NQPMatchRole {
             !! $cur
     }
 
-    multi method INTERPOLATE(Associative \var, int $im, int $monkey, int $s, int $a, $context) {
+    multi method INTERPOLATE(Associative:D \var, int $im, int $monkey, int $s, int $a, $context) {
         my $cur    := self.'!cursor_start_cur'();
         if $a {
             return $cur.'!cursor_start_cur'()
@@ -510,7 +510,7 @@ my class Match is Capture is Cool does NQPMatchRole {
             !! $cur
     }
 
-    multi method INTERPOLATE(Regex \var, int $im, int $monkey, int $s, int $a, $context) {
+    multi method INTERPOLATE(Regex:D \var, $, $, $, $, $) {
         my $maxmatch;
         my $cur    := self.'!cursor_start_cur'();
 


### PR DESCRIPTION
multis of INTERPOLATE.

`perl6 -e 'my $a = rx/aaaaaab/; "a" x 999999 ~ "b" ~~ /$a/; say now - INIT now'` used to report ~9.5s, now reports ~3.3s. This pretty much fixes the performance regression spotted in https://rt.perl.org/Ticket/Display.html?id=132294.

Rakudo builds ok and passes `make m-test m-spectest`.