### PR TITLE
Revert "JSONException -> Rakudo::Internals::JSONException"

### DIFF
--- a/src/core/CompUnit/Repository/FileSystem.pm6
+++ b/src/core/CompUnit/Repository/FileSystem.pm6
@@ -27,7 +27,7 @@ class CompUnit::Repository::FileSystem does CompUnit::Repository::Locally does C
                 try {
                     %!meta = Rakudo::Internals::JSON.from-json: $meta.slurp;
                     CATCH {
-                        when Rakudo::Internals::JSONException {
+                        when JSONException {
                             fail "Invalid JSON found in META6.json";
                         }
                     }

--- a/src/core/Rakudo/Internals/JSON.pm6
+++ b/src/core/Rakudo/Internals/JSON.pm6
@@ -1,4 +1,4 @@
-my class Rakudo::Internals::JSONException is Exception {
+my class JSONException is Exception {
     has $.text;
 
     method message {
@@ -142,7 +142,7 @@ my class Rakudo::Internals::JSON {
     method from-json($text) {
         my $a = JSONPrettyActions.new();
         my $o = JSONPrettyGrammar.parse($text, :actions($a));
-        Rakudo::Internals::JSONException.new(:$text).throw unless $o;
+        JSONException.new(:$text).throw unless $o;
         $o.ast;
     }
     method to-json(|c) { to-json(|c) }


### PR DESCRIPTION
Reverts rakudo/rakudo#1841

These can be changed in the ecosystem but that still leaves an already installed e.g. zef with a compile error if rakudo is upgraded.