### PR TITLE
Untwine Pod

### DIFF
--- a/src/Perl6/Pod.nqp
+++ b/src/Perl6/Pod.nqp
@@ -215,86 +215,84 @@ class Perl6::Pod {
         return subst($a, /\s*$/, '');
     }
 
-    our sub merge_twines(@twines) {
-        my @ret := @twines.shift.ast;
-        for @twines {
-            my @cur   := $_.ast;
-            @ret.push(
-                $*W.add_constant(
-                    'Str', 'str',
-                    nqp::unbox_s(@ret.pop) ~ ' ' ~ nqp::unbox_s(@cur.shift)
-                ).compile_time_value,
-            );
-            nqp::splice(@ret, @cur, +@ret, 0);
+    our sub pod_strings_from_matches(@string_matches) {
+        my @strings := [];
+        for @string_matches {
+            @strings.push($_.ast);
+
         }
-        return @ret;
+        return build_pod_strings(@strings);
+
     }
 
-    our sub build_pod_string(@content) {
-        return $*POD_IN_CODE_BLOCK
-            ?? build_pod_code_string(@content)
-            !! build_pod_regular_string(@content)
-    }
+    # Takes an array of arrays of pod characters (normal character or
+    # formatting code) returns an array of strings and formatting codes
+    our sub build_pod_strings(@strings) {
+        my $in_code := $*POD_IN_CODE_BLOCK;
 
-    our sub build_pod_regular_string(@content) {
-        sub push_regular_strings(@strings, @where) {
-            my $s := subst(nqp::join('', @strings), /\s+/, ' ', :global);
-            my $t := $*W.add_constant(
-                'Str', 'str', $s
-            ).compile_time_value;
-            @where.push($t);
+        sub push_chars(@chars, @where) {
+            if @chars {
+                my $s := nqp::join('', @chars);
+                if ! $in_code {
+                    $s := subst($s, /\s+/, ' ', :global);
+                }
+                $s := $*W.add_constant('Str', 'str', $s).compile_time_value;
+                @where.push($s);
+            }
         }
+
 
         my @res  := [];
-        my @strs := [];
-        for @content -> $elem {
-            if nqp::isstr($elem) {
-                # don't push the leading whitespace
-                if +@res + @strs == 0 && $elem eq ' ' {
-
+        my @chars := [];
+        my int $i := 0;
+        my int $last := nqp::elems(@strings) - 1;
+        while $i <= $last {
+            my @string := @strings[$i];
+            for @string -> $char {
+                if nqp::isstr($char) {
+                    # don't push the leading whitespace unless code block
+                    if $in_code || +@res + @chars != 0 || $char ne ' ' {
+                        @chars.push($char);
+                    }
                 }
                 else {
-                    @strs.push($elem);
+                    # formatting code - join the preceeding characters
+                    # to the result, then add the formatting code
+                    push_chars(@chars, @res);
+                    @chars := [];
+                    @res.push($char);
                 }
             }
-            else {
-                push_regular_strings(@strs, @res);
-                @strs := [];
-                @res.push($elem);
-            }
-        }
-        push_regular_strings(@strs, @res);
 
+            if $i != $last {
+                # space inbetween each string
+                @chars.push(' ');
+            }
+            $i := $i + 1;
+        }
+
+        push_chars(@chars, @res);
         return @res;
     }
 
-    # Code strings need to be handled differently:
-    # Formatting codes need to be saved, but everything
-    # else should be verbatim
-    our sub build_pod_code_string(@content) {
-        sub push_code_strings(@strings, @where) {
-            my $s := nqp::join('', @strings);
-            my $t := $*W.add_constant(
-                'Str', 'str', $s
-            ).compile_time_value;
-            @where.push($t);
-        }
-
-        my @res  := [];
-        my @strs := [];
-        for @content -> $elem {
-            if nqp::isstr($elem) {
-                @strs.push($elem);
-            }
-            else {
-                push_code_strings(@strs, @res);
-                @strs := [];
-                @res.push($elem);
+    our sub build_pod_chars($pod_string_characters) {
+        my @chars := [];
+        if $pod_string_characters {
+            for $pod_string_characters {
+                my $char := $_.ast;
+                # $char can sometimes be an array because of the way
+                # pod_balanced_braces works
+                if nqp::istype($char,VMArray) {
+                    for $char {
+                        @chars.push($_);
+                    }
+                }
+                else {
+                    @chars.push($_.ast);
+                }
             }
         }
-        push_code_strings(@strs, @res);
-
-        return @res;
+        return @chars;
     }
 
     # serializes the given array


### PR DESCRIPTION
This is a re-merge of LLFour:pod-fc-fixes branch, rakudo/rakudo pull #651

The changes to roast (see below) are still required.

Original commit message:

tl;dr =pod C<foo> now becomes [ FormattingCode ] instead of ["",FormattingCode,""]

After merge, merge:

    perl6/roast#90 (tests)
    perl6/doc#261

long story
I started out trying to fix stray empty strings being everywhere:

https://rt.perl.org/Public/Bug/Display.html?id=126966

Turns out empty strings were a symptom of a twine algorithm (every FormattingCode has to be intertwined with a string). This implementation detail side effect then leaked out everywhere:

    In the tests: perl6/roast#90 (depends on odd array indexes because of empty strings)
    in Pod::To::HTML: perl6/Pod-To-HTML#9 (caused by empty strings)
    in the htmlifying code: https://github.com/perl6/doc/blob/master/htmlify.p6#L379
    it sorta meant it had to serialize strings that never got used

The purpose of this commit is to expunge this algorithm. Because it is a relatively large commit I did some due diligence and tested it on a pod file containing the concatenation of all the .pod in docs and then putting $=pod.perl.say at the end.

bash-3.2$ /usr/bin/time -l perl6 test.pod  | wc -c
       58.72 real        58.26 user         0.35 sys
 705699840  maximum resident set size
...
 3672024
bash-3.2$ /usr/bin/time -l p6 test.pod  | wc -c #patched
       59.07 real        58.29 user         0.54 sys
1181294592  maximum resident set size
...
 3663120

I also did a precompile with --target=mbc to see the difference:

1.5M 24 Dec 13:59 test.pod
6.8M 24 Dec 23:08 test.pod.moarvm
6.1M 24 Dec 23:03 test.patched.pod.moarvm

This shows:

    This commit increases the amount of memory used during compilation from 700Mb => 1200Mb
    that there are less characters in the output (due to less "" everywhere)
    The patched one has a smaller image size due to less unnecessary serialization
    They are roughly the same speed

Despite 1. I suggest merging this. It's not caused by my code (I think) but my code exacerbates whatever issue is causing rakudo to need 700Mb to compile a 1.5Mb pod file in the first place. I made a RT:
https://rt.perl.org/Public/Bug/Display.html?id=127020

Given we have precomp now 🎉 this patch only benefits real world non-compiling-large-amounts of pod-code-at-runtime stuff. Also from here it's easier to implement NYI tags like S<> T<> etc.

Oh and =pod B< < B<foo> > > will work instead of dying with LTA error now

Merry christmas!