### PR TITLE
Issue 2613

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ script:
 
 branches:
    only:
-     - issue_2657
+     - master
      - /smoke-me/
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ script:
 
 branches:
    only:
-     - master
+     - issue_2657
      - /smoke-me/
 
 notifications:

--- a/src/Perl6/Metamodel/RoleContainer.nqp
+++ b/src/Perl6/Metamodel/RoleContainer.nqp
@@ -2,7 +2,7 @@ role Perl6::Metamodel::RoleContainer {
     has @!roles_to_compose;
 
     method add_role($obj, $role) {
-        @!roles_to_compose[+@!roles_to_compose] := $role
+        @!roles_to_compose[+@!roles_to_compose] := nqp::decont($role)
     }
 
     method roles_to_compose($obj) {


### PR DESCRIPTION
Fix for #2613. As it turns out, the issue was cause by storing containerized roles into the `@!roles_to_compose` on class causing `Scalar` to be the cached type for checking!