### PR TITLE
Make resolved private method calls callstatic

### DIFF
--- a/src/Perl6/Optimizer.nqp
+++ b/src/Perl6/Optimizer.nqp
@@ -1899,7 +1899,7 @@ class Perl6::Optimizer {
                         $op.shift; $op.shift; # name, package (both pre-resolved now)
                         $op.unshift($inv);
                         $op.unshift($call);
-                        $op.op('call');
+                        $op.op('callstatic');
                         $op.name(NQPMu);
                     }
                 }


### PR DESCRIPTION
- This makes resolved private method calls 11% faster than public method calls.
- This also passes stresstest and to best of knowledge of staticalization I couldn't repro any negative effects, e.g. `with class Foo { my $x = 42; method !z { say $x }; method z { self!z }; method mod { $x = $++ }; }.new { for ^100 -> $x { .z; .mod; } }` seems to update `$x` just fine
- I've no idea if it's acceptable to actually staticalize these calls. If not, I'd love to know why, to better understand when `callstatic` is suitable
