### PR TITLE
Test.pm:  Tweaks to pass() and flunk()

### DIFF
--- a/lib/Test.pm6
+++ b/lib/Test.pm6
@@ -116,8 +116,9 @@ multi sub plan($number_of_tests) is export {
 
 multi sub pass($desc = '') is export {
     $time_after = nqp::time_n;
-    proclaim(1, $desc);
+    my $ok = proclaim(1, $desc);
     $time_before = nqp::time_n;
+    $ok;
 }
 
 multi sub ok(Mu $cond, $desc = '') is export {
@@ -444,7 +445,7 @@ sub _diag(Mu $message, :$force-stderr) {
 }
 
 # In earlier Perls, this is spelled "sub fail"
-multi sub flunk($reason) is export {
+multi sub flunk($reason = '') is export {
     $time_after = nqp::time_n;
     my $ok = proclaim(0, $reason);
     $time_before = nqp::time_n;


### PR DESCRIPTION
* Make pass() always return a True value, just like flunk() always returns False.
* Give a default empty string argument to flunk(), just like pass() which also has one.

Current behavior:

```
> use Test; say 'OUTPUT: ', pass('yeah')
ok 1 - yeah
OUTPUT: 1526587200.5168555

> use Test; say 'OUTPUT: ', flunk('noes')
not ok 1 - noes
# Failed test 'noes'
# at - line 1
OUTPUT: False
```

```
> use Test; pass
ok 1 - 

> use Test; flunk
Calling flunk() will never work with any of these multi signatures:
    ($reason)
```