### PR TITLE
Workaround Nil value for &DEPRECATED in phaser from trait (R#1219)

### DIFF
--- a/src/core/traits.pm6
+++ b/src/core/traits.pm6
@@ -151,7 +151,9 @@ multi sub trait_mod:<is>(Routine:D $r, :$DEPRECATED!) {
     my $new := nqp::istype($DEPRECATED,Bool)
       ?? "something else"
       !! $DEPRECATED;
-    $r.add_phaser( 'ENTER', -> { DEPRECATED($new) } );
+    # XXX just using DEPRECATED(...) calls a Nil, why?
+    my $dep = &DEPRECATED;
+    $r.add_phaser( 'ENTER', -> { $dep($new) } );
 }
 multi sub trait_mod:<is>(Routine:D $r, Mu :$inlinable!) {
     $r.set_inline_info(nqp::decont($inlinable));


### PR DESCRIPTION
  This does not explain why the symbol is Nil, but makes it work
  by carrying the symbol in from the trait scope in a variable.