### PR TITLE
Don't add concreteness guard if return value = Nil

### DIFF
--- a/src/vm/moar/spesh-plugins.nqp
+++ b/src/vm/moar/spesh-plugins.nqp
@@ -257,7 +257,7 @@ sub identity($obj) { $obj }
                 if $definite_check == 0 {
                     nqp::speshguardtypeobj($rv);
                 }
-                elsif $definite_check == 1 {
+                elsif $definite_check == 1 && !nqp::istype($rv, Nil) {
                     nqp::speshguardconcrete($rv);
                 }
 


### PR DESCRIPTION
The guard set doesn't end up matching the values being passed, so the
plugin is repeatedly called when it shouldn't be.

Fixes #2593. Before this change the code in the issue took 4.5s on my machine, /usr/bin/time reported 2.4gb maxresident, and some added logging showed the return type checking spesh plugin being called ~29.5k times. After the change, those values decreased to 0.5s, 89mb, and 30.

This does cause a single spectest fail, in t/spec/S32-temporal/DateTime.t. When run directly, the error is `Type check failed for return value; expected Int:D but got Int (Int) in block <unit> at t/spec/S32-temporal/DateTime.t line 682 # Looks like you planned 299 tests, but ran 248`. However, according to @jnthn, "Hm, that almost looks legit...I wonder if you've fixed a bug too?".