### PR TITLE
Deprecate gethostname() in favor of $*KERNEL.hostname

### DIFF
--- a/src/core/Kernel.pm6
+++ b/src/core/Kernel.pm6
@@ -101,6 +101,10 @@ class Kernel does Systemic {
         $!bits //= $.hardware ~~ m/_64|w|amd64/ ?? 64 !! 32;  # naive approach
     }
 
+    method hostname {
+        nqp::p6box_s(nqp::gethostname)
+    }
+
     has @!signals;  # Signal
 #?if jvm
     method signals (Kernel:D:) {

--- a/src/core/OS.pm6
+++ b/src/core/OS.pm6
@@ -1,4 +1,7 @@
 proto sub gethostname(*%) {*}
-multi sub gethostname(--> Str:D){ nqp::p6box_s(nqp::gethostname) }
+multi sub gethostname(--> Str:D){
+    Rakudo::Deprecations.DEPRECATED('$*KERNEL.hostname()');
+    $*KERNEL.hostname()
+}
 
 # vim: ft=perl6 expandtab sw=4


### PR DESCRIPTION
Rework of #2065