### PR TITLE
Adds comment to avoid deletion

### DIFF
--- a/blib/Perl6/.gitignore
+++ b/blib/Perl6/.gitignore
@@ -1,3 +1,2 @@
 *.pbc
 *.class
-*.moarvm

--- a/blib/Perl6/.gitignore
+++ b/blib/Perl6/.gitignore
@@ -1,2 +1,5 @@
+# Don't remove this file and dir.
+# They are needed to host the bytecode files during the build process
+for any VM.
 *.pbc
 *.class

--- a/blib/Perl6/README.md
+++ b/blib/Perl6/README.md
@@ -1,4 +1,0 @@
-# Don't remove this file and dir
-
-They are needed to host the bytecode files during the build process
-for any VM.

--- a/blib/Perl6/README.md
+++ b/blib/Perl6/README.md
@@ -1,0 +1,4 @@
+# Don't remove this file and dir
+
+They are needed to host the bytecode files during the build process
+for any VM.


### PR DESCRIPTION
Because one could imply move the .gitignore thing to the general file,
and this directory would be deleted. Also eliminated *.moarvm from it,
since it's already in the general file.