### PR TITLE
Fix the error of using  on

### DIFF
--- a/src/Perl6/Metamodel/MROBasedTypeChecking.nqp
+++ b/src/Perl6/Metamodel/MROBasedTypeChecking.nqp
@@ -1,5 +1,5 @@
 role Perl6::Metamodel::MROBasedTypeChecking {
-    method isa($obj, $type) {
+    multi method isa($obj, $type) {
         my $decont := nqp::decont($type);
         for self.mro($obj) {
             if nqp::decont($_) =:= $decont { return 1 }


### PR DESCRIPTION
the error:
```
$ perl6 -e 'say 42.HOW.isa(Metamodel::ClassHOW)'
Too few positionals passed; expected 3 arguments but got 2
  in block <unit> at -e line 1
```

after the change:
```
$ ./perl6 -e 'say 42.HOW.isa(Metamodel::ClassHOW)'
True
```