### PR TITLE
Update 05-messages/03-errors.t to add test for RT #122980.

### DIFF
--- a/t/05-messages/03-errors.t
+++ b/t/05-messages/03-errors.t
@@ -2,7 +2,7 @@ use lib <t/packages/>;
 use Test;
 use Test::Helpers;
 
-plan 10;
+plan 11;
 
 subtest '.map does not explode in optimizer' => {
     plan 3;
@@ -87,5 +87,10 @@ subtest 'unclosed hash quote index operator <> message' => {
         'better and shorter error message for unclosed <> hash operator',
         :gist{ not .match: /:i:s<<expecting any of: / };
 }
+
+# RT #122980
+throws-like 'Int:erator:$;', X::InvalidTypeSmiley,
+    ｢Don't report "missing semicolon" when semicolon present with complicated punctuation.｣,
+    :message{ not .match: /:i:s<<missing semicolon/ };
 
 # vim: ft=perl6 expandtab sw=4


### PR DESCRIPTION
Test RT #122980 check for the invalid "missing semicolon" message. The rakudo versions with the problem were over three years old and the Test libraries were not compatible with 2018 03-errors.t so testing with a symptomatic version had to be manually jury rigged. If test is still wanted think about the best that can be done.