### PR TITLE
Fix Iterator.Rotor when cycle contains Whatever or Inf

### DIFF
--- a/src/core/Rakudo/Iterator.pm
+++ b/src/core/Rakudo/Iterator.pm
@@ -2891,12 +2891,17 @@ class Rakudo::Iterator {
                     )
                   ),
                   nqp::until(                          # fill the buffer
-                    nqp::isge_i(nqp::elems($!buffer),$elems)
+                    (nqp::isge_i(nqp::elems($!buffer),$elems)
+                      && nqp::isne_i($elems,-1))       # eat everything
                       || nqp::eqaddr(
                            (my $pulled := $!iterator.pull-one),
                            IterationEnd
                          ),
                     nqp::push($!buffer,$pulled)
+                  ),
+                  nqp::if(
+                      nqp::iseq_i($elems,-1),
+                      ($elems = nqp::elems($!buffer))
                   ),
                   nqp::if(
                     nqp::not_i(nqp::elems($!buffer))


### PR DESCRIPTION
Whatever or Inf in the rotor cycle were encoded as -1 in the number of elements to consume. This didn't have the desired effect with /signed/ comparisons.

Two tests will be submitted to roast shortly, see: https://github.com/taboege/roast/commit/fa3dea758f846efdfbe32044498b262496c6c8b9