### PR TITLE
Add a BOM on open for utf16 filehandles

### DIFF
--- a/src/core/IO/Handle.pm6
+++ b/src/core/IO/Handle.pm6
@@ -177,8 +177,17 @@ my class IO::Handle {
             $!decoder.set-line-separators(($!nl-in = $nl-in).list);
             $!encoder := $encoding.encoder(:translate-nl);
             $!encoding = $encoding.name;
+
+            # Add a byte order mark to the start of the file for utf16
+            nqp::if(nqp::iseq_s($!encoding, 'utf16'), (
+                if $create && !$exclusive && (!$append || $append && $!path.s == 0) {
+                  self.write: Buf[uint16].new(0xFEFF);
+                })
+            );
         }
         self!set-out-buffer-size($out-buffer);
+
+
         self;
     }
 


### PR DESCRIPTION
When we open a file for write we will write a BOM upon open. Since we
already truncate the file if it exists, this shouldn't cause any loss of
data aside from the previous functionality.

If we are appending, then only add a BOM if there is nothing yet written
to the file. If the file already has data in it, then don't add a byte
order mark.