### PR TITLE
Use the correct ContainerDescriptor for Shaped3Array

### DIFF
--- a/src/core/Shaped3Array.pm6
+++ b/src/core/Shaped3Array.pm6
@@ -18,7 +18,7 @@
             )
         }
         sub AT-POS-CONTAINER(\array, int \one, int \two, int \three) is raw {
-            nqp::p6scalarfromdesc(ContainerDescriptor::BindArrayPos2D.new(
+            nqp::p6scalarfromdesc(ContainerDescriptor::BindArrayPos3D.new(
                nqp::getattr(array, Array, '$!descriptor'),
                nqp::getattr(array, List, '$!reified'),
                one, two, three))


### PR DESCRIPTION
The previous version fails to create Arrays with a dimension of three.
EDITED `my @a[1;1;1]; say @a; # Fails`