### PR TITLE
Allow CStruct pass-by-value in Nativecall

### DIFF
--- a/t/04-nativecall/23-copy-args.c
+++ b/t/04-nativecall/23-copy-args.c
@@ -1,0 +1,54 @@
+#include <stdlib.h>
+#ifdef _WIN32
+#define DLLEXPORT __declspec(dllexport)
+#else
+#define DLLEXPORT extern
+#endif
+
+#include <stdint.h>
+
+struct Simple {
+    int64_t bigint;
+    int32_t smallint;
+    float   smallnum;
+};
+
+DLLEXPORT float PassSimple(struct Simple x) {
+    return x.smallnum * x.bigint * x.smallint;
+}
+
+DLLEXPORT struct Simple ReturnsSimple(float x) {
+    struct Simple retval;
+    retval.smallnum = x;
+    return retval;
+}
+
+DLLEXPORT void TakeStructSimpleCopyCallback(void (*cb)(struct Simple), float x) {
+    struct Simple s;
+    s.smallnum = x;
+    cb(s);
+}
+
+DLLEXPORT float CheckReturnsStructSimpleCopy(struct Simple (*cb)(int32_t, float), int32_t x, float y) {
+    struct Simple r = cb(x, y);
+    return r.smallnum * r.bigint;
+}
+
+struct Point {
+    float x;
+    float y;
+};
+
+struct Size {
+    float width;
+    float height;
+};
+
+struct Rect {
+    struct Point origin;
+    struct Size  size;
+};
+
+DLLEXPORT float PassRect(struct Rect obj) {
+    return obj.origin.x + obj.origin.y + obj.size.width * obj.size.height;
+}

--- a/t/04-nativecall/23-copy-args.t
+++ b/t/04-nativecall/23-copy-args.t
@@ -1,0 +1,68 @@
+use v6;
+
+use lib <lib t/04-nativecall>;
+use CompileTestLib;
+use NativeCall;
+use Test;
+
+plan 6;
+
+compile_test_lib('23-copy-args');
+
+class Simple is repr("CStruct") {
+    has int64 $.bigint;
+    has int32 $.smallint;
+    has num32 $.smallnum;
+}
+
+class Point is repr("CStruct") {
+    has num32 $.x;
+    has num32 $.y;
+};
+
+class Size is repr("CStruct") {
+    has num32 $.width;
+    has num32 $.height;
+}
+
+class Rect is repr("CStruct") {
+    HAS Point $.origin;
+    HAS Size  $.size;
+
+    submethod BUILD(:$x = 0e0, :$y = 0e0, :$w = 0e0; :$h = 0e0) {
+	$!origin := Point.new(:$x, :$y);
+	$!size   := Size.new(width => $w, height => $h);
+    }
+}
+
+
+sub PassSimple(Simple is copy --> num32)      is native('./23-copy-args') { * }
+sub ReturnsSimple(num32 --> Simple) is copy is native('./23-copy-args') { * }
+
+sub TakeStructSimpleCopyCallback(&cb (Simple is copy), num32) is native('./23-copy-args') { * }
+sub CheckReturnsStructSimpleCopy(&cb is copy (int32, num32 --> Simple), int32, num32 --> num32) is native('./23-copy-args') { * }
+
+sub PassRect(Rect is copy --> num32)    is native('./23-copy-args') { * }
+
+my $c = Simple.new(bigint => 1, smallint => 2, smallnum => 2e2);
+is-approx PassSimple($c), 4e2,        'Perl\'s struct is correctly passed by value';
+
+my $r = ReturnsSimple(4e-2);
+isa-ok $r, Simple,                    'Return value is of the right type';
+is-approx $r.smallnum, 4e-2,          'Returned the correct Struct value';
+
+sub struct_callback_copy(Simple $struct is copy) {
+    is-approx $struct.smallnum, 4e2,  'Callback got the Struct value';
+}
+TakeStructSimpleCopyCallback(&struct_callback_copy, 4e2);
+
+sub struct_callback_returns(int32 $a, num32 $b --> Simple) is copy {
+    return Simple.new(bigint => $a, smallnum => $b);
+}
+is-approx CheckReturnsStructSimpleCopy(&struct_callback_returns, 12, 2e2), 2400, 'Callback returned the Struct as copy';
+
+my $v = Rect.new(x => 2e2, y => 2e2, w => 2e1, h => 2e1);
+is-approx PassRect($v), 800, 'Can pass inlined CStruct around'; 
+
+# vim:ft=perl6
+


### PR DESCRIPTION
This is the initial implementation of the pass-by-value
functionality for nativecall, it works on Parameters by recognizing
an 'is copy' trait, and as a new 'is copy' trait on Routine for the
return value. The 'copy' key is then added to the parameter/return
hash. The patch includes also tests of the basic functionality.