### PR TITLE
Implement push-all method for the Seq generator in List::roll(\number)

### DIFF
--- a/src/core/List.pm
+++ b/src/core/List.pm
@@ -1057,6 +1057,15 @@ my class List does Iterable does Positional { # declared in BOOTSTRAP
                              IterationEnd
                          }
                      }
+                     method push-all($target --> IterationEnd) {
+                         nqp::while(
+                             $!todo,
+                             nqp::stmts(
+                                 ($target.push(nqp::atpos($!list,$!elems.rand.floor))),
+                                 ($!todo = $!todo - 1)
+                             )
+                         )
+                     }
                  }.new(self,number.Int))
               !! Seq.new(Rakudo::Iterator.Empty)
     }


### PR DESCRIPTION
Comparing the roll and the pick method of the List data type, you will see
that pick is using both pull-one and push-all Iterator interface entries
while roll is only based on pull-one.

Adding push-all to pick increases list assignment by 20%:
./perl6 -e'my @a = "a".."z"; for ^500_000 {my @b = @a.roll(20);}'

Before this commit, this code was calling pull-one 20 times instead of
a single push-one call.

Based on
http://perl6.online/2018/02/04/46-exploring-the-pick-and-the-roll-methods-in-perl-6-part-3