### PR TITLE
Fix RT#127051

### DIFF
--- a/src/core/Rat.pm
+++ b/src/core/Rat.pm
@@ -79,7 +79,7 @@ multi sub prefix:<->(FatRat:D \a) {
     FatRat.new(-a.numerator, a.denominator);
 }
 
-multi sub infix:<+>(Rational \a, Rational \b) {
+multi sub infix:<+>(Rational:D \a, Rational:D \b) {
     a.denominator == b.denominator
         ?? DON'T_DIVIDE_NUMBERS(a.numerator + b.numerator, a.denominator, a, b)
         !! DIVIDE_NUMBERS
@@ -88,7 +88,7 @@ multi sub infix:<+>(Rational \a, Rational \b) {
             a,
             b
 }
-multi sub infix:<+>(Rational \a, Int \b) {
+multi sub infix:<+>(Rational:D \a, Int:D \b) {
     DON'T_DIVIDE_NUMBERS(
         (a.numerator + b * a.denominator),
         a.denominator,
@@ -96,7 +96,7 @@ multi sub infix:<+>(Rational \a, Int \b) {
         b,
     );
 }
-multi sub infix:<+>(Int \a, Rational \b) {
+multi sub infix:<+>(Int:D \a, Rational:D \b) {
     DON'T_DIVIDE_NUMBERS(
         (a * b.denominator + b.numerator),
         b.denominator,
@@ -105,7 +105,7 @@ multi sub infix:<+>(Int \a, Rational \b) {
     );
 }
 
-multi sub infix:<->(Rational \a, Rational \b) {
+multi sub infix:<->(Rational:D \a, Rational:D \b) {
     a.denominator == b.denominator
         ?? DON'T_DIVIDE_NUMBERS(a.numerator - b.numerator, a.denominator, a, b)
         !! DIVIDE_NUMBERS
@@ -115,7 +115,7 @@ multi sub infix:<->(Rational \a, Rational \b) {
             b
 }
 
-multi sub infix:<->(Rational \a, Int \b) {
+multi sub infix:<->(Rational:D \a, Int:D \b) {
     DON'T_DIVIDE_NUMBERS
         a.numerator - b * a.denominator,
         a.denominator,
@@ -123,7 +123,7 @@ multi sub infix:<->(Rational \a, Int \b) {
         b;
 }
 
-multi sub infix:<->(Int \a, Rational \b) {
+multi sub infix:<->(Int:D \a, Rational:D \b) {
     DON'T_DIVIDE_NUMBERS
         a * b.denominator - b.numerator,
         b.denominator,
@@ -131,7 +131,7 @@ multi sub infix:<->(Int \a, Rational \b) {
         b;
 }
 
-multi sub infix:<*>(Rational \a, Rational \b) {
+multi sub infix:<*>(Rational:D \a, Rational:D \b) {
     DIVIDE_NUMBERS
         a.numerator * b.numerator,
         a.denominator * b.denominator,
@@ -139,7 +139,7 @@ multi sub infix:<*>(Rational \a, Rational \b) {
         b;
 }
 
-multi sub infix:<*>(Rational \a, Int \b) {
+multi sub infix:<*>(Rational:D \a, Int:D \b) {
     DIVIDE_NUMBERS
         a.numerator * b,
         a.denominator,
@@ -147,7 +147,7 @@ multi sub infix:<*>(Rational \a, Int \b) {
         b;
 }
 
-multi sub infix:<*>(Int \a, Rational \b) {
+multi sub infix:<*>(Int:D \a, Rational:D \b) {
     DIVIDE_NUMBERS
         a * b.numerator,
         b.denominator,
@@ -155,7 +155,7 @@ multi sub infix:<*>(Int \a, Rational \b) {
         b;
 }
 
-multi sub infix:</>(Rational \a, Rational \b) {
+multi sub infix:</>(Rational:D \a, Rational:D \b) {
     DIVIDE_NUMBERS
         a.numerator * b.denominator,
         a.denominator * b.numerator,
@@ -163,7 +163,7 @@ multi sub infix:</>(Rational \a, Rational \b) {
         b;
 }
 
-multi sub infix:</>(Rational \a, Int \b) {
+multi sub infix:</>(Rational:D \a, Int:D \b) {
     DIVIDE_NUMBERS
         a.numerator,
         a.denominator * b,
@@ -171,7 +171,7 @@ multi sub infix:</>(Rational \a, Int \b) {
         b;
 }
 
-multi sub infix:</>(Int \a, Rational \b) {
+multi sub infix:</>(Int:D \a, Rational:D \b) {
     b.REDUCE-ME; # RT #126391: [BUG] Bad "divide by 0" error message
     DIVIDE_NUMBERS
         b.denominator * a,
@@ -180,23 +180,23 @@ multi sub infix:</>(Int \a, Rational \b) {
         b;
 }
 
-multi sub infix:</>(Int \a, Int \b) {
+multi sub infix:</>(Int:D \a, Int:D \b) {
     DIVIDE_NUMBERS a, b, a, b
 }
 
-multi sub infix:<%>(Rational \a, Int \b) {
+multi sub infix:<%>(Rational:D \a, Int:D \b) {
     a - floor(a / b) * b
 }
 
-multi sub infix:<%>(Int \a, Rational \b) {
+multi sub infix:<%>(Int:D \a, Rational:D \b) {
     a - floor(a / b) * b
 }
 
-multi sub infix:<%>(Rational \a, Rational \b) {
+multi sub infix:<%>(Rational:D \a, Rational:D \b) {
     a - floor(a / b) * b
 }
 
-multi sub infix:<**>(Rational \a, Int \b) {
+multi sub infix:<**>(Rational:D \a, Int:D \b) {
     b >= 0
         ?? DIVIDE_NUMBERS
             (a.numerator ** b // fail (a.numerator.abs > a.denominator ?? X::Numeric::Overflow !! X::Numeric::Underflow).new),

--- a/t/05-messages/02-errors.t
+++ b/t/05-messages/02-errors.t
@@ -2,7 +2,7 @@ use lib <t/packages/>;
 use Test;
 use Test::Helpers;
 
-plan 29;
+plan 30;
 
 # RT #132295
 
@@ -207,5 +207,53 @@ throws-like ｢
 throws-like ｢Set.new(1..300)<42> = 42｣,
     X::Assignment::RO, :message{ .chars < 100 },
     'X::Assignment::RO does not dump entire contents of variables';
+
+# RT #127051
+subtest 'cannot use Int type object as an operand' => {
+    plan 14;
+
+    throws-like ｢(1/1)+Int｣,
+        X::Parameter::InvalidConcreteness,
+        'A Rational instance cannot be added by an Int type object';
+    throws-like ｢Int+(1/1)｣,
+        X::Parameter::InvalidConcreteness,
+        'An Int type object cannot be added by a Rational instance';
+    throws-like ｢(1/1)-Int｣,
+        X::Parameter::InvalidConcreteness,
+        'A Rational instance cannot be subtracted by an Int type object';
+    throws-like ｢Int-(1/1)｣,
+        X::Parameter::InvalidConcreteness,
+        'An Int type object cannot be subtracted by a Rational instance';
+    throws-like ｢(1/1)*Int｣,
+        X::Parameter::InvalidConcreteness,
+        'A Rational instance cannot be multiplied by an Int type object';
+    throws-like ｢Int*(1/1)｣,
+        X::Parameter::InvalidConcreteness,
+        'An Int type object cannot be multiplied by a Rational instance';
+    throws-like ｢(1/1)/Int｣,
+        X::Parameter::InvalidConcreteness,
+        'A Rational instance cannot be divided by an Int type object';
+    throws-like ｢Int/(1/1)｣,
+        X::Parameter::InvalidConcreteness,
+        'An Int type object cannot be divided by a Rational instance';
+    throws-like ｢Int/Int｣,
+        X::Parameter::InvalidConcreteness,
+        'An Int type object cannot be divided by an Int type object';
+    throws-like ｢Int/1｣,
+        X::Parameter::InvalidConcreteness,
+        'An Int type object cannot be divided by an Int instance';
+    throws-like ｢1/Int｣,
+        X::Parameter::InvalidConcreteness,
+        'An Int instance cannot be divided by an Int type object';
+    throws-like ｢(1/1)%Int｣,
+        X::Parameter::InvalidConcreteness,
+        'A Rational instance modulo an Int type object is incalculable';
+    throws-like ｢Int%(1/1)｣,
+        X::Parameter::InvalidConcreteness,
+        'An Int type object modulo a Rational instance is incalculable';
+    throws-like ｢(1/1)**Int｣,
+        X::Parameter::InvalidConcreteness,
+        'A Rational instance cannot be powered by an Int type object';
+}
 
 # vim: ft=perl6 expandtab sw=4


### PR DESCRIPTION
Hi,
I fixed RT#127051: https://rt.perl.org/Public/Bug/Display.html?id=127051

The changes are:

+ Add smileys to make sure that rational calculation only uses instances not type objects [9910b39]
+ Add tests for exception handling of rational calculation [9adc58c]