### PR TITLE
Rewrote Rat / FatRat stringification to be much faster.

### DIFF
--- a/src/core/Rational.pm6
+++ b/src/core/Rational.pm6
@@ -95,34 +95,52 @@ my role Rational[::NuT = Int, ::DeT = ::("NuT")] does Real {
         my $fract  = self.abs - $whole;
 
         # fight floating point noise issues RT#126016
-        if $fract.Num == 1e0 { ++$whole; $fract = 0 }
+        if $fract.Num == 1e0 && nqp::eqaddr(self.WHAT,Rat) {
+            $whole += 1;
+            $fract = 0;
+        }
 
         my $result = nqp::if(
             nqp::islt_I($!numerator, 0), '-', ''
         ) ~ $whole;
 
         if $fract {
-            my $precision = $!denominator < 100_000
-                ?? 5 !! $!denominator.Str.chars;
-
-            my $fract-result = '';
-            while $fract and $fract-result.chars < $precision {
-                $fract *= 100;
-                my $f   = $fract.floor;
-                $fract -= $f;
-                $fract-result ~= $f < 10 ?? "0$f" !!
-                                 (!$fract and $f %% 10) ?? ($f / 10).floor !! $f;
-            }
-            if $fract and $fract-result.chars < $precision + 1 {
-                $fract *= 10;
-                given $fract.floor {
-                    $fract-result ~= $_;
-                    $fract        -= $_;
+            my $precision;
+            # Stringify Rats to at least 6 significant digits. There does not
+            # appear to be any written spec for this but there are tests in
+            # roast that specifically test for 6 digits.
+            if nqp::eqaddr(self.WHAT,Rat) {
+                if $!denominator < 100000 {
+                    $precision = 6;
+                    $fract *= 1000000;
+                }
+                else {
+                    $precision = nqp::chars($!denominator.Str) + 1;
+                    $fract *= nqp::pow_I(10, nqp::decont($precision), Num, Int);
                 }
             }
-            ++$fract-result if 2*$fract >= 1; # round off fractional result
-
-            $result ~= '.' ~ $fract-result;
+            else {
+                # TODO v6.d FatRats are tested in roast to have a minimum
+                # precision pf 6 decimal places - mostly due to there being no
+                # formal spec and the desire to test SOMETHING. With this
+                # speed increase, 16 digits would work fine; but it isn't spec.  
+                #if $!denominator < 1000000000000000 {
+                #    $precision = 16;
+                #    $fract *= 10000000000000000;
+                #}
+                if $!denominator < 100000 {
+                    $precision = 6;
+                    $fract *= 1000000;
+                }
+                else {
+                    $precision = nqp::chars($!denominator.Str) + nqp::chars($whole.Str) + 1;
+                    $fract *= nqp::pow_I(10, nqp::decont($precision), Num, Int);
+                }
+            }
+            my $f  = $fract.round;
+            my $fc = nqp::chars($f.Str);
+            $f div= 10 while $f %% 10; # Remove trailing zeros
+            $result ~= '.' ~ '0' x ($precision - $fc) ~ $f;
         }
         $result
     }


### PR DESCRIPTION
Rats stringify on average twice as fast, FatRats, depending on the
size of the denominator, range from about the same to 200+ times as
fast. Also fixes a few bugs: FatRat strings very close to 1 no
longer round off to 1. Rats and FatRats no longer ever stringify
with trailing zeros in the fractional part. FatRats are now capable
of stringifying to sixteen minimum significant digits or more if
necessary to accurately express the value, but holding off until v6.d
because it isn't spec. There are 8 tests in roast that expect only 6 digits
of precision from FatRats. They are all six years old or older.

E.G. Right now, Fatrat.new(2,3) stringifies to .666667 (same as Rat.new(2,3) ). With 16 minimum significant digits it would stringify to .6666666666666667. If you are trading off the lower speed of FatRat calculations for higher precision, it seems to me you should get more precise results back.