### PR TITLE
Don't call Regexes in HyperRace's GrepCode

### DIFF
--- a/src/core/Rakudo/Internals/HyperRaceSharedImpl.pm6
+++ b/src/core/Rakudo/Internals/HyperRaceSharedImpl.pm6
@@ -40,7 +40,7 @@ class Rakudo::Internals::HyperRaceSharedImpl {
             my &matcher = &!matcher.clone;
             loop (my int $i = 0; $i < $n; ++$i) {
                 my \item := nqp::atpos($items, $i);
-                $result.push(item) if matcher(item);
+                $result.push(item) if &matcher ~~ Regex ?? item ~~ &matcher !! matcher(item);
             }
             $batch.replace-with($result);
         }


### PR DESCRIPTION
They should be matched against instead. Fixes the `No such method '!cursor_start' for invocant of type 'Str'` error when doing `say +lines().race.grep(/en/)`.

Rakudo builds ok and passes `make m-test m-spectest`.