### PR TITLE
Pass typenames to two compile time exceptions

### DIFF
--- a/src/core/Exception.pm
+++ b/src/core/Exception.pm
@@ -2161,9 +2161,9 @@ my class X::ControlFlow::Return is X::ControlFlow {
 
 my class X::Composition::NotComposable does X::Comp {
     has $.target-name;
-    has $.composer;
+    has $.composer-name;
     method message() {
-        $!composer.^name ~ " is not composable, so $!target-name cannot compose it";
+        $.composer-name ~ " is not composable, so $.target-name cannot compose it";
     }
 }
 
@@ -2328,10 +2328,10 @@ my class X::Inheritance::Unsupported does X::Comp {
     # has been composed, so it's useless to carry it around. Use the
     # name instead.
     has $.child-typename;
-    has $.parent;
+    has $.parent-typename;
     method message {
-        $!parent.^name ~ ' does not support inheritance, so '
-        ~ $!child-typename ~ ' cannot inherit from it';
+        $.parent-typename ~ ' does not support inheritance, so '
+        ~ $.child-typename ~ ' cannot inherit from it';
     }
 }
 

--- a/src/core/Variable.pm
+++ b/src/core/Variable.pm
@@ -117,8 +117,8 @@ multi sub trait_mod:<does>(Variable:D $v, Mu:U $role) {
     }
     else {
         X::Composition::NotComposable.new(
-            target-name => 'a variable',
-            composer    => $role,
+            target-name   => 'a variable',
+            composer-name => $role.^name,
         ).throw;
     }
 }

--- a/src/core/traits.pm
+++ b/src/core/traits.pm
@@ -32,7 +32,7 @@ multi sub trait_mod:<is>(Mu:U $child, Mu:U $parent) {
     else {
         X::Inheritance::Unsupported.new(
             :child-typename($child.^name),
-            :$parent,
+            :parent-typename($parent.^name),
         ).throw;
     }
 }
@@ -316,8 +316,8 @@ multi sub trait_mod:<does>(Mu:U $doee, Mu:U $role) {
     }
     else {
         X::Composition::NotComposable.new(
-            target-name => $doee.^name,
-            composer    => $role,
+            target-name   => $doee.^name,
+            composer-name => $role.^name,
         ).throw;
     }
 }
@@ -496,7 +496,7 @@ multi sub trait_mod:<hides>(Mu:U $child, Mu:U $parent) {
     else {
         X::Inheritance::Unsupported.new(
             :child-typename($child.^name),
-            :$parent,
+            :parent-typename($parent.^name),
         ).throw;
     }
 }


### PR DESCRIPTION
The typenames are the only things needed for the error messages
in X::Inheritance::Unsupported and X::Composition::NotComposable.

With this change it's no longer necessary to use $! twigils when
generating the error messages (cmp. commit a822bcf9cf).

Also this makes two failing tests for RT #129906 (StackOverflowError,
probably caused by failed typechecks for the parameters in question)
in integration/error-reporting.t pass again on the JVM backend.