### PR TITLE
Add strict, replacement options for IO::Handle, Str.encode & other fixes

### DIFF
--- a/src/core/Encoding/Builtin.pm6
+++ b/src/core/Encoding/Builtin.pm6
@@ -17,15 +17,16 @@ class Encoding::Builtin does Encoding {
     method alternative-names() { $!alternative-names }
 
     method decoder(*%options --> Encoding::Decoder) {
+        %options<replacement> = self!rep-char(%options<replacement>) if %options<replacement>:exists && %options<replacement>.DEFINITE && %options<replacement> !=== False;
         Encoding::Decoder::Builtin.new($!name, |%options)
     }
 
     my int $is-win = Rakudo::Internals.IS-WIN;
-    method encoder(:$replacement, :$translate-nl --> Encoding::Encoder) {
+    method encoder(:$replacement, :$translate-nl, :$strict --> Encoding::Encoder) {
         my $encoder = $replacement.DEFINITE && $replacement !=== False
-            ?? Encoding::Encoder::Builtin::Replacement.new($!name,
-                    self!buf-type(), self!rep-char($replacement))
-            !! Encoding::Encoder::Builtin.new($!name, self!buf-type());
+            ?? Encoding::Encoder::Builtin.new($!name, self!buf-type(), :$strict, :replacement(self!rep-char($replacement)))
+            !! Encoding::Encoder::Builtin.new($!name, self!buf-type(), :$strict);
+
         $translate-nl && $is-win
             ?? Encoding::Encoder::TranslateNewlineWrapper.new($encoder)
             !! $encoder

--- a/src/core/IO/Handle.pm6
+++ b/src/core/IO/Handle.pm6
@@ -768,7 +768,7 @@ my class IO::Handle {
 
     proto method encoding(|) {*}
     multi method encoding(IO::Handle:D:) { $!encoding // Nil }
-    multi method encoding(IO::Handle:D: $new-encoding is copy) {
+    multi method encoding(IO::Handle:D: $new-encoding is copy, :$replacement, :$strict) {
         with $new-encoding {
             if $_ eq 'bin' {
                 $_ = Nil;
@@ -789,7 +789,7 @@ my class IO::Handle {
                 $!decoder.set-line-separators($!nl-in.list);
                 $!decoder.add-bytes($prev-decoder.consume-exactly-bytes($available))
                     if $available;
-                $!encoder := $encoding.encoder(:translate-nl);
+                $!encoder := $encoding.encoder(:translate-nl, :$replacement, :$strict);
                 $!encoding = $encoding.name;
             }
             else {
@@ -806,7 +806,7 @@ my class IO::Handle {
                 my $encoding = Encoding::Registry.find($new-encoding);
                 $!decoder := $encoding.decoder(:translate-nl);
                 $!decoder.set-line-separators($!nl-in.list);
-                $!encoder := $encoding.encoder(:translate-nl);
+                $!encoder := $encoding.encoder(:translate-nl, :$replacement, :$strict);
                 $!encoding = $encoding.name;
             }
             else {

--- a/src/core/Rakudo/Internals.pm6
+++ b/src/core/Rakudo/Internals.pm6
@@ -275,8 +275,8 @@ my class Rakudo::Internals {
       'windows-1252',    'windows-1252',
       'windows-1251',    'windows-1251',
       # windows without dash
-      'windows1251',    'windows-1252',
-      'windows1252',    'windows-1251',
+      'windows1251',    'windows-1251',
+      'windows1252',    'windows-1252',
       # utf with dash
       'utf-8',           'utf8',
       'utf-16',          'utf16',

--- a/src/core/Str.pm6
+++ b/src/core/Str.pm6
@@ -2179,9 +2179,9 @@ my class Str does Stringy { # declared in BOOTSTRAP
     }
 
     proto method encode(|) {*}
-    multi method encode(Str:D $encoding = 'utf8', :$replacement, Bool() :$translate-nl = False) {
+    multi method encode(Str:D $encoding = 'utf8', :$replacement, Bool() :$translate-nl = False, :$strict) {
         Encoding::Registry.find($encoding)
-            .encoder(:$replacement, :$translate-nl)
+            .encoder(:$replacement, :$translate-nl, :$strict)
             .encode-chars(self)
     }
 


### PR DESCRIPTION
* Combine Encoding::Encoder::Builtin::Replacement and
Encoding::Encoder::Builtin
 into one class. They were essentially duplicated, and we can achieve the
same
 goal without adding any additional overhead.

* Encoding.decoder:  make sure :!replacement does not attempt to use a
 replacement. If we get Bool False, we don't want to use a replacement.
 Also make sure the methods accept Bool's and don't assume we will only
 get a Str type. This makes it act identically to how Encoding.encoder
 processes the replacement option.

* Throw during encoder setup on JVM when trying to use a replacement
 or :strict instead of throwing in encode-chars. Will speed things up
 if encode-chars is called many times.

* Add :strict and :replacement options to IO::Handle.encoding()

* Add :strict option to Str.encode


Fix bug mapping windows1252/windows1251 without a dash

This bug did not result in any regression, since we did not accept
windows-1252 or windows-1251 without the dash until very recently. By
accident windows1252 was mapping to windows-1251 and windows1251 was
mapping to windows-1252.