### PR TITLE
Use the new nqp::fromI_I in Int.new

### DIFF
--- a/src/core/Int.pm
+++ b/src/core/Int.pm
@@ -28,11 +28,11 @@ my class Int does Real { # declared in BOOTSTRAP
     multi method new(      \value) { self.new: value.Int }
     multi method new(int   \value) {
         # rebox the value, so we get rid of any potential mixins
-        nqp::div_I(nqp::decont(value), 1, self)
+        nqp::fromI_I(nqp::decont(value), self)
     }
     multi method new(Int:D \value = 0) {
         # rebox the value, so we get rid of any potential mixins
-        nqp::div_I(nqp::decont(value), 1, self)
+        nqp::fromI_I(nqp::decont(value), self)
     }
 
     multi method perl(Int:D:) {


### PR DESCRIPTION
The op will create a new Int using the value of the given Int, but
remove any mix-ins.

Requires https://github.com/MoarVM/MoarVM/pull/737 and https://github.com/perl6/nqp/pull/378.

Rakudo builds ok and passes `make m-test m-spectest`.