### PR TITLE
Create consistently ordered Signal enum via list

### DIFF
--- a/src/core/signals.pm6
+++ b/src/core/signals.pm6
@@ -1,13 +1,14 @@
 my enum Signal (
     |nqp::stmts(
-        ( my $res  := nqp::hash ),
+        ( my $res  := nqp::list ),
         ( my $iter := nqp::iterator(nqp::getsignals) ),
         nqp::while(
             $iter,
             nqp::stmts(
-                ( my $p := nqp::shift($iter) ),
-                nqp::bindkey($res, nqp::iterkey_s($p), nqp::abs_i(nqp::iterval($p)) )
-            )
+                ( my $p := nqp::p6bindattrinvres(nqp::create(Pair), Pair, '$!key', nqp::shift($iter)) ),
+                nqp::bindattr($p, Pair, '$!value', nqp::abs_i(nqp::shift($iter)) ),
+                nqp::push($res, $p),
+            ),
         ),
         $res
     )


### PR DESCRIPTION
This is the Rakudo component of a whole spanning the MoarVM, NQP,
and Rakudo repos.
[MoarVM](https://github.com/MoarVM/MoarVM/pull/870)
[NQP](https://github.com/perl6/nqp/pull/457)

Create Signal enums with a definite order. The output of getsignals has
been changed to an interleaved list in the backends so that order can be
maintained.

This makes sure that output of .pred and .succ remains consistent.