### PR TITLE
Fixes #1258

### DIFF
--- a/src/core/Supply.pm
+++ b/src/core/Supply.pm
@@ -671,7 +671,7 @@ my class Supply does Awaitable {
 
     my class ConcQueue is repr('ConcBlockingQueue') { }
     multi method list(Supply:D:) {
-        $.Seq.list
+        self.Seq.list
     }
     method Seq(Supply:D:) {
         gather {

--- a/src/core/Supply.pm
+++ b/src/core/Supply.pm
@@ -671,6 +671,9 @@ my class Supply does Awaitable {
 
     my class ConcQueue is repr('ConcBlockingQueue') { }
     multi method list(Supply:D:) {
+        $.Seq.list
+    }
+    method Seq(Supply:D:) {
         gather {
             my Mu \queue = nqp::create(ConcQueue);
             my $exception;


### PR DESCRIPTION
Fixes #1258 renaming the Supply.list to Supply.Seq and creating Supply.list that calls Supply.Seq.list