### PR TITLE
REPL: exit by pressing ^D twice, not once

### DIFF
--- a/src/core/REPL.pm6
+++ b/src/core/REPL.pm6
@@ -303,8 +303,8 @@ do {
         method interactive_prompt() { '> ' }
 
         method repl-loop(*%adverbs) {
-
-            say "To exit type 'exit' or '^D'";
+            my $exit_char = ($*VM.osname eq 'win32') ?? '^Z' !! '^D';
+            say "To exit, type 'exit' or '$exit_char'.";
 
             my $prompt;
             my $code;
@@ -314,14 +314,22 @@ do {
             }
             reset;
 
+            my Bool $should_exit = False;
+
             REPL: loop {
                 my $newcode = self.repl-read(~$prompt);
 
                 my $initial_out_position = $*OUT.tell;
 
                 # An undef $newcode implies ^D or similar
-                if !$newcode.defined {
-                    last;
+                if $newcode.defined {
+                    $should_exit = False;
+                } else {
+                    last if $should_exit;
+                    $should_exit = True;
+                    say "Type '$exit_char' once more to exit.";
+                    reset;
+                    next;
                 }
 
                 $code = $code ~ $newcode ~ "\n";

--- a/t/02-rakudo/repl.t
+++ b/t/02-rakudo/repl.t
@@ -5,13 +5,15 @@ use Test::Helpers;
 
 plan 42;
 
+my $exit-char = ($*VM.osname eq 'win32') ?? '^Z' !! '^D';
 my $*REPL-SCRUBBER = -> $_ is copy {
     s/^^ "You may want to `zef install Readline` or `zef install Linenoise`"
         " or use rlwrap for a line editor\n\n"//;
-    s/^^ "To exit type 'exit' or '^D'\n"//;
+    s/^^ "To exit, type 'exit' or '{$exit-char}'.\n"//;
     s:g/ ^^ "> "  //; # Strip out the prompts
     s:g/    ">" $ //; # Strip out the final prompt
     s:g/ ^^ "* "+ //; # Strip out the continuation-prompts
+    s/^^ "Type '{$exit-char}' once more to exit.\n"//;
     $_
 }
 


### PR DESCRIPTION
This allows clearing the current line without exiting and prevents typos
from forcing it to exit.