### PR TITLE
Fix arg type in X::Str::Sprintf::Directives::Count

### DIFF
--- a/src/core/Exception.pm6
+++ b/src/core/Exception.pm6
@@ -2040,7 +2040,7 @@ my class X::Str::Trans::InvalidArg is Exception {
 
 my class X::Str::Sprintf::Directives::Count is Exception {
     has int $.args-used;
-    has num $.args-have;
+    has int $.args-have;
     method message() {
         "Your printf-style directives specify "
         ~ ($.args-used == 1 ?? "1 argument, but "


### PR DESCRIPTION
`$.args-have` used to get its value from a `numify` call (which returned a num). It now
gets it from `nqp::elems` which returns an int.

Rakudo builds ok and passes `make m-test j-test m-spectest`. I can't run a full spectest with the JVM Rakudo on this machine, but it also passes t/spec/S32-str/sprintf.t.

Fixes the errors in t/spec/S32-str/sprintf.t caused by https://github.com/perl6/nqp/commit/efb316e550.