### PR TITLE
Add Set candidate for SetHash's STORE

### DIFF
--- a/src/core/SetHash.pm6
+++ b/src/core/SetHash.pm6
@@ -176,9 +176,23 @@ my class SetHash does Setty {
     }
 
 #--- interface methods
-    method STORE(*@pairs --> SetHash:D) {
+    proto method STORE(|) {*}
+
+    multi method STORE(*@pairs --> SetHash:D) {
         nqp::if(
           (my $iterator := @pairs.iterator).is-lazy,
+          Failure.new(X::Cannot::Lazy.new(:action<initialize>,:what(self.^name))),
+          self.SET-SELF(
+            Rakudo::QuantHash.ADD-PAIRS-TO-SET(
+              nqp::create(Rakudo::Internals::IterationSet), $iterator
+            )
+          )
+        )
+    }
+
+    multi method STORE(%set --> SetHash:D) {
+        nqp::if(
+          (my $iterator := %set.iterator).is-lazy,
           Failure.new(X::Cannot::Lazy.new(:action<initialize>,:what(self.^name))),
           self.SET-SELF(
             Rakudo::QuantHash.ADD-PAIRS-TO-SET(


### PR DESCRIPTION
So set metaops like `∖=` will DWIM. A possible final fix for GH #1203. `perl6 -e 'my %days := SetHash.new: Date.today … Date.new: "2018-06-02"; say %days.elems; %days ∖= %days.grep: *.key.day-of-week > 5; say %days.elems'` now prints out 14 and 10, instead of 14 and 1.

Rakudo builds ok and passes `make m-test m-spectest` (will add some new test to roast if this is merged).