### PR TITLE
Add type constraints to port numbers in IO::Socket::Async

### DIFF
--- a/t/05-messages/02-errors.t
+++ b/t/05-messages/02-errors.t
@@ -16,15 +16,12 @@ throws-like { for [:a] X [:b] -> ($i, $j) { } },
     message => / '<anon>' /,
     "anonymous subs get '<anon>' in arity error messages";
 
-todo 'needs better error message';
-
-skip 'crashes: https://github.com/rakudo/rakudo/issues/2402';
-#throws-like {
-#    sub l { IO::Socket::Async.listen: "localhost", 111390 }
-#    react whenever l() {
-#        whenever l() {} # try to listen on already open sock
-#    }
-#}, X::AdHoc, message => /'something good'/;
+throws-like {
+    sub l { IO::Socket::Async.listen: "localhost", 111390 }
+    react whenever l() {
+        whenever l() {} # try to listen on already open sock
+    }
+}, X::TypeCheck::Binding::Parameter, message => /'type check failed'/;
 
 # RT #132283
 is-deeply class { has $.bar }.^methods».name.sort, <BUILDALL bar>,


### PR DESCRIPTION
I believe this fixes #2424.  I'm not sure if this is an acceptable way to fix it.  I also don't have the ability to test this on Windows (but see no reason it wouldn't work - famous last words, I know)  I couple things:

I defined a subset (Port-Number) in I::S::A that includes undefined and ^65536.  I changed the class properties representing port numbers to use the subset.  I also matched the coerced port numbers in the various methods that take port numbers against this subset.

This does change the exceptions thrown - I'm not sure if this is unacceptable or not.  I do believe the exceptions make more sense now.

I also changed the test for an invalid high port number, restoring it's ability to execute again.  I removed the todo noting the less-than-helpful exception that was previously thrown.

If I should do something differently, I'm open to that.