### PR TITLE
Fixed method cloning

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -887,7 +887,7 @@ N: Oleksii Varianyk
 U: cono
 E: q@cono.org.ua
 
-N: Vadim Belamn
+N: Vadim Belman
 U: vrurg
 E: vrurg@cpan.org
 

--- a/CREDITS
+++ b/CREDITS
@@ -887,4 +887,8 @@ N: Oleksii Varianyk
 U: cono
 E: q@cono.org.ua
 
+N: Vadim Belamn
+U: vrurg
+E: vrurg@cpan.org
+
 =cut

--- a/src/Perl6/Metamodel/BOOTSTRAP.nqp
+++ b/src/Perl6/Metamodel/BOOTSTRAP.nqp
@@ -1212,7 +1212,7 @@ class ContainerDescriptor::BindArrayPos2D does ContainerDescriptor::Whence {
         $self
     }
 
-    method name() { 
+    method name() {
         'element at [' ~ $!one ~ ',' ~ $!two ~ ']'  # XXX name ?
     }
     method assigned($scalar) {

--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -2472,6 +2472,10 @@ class Perl6::World is HLL::World {
             unless $precomp {
                 $compiler_thunk();
             }
+            my $code_obj := nqp::getcodeobj(nqp::curcode());
+            unless nqp::isnull($code_obj) {
+                return $code_obj(|@pos, |%named);
+            }
             $precomp(|@pos, |%named);
         });
         @compstuff[1] := $compiler_thunk;
@@ -2511,6 +2515,7 @@ class Perl6::World is HLL::World {
                     self.context().add_cleanup_task(sub () {
                         nqp::bindattr($clone, $code_type, '@!compstuff', nqp::null());
                     });
+                    self.context().add_clone_for_cuid($clone, $cuid);
                     my $tmp := $fixups.unique('tmp_block_fixup');
                     $fixups.push(QAST::Stmt.new(
                         QAST::Op.new(


### PR DESCRIPTION
Fix for rakudo/rakudo#2772

Two changes:

- Stub is now passing the call to precompiled code only if current code object is unavailable. 
- Method code objects were not added to the list of clones previously.