### PR TITLE
Prevent REPL from writing to filehandle when opening a file.

### DIFF
--- a/src/core/REPL.pm6
+++ b/src/core/REPL.pm6
@@ -396,7 +396,7 @@ do {
 
         method repl-print(Mu $value --> Nil) {
             nqp::can($value, 'gist')
-              and $value.say
+              and say $value
               or say "(low-level object `$value.^name()`)";
 
             CATCH {

--- a/t/02-rakudo/repl.t
+++ b/t/02-rakudo/repl.t
@@ -3,7 +3,7 @@ use lib <t/packages>;
 use Test;
 use Test::Helpers;
 
-plan 44;
+plan 45;
 
 my $*REPL-SCRUBBER = -> $_ is copy {
     s/^^ "You may want to `zef install Readline` or `zef install Linenoise`"
@@ -307,3 +307,9 @@ is-run-repl 'say "b".subst(/(.)/,{$0~$0}); say "%20" ~~ /:i \%(<[0..9A..F]>**2)/
 # https://github.com/rakudo/rakudo/issues/1925
 is-run-repl '&say.package', :out{.contains: 'GLOBAL'}, :err(''),
     ｢REPL can auto-print non-Mu things that lack .WHERE and .gist｣;
+
+#https://github.com/rakudo/rakudo/issues/2184
+is-run-repl 'my $fh = $*EXECUTABLE.open(:r)', 
+	:out{.contains: 'IO::Handle' and not .contains('Failed to write')}, 
+	:err(''),
+	｢no complaints about failed writing to filehandle when opening a file｣;


### PR DESCRIPTION
This is a fix for issue #2184.