### PR TITLE
Fix Multiple Statevar Initialization Bugs

### DIFF
--- a/docs/ops.markdown
+++ b/docs/ops.markdown
@@ -213,7 +213,18 @@ Sets the "pre" flag on the current frame.
 * p6sort(Mu @data, Mu &comparator)
 
 ## p6stateinit
-* p6stateinit()
+* p6stateinit(str $sym)
+
+Looks up the given symbol to determine if the associated variable (within this closure instance) has been assigned a value by the HLL. If so, we do not want to assign again.
+
+## p6stateinitbulk
+* p6stateinitbulk(list_s $symlist)
+
+Given a list of symbols, determine if the associated variables (within this closure instance) have been assigned a value by the HLL. Used to perform the state-initialization check on multiple variables at once (like in the case of a destructuring assignment).
+
+```perl6
+state ($a, $b, $c) = 1, 2, 3;
+```
 
 ## p6staticouter
 * p6staticouter(Mu $coderef)

--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -2671,7 +2671,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
           QAST::Op.new(
             :op('if'),
             QAST::Op.new( :op('p6stateinit'),
-                QAST::Var.new( :name($sym), :scope('lexical') )
+                QAST::SVal.new( :value($sym) )
             ),
             QAST::Op.new(
               :op('p6store'),
@@ -3558,7 +3558,8 @@ class Perl6::Actions is HLL::Actions does STDActions {
                     }
 
                     $past := QAST::Op.new( :op('if'),
-                        QAST::Op.new( :op('p6stateinit'), $orig_past ),
+                        QAST::Op.new( :op('p6stateinit'),
+                            QAST::SVal.new( :value($orig_past.name) ) ),
                         $past,
                         $orig_past);
                     $past.nosink(1);
@@ -3661,7 +3662,8 @@ class Perl6::Actions is HLL::Actions does STDActions {
                     my $node      := $condition;
                     my $prev      := $condition;
                     while $i < nqp::elems($orig_list) {
-                        $node.push( QAST::Op.new( :op('p6stateinit'), $orig_list[$i] ) );
+                        $node.push( QAST::Op.new( :op('p6stateinit'),
+                            QAST::SVal.new( :value($orig_list[$i].name) ) ));
                         $node.push( QAST::Op.new( :op('if') ) );
                         $prev := $node;
                         $node := $node[1];
@@ -3944,7 +3946,8 @@ class Perl6::Actions is HLL::Actions does STDActions {
                 elsif %cont_info<build_ast> {
                     if $*SCOPE eq 'state' {
                         $past := QAST::Op.new( :op('if'),
-                            QAST::Op.new( :op('p6stateinit'), $past ),
+                            QAST::Op.new( :op('p6stateinit'),
+                                QAST::SVal.new( :value($past.name) ) ),
                             QAST::Op.new( :op('bind'), $past, %cont_info<build_ast> ),
                             $past);
                     }

--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -2670,7 +2670,9 @@ class Perl6::Actions is HLL::Actions does STDActions {
           :op('decont'),
           QAST::Op.new(
             :op('if'),
-            QAST::Op.new( :op('p6stateinit') ),
+            QAST::Op.new( :op('p6stateinit'),
+                QAST::Var.new( :name($sym), :scope('lexical') )
+            ),
             QAST::Op.new(
               :op('p6store'),
               WANTED(QAST::Var.new(:name($sym), :scope('lexical')),'once'),
@@ -3556,7 +3558,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
                     }
 
                     $past := QAST::Op.new( :op('if'),
-                        QAST::Op.new( :op('p6stateinit') ),
+                        QAST::Op.new( :op('p6stateinit'), $orig_past ),
                         $past,
                         $orig_past);
                     $past.nosink(1);
@@ -3655,7 +3657,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
                 }
                 if $*SCOPE eq 'state' {
                     $list := QAST::Op.new( :op('if'),
-                        QAST::Op.new( :op('p6stateinit') ),
+                        QAST::Op.new( :op('p6stateinit'), $orig_list ),
                         $list, $orig_list);
                 }
             }
@@ -3930,7 +3932,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
                 elsif %cont_info<build_ast> {
                     if $*SCOPE eq 'state' {
                         $past := QAST::Op.new( :op('if'),
-                            QAST::Op.new( :op('p6stateinit') ),
+                            QAST::Op.new( :op('p6stateinit'), $past ),
                             QAST::Op.new( :op('bind'), $past, %cont_info<build_ast> ),
                             $past);
                     }

--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -3656,9 +3656,21 @@ class Perl6::Actions is HLL::Actions does STDActions {
                     );
                 }
                 if $*SCOPE eq 'state' {
-                    $list := QAST::Op.new( :op('if'),
-                        QAST::Op.new( :op('p6stateinit'), $orig_list ),
-                        $list, $orig_list);
+                    my $i         := 0;
+                    my $condition := QAST::Op.new( :op('if') );
+                    my $node      := $condition;
+                    my $prev      := $condition;
+                    while $i < nqp::elems($orig_list) {
+                        $node.push( QAST::Op.new( :op('p6stateinit'), $orig_list[$i] ) );
+                        $node.push( QAST::Op.new( :op('if') ) );
+                        $prev := $node;
+                        $node := $node[1];
+                        $i++;
+                    }
+                    $prev.pop;
+                    $prev.push( QAST::IVal.new(:value(1)) );
+
+                    $list := QAST::Op.new( :op('if'), $condition, $list, $orig_list );
                 }
             }
             elsif @nosigil {

--- a/src/vm/jvm/Perl6/Ops.nqp
+++ b/src/vm/jvm/Perl6/Ops.nqp
@@ -108,7 +108,7 @@ $ops.add_hll_op('perl6', 'p6decontrv', :!inlinable, -> $qastcomp, $op {
 });
 $ops.map_classlib_hll_op('perl6', 'p6capturelex', $TYPE_P6OPS, 'p6capturelex', [$RT_OBJ], $RT_OBJ, :tc, :!inlinable);
 $ops.map_classlib_hll_op('perl6', 'p6bindassert', $TYPE_P6OPS, 'p6bindassert', [$RT_OBJ, $RT_OBJ], $RT_OBJ, :tc);
-$ops.map_classlib_hll_op('perl6', 'p6stateinit', $TYPE_P6OPS, 'p6stateinit', [], $RT_INT, :tc, :!inlinable);
+$ops.map_classlib_hll_op('perl6', 'p6stateinit', $TYPE_P6OPS, 'p6stateinit', [$RT_OBJ], $RT_INT, :tc);
 $ops.map_classlib_hll_op('perl6', 'p6setpre', $TYPE_P6OPS, 'p6setpre', [], $RT_OBJ, :tc);
 $ops.map_classlib_hll_op('perl6', 'p6clearpre', $TYPE_P6OPS, 'p6clearpre', [], $RT_OBJ, :tc);
 $ops.map_classlib_hll_op('perl6', 'p6inpre', $TYPE_P6OPS, 'p6inpre', [], $RT_INT, :tc);

--- a/src/vm/jvm/Perl6/Ops.nqp
+++ b/src/vm/jvm/Perl6/Ops.nqp
@@ -108,7 +108,8 @@ $ops.add_hll_op('perl6', 'p6decontrv', :!inlinable, -> $qastcomp, $op {
 });
 $ops.map_classlib_hll_op('perl6', 'p6capturelex', $TYPE_P6OPS, 'p6capturelex', [$RT_OBJ], $RT_OBJ, :tc, :!inlinable);
 $ops.map_classlib_hll_op('perl6', 'p6bindassert', $TYPE_P6OPS, 'p6bindassert', [$RT_OBJ, $RT_OBJ], $RT_OBJ, :tc);
-$ops.map_classlib_hll_op('perl6', 'p6stateinit', $TYPE_P6OPS, 'p6stateinit', [$RT_OBJ], $RT_INT, :tc);
+$ops.map_classlib_hll_op('perl6', 'p6stateinit', $TYPE_P6OPS, 'p6stateinit', [$RT_STR], $RT_INT, :tc);
+$ops.map_classlib_hll_op('perl6', 'p6stateinitbulk', $TYPE_P6OPS, 'p6stateinitbulk', [$RT_OBJ], $RT_INT, :tc);
 $ops.map_classlib_hll_op('perl6', 'p6setpre', $TYPE_P6OPS, 'p6setpre', [], $RT_OBJ, :tc);
 $ops.map_classlib_hll_op('perl6', 'p6clearpre', $TYPE_P6OPS, 'p6clearpre', [], $RT_OBJ, :tc);
 $ops.map_classlib_hll_op('perl6', 'p6inpre', $TYPE_P6OPS, 'p6inpre', [], $RT_INT, :tc);

--- a/src/vm/jvm/runtime/org/perl6/rakudo/RakOps.java
+++ b/src/vm/jvm/runtime/org/perl6/rakudo/RakOps.java
@@ -507,7 +507,18 @@ public final class RakOps {
     }
 
     public static long p6stateinit(SixModelObject obj, ThreadContext tc) {
-        return tc.curFrame.stateInit ? 1 : 0;
+        long doInit = tc.curFrame.stateInit ? 1 : 0;
+
+        // Find num of lexical, so that we can mark it as HLL inited
+        CodeRef cr = tc.curFrame.codeRef;
+        for (int i = 0; i < cr.staticInfo.oLexicalNames.length; i++) {
+            if (obj == tc.curFrame.oLex[i]) {
+                boolean doHllInit        = !cr.oLexStateIsHllInit[i];
+                cr.oLexStateIsHllInit[i] = true;
+                return doInit == 1 ? doInit : (long)(doHllInit ? 1 : 0);
+            }
+        }
+        return doInit;
     }
 
     public static SixModelObject p6setfirstflag(SixModelObject codeObj, ThreadContext tc) {

--- a/src/vm/jvm/runtime/org/perl6/rakudo/RakOps.java
+++ b/src/vm/jvm/runtime/org/perl6/rakudo/RakOps.java
@@ -506,7 +506,7 @@ public final class RakOps {
         return indices;
     }
 
-    public static long p6stateinit(ThreadContext tc) {
+    public static long p6stateinit(SixModelObject obj, ThreadContext tc) {
         return tc.curFrame.stateInit ? 1 : 0;
     }
 

--- a/src/vm/jvm/runtime/org/perl6/rakudo/RakOps.java
+++ b/src/vm/jvm/runtime/org/perl6/rakudo/RakOps.java
@@ -507,18 +507,16 @@ public final class RakOps {
     }
 
     public static long p6stateinit(SixModelObject obj, ThreadContext tc) {
-        long doInit = tc.curFrame.stateInit ? 1 : 0;
-
         // Find num of lexical, so that we can mark it as HLL inited
         CodeRef cr = tc.curFrame.codeRef;
         for (int i = 0; i < cr.staticInfo.oLexicalNames.length; i++) {
             if (obj == tc.curFrame.oLex[i]) {
                 boolean doHllInit        = !cr.oLexStateIsHllInit[i];
                 cr.oLexStateIsHllInit[i] = true;
-                return doInit == 1 ? doInit : (long)(doHllInit ? 1 : 0);
+                return (long)(doHllInit ? 1 : 0);
             }
         }
-        return doInit;
+        return 0;
     }
 
     public static SixModelObject p6setfirstflag(SixModelObject codeObj, ThreadContext tc) {

--- a/src/vm/moar/Perl6/Ops.nqp
+++ b/src/vm/moar/Perl6/Ops.nqp
@@ -41,6 +41,9 @@ MAST::ExtOpRegistry.register_extop('p6capturelexwhere',
 MAST::ExtOpRegistry.register_extop('p6stateinit',
     $MVM_operand_int64 +| $MVM_operand_write_reg,
     $MVM_operand_str   +| $MVM_operand_read_reg);
+MAST::ExtOpRegistry.register_extop('p6stateinitbulk',
+    $MVM_operand_int64 +| $MVM_operand_write_reg,
+    $MVM_operand_obj   +| $MVM_operand_read_reg);
 MAST::ExtOpRegistry.register_extop('p6setfirstflag',
     $MVM_operand_obj   +| $MVM_operand_write_reg,
     $MVM_operand_obj   +| $MVM_operand_read_reg);
@@ -175,7 +178,8 @@ $ops.add_hll_op('perl6', 'p6bindassert', -> $qastcomp, $op {
 
     MAST::InstructionList.new(@ops, $value_res.result_reg, $MVM_reg_obj)
 });
-$ops.add_hll_moarop_mapping('perl6', 'p6stateinit', 'p6stateinit');
+$ops.add_hll_moarop_mapping('perl6', 'p6stateinit',     'p6stateinit');
+$ops.add_hll_moarop_mapping('perl6', 'p6stateinitbulk', 'p6stateinitbulk');
 $ops.add_hll_moarop_mapping('perl6', 'p6setpre', 'p6setpre');
 $ops.add_hll_moarop_mapping('perl6', 'p6clearpre', 'p6clearpre');
 $ops.add_hll_moarop_mapping('perl6', 'p6setfirstflag', 'p6setfirstflag');

--- a/src/vm/moar/Perl6/Ops.nqp
+++ b/src/vm/moar/Perl6/Ops.nqp
@@ -39,7 +39,8 @@ MAST::ExtOpRegistry.register_extop('p6capturelexwhere',
     $MVM_operand_obj   +| $MVM_operand_write_reg,
     $MVM_operand_obj   +| $MVM_operand_read_reg);
 MAST::ExtOpRegistry.register_extop('p6stateinit',
-    $MVM_operand_int64 +| $MVM_operand_write_reg);
+    $MVM_operand_int64 +| $MVM_operand_write_reg,
+    $MVM_operand_obj   +| $MVM_operand_read_reg);
 MAST::ExtOpRegistry.register_extop('p6setfirstflag',
     $MVM_operand_obj   +| $MVM_operand_write_reg,
     $MVM_operand_obj   +| $MVM_operand_read_reg);

--- a/src/vm/moar/Perl6/Ops.nqp
+++ b/src/vm/moar/Perl6/Ops.nqp
@@ -40,7 +40,7 @@ MAST::ExtOpRegistry.register_extop('p6capturelexwhere',
     $MVM_operand_obj   +| $MVM_operand_read_reg);
 MAST::ExtOpRegistry.register_extop('p6stateinit',
     $MVM_operand_int64 +| $MVM_operand_write_reg,
-    $MVM_operand_obj   +| $MVM_operand_read_reg);
+    $MVM_operand_str   +| $MVM_operand_read_reg);
 MAST::ExtOpRegistry.register_extop('p6setfirstflag',
     $MVM_operand_obj   +| $MVM_operand_write_reg,
     $MVM_operand_obj   +| $MVM_operand_read_reg);

--- a/src/vm/moar/ops/perl6_ops.c
+++ b/src/vm/moar/ops/perl6_ops.c
@@ -237,22 +237,26 @@ static MVMuint8 s_p6stateinit[] = {
     MVM_operand_obj   | MVM_operand_read_reg
 };
 static void p6stateinit(MVMThreadContext *tc, MVMuint8 *cur_op) {
-    MVMint64 do_init = tc->cur_frame->flags & MVM_FRAME_FLAG_STATE_INIT ? 1 : 0;
+    MVMObject          *var    = GET_REG(tc, 2).o;
+    MVMCodeBody        *crbody = &((MVMCode *)tc->cur_frame->code_ref)->body;
+    MVMStaticFrameBody *sfbody = &tc->cur_frame->static_info->body;
+    MVMuint32 i;
+
+    if ( !sfbody->has_state_vars ) {
+        GET_REG(tc, 0).i64 = 0;
+        return;
+    }
 
     /* Find num of lexical, so that we can mark it as HLL inited */
-    MVMObject   *var    = GET_REG(tc, 2).o;
-    MVMCodeBody *crbody = &((MVMCode *)tc->cur_frame->code_ref)->body;
-    MVMuint32 i;
-    for (i = 0; i < tc->cur_frame->static_info->body.num_lexicals; i++) {
+    for (i = 0; i < sfbody->num_lexicals; i++) {
         MVMRegister *env_val     = &tc->cur_frame->env[i];
         MVMuint8    *is_hll_init = &crbody->state_vars_is_hll_init[i];
         if (env_val && var == env_val->o) {
-            GET_REG(tc, 0).i64 = do_init || !*is_hll_init;
+            GET_REG(tc, 0).i64 = !*is_hll_init;
             *is_hll_init = 1;
             return;
         }
     }
-    GET_REG(tc, 0).i64 = do_init;
 }
 
 /* First FIRST, use a flag in the object header. */

--- a/src/vm/moar/ops/perl6_ops.c
+++ b/src/vm/moar/ops/perl6_ops.c
@@ -233,10 +233,26 @@ static void p6captureouters(MVMThreadContext *tc, MVMuint8 *cur_op) {
 }
 
 static MVMuint8 s_p6stateinit[] = {
-    MVM_operand_int64 | MVM_operand_write_reg
+    MVM_operand_int64 | MVM_operand_write_reg,
+    MVM_operand_obj   | MVM_operand_read_reg
 };
 static void p6stateinit(MVMThreadContext *tc, MVMuint8 *cur_op) {
-    GET_REG(tc, 0).i64 = tc->cur_frame->flags & MVM_FRAME_FLAG_STATE_INIT ? 1 : 0;
+    MVMint64 do_init = tc->cur_frame->flags & MVM_FRAME_FLAG_STATE_INIT ? 1 : 0;
+
+    /* Find num of lexical, so that we can mark it as HLL inited */
+    MVMObject   *var    = GET_REG(tc, 2).o;
+    MVMCodeBody *crbody = &((MVMCode *)tc->cur_frame->code_ref)->body;
+    MVMuint32 i;
+    for (i = 0; i < tc->cur_frame->static_info->body.num_lexicals; i++) {
+        MVMRegister *env_val     = &tc->cur_frame->env[i];
+        MVMuint8    *is_hll_init = &crbody->state_vars_is_hll_init[i];
+        if (env_val && var == env_val->o) {
+            GET_REG(tc, 0).i64 = do_init || !*is_hll_init;
+            *is_hll_init = 1;
+            return;
+        }
+    }
+    GET_REG(tc, 0).i64 = do_init;
 }
 
 /* First FIRST, use a flag in the object header. */
@@ -508,7 +524,7 @@ MVM_DLL_EXPORT void Rakudo_ops_init(MVMThreadContext *tc) {
     MVM_ext_register_extop(tc, "p6capturelexwhere",  p6capturelexwhere, 2, s_p6capturelexwhere, NULL, NULL, 0);
     MVM_ext_register_extop(tc, "p6getouterctx", p6getouterctx, 2, s_p6getouterctx, NULL, NULL, MVM_EXTOP_PURE | MVM_EXTOP_ALLOCATING);
     MVM_ext_register_extop(tc, "p6captureouters", p6captureouters, 2, s_p6captureouters, NULL, NULL, 0);
-    MVM_ext_register_extop(tc, "p6stateinit", p6stateinit, 1, s_p6stateinit, NULL, NULL, 0);
+    MVM_ext_register_extop(tc, "p6stateinit", p6stateinit, 2, s_p6stateinit, NULL, NULL, 0);
     MVM_ext_register_extop(tc, "p6setfirstflag", p6setfirstflag, 2, s_p6setfirstflag, NULL, NULL, 0);
     MVM_ext_register_extop(tc, "p6takefirstflag", p6takefirstflag, 1, s_p6takefirstflag, NULL, NULL, 0);
     MVM_ext_register_extop(tc, "p6setpre", p6setpre, 1, s_p6setpre, NULL, NULL, 0);

--- a/src/vm/moar/ops/perl6_ops.c
+++ b/src/vm/moar/ops/perl6_ops.c
@@ -240,6 +240,7 @@ static void p6stateinit(MVMThreadContext *tc, MVMuint8 *cur_op) {
     MVMObject          *var    = GET_REG(tc, 2).o;
     MVMCodeBody        *crbody = &((MVMCode *)tc->cur_frame->code_ref)->body;
     MVMStaticFrameBody *sfbody = &tc->cur_frame->static_info->body;
+    MVMuint8           *is_hll_init = crbody->state_vars_is_hll_init;
     MVMuint32 i;
 
     if ( !sfbody->has_state_vars ) {
@@ -250,13 +251,13 @@ static void p6stateinit(MVMThreadContext *tc, MVMuint8 *cur_op) {
     /* Find num of lexical, so that we can mark it as HLL inited */
     for (i = 0; i < sfbody->num_lexicals; i++) {
         MVMRegister *env_val     = &tc->cur_frame->env[i];
-        MVMuint8    *is_hll_init = &crbody->state_vars_is_hll_init[i];
         if (env_val && var == env_val->o) {
-            GET_REG(tc, 0).i64 = !*is_hll_init;
-            *is_hll_init = 1;
+            GET_REG(tc, 0).i64 = !MVM_BITARR8_CHECK(is_hll_init, i);
+            MVM_BITARR8_SET(is_hll_init, i);
             return;
         }
     }
+    GET_REG(tc, 0).i64 = 0;
 }
 
 /* First FIRST, use a flag in the object header. */

--- a/src/vm/moar/ops/perl6_ops.c
+++ b/src/vm/moar/ops/perl6_ops.c
@@ -234,20 +234,53 @@ static void p6captureouters(MVMThreadContext *tc, MVMuint8 *cur_op) {
 
 static MVMuint8 s_p6stateinit[] = {
     MVM_operand_int64 | MVM_operand_write_reg,
-    MVM_operand_str   | MVM_operand_read_reg
+    MVM_operand_str   | MVM_operand_read_reg,
 };
+static MVMuint8 s_p6stateinitbulk[] = {
+    MVM_operand_int64 | MVM_operand_write_reg,
+    MVM_operand_obj   | MVM_operand_read_reg,
+};
+static void process_state_init(MVMThreadContext *tc, MVMint64 *rv, MVMString *sym) {
+    /* Find num of lexical, so that we can mark it as HLL inited */
+    MVMint64  idx         = MVM_frame_lexical_idx(tc, tc->cur_frame, sym);
+    MVMuint8 *is_hll_init = ((MVMCode *)tc->cur_frame->code_ref)->body.state_vars_is_hll_init;
+
+    *rv = !MVM_BITARR8_CHECK(is_hll_init, idx);
+    MVM_BITARR8_SET(is_hll_init, idx);
+}
 static void p6stateinit(MVMThreadContext *tc, MVMuint8 *cur_op) {
     MVMStaticFrameBody *sfbody = &tc->cur_frame->static_info->body;
     if ( !sfbody->has_state_vars ) {
         GET_REG(tc, 0).i64 = 0;
     }
     else {
-        /* Find num of lexical, so that we can mark it as HLL inited */
-        MVMint64  idx         = MVM_frame_lexical_idx(tc, tc->cur_frame, GET_REG(tc, 2).s );
-        MVMuint8 *is_hll_init = ((MVMCode *)tc->cur_frame->code_ref)->body->state_vars_is_hll_init;
+        process_state_init( tc, &GET_REG(tc, 0).i64, GET_REG(tc, 2).s );
+    }
+}
+static void p6stateinitbulk(MVMThreadContext *tc, MVMuint8 *cur_op) {
+    MVMStaticFrameBody *sfbody = &tc->cur_frame->static_info->body;
+    if ( !sfbody->has_state_vars ) {
+        GET_REG(tc, 0).i64 = 0;
+    }
+    else {
+        MVMObject *arr     = GET_REG(tc, 2).o;
+        MVMSTable *st      = STABLE(arr);
+        void      *objbody = OBJECT_BODY(arr);
 
-        GET_REG(tc, 0).i64 = !MVM_BITARR8_CHECK(is_hll_init, idx);
-        MVM_BITARR8_SET(is_hll_init, idx);
+        MVMint64 i;
+        MVMint64 res   = 1;
+        MVMint64 elems = REPR(arr)->elems(tc, st, arr, objbody);
+        for (i = 0; i < elems; i++) {
+            MVMRegister str;
+            MVMint64 init_val = 0;
+
+            REPR(arr)->pos_funcs.at_pos(tc, st, arr, objbody, i, &str, MVM_reg_str);
+
+            process_state_init( tc, &init_val, str.s );
+            res &= init_val;
+            if ( !res ) break;
+        }
+        GET_REG(tc, 0).i64 = res;
     }
 }
 
@@ -521,6 +554,7 @@ MVM_DLL_EXPORT void Rakudo_ops_init(MVMThreadContext *tc) {
     MVM_ext_register_extop(tc, "p6getouterctx", p6getouterctx, 2, s_p6getouterctx, NULL, NULL, MVM_EXTOP_PURE | MVM_EXTOP_ALLOCATING);
     MVM_ext_register_extop(tc, "p6captureouters", p6captureouters, 2, s_p6captureouters, NULL, NULL, 0);
     MVM_ext_register_extop(tc, "p6stateinit", p6stateinit, 2, s_p6stateinit, NULL, NULL, 0);
+    MVM_ext_register_extop(tc, "p6stateinitbulk", p6stateinitbulk, 2, s_p6stateinitbulk, NULL, NULL, 0);
     MVM_ext_register_extop(tc, "p6setfirstflag", p6setfirstflag, 2, s_p6setfirstflag, NULL, NULL, 0);
     MVM_ext_register_extop(tc, "p6takefirstflag", p6takefirstflag, 1, s_p6takefirstflag, NULL, NULL, 0);
     MVM_ext_register_extop(tc, "p6setpre", p6setpre, 1, s_p6setpre, NULL, NULL, 0);


### PR DESCRIPTION
This PR is one part of a series spanning the MoarVM, NQP, and Rakudo repositories.
[MoarVM](https://github.com/MoarVM/MoarVM/pull/916)
[NQP](https://github.com/perl6/nqp/pull/487)

This series of PRs modifies the state init check to instead keep a record of the statevars that have been 'HLL init-ed' and have that value determine whether to perform the assignment or not. If the statevar is not assigned to on the first invocation, it is shown as needing assignment the next time it is encountered despite what the MVM_FRAME_FLAG_STATE_INIT value is. If the statevar has been assigned to already and is encountered again within the same frame invocation (as the C-style loop example below), it is aware the that assignment has occurred and does not repeat it.

I had submitted a PR similar to this in the past, but this one has been rebased to a much newer HEAD and changed enough to the point that it feels appropriate to open a new PR.

### Specific modifications made are:

* Modified the ```p6stateinit``` extop to take a symbol as an argument. Within the function, lookup that symbol within the frame's lexical registry and determine whether the 'HLL assignment' has taken place. If so, do not assign again.

  * The value that persists whether an 'HLL assignment' has taken place is stored in the CodeRef object (alongside the statevar values themselves), which is unique to each closure. This 'isHllInit' value is a variable-length bit array, with each lexical represented by one bit.

* Added a new extop, ```p6stateinitbulk```, that will take a list of symbols and check multiple in one extop execution (for use in destructuring state assignments)

* Implemented for both the MoarVM and JVM backends.

### Issue being addressed:

In the past, we have determined whether to perform an assignment to a state variable by determining whether or not it was the first invocation of a closure (or clone of a frame). In MoarVM, an MVM_FRAME_FLAG_STATE_INIT value is set on the first frame of a given closure.

This works most of the time, but there are some instances where this is producing undesired results (see [RT #102994](https://rt.perl.org/Public/Bug/Display.html?id=102994))

```perl6
sub f($x) {
    return if $x;
    state $y = 5;
    $y;
} 

f(1);
say f(0);
# OUTPUT:   (Any)
# EXPECTED: 5
```

Since during the first invocation of this closure (when MVM_FRAME_FLAG_STATE_INIT is set) the statevar is not assigned to, on the next invocation the assignment is skipped and the unassigned value (Any) is returned.

In the case of 'once' with a C-style loop conditional (see [GH issue 1684](https://github.com/rakudo/rakudo/issues/1684)), this method also produces some unexpected results.

```perl6
loop (my $i = 0; $i < once { print $i; 10 }; ++$i ) { }
# OUTPUT:   012345678910
# EXPECTED: 0
```

In this case, the 'once' appears in the e2 expression in the C-style loop. The statevar init check occurs within the loop conditional and is executed multiple times within the same initial closure invocation. Because of this, MVM_FRAME_FLAG_STATE_INIT is set and the code within the block (containing print) is executed for each iteration.
