### PR TITLE
Fix R#1488 - multi sub infix:<cmp>(\a, \b) is missing decont. Zoffix++

### DIFF
--- a/src/core/Order.pm
+++ b/src/core/Order.pm
@@ -8,7 +8,7 @@ sub ORDER(int $i) {
 
 proto sub infix:<cmp>(Mu $, Mu $) is pure {*}
 multi sub infix:<cmp>(\a, \b) {
-    nqp::eqaddr(a,b)
+    nqp::eqaddr(nqp::decont(a), nqp::decont(b))
       ?? Same
       !! a.Stringy cmp b.Stringy
 }


### PR DESCRIPTION
Phixes: https://github.com/rakudo/rakudo/issues/1488

There's every chance that the codebase contains more problems like
this.