### PR TITLE
Improve err for obs positionals w/ quantifiers

### DIFF
--- a/src/core/Exception.pm6
+++ b/src/core/Exception.pm6
@@ -1395,7 +1395,7 @@ my class X::Syntax::ParentAsHash does X::Syntax {
         "Syntax error while specifying a parent class:\n"
         ~ "Must specify a space between {$.parent.^name} and \{";
     }
-}  
+}
 
 my class X::Syntax::Malformed::Elsif does X::Syntax {
     has $.what = 'else if';
@@ -2142,7 +2142,11 @@ my class X::Cannot::Capture is Exception {
 
 my class X::Backslash::UnrecognizedSequence does X::Syntax {
     has $.sequence;
-    method message() { "Unrecognized backslash sequence: '\\$.sequence'" }
+    has $.suggestion;
+    method message() {
+        "Unrecognized backslash sequence: '\\$.sequence'"
+        ~ (nqp::defined($!suggestion) ?? ". Did you mean $!suggestion?" !! '')
+    }
 }
 
 my class X::Backslash::NonVariableDollar does X::Syntax {


### PR DESCRIPTION
This addresses issue #2110 .

Example: /\1+/ would previously give two messages, one about \1
being obs and "quantifier quantifies nothing".

Now the new behavior will just be to report the unrecognized backslash
sequence and offer a suggestion.

Thanks zoffixznet for determining what needed to be done and providing
some of the code.

Note that I could not figure out a way to test the backslash:misc token in "rule cc" - there's something strange going on their that is beyond my understanding for how to trigger that unrecognized backslash sequence token there, so it might be good for someone else to look at what I did there.