### PR TITLE
Fix is-lazy propagation bug in List::Reifier

### DIFF
--- a/src/core/List.pm6
+++ b/src/core/List.pm6
@@ -187,7 +187,7 @@ my class List does Iterable does Positional { # declared in BOOTSTRAP
                   nqp::while(
                     $iter && nqp::eqaddr($res, False),
                     nqp::if(
-                      nqp::eqaddr((my $cur := nqp::shift($iter)), Slip),
+                      nqp::istype((my $cur := nqp::shift($iter)), Slip),
                       ($res := $cur.is-lazy),
                     ),
                   ),

--- a/src/core/List.pm6
+++ b/src/core/List.pm6
@@ -187,7 +187,7 @@ my class List does Iterable does Positional { # declared in BOOTSTRAP
                   nqp::while(
                     $iter && nqp::eqaddr($res, False),
                     nqp::if(
-                      nqp::can((my $cur := nqp::shift($iter)), 'is-lazy'),
+                      nqp::eqaddr((my $cur := nqp::shift($iter)), Slip),
                       ($res := $cur.is-lazy),
                     ),
                   ),


### PR DESCRIPTION
Triangle reduce was not recognizing Lists containing lazy Slips as lazy.
This can be tracked back to the is-lazy method on List::Reifier (and was
ultimately being propagated up to the triangle reduce routine). is-lazy
in List::Reifier was not considering the possibility of lazy Slips. Fix
this by having the method check any $!future elements it may have for
laziness.

See [Github Issue #2122](https://github.com/rakudo/rakudo/issues/2122)