### PR TITLE
Fix RT #2143. Make Distribution::Resource.^mro not error.

### DIFF
--- a/src/core/Distribution.pm6
+++ b/src/core/Distribution.pm6
@@ -181,13 +181,13 @@ class Distribution::Resource {
     }
 
     # delegate appropriate IO::Path methods to the resource IO::Path object
-    method Str(|c) {
+    multi method Str(::?CLASS:D: |c) {
         self.IO.Str(|c)
     }
-    method gist(|c) {
+    multi method gist(::?CLASS:D: |c) {
         self.IO.gist(|c)
     }
-    method perl(|c) {
+    multi method perl(::?CLASS:D: |c) {
         self.IO.perl(|c)
     }
     method absolute(|c) {


### PR DESCRIPTION
This commit fixes RT #2143. Besides just making `say
Distribution::Resource.^mro` not error, `.WHAT`, `.gist,`, `.perl`,
and `.say` now also work on the type object.

Credit to zoffixznet for figuring out how to solve the problem,
as I just followed their instructions. See this irc log for more
context, http://colabti.org/irclogger/irclogger_log/perl6?date=2018-07-29#l84