### PR TITLE
Differentiate precomp NC sub setup markers

### DIFF
--- a/lib/NativeCall.pm6
+++ b/lib/NativeCall.pm6
@@ -260,6 +260,7 @@ my Lock $setup-lock .= new;
 # native call.
 our role Native[Routine $r, $libname where Str|Callable|List|IO::Path|Distribution::Resource] {
     has int $!setup;
+    has int $!precomp-setup;
     has native_callsite $!call is box_target;
     has Mu $!rettype;
     has $!cpp-name-mangler;
@@ -272,7 +273,7 @@ our role Native[Routine $r, $libname where Str|Callable|List|IO::Path|Distributi
 
     method !setup() {
         $setup-lock.protect: {
-            return if $!setup;
+            return if $!setup || $*W && $*W.is_precompilation_mode && $!precomp-setup;
             # Make sure that C++ methods are treated as mangled (unless set otherwise)
             if self.package.REPR eq 'CPPStruct' and not self.does(NativeCallMangled) {
               self does NativeCallMangled[True];
@@ -294,7 +295,7 @@ our role Native[Routine $r, $libname where Str|Callable|List|IO::Path|Distributi
                 return_hash_for($r.signature, $r, :$!entry-point));
             $!rettype := nqp::decont(map_return_type($r.returns)) unless $!rettype;
             $!arity = $r.signature.arity;
-            $!setup = $jitted ?? 2 !! 1;
+            ($*W && $*W.is_precompilation_mode ?? $!precomp-setup !! $!setup) = $jitted ?? 2 !! 1;
 
             $!any-optionals = self!any-optionals;
 

--- a/t/04-nativecall/00-misc.t
+++ b/t/04-nativecall/00-misc.t
@@ -1,0 +1,17 @@
+use lib <t/packages/>;
+use Test;
+use Test::Helpers;
+
+plan 1;
+
+{ # https://github.com/rakudo/rakudo/issues/1576
+    (my $dir := make-temp-dir).add('Foo.pm6').spurt: ｢
+        use NativeCall;
+        sub strlen(Str --> int32) is native is export {}
+        BEGIN say strlen '123';
+        say strlen '12345';
+    ｣;
+    is-run ｢say strlen '1234567'; say strlen '123456789'｣,
+        :compiler-args[«-I "$dir.absolute()" -MFoo»], :out("3\n5\n7\n9\n"),
+    'no segfaults when using NC routine after using it during precomp';
+}


### PR DESCRIPTION
Fixes https://github.com/rakudo/rakudo/issues/1576 R#1576

If a NativeCalled sub used is during precomp, it's marked as
`$!setup`. However, when it's later used in non-precomp environment,
the stuff setup does is not available and so we get a SEGV.

Fix by using a separate marker for $!setup when we're in precomp
mode so that when we switch to non-precomp mode, we setup again.