### PR TITLE
Separate adding child block from creating code obj

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -1084,9 +1084,8 @@ class Perl6::Actions is HLL::Actions does STDActions {
             );
 
             $*W.pop_lexpad();
-            $*W.add_child_to_outer_block($block);
             $*W.add_phaser(
-                $/, 'INIT', $*W.create_simple_code_object($block, 'Block'), $block
+                $/, 'INIT', $*W.create_code_obj_and_add_child($block, 'Block'), $block
             );
         }
     }
@@ -4929,8 +4928,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
         }
         else {
             $con_block.push($value_ast);
-            $*W.add_child_to_outer_block($con_block);
-            my $value_thunk := $*W.create_simple_code_object($con_block, 'Block');
+            my $value_thunk := $*W.create_code_obj_and_add_child($con_block, 'Block');
             $value := $*W.handle-begin-time-exceptions($/, 'evaluating a constant', $value_thunk);
             $*W.add_constant_folded_result($value);
         }
@@ -8336,9 +8334,8 @@ class Perl6::Actions is HLL::Actions does STDActions {
         my $rep_block := $*SUBST_RHS_BLOCK;
         $rep_block.push(QAST::Stmts.new($right, :node($<sibble><right>)));
         $*W.cur_lexpad()[0].push($rep_block);
-        $*W.add_child_to_outer_block($rep_block);
         my $closure := block_closure(reference_to_code_object(
-            $*W.create_simple_code_object($rep_block, 'Code'),
+            $*W.create_code_obj_and_add_child($rep_block, 'Code'),
             $rep_block));
 
         # self.match($rx_coderef, |%options);
@@ -8495,10 +8492,9 @@ class Perl6::Actions is HLL::Actions does STDActions {
         nqp::bindattr($quasi_ast, $ast_class, '$!Str', $/.Str());
         $*W.add_object($quasi_ast);
         my $throwaway_block := QAST::Block.new();
-        $*W.add_child_to_outer_block($throwaway_block);
         my $quasi_context := block_closure(
             reference_to_code_object(
-                $*W.create_simple_code_object($throwaway_block, 'Block'),
+                $*W.create_code_obj_and_add_child($throwaway_block, 'Block'),
                 $throwaway_block
             ));
         make QAST::Op.new(:op<callmethod>, :name<incarnate>,
@@ -9254,9 +9250,8 @@ class Perl6::Actions is HLL::Actions does STDActions {
         }
         $*W.pop_lexpad();
 
-        $*W.add_child_to_outer_block($block);
         reference_to_code_object(
-            $*W.create_simple_code_object($block, 'Code'),
+            $*W.create_code_obj_and_add_child($block, 'Code'),
             $block);
     }
 

--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -1084,6 +1084,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
             );
 
             $*W.pop_lexpad();
+            $*W.add_child_to_outer_block($block);
             $*W.add_phaser(
                 $/, 'INIT', $*W.create_simple_code_object($block, 'Block'), $block
             );
@@ -4928,6 +4929,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
         }
         else {
             $con_block.push($value_ast);
+            $*W.add_child_to_outer_block($con_block);
             my $value_thunk := $*W.create_simple_code_object($con_block, 'Block');
             $value := $*W.handle-begin-time-exceptions($/, 'evaluating a constant', $value_thunk);
             $*W.add_constant_folded_result($value);
@@ -8334,6 +8336,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
         my $rep_block := $*SUBST_RHS_BLOCK;
         $rep_block.push(QAST::Stmts.new($right, :node($<sibble><right>)));
         $*W.cur_lexpad()[0].push($rep_block);
+        $*W.add_child_to_outer_block($rep_block);
         my $closure := block_closure(reference_to_code_object(
             $*W.create_simple_code_object($rep_block, 'Code'),
             $rep_block));
@@ -8492,6 +8495,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
         nqp::bindattr($quasi_ast, $ast_class, '$!Str', $/.Str());
         $*W.add_object($quasi_ast);
         my $throwaway_block := QAST::Block.new();
+        $*W.add_child_to_outer_block($throwaway_block);
         my $quasi_context := block_closure(
             reference_to_code_object(
                 $*W.create_simple_code_object($throwaway_block, 'Block'),
@@ -9249,6 +9253,8 @@ class Perl6::Actions is HLL::Actions does STDActions {
             $block.push(QAST::Stmts.new(autosink($to_thunk)));
         }
         $*W.pop_lexpad();
+
+        $*W.add_child_to_outer_block($block);
         reference_to_code_object(
             $*W.create_simple_code_object($block, 'Code'),
             $block);

--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -2172,21 +2172,18 @@ class Perl6::World is HLL::World {
         $to_thunk.wanted: 1 if $mark-wanted;
         $block.push($to_thunk);
         self.pop_lexpad();
-        self.add_child_to_outer_block( $block );
-        self.create_simple_code_object($block, 'Code');
+        self.create_code_obj_and_add_child($block, 'Code');
     }
 
-    method add_child_to_outer_block($block) {
+    # Creates a simple code object with an empty signature
+    # Also makes the passed block a child of outer block on lexpad
+    method create_code_obj_and_add_child($block, $type) {
         if $*WANTEDOUTERBLOCK {
             $*WANTEDOUTERBLOCK[0].push($block);
         }
         else {
             self.cur_lexpad()[0].push($block);
         }
-    }
-
-    # Creates a simple code object with an empty signature
-    method create_simple_code_object($block, $type) {
         my $sig := self.create_signature(nqp::hash('parameter_objects', []));
         return self.create_code_object($block, $type, $sig);
     }
@@ -3848,8 +3845,7 @@ class Perl6::World is HLL::World {
         my $capturer := self.cur_lexpad();
         my $c_block  := QAST::Block.new( :blocktype('declaration_static'),
                                          :name('!LEXICAL_FIXUP_CSCOPE') );
-        self.add_child_to_outer_block( $c_block );
-        self.create_simple_code_object($c_block, 'Code');
+        self.create_code_obj_and_add_child($c_block, 'Code');
         $capturer[0].push(QAST::Op.new(
             :op('callmethod'), :name('resolve'),
             QAST::WVal.new( :value($fixup_list) ),

--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -2172,17 +2172,21 @@ class Perl6::World is HLL::World {
         $to_thunk.wanted: 1 if $mark-wanted;
         $block.push($to_thunk);
         self.pop_lexpad();
+        self.add_child_to_outer_block( $block );
         self.create_simple_code_object($block, 'Code');
     }
 
-    # Creates a simple code object with an empty signature
-    method create_simple_code_object($block, $type) {
+    method add_child_to_outer_block($block) {
         if $*WANTEDOUTERBLOCK {
             $*WANTEDOUTERBLOCK[0].push($block);
         }
         else {
             self.cur_lexpad()[0].push($block);
         }
+    }
+
+    # Creates a simple code object with an empty signature
+    method create_simple_code_object($block, $type) {
         my $sig := self.create_signature(nqp::hash('parameter_objects', []));
         return self.create_code_object($block, $type, $sig);
     }
@@ -3844,6 +3848,7 @@ class Perl6::World is HLL::World {
         my $capturer := self.cur_lexpad();
         my $c_block  := QAST::Block.new( :blocktype('declaration_static'),
                                          :name('!LEXICAL_FIXUP_CSCOPE') );
+        self.add_child_to_outer_block( $c_block );
         self.create_simple_code_object($c_block, 'Code');
         $capturer[0].push(QAST::Op.new(
             :op('callmethod'), :name('resolve'),


### PR DESCRIPTION
Not a necessary change, but one that I think make things a bit clearer.

Previously, the create_simple_code_object method in the Perl6 World
would add the block passed to it to the desired outer block in addition
to returning a code object for it. From the name, it is not clear that
the method has such side-effects. Separating the actions in order to
make it explicit that we performing both of these.