### PR TITLE
Issue 1304 Continued: Re-enable negated chaining on the JVM

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -7451,9 +7451,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
 
             if $metasym eq '!' {
                 $helper := '&METAOP_NEGATE';
-#?if moar
                 if $base<OPER><O>.made<pasttype> eq 'chain' { $astop := 'chain' }
-#?endif
             }
             if    $metasym eq 'R' { $helper := '&METAOP_REVERSE'; $t := nqp::flip($t) if $t; }
             elsif $metasym eq 'X' { $helper := '&METAOP_CROSS'; $t := nqp::uc($t); }  # disable transitive thunking for now


### PR DESCRIPTION
This statement was previously restricted to MoarVM only as the JVM
implementation's chain op was not yet set up to handle a child as the callee.

Now, as of commit 84278100acbf589a37f5baa85ffe27d68de52d13 (in the NQP
repo), the chain op's JVM implementation works the same way that
MoarVM's does, making this negated chaining implementation functional
on the JVM backend as well.

See <https://github.com/rakudo/rakudo/issues/1304>.