### PR TITLE
Speedup Rational.Str

### DIFF
--- a/src/core/Rational.pm
+++ b/src/core/Rational.pm
@@ -99,7 +99,14 @@ my role Rational[::NuT = Int, ::DeT = ::("NuT")] does Real {
                 ?? 6 !! $!denominator.Str.chars + 1;
 
             my $fract-result = '';
-            while $fract and $fract-result.chars < $precision {
+            while $fract and $fract-result.chars < $precision - 1 {
+                $fract *= 100;
+                my $f   = $fract.floor;
+                $fract -= $f;
+                $fract-result ~= $f < 10 ?? "0$f" !!
+                                 (!$fract and $f %% 10) ?? ($f / 10).floor !! $f;
+            }
+            if $fract and $fract-result.chars < $precision {
                 $fract *= 10;
                 given $fract.floor {
                     $fract-result ~= $_;


### PR DESCRIPTION
By generating the fractional part two characters at a time instead of
one.

For a FatRat that ends up being a 1571 char string, time before was 2.75s, time after is 1.9s.
For a FatRat that ends up being a 3139 char string, time before was 16.2s, time after is 12.6s.

Rakudo builds ok and passes `make m-test m-spectest`.