### PR TITLE
Rewrite List cmp in NQP for faster execution

### DIFF
--- a/src/core/List.pm6
+++ b/src/core/List.pm6
@@ -1641,7 +1641,7 @@ proto sub prefix:<|>(|) {*}
 multi sub prefix:<|>(\x) { x.Slip }
 
 sub CMP-SLOW(@a, @b) {
-    (@a Zcmp @b).first(&prefix:<?>) || @a <=> @b
+    (@a Zcmp @b).first(&prefix:<?>) || &infix:<cmp>( |do .is-lazy for @a, @b ) || @a <=> @b
 }
 
 multi sub infix:<cmp>(@a, @b) {

--- a/src/core/List.pm6
+++ b/src/core/List.pm6
@@ -1640,19 +1640,31 @@ multi sub rotate(@a, Int:D $n) { @a.rotate($n) }
 proto sub prefix:<|>(|) {*}
 multi sub prefix:<|>(\x) { x.Slip }
 
+sub CMP-SLOW(@a, @b) {
+    (@a Zcmp @b).first(&prefix:<?>) || @a <=> @b
+}
+
 multi sub infix:<cmp>(@a, @b) {
-    nqp::stmts(
-        ( my int $ord = nqp::cmp_i( ( my int $n_a = @a.elems ), ( my int $n_b = @b.elems ) ) ),
-        ( my int $res = ( my int $i = 0) ),
-        ( my int $total_iters = nqp::islt_i($ord, 0) ?? $n_a !! $n_b ),
-        nqp::while(
-            nqp::not_i($res) && nqp::islt_i($i, $total_iters),
-            nqp::stmts(
-                $res = &infix:<cmp>(@a.AT-POS($i), @b.AT-POS($i)),
-                $i   = nqp::add_i($i, 1)
-            )
-        ),
-        ORDER( $res ?? $res !! $ord )
+    nqp::if(
+        @a.is-lazy || @b.is-lazy,
+        CMP-SLOW(@a, @b),
+        nqp::stmts(
+            ( my $a_r := nqp::getattr(@a, List, '$!reified') ),
+            ( my $b_r := nqp::getattr(@b, List, '$!reified') ),
+            ( my int $ord = nqp::cmp_i(
+                ( my int $n_a = nqp::elems($a_r) ), ( my int $n_b = nqp::elems($b_r) )
+            )),
+            ( my int $res = ( my int $i = 0) ),
+            ( my int $total_iters = nqp::islt_i($ord, 0) ?? $n_a !! $n_b ),
+            nqp::while(
+                nqp::not_i($res) && nqp::islt_i($i, $total_iters),
+                nqp::stmts(
+                    $res = &infix:<cmp>(nqp::atpos($a_r, $i), nqp::atpos($b_r, $i)),
+                    $i   = nqp::add_i($i, 1)
+                )
+            ),
+            ORDER( $res ?? $res !! $ord )
+        )
     )
 }
 

--- a/src/core/Rakudo/Iterator.pm6
+++ b/src/core/Rakudo/Iterator.pm6
@@ -3844,18 +3844,21 @@ class Rakudo::Iterator {
                     nqp::stmts(
                       (my int $i = -1),
                       (my int $elems = nqp::elems($!iters)),
+                      (my int $is_iterend = 0),
                       (my $buf :=
                         nqp::setelems(nqp::create(IterationBuffer),$elems)),
-                      nqp::until(
-                        nqp::iseq_i(($i = nqp::add_i($i,1)),$elems)
-                         || nqp::eqaddr(
-                              (my $pulled := nqp::atpos($!iters,$i).pull-one),
-                              IterationEnd
-                            ),
-                        nqp::bindpos($buf,$i,$pulled)
+                      nqp::while(
+                        nqp::islt_i(($i = nqp::add_i($i,1)),$elems),
+                        nqp::if(
+                          nqp::eqaddr(
+                            (my $pulled := nqp::atpos($!iters,$i).pull-one), IterationEnd
+                          ),
+                          $is_iterend = 1,
+                          nqp::bindpos($buf,$i,$pulled)
+                        )
                       ),
                       nqp::if(
-                        nqp::islt_i($i,$elems),  # at least one exhausted
+                        $is_iterend,  # at least one exhausted
                         nqp::stmts(
 #?if jvm
                           ($!iters := Mu),
@@ -3930,18 +3933,21 @@ class Rakudo::Iterator {
                     nqp::stmts(
                       (my int $i = -1),
                       (my int $elems = nqp::elems($!iters)),
+                      (my int $is_iterend = 0),
                       (my $list :=
                         nqp::setelems(nqp::create(IterationBuffer),$elems)),
-                      nqp::until(
-                        nqp::iseq_i(($i = nqp::add_i($i,1)),$elems)
-                         || nqp::eqaddr(
-                              (my $pulled := nqp::atpos($!iters,$i).pull-one),
-                              IterationEnd
-                            ),
-                        nqp::bindpos($list,$i,$pulled)
+                      nqp::while(
+                        nqp::islt_i(($i = nqp::add_i($i,1)),$elems),
+                        nqp::if(
+                          nqp::eqaddr(
+                            (my $pulled := nqp::atpos($!iters,$i).pull-one), IterationEnd
+                          ),
+                          $is_iterend = 1,
+                          nqp::bindpos($list,$i,$pulled)
+                        )
                       ),
                       nqp::if(
-                        nqp::islt_i($i,$elems),  # at least one exhausted
+                        $is_iterend,  # at least one exhausted
                         nqp::stmts(
 #?if jvm
                           ($!iters := Mu),


### PR DESCRIPTION
* Check that @a and @b are not lazy. If they are fall back to slow path
* In fast path, extract '$!reified' elements and use lower-level ops
  like nqp::elems and nqp::atpos on them instead of high-level
  equivalents

In the slow path, add laziness check. This fixes a bug with comparison
of lazy arrays where one is exhausted, and when the the number of elems
is compared a Failure occurs ("Lazy Lists Cannot .elems")

In order for the laziness check to work in instances where two identical
lazy lists are compared, modify "ZipIterable" so that all the sub-
iterators are pulled an equal number of times, even if one of the
earlier iterators pulled "IterationEnd"