### PR TITLE
Fix placeholder method error

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -9445,6 +9445,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
             pos_slurpy        => $pos_slurpy,
             named_slurpy      => $named_slurpy,
             placeholder       => $full_name,
+            ast               => $/,
             is_multi_invocant => 1,
             sigil             => ~$sigil);
 

--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -4324,7 +4324,9 @@ class Perl6::Actions is HLL::Actions does STDActions {
                 my $placeholder := nqp::shift($placeholders);
                 my $name := $placeholder<placeholder>;
                 my $non-placeholder-name;
-                if $placeholder<named_names> {
+                if $placeholder<pos_slurpy> || $placeholder<named_slurpy> {
+                    $non-placeholder-name := nqp::concat('*', $name);
+                } elsif $placeholder<named_names> {
                     $non-placeholder-name := nqp::concat(':', nqp::concat(nqp::substr($name, 0, 1), nqp::substr($name, 2)));
                 } else {
                     $non-placeholder-name := nqp::concat(nqp::substr($name, 0, 1), nqp::substr($name, 2));

--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -4268,29 +4268,6 @@ class Perl6::Actions is HLL::Actions does STDActions {
         }
         else {
             $past := WANTED($<blockoid>.ast,'method_def');
-            if $past.ann('placeholder_sig') {
-                my $placeholders := nqp::iterator($past.ann('placeholder_sig'));
-                my @non-placeholder-names;
-                my $method-name := $<longname><name>;
-                while $placeholders {
-                    my $placeholder := nqp::shift($placeholders);
-                    my $name := $placeholder<placeholder>;
-                    my $non-placeholder-name;
-                    if $placeholder<named_names> {
-                        $non-placeholder-name := nqp::concat(':', nqp::concat(nqp::substr($name, 0, 1), nqp::substr($name, 2)));
-                    } else {
-                        $non-placeholder-name := nqp::concat(nqp::substr($name, 0, 1), nqp::substr($name, 2));
-                    }
-                    nqp::push( @non-placeholder-names, $non-placeholder-name);
-                }
-
-                my $non-placeholder-names := nqp::join(', ', @non-placeholder-names);
-
-                my $first-placeholder := $past.ann('placeholder_sig')[0];
-                my $first-placeholder-name := $first-placeholder<placeholder>;
-
-                $first-placeholder<ast>.PRECURSOR.panic("Placeholder variables (eg. $first-placeholder-name) cannot be used in a method.\nPlease specify an explicit signature, like $*METHODTYPE $method-name ($non-placeholder-names) \{ ... \}");
-            }
             if is_clearly_returnless($past) {
                 $past[1] := QAST::Op.new(
                     :op(decontrv_op()),
@@ -4338,6 +4315,30 @@ class Perl6::Actions is HLL::Actions does STDActions {
             }
         }
         $past.name($name ?? $name !! '<anon>');
+
+        if $past.ann('placeholder_sig') {
+            my $placeholders := nqp::iterator($past.ann('placeholder_sig'));
+            my @non-placeholder-names;
+            my $method-name := $past.name;
+            while $placeholders {
+                my $placeholder := nqp::shift($placeholders);
+                my $name := $placeholder<placeholder>;
+                my $non-placeholder-name;
+                if $placeholder<named_names> {
+                    $non-placeholder-name := nqp::concat(':', nqp::concat(nqp::substr($name, 0, 1), nqp::substr($name, 2)));
+                } else {
+                    $non-placeholder-name := nqp::concat(nqp::substr($name, 0, 1), nqp::substr($name, 2));
+                }
+                nqp::push( @non-placeholder-names, $non-placeholder-name);
+            }
+
+            my $non-placeholder-names := nqp::join(', ', @non-placeholder-names);
+
+            my $first-placeholder := $past.ann('placeholder_sig')[0];
+            my $first-placeholder-name := $first-placeholder<placeholder>;
+
+            $first-placeholder<ast>.PRECURSOR.panic("Placeholder variables (eg. $first-placeholder-name) cannot be used in a method.\nPlease specify an explicit signature, like $*METHODTYPE $method-name ($non-placeholder-names) \{ ... \}");
+        }
 
         my $code := methodize_block($/, $*DECLARAND, $past, $*SIG_OBJ,
             %*SIG_INFO, :yada(is_yada($/)));

--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -4337,7 +4337,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
             my $first-placeholder := $past.ann('placeholder_sig')[0];
             my $first-placeholder-name := $first-placeholder<placeholder>;
 
-            $first-placeholder<ast>.PRECURSOR.panic("Placeholder variables (eg. $first-placeholder-name) cannot be used in a method.\nPlease specify an explicit signature, like $*METHODTYPE $method-name ($non-placeholder-names) \{ ... \}");
+            $first-placeholder<node>.PRECURSOR.panic("Placeholder variables (eg. $first-placeholder-name) cannot be used in a method.\nPlease specify an explicit signature, like $*METHODTYPE $method-name ($non-placeholder-names) \{ ... \}");
         }
 
         my $code := methodize_block($/, $*DECLARAND, $past, $*SIG_OBJ,
@@ -9447,7 +9447,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
             pos_slurpy        => $pos_slurpy,
             named_slurpy      => $named_slurpy,
             placeholder       => $full_name,
-            ast               => $/,
+            node              => $/,
             is_multi_invocant => 1,
             sigil             => ~$sigil);
 

--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -4286,9 +4286,10 @@ class Perl6::Actions is HLL::Actions does STDActions {
 
                 my $non-placeholder-names := nqp::join(', ', @non-placeholder-names);
 
-                my $first-placeholder-name := $past.ann('placeholder_sig')[0]<placeholder>;
+                my $first-placeholder := $past.ann('placeholder_sig')[0];
+                my $first-placeholder-name := $first-placeholder<placeholder>;
 
-                $/.PRECURSOR.panic("Placeholder variables (eg. $first-placeholder-name) cannot be used in a method.\nPlease specify an explicit signature, like $*METHODTYPE $method-name ($non-placeholder-names) \{ ... \}");
+                $first-placeholder<ast>.PRECURSOR.panic("Placeholder variables (eg. $first-placeholder-name) cannot be used in a method.\nPlease specify an explicit signature, like $*METHODTYPE $method-name ($non-placeholder-names) \{ ... \}");
             }
             if is_clearly_returnless($past) {
                 $past[1] := QAST::Op.new(

--- a/t/05-messages/03-errors.t
+++ b/t/05-messages/03-errors.t
@@ -2,7 +2,7 @@ use lib <t/packages/>;
 use Test;
 use Test::Helpers;
 
-plan 24;
+plan 25;
 
 subtest '.map does not explode in optimizer' => {
     plan 3;
@@ -171,5 +171,9 @@ else {
 cmp-ok X::OutOfRange.new(
     :what<a range>, :got(0..3000), :range(1..3000)
 ).message.chars, '<', 150, 'X::OutOfRange does not stringify given Ranges';
+
+# https://github.com/rakudo/rakudo/issues/2320
+is-run 'class { method z { $^a } }', :err{ my @lines = $^msg.lines; @lines.grep({ !/'⏏'/ && .contains: '$^a' }) }, :exitcode{.so},
+'Use placeholder variables in a method should yield a useful error message';
 
 # vim: ft=perl6 expandtab sw=4


### PR DESCRIPTION
Addresses GH #2320 

There are a few things I'd like some discussion on for this PR:

  * I noticed there's an `X::Signature::Placeholder` - should this error be using something like that for its exception?  I understand the documentation for that exception class indicates an explicit signature conflicting with a placeholder, but the class name itself implies a more broad category.
  * I haven't added tests yet - what's the best way to test error messages without them being too brittle?
  * I didn't know that there was such a thing as slurpy placeholders - I don't know what that would look like, so this change might not work with those!