### PR TITLE
[IP6NS Grant] Implement .set-option/.get-option for async and INET sockets

### DIFF
--- a/src/core/IO/Socket.pm6
+++ b/src/core/IO/Socket.pm6
@@ -111,6 +111,14 @@ my role IO::Socket {
         $!PIO := nqp::null;
     }
 
+    method get-option(Int:D \option --> Int) {
+        nqp::box_i(nqp::getsockopt($!PIO, nqp::unbox_i(option)), Int)
+    }
+
+    method set-option(Int:D \option, Int:D \value) {
+        nqp::setsockopt($!PIO, nqp::unbox_i(option), nqp::unbox_i(value))
+    }
+
     method native-descriptor(::?CLASS:D:) {
         nqp::filenofh($!PIO)
     }

--- a/src/core/IO/Socket.pm6
+++ b/src/core/IO/Socket.pm6
@@ -111,15 +111,17 @@ my role IO::Socket {
         $!PIO := nqp::null;
     }
 
-    method get-option(Int:D \option --> Int) {
+#?if !js
+    method get-option(Int() \option --> Num) {
         fail('Socket not available') unless $!PIO;
         nqp::getsockopt($!PIO, nqp::unbox_i(option))
     }
 
-    method set-option(Int:D \option, Int:D \value --> Nil) {
+    method set-option(Int() \option, Int() \value --> Nil) {
         fail('Socket not available') unless $!PIO;
         nqp::setsockopt($!PIO, nqp::unbox_i(option), nqp::unbox_i(value))
     }
+#?endif
 
     method native-descriptor(--> Int) {
         fail('Socket not available') unless $!PIO;

--- a/src/core/IO/Socket.pm6
+++ b/src/core/IO/Socket.pm6
@@ -106,20 +106,23 @@ my role IO::Socket {
     }
 
     method close(--> True) {
-        fail("Not connected!") unless $!PIO;
+        fail("Socket not available") unless $!PIO;
         nqp::closefh($!PIO);
         $!PIO := nqp::null;
     }
 
     method get-option(Int:D \option --> Int) {
-        nqp::box_i(nqp::getsockopt($!PIO, nqp::unbox_i(option)), Int)
+        fail('Socket not available') unless $!PIO;
+        nqp::getsockopt($!PIO, nqp::unbox_i(option))
     }
 
-    method set-option(Int:D \option, Int:D \value) {
+    method set-option(Int:D \option, Int:D \value --> Nil) {
+        fail('Socket not available') unless $!PIO;
         nqp::setsockopt($!PIO, nqp::unbox_i(option), nqp::unbox_i(value))
     }
 
-    method native-descriptor(::?CLASS:D:) {
+    method native-descriptor(--> Int) {
+        fail('Socket not available') unless $!PIO;
         nqp::filenofh($!PIO)
     }
 }

--- a/src/core/IO/Socket/Async.pm6
+++ b/src/core/IO/Socket/Async.pm6
@@ -208,16 +208,19 @@ my class IO::Socket::Async {
             self.bless(:&on-close, :$VMIO-tobe, :$socket-host, :$socket-port);
         }
 
+        method get-option(Int:D \option --> Int) {
+            my Mu \VMIO = await $!VMIO-tobe;
+            nqp::getsockopt(VMIO, nqp::unbox_i(option))
+        }
+
+        method set-option(Int:D \option, Int:D \value --> Nil) {
+            my Mu \VMIO = await $!VMIO-tobe;
+            nqp::setsockopt(VMIO, nqp::unbox_i(option), nqp::unbox_i(value))
+        }
+
         method native-descriptor(--> Int) {
-            nqp::filenofh(await $!VMIO-tobe)
-        }
-
-        method get-option(IO::Socket::Async:D: Int:D \option --> Int) {
-            nqp::box_i(nqp::getsockopt($!VMIO-tobe, nqp::unbox_i(option)), Int)
-        }
-
-        method set-option(IO::Socket::Async:D: Int:D \option, Int:D \value) {
-            nqp::setsockopt(await $!VMIO-tobe, nqp::unbox_i(option), nqp::unbox_i(value))
+            my Mu \VMIO = await $!VMIO-tobe;
+            nqp::filenofh(VMIO)
         }
     }
 
@@ -317,15 +320,16 @@ my class IO::Socket::Async {
             :$host, :$port, :$backlog, :$encoding, :$scheduler
     }
 
-    method native-descriptor(--> Int) {
-        nqp::filenofh($!VMIO)
-
     method get-option(IO::Socket::Async:D: Int:D \option --> Int) {
-        nqp::box_i(nqp::getsockopt($!VMIO, nqp::unbox_i(option)), Int)
+        nqp::getsockopt($!VMIO, nqp::unbox_i(option))
     }
 
-    method set-option(IO::Socket::Async:D: Int:D \option, Int:D \value) {
+    method set-option(IO::Socket::Async:D: Int:D \option, Int:D \value --> Nil) {
         nqp::setsockopt($!VMIO, nqp::unbox_i(option), nqp::unbox_i(value))
+    }
+
+    method native-descriptor(IO::Socket::Async:D: --> Int) {
+        nqp::filenofh($!VMIO)
     }
 
     sub setup-close(\socket --> Nil) {

--- a/src/core/IO/Socket/Async.pm6
+++ b/src/core/IO/Socket/Async.pm6
@@ -208,19 +208,18 @@ my class IO::Socket::Async {
             self.bless(:&on-close, :$VMIO-tobe, :$socket-host, :$socket-port);
         }
 
-        method get-option(Int:D \option --> Int) {
-            my Mu \VMIO = await $!VMIO-tobe;
-            nqp::getsockopt(VMIO, nqp::unbox_i(option))
+#?if !js
+        method get-option(Int() \option --> Int) {
+            nqp::getsockopt((await $!VMIO-tobe), nqp::unbox_i(option))
         }
 
-        method set-option(Int:D \option, Int:D \value --> Nil) {
-            my Mu \VMIO = await $!VMIO-tobe;
-            nqp::setsockopt(VMIO, nqp::unbox_i(option), nqp::unbox_i(value))
+        method set-option(Int() \option, Int() \value --> Nil) {
+            nqp::setsockopt((await $!VMIO-tobe), nqp::unbox_i(option), nqp::unbox_i(value))
         }
+#?endif
 
         method native-descriptor(--> Int) {
-            my Mu \VMIO = await $!VMIO-tobe;
-            nqp::filenofh(VMIO)
+            nqp::filenofh(await $!VMIO-tobe)
         }
     }
 
@@ -320,13 +319,15 @@ my class IO::Socket::Async {
             :$host, :$port, :$backlog, :$encoding, :$scheduler
     }
 
-    method get-option(IO::Socket::Async:D: Int:D \option --> Int) {
+#?if !js
+    method get-option(Int() \option --> Int) {
         nqp::getsockopt($!VMIO, nqp::unbox_i(option))
     }
 
-    method set-option(IO::Socket::Async:D: Int:D \option, Int:D \value --> Nil) {
+    method set-option(Int() \option, Int() \value --> Nil) {
         nqp::setsockopt($!VMIO, nqp::unbox_i(option), nqp::unbox_i(value))
     }
+#?endif
 
     method native-descriptor(IO::Socket::Async:D: --> Int) {
         nqp::filenofh($!VMIO)

--- a/src/core/IO/Socket/Async.pm6
+++ b/src/core/IO/Socket/Async.pm6
@@ -211,6 +211,14 @@ my class IO::Socket::Async {
         method native-descriptor(--> Int) {
             nqp::filenofh(await $!VMIO-tobe)
         }
+
+        method get-option(IO::Socket::Async:D: Int:D \option --> Int) {
+            nqp::box_i(nqp::getsockopt($!VMIO-tobe, nqp::unbox_i(option)), Int)
+        }
+
+        method set-option(IO::Socket::Async:D: Int:D \option, Int:D \value) {
+            nqp::setsockopt(await $!VMIO-tobe, nqp::unbox_i(option), nqp::unbox_i(value))
+        }
     }
 
     my class SocketListenerTappable does Tappable {
@@ -311,6 +319,13 @@ my class IO::Socket::Async {
 
     method native-descriptor(--> Int) {
         nqp::filenofh($!VMIO)
+
+    method get-option(IO::Socket::Async:D: Int:D \option --> Int) {
+        nqp::box_i(nqp::getsockopt($!VMIO, nqp::unbox_i(option)), Int)
+    }
+
+    method set-option(IO::Socket::Async:D: Int:D \option, Int:D \value) {
+        nqp::setsockopt($!VMIO, nqp::unbox_i(option), nqp::unbox_i(value))
     }
 
     sub setup-close(\socket --> Nil) {

--- a/src/core/sockopts.pm6
+++ b/src/core/sockopts.pm6
@@ -1,22 +1,19 @@
 my role SockOptLike {
-    multi method CALL-ME(Int() $sonum) {
-        return self unless $sonum;
-        nextsame
+    multi method CALL-ME(Int() $option) {
+        $option ?? (callsame) !! self
     }
 }
 
-my enum SockOpt does SockOptLike (
-    |nqp::stmts(
-        ( my \res  := nqp::list ),
-        ( my \iter := nqp::iterator(nqp::getsockopts()) ),
-        nqp::while(
-            iter,
-            nqp::stmts(
-                ( my \p := nqp::p6bindattrinvres(nqp::create(Pair), Pair, '$!key', nqp::shift(iter)) ),
-                nqp::bindattr(p, Pair, '$!value', nqp::abs_i(nqp::shift(iter)) ),
-                nqp::push(res, p)
-            )
-        ),
-        res
-    )
-);
+enum SockOpt does SockOptLike ( |do {
+    my $res  := nqp::list();
+    my $iter := nqp::iterator(nqp::getsockopts());
+    nqp::while(
+      $iter,
+      nqp::stmts(
+        ( my $p := nqp::p6bindattrinvres(nqp::create(Pair), Pair, '$!key', nqp::shift($iter)) ),
+        nqp::bindattr($p, Pair, '$!value', nqp::abs_i(nqp::shift($iter)));
+        nqp::push($res, $p);
+      )
+    );
+    $res
+});

--- a/src/core/sockopts.pm6
+++ b/src/core/sockopts.pm6
@@ -1,0 +1,22 @@
+my role SockOptLike {
+    multi method CALL-ME(Int() $sonum) {
+        return self unless $sonum;
+        nextsame
+    }
+}
+
+my enum SockOpt does SockOptLike (
+    |nqp::stmts(
+        ( my \res  := nqp::list ),
+        ( my \iter := nqp::iterator(nqp::getsockopts()) ),
+        nqp::while(
+            iter,
+            nqp::stmts(
+                ( my \p := nqp::p6bindattrinvres(nqp::create(Pair), Pair, '$!key', nqp::shift(iter)) ),
+                nqp::bindattr(p, Pair, '$!value', nqp::abs_i(nqp::shift(iter)) ),
+                nqp::push(res, p)
+            )
+        ),
+        res
+    )
+);

--- a/tools/build/jvm_core_sources
+++ b/tools/build/jvm_core_sources
@@ -173,6 +173,7 @@ src/core/IO/Socket/INET.pm6
 src/core/IO/Socket/Async.pm6
 src/core/Proc.pm6
 src/core/signals.pm6
+src/core/sockopts.pm6
 src/core/Proc/Async.pm6
 src/core/Systemic.pm6
 src/core/VM.pm6

--- a/tools/build/moar_core_sources
+++ b/tools/build/moar_core_sources
@@ -175,6 +175,7 @@ src/core/IO/Socket/INET.pm6
 src/core/IO/Socket/Async.pm6
 src/core/Proc.pm6
 src/core/signals.pm6
+src/core/sockopts.pm6
 src/core/Proc/Async.pm6
 src/core/Systemic.pm6
 src/core/VM.pm6


### PR DESCRIPTION
Done:
- expose socket option types as constants
- write `.get-option`/`.set-option` methods for `IO::Socket` and `IO::Socket::Async
- wait until `.native-descriptor` for async sockets is merged so `.get-option`/`.set-option` can be used with `IO::Socket::Async::ListenSocket`

Todo:
- nothing