### PR TITLE
Make MONKEY-TYPING imply `no precompilation`

### DIFF
--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -952,6 +952,12 @@ class Perl6::World is HLL::World {
       'worries',            1,
     );
 
+    # pragmas that imply `no precompilation`
+    my %no_precompilation_pragmas := nqp::hash(
+        'MONKEY',           1,
+        'MONKEY-TYPING',    1,
+    );
+
     # not yet implemented pragmas
     my %nyi_pragma := nqp::hash(
       'internals',  1,
@@ -1076,6 +1082,12 @@ class Perl6::World is HLL::World {
         else {
             $RMD("  '$name' is not a valid pragma") if $RMD;
             return 0;                        # go try module
+        }
+
+        if nqp::existskey(%no_precompilation_pragmas, $name) {
+            unless $*COMPILING_CORE_SETTING {
+                self.do_pragma($/, 'precompilation', 0, NQPMu);
+            }
         }
 
         $RMD("Successfully handled '$name' as a pragma") if $RMD;


### PR DESCRIPTION
It's not possible to load two precompiled modules that both do a
monkey-patch to the same type. Precompiling them will thus result in
modules that cannot be loaded together with others.

So far we've expected module authors to read the docs and remember to
add `no precompilation`. That's less reliable than the compiler just
doing the right thing for them. Especially given that the problem will
probably never be noticed by a module author when writing tests for
their module, but instead when somebody uses that module together with
others in a larger application.