### PR TITLE
Use path-spec instead of path for module-not-found errors

### DIFF
--- a/src/core/CompUnit/Repository.pm6
+++ b/src/core/CompUnit/Repository.pm6
@@ -28,7 +28,7 @@ role CompUnit::Repository {
         self.next-repo
           ?? self.next-repo.load($file)
           !! nqp::die("Could not find $file in:\n"
-              ~ $*REPO.repo-chain.map(*.Str).join("\n").indent(4));
+              ~ $*REPO.repo-chain.map(*.path-spec).join("\n").indent(4));
     }
 
     # Returns the CompUnit objects describing all of the compilation

--- a/src/core/CompUnit/Repository/AbsolutePath.pm6
+++ b/src/core/CompUnit/Repository/AbsolutePath.pm6
@@ -32,7 +32,7 @@ class CompUnit::Repository::AbsolutePath does CompUnit::Repository {
         }
 
         return self.next-repo.load($file) if self.next-repo;
-        die("Could not find $file in:\n" ~ $*REPO.repo-chain.map(*.Str).join("\n").indent(4));
+        die("Could not find $file in:\n" ~ $*REPO.repo-chain.map(*.path-spec).join("\n").indent(4));
     }
 
     method loaded(--> Iterable:D) {

--- a/src/core/Exception.pm6
+++ b/src/core/Exception.pm6
@@ -3029,7 +3029,7 @@ my class X::CompUnit::UnsatisfiedDependency is Exception {
         is-core($name)
             ?? "{$name} is a builtin type, not an external module"
             !! "Could not find $.specification at line $line in:\n"
-                ~ $*REPO.repo-chain.map(*.Str).join("\n").indent(4)
+                ~ $*REPO.repo-chain.map(*.path-spec).join("\n").indent(4)
                 ~ ($.specification ~~ / $<name>=.+ '::from' $ /
                     ?? "\n\nIf you meant to use the :from adverb, use"
                         ~ " a single colon for it: $<name>:from<...>\n"


### PR DESCRIPTION
The path portion of the path-spec is often not enough to debug what wasn't found. This change includes the entire path-spec when giving an error for e.g. `use NotFound;`

```
$ install/bin/perl6 -I . -e 'use NotFound;'
===SORRY!===
Could not find NotFound at line 1 in:
    file#/Users/ugexe/repos/rakudo
    inst#/Users/ugexe/.perl6
    inst#/Users/ugexe/repos/rakudo/install/share/perl6/site
    inst#/Users/ugexe/repos/rakudo/install/share/perl6/vendor
    inst#/Users/ugexe/repos/rakudo/install/share/perl6
    ap#
    nqp#
    perl5#
```

It might be best to remove the empty repos from output, but they are used in determining the other repo's repo-id so their removal should be considered outside of this PR.