### PR TITLE
Micro-optimize List.roll($n)

### DIFF
--- a/src/core/List.pm6
+++ b/src/core/List.pm6
@@ -1077,11 +1077,15 @@ my class List does Iterable does Positional { # declared in BOOTSTRAP
                          }
                      }
                      method push-all($target --> IterationEnd) {
-                         nqp::while(
-                             $!todo,
-                             nqp::stmts(
-                                 ($target.push(nqp::atpos($!list,$!elems.rand.floor))),
-                                 ($!todo = $!todo - 1)
+                         nqp::stmts(
+                             (my int $todo  = $!todo),
+                             (my int $elems = $!elems),
+                             nqp::while(
+                                 $todo,
+                                 nqp::stmts(
+                                     ($target.push(nqp::atpos($!list,$elems.rand.floor))),
+                                     ($todo = $todo - 1)
+                                 )
                              )
                          )
                      }


### PR DESCRIPTION
Lexicals are faster than private attributes.

Passes `make m-test m-spectest`.

`my $l = 1000000; my @a = ^1000; my @b = @a.roll($l); say now - INIT now` decreases from ~3.0s to ~2.8s.