### PR TITLE
Ignore library versions on OpenBSD.

### DIFF
--- a/src/core/IO/Notification.pm6
+++ b/src/core/IO/Notification.pm6
@@ -26,7 +26,7 @@ my class IO::Notification {
                 }
                 else {
                     my $event = rename ?? FileRenamed !! FileChanged;
-                    my $full-path = $is-dir ?? $*SPEC.catdir($path, path) !! $path;
+                    my $full-path = ( $is-dir and path ) ?? $*SPEC.catdir($path, path) !! $path;
                     $s.emit(Change.new(:path($full-path), :$event));
                 }
             },

--- a/src/core/VM.pm6
+++ b/src/core/VM.pm6
@@ -55,6 +55,7 @@ class VM does Systemic {
     method platform-library-name(IO::Path $library, Version :$version) {
         my int $is-win = Rakudo::Internals.IS-WIN;
         my int $is-darwin = self.osname eq 'darwin';
+        my int $is-openbsd = self.osname eq 'openbsd';
 
         my $basename  = $library.basename;
         my int $full-path = $library ne $basename;
@@ -73,7 +74,7 @@ class VM does Systemic {
 #?endif
 
         $platform-name ~= '.' ~ $version
-            if $version.defined and nqp::iseq_i(nqp::add_i($is-darwin,$is-win),0);
+            if $version.defined and nqp::iseq_i(nqp::add_i($is-darwin,$is-win,$is-openbsd),0);
 
         $full-path
           ?? $dirname.IO.add($platform-name).absolute


### PR DESCRIPTION
See the commit for details. This seems reasonable to me, since absolute ABI
version numbers don't really carry the information that is desired. In an ideal
world, rakudo would perhaps follow the way libraries work in C programs: at
build time, you say -lcairo and the system linker picks a version. The compiled
program then includes the major version (SONAME) that was used, since this
corresponds to the ABI it needs. On the other hand, what I think the intention
really was is to specify the API version, since that is what is presumably
relevant for NativeCall-based modules. Unfortunately, the shared object does
not carry that information (and the ABI version works better on Linuxes as a
proxy than it does on OpenBSD; I don't know about other Unices).