### PR TITLE
Fix for GH issue #1968

### DIFF
--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -1020,7 +1020,13 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         <pod_configuration($<spaces>)> <pod_newline>+
         [
         || <delimited_code_content($<spaces>)> $<spaces> '=end' \h+
-            [ <pod-delim-code-typ> [ <pod_newline> | $ ]
+            [ $<end>=<pod-delim-code-typ> [ <pod_newline> | $ ]
+              { if ~$<end> ne ~$<typ> {
+                         $/.typed_panic: 'X::Syntax::Pod::BeginWithoutEnd',
+                         type    => ~$<typ>,
+                         spaces  => ~$<spaces>,
+                         instead => $<end> ?? ~$<end> !! ''
+              }}
               || $<instead>=<identifier>? {
                      $/.typed_panic: 'X::Syntax::Pod::BeginWithoutEnd',
                      type    => $<typ>,
@@ -1029,6 +1035,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
                  }
             ]
         ]
+# TODO GH #1968: detect mismatched =begin/=end types
     }
 
     token delimited_code_content($spaces = '') {

--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -918,7 +918,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
     token pod_string_character {
         <pod_balanced_braces> || <pod_formatting_code> || $<char>=[ \N || [
             <?{ $*POD_IN_FORMATTINGCODE }> \n [
-                <?{ $*POD_DELIMITED_CODE_BLOCK }> <!before \h* '=end' \h+ code> ||
+                <?{ $*POD_DELIMITED_CODE_BLOCK }> <!before \h* '=end' \h+ <pod-delim-code-typ> > ||
                 <!before \h* '=' \w>
                 ]
             ]
@@ -941,7 +941,12 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
          ^^ $<spaces> '=end' \h+
          [
             'comment' [ <pod_newline> | $ ]
-            || $<instead>=<identifier>? {$/.typed_panic: 'X::Syntax::Pod::BeginWithoutEnd', type => 'comment', spaces => ~$<spaces>, instead => $<instead> ?? ~$<instead> !! ''}
+            || $<instead>=<identifier>? {
+                   $/.typed_panic: 'X::Syntax::Pod::BeginWithoutEnd',
+                       type    => 'comment',
+                       spaces  => ~$<spaces>,
+                       instead => $<instead> ?? ~$<instead> !! ''
+               }
          ]
         ]
     }
@@ -969,7 +974,12 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
          ^^ $<spaces> '=end' \h+
          [
              $<type> [ <pod_newline> | $ ]
-             || $<instead>=<identifier>? {$/.typed_panic: 'X::Syntax::Pod::BeginWithoutEnd', type => ~$<type>, spaces => ~$<spaces>, instead => $<instead> ?? ~$<instead> !! ''}
+             || $<instead>=<identifier>? {
+                    $/.typed_panic: 'X::Syntax::Pod::BeginWithoutEnd',
+                        type    => ~$<type>,
+                        spaces  => ~$<spaces>,
+                        instead => $<instead> ?? ~$<instead> !! ''
+                    }
          ]
         ]
     }
@@ -986,23 +996,37 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
          ^^ \h* '=end' \h+
          [
             'table' [ <pod_newline> | $ ]
-             || $<instead>=<identifier>? {$/.typed_panic: 'X::Syntax::Pod::BeginWithoutEnd', type => 'table', spaces => ~$<spaces>, instead => $<instead> ?? ~$<instead> !! ''}
+             || $<instead>=<identifier>? {
+                    $/.typed_panic: 'X::Syntax::Pod::BeginWithoutEnd',
+                        type    => 'table',
+                        spaces  => ~$<spaces>,
+                        instead => $<instead> ?? ~$<instead> !! ''
+                    }
          ]
         ]
     }
 
+    # There are several different identifiers for pod blocks
+    # that are treated essentially the same: 'code', 'input',
+    # and 'output'.
+    token pod-delim-code-typ { code | input | output }
     token pod_block:sym<delimited_code> {
         ^^
         $<spaces> = [ \h* ]
-        '=begin' \h+ 'code' {}
+        '=begin' \h+ $<typ>=<pod-delim-code-typ> {}
         :my $*POD_ALLOW_FCODES  := 0;
         :my $*POD_IN_CODE_BLOCK := 1;
         :my $*POD_DELIMITED_CODE_BLOCK := 1;
         <pod_configuration($<spaces>)> <pod_newline>+
         [
         || <delimited_code_content($<spaces>)> $<spaces> '=end' \h+
-            [ 'code' [ <pod_newline> | $ ]
-              || $<instead>=<identifier>? {$/.typed_panic: 'X::Syntax::Pod::BeginWithoutEnd', type => 'code', spaces => ~$<spaces>, instead => $<instead> ?? ~$<instead> !! ''}
+            [ <pod-delim-code-typ> [ <pod_newline> | $ ]
+              || $<instead>=<identifier>? {
+                     $/.typed_panic: 'X::Syntax::Pod::BeginWithoutEnd',
+                     type    => $<typ>,
+                     spaces  => ~$<spaces>,
+                     instead => $<instead> ?? ~$<instead> !! ''
+                 }
             ]
         ]
     }
@@ -1011,7 +1035,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         ^^
         (
         | $spaces
-            <!before '=end' \h+ 'code' [ <pod_newline> | $ ]>
+            <!before '=end' \h+ <pod-delim-code-typ> [ <pod_newline> | $ ]>
             <pod_string>**0..1 <pod_newline>
         | <pod_newline>
         )*
@@ -1076,7 +1100,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
     token pod_block:sym<paragraph_code> {
         ^^
         $<spaces> = [ \h* ]
-        '=for' \h+ 'code' {}
+        '=for' \h+ <pod-delim-code-typ> {}
         :my $*POD_ALLOW_FCODES := 0;
         :my $*POD_IN_CODE_BLOCK := 1;
         <pod_configuration($<spaces>)> <pod_newline>
@@ -1123,7 +1147,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
     token pod_block:sym<abbreviated_code> {
         ^^
         $<spaces> = [ \h* ]
-        '=code' {}
+        '=' <pod-delim-code-typ> {}
         :my $*POD_ALLOW_FCODES  := 0;
         :my $*POD_IN_CODE_BLOCK := 1;
         [\h*\n|\h+]

--- a/t/07-pod-to-text/02-input-output.t
+++ b/t/07-pod-to-text/02-input-output.t
@@ -1,0 +1,132 @@
+use v6.c;
+use Test;
+
+use Pod::To::Text;
+
+plan 1;
+
+my $ix = -1;
+
+subtest 'Input blocks' => {
+    plan 3;
+
+    =begin input
+    say 1;
+
+    say 2;
+    =end input
+
+    is Pod::To::Text.render($=pod[++$ix]),
+        q:to/END/, "Empty lines don't get added spaces";
+            say 1;
+
+            say 2;
+        END
+
+    =begin input
+    my $a = -5;
+    say ++$a.=abs;
+    # OUTPUT: «6␤»
+    =end input
+
+    is Pod::To::Text.render($=pod[++$ix]),
+        q:to/END/, "Plain continuation lines are aligned";
+            my $a = -5;
+            say ++$a.=abs;
+            # OUTPUT: «6␤»
+        END
+
+    =begin input :allow<B L>
+    sub exclaim B<($phrase)> {
+        say $phrase L<~> "!!!!"
+    }
+    exclaim "Howdy, World";
+    =end input
+    is Pod::To::Text.render($=pod[++$ix]),
+        q:to/END/, "Formatting Codes in code block";
+            sub exclaim ($phrase) {
+                say $phrase ~ "!!!!"
+            }
+            exclaim "Howdy, World";
+        END
+
+=begin comment
+    =input
+    line 1
+    line 2
+
+    is Pod::To::Text.render($=pod[++$ix]),
+        q:to/END/, "Simple block with no blank lines";
+            line 1
+            line 2
+        END
+
+    =for input
+    line 1
+    line 2
+
+    is Pod::To::Text.render($=pod[++$ix]),
+        q:to/END/, "Simple block with no blank lines";
+            line 1
+            line 2
+        END
+=end comment
+}
+
+=begin comment
+subtest 'Output blocks' => {
+    plan 3;
+
+    =begin output
+    say 1;
+
+    say 2;
+    =end output
+
+    is Pod::To::Text.render($=pod[++$ix]),
+        q:to/END/, "Empty lines don't get added spaces";
+            say 1;
+
+            say 2;
+        END
+
+    =begin output
+    my $a = -5;
+    say ++$a.=abs;
+    # OUTPUT: «6␤»
+    =end output
+
+    is Pod::To::Text.render($=pod[++$ix]),
+        q:to/END/, "Plain continuation lines are aligned";
+            my $a = -5;
+            say ++$a.=abs;
+            # OUTPUT: «6␤»
+        END
+
+    =begin output :allow<B L>
+    sub exclaim B<($phrase)> {
+        say $phrase L<~> "!!!!"
+    }
+    exclaim "Howdy, World";
+    =end output
+    is Pod::To::Text.render($=pod[++$ix]),
+        q:to/END/, "Formatting Codes in code block";
+            sub exclaim ($phrase) {
+                say $phrase ~ "!!!!"
+            }
+            exclaim "Howdy, World";
+        END
+
+    =output
+    line 1
+    line 2
+
+    is Pod::To::Text.render($=pod[++$ix]),
+        q:to/END/, "Simple block with no blank lines";
+            line 1
+            line 2
+        END
+}
+=end comment
+
+# vim: expandtab shiftwidth=4 ft=perl6

--- a/t/07-pod-to-text/02-input-output.t
+++ b/t/07-pod-to-text/02-input-output.t
@@ -11,6 +11,10 @@ my $p = -1;
 
 # Provides tests for fixed issue GH #1968.
 
+#===- tests expected to fail: ===
+# TODO
+
+#===- tests expected to work: ===
 # explicit code blocks
 {
 =begin code

--- a/t/07-pod-to-text/02-input-output.t
+++ b/t/07-pod-to-text/02-input-output.t
@@ -3,176 +3,103 @@ use Test;
 
 use Pod::To::Text;
 
-plan 1;
+plan 12;
 
-my $r:
+my $r;
+my $rp;
 my $p = -1;
 
-subtest 'Input blocks' => {
-    plan 3;
-
-    =begin input
+# explicit code blocks
+{
+=begin code
+say 1;
+say 2;
+=end code
+$r = $=pod[++$p];
+isa-ok $r, Pod::Block::Code;
+# code blocks should get indented 4 spaces by Pod::To::Text
+$rp = Pod::To::Text.render($r),
+is $rp,
+q:to/END/, "Empty lines don't get added spaces";
     say 1;
-
     say 2;
-    =end input
+END
 
-    $r = $=pod[++$p];
-    is Pod::To::Text.render($r),
-        q:to/END/, "Empty lines don't get added spaces";
-            say 1;
+=code
+say 1;
+say 2;
 
-            say 2;
-        END
-
-    =begin input
-    my $a = -5;
-    say ++$a.=abs;
-    # OUTPUT: «6␤»
-    =end input
-
-    is Pod::To::Text.render($=pod[++$p]),
-        q:to/END/, "Plain continuation lines are aligned";
-            my $a = -5;
-            say ++$a.=abs;
-            # OUTPUT: «6␤»
-        END
-
-    =begin input :allow<B L>
-    sub exclaim B<($phrase)> {
-        say $phrase L<~> "!!!!"
-    }
-    exclaim "Howdy, World";
-    =end input
-    is Pod::To::Text.render($=pod[++$p]),
-        q:to/END/, "Formatting Codes in code block";
-            sub exclaim ($phrase) {
-                say $phrase ~ "!!!!"
-            }
-            exclaim "Howdy, World";
-        END
-
-    =input
-    line 1
-    line 2
-
-    my $r = $=pod[++$p];
-    my $fp = open 't.test', :w;
-    $fp.say: '# pod type:';
-    my $t = $r.WHAT;
-    $fp.say: $t;
-    $fp.say: '# .perl:';
-    $fp.say: $r.perl;
-    $fp.say: '# render:';
-    $fp.print(Pod::To::Text.render($r));
-
-    =begin input
-    line 1
-    line 2
-    =end input
-    $r = $=pod[++$p];
-    $fp.say: '# .perl:';
-    $fp.say: $r.perl;
-    $fp.say: '# render:';
-    $fp.print(Pod::To::Text.render($r));
-
-    $fp.close;
-=begin comment
-    is Pod::To::Text.render($=pod[++$p]),
-        q:to/END/, "Simple block with no blank lines";
-            line 1
-            line 2
-        END
-
-    =for input
-    line 1
-    line 2
-
-    is Pod::To::Text.render($=pod[++$p]),
-        q:to/END/, "Simple block with no blank lines";
-            line 1
-            line 2
-        END
-=end comment
-}
-
-=begin comment
-subtest 'Output blocks' => {
-    plan 3;
-
-    =begin output
+$r = $=pod[++$p];
+isa-ok $r, Pod::Block::Code;
+# code blocks should get indented 4 spaces by Pod::To::Text
+$rp = Pod::To::Text.render($r),
+is $rp,
+q:to/END/, "Empty lines don't get added spaces";
     say 1;
-
     say 2;
-    =end output
-
-    is Pod::To::Text.render($=pod[++$p]),
-        q:to/END/, "Empty lines don't get added spaces";
-            say 1;
-
-            say 2;
-        END
-
-    =begin output
-    my $a = -5;
-    say ++$a.=abs;
-    # OUTPUT: «6␤»
-    =end output
-
-    is Pod::To::Text.render($=pod[++$p]),
-        q:to/END/, "Plain continuation lines are aligned";
-            my $a = -5;
-            say ++$a.=abs;
-            # OUTPUT: «6␤»
-        END
-
-    =begin output :allow<B L>
-    sub exclaim B<($phrase)> {
-        say $phrase L<~> "!!!!"
-    }
-    exclaim "Howdy, World";
-    =end output
-    is Pod::To::Text.render($=pod[++$p]),
-        q:to/END/, "Formatting Codes in code block";
-            sub exclaim ($phrase) {
-                say $phrase ~ "!!!!"
-            }
-            exclaim "Howdy, World";
-        END
-
-    =output
-    line 1
-    line 2
-
-    is Pod::To::Text.render($=pod[++$p]),
-        q:to/END/, "Simple block with no blank lines";
-            line 1
-            line 2
-        END
+END
 }
-=end comment
 
-# return type of pod
-    given $pod {
-        when Pod::Heading      { heading2text($pod)             }
-        when Pod::Block::Code  { code2text($pod)                }
-        when Pod::Block::Named { named2text($pod)               }
-        when Pod::Block::Para  { twrap( $pod.contents.map({pod2text($_)}).join("") ) }
-        when Pod::Block::Table { table2text($pod)               }
-        when Pod::Block::Declarator { declarator2text($pod)     }
-        when Pod::Item         { item2text($pod).indent(2)      }
-        when Pod::FormattingCode { formatting2text($pod)        }
-        when Positional        { .flat».&pod2text.grep(?*).join: "\n\n" }
-        when Pod::Block::Comment { '' }
-        when Pod::Config       { '' }
-        default                { $pod.Str                       }
-    }
+# implicit code blocks: input
+{
+=begin input
+say 1;
+say 2;
+=end input
+$r = $=pod[++$p];
+isa-ok $r, Pod::Block::Code;
+# code blocks should get indented 4 spaces by Pod::To::Text
+$rp = Pod::To::Text.render($r),
+is $rp,
+q:to/END/, "Empty lines don't get added spaces";
+    say 1;
+    say 2;
+END
 
-sub pod-type($pod) {
-    my $t = 'unknown';
-    given $pod {
-        when Pod::Block::Code { return 'Pod::Block::Code' }
-        default { 
-    }
+=input
+say 1;
+say 2;
+
+$r = $=pod[++$p];
+isa-ok $r, Pod::Block::Code;
+# code blocks should get indented 4 spaces by Pod::To::Text
+$rp = Pod::To::Text.render($r),
+is $rp,
+q:to/END/, "Empty lines don't get added spaces";
+    say 1;
+    say 2;
+END
 }
+
+# implicit code blocks: output
+{
+=begin output
+say 1;
+say 2;
+=end output
+$r = $=pod[++$p];
+isa-ok $r, Pod::Block::Code;
+# code blocks should get indented 4 spaces by Pod::To::Text
+$rp = Pod::To::Text.render($r),
+is $rp,
+q:to/END/, "Empty lines don't get added spaces";
+    say 1;
+    say 2;
+END
+
+=output
+say 1;
+say 2;
+
+$r = $=pod[++$p];
+isa-ok $r, Pod::Block::Code;
+# code blocks should get indented 4 spaces by Pod::To::Text
+$rp = Pod::To::Text.render($r),
+is $rp,
+q:to/END/, "Empty lines don't get added spaces";
+    say 1;
+    say 2;
+END
+}
+
 # vim: expandtab shiftwidth=4 ft=perl6

--- a/t/07-pod-to-text/02-input-output.t
+++ b/t/07-pod-to-text/02-input-output.t
@@ -20,7 +20,7 @@ isa-ok $r, Pod::Block::Code;
 # code blocks should get indented 4 spaces by Pod::To::Text
 $rp = Pod::To::Text.render($r),
 is $rp,
-q:to/END/, "Empty lines don't get added spaces";
+q:to/END/;
     say 1;
     say 2;
 END
@@ -34,7 +34,7 @@ isa-ok $r, Pod::Block::Code;
 # code blocks should get indented 4 spaces by Pod::To::Text
 $rp = Pod::To::Text.render($r),
 is $rp,
-q:to/END/, "Empty lines don't get added spaces";
+q:to/END/;
     say 1;
     say 2;
 END
@@ -51,7 +51,7 @@ isa-ok $r, Pod::Block::Code;
 # code blocks should get indented 4 spaces by Pod::To::Text
 $rp = Pod::To::Text.render($r),
 is $rp,
-q:to/END/, "Empty lines don't get added spaces";
+q:to/END/;
     say 1;
     say 2;
 END
@@ -65,7 +65,7 @@ isa-ok $r, Pod::Block::Code;
 # code blocks should get indented 4 spaces by Pod::To::Text
 $rp = Pod::To::Text.render($r),
 is $rp,
-q:to/END/, "Empty lines don't get added spaces";
+q:to/END/;
     say 1;
     say 2;
 END
@@ -82,7 +82,7 @@ isa-ok $r, Pod::Block::Code;
 # code blocks should get indented 4 spaces by Pod::To::Text
 $rp = Pod::To::Text.render($r),
 is $rp,
-q:to/END/, "Empty lines don't get added spaces";
+q:to/END/;
     say 1;
     say 2;
 END
@@ -96,7 +96,7 @@ isa-ok $r, Pod::Block::Code;
 # code blocks should get indented 4 spaces by Pod::To::Text
 $rp = Pod::To::Text.render($r),
 is $rp,
-q:to/END/, "Empty lines don't get added spaces";
+q:to/END/;
     say 1;
     say 2;
 END

--- a/t/07-pod-to-text/02-input-output.t
+++ b/t/07-pod-to-text/02-input-output.t
@@ -9,6 +9,8 @@ my $r;
 my $rp;
 my $p = -1;
 
+# Provides tests for fixed issue GH #1968.
+
 # explicit code blocks
 {
 =begin code


### PR DESCRIPTION
Fix for GH #1968: pod input/output newlines are not preserved.

Fixed by ensuring the pod input and output blocks are treated the same as code blocks.

Added tests for the fix.