### PR TITLE
Fix for rakudo/rakudo#2169

### DIFF
--- a/src/Perl6/Metamodel/BOOTSTRAP.nqp
+++ b/src/Perl6/Metamodel/BOOTSTRAP.nqp
@@ -1154,10 +1154,16 @@ class ContainerDescriptor {
         $!of.HOW.archetypes.generic
     }
 
+    method is_default_generic() {
+        $!default.HOW.archetypes.generic
+    }
+
     method instantiate_generic($type_environment) {
         my $ins_of := $!of.HOW.instantiate_generic($!of, $type_environment);
+        my $ins_default := self.is_default_generic ?? $!default.HOW.instantiate_generic($!default, $type_environment) !! $!default;
         my $ins := nqp::clone(self);
         nqp::bindattr($ins, $?CLASS, '$!of', $ins_of);
+        nqp::bindattr($ins, $?CLASS, '$!default', $ins_default);
         $ins
     }
 }
@@ -1212,7 +1218,7 @@ class ContainerDescriptor::BindArrayPos2D does ContainerDescriptor::Whence {
         $self
     }
 
-    method name() { 
+    method name() {
         'element at [' ~ $!one ~ ',' ~ $!two ~ ']'  # XXX name ?
     }
     method assigned($scalar) {


### PR DESCRIPTION
ContainerDescriptor $!default gets instantiated alongside with $!of if
necessary.

Possible problem: if instantiation will be issued based on
ContainerDescriptor.is_generic() return then in cases when $!of is a
non-generic value but the default is set to a generic then default won't
be instantiated. At this moment such situation is not possible because
rakudo dies when `is default` parameter is a generic.

rakudo/rakudo#2169