### PR TITLE
Issue 1204: Don't wrap quoteword in Slip if one word

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -9774,7 +9774,17 @@ class Perl6::QActions is HLL::Actions does STDActions {
             }
         }
         walk($past);
-        +@($result) == 1 ?? $result[0] !! QAST::Stmts.new( $result )
+
+        # Strip out list op and possible Slip if only one resulting word
+        nqp::if(
+            +@($result) == 1,
+            nqp::if(
+                nqp::istype($result[0], QAST::Op) && $result[0].name eq 'Slip',
+                $result[0][0],
+                $result[0]
+            ),
+            QAST::Stmts.new( $result )
+        )
     }
 
     method postprocess_heredoc($/, $past) {

--- a/src/core/allomorphs.pm
+++ b/src/core/allomorphs.pm
@@ -159,9 +159,16 @@ multi sub val(Mu) {
     Mu
 }
 
-# needed to preserve slip-ness
-multi sub val(Slip:D $maybevals) {
-    val(|$maybevals).Slip
+# if Slip, preserve slipness
+multi sub val(List:D $maybevals) {
+    nqp::stmts(
+        (my $output := val(|$maybevals)),
+        nqp::if(
+            nqp::istype($maybevals, Slip),
+            $output.Slip,
+            $output
+        )
+    )
 }
 
 multi sub val(Pair:D \ww-thing) is raw {


### PR DESCRIPTION
When using word quoting with interpolation, interpolated words are
wrapped in a Slip. This is desirable when there are multiple words, as
the interpolated values in the Slip get integrated into the surrounding
List, but is problematic when there is only one word total (prior to
interpolation).

If there is only one word, don't wrap it in a Slip. This fixes the issue
when using both qqww and << >>.

Also added "val" sub variant that handles both Slips and Lists, as it
was there was not a good candidate for dealing with the List returned by
the "words" method (on the << >> path).