### PR TITLE
Always coerce first argument to &round to Numeric.

### DIFF
--- a/src/core/Numeric.pm6
+++ b/src/core/Numeric.pm6
@@ -197,9 +197,8 @@ multi sub ceiling($a)          { $a.Numeric.ceiling }
 multi sub ceiling(Numeric $a)  { $a.ceiling }
 
 proto sub round($, $?, *%) is pure      {*}
-multi sub round($a)                 { $a.Numeric.round }
-multi sub round(Numeric $a)         { $a.round }
-multi sub round(Numeric $a, $scale) { $a.round($scale) }
+multi sub round(Numeric() $a)         { $a.round }
+multi sub round(Numeric() $a, $scale) { $a.round($scale) }
 
 proto sub infix:<+>($?, $?, *%) is pure   {*}
 multi sub infix:<+>($x = 0)      { $x.Numeric }


### PR DESCRIPTION
Fixes rakudo/rakudo#1745.