### PR TITLE
Issue 1305: Throw exception on attempted assign to range pos

### DIFF
--- a/src/core/Range.pm
+++ b/src/core/Range.pm
@@ -454,6 +454,8 @@ my class Range is Cool does Iterable does Positional {
                     && !(!topic.excludes-max && $!excludes-max))
     }
 
+    method ASSIGN-POS(Range:D: |) { X::Assignment::RO.new(value => self).throw }
+
     multi method AT-POS(Range:D: int \pos) {
         $!is-int
             ?? self.EXISTS-POS(pos)


### PR DESCRIPTION
Range is immutable as mentioned in the spec
<https://github.com/perl6/specs/blob/master/S02-bits.pod#immutable-types>

Assignment failed before, but this provides a clearer error message.
