### PR TITLE
Fix RT#126669

### DIFF
--- a/src/core/Exception.pm
+++ b/src/core/Exception.pm
@@ -1049,6 +1049,8 @@ my class X::Undeclared::Symbols does X::Comp {
                 local => "temp (or dynamic var)",
                 new => "method call syntax",
                 foreach => "for",
+                use => '"v" prefix for pragma (e.g., "use v6;", "use v6.c;")',
+                need => '"v" prefix for pragma (e.g., "need v6;", "need v6.c;")',
             }
             $r ~= "Undeclared routine" ~ (%.unk_routines.elems == 1 ?? "" !! "s") ~ ":\n";
             for %.unk_routines.sort(*.key) {

--- a/t/05-messages/02-errors.t
+++ b/t/05-messages/02-errors.t
@@ -2,7 +2,7 @@ use lib <t/packages/>;
 use Test;
 use Test::Helpers;
 
-plan 33;
+plan 35;
 
 # RT #132295
 
@@ -271,5 +271,16 @@ throws-like { my $r = 1..5; $r[42] = 21 }, X::Assignment::RO,
 # the this test checks.
 is-run 'EVAL "*+*"', :compiler-args[<--optimize=off>],
     'optimizer flag gets propagated to EVAL';
+
+
+# RT126669
+
+throws-like { EVAL "use 6.0;" }, X::Undeclared::Symbols,
+    :message{ .contains: 'use "v" prefix for pragma (e.g., "use v6;", "use v6.c;")' },
+    'suggests to use "use v6;" or "use v6.c;" when "use 6.0" is called';
+
+throws-like { EVAL "need 6.0;" }, X::Undeclared::Symbols,
+    :message{ .contains: 'use "v" prefix for pragma (e.g., "need v6;", "need v6.c;")' },
+    'suggests to use "need v6;" or "need v6.c;" when "need 6.0" is called';
 
 # vim: ft=perl6 expandtab sw=4


### PR DESCRIPTION
Hi,

I fixed RT#126669: https://rt.perl.org/Public/Bug/Display.html?id=126669

The changes are:
+ Add error messages for Perl5-style pragma (e.g., "use 6.0", "need 6.0") [2dc93ac]
+ Add tests for X::Undeclared::Symbols exception for when Perl5-style pragma is used [4ec5936]