### PR TITLE
Revert "Include source file name in module-not-found error message."

### DIFF
--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -1266,8 +1266,7 @@ class Perl6::World is HLL::World {
             :auth-matcher(%opts<auth> // $true),
             :api-matcher(%opts<api> // $true),
             :version-matcher(%opts<ver> // $true),
-            :source-line-number($line),
-            :source-file-name(self.current_file)
+            :source-line-number($line)
         );
         self.add_object($spec);
         my $registry := self.find_symbol(['CompUnit', 'RepositoryRegistry'], :setting-only);

--- a/src/core/CompUnit/DependencySpecification.pm6
+++ b/src/core/CompUnit/DependencySpecification.pm6
@@ -1,7 +1,6 @@
 class CompUnit::DependencySpecification {
     has str $.short-name is required;
     has int $.source-line-number = 0;
-    has str $.source-file-name = '';
     has str $.from = 'Perl6';
     has $.version-matcher = True;
     has $.auth-matcher = True;

--- a/src/core/Exception.pm6
+++ b/src/core/Exception.pm6
@@ -2966,10 +2966,9 @@ my class X::CompUnit::UnsatisfiedDependency is Exception {
     method message() {
         my $name = $.specification.short-name;
         my $line = $.specification.source-line-number;
-        my $file = $.specification.source-file-name;
         is-core($name)
             ?? "{$name} is a builtin type, not an external module"
-            !! "Could not find $.specification at $file:$line in:\n"
+            !! "Could not find $.specification at line $line in:\n"
                 ~ $*REPO.repo-chain.map(*.Str).join("\n").indent(4)
                 ~ ($.specification ~~ / $<name>=.+ '::from' $ /
                     ?? "\n\nIf you meant to use the :from adverb, use"


### PR DESCRIPTION
Reverts rakudo/rakudo#2038

The API here was not agreed upon, and making a release with it as-is risks the API being used externally.