### PR TITLE
Optimize more ops on native attributes

### DIFF
--- a/src/Perl6/Optimizer.nqp
+++ b/src/Perl6/Optimizer.nqp
@@ -1913,7 +1913,7 @@ class Perl6::Optimizer {
         $op.op: 'callstatic'; # by now we know 'tis a core op
 
         # if we got a native int/num, we can rewrite into nqp ops
-        if nqp::istype($var,QAST::Var) && $var.scope eq 'lexicalref'
+        if nqp::istype($var,QAST::Var) && ($var.scope eq 'lexicalref' || $var.scope eq 'attributeref')
         && ((my $primspec := nqp::objprimspec($var.returns)) == 1 # native int
           || $primspec == 2 || $primspec == 4 || $primspec == 5) # native num or "emulated" 64bit int
         {


### PR DESCRIPTION
By re-writing into native ops.

Rakudo builds ok and passes `make m-test m-spectest`.

At least partially fixes https://github.com/rakudo/rakudo/issues/2392.

Before, `class Foo { has int $!x; has int $!y; method z { $!x ≤ ++$!y } }; my $f = Foo.new(:x((^10).pick), :y((^10).pick)); my $z; for ^1_000_000 { $z = $f.z; }; say $z; say now - INIT now` took 0.60s, after it takes 0.11s.