### PR TITLE
merges class symbols into stub when using require stub:file<>

### DIFF
--- a/src/core/operators.pm6
+++ b/src/core/operators.pm6
@@ -650,6 +650,10 @@ sub REQUIRE_IMPORT($compunit, $existing-path,$top-existing-pkg,$stubname, *@syms
     if @missing {
         X::Import::MissingSymbols.new(:from($compunit.short-name), :@missing).throw;
     }
+    nqp::gethllsym('perl6','ModuleLoader').merge_globals(
+        $block.AT-KEY($stubname).WHO,
+        $GLOBALish,
+    ) if $stubname;
     # Merge GLOBAL from compunit.
     nqp::gethllsym('perl6','ModuleLoader').merge_globals(
         $block<%REQUIRE_SYMBOLS>,


### PR DESCRIPTION
This fixes:perl6/roast#522 

# Usage:

## Pre pull request

```perl6
BEGIN: './A.pm6'.IO.spurt: 'class A { method a() { return 1; }   } ';

require STUB:file('./A.pm6'.IO.absolute);

say STUB::.keys; # Grepper
```

## Post pull request

```perl6
BEGIN: './A.pm6'.IO.spurt: 'class A { method a() { return 1; }   } ';

require STUB:file('./A.pm6'.IO.absolute);

say STUB::.keys; # Grepper, A

my $new-a = STUB::<A>.new;
$new-a.a; # returned 1
```