### PR TITLE
Issue 1397: Reifiy pending elements in Seq prior to rotor call

### DIFF
--- a/src/core/Rakudo/Iterator.pm
+++ b/src/core/Rakudo/Iterator.pm
@@ -2795,6 +2795,7 @@ class Rakudo::Iterator {
             has $!cycle;
             has $!buffer;
             has int $!complete;
+            has int $!is-exhausted = 0;
             method !SET-SELF(\iterator,\cycle,\partial) {
                 nqp::stmts(
                   ($!iterator := iterator),
@@ -2812,6 +2813,9 @@ class Rakudo::Iterator {
                 )
             }
             method pull-one() is raw {
+              nqp::if(
+                $!is-exhausted,
+                IterationEnd,
                 nqp::stmts(
                   nqp::if(
                     nqp::istype((my $todo := $!cycle.pull-one),Pair),
@@ -2896,6 +2900,7 @@ class Rakudo::Iterator {
                   nqp::if(
                     nqp::not_i(nqp::elems($!buffer))
                       || (nqp::eqaddr($pulled,IterationEnd)
+                           && ($!is-exhausted = 1)
                            && $!complete
                            && nqp::islt_i(nqp::elems($!buffer),$elems)
                          ),
@@ -2946,6 +2951,7 @@ class Rakudo::Iterator {
                     )
                   )
                 )
+              )
             }
             method is-lazy() { $!iterator.is-lazy }
         }.new(iterator,cycle,partial)


### PR DESCRIPTION
There are instances where a Seq is newly created and its elements have
not been iterated/cached yet. Calling a method like rotor that
anticipates such elements will fail. Add a method in Seq that intercepts
the Seq and reifies any pending elements prior to dispatching it to the
Any rotor method for processing.

Addresses [Issue 1397](https://github.com/rakudo/rakudo/issues/1397)