### PR TITLE
Don't hardcode gmake locations

### DIFF
--- a/Configure.pl
+++ b/Configure.pl
@@ -150,7 +150,7 @@ MAIN: {
 
     my $make = 'make';
     if ($^O eq 'solaris') {
-        if (not -X '/usr/bin/gmake') {
+        if (-z `which gmaker`) {
             die "gmake is required to compile rakudo. Please install by 'pkg install gnu-make'";
         }
         $make = 'gmake';

--- a/Configure.pl
+++ b/Configure.pl
@@ -150,7 +150,7 @@ MAIN: {
 
     my $make = 'make';
     if ($^O eq 'solaris') {
-        if (-z `which gmaker`) {
+        if (-z `which gmake`) {
             die "gmake is required to compile rakudo. Please install by 'pkg install gnu-make'";
         }
         $make = 'gmake';


### PR DESCRIPTION
Many Solaris users use gmake from [CSW](http://opencsw.org/) or compile gmake themselves. There is no need to hardcode gmake's location. Testing the presence in the PATH is enough.