### PR TITLE
Implement fails-like routine in Test.pm6

### DIFF
--- a/lib/Test.pm6
+++ b/lib/Test.pm6
@@ -628,6 +628,25 @@ sub throws-like($code, $ex_type, $reason?, *%matcher) is export {
     }, $reason // "did we throws-like $ex_type.^name()?";
 }
 
+sub fails-like (
+    \test where Callable:D|Str:D, $ex-type, $reason?, *%matcher
+) is export {
+    subtest sub {
+        plan 2;
+        CATCH { default {
+            with "expected code to fail but it threw {.^name} instead" {
+                .&flunk;
+                .&skip;
+                return False;
+            }
+        }}
+        my $res = test ~~ Callable ?? test.() !! test.EVAL;
+        isa-ok $res, Failure, 'code returned a Failure';
+        throws-like { $res.sink }, $ex-type,
+            'Failure threw when sunk', |%matcher,
+    }, $reason // "did we fails-like $ex-type.^name()?"
+}
+
 sub _is_deeply(Mu $got, Mu $expected) {
     $got eqv $expected;
 }

--- a/t/spectest.data
+++ b/t/spectest.data
@@ -919,6 +919,7 @@ S24-testing/11-plan-skip-all-subtests.t
 S24-testing/12-subtest-todo.t
 S24-testing/13-cmp-ok.t
 S24-testing/14-like-unlike.t
+S24-testing/fails-like.t
 S24-testing/line-numbers.t
 S26-documentation/01-delimited.t
 S26-documentation/02-paragraph.t


### PR DESCRIPTION
Same as throws-like, except checks the code returns an armed Failure.

Failures are a ubiquitous feature of the language, yet there's no
convenient way to test for them:

- isa-ok: only tests for type, not the exception contained within,
    and doesn't mark Failures as handled causing warnings
    when those Failures are GCed
- throws-ok: explodes Failures, making it impossible to differentiate
    between code that throws and code that fails (we already had a bug
    in core that wasn't caught by roast for this reason)
- fails-like helper routine is already used extensively in roast,
    showing there is real need for this routine