### PR TITLE
X::NYI uses optional $.feature in method message

### DIFF
--- a/src/core/Exception.pm6
+++ b/src/core/Exception.pm6
@@ -782,7 +782,7 @@ my class X::NYI is Exception {
     has $.did-you-mean;
     has $.workaround;
     method message() {
-        my $msg = "$.feature not yet implemented. Sorry.";
+        my $msg = "{ $.feature andthen "$_ not" orelse "Not" } yet implemented. Sorry.";
         $msg ~= "\nDid you mean: {$.did-you-mean.gist}?" if $.did-you-mean;
         $msg ~= "\nWorkaround: $.workaround" if $.workaround;
         $msg


### PR DESCRIPTION
Methods `message` checks wether $.feature is set and returns slightly different error texts. 
But there are still other exceptions that use variables that might not have been set.  I dont know wether some of those variables are ment to have a `is required` on them or not.