### PR TITLE
Issue 1888: Emit enum to supply on signal

### DIFF
--- a/src/core/signals.pm6
+++ b/src/core/signals.pm6
@@ -46,7 +46,7 @@ multi sub signal(Signal $signal, *@signals, :$scheduler = $*SCHEDULER) {
 
             method tap(&emit, &, &, &tap) {
                 my $cancellation := nqp::signal($!scheduler.queue(:hint-time-sensitive),
-                    -> $signum { emit($signum) },
+                    -> $signum { emit(Signal($signum)) },
                     nqp::unbox_i($!signal),
                     SignalCancellation);
                 my $t = Tap.new({ nqp::cancel($cancellation) });


### PR DESCRIPTION
On the recent modification of the signal sub, there was a subtle change
to the form of the signum emitted by the signal handler. Pre-change it
emitted the signum in the form of the corresponding Signal enum and
post-change it emits the signum as an Int. Changing it so that it will
one again emit the Signal enum as it is more useful in varying contexts.
AlexDaniel++ for discovering this.