### PR TITLE
Make infix:<!=> for Ints consistent with...

### DIFF
--- a/src/core/Int.pm6
+++ b/src/core/Int.pm6
@@ -376,7 +376,7 @@ multi sub infix:<==>(int $a, int $b) {
 }
 
 multi sub infix:<!=>(int $a, int $b) { nqp::p6bool(nqp::isne_i($a, $b)) }
-multi sub infix:<!=>(Int:D $a, Int:D $b) { nqp::p6bool(nqp::isne_I($a, $b)) }
+multi sub infix:<!=>(Int:D \a, Int:D \b) { nqp::p6bool(nqp::isne_I(nqp::decont(a), nqp::decont(b))) }
 
 multi sub infix:«<»(Int:D \a, Int:D \b) {
     nqp::p6bool(nqp::islt_I(nqp::decont(a), nqp::decont(b)))


### PR DESCRIPTION
the other infix operators.

Rakudo builds ok and passes `make m-test m-spectest`.