### PR TITLE
Normalize proto bodies

### DIFF
--- a/src/core/Any-iterable-methods.pm
+++ b/src/core/Any-iterable-methods.pm
@@ -8,7 +8,7 @@
 use MONKEY-TYPING;
 augment class Any {
 
-    proto method map(|) is nodal { * }
+    proto method map(|) is nodal {*}
     multi method map(Hash \h) {
         die "Cannot map a {self.^name} to a {h.^name}.
 Did you mean to add a stub (\{...\}) or did you mean to .classify?"
@@ -767,7 +767,7 @@ Did you mean to add a stub (\{...\}) or did you mean to .classify?"
         )
     }
 
-    proto method flatmap (|) is nodal { * }
+    proto method flatmap (|) is nodal {*}
     multi method flatmap(&block, :$label) {
         self.map(&block, :$label).flat
     }
@@ -992,7 +992,7 @@ Did you mean to add a stub (\{...\}) or did you mean to .classify?"
         )
     }
 
-    proto method grep(|) is nodal { * }
+    proto method grep(|) is nodal {*}
     multi method grep(Bool:D $t) {
         X::Match::Bool.new( type => '.grep').throw
     }
@@ -1065,7 +1065,7 @@ Did you mean to add a stub (\{...\}) or did you mean to .classify?"
         }
     }
 
-    proto method first(|) is nodal { * }
+    proto method first(|) is nodal {*}
     multi method first(Bool:D $t) {
         Failure.new(X::Match::Bool.new( type => '.first' ))
     }
@@ -1177,7 +1177,7 @@ Did you mean to add a stub (\{...\}) or did you mean to .classify?"
         )
     }
 
-    proto method min (|) is nodal { * }
+    proto method min (|) is nodal {*}
     multi method min() {
         nqp::stmts(
           nqp::if(
@@ -1211,7 +1211,7 @@ Did you mean to add a stub (\{...\}) or did you mean to .classify?"
         )
     }
 
-    proto method max (|) is nodal { * }
+    proto method max (|) is nodal {*}
     multi method max() {
         nqp::stmts(
           nqp::if(
@@ -1288,7 +1288,7 @@ Did you mean to add a stub (\{...\}) or did you mean to .classify?"
         )
     }
 
-    proto method minmax (|) is nodal { * }
+    proto method minmax (|) is nodal {*}
     multi method minmax() {
         nqp::stmts(
           nqp::if(
@@ -1391,7 +1391,7 @@ Did you mean to add a stub (\{...\}) or did you mean to .classify?"
         )
     }
 
-    proto method sort(|) is nodal { * }
+    proto method sort(|) is nodal {*}
     multi method sort() {
         nqp::if(
           nqp::eqaddr(
@@ -1459,14 +1459,14 @@ Did you mean to add a stub (\{...\}) or did you mean to .classify?"
         )
     }
 
-    proto method reduce(|) { * }
+    proto method reduce(|) {*}
     multi method reduce(&with) is nodal {
         return unless self.DEFINITE;
         my $reducer := find-reducer-for-op(&with);
         $reducer(&with)(self) if $reducer;
     }
 
-    proto method produce(|) { * }
+    proto method produce(|) {*}
     multi method produce(&with) is nodal {
         return unless self.DEFINITE;
         my $reducer := find-reducer-for-op(&with);
@@ -1781,7 +1781,7 @@ Did you mean to add a stub (\{...\}) or did you mean to .classify?"
         }.new(self, &with))
     }
 
-    proto method pairup(|) is nodal { * }
+    proto method pairup(|) is nodal {*}
     multi method pairup(Any:U:) { () }
     multi method pairup(Any:D:) {
         my \iter := self.iterator;
@@ -1810,7 +1810,7 @@ Did you mean to add a stub (\{...\}) or did you mean to .classify?"
         }
     }
 
-    proto method head(|) { * }
+    proto method head(|) {*}
     multi method head(Any:D:) is raw {
         nqp::if(
           nqp::eqaddr((my $pulled := self.iterator.pull-one),IterationEnd),
@@ -1827,7 +1827,7 @@ Did you mean to add a stub (\{...\}) or did you mean to .classify?"
         Seq.new(Rakudo::Iterator.NextNValues(self.iterator,$n))
     }
 
-    proto method tail(|) { * }
+    proto method tail(|) {*}
     multi method tail(Any:D:) is raw {
         nqp::if(
           nqp::eqaddr((my $pulled :=
@@ -1852,7 +1852,7 @@ Did you mean to add a stub (\{...\}) or did you mean to .classify?"
         )
     }
 
-    proto method minpairs(|) { * }
+    proto method minpairs(|) {*}
     multi method minpairs(Any:D:) {
         my @found;
         for self.pairs {
@@ -1870,7 +1870,7 @@ Did you mean to add a stub (\{...\}) or did you mean to .classify?"
         Seq.new(@found.iterator)
     }
 
-    proto method maxpairs(|) { * }
+    proto method maxpairs(|) {*}
     multi method maxpairs(Any:D:) {
         my @found;
         for self.pairs {
@@ -1888,7 +1888,7 @@ Did you mean to add a stub (\{...\}) or did you mean to .classify?"
         Seq.new(@found.iterator)
     }
 
-    proto method batch(|) is nodal { * }
+    proto method batch(|) is nodal {*}
     multi method batch(Any:D: Int:D :$elems!) {
         Seq.new(Rakudo::Iterator.Batch(self.iterator,$elems,1))
     }
@@ -1896,7 +1896,7 @@ Did you mean to add a stub (\{...\}) or did you mean to .classify?"
         Seq.new(Rakudo::Iterator.Batch(self.iterator,$batch,1))
     }
 
-    proto method rotor(|) is nodal { * }
+    proto method rotor(|) is nodal {*}
     multi method rotor(Any:D: Int:D $batch, :$partial) {
         Seq.new(Rakudo::Iterator.Batch(self.iterator,$batch,$partial))
     }
@@ -1904,14 +1904,14 @@ Did you mean to add a stub (\{...\}) or did you mean to .classify?"
         Seq.new(Rakudo::Iterator.Rotor(self.iterator,@cycle,$partial))
     }
 
-    proto method skip(|) { * }
+    proto method skip(|) {*}
     multi method skip()         { Seq.new(self.iterator).skip }
     multi method skip(Int() $n) { Seq.new(self.iterator).skip($n) }
 }
 
 BEGIN Attribute.^compose;
 
-proto sub infix:<min>(|) is pure { * }
+proto sub infix:<min>(|) is pure {*}
 multi sub infix:<min>(Mu:D \a, Mu:U) { a }
 multi sub infix:<min>(Mu:U, Mu:D \b) { b }
 multi sub infix:<min>(Mu:D \a, Mu:D \b) { (a cmp b) < 0 ?? a !! b }
@@ -1922,7 +1922,7 @@ multi sub infix:<min>(num   \a, num   \b) { nqp::if(nqp::islt_i(nqp::cmp_n(a, b)
 multi sub infix:<min>(+args is raw) { args.min }
 sub min(+args, :&by = &infix:<cmp>) { args.min(&by) }
 
-proto sub infix:<max>(|) is pure { * }
+proto sub infix:<max>(|) is pure {*}
 multi sub infix:<max>(Mu:D \a, Mu:U) { a }
 multi sub infix:<max>(Mu:U, Mu:D \b) { b }
 multi sub infix:<max>(Mu:D \a, Mu:D \b) { (a cmp b) > 0 ?? a !! b }
@@ -1933,7 +1933,7 @@ multi sub infix:<max>(num   \a, num   \b) { nqp::if(nqp::isgt_i(nqp::cmp_n(a, b)
 multi sub infix:<max>(+args) { args.max }
 sub max(+args, :&by = &infix:<cmp>) { args.max(&by) }
 
-proto sub infix:<minmax>(|) is pure { * }
+proto sub infix:<minmax>(|) is pure {*}
 multi sub infix:<minmax>(+args) { args.minmax }
 sub minmax(+args, :&by = &infix:<cmp>) { args.minmax(&by) }
 
@@ -1951,22 +1951,22 @@ proto sub first(|) {*}
 multi sub first(Bool:D $t, |) { Failure.new(X::Match::Bool.new(:type<first>)) }
 multi sub first(Mu $test, +values, *%a) { values.first($test,|%a) }
 
-proto sub join(|) { * }
+proto sub join(|) {*}
 multi sub join($sep = '', *@values) { @values.join($sep) }
 
-proto sub reduce (|) { * }
+proto sub reduce (|) {*}
 multi sub reduce (&with, +list)  { list.reduce(&with) }
 
-proto sub produce (|) { * }
+proto sub produce (|) {*}
 multi sub produce (&with, +list)  { list.produce(&with) }
 
-proto sub unique(|) { * }
+proto sub unique(|) {*}
 multi sub unique(+values, |c) { my $laze = values.is-lazy; values.unique(|c).lazy-if($laze) }
 
-proto sub squish(|) { * }
+proto sub squish(|) {*}
 multi sub squish(+values, |c) { my $laze = values.is-lazy; values.squish(|c).lazy-if($laze) }
 
-proto sub repeated(|) { * }
+proto sub repeated(|) {*}
 multi sub repeated(+values, |c) { my $laze = values.is-lazy; values.repeated(|c).lazy-if($laze) }
 
 proto sub sort(|) {*}

--- a/src/core/Any.pm
+++ b/src/core/Any.pm
@@ -21,17 +21,17 @@ my class Any { # declared in BOOTSTRAP
         nqp::p6bool(nqp::istype(topic, self)) # so that all(@foo) ~~ Type works as expected
     }
 
-    proto method EXISTS-KEY(|) is nodal { * }
+    proto method EXISTS-KEY(|) is nodal {*}
     multi method EXISTS-KEY(Any:U: $ --> False) { }
     multi method EXISTS-KEY(Any:D: $ --> False) { }
 
-    proto method DELETE-KEY(|) is nodal { * }
+    proto method DELETE-KEY(|) is nodal {*}
     multi method DELETE-KEY(Any:U: $ --> Nil) { }
     multi method DELETE-KEY(Any:D: $) {
         Failure.new("Can not remove values from a {self.^name}")
     }
 
-    proto method DELETE-POS(|) is nodal { * }
+    proto method DELETE-POS(|) is nodal {*}
     multi method DELETE-POS(Any:U: $pos --> Nil) { }
     multi method DELETE-POS(Any:D: $pos) {
         Failure.new("Can not remove elements from a {self.^name}")
@@ -49,77 +49,77 @@ my class Any { # declared in BOOTSTRAP
 
     method cache() { self.list }
 
-    proto method list(|) is nodal { * }
+    proto method list(|) is nodal {*}
     multi method list(Any:U:) { infix:<,>(self) }
     multi method list(Any:D \SELF:) { infix:<,>(SELF) }
 
-    proto method flat(|) is nodal { * }
+    proto method flat(|) is nodal {*}
     multi method flat() { self.list.flat }
 
-    proto method eager(|) is nodal { * }
+    proto method eager(|) is nodal {*}
     multi method eager() { self.list.eager }
 
-    proto method serial(|) is nodal { * }
+    proto method serial(|) is nodal {*}
     multi method serial() { self }
 
     # derived from .list
-    proto method List(|) is nodal { * }
+    proto method List(|) is nodal {*}
     multi method List() { self.list }
-    proto method Slip(|) is nodal { * }
+    proto method Slip(|) is nodal {*}
     multi method Slip() { self.list.Slip }
-    proto method Array(|) is nodal { * }
+    proto method Array(|) is nodal {*}
     multi method Array() { self.list.Array }
-    proto method Seq(|) is nodal { * }
+    proto method Seq(|) is nodal {*}
     multi method Seq() { Seq.new(self.iterator) }
 
-    proto method hash(|) is nodal { * }
+    proto method hash(|) is nodal {*}
     multi method hash(Any:U:) { my % = () }
     multi method hash(Any:D:) { my % = self }
 
     # derived from .hash
-    proto method Hash(|) is nodal { * }
+    proto method Hash(|) is nodal {*}
     multi method Hash() { self.hash.Hash }
 
-    proto method Map(|) is nodal { * }
+    proto method Map(|) is nodal {*}
     multi method Map() { self.hash.Map }
 
-    proto method elems(|) is nodal { * }
+    proto method elems(|) is nodal {*}
     multi method elems(Any:U: --> 1) { }
     multi method elems(Any:D:) { self.list.elems }
 
-    proto method end(|) is nodal { * }
+    proto method end(|) is nodal {*}
     multi method end(Any:U: --> 0) { }
     multi method end(Any:D:) { self.list.end }
 
-    proto method keys(|) is nodal { * }
+    proto method keys(|) is nodal {*}
     multi method keys(Any:U:) { () }
     multi method keys(Any:D:) { self.list.keys }
 
-    proto method kv(|) is nodal { * }
+    proto method kv(|) is nodal {*}
     multi method kv(Any:U:) { () }
     multi method kv(Any:D:) { self.list.kv }
 
-    proto method values(|) is nodal { * }
+    proto method values(|) is nodal {*}
     multi method values(Any:U:) { () }
     multi method values(Any:D:) { self.list }
 
-    proto method pairs(|) is nodal { * }
+    proto method pairs(|) is nodal {*}
     multi method pairs(Any:U:) { () }
     multi method pairs(Any:D:) { self.list.pairs }
 
-    proto method antipairs(|) is nodal { * }
+    proto method antipairs(|) is nodal {*}
     multi method antipairs(Any:U:) { () }
     multi method antipairs(Any:D:) { self.list.antipairs }
 
-    proto method invert(|) is nodal { * }
+    proto method invert(|) is nodal {*}
     multi method invert(Any:U:) { () }
     multi method invert(Any:D:) { self.list.invert }
 
-    proto method pick(|) is nodal { * }
+    proto method pick(|) is nodal {*}
     multi method pick()   { self.list.pick     }
     multi method pick($n) { self.list.pick($n) }
 
-    proto method roll(|) is nodal { * }
+    proto method roll(|) is nodal {*}
     multi method roll()   { self.list.roll     }
     multi method roll($n) { self.list.roll($n) }
 
@@ -127,7 +127,7 @@ my class Any { # declared in BOOTSTRAP
 
     method match(Any:U: |) { self.Str; nqp::getlexcaller('$/') = Nil }
 
-    proto method classify(|) is nodal { * }
+    proto method classify(|) is nodal {*}
     multi method classify() {
         die "Must specify something to classify with, a Callable, Hash or List";
     }
@@ -141,7 +141,7 @@ my class Any { # declared in BOOTSTRAP
         Hash.^parameterize(Any,Any).new.classify-list( $test, self, :&as );
     }
 
-    proto method categorize(|) is nodal { * }
+    proto method categorize(|) is nodal {*}
     multi method categorize() {
         die "Must specify something to categorize with, a Callable, Hash or List";
     }
@@ -166,7 +166,7 @@ my class Any { # declared in BOOTSTRAP
     method deepmap(&block) is nodal { deepmap(&block, self) }
 
     # XXX GLR Do we need tree post-GLR?
-    proto method tree(|) is nodal { * }
+    proto method tree(|) is nodal {*}
     multi method tree(Any:U:) { self }
     multi method tree(Any:D:) {
         nqp::istype(self, Iterable)
@@ -194,25 +194,25 @@ my class Any { # declared in BOOTSTRAP
         SELF.push(|values);
     }
 
-    proto method append(|) is nodal { * }
+    proto method append(|) is nodal {*}
     multi method append(Any:U \SELF: |values) {
         SELF = nqp::istype(SELF,Positional) ?? SELF.new !! Array.new;
         SELF.append(|values);
     }
 
-    proto method unshift(|) is nodal { * }
+    proto method unshift(|) is nodal {*}
     multi method unshift(Any:U \SELF: |values) {
         SELF = Array.new;
         SELF.unshift(|values);
     }
 
-    proto method prepend(|) is nodal { * }
+    proto method prepend(|) is nodal {*}
     multi method prepend(Any:U \SELF: |values) {
         SELF = Array.new;
         SELF.prepend(|values);
     }
 
-    proto method EXISTS-POS(|) is nodal { * }
+    proto method EXISTS-POS(|) is nodal {*}
     multi method EXISTS-POS(Any:U: Any:D $ --> False) { }
     multi method EXISTS-POS(Any:U: Any:U $pos) {
         die "Cannot use '{$pos.^name}' as an index";
@@ -317,7 +317,7 @@ my class Any { # declared in BOOTSTRAP
         Rakudo::Internals.WALK-AT-POS(self,@indices).AT-POS($final)
     }
 
-    proto method ZEN-POS(|) { * }
+    proto method ZEN-POS(|) {*}
     multi method ZEN-POS(*%unexpected) {
         %unexpected
           ?? Failure.new(X::Adverb.new(
@@ -327,7 +327,7 @@ my class Any { # declared in BOOTSTRAP
           !! self
     }
 
-    proto method ZEN-KEY(|) { * }
+    proto method ZEN-KEY(|) {*}
     multi method ZEN-KEY(*%unexpected) {
         %unexpected
           ?? Failure.new(X::Adverb.new(
@@ -337,7 +337,7 @@ my class Any { # declared in BOOTSTRAP
           !! self
     }
 
-    proto method ASSIGN-POS(|) is nodal { * }
+    proto method ASSIGN-POS(|) is nodal {*}
     multi method ASSIGN-POS(Any:U \SELF: \pos, Mu \assignee) {
        SELF.AT-POS(pos) = assignee;                     # defer < 0 check
     }
@@ -371,7 +371,7 @@ my class Any { # declared in BOOTSTRAP
         Rakudo::Internals.WALK-AT-POS(self,@indices).ASSIGN-POS($final,value)
     }
 
-    proto method BIND-POS(|) { * }
+    proto method BIND-POS(|) {*}
     multi method BIND-POS(Any:D: **@indices is raw) is raw {
 # looks like Array.pop doesn't really return a bindable container
 #        my \value := @indices.pop;
@@ -395,7 +395,7 @@ my class Any { # declared in BOOTSTRAP
     method none() is nodal { Junction.new("none",self) }
 
     # internals
-    proto method AT-KEY(|) is nodal { * }
+    proto method AT-KEY(|) is nodal {*}
     multi method AT-KEY(Any:D: $key) is raw {
         Failure.new( self ~~ Associative
           ?? "Associative indexing implementation missing from type {self.WHAT.perl}"
@@ -420,7 +420,7 @@ my class Any { # declared in BOOTSTRAP
         )
     }
 
-    proto method BIND-KEY(|) is nodal { * }
+    proto method BIND-KEY(|) is nodal {*}
     multi method BIND-KEY(Any:D: \k, \v) is raw {
         Failure.new(X::Bind.new(target => self.^name))
     }
@@ -430,7 +430,7 @@ my class Any { # declared in BOOTSTRAP
         $BIND
     }
 
-    proto method ASSIGN-KEY(|) is nodal { * }
+    proto method ASSIGN-KEY(|) is nodal {*}
     multi method ASSIGN-KEY(\SELF: \key, Mu \assignee) is raw {
         SELF.AT-KEY(key) = assignee;
     }
@@ -442,26 +442,26 @@ my class Any { # declared in BOOTSTRAP
     }
     method FLATTENABLE_HASH() is nodal { nqp::hash() }
 
-    proto method Set(|) is nodal { * }
+    proto method Set(|) is nodal {*}
     multi method Set(Any:) { Set.new-from-pairs(self.list) }
 
-    proto method SetHash(|) is nodal { * }
+    proto method SetHash(|) is nodal {*}
     multi method SetHash(Any:) { SetHash.new-from-pairs(self.list) }
 
-    proto method Bag(|) is nodal { * }
+    proto method Bag(|) is nodal {*}
     multi method Bag(Any:) { Bag.new-from-pairs(self.list) }
 
-    proto method BagHash(|) is nodal { * }
+    proto method BagHash(|) is nodal {*}
     multi method BagHash(Any:) { BagHash.new-from-pairs(self.list) }
 
-    proto method Mix(|) is nodal { * }
+    proto method Mix(|) is nodal {*}
     multi method Mix(Any:) { Mix.new-from-pairs(self.list) }
 
-    proto method MixHash(|) is nodal { * }
+    proto method MixHash(|) is nodal {*}
     multi method MixHash() { MixHash.new-from-pairs(self.list) }
 
     # XXX GLR does this really need to force a list?
-    proto method Supply(|) is nodal { * }
+    proto method Supply(|) is nodal {*}
     multi method Supply() { self.list.Supply }
 
     method nl-out() { "\n" }
@@ -483,7 +483,7 @@ my class Any { # declared in BOOTSTRAP
 Metamodel::ClassHOW.exclude_parent(Any);
 
 # builtin ops
-proto sub infix:<===>(Mu $?, Mu $?) is pure { * }
+proto sub infix:<===>(Mu $?, Mu $?) is pure {*}
 multi sub infix:<===>($?)    { Bool::True }
 multi sub infix:<===>(\a, \b) {
     nqp::p6bool(
@@ -493,50 +493,50 @@ multi sub infix:<===>(\a, \b) {
     )
 }
 
-proto sub infix:<before>(Mu $?, Mu $?)  is pure { * }
+proto sub infix:<before>(Mu $?, Mu $?)  is pure {*}
 multi sub infix:<before>($?)      { Bool::True }
 multi sub infix:<before>(\a, \b)   { (a cmp b) < 0 }
 
-proto sub infix:<after>(Mu $?, Mu $?) is pure { * }
+proto sub infix:<after>(Mu $?, Mu $?) is pure {*}
 multi sub infix:<after>($x?)       { Bool::True }
 multi sub infix:<after>(\a, \b)    { (a cmp b) > 0 }
 
-proto prefix:<++>(Mu)             { * }
+proto prefix:<++>(Mu)             {*}
 multi prefix:<++>(Mu:D $a is rw) { $a = $a.succ }
 multi prefix:<++>(Mu:U $a is rw) { $a = 1 }
-proto prefix:<-->(Mu)             { * }
+proto prefix:<-->(Mu)             {*}
 multi prefix:<-->(Mu:D $a is rw) { $a = $a.pred }
 multi prefix:<-->(Mu:U $a is rw) { $a = -1 }
 
-proto postfix:<++>(Mu)             { * }
+proto postfix:<++>(Mu)             {*}
 multi postfix:<++>(Mu:D $a is rw) { my $b = $a; $a = $a.succ; $b }
 multi postfix:<++>(Mu:U $a is rw) { $a = 1; 0 }
-proto postfix:<-->(Mu)             { * }
+proto postfix:<-->(Mu)             {*}
 multi postfix:<-->(Mu:D $a is rw) { my $b = $a; $a = $a.pred; $b }
 multi postfix:<-->(Mu:U $a is rw) { $a = -1; 0 }
 
-proto sub pick(|) { * }
+proto sub pick(|) {*}
 multi sub pick($n, +values) { values.pick($n) }
 
-proto sub roll(|) { * }
+proto sub roll(|) {*}
 multi sub roll($n, +values) { values.roll($n) }
 
-proto sub keys(|) { * }
+proto sub keys(|) {*}
 multi sub keys($x) { $x.keys }
 
-proto sub values(|) { * }
+proto sub values(|) {*}
 multi sub values($x) { $x.values }
 
-proto sub pairs(|) { * }
+proto sub pairs(|) {*}
 multi sub pairs($x) { $x.pairs }
 
-proto sub kv(|) { * }
+proto sub kv(|) {*}
 multi sub kv($x) { $x.kv }
 
-proto sub elems(|) is nodal { * }
+proto sub elems(|) is nodal {*}
 multi sub elems($a) { $a.elems }
 
-proto sub end(|) { * }
+proto sub end(|) {*}
 multi sub end($a) { $a.end }
 
 proto sub sum(|) {*}
@@ -563,7 +563,7 @@ sub categorize( $test, +items, *%named ) {
     }
 }
 
-proto sub item(|) is pure { * }
+proto sub item(|) is pure {*}
 multi sub item(\x)    { my $ = x }
 multi sub item(|c)    { my $ = c.list }
 multi sub item(Mu $a) { $a }

--- a/src/core/Complex.pm
+++ b/src/core/Complex.pm
@@ -8,7 +8,7 @@ my class Complex is Cool does Numeric {
         $!im = im;
         self
     }
-    proto method new(|) { * }
+    proto method new(|) {*}
     multi method new() { self.new: 0, 0 }
     multi method new(Real \re, Real \im) { nqp::create(self)!SET-SELF(re, im) }
 
@@ -487,7 +487,7 @@ multi sub infix:«<=>»(Complex:D \a, Complex:D \b --> Order:D) {
 multi sub infix:«<=>»(Num(Real) \a, Complex:D \b --> Order:D) { a.Complex <=> b }
 multi sub infix:«<=>»(Complex:D \a, Num(Real) \b --> Order:D) { a <=> b.Complex }
 
-proto sub postfix:<i>(\a --> Complex:D) is pure { * }
+proto sub postfix:<i>(\a --> Complex:D) is pure {*}
 multi sub postfix:<i>(Real      \a --> Complex:D) { Complex.new(0e0, a);     }
 multi sub postfix:<i>(Complex:D \a --> Complex:D) { Complex.new(-a.im, a.re) }
 multi sub postfix:<i>(Numeric   \a --> Complex:D) { a * Complex.new(0e0, 1e0) }

--- a/src/core/Cool.pm
+++ b/src/core/Cool.pm
@@ -43,7 +43,7 @@ my class Cool { # declared in BOOTSTRAP
     multi method exp(Cool:D: )      { self.Numeric.exp          }
     multi method exp(Cool:D: $base) { self.Numeric.exp($base.Numeric) }
 
-    proto method round(|) { * }
+    proto method round(|) {*}
     multi method round()      { self.Numeric.round()      }
     multi method round($base) { self.Numeric.round($base) }
 
@@ -109,7 +109,7 @@ my class Cool { # declared in BOOTSTRAP
 
     method chomp(Cool:D:) { self.Str.chomp }
 
-    proto method chop(|)                { * }
+    proto method chop(|)                {*}
     multi method chop(Cool:D:)          { self.Str.chop }
     multi method chop(Cool:D: Int() $n) { self.Str.chop($n) }
 
@@ -184,7 +184,7 @@ my class Cool { # declared in BOOTSTRAP
         $match
     }
 
-    proto method IO(|) { * }
+    proto method IO(|) {*}
     multi method IO(Cool:D:) { IO::Path.new(self) }
     multi method IO(Cool:U:) { IO::Path }
 
@@ -209,7 +209,7 @@ my class Cool { # declared in BOOTSTRAP
         )
     }
 
-    proto method Int(|) { * }
+    proto method Int(|) {*}
     multi method Int()  {
         nqp::if(
             nqp::istype((my $numeric := self.Numeric), Failure),
@@ -218,7 +218,7 @@ my class Cool { # declared in BOOTSTRAP
         )
     }
 
-    proto method UInt(|) { * }
+    proto method UInt(|) {*}
     multi method UInt()  {
         my $got := self.Int;
         $got < 0
@@ -263,7 +263,7 @@ my class Cool { # declared in BOOTSTRAP
 }
 Metamodel::ClassHOW.exclude_parent(Cool);
 
-proto sub chop(|) { * }
+proto sub chop(|) {*}
 multi sub chop(Cool:D $s --> Str:D) { $s.chop }
 multi sub chop(Cool:D $s, Int() $n --> Str:D) { $s.chop($n) }
 
@@ -282,19 +282,19 @@ sub indices(Cool $s, |c) {
     $s.indices(|c);
 }
 
-proto sub rindex($, $, $?) is pure { * };
+proto sub rindex($, $, $?) is pure {*};
 multi sub rindex(Cool $s, Cool $needle, Cool $pos) { $s.rindex($needle, $pos) };
 multi sub rindex(Cool $s, Cool $needle)            { $s.rindex($needle) };
 
-proto sub ords($) is pure     { * }
+proto sub ords($) is pure     {*}
 multi sub ords(Cool $s)       { ords($s.Stringy) }
 
-proto sub comb($, $, $?)            { * }
+proto sub comb($, $, $?)            {*}
 multi sub comb(Regex $matcher, Cool $input, $limit = *) { $input.comb($matcher, $limit) }
 multi sub comb(Str $matcher, Cool $input, $limit = *) { $input.comb($matcher, $limit) }
 multi sub comb(Int:D $matcher, Cool $input, $limit = *) { $input.comb($matcher, $limit) }
 
-proto sub wordcase($) is pure { * }
+proto sub wordcase($) is pure {*}
 multi sub wordcase(Str:D $x) {$x.wordcase }
 multi sub wordcase(Cool $x)  {$x.Str.wordcase }
 

--- a/src/core/Date.pm
+++ b/src/core/Date.pm
@@ -157,7 +157,7 @@ my class Date does Dateish {
         $dt.day == $!day && $dt.month == $!month && $dt.year == $!year
     }
 
-    proto method DateTime()  { * }
+    proto method DateTime()  {*}
     multi method DateTime(Date:D:) { DateTime.new(:$!year, :$!month, :$!day) }
     multi method DateTime(Date:U:) { DateTime }
     method Date() { self }

--- a/src/core/DateTime.pm
+++ b/src/core/DateTime.pm
@@ -366,7 +366,7 @@ my class DateTime does Dateish {
     method utc()   { self.in-timezone(0) }
     method local() { self.in-timezone($*TZ) }
 
-    proto method Date() { * }
+    proto method Date() {*}
     multi method Date(DateTime:D:) { Date.new($!year,$!month,$!day) }
     multi method Date(DateTime:U:) { Date }
     method DateTime() { self }

--- a/src/core/IO/Path.pm
+++ b/src/core/IO/Path.pm
@@ -214,7 +214,7 @@ my class IO::Path is Cool does IO {
     }
 #?endif
 
-    proto method absolute(|) { * }
+    proto method absolute(|) {*}
     multi method absolute (IO::Path:D:) {
         $!abspath //= $!SPEC.rel2abs($!path,$!CWD)
     }
@@ -326,7 +326,7 @@ my class IO::Path is Cool does IO {
         $resolved = $sep unless nqp::chars($resolved);
         IO::Path!new-from-absolute-path($resolved,:$!SPEC,:CWD($sep));
     }
-    proto method parent(|) { * }
+    proto method parent(|) {*}
     multi method parent(IO::Path:D: UInt:D $depth) {
         my $io = self;
         $io .= parent xx $depth;
@@ -402,7 +402,7 @@ my class IO::Path is Cool does IO {
         self.bless: :path($!SPEC.join: '', $!path, what), :$!SPEC, :$!CWD;
     }
 
-    proto method chdir(|) { * }
+    proto method chdir(|) {*}
     multi method chdir(IO::Path:D: Str() $path, :$test!) {
         DEPRECATED(
             :what<:$test argument>,
@@ -605,7 +605,7 @@ my class IO::Path is Cool does IO {
         }
     }
 
-    proto method slurp() { * }
+    proto method slurp() {*}
     multi method slurp(IO::Path:D: :$enc, :$bin) {
         # We use an IO::Handle in binary mode, and then decode the string
         # all in one go, which avoids the overhead of setting up streaming

--- a/src/core/Int.pm
+++ b/src/core/Int.pm
@@ -79,7 +79,7 @@ my class Int does Real { # declared in BOOTSTRAP
 
     method sqrt(Int:D:) { nqp::p6box_n(nqp::sqrt_n(nqp::tonum_I(self))) }
 
-    proto method base(|) { * }
+    proto method base(|) {*}
     multi method base(Int:D: Int:D $base) {
         2 <= $base <= 36
           ?? nqp::p6box_s(nqp::base_I(self,nqp::unbox_i($base)))

--- a/src/core/List.pm
+++ b/src/core/List.pm
@@ -393,7 +393,7 @@ my class List does Iterable does Positional { # declared in BOOTSTRAP
         )
     }
 
-    proto method fmt(|) { * }
+    proto method fmt(|) {*}
     multi method fmt() {
         nqp::if(
           (my int $elems = self.elems),             # reifies
@@ -724,7 +724,7 @@ my class List does Iterable does Positional { # declared in BOOTSTRAP
 
     # Store in List targets containers with in the list. This handles list
     # assignments, like ($a, $b) = foo().
-    proto method STORE(|) { * }
+    proto method STORE(|) {*}
     multi method STORE(List:D: Iterable:D \iterable) {
         # First pass -- scan lhs containers and pick out scalar versus list
         # assignment. This also reifies the RHS values we need, and deconts
@@ -932,7 +932,7 @@ my class List does Iterable does Positional { # declared in BOOTSTRAP
         )
     }
 
-    proto method pick(|) is nodal { * }
+    proto method pick(|) is nodal {*}
     multi method pick(List:D:) {
         self.is-lazy
          ?? Failure.new(X::Cannot::Lazy.new(:action('.pick from')))
@@ -993,7 +993,7 @@ my class List does Iterable does Positional { # declared in BOOTSTRAP
         }.new(self,$elems,$number))
     }
 
-    proto method roll(|) is nodal { * }
+    proto method roll(|) is nodal {*}
     multi method roll() {
         self.is-lazy
           ?? Failure.new(X::Cannot::Lazy.new(:action('.roll from')))
@@ -1477,7 +1477,7 @@ multi flat(Iterable \a)    {     a.flat }
 
 sub cache(+@l) { @l }
 
-proto sub infix:<xx>(|) { * }
+proto sub infix:<xx>(|) {*}
 multi sub infix:<xx>() { Failure.new("No zero-arg meaning for infix:<xx>") }
 multi sub infix:<xx>(Mu \x) { x }
 multi sub infix:<xx>(&x, Num() $n) {
@@ -1518,7 +1518,7 @@ multi sub infix:<xx>(Mu \x, Int:D $n) is pure {
     Seq.new(Rakudo::Iterator.OneValueTimes(x,$n))
 }
 
-proto sub reverse(|)   { * }
+proto sub reverse(|)   {*}
 multi sub reverse(@a)  { @a.reverse }
 multi sub reverse(+@a) { @a.reverse }
 

--- a/src/core/Mu.pm
+++ b/src/core/Mu.pm
@@ -10,7 +10,7 @@ my class Mu { # declared in BOOTSTRAP
 
     method sink(--> Nil) { }
 
-    proto method ACCEPTS(|) { * }
+    proto method ACCEPTS(|) {*}
     multi method ACCEPTS(Mu:U: Any \topic) {
         nqp::p6bool(nqp::istype(topic, self))
     }
@@ -42,7 +42,7 @@ my class Mu { # declared in BOOTSTRAP
         )
     }
 
-    proto method iterator(|) { * }
+    proto method iterator(|) {*}
     multi method iterator(Mu:) {
         my $buf := nqp::create(IterationBuffer);
         $buf.push(Mu);
@@ -52,8 +52,8 @@ my class Mu { # declared in BOOTSTRAP
         Rakudo::Iterator.ReifiedList($buf)
     }
 
-    proto method split(|) { * }
-    proto method splice(|) is nodal { * }
+    proto method split(|) {*}
+    proto method splice(|) is nodal {*}
 
     method emit {
         emit self;
@@ -72,7 +72,7 @@ my class Mu { # declared in BOOTSTRAP
         $list;
     }
 
-    proto method WHY(|) { * }
+    proto method WHY(|) {*}
     multi method WHY(Mu:) {
         my Mu $why;
 
@@ -108,7 +108,7 @@ Perhaps it can be found at https://docs.perl6.org/type/$name"
         nqp::p6bool(nqp::isconcrete(self))
     }
 
-    proto method new(|) { * }
+    proto method new(|) {*}
     multi method new(*%attrinit) {
         nqp::if(
           nqp::eqaddr(
@@ -123,7 +123,7 @@ Perhaps it can be found at https://docs.perl6.org/type/$name"
         X::Constructor::Positional.new(:type( self )).throw();
     }
 
-    proto method is-lazy (|) { * }
+    proto method is-lazy (|) {*}
     multi method is-lazy(Mu: --> False) { }
 
     method CREATE() {
@@ -535,18 +535,18 @@ Perhaps it can be found at https://docs.perl6.org/type/$name"
         self
     }
 
-    proto method Numeric(|) { * }
+    proto method Numeric(|) {*}
     multi method Numeric(Mu:U \v:) {
         warn "Use of uninitialized value of type {self.^name} in numeric context";
         0
     }
-    proto method Real(|) { * }
+    proto method Real(|) {*}
     multi method Real(Mu:U \v:) {
         warn "Use of uninitialized value of type {self.^name} in numeric context";
         0
     }
 
-    proto method Str(|) { * }
+    proto method Str(|) {*}
     multi method Str(Mu:U \v:) {
         my $name = (defined($*VAR_NAME) ?? $*VAR_NAME !! try v.VAR.?name) // '';
         $name   ~= ' ' if $name ne '';
@@ -563,7 +563,7 @@ Perhaps it can be found at https://docs.perl6.org/type/$name"
         )
     }
 
-    proto method Stringy(|) { * }
+    proto method Stringy(|) {*}
     multi method Stringy(Mu:U \v:) {
         my $*VAR_NAME = try v.VAR.?name;
         self.Str
@@ -572,7 +572,7 @@ Perhaps it can be found at https://docs.perl6.org/type/$name"
 
     method item(Mu \item:) is raw { item }
 
-    proto method say(|) { * }
+    proto method say(|) {*}
     multi method say() { say(self) }
     method print() { print(self) }
     method put() { put(self) }
@@ -602,7 +602,7 @@ Perhaps it can be found at https://docs.perl6.org/type/$name"
         }
     }
 
-    proto method gist(|) { * }
+    proto method gist(|) {*}
     multi method gist(Mu:U:) { '(' ~ self.^shortname ~ ')' }
     multi method gist(Mu:D:) { self.perl }
 
@@ -634,7 +634,7 @@ Perhaps it can be found at https://docs.perl6.org/type/$name"
         }
     }
 
-    proto method perl(|) { * }
+    proto method perl(|) {*}
     multi method perl(Mu:U:) { self.^name }
     multi method perl(Mu:D:) {
         nqp::if(
@@ -651,7 +651,7 @@ Perhaps it can be found at https://docs.perl6.org/type/$name"
         )
     }
 
-    proto method DUMP(|) { * }
+    proto method DUMP(|) {*}
     multi method DUMP(Mu:U:) { self.perl }
     multi method DUMP(Mu:D: :$indent-step = 4, :%ctx?) {
         return DUMP(self, :$indent-step) unless %ctx;
@@ -708,7 +708,7 @@ Perhaps it can be found at https://docs.perl6.org/type/$name"
         @pieces.DUMP-PIECES($before, :$indent-step);
     }
 
-    proto method isa(|) { * }
+    proto method isa(|) {*}
     multi method isa(Mu \SELF: Mu $type) {
         nqp::p6bool(SELF.^isa($type.WHAT))
     }
@@ -732,7 +732,7 @@ Perhaps it can be found at https://docs.perl6.org/type/$name"
         SELF.^can($name)
     }
 
-    proto method clone (|) { * }
+    proto method clone (|) {*}
     multi method clone(Mu:U: *%twiddles) {
         %twiddles and die 'Cannot set attribute values when cloning a type object';
         self
@@ -942,26 +942,26 @@ Perhaps it can be found at https://docs.perl6.org/type/$name"
 }
 
 
-proto sub defined(Mu) is pure { * }
+proto sub defined(Mu) is pure {*}
 multi sub defined(Mu \x) { x.defined }
 
-proto sub infix:<~~>(Mu \topic, Mu \matcher) { * }
+proto sub infix:<~~>(Mu \topic, Mu \matcher) {*}
 multi sub infix:<~~>(Mu \topic, Mu \matcher) {
     matcher.ACCEPTS(topic).Bool;
 }
 
-proto sub infix:<!~~>(Mu \topic, Mu \matcher) { * }
+proto sub infix:<!~~>(Mu \topic, Mu \matcher) {*}
 multi sub infix:<!~~>(Mu \topic, Mu \matcher) {
     matcher.ACCEPTS(topic).not;
 }
 
-proto sub infix:<=:=>(Mu $?, Mu $?) is pure { * }
+proto sub infix:<=:=>(Mu $?, Mu $?) is pure {*}
 multi sub infix:<=:=>($?)      { Bool::True }
 multi sub infix:<=:=>(Mu \a, Mu \b) {
     nqp::p6bool(nqp::eqaddr(a, b));
 }
 
-proto sub infix:<eqv>(Any $?, Any $?) is pure { * }
+proto sub infix:<eqv>(Any $?, Any $?) is pure {*}
 multi sub infix:<eqv>($?)            { Bool::True }
 
 # Last ditch snapshot semantics.  We shouldn't come here too often, so
@@ -1074,9 +1074,9 @@ sub DUMP(|args (*@args, :$indent-step = 4, :%ctx?)) {
 }
 
 # U+2212 minus (forward call to regular minus)
-proto sub  infix:<−>(|)  is pure { * }
+proto sub  infix:<−>(|)  is pure {*}
 multi sub  infix:<−>(|c)         {  infix:<->(|c) }
-proto sub prefix:<−>(|)  is pure { * }
+proto sub prefix:<−>(|)  is pure {*}
 multi sub prefix:<−>(|c)         { prefix:<->(|c) }
 
 # These must collapse Junctions

--- a/src/core/Numeric.pm
+++ b/src/core/Numeric.pm
@@ -42,13 +42,13 @@ multi sub infix:<eqv>(Numeric:D \a, Numeric:D \b) {
 
 ## arithmetic operators
 
-proto sub prefix:<+>($?) is pure { * }
+proto sub prefix:<+>($?) is pure {*}
 multi sub prefix:<+>(\a) { a.Numeric }
 
-proto sub prefix:<->($?) is pure { * }
+proto sub prefix:<->($?) is pure {*}
 multi sub prefix:<->(\a) { -a.Numeric }
 
-proto sub abs($) is pure { * }
+proto sub abs($) is pure {*}
 multi sub abs(\a) { abs a.Numeric }
 
 proto sub sign($) is pure {*}
@@ -169,53 +169,53 @@ proto sub sqrt($) is pure {*}
 multi sub sqrt(Numeric \x) { x.sqrt }
 multi sub sqrt(Cool \x)    { x.Numeric.sqrt }
 
-proto sub roots($, $) is pure { * }
+proto sub roots($, $) is pure {*}
 multi sub roots($x, Cool $n) { $x.Numeric.Complex.roots($n.Int) }
 multi sub roots($x, Numeric $n) { $x.Numeric.Complex.roots($n.Int) }
 
-proto sub floor($) is pure   { * }
+proto sub floor($) is pure   {*}
 multi sub floor($a)          { $a.Numeric.floor }
 multi sub floor(Numeric $a)  { $a.floor }
 
-proto sub ceiling($) is pure   { * }
+proto sub ceiling($) is pure   {*}
 multi sub ceiling($a)          { $a.Numeric.ceiling }
 multi sub ceiling(Numeric $a)  { $a.ceiling }
 
-proto sub round($, $?) is pure      { * }
+proto sub round($, $?) is pure      {*}
 multi sub round($a)                 { $a.Numeric.round }
 multi sub round(Numeric $a)         { $a.round }
 multi sub round(Numeric $a, $scale) { $a.round($scale) }
 
-proto sub infix:<+>(Mu $?, Mu $?) is pure   { * }
+proto sub infix:<+>(Mu $?, Mu $?) is pure   {*}
 multi sub infix:<+>($x = 0)      { $x.Numeric }
 multi sub infix:<+>(\a, \b)    { a.Numeric + b.Numeric }
 
-proto sub infix:<->(Mu $?, Mu $?) is pure   { * }
+proto sub infix:<->(Mu $?, Mu $?) is pure   {*}
 multi sub infix:<->($x = 0)      { -$x.Numeric }
 multi sub infix:<->(\a, \b)    { a.Numeric - b.Numeric }
 
-proto sub infix:<*>(Mu $?, Mu $?) is pure   { * }
+proto sub infix:<*>(Mu $?, Mu $?) is pure   {*}
 multi sub infix:<*>($x = 1)      { $x.Numeric }
 multi sub infix:<*>(\a, \b)    { a.Numeric * b.Numeric }
 
 sub infix:<×>(|c) is pure { infix:<*>(|c) }
 
-proto sub infix:</>(Mu $?, Mu $?) is pure { * }
+proto sub infix:</>(Mu $?, Mu $?) is pure {*}
 multi sub infix:</>() { Failure.new("No zero-arg meaning for infix:</>") }
 multi sub infix:</>($x)          { $x.Numeric }
 multi sub infix:</>(\a, \b)    { a.Numeric / b.Numeric }
 
 sub infix:<÷>(|c) is pure { infix:</>(|c) }
 
-proto sub infix:<div>(Mu $?, Mu $?) is pure  { * }
+proto sub infix:<div>(Mu $?, Mu $?) is pure  {*}
 # rest of infix:<div> is in Int.pm
 
-proto sub infix:<%>(Mu $?, Mu $?) is pure   { * }
+proto sub infix:<%>(Mu $?, Mu $?) is pure   {*}
 multi sub infix:<%>() { Failure.new("No zero-arg meaning for infix:<%>") }
 multi sub infix:<%>($x)          { $x }
 multi sub infix:<%>(\a, \b)    { a.Real % b.Real }
 
-proto sub infix:<%%>(Mu $?, Mu $?) is pure  { * }
+proto sub infix:<%%>(Mu $?, Mu $?) is pure  {*}
 multi sub infix:<%%>() { Failure.new("No zero-arg meaning for infix:<%%>") }
 multi sub infix:<%%>($)         { Bool::True }
 multi sub infix:<%%>(Int:D \a, Int:D \b) {
@@ -247,32 +247,32 @@ multi sub infix:<%%>(\a, \b) {
     )
 }
 
-proto sub infix:<lcm>(Mu $?, Mu $?) is pure  { * }
+proto sub infix:<lcm>(Mu $?, Mu $?) is pure  {*}
 multi sub infix:<lcm>(Int $x = 1) { $x }
 multi sub infix:<lcm>(\a, \b)   { a.Int lcm b.Int }
 
-proto sub infix:<gcd>(Mu $?, Mu $?) is pure { * }
+proto sub infix:<gcd>(Mu $?, Mu $?) is pure {*}
 multi sub infix:<gcd>() { Failure.new('No zero-arg meaning for infix:<gcd>') }
 multi sub infix:<gcd>(Int $x)    { $x }
 multi sub infix:<gcd>(\a, \b)  { a.Int gcd b.Int }
 
-proto sub infix:<**>(Mu $?, Mu $?) is pure  { * }
+proto sub infix:<**>(Mu $?, Mu $?) is pure  {*}
 multi sub infix:<**>($x = 1)     { $x.Numeric }
 multi sub infix:<**>(\a, \b)   { a.Numeric ** b.Numeric }
 
-proto sub postfix:<ⁿ>(Mu $, Mu $) is pure  { * }
+proto sub postfix:<ⁿ>(Mu $, Mu $) is pure  {*}
 multi sub postfix:<ⁿ>(\a, \b)  { a ** b }
 
 ## relational operators
 
-proto sub infix:«<=>»(Mu $, Mu $?) is pure { * }
+proto sub infix:«<=>»(Mu $, Mu $?) is pure {*}
 multi sub infix:«<=>»(\a, \b)  { a.Real <=> b.Real }
 
-proto sub infix:<==>(Mu $?, Mu $?) is pure { * }
+proto sub infix:<==>(Mu $?, Mu $?) is pure {*}
 multi sub infix:<==>($?)        { Bool::True }
 multi sub infix:<==>(\a, \b)   { a.Numeric == b.Numeric }
 
-proto sub infix:<≅>(Mu $?, Mu $?, *%) { * }  # note, can't be pure due to dynvar
+proto sub infix:<≅>(Mu $?, Mu $?, *%) {*}  # note, can't be pure due to dynvar
 multi sub infix:<≅>($?) { Bool::True }
 multi sub infix:<≅>(\a, \b, :$tolerance = $*TOLERANCE)    {
     # If operands are non-0, scale the tolerance to the larger of the abs values.
@@ -286,64 +286,64 @@ multi sub infix:<≅>(\a, \b, :$tolerance = $*TOLERANCE)    {
 }
 sub infix:<=~=>(|c) { infix:<≅>(|c) }
 
-proto sub infix:<!=>(Mu $?, Mu $?) is pure  { * }
+proto sub infix:<!=>(Mu $?, Mu $?) is pure  {*}
 multi sub infix:<!=>($?)                    { Bool::True }
 multi sub infix:<!=>(Mu \a, Mu \b)          { not a == b }
-proto sub infix:<≠> (Mu $?, Mu $?) is pure  { * }
+proto sub infix:<≠> (Mu $?, Mu $?) is pure  {*}
 multi sub infix:<≠> ($?)                    { Bool::True }
 multi sub infix:<≠> (Mu \a, Mu \b)          { not a == b }
 
-proto sub infix:«<»(Mu $?, Mu $?) is pure   { * }
+proto sub infix:«<»(Mu $?, Mu $?) is pure   {*}
 multi sub infix:«<»($?)         { Bool::True }
 multi sub infix:«<»(\a, \b)    { a.Real < b.Real }
 
-proto sub infix:«<=»(Mu $?, Mu $?) is pure { * }
+proto sub infix:«<=»(Mu $?, Mu $?) is pure {*}
 multi sub infix:«<=»($?)                   { Bool::True }
 multi sub infix:«<=»(\a, \b)               { a.Real <= b.Real }
-proto sub infix:«≤» (Mu $?, Mu $?) is pure { * }
+proto sub infix:«≤» (Mu $?, Mu $?) is pure {*}
 multi sub infix:«≤» ($?)                   { Bool::True }
 multi sub infix:«≤» (\a, \b)               { a.Real  ≤ b.Real }
 
-proto sub infix:«>»(Mu $?, Mu $?) is pure   { * }
+proto sub infix:«>»(Mu $?, Mu $?) is pure   {*}
 multi sub infix:«>»($?)         { Bool::True }
 multi sub infix:«>»(\a, \b)    { a.Real > b.Real }
 
-proto sub infix:«>=»(Mu $?, Mu $?) is pure  { * }
+proto sub infix:«>=»(Mu $?, Mu $?) is pure  {*}
 multi sub infix:«>=»($?)                    { Bool::True }
 multi sub infix:«>=»(\a, \b)                { a.Real >= b.Real }
-proto sub infix:«≥» (Mu $?, Mu $?) is pure  { * }
+proto sub infix:«≥» (Mu $?, Mu $?) is pure  {*}
 multi sub infix:«≥» ($?)                    { Bool::True }
 multi sub infix:«≥» (\a, \b)                { a.Real  ≥ b.Real }
 
 
 ## bitwise operators
 
-proto sub infix:<+&>(Mu $?, Mu $?) is pure { * }
+proto sub infix:<+&>(Mu $?, Mu $?) is pure {*}
 multi sub infix:<+&>()           { +^0 }
 multi sub infix:<+&>($x)         { $x }
 multi sub infix:<+&>($x, $y)     { $x.Numeric.Int +& $y.Numeric.Int }
 
-proto sub infix:<+|>(Mu $?, Mu $?) is pure { * }
+proto sub infix:<+|>(Mu $?, Mu $?) is pure {*}
 multi sub infix:<+|>()           { 0 }
 multi sub infix:<+|>($x)         { $x }
 multi sub infix:<+|>($x, $y)     { $x.Numeric.Int +| $y.Numeric.Int }
 
-proto sub infix:<+^>(Mu $?, Mu $?) is pure { * }
+proto sub infix:<+^>(Mu $?, Mu $?) is pure {*}
 multi sub infix:<+^>()           { 0 }
 multi sub infix:<+^>($x)         { $x }
 multi sub infix:<+^>($x, $y)     { $x.Numeric.Int +^ $y.Numeric.Int }
 
-proto sub infix:«+<»(Mu $?, Mu $?) is pure { * }
+proto sub infix:«+<»(Mu $?, Mu $?) is pure {*}
 multi sub infix:«+<»() { Failure.new("No zero-arg meaning for infix:«+<»") }
 multi sub infix:«+<»($x)         { $x }
 multi sub infix:«+<»($x,$y)      { $x.Numeric.Int +< $y.Numeric.Int }
 
-proto sub infix:«+>»(Mu $?, Mu $?) is pure { * }
+proto sub infix:«+>»(Mu $?, Mu $?) is pure {*}
 multi sub infix:«+>»() { Failure.new("No zero-arg meaning for infix:«+>»") }
 multi sub infix:«+>»($x)         { $x }
 multi sub infix:«+>»($x,$y)      { $x.Numeric.Int +> $y.Numeric.Int }
 
-proto sub prefix:<+^>(Mu $) is pure { * }
+proto sub prefix:<+^>(Mu $) is pure {*}
 multi sub prefix:<+^>($x)        { +^ $x.Numeric.Int }
 
 # vim: ft=perl6 expandtab sw=4

--- a/src/core/Proc/Async.pm
+++ b/src/core/Proc/Async.pm
@@ -118,7 +118,7 @@ my class Proc::Async {
     has $!encoder;
     has @!close-after-exit;
 
-    proto method new(|) { * }
+    proto method new(|) {*}
     multi method new(*@args where .so) {
         my $path = @args.shift;
         self.bless(:$path, :@args, |%_)
@@ -165,7 +165,7 @@ my class Proc::Async {
         }
     }
 
-    proto method stdout(|) { * }
+    proto method stdout(|) {*}
     multi method stdout(Proc::Async:D: :$bin!) {
         die X::Proc::Async::SupplyOrStd.new if $!merge_supply;
         die X::Proc::Async::BindOrUse.new(:handle<stdout>, :use('get the stdout Supply'))
@@ -183,7 +183,7 @@ my class Proc::Async {
             $enc, $!stdout_descriptor_vow, 1, :$translate-nl
     }
 
-    proto method stderr(|) { * }
+    proto method stderr(|) {*}
     multi method stderr(Proc::Async:D: :$bin!) {
         die X::Proc::Async::SupplyOrStd.new if $!merge_supply;
         die X::Proc::Async::BindOrUse.new(:handle<stderr>, :use('get the stderr Supply'))
@@ -201,7 +201,7 @@ my class Proc::Async {
             $enc, $!stderr_descriptor_vow, 2, :$translate-nl
     }
 
-    proto method Supply(|) { * }
+    proto method Supply(|) {*}
     multi method Supply(Proc::Async:D: :$bin!) {
         die X::Proc::Async::SupplyOrStd.new if $!stdout_supply || $!stderr_supply;
         die X::Proc::Async::BindOrUse.new(:handle<stdout>, :use('get the output Supply'))
@@ -405,7 +405,7 @@ my class Proc::Async {
 
     # Note: some of the duplicated code in methods could be moved to
     # proto, but at the moment (2017-06-02) that makes the call 24% slower
-    proto method kill(|) { * }
+    proto method kill(|) {*}
     multi method kill(Proc::Async:D: Signal:D \signal = SIGHUP) {
         X::Proc::Async::MustBeStarted.new(:method<kill>, proc => self).throw if !$!started;
         nqp::killprocasync($!process_handle, signal.value)

--- a/src/core/Rakudo/Internals.pm
+++ b/src/core/Rakudo/Internals.pm
@@ -1436,7 +1436,7 @@ my class Rakudo::Internals {
         $target
     }
 
-    proto method coremap(|) { * }
+    proto method coremap(|) {*}
 
     multi method coremap(\op, Associative \h, Bool :$deep) {
         my @keys = h.keys;

--- a/src/core/Range.pm
+++ b/src/core/Range.pm
@@ -373,7 +373,7 @@ my class Range is Cool does Iterable does Positional {
     }
 
     method bounds() { (nqp::decont($!min), nqp::decont($!max)) }
-    proto method int-bounds(|) { * }
+    proto method int-bounds(|) {*}
     multi method int-bounds($from is rw, $to is rw) {
         nqp::if(
           $!is-int,
@@ -481,7 +481,7 @@ my class Range is Cool does Iterable does Positional {
             !! "{$!min.perl}{'^' if $!excludes-min}..{'^' if $!excludes-max}$!max.perl()"
     }
 
-    proto method roll(|) { * }
+    proto method roll(|) {*}
     multi method roll(Range:D: Whatever) {
         if self.elems -> $elems {
             $!is-int
@@ -545,7 +545,7 @@ my class Range is Cool does Iterable does Positional {
         }
     }
 
-    proto method pick(|)        { * }
+    proto method pick(|)        {*}
     multi method pick()          { self.roll };
     multi method pick(Whatever)  { self.list.pick(*) };
     multi method pick(Int(Cool) $todo) {

--- a/src/core/Real.pm
+++ b/src/core/Real.pm
@@ -37,7 +37,7 @@ my role Real does Numeric {
     method floor() { self.Bridge.floor }
     method ceiling() { self.Bridge.ceiling }
 
-    proto method round(|) { * }
+    proto method round(|) {*}
     multi method round(Real:D:) {
         (self + 1/2).floor; # Rat NYI here, so no .5
     }
@@ -174,7 +174,7 @@ multi sub truncate(Real:D $x) { $x.truncate }
 multi sub truncate(Cool:D $x) { $x.Numeric.truncate }
 
 
-proto sub atan2($, $?)    { * }
+proto sub atan2($, $?)    {*}
 multi sub atan2(Real \a, Real \b = 1e0) { a.Bridge.atan2(b.Bridge) }
 # should really be (Cool, Cool), and then (Cool, Real) and (Real, Cool)
 # candidates, but since Int both conforms to Cool and Real, we'd get lots

--- a/src/core/ShapedArray.pm
+++ b/src/core/ShapedArray.pm
@@ -291,7 +291,7 @@
             }.new(to,from).sink-all
         }
 
-        proto method STORE(|) { * }
+        proto method STORE(|) {*}
         multi method STORE(::?CLASS:D: ::?CLASS:D \in) {
             nqp::if(
               in.shape eqv self.shape,

--- a/src/core/Str.pm
+++ b/src/core/Str.pm
@@ -336,7 +336,7 @@ my class Str does Stringy { # declared in BOOTSTRAP
         '"' ~ Rakudo::Internals.PERLIFY-STR(self) ~ '"'
     }
 
-    proto method comb(|) { * }
+    proto method comb(|) {*}
     multi method comb(Str:D:) {
         Seq.new(class :: does Iterator {
             has str $!str;
@@ -1291,7 +1291,7 @@ my class Str does Stringy { # declared in BOOTSTRAP
     }
 #?endif
 
-    proto method lines(|) { * }
+    proto method lines(|) {*}
     multi method lines(Str:D: :$count!) {
         # we should probably deprecate this feature
         $count ?? self.lines.elems !! self.lines;
@@ -2155,7 +2155,7 @@ my class Str does Stringy { # declared in BOOTSTRAP
         nqp::islt_i($pos, $left) ?? '' !! nqp::p6box_s(nqp::substr($str, $left, $pos + 1 - $left));
     }
 
-    proto method words(|) { * }
+    proto method words(|) {*}
     multi method words(Str:D: :$autoderef!) { # in Actions.postprocess_words
         my @list := self.words.List;
         return @list == 1 ?? @list[0] !! @list;
@@ -2706,7 +2706,7 @@ my class Str does Stringy { # declared in BOOTSTRAP
         }).join;
     }
 
-    proto method codes(|) { * }
+    proto method codes(|) {*}
     multi method codes(Str:D: --> Int:D) {
 #?if moar
         nqp::codes(self)
@@ -2720,7 +2720,7 @@ my class Str does Stringy { # declared in BOOTSTRAP
         0
     }
 
-    proto method chars(|) { * }
+    proto method chars(|) {*}
     multi method chars(Str:D: --> Int:D) {
         nqp::p6box_i(nqp::chars($!value))
     }
@@ -2729,7 +2729,7 @@ my class Str does Stringy { # declared in BOOTSTRAP
         0
     }
 
-    proto method uc(|) { * }
+    proto method uc(|) {*}
     multi method uc(Str:D:) {
         nqp::p6box_s(nqp::uc($!value));
     }
@@ -2737,7 +2737,7 @@ my class Str does Stringy { # declared in BOOTSTRAP
         self.Str;
     }
 
-    proto method lc(|) { * }
+    proto method lc(|) {*}
     multi method lc(Str:D:) {
         nqp::p6box_s(nqp::lc($!value));
     }
@@ -2745,7 +2745,7 @@ my class Str does Stringy { # declared in BOOTSTRAP
         self.Str;
     }
 
-    proto method tc(|) { * }
+    proto method tc(|) {*}
     multi method tc(Str:D:) {
         nqp::p6box_s(nqp::tc(nqp::substr($!value,0,1)) ~ nqp::substr($!value,1));
     }
@@ -2753,7 +2753,7 @@ my class Str does Stringy { # declared in BOOTSTRAP
         self.Str
     }
 
-    proto method fc(|) { * }
+    proto method fc(|) {*}
     multi method fc(Str:D:) {
         nqp::p6box_s(nqp::fc($!value));
     }
@@ -2761,7 +2761,7 @@ my class Str does Stringy { # declared in BOOTSTRAP
         self.Str;
     }
 
-    proto method tclc(|) { * }
+    proto method tclc(|) {*}
     multi method tclc(Str:D:) {
         nqp::p6box_s(nqp::tclc($!value))
     }
@@ -2769,7 +2769,7 @@ my class Str does Stringy { # declared in BOOTSTRAP
         self.Str
     }
 
-    proto method flip(|) { * }
+    proto method flip(|) {*}
     multi method flip(Str:D:) {
         nqp::p6box_s(nqp::flip($!value))
     }
@@ -2777,7 +2777,7 @@ my class Str does Stringy { # declared in BOOTSTRAP
         self.Str
     }
 
-    proto method ord(|) { * }
+    proto method ord(|) {*}
     multi method ord(Str:D: --> Int:D) {
         nqp::chars($!value)
           ?? nqp::p6box_i(nqp::ord($!value))
@@ -2919,7 +2919,7 @@ sub trim-leading (Cool:D $s --> Str:D) { $s.trim-leading }
 sub trim-trailing(Cool:D $s --> Str:D) { $s.trim-trailing }
 
 # the opposite of Real.base, used for :16($hex_str)
-proto sub UNBASE (|) { * }
+proto sub UNBASE (|) {*}
 multi sub UNBASE(Int:D $base, Any:D $num) {
     X::Numeric::Confused.new(:$num, :$base).throw;
 }
@@ -2961,8 +2961,8 @@ sub UNBASE_BRACKET($base, @a) {
     }
     $v;
 }
-proto sub infix:<unicmp>(|) is pure { * }
-proto sub infix:<coll>(|) { * }
+proto sub infix:<unicmp>(|) is pure {*}
+proto sub infix:<coll>(|) {*}
 #?if moar
 multi sub infix:<unicmp>(Str:D \a, Str:D \b --> Order:D) {
     ORDER(
@@ -3015,12 +3015,12 @@ sub chrs(*@c --> Str:D) {
     nqp::join("",$result)
 }
 
-proto sub parse-base(|) { * }
+proto sub parse-base(|) {*}
 multi sub parse-base(Str:D $str, Int:D $radix) { $str.parse-base($radix) }
 
 sub parse-names(Str:D $str) { $str.parse-names }
 
-proto sub substr(|) { * }
+proto sub substr(|) {*}
 multi sub substr(Str:D \what, Int:D \start) {
     my str $str  = nqp::unbox_s(what);
     my int $max  = nqp::chars($str);

--- a/src/core/array_operators.pm
+++ b/src/core/array_operators.pm
@@ -1,5 +1,5 @@
 # The [...] term creates an Array.
-proto circumfix:<[ ]>(|) { * }
+proto circumfix:<[ ]>(|) {*}
 multi circumfix:<[ ]>() {
     nqp::create(Array)
 }

--- a/src/core/control.pm
+++ b/src/core/control.pm
@@ -50,14 +50,14 @@ multi sub return(**@x is raw --> Nil) {
     nqp::throwpayloadlexcaller(nqp::const::CONTROL_RETURN, @x);
 }
 
-proto sub take-rw(|) { * }
+proto sub take-rw(|) {*}
 multi sub take-rw()   { die "take-rw without parameters doesn't make sense" }
 multi sub take-rw(\x) { THROW(nqp::const::CONTROL_TAKE, x) }
 multi sub take-rw(|) {
     THROW(nqp::const::CONTROL_TAKE,RETURN-LIST(nqp::p6argvmarray))
 }
 
-proto sub take(|) { * }
+proto sub take(|) {*}
 multi sub take()   { die "take without parameters doesn't make sense" }
 multi sub take(\x) {
     THROW(nqp::const::CONTROL_TAKE, nqp::p6recont_ro(x))
@@ -69,22 +69,22 @@ multi sub take(|) {
     )
 }
 
-proto sub goto(|) { * }
+proto sub goto(|) {*}
 multi sub goto(Label:D \x --> Nil) { x.goto }
 
-proto sub last(|) { * }
+proto sub last(|) {*}
 multi sub last(--> Nil) { nqp::throwextype(nqp::const::CONTROL_LAST); Nil }
 multi sub last(Label:D \x --> Nil) { x.last }
 
-proto sub next(|) { * }
+proto sub next(|) {*}
 multi sub next(--> Nil) { nqp::throwextype(nqp::const::CONTROL_NEXT); Nil }
 multi sub next(Label:D \x --> Nil) { x.next }
 
-proto sub redo(|) { * }
+proto sub redo(|) {*}
 multi sub redo(--> Nil) { nqp::throwextype(nqp::const::CONTROL_REDO); Nil }
 multi sub redo(Label:D \x --> Nil) { x.redo }
 
-proto sub succeed(|) { * }
+proto sub succeed(|) {*}
 multi sub succeed(--> Nil) { THROW-NIL(nqp::const::CONTROL_SUCCEED) }
 multi sub succeed(\x --> Nil) { THROW(nqp::const::CONTROL_SUCCEED, x) }
 multi sub succeed(| --> Nil) {

--- a/src/core/hash_slice.pm
+++ b/src/core/hash_slice.pm
@@ -1,6 +1,6 @@
 # all sub postcircumfix {} candidates here please
 
-proto sub postcircumfix:<{ }>(|) is nodal { * }
+proto sub postcircumfix:<{ }>(|) is nodal {*}
 
 # %h<key>
 multi sub postcircumfix:<{ }>( \SELF, \key ) is raw {
@@ -158,7 +158,7 @@ multi sub postcircumfix:<{ }>( \SELF, *%other ) is raw {
 }
 
 
-proto sub postcircumfix:<{; }>(|) is nodal { * }
+proto sub postcircumfix:<{; }>(|) is nodal {*}
 
 sub MD-HASH-SLICE-ONE-POSITION(\SELF, \indices, \idx, int $dim, \target) {
     my int $next-dim = $dim + 1;

--- a/src/core/io_operators.pm
+++ b/src/core/io_operators.pm
@@ -1,6 +1,6 @@
 my class IO::ArgFiles { ... }
 
-proto sub print(|) { * }
+proto sub print(|) {*}
 multi sub print(Str:D \x) {
     $*OUT.print(x);
 }
@@ -13,7 +13,7 @@ multi sub print(**@args is raw) {
     $*OUT.print($str);
 }
 
-proto sub say(|) { * }
+proto sub say(|) {*}
 multi sub say() { $*OUT.print-nl }
 multi sub say(Str:D \x) {
     my $out := $*OUT;
@@ -33,7 +33,7 @@ multi sub say(**@args is raw) {
     $out.print(nqp::concat($str,$out.nl-out));
 }
 
-proto sub put(|) { * }
+proto sub put(|) {*}
 multi sub put() { $*OUT.print-nl }
 multi sub put(Str:D \x) {
     my $out := $*OUT;
@@ -53,7 +53,7 @@ multi sub put(**@args is raw) {
     $out.print(nqp::concat($str,$out.nl-out));
 }
 
-proto sub note(|) { * }
+proto sub note(|) {*}
 multi sub note() {
     my $err := $*ERR;
     $err.print(nqp::concat("Noted",$err.nl-out));
@@ -86,34 +86,34 @@ multi sub prompt($msg) {
     $*IN.get;
 }
 
-proto sub dir(|) { * }
+proto sub dir(|) {*}
 multi sub dir(*%_) { $*SPEC.curdir.IO.dir(:!absolute, |%_) }
 multi sub dir(IO::Path:D $path, |c) { $path.dir(|c) }
 multi sub dir(IO()       $path, |c) { $path.dir(|c) }
 
-proto sub open(|) { * }
+proto sub open(|) {*}
 multi sub open(IO() $path, |c) { IO::Handle.new(:$path).open(|c) }
 
-proto sub lines(|) { * }
+proto sub lines(|) {*}
 multi sub lines($what = $*ARGFILES, |c) { $what.lines(|c) }
 
-proto sub words(|) { * }
+proto sub words(|) {*}
 multi sub words($what = $*ARGFILES, |c) { $what.words(|c) }
 
-proto sub get  (|) { * }
+proto sub get  (|) {*}
 multi sub get  (IO::Handle:D $fh = $*ARGFILES) { $fh.get  }
 
-proto sub getc (|) { * }
+proto sub getc (|) {*}
 multi sub getc (IO::Handle:D $fh = $*ARGFILES) { $fh.getc }
 
-proto sub close(|) { * }
+proto sub close(|) {*}
 multi sub close(IO::Handle:D $fh) { $fh.close }
 
-proto sub slurp(|) { * }
+proto sub slurp(|) {*}
 multi sub slurp(IO::Handle:D $fh = $*ARGFILES, |c) { $fh.slurp(|c) }
 multi sub slurp(IO() $path, |c) { $path.slurp(|c) }
 
-proto sub spurt(|) { * }
+proto sub spurt(|) {*}
 multi sub spurt(IO::Handle:D $fh,   |c) { $fh  .spurt(|c) }
 multi sub spurt(IO()       $path, |c) { $path.spurt(|c) }
 

--- a/src/core/metaops.pm
+++ b/src/core/metaops.pm
@@ -116,7 +116,7 @@ sub METAOP_ZIP(\op, &reduce) {
     )
 }
 
-proto sub METAOP_REDUCE_LEFT(|) { * }
+proto sub METAOP_REDUCE_LEFT(|) {*}
 multi sub METAOP_REDUCE_LEFT(\op, \triangle) {
     if op.count > 2 and op.count < Inf {
         my $count = op.count;
@@ -212,7 +212,7 @@ multi sub METAOP_REDUCE_LEFT(\op) {
     }
 }
 
-proto sub METAOP_REDUCE_RIGHT(|) { * }
+proto sub METAOP_REDUCE_RIGHT(|) {*}
 multi sub METAOP_REDUCE_RIGHT(\op, \triangle) {
     nqp::if(
       op.count < Inf && nqp::isgt_i((my int $count = op.count),2),
@@ -398,7 +398,7 @@ multi sub METAOP_REDUCE_RIGHT(\op) {
     )
 }
 
-proto sub METAOP_REDUCE_LIST(|) { * }
+proto sub METAOP_REDUCE_LIST(|) {*}
 multi sub METAOP_REDUCE_LIST(\op, \triangle) {
     sub (+values) {
         GATHER({
@@ -414,7 +414,7 @@ multi sub METAOP_REDUCE_LIST(\op) {
     sub (+values) { op.(|values) }
 }
 
-proto sub METAOP_REDUCE_LISTINFIX(|) { * }
+proto sub METAOP_REDUCE_LISTINFIX(|) {*}
 multi sub METAOP_REDUCE_LISTINFIX(\op, \triangle) {
     sub (|values) {
         my \p = values[0];
@@ -436,7 +436,7 @@ multi sub METAOP_REDUCE_LISTINFIX(\op) {
     }
 }
 
-proto sub METAOP_REDUCE_CHAIN(|) { * }
+proto sub METAOP_REDUCE_CHAIN(|) {*}
 multi sub METAOP_REDUCE_CHAIN(\op, \triangle) {
     sub (+values) {
         my $state = True;
@@ -526,7 +526,7 @@ sub METAOP_HYPER_PREFIX(\op) {
 
 sub METAOP_HYPER_CALL(\list, |args) { deepmap(-> $c { $c(|args) }, list) }
 
-proto sub HYPER(|) { * }
+proto sub HYPER(|) {*}
 
 multi sub HYPER(&op, \left, \right, :$dwim-left, :$dwim-right) {
     op(left, right);
@@ -643,7 +643,7 @@ multi sub HYPER(\op, \obj) {
     )
 }
 
-proto sub deepmap(|) { * }
+proto sub deepmap(|) {*}
 
 multi sub deepmap(\op, \obj) {
     Rakudo::Internals.coremap(op, obj, :deep)
@@ -654,7 +654,7 @@ multi sub deepmap(\op, Associative \h) {
     hash @keys Z deepmap(op, h{@keys})
 }
 
-proto sub nodemap(|) { * }
+proto sub nodemap(|) {*}
 multi sub nodemap(\op, \obj) {
     my Mu $rpa := nqp::create(IterationBuffer);
     my \objs := obj.list;
@@ -697,7 +697,7 @@ multi sub nodemap(\op, Associative \h) {
     hash @keys Z nodemap(op, h{@keys})
 }
 
-proto sub duckmap(|) { * }
+proto sub duckmap(|) {*}
 multi sub duckmap(\op, \obj) {
     Rakudo::Internals.coremap(sub (\arg) { CATCH { return arg ~~ Iterable:D ?? duckmap(op,arg) !! arg }; op.(arg); }, obj);
 }

--- a/src/core/operators.pm
+++ b/src/core/operators.pm
@@ -12,7 +12,7 @@ my class X::Does::TypeObject is Exception {
     method message() { "Cannot use 'does' operator with a type object." }
 }
 
-proto sub infix:<does>(|) { * }
+proto sub infix:<does>(|) {*}
 multi sub infix:<does>(Mu:D \obj, Mu:U \rolish) is raw {
     # XXX Mutability check.
     my $role := rolish.HOW.archetypes.composable() ?? rolish !!
@@ -51,7 +51,7 @@ multi sub infix:<cmp>(Rational:D \a, Rational:D \b) is default {
     a.isNaN || b.isNaN ?? a.Num cmp b.Num !! a <=> b
 }
 
-proto sub infix:<but>(|) is pure { * }
+proto sub infix:<but>(|) is pure {*}
 multi sub infix:<but>(Mu:D \obj, Mu:U \rolish) {
     my $role := rolish.HOW.archetypes.composable() ?? rolish !!
                 rolish.HOW.archetypes.composalizable() ?? rolish.HOW.composalize(rolish) !!
@@ -466,7 +466,7 @@ sub WHAT(Mu \x) { x.WHAT }
 sub HOW (Mu \x) { x.HOW }
 sub VAR (Mu \x) { x.VAR }
 
-proto sub infix:<...>(|) { * }
+proto sub infix:<...>(|) {*}
 multi sub infix:<...>(\a, Mu \b) { Seq.new(SEQUENCE(a, b).iterator) }
 multi sub infix:<...>(|lol) {
     my @lol := lol.list;
@@ -506,13 +506,13 @@ multi sub infix:<...>(|lol) {
     }
 }
 
-proto sub infix:<...^>(|) { * }
+proto sub infix:<...^>(|) {*}
 multi sub infix:<...^>(\a, Mu \b) { Seq.new(SEQUENCE(a, b, :exclude_end(1)).iterator) }
 
-proto sub infix:<…>(|) { * }
+proto sub infix:<…>(|) {*}
 multi sub infix:<…>(|c) { infix:<...>(|c) }
 
-proto sub infix:<…^>(|) { * }
+proto sub infix:<…^>(|) {*}
 multi sub infix:<…^>(|c) { infix:<...^>(|c) }
 
 multi sub undefine(Mu \x) is raw { x = Nil }


### PR DESCRIPTION
Convert all `{ * }` to `{*}` for consistency.

Rakudo builds OK and passes `make m-test m-spectest`.