### PR TITLE
RT#102994: State init vars if not set on first pass (CodeRef edition)

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -2358,7 +2358,9 @@ class Perl6::Actions is HLL::Actions does STDActions {
         # generate code that runs the block only once
         make QAST::Op.new(
             :op('if'),
-            QAST::Op.new( :op('p6stateinit') ),
+            QAST::Op.new( :op('p6stateinit'),
+                QAST::Var.new( :name($sym), :scope('lexical') )
+            ),
             QAST::Op.new(
                 :op('p6store'),
                 WANTED(QAST::Var.new( :name($sym), :scope('lexical') ),'once'),
@@ -3231,7 +3233,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
                     }
 
                     $past := QAST::Op.new( :op('if'),
-                        QAST::Op.new( :op('p6stateinit') ),
+                        QAST::Op.new( :op('p6stateinit'), $orig_past ),
                         $past,
                         $orig_past);
                     $past.nosink(1);
@@ -3330,7 +3332,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
                 }
                 if $*SCOPE eq 'state' {
                     $list := QAST::Op.new( :op('if'),
-                        QAST::Op.new( :op('p6stateinit') ),
+                        QAST::Op.new( :op('p6stateinit'), $orig_list ),
                         $list, $orig_list);
                 }
             }
@@ -3605,7 +3607,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
                 elsif %cont_info<build_ast> {
                     if $*SCOPE eq 'state' {
                         $past := QAST::Op.new( :op('if'),
-                            QAST::Op.new( :op('p6stateinit') ),
+                            QAST::Op.new( :op('p6stateinit'), $past ),
                             QAST::Op.new( :op('bind'), $past, %cont_info<build_ast> ),
                             $past);
                     }

--- a/src/vm/jvm/Perl6/Ops.nqp
+++ b/src/vm/jvm/Perl6/Ops.nqp
@@ -98,7 +98,7 @@ $ops.map_classlib_hll_op('perl6', 'p6typecheckrv', $TYPE_P6OPS, 'p6typecheckrv',
 $ops.map_classlib_hll_op('perl6', 'p6decontrv', $TYPE_P6OPS, 'p6decontrv', [$RT_OBJ, $RT_OBJ], $RT_OBJ, :tc);
 $ops.map_classlib_hll_op('perl6', 'p6capturelex', $TYPE_P6OPS, 'p6capturelex', [$RT_OBJ], $RT_OBJ, :tc, :!inlinable);
 $ops.map_classlib_hll_op('perl6', 'p6bindassert', $TYPE_P6OPS, 'p6bindassert', [$RT_OBJ, $RT_OBJ], $RT_OBJ, :tc);
-$ops.map_classlib_hll_op('perl6', 'p6stateinit', $TYPE_P6OPS, 'p6stateinit', [], $RT_INT, :tc, :!inlinable);
+$ops.map_classlib_hll_op('perl6', 'p6stateinit', $TYPE_P6OPS, 'p6stateinit', [$RT_OBJ], $RT_INT, :tc);
 $ops.map_classlib_hll_op('perl6', 'p6setpre', $TYPE_P6OPS, 'p6setpre', [], $RT_OBJ, :tc);
 $ops.map_classlib_hll_op('perl6', 'p6clearpre', $TYPE_P6OPS, 'p6clearpre', [], $RT_OBJ, :tc);
 $ops.map_classlib_hll_op('perl6', 'p6inpre', $TYPE_P6OPS, 'p6inpre', [], $RT_INT, :tc);

--- a/src/vm/jvm/runtime/org/perl6/rakudo/RakOps.java
+++ b/src/vm/jvm/runtime/org/perl6/rakudo/RakOps.java
@@ -595,7 +595,7 @@ public final class RakOps {
         return indices;
     }
 
-    public static long p6stateinit(ThreadContext tc) {
+    public static long p6stateinit(SixModelObject obj, ThreadContext tc) {
         return tc.curFrame.stateInit ? 1 : 0;
     }
 

--- a/src/vm/jvm/runtime/org/perl6/rakudo/RakOps.java
+++ b/src/vm/jvm/runtime/org/perl6/rakudo/RakOps.java
@@ -596,7 +596,18 @@ public final class RakOps {
     }
 
     public static long p6stateinit(SixModelObject obj, ThreadContext tc) {
-        return tc.curFrame.stateInit ? 1 : 0;
+        long doInit = tc.curFrame.stateInit ? 1 : 0;
+
+        // Find num of lexical, so that we can mark it as HLL inited
+        CodeRef cr = tc.curFrame.codeRef;
+        for (int i = 0; i < cr.staticInfo.oLexicalNames.length; i++) {
+            if (obj == tc.curFrame.oLex[i]) {
+                boolean doHllInit        = !cr.oLexStateIsHllInit[i];
+                cr.oLexStateIsHllInit[i] = true;
+                return doInit == 1 ? doInit : (long)(doHllInit ? 1 : 0);
+            }
+        }
+        return doInit;
     }
 
     public static SixModelObject p6setfirstflag(SixModelObject codeObj, ThreadContext tc) {

--- a/src/vm/moar/Perl6/Ops.nqp
+++ b/src/vm/moar/Perl6/Ops.nqp
@@ -63,7 +63,8 @@ MAST::ExtOpRegistry.register_extop('p6capturelexwhere',
     $MVM_operand_obj   +| $MVM_operand_write_reg,
     $MVM_operand_obj   +| $MVM_operand_read_reg);
 MAST::ExtOpRegistry.register_extop('p6stateinit',
-    $MVM_operand_int64 +| $MVM_operand_write_reg);
+    $MVM_operand_int64 +| $MVM_operand_write_reg,
+    $MVM_operand_obj   +| $MVM_operand_read_reg);
 MAST::ExtOpRegistry.register_extop('p6setfirstflag',
     $MVM_operand_obj   +| $MVM_operand_write_reg,
     $MVM_operand_obj   +| $MVM_operand_read_reg);

--- a/src/vm/moar/ops/perl6_ops.c
+++ b/src/vm/moar/ops/perl6_ops.c
@@ -476,7 +476,8 @@ static void p6stateinit(MVMThreadContext *tc, MVMuint8 *cur_op) {
     /* Find num of lexical, so that we can mark it as HLL inited */
     MVMObject   *var    = GET_REG(tc, 2).o;
     MVMCodeBody *crbody = &((MVMCode *)tc->cur_frame->code_ref)->body;
-    for (MVMuint32 i = 0; i < tc->cur_frame->static_info->body.num_lexicals; i++) {
+    MVMuint32 i;
+    for (i = 0; i < tc->cur_frame->static_info->body.num_lexicals; i++) {
         MVMRegister *env_val     = &tc->cur_frame->env[i];
         MVMuint8    *is_hll_init = &crbody->state_vars_is_hll_init[i];
         if (env_val && var == env_val->o) {


### PR DESCRIPTION
Given the following subroutine:

    sub f($x) {
        return if $x;
        state $y = 5;
        $y;
    }

Previously, ```$y``` would only be assigned a value if the statement is
reached on the first invocation of the closure. So if ```f(1)``` is called first,
each subsequent ```f(0)``` call returns ```(Any)```

To address this, added an indicator on the code ref associated with the block (in
corresponding MoarVM/JVM developments) and modified ```p6stateinit``` to take a var
and check whether it has been assigned to. If the assignment was not
reached in the first pass in the life of a closure, the is_hll_init
value indicates that it requires HLL assignment the next time it is
encountered.

See [RT#102994](https://rt.perl.org/Public/Bug/Display.html?id=102994)