### PR TITLE
Use explicit native types in some places

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -712,7 +712,7 @@ role STDActions {
 
         my $docast := $doc.MATCH.ast;
         if $docast.has_compile_time_value {
-            my $dedented := nqp::unbox_s($docast.compile_time_value.indent($indent));
+            my str $dedented := nqp::unbox_s($docast.compile_time_value.indent($indent));
             $origast.push($*W.add_string_constant($dedented));
         }
         else {
@@ -7955,7 +7955,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
     }
 
     method rad_number($/) {
-        my $radix    := nqp::radix(10, $<radix>, 0, 0)[0];
+        my int $radix := nqp::radix(10, $<radix>, 0, 0)[0];
 
         if $<bracket> { # the "list of place values" case
             make QAST::Op.new(:name('&UNBASE_BRACKET'), :op('call'),

--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -1729,7 +1729,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
             my $p6cursor := $*W.find_symbol(['Match']);
             nqp::bindattr_i($new, NQPMatch, '$!from',  nqp::getattr_i($ret, $p6cursor, '$!from'));
             nqp::bindattr_i($new, NQPMatch, '$!pos',   nqp::getattr_i($ret, $p6cursor, '$!pos'));
-            my $p6c_name := nqp::getattr_s($ret, $p6cursor, '$!name');
+            my str $p6c_name := nqp::getattr_s($ret, $p6cursor, '$!name');
             if !nqp::isnull_s($p6c_name) {
                 nqp::bindattr($new,   NQPMatch, '$!name',  $p6c_name);
             }

--- a/src/Perl6/Metamodel/BOOTSTRAP.nqp
+++ b/src/Perl6/Metamodel/BOOTSTRAP.nqp
@@ -2291,7 +2291,7 @@ BEGIN {
                             my $type_obj       := nqp::atpos(nqp::atkey($cur_candidate, 'types'), $i);
                             my int $type_flags := nqp::atpos_i(nqp::atkey($cur_candidate, 'type_flags'), $i);
                             my int $got_prim   := nqp::captureposprimspec($capture, $i);
-                            my $rwness         := nqp::atpos_i(nqp::atkey($cur_candidate, 'rwness'), $i);
+                            my int $rwness     := nqp::atpos_i(nqp::atkey($cur_candidate, 'rwness'), $i);
                             if $rwness && !nqp::isrwcont(nqp::captureposarg($capture, $i)) {
                                 # If we need a container but don't have one it clearly can't work.
                                 $rwness_mismatch := 1;

--- a/src/vm/moar/Perl6/Ops.nqp
+++ b/src/vm/moar/Perl6/Ops.nqp
@@ -1,25 +1,25 @@
 # Operand read/write/literal flags.
-my $MVM_operand_literal     := 0;
-my $MVM_operand_read_reg    := 1;
-my $MVM_operand_write_reg   := 2;
-my $MVM_operand_read_lex    := 3;
-my $MVM_operand_write_lex   := 4;
-my $MVM_operand_rw_mask     := 7;
+my int $MVM_operand_literal     := 0;
+my int $MVM_operand_read_reg    := 1;
+my int $MVM_operand_write_reg   := 2;
+my int $MVM_operand_read_lex    := 3;
+my int $MVM_operand_write_lex   := 4;
+my int $MVM_operand_rw_mask     := 7;
 
 # Register data types.
-my $MVM_reg_void            := 0;
-my $MVM_reg_int64           := 4;
-my $MVM_reg_num64           := 6;
-my $MVM_reg_str             := 7;
-my $MVM_reg_obj             := 8;
-my $MVM_reg_uint64          := 20;
+my int $MVM_reg_void            := 0;
+my int $MVM_reg_int64           := 4;
+my int $MVM_reg_num64           := 6;
+my int $MVM_reg_str             := 7;
+my int $MVM_reg_obj             := 8;
+my int $MVM_reg_uint64          := 20;
 
 # Operand data types.
-my $MVM_operand_int64       := nqp::bitshiftl_i($MVM_reg_int64, 3);
-my $MVM_operand_num64       := nqp::bitshiftl_i($MVM_reg_num64, 3);
-my $MVM_operand_str         := nqp::bitshiftl_i($MVM_reg_str, 3);
-my $MVM_operand_obj         := nqp::bitshiftl_i($MVM_reg_obj, 3);
-my $MVM_operand_uint64      := nqp::bitshiftl_i($MVM_reg_uint64, 3);
+my int $MVM_operand_int64       := nqp::bitshiftl_i($MVM_reg_int64, 3);
+my int $MVM_operand_num64       := nqp::bitshiftl_i($MVM_reg_num64, 3);
+my int $MVM_operand_str         := nqp::bitshiftl_i($MVM_reg_str, 3);
+my int $MVM_operand_obj         := nqp::bitshiftl_i($MVM_reg_obj, 3);
+my int $MVM_operand_uint64      := nqp::bitshiftl_i($MVM_reg_uint64, 3);
 
 # Register MoarVM extops.
 use MASTNodes;


### PR DESCRIPTION
Rakudo builds ok and passes `make m-test m-spectest`.