### PR TITLE
Issue 1843: Limit slice end index in splice implementation

### DIFF
--- a/src/core/Array.pm6
+++ b/src/core/Array.pm6
@@ -1061,7 +1061,7 @@ my class Array { # declared in BOOTSTRAP
               $result,
               List,
               '$!reified',
-              nqp::slice($reified,$offset,nqp::sub_i(nqp::add_i($offset,$size),1))
+              nqp::slice($reified,$offset,nqp::sub_i(nqp::add_i($offset,removed),1))
             )
           ),
           nqp::p6bindattrinvres($result,Array,'$!descriptor',$!descriptor)


### PR DESCRIPTION
Splice allows the user to enter a number of elems greater than the elems
in the list (the extra is just ignored). However, nqp::slice throws an
exception if too large an index is submitted. Check that the end index
is not greater than the total elems.
