### PR TITLE
Add two special cases for infix:<,>

### DIFF
--- a/src/core/List.pm6
+++ b/src/core/List.pm6
@@ -1492,6 +1492,12 @@ my class List does Iterable does Positional { # declared in BOOTSTRAP
 # The , operator produces a List.
 proto sub infix:<,>(|) is pure {*}
 multi sub infix:<,>() { nqp::create(List) }
+multi sub infix:<,>(Int \a, Int \b) is default {
+    nqp::p6bindattrinvres(nqp::create(List),List,'$!reified',nqp::list(a,b))
+}
+multi sub infix:<,>(Str \a, Str \b) {
+    nqp::p6bindattrinvres(nqp::create(List),List,'$!reified',nqp::list(a,b))
+}
 multi sub infix:<,>(|) {
 
     # look for a Slip in the parameters


### PR DESCRIPTION
Since these are likely to be common cases, give them a fast path.

Passes `make m-test m-spectest`.

`my $a; my $b; ($a,$b) = "a","b" for ^1000000` decreases from ~5.4s to ~4.9s.