### PR TITLE
Issue 1341: Elevate statevars to enclosing block when wrapped

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -130,6 +130,14 @@ sub wanted($ast,$by) {
                 QAST::WVal.new( :value($*W.find_symbol(['Seq']))),
                 block_closure($block) );
 
+            # Elevate statevars to enclosing thunk
+            if $body.has_ann('has_statevar') && $block.has_ann('past_block') {
+                Perl6::Actions::migrate_blocks(
+                    $body, $block.ann('past_block'),
+                    -> $n { nqp::istype($n, QAST::Var) && $n.decl eq 'statevar' }
+                )
+            }
+
             # conditional (if not always true (or if repeat))
             if $repeat || !$cond.has_compile_time_value || !$cond.compile_time_value == $while {
                 $cond := QAST::Op.new( :op<callmethod>, :name<not>, $cond ) unless $while;
@@ -3201,6 +3209,10 @@ class Perl6::Actions is HLL::Actions does STDActions {
                         $<initializer><sym> eq '::=');
                 }
                 if $*SCOPE eq 'state' {
+                    if nqp::istype( (my $outer_block := $*W.cur_lexpad), QAST::Block) {
+                        $outer_block.annotate('has_statevar', $outer_block[0]);
+                    }
+
                     $past := QAST::Op.new( :op('if'),
                         QAST::Op.new( :op('p6stateinit') ),
                         $past,
@@ -6537,7 +6549,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
     # hash). Others get thunked and so need to have certain blocks in an
     # expression moved into the thunk. This performs the migration. Takes an
     # optional predicate to decide whether to move a block.
-    sub migrate_blocks($from, $to, $predicate?) {
+    our sub migrate_blocks($from, $to, $predicate?) {
         my @decls := @($from[0]);
         my int $n := nqp::elems(@decls);
         my int $i := 0;


### PR DESCRIPTION
Previously in some blocks following the "do" statement prefix, statevars
would be seemingly reset after each iteration of the loop.

Given the statement:

    say do loop { state $x = 0; last if ++$x > 2; $x }

This statement would result in multiple thunk refs being produced, and
ultimately, would be wrapped in a block that is used as a cloning target
in looping and a new container would be declared and initialized for
each iteration.

The QAST would look like this (trimmed to relevant parts):

    - QAST::Block(:cuid(3) :blocktype(declaration_static))
      - QAST::Stmts  { state $x = 0; last if ++$x > 2; $x }
      - QAST::Stmts
        - QAST::Block(:cuid(1) :blocktype(immediate)) <wanted>
          - QAST::Stmts
            - QAST::Var(lexical $x :decl(statevar))
            - QAST::Var(lexical $_ :decl(var))

After this commit the QAST looks like this:

    - QAST::Block(:cuid(3) :blocktype(declaration_static))
      - QAST::Stmts  { state $x = 0; last if ++$x > 2; $x }
        - QAST::Var(lexical $x :decl(statevar))
      - QAST::Stmts
        - QAST::Block(:cuid(1) :blocktype(immediate)) <wanted>
          - QAST::Stmts
            - QAST::Op(null)
            - QAST::Var(lexical $_ :decl(var))

This way the statevar is declared in the block being cloned and thus the
same container is used in each iteration.

Note the enclosing block is a block newly created via the make_thunk_ref sub,
and contains no child nodes other than the first Stmts (that has no children prior
to this commit) and the second Stmts containing the cuid(1) subtree.

See [Github Issue 1341](https://github.com/rakudo/rakudo/issues/1341)