### PR TITLE
RFC: IO::Path.resolve for windows 2nd attempt

### DIFF
--- a/src/core/IO/Spec/Win32.pm
+++ b/src/core/IO/Spec/Win32.pm
@@ -254,11 +254,11 @@ my class IO::Spec::Win32 is IO::Spec::Unix {
           nqp::eqat($volume, ':', 1) # this chunk == ~~ /^<[A..Z a..z]>':'/
             && ( (nqp::isge_i($temp, 65) && nqp::isle_i($temp, 90))
               || (nqp::isge_i($temp, 97) && nqp::isle_i($temp, 122))),
-          ($volume = nqp::uc($volume)),
-          nqp::if(
-            ($temp = nqp::chars($volume))
-              && nqp::isfalse(nqp::eqat($volume, ｢\｣, nqp::sub_i($temp, 1))),
-            ($volume = nqp::concat($volume, ｢\｣))));
+          ($volume = nqp::uc($volume)));
+        nqp::if(
+          ($temp = nqp::chars($volume))
+            && nqp::isfalse(nqp::eqat($volume, ｢\｣, nqp::sub_i($temp, 1))),
+          ($volume = nqp::concat($volume, ｢\｣)));
 
         $path = join ｢\｣, $path, @rest.flat;
 


### PR DESCRIPTION
The first of the 2 commits actually do break spec tests. I've added some details to the commit message as well.

In my opinion the spec test could be wrong, that's why I am still sending this PR. I am assuming that when you work on a `:volume<C:>` and you create a path with this volume that you must create the \ ( of C:**\\**$whatever ).

This is the result of resolve with IO::Spec::Win32 Spec:
> ./perl6 -e '$*SPEC = IO::Spec::Win32; "C:\\foo\\bar".IO.resolve.say'
"C:\foo\bar".IO
