### PR TITLE
Revert Enum:D ACCEPTSing Enum:U

### DIFF
--- a/src/core/Enumeration.pm6
+++ b/src/core/Enumeration.pm6
@@ -30,8 +30,6 @@ my role Enumeration {
         )
     }
 
-    # Make sure we always accept any element of the enumeration
-    multi method ACCEPTS(::?CLASS:D: ::?CLASS:U $ --> True) { }
     multi method ACCEPTS(::?CLASS:D: ::?CLASS:D \v) { self === v }
 
     proto method CALL-ME(|) {*}


### PR DESCRIPTION
That's what elements of an enumeration really are, the :D's and
the enumeration itself is a :U. For :D's to be accepting :U's
it makes as little sence as an Int:D constraint accepting an `Int`

This is part of fixing https://github.com/rakudo/rakudo/issues/2073
A more complete fix might involve banning the use of Enum:D's in
the same place as other types and instead requiring the use of
`where` clauses for such use.