### PR TITLE
Drop extraneous spaces in code and table blocks

### DIFF
--- a/lib/Pod/To/Text.pm6
+++ b/lib/Pod/To/Text.pm6
@@ -36,7 +36,7 @@ sub heading2text($pod) {
 }
 
 sub code2text($pod) {
-    "    " ~ $pod.contents>>.&pod2text.subst(/\n/, "\n    ", :g)
+    $pod.contents>>.&pod2text.join.indent(4)
 }
 
 sub item2text($pod) {
@@ -64,17 +64,18 @@ sub table2text($pod) {
     @rows.unshift($pod.headers.item) if $pod.headers;
     my @maxes;
     my $cols = [max] @rows.map({ .elems });
-    for 0..^$cols -> $i {
+    for ^$cols -> $i {
         @maxes.push([max] @rows.map({ $i < $_ ?? $_[$i].chars !! 0 }));
     }
+    @maxes[*-1] = 0;  # Don't pad last column with spaces
     my $ret;
     if $pod.config<caption> {
         $ret = $pod.config<caption> ~ "\n"
     }
     for @rows -> $row {
-        for 0..($row.elems - 1) -> $i {
-            $ret ~= $row[$i].fmt("%-{@maxes[$i]}s") ~ "  ";
-        }
+        # Gutter of two spaces between columns
+        $ret ~= join '  ',
+            (@maxes Z=> @$row).map: { .value.fmt("%-{.key}s") };
         $ret ~= "\n";
     }
     $ret

--- a/t/07-pod-to-text/01-whitespace.t
+++ b/t/07-pod-to-text/01-whitespace.t
@@ -1,0 +1,75 @@
+use v6.c;
+use lib <t/spec/packages>;
+use Test;
+
+use Pod::To::Text;
+
+plan 2;
+
+my $ix = -1;
+
+subtest 'Code blocks' => {
+    plan 3;
+
+    =begin code
+    say 1;
+
+    say 2;
+    =end code
+
+    is Pod::To::Text.render($=pod[++$ix]),
+        q:to/END/, "Empty lines don't get added spaces";
+            say 1;
+
+            say 2;
+        END
+
+    =begin code
+    my $a = -5;
+    say ++$a.=abs;
+    # OUTPUT: «6␤»
+    =end code
+
+    is Pod::To::Text.render($=pod[++$ix]),
+        q:to/END/, "Plain continuation lines are aligned";
+            my $a = -5;
+            say ++$a.=abs;
+            # OUTPUT: «6␤»
+        END
+
+    =begin code :allow<B L>
+    sub exclaim B<($phrase)> {
+        say $phrase L<~> "!!!!"
+    }
+    exclaim "Howdy, World";
+    =end code
+    is Pod::To::Text.render($=pod[++$ix]),
+        q:to/END/, "Formatting Codes in code block";
+            sub exclaim ($phrase) {
+                say $phrase ~ "!!!!"
+            }
+            exclaim "Howdy, World";
+        END
+}
+
+subtest 'Tables' => {
+    plan 1;
+
+=begin table
+    \+term          | prefix
+    term1 \+ term2  | infix
+    term\+\+        | postfix
+    (term)          | circumfix
+    term1[term2]    | postcircumfix
+=end table
+    is Pod::To::Text.render($=pod[++$ix]),
+        q:to/END/, "Final table row is not space-padded";
+        +term          prefix
+        term1 + term2  infix
+        term++         postfix
+        (term)         circumfix
+        term1[term2]   postcircumfix
+        END
+}
+
+# vim: expandtab shiftwidth=4 ft=perl6

--- a/tools/build/Makefile-JVM.in
+++ b/tools/build/Makefile-JVM.in
@@ -178,7 +178,7 @@ j-test    : j-coretest
 j-fulltest: j-coretest j-stresstest
 
 j-coretest: j-all
-	$(J_HARNESS5) t/01-sanity t/02-rakudo t/03-jvm t/04-nativecall t/05-messages t/06-telemetry
+	$(J_HARNESS5) t/01-sanity t/02-rakudo t/03-jvm t/04-nativecall t/05-messages t/06-telemetry t/07-pod-to-text
 
 # Run the spectests that we know work.
 j-spectest: j-testable t/spectest.data

--- a/tools/build/Makefile-Moar.in
+++ b/tools/build/Makefile-Moar.in
@@ -231,7 +231,7 @@ m-quicktest: m-quicktest$(HARNESS_TYPE)
 m-stresstest: m-stresstest$(HARNESS_TYPE)
 
 m-coretest5: m-all
-	$(M_HARNESS5) t/01-sanity t/02-rakudo t/04-nativecall t/05-messages t/06-telemetry
+	$(M_HARNESS5) t/01-sanity t/02-rakudo t/04-nativecall t/05-messages t/06-telemetry t/07-pod-to-text
 
 # Run the spectests that we know work.
 m-spectest5: m-testable t/spectest.data
@@ -248,7 +248,7 @@ m-stresstest5: m-testable t/spectest.data
 
 
 m-coretest6: m-all
-	$(M_HARNESS6) t/01-sanity t/02-rakudo t/04-nativecall t/05-messages t/06-telemetry
+	$(M_HARNESS6) t/01-sanity t/02-rakudo t/04-nativecall t/05-messages t/06-telemetry t/07-pod-to-text
 
 # Run the spectests that we know work.
 m-spectest6: m-testable t/spectest.data


### PR DESCRIPTION
code2text() was missing a .join call, so inserted extra spaces between
chunks (e.g. around embedded formatting codes).

table2text() was padding the final column in each row, which is not
desirable in a plain text format.