### PR TITLE
Implement .native-descriptor for async sockets

### DIFF
--- a/src/core/IO/Socket/Async.pm6
+++ b/src/core/IO/Socket/Async.pm6
@@ -122,7 +122,8 @@ my class IO::Socket::Async {
                     nqp::decont($!buf), SocketCancellation);
                 $tap := Tap.new({ nqp::cancel($cancellation) });
                 tap($tap);
-            }
+            };
+
             $!close-promise.then: {
                 $lock.protect: {
                     unless $finished {
@@ -165,42 +166,61 @@ my class IO::Socket::Async {
         $!close-vow.keep(True);
     }
 
-    method connect(IO::Socket::Async:U: Str() $host, Int() $port,
-                   :$enc = 'utf-8', :$scheduler = $*SCHEDULER) {
-        my $p = Promise.new;
+    sub create-socket(Bool :$listening = False, :$scheduler = $*SCHEDULER --> Promise) {
+        my Promise $p .= new;
         my $v = $p.vow;
-        my $encoding = Encoding::Registry.find($enc);
-        nqp::asyncconnect(
+        nqp::asyncsocket(
             $scheduler.queue,
-            -> Mu \socket, Mu \err, Mu \peer-host, Mu \peer-port, Mu \socket-host, Mu \socket-port {
+            -> Mu \socket, Mu \err {
                 if err {
-                    $v.break(err);
-                }
-                else {
-                    my $client_socket := nqp::create(self);
-                    nqp::bindattr($client_socket, IO::Socket::Async, '$!VMIO', socket);
-                    nqp::bindattr($client_socket, IO::Socket::Async, '$!enc', $encoding.name);
-                    nqp::bindattr($client_socket, IO::Socket::Async, '$!encoder',
-                        $encoding.encoder());
-                    nqp::bindattr($client_socket, IO::Socket::Async, '$!peer-host', peer-host);
-                    nqp::bindattr($client_socket, IO::Socket::Async, '$!peer-port', peer-port);
-                    nqp::bindattr($client_socket, IO::Socket::Async, '$!socket-host', socket-host);
-                    nqp::bindattr($client_socket, IO::Socket::Async, '$!socket-port', socket-port);
-
-                    setup-close($client_socket);
-                    $v.keep($client_socket);
+                    $v.break: err;
+                } else {
+                    $v.keep: socket;
                 }
             },
-            $host, $port, SocketCancellation);
+            nqp::unbox_i($listening ?? 1 !! 0),
+            SocketCancellation
+        );
+        $p;
+    }
+
+    method connect(IO::Socket::Async:U: Str() $host, Int() $port,
+                   :$enc = 'utf-8', :$scheduler = $*SCHEDULER) {
+        my Promise $p .= new;
+        my $v = $p.vow;
+        my \server-socket = await create-socket(:$scheduler);
+        nqp::asyncconnect(
+            $scheduler.queue,
+            -> Mu \client-socket, Mu \err, Mu \peer-host, Mu \peer-port, Mu \socket-host, Mu \socket-port {
+                if err {
+                    $v.break: err;
+                } else {
+                    my \client = nqp::create(self);
+                    my $encoding      = Encoding::Registry.find($enc);
+                    nqp::bindattr(client, IO::Socket::Async, '$!VMIO', client-socket);
+                    nqp::bindattr(client, IO::Socket::Async, '$!enc', $encoding.name);
+                    nqp::bindattr(client, IO::Socket::Async, '$!encoder', $encoding.encoder());
+                    nqp::bindattr(client, IO::Socket::Async, '$!peer-host', peer-host);
+                    nqp::bindattr(client, IO::Socket::Async, '$!peer-port', peer-port);
+                    nqp::bindattr(client, IO::Socket::Async, '$!socket-host', socket-host);
+                    nqp::bindattr(client, IO::Socket::Async, '$!socket-port', socket-port);
+                    setup-close(client);
+                    $v.keep: client;
+                }
+            },
+            server-socket, $host, $port, SocketCancellation);
         $p
     }
 
     class ListenSocket is Tap {
+        has         $!VMIO;
         has Promise $.socket-host;
         has Promise $.socket-port;
 
-        method new(&on-close, Promise :$socket-host, Promise :$socket-port) {
-            self.bless(:&on-close, :$socket-host, :$socket-port);
+        submethod BUILD(Mu :$!VMIO, Promise :$!socket-host, Promise :$!socket-port) { }
+
+        method new(&on-close, Mu :$VMIO, Promise :$socket-host, Promise :$socket-port) {
+            self.bless: :&on-close, :$VMIO, :$socket-host, :$socket-port;
         }
     }
 
@@ -217,9 +237,10 @@ my class IO::Socket::Async {
 
         method !SET-SELF($!host, $!port, $!backlog, $!encoding, $!scheduler) { self }
 
-        method tap(&emit, &done, &quit, &tap) {
+        method tap(&emit, &done, &quit, &tap --> ListenSocket) {
             my $lock := Lock::Async.new;
             my $tap;
+            my $VMIO = await create-socket(:listening, :$!scheduler);
             my int $finished = 0;
             my Promise $socket-host .= new;
             my Promise $socket-port .= new;
@@ -242,23 +263,23 @@ my class IO::Socket::Async {
                                 $finished = 1;
                             }
                             elsif socket {
-                                my $client_socket := nqp::create(IO::Socket::Async);
-                                nqp::bindattr($client_socket, IO::Socket::Async,
+                                my \client := nqp::create(IO::Socket::Async);
+                                nqp::bindattr(client, IO::Socket::Async,
                                     '$!VMIO', socket);
-                                nqp::bindattr($client_socket, IO::Socket::Async,
+                                nqp::bindattr(client, IO::Socket::Async,
                                     '$!enc', $!encoding.name);
-                                nqp::bindattr($client_socket, IO::Socket::Async,
+                                nqp::bindattr(client, IO::Socket::Async,
                                     '$!encoder', $!encoding.encoder());
-                                nqp::bindattr($client_socket, IO::Socket::Async,
+                                nqp::bindattr(client, IO::Socket::Async,
                                     '$!peer-host', peer-host);
-                                nqp::bindattr($client_socket, IO::Socket::Async,
+                                nqp::bindattr(client, IO::Socket::Async,
                                     '$!peer-port', peer-port);
-                                nqp::bindattr($client_socket, IO::Socket::Async,
+                                nqp::bindattr(client, IO::Socket::Async,
                                     '$!socket-host', socket-host);
-                                nqp::bindattr($client_socket, IO::Socket::Async,
+                                nqp::bindattr(client, IO::Socket::Async,
                                     '$!socket-port', socket-port);
-                                setup-close($client_socket);
-                                emit($client_socket);
+                                setup-close(client);
+                                emit(client);
                             }
                             elsif socket-host {
                                 $host-vow.keep(~socket-host);
@@ -266,18 +287,20 @@ my class IO::Socket::Async {
                             }
                         }
                     },
-                    $!host, $!port, $!backlog, SocketCancellation);
+                    nqp::decont($VMIO), $!host, $!port, $!backlog, SocketCancellation);
                 $tap = ListenSocket.new: {
                     my $p = Promise.new;
                     my $v = $p.vow;
                     nqp::cancelnotify($cancellation, $!scheduler.queue, { $v.keep(True); });
                     $p
-                }, :$socket-host, :$socket-port;
+                }, :$VMIO, :$socket-host, :$socket-port;
                 tap($tap);
+
                 CATCH {
                     default {
-                        tap($tap = ListenSocket.new({ Nil },
-                            :$socket-host, :$socket-port)) unless $tap;
+                        $tap = ListenSocket.new({ Nil }, :$VMIO,
+                            :$socket-host, :$socket-port) unless $tap;
+                        tap($tap);
                         quit($_);
                     }
                 }
@@ -292,9 +315,10 @@ my class IO::Socket::Async {
 
     method listen(IO::Socket::Async:U: Str() $host, Int() $port, Int() $backlog = 128,
                   :$enc = 'utf-8', :$scheduler = $*SCHEDULER) {
-        my $encoding = Encoding::Registry.find($enc);
-        Supply.new: SocketListenerTappable.new:
-            :$host, :$port, :$backlog, :$encoding, :$scheduler
+        my $encoding = Encoding::Registry.find: $enc;
+        my $tappable =  SocketListenerTappable.new:
+            :$host, :$port, :$backlog, :$encoding, :$scheduler;
+        Supply.new: $tappable;
     }
 
     sub setup-close(\socket --> Nil) {
@@ -314,14 +338,14 @@ my class IO::Socket::Async {
                     $p.break(err);
                 }
                 else {
-                    my $client_socket := nqp::create(self);
-                    nqp::bindattr($client_socket, IO::Socket::Async, '$!VMIO', socket);
-                    nqp::bindattr_i($client_socket, IO::Socket::Async, '$!udp', 1);
-                    nqp::bindattr($client_socket, IO::Socket::Async, '$!enc', $encoding.name);
-                    nqp::bindattr($client_socket, IO::Socket::Async, '$!encoder',
+                    my \client := nqp::create(self);
+                    nqp::bindattr(client, IO::Socket::Async, '$!VMIO', socket);
+                    nqp::bindattr_i(client, IO::Socket::Async, '$!udp', 1);
+                    nqp::bindattr(client, IO::Socket::Async, '$!enc', $encoding.name);
+                    nqp::bindattr(client, IO::Socket::Async, '$!encoder',
                         $encoding.encoder());
-                    setup-close($client_socket);
-                    $p.keep($client_socket);
+                    setup-close(client);
+                    $p.keep(client);
                 }
             },
             nqp::null_s(), 0, $broadcast ?? 1 !! 0,
@@ -340,14 +364,14 @@ my class IO::Socket::Async {
                     $p.break(err);
                 }
                 else {
-                    my $client_socket := nqp::create(self);
-                    nqp::bindattr($client_socket, IO::Socket::Async, '$!VMIO', socket);
-                    nqp::bindattr_i($client_socket, IO::Socket::Async, '$!udp', 1);
-                    nqp::bindattr($client_socket, IO::Socket::Async, '$!enc', $encoding.name);
-                    nqp::bindattr($client_socket, IO::Socket::Async, '$!encoder',
+                    my \client := nqp::create(self);
+                    nqp::bindattr(client, IO::Socket::Async, '$!VMIO', socket);
+                    nqp::bindattr_i(client, IO::Socket::Async, '$!udp', 1);
+                    nqp::bindattr(client, IO::Socket::Async, '$!enc', $encoding.name);
+                    nqp::bindattr(client, IO::Socket::Async, '$!encoder',
                         $encoding.encoder());
-                    setup-close($client_socket);
-                    $p.keep($client_socket);
+                    setup-close(client);
+                    $p.keep(client);
                 }
             },
             nqp::unbox_s($host), nqp::unbox_i($port), $broadcast ?? 1 !! 0,


### PR DESCRIPTION
This will allow users to get the native descriptor of the sockets later
on. See https://github.com/perl6/nqp/pull/505 and https://github.com/MoarVM/MoarVM/pull/980