### PR TITLE
Fix R#1990

### DIFF
--- a/src/Perl6/Optimizer.nqp
+++ b/src/Perl6/Optimizer.nqp
@@ -1916,6 +1916,9 @@ class Perl6::Optimizer {
               elsif $sigil eq '$' {
                 $assignop := 'assign';
               }
+              elsif $sigil eq '@' || $sigil eq '%' {
+                $assignop := 'p6store';
+              }
               else {
                 # TODO support @ and % sigils and check what else we need
                 # to "copy" from assign_op in Actions


### PR DESCRIPTION
Zoffix++, in https://github.com/rakudo/rakudo/issues/1990, pointed
out that there's an optimization opportunity in optimize_nameless_call
where the, faster, p6store op can be used instead when assigning
@ and % sigiled variables