### PR TITLE
Fixed the bug #2688 (wrong values for asinh of negative argument)

### DIFF
--- a/src/core/Num.pm6
+++ b/src/core/Num.pm6
@@ -197,7 +197,10 @@ my class Num does Real { # declared in BOOTSTRAP
     multi method asinh(Num:D: ) {
         nqp::isnanorinf(self)
             ?? self
-            !! (self + (self * self + 1e0).sqrt).log;
+            !!
+                self >= 0
+                    ?? (self + (self * self + 1e0).sqrt).log
+                    !! -(-1e0 * self).asinh
     }
     proto method cosh(|) {*}
     multi method cosh(Num:D: ) {
@@ -559,12 +562,14 @@ multi sub asinh(num $x --> num) {
     # ln(x + √(x²+1))
     nqp::isnanorinf($x)
         ?? $x
-        !! nqp::log_n(
-            nqp::add_n(
-                $x,
-                nqp::pow_n( nqp::add_n(nqp::mul_n($x,$x), 1e0), .5e0 )
+        !! $x >= 0
+            ?? nqp::log_n(
+                nqp::add_n(
+                    $x,
+                    nqp::pow_n( nqp::add_n(nqp::mul_n($x,$x), 1e0), .5e0 )
+                )
             )
-        )
+            !! -asinh(-$x);
 }
 
 multi sub cosh(num $x --> num) {


### PR DESCRIPTION
This is an attempt to fix the bug #2688 by using the formula asinh x = log(x + √(x² + 1)) only for x ≥ 0, and using asinh x = - asinh(- x) for x < 0.

I did various tests with the new asinh, fed it positive, negative and zero arguments, and tried infinities and NaN too, and it responded well. However, I have zero experience with writing the compiler and I just hacked it somehow. If there's something wrong, I won't be surprised to be refused.