### PR TITLE
Fix GH #1968: input/output block lines are squeezed

### DIFF
--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -918,7 +918,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
     token pod_string_character {
         <pod_balanced_braces> || <pod_formatting_code> || $<char>=[ \N || [
             <?{ $*POD_IN_FORMATTINGCODE }> \n [
-                <?{ $*POD_DELIMITED_CODE_BLOCK }> <!before \h* '=end' \h+ code> ||
+                <?{ $*POD_DELIMITED_CODE_BLOCK }> <!before \h* '=end' \h+ <pod-delim-code-typ> > ||
                 <!before \h* '=' \w>
                 ]
             ]
@@ -941,7 +941,12 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
          ^^ $<spaces> '=end' \h+
          [
             'comment' [ <pod_newline> | $ ]
-            || $<instead>=<identifier>? {$/.typed_panic: 'X::Syntax::Pod::BeginWithoutEnd', type => 'comment', spaces => ~$<spaces>, instead => $<instead> ?? ~$<instead> !! ''}
+            || $<instead>=<identifier>? {
+                   $/.typed_panic: 'X::Syntax::Pod::BeginWithoutEnd',
+                       type    => 'comment',
+                       spaces  => ~$<spaces>,
+                       instead => $<instead> ?? ~$<instead> !! ''
+               }
          ]
         ]
     }
@@ -969,7 +974,12 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
          ^^ $<spaces> '=end' \h+
          [
              $<type> [ <pod_newline> | $ ]
-             || $<instead>=<identifier>? {$/.typed_panic: 'X::Syntax::Pod::BeginWithoutEnd', type => ~$<type>, spaces => ~$<spaces>, instead => $<instead> ?? ~$<instead> !! ''}
+             || $<instead>=<identifier>? {
+                    $/.typed_panic: 'X::Syntax::Pod::BeginWithoutEnd',
+                        type    => ~$<type>,
+                        spaces  => ~$<spaces>,
+                        instead => $<instead> ?? ~$<instead> !! ''
+                    }
          ]
         ]
     }
@@ -986,23 +996,43 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
          ^^ \h* '=end' \h+
          [
             'table' [ <pod_newline> | $ ]
-             || $<instead>=<identifier>? {$/.typed_panic: 'X::Syntax::Pod::BeginWithoutEnd', type => 'table', spaces => ~$<spaces>, instead => $<instead> ?? ~$<instead> !! ''}
+             || $<instead>=<identifier>? {
+                    $/.typed_panic: 'X::Syntax::Pod::BeginWithoutEnd',
+                        type    => 'table',
+                        spaces  => ~$<spaces>,
+                        instead => $<instead> ?? ~$<instead> !! ''
+                    }
          ]
         ]
     }
 
+    # There are several different identifiers for pod blocks
+    # that are treated essentially the same: 'code', 'input',
+    # and 'output'.
+    token pod-delim-code-typ { code | input | output }
     token pod_block:sym<delimited_code> {
         ^^
         $<spaces> = [ \h* ]
-        '=begin' \h+ 'code' {}
+        '=begin' \h+ $<typ>=<pod-delim-code-typ> {}
         :my $*POD_ALLOW_FCODES  := 0;
         :my $*POD_IN_CODE_BLOCK := 1;
         :my $*POD_DELIMITED_CODE_BLOCK := 1;
         <pod_configuration($<spaces>)> <pod_newline>+
         [
         || <delimited_code_content($<spaces>)> $<spaces> '=end' \h+
-            [ 'code' [ <pod_newline> | $ ]
-              || $<instead>=<identifier>? {$/.typed_panic: 'X::Syntax::Pod::BeginWithoutEnd', type => 'code', spaces => ~$<spaces>, instead => $<instead> ?? ~$<instead> !! ''}
+            [ $<end>=<pod-delim-code-typ> [ <pod_newline> | $ ]
+              { if ~$<end> ne ~$<typ> {
+                         $/.typed_panic: 'X::Syntax::Pod::BeginWithoutEnd',
+                         type    => ~$<typ>,
+                         spaces  => ~$<spaces>,
+                         instead => $<end> ?? ~$<end> !! ''
+              }}
+              || $<instead>=<identifier>? {
+                     $/.typed_panic: 'X::Syntax::Pod::BeginWithoutEnd',
+                     type    => $<typ>,
+                     spaces  => ~$<spaces>,
+                     instead => $<instead> ?? ~$<instead> !! ''
+                 }
             ]
         ]
     }
@@ -1011,7 +1041,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         ^^
         (
         | $spaces
-            <!before '=end' \h+ 'code' [ <pod_newline> | $ ]>
+            <!before '=end' \h+ <pod-delim-code-typ> [ <pod_newline> | $ ]>
             <pod_string>**0..1 <pod_newline>
         | <pod_newline>
         )*
@@ -1076,7 +1106,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
     token pod_block:sym<paragraph_code> {
         ^^
         $<spaces> = [ \h* ]
-        '=for' \h+ 'code' {}
+        '=for' \h+ <pod-delim-code-typ> {}
         :my $*POD_ALLOW_FCODES := 0;
         :my $*POD_IN_CODE_BLOCK := 1;
         <pod_configuration($<spaces>)> <pod_newline>
@@ -1123,7 +1153,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
     token pod_block:sym<abbreviated_code> {
         ^^
         $<spaces> = [ \h* ]
-        '=code' {}
+        '=' <pod-delim-code-typ> {}
         :my $*POD_ALLOW_FCODES  := 0;
         :my $*POD_IN_CODE_BLOCK := 1;
         [\h*\n|\h+]

--- a/t/07-pod-to-text/01-whitespace.t
+++ b/t/07-pod-to-text/01-whitespace.t
@@ -3,7 +3,7 @@ use Test;
 
 use Pod::To::Text;
 
-plan 2;
+plan 4;
 
 my $ix = -1;
 
@@ -44,6 +44,94 @@ subtest 'Code blocks' => {
     =end code
     is Pod::To::Text.render($=pod[++$ix]),
         q:to/END/, "Formatting Codes in code block";
+            sub exclaim ($phrase) {
+                say $phrase ~ "!!!!"
+            }
+            exclaim "Howdy, World";
+        END
+}
+
+subtest 'Input blocks' => {
+    plan 3;
+
+    =begin input
+    say 1;
+
+    say 2;
+    =end input
+
+    is Pod::To::Text.render($=pod[++$ix]),
+        q:to/END/, "Empty lines don't get added spaces";
+            say 1;
+
+            say 2;
+        END
+
+    =begin input
+    my $a = -5;
+    say ++$a.=abs;
+    # OUTPUT: «6␤»
+    =end input
+
+    is Pod::To::Text.render($=pod[++$ix]),
+        q:to/END/, "Plain continuation lines are aligned";
+            my $a = -5;
+            say ++$a.=abs;
+            # OUTPUT: «6␤»
+        END
+
+    =begin input :allow<B L>
+    sub exclaim B<($phrase)> {
+        say $phrase L<~> "!!!!"
+    }
+    exclaim "Howdy, World";
+    =end input
+    is Pod::To::Text.render($=pod[++$ix]),
+        q:to/END/, "Formatting Codes in input block";
+            sub exclaim ($phrase) {
+                say $phrase ~ "!!!!"
+            }
+            exclaim "Howdy, World";
+        END
+}
+
+subtest 'Output blocks' => {
+    plan 3;
+
+    =begin output
+    say 1;
+
+    say 2;
+    =end output
+
+    is Pod::To::Text.render($=pod[++$ix]),
+        q:to/END/, "Empty lines don't get added spaces";
+            say 1;
+
+            say 2;
+        END
+
+    =begin output
+    my $a = -5;
+    say ++$a.=abs;
+    # OUTPUT: «6␤»
+    =end output
+
+    is Pod::To::Text.render($=pod[++$ix]),
+        q:to/END/, "Plain continuation lines are aligned";
+            my $a = -5;
+            say ++$a.=abs;
+            # OUTPUT: «6␤»
+        END
+
+    =begin output :allow<B L>
+    sub exclaim B<($phrase)> {
+        say $phrase L<~> "!!!!"
+    }
+    exclaim "Howdy, World";
+    =end output
+    is Pod::To::Text.render($=pod[++$ix]),
+        q:to/END/, "Formatting Codes in output block";
             sub exclaim ($phrase) {
                 say $phrase ~ "!!!!"
             }

--- a/t/07-pod-to-text/02-input-output.t
+++ b/t/07-pod-to-text/02-input-output.t
@@ -1,0 +1,147 @@
+use v6.c;
+use Test;
+
+use Pod::To::Text;
+
+plan 18;
+
+my $r;
+my $rp;
+my $p = -1;
+
+# explicit code blocks
+{
+=begin code
+say 1;
+say 2;
+=end code
+$r = $=pod[++$p];
+isa-ok $r, Pod::Block::Code;
+# code blocks should get indented 4 spaces by Pod::To::Text
+$rp = Pod::To::Text.render($r),
+is $rp,
+q:to/END/;
+    say 1;
+    say 2;
+END
+
+=code
+say 1;
+say 2;
+
+$r = $=pod[++$p];
+isa-ok $r, Pod::Block::Code;
+# code blocks should get indented 4 spaces by Pod::To::Text
+$rp = Pod::To::Text.render($r),
+is $rp,
+q:to/END/;
+    say 1;
+    say 2;
+END
+
+=for code
+say 1;
+say 2;
+
+$r = $=pod[++$p];
+isa-ok $r, Pod::Block::Code;
+# code blocks should get indented 4 spaces by Pod::To::Text
+$rp = Pod::To::Text.render($r),
+is $rp,
+q:to/END/;
+    say 1;
+    say 2;
+END
+}
+
+# implicit code blocks: input
+{
+=begin input
+say 1;
+say 2;
+=end input
+$r = $=pod[++$p];
+isa-ok $r, Pod::Block::Code;
+# code blocks should get indented 4 spaces by Pod::To::Text
+$rp = Pod::To::Text.render($r),
+is $rp,
+q:to/END/;
+    say 1;
+    say 2;
+END
+
+=input
+say 1;
+say 2;
+
+$r = $=pod[++$p];
+isa-ok $r, Pod::Block::Code;
+# code blocks should get indented 4 spaces by Pod::To::Text
+$rp = Pod::To::Text.render($r),
+is $rp,
+q:to/END/;
+    say 1;
+    say 2;
+END
+
+=for input
+say 1;
+say 2;
+
+$r = $=pod[++$p];
+isa-ok $r, Pod::Block::Code;
+# code blocks should get indented 4 spaces by Pod::To::Text
+$rp = Pod::To::Text.render($r),
+is $rp,
+q:to/END/;
+    say 1;
+    say 2;
+END
+}
+
+# implicit code blocks: output
+{
+=begin output
+say 1;
+say 2;
+=end output
+$r = $=pod[++$p];
+isa-ok $r, Pod::Block::Code;
+# code blocks should get indented 4 spaces by Pod::To::Text
+$rp = Pod::To::Text.render($r),
+is $rp,
+q:to/END/;
+    say 1;
+    say 2;
+END
+
+=output
+say 1;
+say 2;
+
+$r = $=pod[++$p];
+isa-ok $r, Pod::Block::Code;
+# code blocks should get indented 4 spaces by Pod::To::Text
+$rp = Pod::To::Text.render($r),
+is $rp,
+q:to/END/;
+    say 1;
+    say 2;
+END
+
+=for output
+say 1;
+say 2;
+
+$r = $=pod[++$p];
+isa-ok $r, Pod::Block::Code;
+# code blocks should get indented 4 spaces by Pod::To::Text
+$rp = Pod::To::Text.render($r),
+is $rp,
+q:to/END/;
+    say 1;
+    say 2;
+END
+}
+
+# vim: expandtab shiftwidth=4 ft=perl6


### PR DESCRIPTION
Original issue: Pod input and output blocks don't preserve newlines

The input and output blocks should be treated essentially the same as
code blocks, and newlines should be preserved. But before this fix
newlines WERE removed. This commit corrects that.

Major changes:

    1. File changed to equate code/input/output pod blocks:

        + src/Perl6/Grammar.nqp

    2. Test file added:

        + t/07-pod-to-text/02-input-output.t

        The tests include tests missing for the existing code block tests.

    3. Test file modified to add equivalent tests for 'input' and
       'code' blocks:

        + t/07-pod-to-text/01-whitespace.t

Other changes:

+ Formatted some long lines in src/Perl6/Grammar.nqp to ease editing
  with CLI editors.