### PR TITLE
Make native arrays throw when storing lazy Seq

### DIFF
--- a/src/core/native_array.pm6
+++ b/src/core/native_array.pm6
@@ -89,7 +89,7 @@ my class array does Iterable {
 
     my role strarray[::T] does Positional[T] is array_type(T) {
 #- start of generated part of strarray role -----------------------------------
-#- Generated on 2018-08-21T10:43:21+01:00 by tools/build/makeNATIVE_ARRAY.p6
+#- Generated on 2018-08-28T17:41:48-04:00 by tools/build/makeNATIVE_ARRAY.p6
 #- PLEASE DON'T CHANGE ANYTHING BELOW THIS LINE
 
         multi method AT-POS(strarray:D: int $idx) is raw {
@@ -131,9 +131,9 @@ my class array does Iterable {
         multi method STORE(strarray:D: Seq:D \seq) {
             nqp::if(
               (my $iterator := seq.iterator).is-lazy,
-              Failure.new(X::Cannot::Lazy.new(
+              X::Cannot::Lazy.new(
                 :action<store>, :what(self.^name)
-              )),
+              ).throw,
               nqp::stmts(
                 $iterator.push-all(self),
                 self
@@ -574,7 +574,7 @@ my class array does Iterable {
 
     my role intarray[::T] does Positional[T] is array_type(T) {
 #- start of generated part of intarray role -----------------------------------
-#- Generated on 2018-08-21T10:43:21+01:00 by tools/build/makeNATIVE_ARRAY.p6
+#- Generated on 2018-08-28T17:41:48-04:00 by tools/build/makeNATIVE_ARRAY.p6
 #- PLEASE DON'T CHANGE ANYTHING BELOW THIS LINE
 
         multi method AT-POS(intarray:D: int $idx) is raw {
@@ -616,9 +616,9 @@ my class array does Iterable {
         multi method STORE(intarray:D: Seq:D \seq) {
             nqp::if(
               (my $iterator := seq.iterator).is-lazy,
-              Failure.new(X::Cannot::Lazy.new(
+              X::Cannot::Lazy.new(
                 :action<store>, :what(self.^name)
-              )),
+              ).throw,
               nqp::stmts(
                 $iterator.push-all(self),
                 self
@@ -1111,7 +1111,7 @@ my class array does Iterable {
 
     my role numarray[::T] does Positional[T] is array_type(T) {
 #- start of generated part of numarray role -----------------------------------
-#- Generated on 2018-08-21T10:43:21+01:00 by tools/build/makeNATIVE_ARRAY.p6
+#- Generated on 2018-08-28T17:41:48-04:00 by tools/build/makeNATIVE_ARRAY.p6
 #- PLEASE DON'T CHANGE ANYTHING BELOW THIS LINE
 
         multi method AT-POS(numarray:D: int $idx) is raw {
@@ -1153,9 +1153,9 @@ my class array does Iterable {
         multi method STORE(numarray:D: Seq:D \seq) {
             nqp::if(
               (my $iterator := seq.iterator).is-lazy,
-              Failure.new(X::Cannot::Lazy.new(
+              X::Cannot::Lazy.new(
                 :action<store>, :what(self.^name)
-              )),
+              ).throw,
               nqp::stmts(
                 $iterator.push-all(self),
                 self

--- a/src/core/native_array.pm6
+++ b/src/core/native_array.pm6
@@ -293,9 +293,7 @@ my class array does Iterable {
         multi method splice(strarray:D: Int:D $offset, Int:D $size, Seq:D \seq) {
             nqp::if(
               seq.is-lazy,
-              Failure.new(X::Cannot::Lazy.new(
-                :action<splice>, :what(self.^name)
-              )),
+              X::Cannot::Lazy.new(:action<splice>, :what(self.^name)).throw,
               nqp::stmts(
                 nqp::unless(
                   nqp::istype(
@@ -778,9 +776,7 @@ my class array does Iterable {
         multi method splice(intarray:D: Int:D $offset, Int:D $size, Seq:D \seq) {
             nqp::if(
               seq.is-lazy,
-              Failure.new(X::Cannot::Lazy.new(
-                :action<splice>, :what(self.^name)
-              )),
+              X::Cannot::Lazy.new(:action<splice>, :what(self.^name)).throw,
               nqp::stmts(
                 nqp::unless(
                   nqp::istype(
@@ -1315,9 +1311,7 @@ my class array does Iterable {
         multi method splice(numarray:D: Int:D $offset, Int:D $size, Seq:D \seq) {
             nqp::if(
               seq.is-lazy,
-              Failure.new(X::Cannot::Lazy.new(
-                :action<splice>, :what(self.^name)
-              )),
+              X::Cannot::Lazy.new(:action<splice>, :what(self.^name)).throw,
               nqp::stmts(
                 nqp::unless(
                   nqp::istype(

--- a/tools/build/makeNATIVE_ARRAY.p6
+++ b/tools/build/makeNATIVE_ARRAY.p6
@@ -88,9 +88,9 @@ for $*IN.lines -> $line {
         multi method STORE(#type#array:D: Seq:D \seq) {
             nqp::if(
               (my $iterator := seq.iterator).is-lazy,
-              Failure.new(X::Cannot::Lazy.new(
+              X::Cannot::Lazy.new(
                 :action<store>, :what(self.^name)
-              )),
+              ).throw,
               nqp::stmts(
                 $iterator.push-all(self),
                 self

--- a/tools/build/makeNATIVE_ARRAY.p6
+++ b/tools/build/makeNATIVE_ARRAY.p6
@@ -250,9 +250,7 @@ for $*IN.lines -> $line {
         multi method splice(#type#array:D: Int:D $offset, Int:D $size, Seq:D \seq) {
             nqp::if(
               seq.is-lazy,
-              Failure.new(X::Cannot::Lazy.new(
-                :action<splice>, :what(self.^name)
-              )),
+              X::Cannot::Lazy.new(:action<splice>, :what(self.^name)).throw,
               nqp::stmts(
                 nqp::unless(
                   nqp::istype(


### PR DESCRIPTION
Currently a Failure is returned when attempting to store a lazy Seq but
since the result is not sunk, the Failure is not thrown. This leads to
odd results like below:

    my int @geo = 2, 4, 8 ... *;
    say @geo[2..10];

    # OUTPUT:   [0 0 0 0 0 0 0 0 0]
    # EXPECTED: FAILED

Resolve by explicitly throwing.