### PR TITLE
GH#1758: Only suggest a submethod if it's local

### DIFF
--- a/src/core/Exception.pm6
+++ b/src/core/Exception.pm6
@@ -171,7 +171,11 @@ my class X::Method::NotFound is Exception {
         }
 
         if nqp::can($!invocant.HOW, 'methods') {
-            for $!invocant.^methods(:all)>>.name -> $method_name {
+            my @invocant_methods = $!invocant.^methods(:local)>>.name;
+            for $!invocant.^methods(:all) -> $method_candidate {
+                my $method_name = $method_candidate.name;
+                # GH#1758 do not suggest a submethod from a parent
+                next if $method_candidate.^name eq 'Submethod' && !@invocant_methods.first($method_name, :k).defined;
                 my $dist = StrDistance.new(:before($.method), :after($method_name));
                 if $dist <= $max_length {
                     %suggestions{$method_name} = $dist;

--- a/t/05-messages/01-errors.t
+++ b/t/05-messages/01-errors.t
@@ -2,7 +2,7 @@ use lib <t/packages/>;
 use Test;
 use Test::Helpers;
 
-plan 48;
+plan 50;
 
 # RT #129763
 throws-like '1++', X::Multi::NoMatch,
@@ -226,6 +226,19 @@ throws-like { Blob.splice }, X::Multi::NoMatch,
         X::Method::NotFound,
         message => all(/<<"No such method 'starts-wizh'" \W/, /<<'starts-with'>>/),
         'longer method names are suggested also';
+}
+
+# https://github.com/rakudo/rakudo/issues/1758
+{
+    throws-like q| class GH1758_1 { submethod x { }; }; class B is GH1758_1 {}; B.new._ |,
+        X::Method::NotFound,
+        :message{ !.contains: "Did you mean 'x'" },
+        'Ancestor submethods should not be typo-suggested';
+
+    throws-like q| class GH1758_2 { submethod x { };}; GH1758_2.new._ |,
+        X::Method::NotFound,
+        message => /"Did you mean 'x'"/,
+        'Ancestor submethods should not be typo-suggested';
 }
 
 subtest '`IO::Socket::INET.new: :listen` fails with useful error' => {


### PR DESCRIPTION
This avoids us suggesting a submethod from a parent class, which would
always result into an error.