### PR TITLE
Include source file name in module-not-found error message.

### DIFF
--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -1266,7 +1266,8 @@ class Perl6::World is HLL::World {
             :auth-matcher(%opts<auth> // $true),
             :api-matcher(%opts<api> // $true),
             :version-matcher(%opts<ver> // $true),
-            :source-line-number($line)
+            :source-line-number($line),
+            :source-file-name(self.current_file)
         );
         self.add_object($spec);
         my $registry := self.find_symbol(['CompUnit', 'RepositoryRegistry'], :setting-only);

--- a/src/core/CompUnit/DependencySpecification.pm6
+++ b/src/core/CompUnit/DependencySpecification.pm6
@@ -1,6 +1,7 @@
 class CompUnit::DependencySpecification {
     has str $.short-name is required;
     has int $.source-line-number = 0;
+    has str $.source-file-name = '';
     has str $.from = 'Perl6';
     has $.version-matcher = True;
     has $.auth-matcher = True;

--- a/src/core/Exception.pm6
+++ b/src/core/Exception.pm6
@@ -2958,9 +2958,10 @@ my class X::CompUnit::UnsatisfiedDependency is Exception {
     method message() {
         my $name = $.specification.short-name;
         my $line = $.specification.source-line-number;
+        my $file = $.specification.source-file-name;
         is-core($name)
             ?? "{$name} is a builtin type, not an external module"
-            !! "Could not find $.specification at line $line in:\n"
+            !! "Could not find $.specification at $file:$line in:\n"
                 ~ $*REPO.repo-chain.map(*.Str).join("\n").indent(4)
                 ~ ($.specification ~~ / $<name>=.+ '::from' $ /
                     ?? "\n\nIf you meant to use the :from adverb, use"


### PR DESCRIPTION
Fixes rakudo/rakudo#2022.

I'm a bit unhappy with the attribute name `source-file-name` because as far as I understand the specification is about the thing that's to be loaded, not the place where it's loaded *from*, so the naming is a bit confusing IMO. But then again `source-line-number` already existed so I went along.