### PR TITLE
Adds doc for option that apparently works

### DIFF
--- a/src/Perl6/Compiler.nqp
+++ b/src/Perl6/Compiler.nqp
@@ -103,6 +103,7 @@ and, by default, also executes the compiled code.
   --encoding=mode      specify string encoding mode
   -o, --output=name    specify name of output file
   -v, --version        display version information
+  -V                   print configuration summary
   --stagestats         display time spent in the compilation stages
   --ll-exception       display a low level backtrace on errors
   --profile[=kind]     write profile information to an HTML file (MoarVM)


### PR DESCRIPTION
Just use 

     perl6 -V

and it shows a bunch of variables and their values. This was also an option in perl5, which was apparently carried over.