### PR TITLE
Improve wrong arity error for anonymous subs

### DIFF
--- a/src/Perl6/Metamodel/BOOTSTRAP.nqp
+++ b/src/Perl6/Metamodel/BOOTSTRAP.nqp
@@ -166,6 +166,7 @@ my class Binder {
         }
         my str $s := $arity == 1 ?? "" !! "s";
         my str $routine := nqp::getcodeobj(nqp::ctxcode($lexpad)).name;
+        $routine := '<anon>' unless $routine;
 
         if $arity == $count {
             return "$error_prefix positionals passed to '$routine'; expected $arity argument$s but got $num_pos_args";


### PR DESCRIPTION
If the routine doesn't have a name, use `'<anon>'` instead.

Rakudo builds ok and passes `make m-test m-spectest`.



----------
(edit by @zoffixznet: wrap `'<anon>'` to code tags, so it does not get interpreted as HTML)