### PR TITLE
Add ⏨ as exponent notation for floats.

### DIFF
--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -3655,7 +3655,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         ]
     }
 
-    token escale { <[Ee]> <sign> <decint> }
+    token escale { <[Ee⏨]> <sign> <decint> }
 
     token sign { '+' | '-' | '−' | '' }
 


### PR DESCRIPTION
To address #1347 in case anyone eventually cares.