### PR TITLE
Issue 1891: Add role to Signal for custom zero logic

### DIFF
--- a/src/core/Enumeration.pm6
+++ b/src/core/Enumeration.pm6
@@ -34,7 +34,8 @@ my role Enumeration {
     multi method ACCEPTS(::?CLASS:D: ::?CLASS:U $ --> True) { }
     multi method ACCEPTS(::?CLASS:D: ::?CLASS:D \v) { self === v }
 
-    method CALL-ME(|) {
+    proto method CALL-ME(|) {*}
+    multi method CALL-ME(|) {
         my $x := nqp::atpos(nqp::p6argvmarray(), 1).AT-POS(0);
         nqp::istype($x, ::?CLASS)
             ?? $x

--- a/src/core/signals.pm6
+++ b/src/core/signals.pm6
@@ -1,5 +1,5 @@
 my role Signally {
-    multi method CALL-ME(Int $signum) {
+    multi method CALL-ME(Int() $signum) {
         return self if $signum == 0;
         nextsame
     }

--- a/src/core/signals.pm6
+++ b/src/core/signals.pm6
@@ -1,4 +1,10 @@
-my enum Signal (
+my role Signally {
+    multi method CALL-ME(Int $signum) {
+        return self if $signum == 0;
+        nextsame
+    }
+}
+my enum Signal does Signally (
     |nqp::stmts(
         ( my $res  := nqp::list ),
         ( my $iter := nqp::iterator(nqp::getsignals) ),


### PR DESCRIPTION
This add custom logic for ```Signal(0)``` so that it will return the type object
like it did previously.

See [Issue 1891](https://github.com/rakudo/rakudo/issues/1891)

I set the target of the PR to the post-release branch, but if it makes more
sense to merge it into master before release, then I am okay with it being
changed.
