### PR TITLE
Issue 1304: Preserve operator chaining when operators negated

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -7343,7 +7343,12 @@ class Perl6::Actions is HLL::Actions does STDActions {
             }
             my $t        := $basepast.ann('thunky') || $base<OPER><O>.made<thunky>;
             my $helper   := '';
-            if    $metasym eq '!' { $helper := '&METAOP_NEGATE'; }
+            my $astop    := 'call';
+
+            if $metasym eq '!' {
+                $helper := '&METAOP_NEGATE';
+                if $base<OPER><O>.made<pasttype> eq 'chain' { $astop := 'chain' }
+            }
             if    $metasym eq 'R' { $helper := '&METAOP_REVERSE'; $t := nqp::flip($t) if $t; }
             elsif $metasym eq 'X' { $helper := '&METAOP_CROSS'; $t := nqp::uc($t); }  # disable transitive thunking for now
             elsif $metasym eq 'Z' { $helper := '&METAOP_ZIP'; $t := nqp::uc($t); }
@@ -7354,7 +7359,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
                 if $metasym eq 'X' || $metasym eq 'Z';
             $metapast.annotate('thunky', $t) if $t;
             $metapast.annotate('is_pure', $purity) if $purity;
-            $ast := QAST::Op.new( :node($/), :op<call>, $metapast );
+            $ast := QAST::Op.new( :node($/), :op($astop), $metapast );
             $ast.annotate('thunky', $t) if $t;
         }
 


### PR DESCRIPTION
This is one part in a two part fix to [Issue 1304](https://github.com/rakudo/rakudo/issues/1304).
The NQP component to this fix can be found [here](https://github.com/perl6/nqp/pull/387).

If the behavior on the base operator is to allow 'chaining' (as it is
for '<' and '>' in the grammar) and the metaop is '!', then preserve
chaining on the op wrapping the metaop and baseop.

Previously, applying the negation metaoperator toward operators that
allowed chaining (eg. '<', or '>') wouldn't preserve the chaining
behavior.

This commit is being made in conjunction with development in NQP
altering the chain op.