### PR TITLE
Fix for SHORT-GIST dying with a non-Any inheriting parameter type

### DIFF
--- a/src/core/Rakudo/Internals.pm6
+++ b/src/core/Rakudo/Internals.pm6
@@ -661,9 +661,10 @@ implementation detail and has no serviceable parts inside"
         }
     }
 
-    method SHORT-GIST(\thing) {
+    method SHORT-GIST(Mu \thing) {
+        my str $gist = nqp::can(thing, 'gist') ??  thing.gist !! thing.^name;
         nqp::if(
-          nqp::isgt_i(nqp::chars(my str $gist = thing.gist), 23),
+          nqp::isgt_i(nqp::chars($gist), 23),
           nqp::concat(nqp::substr($gist, 0, 20), '...'),
           $gist);
     }


### PR DESCRIPTION
If `SHORT-GIST` method of `Rakudo::Internals` gets a non-Any inheriting object as a parameter it dies. As the method is used by exceptions, sometimes it results in obscuring the original exception/error.