### PR TITLE
Refactor $*KERNEL internal use of uname

### DIFF
--- a/src/core/Kernel.pm6
+++ b/src/core/Kernel.pm6
@@ -8,11 +8,53 @@ class Kernel does Systemic {
     has Str $!hardware;
     has Str $!arch;
     has Int $!bits;
-    has Bool $!has_uname;
 
-    method !uname($opt) {
-        $!has_uname //= ("/bin/uname", "/usr/bin/uname").first({ .IO.e && .IO.x }).so;
-        $!has_uname ?? qqx/uname $opt/.chomp !! 'unknown';
+#?if moar
+    has $!uname;
+    method !uname {
+        $!uname ?? $!uname !! ($!uname := nqp::uname())
+    }
+#?endif
+
+    method !uname-s {
+#?if moar
+        nqp::atpos_s(self!uname, nqp::const::UNAME_SYSNAME)
+#?endif
+#?if !moar
+        try shell('uname -s', :out, :!err).out.slurp(:close).chomp;
+#?endif
+    }
+
+    method !uname-r {
+#?if moar
+        nqp::atpos_s(self!uname, nqp::const::UNAME_RELEASE)
+#?endif
+#?if !moar
+        try shell('uname -r', :out, :!err).out.slurp(:close).chomp;
+#?endif
+    }
+
+    method !uname-v {
+#?if moar
+        nqp::atpos_s(self!uname, nqp::const::UNAME_VERSION)
+#?endif
+#?if !moar
+        try shell('uname -v', :out, :!err).out.slurp(:close).chomp;
+#?endif
+    }
+
+    method !uname-m {
+#?if moar
+        nqp::atpos_s(self!uname, nqp::const::UNAME_MACHINE)
+#?endif
+#?if !moar
+        try shell('uname -m', :out, :!err).out.slurp(:close).chomp;
+#?endif
+    }
+
+    method !uname-p {
+        # TODO: find a way to get this without shelling out
+        try shell("uname -p", :out, :!err).out.slurp(:close).chomp;
     }
 
     submethod BUILD(:$!auth = "unknown" --> Nil) { }
@@ -27,71 +69,36 @@ class Kernel does Systemic {
                     'browser';
                 }
                 default {
-                    lc self!uname('-s');
+                    lc self!uname-s();
                 }
             }
         }
     }
 
     method version {
-        $!version //= Version.new( do {
-            given $*DISTRO.name {
-                when 'freebsd' {
-                    self!uname('-r'); # -K -U not introduced until 10.0
-                }
-                when 'macosx' {
-                    my $unamev = self!uname('-v');
-                    $unamev ~~ m/^Darwin \s+ Kernel \s+ Version \s+ (<[\d\.]>+)/
-                      ?? ~$0
-                      !! $unamev.chomp;
-                }
-                default {
-                    given $.name {
-                        when 'linux' {
-                            # somewhat counter-intuitively the '-r' is what
-                            # most people think of the kernel version
-                            self!uname('-r');
-                        }
-                        default {
-                            self!uname('-v');
-                        }
-                    }
-                }
-            }
-        } );
+        # it doesn't make sense to return a Version object here, but its currently enforced by roast
+        # TODO: remove Version checks from roast? and check ecosystem for fallout.
+        $!version //= Version.new(self!uname-v());
     }
 
     method release {
-        $!release //= do {
-            given $*DISTRO.name {
-                when any <openbsd netbsd dragonfly> { # needs adapting
-                    self!uname('-r');
-                }
-                default {
-                    self!uname('-v');
-                }
-            }
-        }
+        # somewhat counter-intuitively the UNAME_RELEASE is what
+        # most people think of the kernel version
+        $!release //= self!uname-r();
     }
 
     method hardware {
-        $!hardware //= do {
-            given $*DISTRO.name {
-                default {
-                    self!uname('-m');
-                }
-            }
-        }
+        $!hardware //= self!uname-m();
     }
 
     method arch {
         $!arch //= do {
             given $*DISTRO.name {
                 when 'raspbian' {
-                    self!uname('-m');
+                    self!uname-m();
                 }
                 default {
-                    self!uname('-p');
+                    self!uname-p();
                 }
             }
         }


### PR DESCRIPTION
Uses `nqp::uname()` on MoarVM instead of shelling out, while shelling out on other backends.

Changes .release() and .version() to return more appropriate values -- uname version instead of uname release for .version(), and uname release instead of uname version for .release() 😕 By making these consistent with their uname counterpart people can better understand the values it may contain and by what name.