### PR TITLE
Add a CACHEDIR.TAG to precomp dirs

### DIFF
--- a/src/core/CompUnit/PrecompilationStore/File.pm6
+++ b/src/core/CompUnit/PrecompilationStore/File.pm6
@@ -191,6 +191,11 @@ class CompUnit::PrecompilationStore::File does CompUnit::PrecompilationStore {
     {
         unless $!prefix.e {
             $!prefix.mkdir or return;
+            try $!prefix.child('CACHEDIR.TAG').spurt:
+                "Signature: 8a477f597d28d172789f06886806bc55\n" ~
+                "# This file is a cache directory tag created by rakudo.\n" ~
+                "# For information about cache directory tags, see:\n" ~
+                "#       http://www.brynosaurus.com/cachedir/\n";
         }
         return unless $!prefix.w;
         self!lock();


### PR DESCRIPTION
The `CACHEDIR.TAG` file is an informal standard for declaring any directory is an expendable cache by putting a file with a magic string in it, handy for software that can't or won't use fixed cache locations (e.g. `XDG_CACHE_DIR`).

It's not required by any means, but polite to have, as it lets generic system tools know this directory is safe to blow away or exclude from things like backups.

This patch plays it safe and only adds the file to new dirs; having it check and backfill existing ones would waste precious cycles during startup and I didn't feel brave enough to attempt it in any case.