### PR TITLE
Issue 1918: Fix for .assuming sub with **@ and +@ params

### DIFF
--- a/src/core/Parameter.pm6
+++ b/src/core/Parameter.pm6
@@ -36,6 +36,8 @@ my class Parameter { # declared in BOOTSTRAP
 
     my constant $SIG_ELEM_IS_NOT_POSITIONAL = $SIG_ELEM_SLURPY_POS
                                            +| $SIG_ELEM_SLURPY_NAMED
+                                           +| $SIG_ELEM_SLURPY_LOL
+                                           +| $SIG_ELEM_SLURPY_ONEARG
                                            +| $SIG_ELEM_IS_CAPTURE;
     my constant $SIG_ELEM_IS_SLURPY = $SIG_ELEM_SLURPY_POS
                                    +| $SIG_ELEM_SLURPY_NAMED


### PR DESCRIPTION
Add slurpy_lol (**@) and slurpy_onearg (+@) to param types that are not
considered positional.

This caused an issue when using '.assuming'. The fact that they were
considered both positional and slurpy caused them
to be added multiple times to a new param list and miscompiled on EVAL
(The below example would result in a redeclaration error).

    sub x(+@a, :$b) { say "{@a.perl} and $b" }; &x.assuming(:!b);

See [GH Issue 1918](https://github.com/rakudo/rakudo/issues/1918).