### PR TITLE
Fix Regex.ACCEPTS: NDF does not set $/ #2176

### DIFF
--- a/src/core/Regex.pm6
+++ b/src/core/Regex.pm6
@@ -34,7 +34,8 @@ my class Regex { # declared in BOOTSTRAP
     }
 
 #?if !jvm
-    multi method ACCEPTS(Regex:D \SELF: Uni:D \uni) {  # RT #130458
+    multi method ACCEPTS(Regex:D \SELF: Uni:D \uni) {
+        $/ := nqp::getlexrelcaller(nqp::ctxcallerskipthunks(nqp::ctx()),'$/');
         self.ACCEPTS(uni.Str)
     }
 #?endif


### PR DESCRIPTION
Fix #2176

Behavior before:
```
> say so "7\x[308]".NFD ~~ /^ \d+ $/; dd $/.orig;
True
Nil
```

Behavior after:
```
> say so "7\x[308]".NFD ~~ /^ \d+ $/; dd $/.orig;
True
"7̈"
```

@zoffixznet 's suggestion ```$/ := nqp::getlexcaller('$/');``` did not work, but using ```$/ := nqp::getlexrelcaller(nqp::ctxcallerskipthunks(nqp::ctx()),'$/');``` as found here: https://github.com/rakudo/rakudo/blob/c4bb1b19d/src/core/Regex.pm6#L109 is what seems to fix the issue.

This does not fix https://github.com/perl6/roast/commit/b8bae2967#diff-c90019d7badd770a0d9abeea8d59795aR91 as ```$/.WHAT``` is a ```Str``` and not ```NFD```.