### PR TITLE
Improve the error message for slicing a shaped array

### DIFF
--- a/src/core/array_slice.pm6
+++ b/src/core/array_slice.pm6
@@ -86,14 +86,6 @@ multi sub POSITIONS(
         nqp::bindattr(pos-list, List, '$!todo', todo);
     }
     else {
-        if nqp::defined(SELF.shape) and !nqp::eqaddr(pos.WHAT,Range) {
-            if SELF.shape.elems > 1 {
-                X::NYI.new(
-                    feature => 'Slices of shaped arrays',
-                    did-you-mean => pos.join(';'),
-                ).throw;
-            }
-        }
         pos-iter.push-all: target;
     }
     pos-list
@@ -240,6 +232,12 @@ multi sub postcircumfix:<[ ]>( \SELF, Iterable:D \pos ) is raw {
     nqp::iscont(pos)
       ?? SELF.AT-POS(pos.Int)
       !! POSITIONS(SELF, pos).map({ SELF[$_] }).eager.list;
+}
+multi sub postcircumfix:<[ ]>( Array \SELF where SELF.shape.elems > 1, Iterable:D \pos ) is raw {
+   X::NYI.new(
+       feature => 'Slices of shaped arrays',
+       did-you-mean => (pos.join(';') unless nqp::eqaddr(pos.WHAT,Range)),
+   ).throw;
 }
 multi sub postcircumfix:<[ ]>(\SELF, Iterable:D \pos, Mu \val ) is raw {
     # MMD is not behaving itself so we do this by hand.

--- a/src/core/array_slice.pm6
+++ b/src/core/array_slice.pm6
@@ -86,6 +86,14 @@ multi sub POSITIONS(
         nqp::bindattr(pos-list, List, '$!todo', todo);
     }
     else {
+        if nqp::defined(SELF.shape) and !nqp::eqaddr(pos.WHAT,Range) {
+            if SELF.shape.elems > 1 {
+                X::NYI.new(
+                    feature => 'Slices of shaped arrays',
+                    did-you-mean => pos.join(';'),
+                ).throw;
+            }
+        }
         pos-iter.push-all: target;
     }
     pos-list

--- a/t/05-messages/03-errors.t
+++ b/t/05-messages/03-errors.t
@@ -2,7 +2,7 @@ use lib <t/packages/>;
 use Test;
 use Test::Helpers;
 
-plan 15;
+plan 16;
 
 subtest '.map does not explode in optimizer' => {
     plan 3;
@@ -126,5 +126,10 @@ subtest '.polymod with zero divisor does not reference guts in error' => {
 # RT 126220
 throws-like '++.++', X::Multi::NoMatch,
     '++.++ construct does not throw LTA errors';
+
+# https://github.com/rakudo/rakudo/issues/1943
+throws-like 'my @x[2,2]; @x[0,1]', X::NYI,
+    message => /｢Did you mean: 0;1｣/,
+    'did you mean to slice that shaped array';
 
 # vim: ft=perl6 expandtab sw=4


### PR DESCRIPTION
This generates a better NYI error message for the case when a user takes a slice of a shaped array, and it looks like they may have inadvertently used a comma instead of a semicolon to access an element of the shaped array.

Before:
```
$ perl6 -e 'my @x[2;2]; @x[0,1]'
Partially dimensioned views of shaped arrays not yet implemented. Sorry.
  in block <unit> at -e line 1
```
After:
```
$ ./perl6 -e 'my @x[2;2]; @x[0,1]'
Slices of shaped arrays not yet implemented. Sorry.
Did you mean: 0;1?
  in block <unit> at -e line 1
```
Resolves #1943