### PR TITLE
Fix function signature

### DIFF
--- a/t/04-nativecall/01-argless.c
+++ b/t/04-nativecall/01-argless.c
@@ -34,7 +34,7 @@ DLLEXPORT int* ArglessPointer()
 }
 
 char *my_str = "Just a string";
-DLLEXPORT int* ArglessUTF8String()
+DLLEXPORT char* ArglessUTF8String()
 {
     return my_str;
 }


### PR DESCRIPTION
Current signature is int*, but it actually returns a char* which gives a
warning. It still works because Perl declares the nativecall as a Str
anyway.  This just avoids the warning.

Address issue https://github.com/rakudo/rakudo/issues/1380