### PR TITLE
Fix for failing build on macOS

### DIFF
--- a/Configure.pl
+++ b/Configure.pl
@@ -319,8 +319,6 @@ MAIN: {
         $config{ldflags} =~ s/\Q$nqp_config{'moar::ldrpath_relocatable'}\E ?//;
         $config{ldflags} .= ' ' . ($options{'no-relocatable'} ? $nqp_config{'moar::ldrpath'} : $nqp_config{'moar::ldrpath_relocatable'});
 
-        $config{rakudoshared} = $options{'no-relocatable'} ? $nqp_config{'moar::moarshared_norelocatable'} : $nqp_config{'moar::moarshared_relocatable'};
-
         if ($win) {
             if ($prefix . $slash . 'bin' ne $nqp_config{'moar::libdir'}) {
                 $config{'m_install'} = "\t" . '$(CP) ' . $nqp_config{'moar::libdir'} . $slash . $nqp_config{'moar::moar'} . ' $(PREFIX)' . $slash . 'bin';

--- a/tools/build/Makefile-Moar.in
+++ b/tools/build/Makefile-Moar.in
@@ -226,14 +226,14 @@ $(M_VALGRIND_RUNNER): tools/build/create-moar-runner.p6 $(M_C_RUNNER) $(PERL6_MO
 $(M_C_RUNNER): src/vm/moar/runner/main.c
 	$(RM_F) $(M_C_RUNNER)
 # Using only the pkgconfig moar includes does not work, because moar.h assumes all the specific includes below.
-	$(M_CC) @moar::ccshared@ @rakudoshared@ @static_nqp_home_define@ @static_perl6_home_define@ $(M_CFLAGS) $(M_LDFLAGS) -I$(M_INCPATH) -I$(M_INCPATH)/moar \
+	$(M_CC) @moar::ccshared@ @static_nqp_home_define@ @static_perl6_home_define@ $(M_CFLAGS) $(M_LDFLAGS) -I$(M_INCPATH) -I$(M_INCPATH)/moar \
 	    -I$(M_INCPATH)/libatomic_ops -I$(M_INCPATH)/dyncall -I$(M_INCPATH)/sha1 -I$(M_INCPATH)/tinymt -I$(M_INCPATH)/libtommath -I$(M_INCPATH)/libuv \
 	    -L@moar::libdir@ $(M_MINGW_UNICODE) @moar::ccout@$@ src/vm/moar/runner/main.c -lmoar $(M_C_RUNNER_LIBS)
 
 $(M_C_DEBUG_RUNNER): src/vm/moar/runner/main.c
 	$(RM_F) $(M_C_DEBUG_RUNNER)
 # Using only the pkgconfig moar includes does not work, because moar.h assumes all the specific includes below.
-	$(M_CC) @moar::ccshared@ @rakudoshared@ @static_nqp_home_define@ @static_perl6_home_define@ -DMOAR_PERL6_RUNNER_DEBUG $(M_CFLAGS) $(M_LDFLAGS) -I$(M_INCPATH) -I$(M_INCPATH)/moar \
+	$(M_CC) @moar::ccshared@ @static_nqp_home_define@ @static_perl6_home_define@ -DMOAR_PERL6_RUNNER_DEBUG $(M_CFLAGS) $(M_LDFLAGS) -I$(M_INCPATH) -I$(M_INCPATH)/moar \
 	    -I$(M_INCPATH)/libatomic_ops -I$(M_INCPATH)/dyncall -I$(M_INCPATH)/moar -I$(M_INCPATH)/sha1 -I$(M_INCPATH)/tinymt -I$(M_INCPATH)/libtommath -I$(M_INCPATH)/libuv \
 	    -L@moar::libdir@ $(M_MINGW_UNICODE) @moar::ccout@$@ src/vm/moar/runner/main.c -lmoar $(M_C_RUNNER_LIBS)
 


### PR DESCRIPTION
Build fails due to wrong command line used to build the runners.

This reverts commit efb35b003fab51a74f71592729761df8ab61010f.