### PR TITLE
Use the actual object instance instead of a type object - Fixes #2352

### DIFF
--- a/src/core/ShapedArray.pm6
+++ b/src/core/ShapedArray.pm6
@@ -27,7 +27,7 @@
                     nqp::atposnd(reified,idxs),      # found it
                     nqp::p6scalarfromdesc(
                       ContainerDescriptor::BindArrayPosND.new(
-                        nqp::getattr(array, Array, '$!descriptor'),
+                        nqp::getattr(self, Array, '$!descriptor'),
                         reified, idxs
                       )
                     )


### PR DESCRIPTION
This is probably a copy paste error
as there are similar constructor calls where \array
was taken as the object.