### PR TITLE
Fix use of uninitialized value in IO::Notification

### DIFF
--- a/src/core/IO/Notification.pm6
+++ b/src/core/IO/Notification.pm6
@@ -26,7 +26,7 @@ my class IO::Notification {
                 }
                 else {
                     my $event = rename ?? FileRenamed !! FileChanged;
-                    my $full-path = $is-dir ?? $*SPEC.catdir($path, path) !! $path;
+                    my $full-path = ( $is-dir and path ) ?? $*SPEC.catdir($path, path) !! $path;
                     $s.emit(Change.new(:path($full-path), :$event));
                 }
             },


### PR DESCRIPTION
When libuv returns a NULL path (which it does for directory
notifications on kqueue/kevent systems, at minimum), the path returned
from nqp::watchfile turns into an undef Str. Hence do not try to concat
this undef with the directory path.