### PR TITLE
Add given value to (s)printf bad-directive-type error

### DIFF
--- a/src/core/Exception.pm6
+++ b/src/core/Exception.pm6
@@ -2112,8 +2112,9 @@ my class X::Str::Sprintf::Directives::Unsupported is Exception {
 my class X::Str::Sprintf::Directives::BadType is Exception {
     has str $.type;
     has str $.directive;
+    has $.value;
     method message() {
-        "Directive $.directive not applicable for type $.type"
+        "Directive $.directive not applicable for value of type $.type ($.value[0])"
     }
 }
 

--- a/src/core/Rakudo/Internals.pm6
+++ b/src/core/Rakudo/Internals.pm6
@@ -1370,6 +1370,7 @@ implementation detail and has no serviceable parts inside"
                 X::Str::Sprintf::Directives::BadType.new:
                     type      => nqp::atkey(nqp::atkey(payload, 'BAD_TYPE_FOR_DIRECTIVE'), 'TYPE'),
                     directive => nqp::atkey(nqp::atkey(payload, 'BAD_TYPE_FOR_DIRECTIVE'), 'DIRECTIVE'),
+                    value     => nqp::atkey(nqp::atkey(payload, 'BAD_TYPE_FOR_DIRECTIVE'), 'VALUE'),
             }
             elsif nqp::existskey(payload, 'BAD_DIRECTIVE') {
                 X::Str::Sprintf::Directives::Unsupported.new:


### PR DESCRIPTION
which is `X::Str::Sprintf::Directives::BadType`. Requires https://github.com/perl6/nqp/pull/521. Rakudo builds ok and passes `make m-test m-spectest`. Fixes https://github.com/rakudo/rakudo/issues/2724.