### PR TITLE
Fix potential race condition in Proc::Async start

### DIFF
--- a/src/core/Proc/Async.pm6
+++ b/src/core/Proc/Async.pm6
@@ -271,17 +271,21 @@ my class Proc::Async {
         $promise;
     }
 
+    has $!start-lock = Lock.new;
     method start(Proc::Async:D: :$scheduler = $*SCHEDULER, :$ENV, :$cwd = $*CWD) {
         X::Proc::Async::AlreadyStarted.new(proc => self).throw if $!started;
-        $!started = True;
+        $!start-lock.protect: {
+            X::Proc::Async::AlreadyStarted.new(proc => self).throw if $!started;
+            $!started = True;
 
-        my @blockers;
-        if $!stdin-fd ~~ Promise {
-            @blockers.push($!stdin-fd.then({ $!stdin-fd := .result }));
+            my @blockers;
+            if $!stdin-fd ~~ Promise {
+                @blockers.push($!stdin-fd.then({ $!stdin-fd := .result }));
+            }
+            @blockers
+                ?? start { await @blockers; await self!start-internal(:$scheduler, :$ENV, :$cwd) }
+                !! self!start-internal(:$scheduler, :$ENV, :$cwd)
         }
-        @blockers
-            ?? start { await @blockers; await self!start-internal(:$scheduler, :$ENV, :$cwd) }
-            !! self!start-internal(:$scheduler, :$ENV, :$cwd)
     }
 
     method !start-internal(:$scheduler, :$ENV, :$cwd) {


### PR DESCRIPTION
There is potential for a race here if two threads call start on the same
Proc::Async instance. Add a lock to mitigate that risk.