### PR TITLE
Prepend inst# to home when setting up repositories

### DIFF
--- a/src/core/CompUnit/RepositoryRegistry.pm6
+++ b/src/core/CompUnit/RepositoryRegistry.pm6
@@ -95,8 +95,7 @@ class CompUnit::RepositoryRegistry {
                    (nqp::existskey($ENV,'HOMEPATH')
                      ?? nqp::atkey($ENV,'HOMEPATH') !! '')
                  ) -> $home-path {
-                $home = "$home-path/.perl6";
-                my str $path = "inst#$home";
+                $home = "inst#$home-path/.perl6";
             }
         }
 
@@ -147,7 +146,7 @@ class CompUnit::RepositoryRegistry {
                 CompUnit::Repository::Installation.new(:prefix("$prefix/site"), :$next-repo)
             )) unless nqp::existskey($unique, $site);
             nqp::bindkey($custom-lib, 'home', $next-repo := self!register-repository(
-                "inst#$home/.perl6",
+                $home,
                 CompUnit::Repository::Installation.new(:prefix($home), :$next-repo)
             )) if $home and not nqp::existskey($unique, $home);
         }


### PR DESCRIPTION
The keys to the `$repos` hash are in the form of `inst#/path/to/repo` (among
others), but $home was just the path before this change, causing all
`nqp::atkey($repos, $home)` calls to come back as null