### PR TITLE
Issue 1261: Throw BIND-KEY Exception instead of using Failure

### DIFF
--- a/src/core/Any.pm
+++ b/src/core/Any.pm
@@ -422,7 +422,7 @@ my class Any { # declared in BOOTSTRAP
 
     proto method BIND-KEY(|) is nodal {*}
     multi method BIND-KEY(Any:D: \k, \v) is raw {
-        Failure.new(X::Bind.new(target => self.^name))
+        X::Bind.new(target => self.^name).throw
     }
     multi method BIND-KEY(Any:U \SELF: $key, $BIND ) is raw {
         SELF = Hash.new;


### PR DESCRIPTION
As suggested by zoffix and jnthn, since the result of BIND-KEY does not
sink, the Exception within the Failure is never thrown. Throws now.

Addresses [Issue 1261](https://github.com/rakudo/rakudo/issues/1261)