### PR TITLE
JSONException -> Rakudo::Internals::JSONException

### DIFF
--- a/src/core/CompUnit/Repository/FileSystem.pm6
+++ b/src/core/CompUnit/Repository/FileSystem.pm6
@@ -27,7 +27,7 @@ class CompUnit::Repository::FileSystem does CompUnit::Repository::Locally does C
                 try {
                     %!meta = Rakudo::Internals::JSON.from-json: $meta.slurp;
                     CATCH {
-                        when JSONException {
+                        when Rakudo::Internals::JSONException {
                             fail "Invalid JSON found in META6.json";
                         }
                     }

--- a/src/core/Rakudo/Internals/JSON.pm6
+++ b/src/core/Rakudo/Internals/JSON.pm6
@@ -1,4 +1,4 @@
-my class JSONException is Exception {
+my class Rakudo::Internals::JSONException is Exception {
     has $.text;
 
     method message {
@@ -142,7 +142,7 @@ my class Rakudo::Internals::JSON {
     method from-json($text) {
         my $a = JSONPrettyActions.new();
         my $o = JSONPrettyGrammar.parse($text, :actions($a));
-        JSONException.new(:$text).throw unless $o;
+        Rakudo::Internals::JSONException.new(:$text).throw unless $o;
         $o.ast;
     }
     method to-json(|c) { to-json(|c) }


### PR DESCRIPTION
Rename class. No need to pollute global namespace.