### PR TITLE
Fix build on Windows

### DIFF
--- a/Configure.pl
+++ b/Configure.pl
@@ -23,11 +23,6 @@ my $slash  = $win ? '\\' : '/';
 # (not included with *every* Perl installation)
 use ExtUtils::Command;
 
-# This allows us to run on ancient perls.
-sub defined_or($$) {
-    defined $_[0] ? $_[0] : $_[1]
-}
-
 MAIN: {
     if (-r 'config.default') {
         unshift @ARGV, shellwords(slurp('config.default'));
@@ -346,7 +341,7 @@ MAIN: {
                                   . "\t" . '$(M_RUN_PERL6) tools/build/create-moar-runner.p6 perl6 $(M_RUNNER) $(DESTDIR)$(PREFIX)/bin/perl6-valgrind-m "valgrind" "" "" ""';
         }
         $config{'c_runner_libs'} = join ' ', @c_runner_libs;
-        $config{'moar_lib'} = sprintf(defined_or($nqp_config{'moar::ldimp'}, $nqp_config{'moar::ldusr'}), $nqp_config{'moar::name'});
+        $config{'moar_lib'} = sprintf(($nqp_config{'moar::ldimp'} ? $nqp_config{'moar::ldimp'} : $nqp_config{'moar::ldusr'}), $nqp_config{'moar::name'});
 
         unless (@errors) {
             print "Using $config{'m_nqp'} (version $nqp_config{'nqp::version'} / MoarVM $nqp_config{'moar::version'}).\n";

--- a/Configure.pl
+++ b/Configure.pl
@@ -318,7 +318,9 @@ MAIN: {
         $config{ldflags} =~ s/\Q$nqp_config{'moar::ldrpath'}\E ?//;
         $config{ldflags} =~ s/\Q$nqp_config{'moar::ldrpath_relocatable'}\E ?//;
         $config{ldflags} .= ' ' . ($options{'no-relocatable'} ? $nqp_config{'moar::ldrpath'} : $nqp_config{'moar::ldrpath_relocatable'});
-
+        
+        my @c_runner_libs;
+        
         if ($win) {
             if ($prefix . $slash . 'bin' ne $nqp_config{'moar::libdir'}) {
                 $config{'m_install'} = "\t" . '$(CP) ' . $nqp_config{'moar::libdir'} . $slash . $nqp_config{'moar::moar'} . ' $(PREFIX)' . $slash . 'bin';
@@ -327,7 +329,7 @@ MAIN: {
             if ($nqp_config{'moar::os'} eq 'mingw32') {
                 $config{'mingw_unicode'} = '-municode';
             }
-            $config{'c_runner_libs'} = '-lShlwapi';
+            push @c_runner_libs, 'Shlwapi';
         } else {
             $config{'m_cleanups'} = "  \$(M_GDB_RUNNER) \\\n  \$(M_LLDB_RUNNER) \\\n  \$(M_VALGRIND_RUNNER)";
             $config{'m_all'}      = '$(M_GDB_RUNNER) $(M_LLDB_RUNNER) $(M_VALGRIND_RUNNER)';
@@ -335,6 +337,9 @@ MAIN: {
                                   . "\t" . '$(M_RUN_PERL6) tools/build/create-moar-runner.p6 perl6 $(M_RUNNER) $(DESTDIR)$(PREFIX)/bin/perl6-lldb-m "lldb" "" "" ""' . "\n"
                                   . "\t" . '$(M_RUN_PERL6) tools/build/create-moar-runner.p6 perl6 $(M_RUNNER) $(DESTDIR)$(PREFIX)/bin/perl6-valgrind-m "valgrind" "" "" ""';
         }
+        $config{'c_runner_libs'} = join ' ',
+            (map { sprintf $nqp_config{'moar::ldusr'}, $_; } @c_runner_libs),
+            $nqp_config{'moar::sharedlib'};
 
         unless (@errors) {
             print "Using $config{'m_nqp'} (version $nqp_config{'nqp::version'} / MoarVM $nqp_config{'moar::version'}).\n";

--- a/Configure.pl
+++ b/Configure.pl
@@ -22,6 +22,12 @@ my $slash  = $win ? '\\' : '/';
 # Try `use`ing it here so users know if they need to install this module
 # (not included with *every* Perl installation)
 use ExtUtils::Command;
+
+# This allows us to run on ancient perls.
+sub defined_or($$) {
+    defined $_[0] ? $_[0] : $_[1]
+}
+
 MAIN: {
     if (-r 'config.default') {
         unshift @ARGV, shellwords(slurp('config.default'));
@@ -339,7 +345,7 @@ MAIN: {
         }
         $config{'c_runner_libs'} = join ' ',
             (map { sprintf $nqp_config{'moar::ldusr'}, $_; } @c_runner_libs),
-            $nqp_config{'moar::sharedlib'};
+            sprintf(defined_or($nqp_config{'moar::ldimp'}, $nqp_config{'moar::ldusr'}), $nqp_config{'moar::name'});
 
         unless (@errors) {
             print "Using $config{'m_nqp'} (version $nqp_config{'nqp::version'} / MoarVM $nqp_config{'moar::version'}).\n";

--- a/Configure.pl
+++ b/Configure.pl
@@ -337,7 +337,7 @@ MAIN: {
             if ($nqp_config{'moar::os'} eq 'mingw32') {
                 $config{'mingw_unicode'} = '-municode';
             }
-            push @c_runner_libs, 'Shlwapi';
+            push @c_runner_libs, sprintf($nqp_config{'moar::ldusr'}, 'Shlwapi');
         } else {
             $config{'m_cleanups'} = "  \$(M_GDB_RUNNER) \\\n  \$(M_LLDB_RUNNER) \\\n  \$(M_VALGRIND_RUNNER)";
             $config{'m_all'}      = '$(M_GDB_RUNNER) $(M_LLDB_RUNNER) $(M_VALGRIND_RUNNER)';
@@ -345,20 +345,13 @@ MAIN: {
                                   . "\t" . '$(M_RUN_PERL6) tools/build/create-moar-runner.p6 perl6 $(M_RUNNER) $(DESTDIR)$(PREFIX)/bin/perl6-lldb-m "lldb" "" "" ""' . "\n"
                                   . "\t" . '$(M_RUN_PERL6) tools/build/create-moar-runner.p6 perl6 $(M_RUNNER) $(DESTDIR)$(PREFIX)/bin/perl6-valgrind-m "valgrind" "" "" ""';
         }
-        $config{'c_runner_libs'} = join ' ',
-            (map { sprintf $nqp_config{'moar::ldusr'}, $_; } @c_runner_libs),
-            sprintf(defined_or($nqp_config{'moar::ldimp'}, $nqp_config{'moar::ldusr'}), $nqp_config{'moar::name'});
+        $config{'c_runner_libs'} = join ' ', @c_runner_libs;
+        $config{'moar_lib'} = sprintf(defined_or($nqp_config{'moar::ldimp'}, $nqp_config{'moar::ldusr'}), $nqp_config{'moar::name'});
 
         unless (@errors) {
             print "Using $config{'m_nqp'} (version $nqp_config{'nqp::version'} / MoarVM $nqp_config{'moar::version'}).\n";
 
             $config{'perl6_ops_dll'} = sprintf($nqp_config{'moar::dll'}, 'perl6_ops_moar');
-
-            # Add moar library to link command
-            # TODO: Get this from Moar somehow
-            $config{'moarimplib'} = $win || $^O eq 'darwin'
-                                  ? $nqp_config{'moar::libdir'} . '/' . $nqp_config{'moar::sharedlib'}
-                                  : '';
 
             fill_template_file('tools/build/Makefile-Moar.in', $MAKEFILE, %config, %nqp_config);
         }

--- a/Configure.pl
+++ b/Configure.pl
@@ -320,10 +320,12 @@ MAIN: {
         $errors{moar}{'no gen-nqp'} = @errors && !defined $options{'gen-nqp'};
 
         # Strip rpath from ldflags so we can set it differently ourself.
-        $config{ldflags} = join(' ', $nqp_config{'moar::ldflags'}, $nqp_config{'moar::ldmiscflags'}, $nqp_config{'moar::ldoptiflags'}, $nqp_config{'moar::ldlibs'});
+        $config{ldflags} = $nqp_config{'moar::ldflags'};
         $config{ldflags} =~ s/\Q$nqp_config{'moar::ldrpath'}\E ?//;
         $config{ldflags} =~ s/\Q$nqp_config{'moar::ldrpath_relocatable'}\E ?//;
         $config{ldflags} .= ' ' . ($options{'no-relocatable'} ? $nqp_config{'moar::ldrpath'} : $nqp_config{'moar::ldrpath_relocatable'});
+        
+        $config{ldlibs} = $nqp_config{'moar::ldlibs'};
         
         my @c_runner_libs;
         

--- a/tools/build/Makefile-Moar.in
+++ b/tools/build/Makefile-Moar.in
@@ -229,16 +229,16 @@ $(M_C_RUNNER): src/vm/moar/runner/main.c
 # Using only the pkgconfig moar includes does not work, because moar.h assumes all the specific includes below.
 	$(M_CC) @moar::ccswitch@ @static_nqp_home_define@ @static_perl6_home_define@ $(M_CFLAGS) $(M_CCINC)$(M_INCPATH) $(M_CCINC)$(M_INCPATH)/moar \
 	    $(M_CCINC)$(M_INCPATH)/libatomic_ops $(M_CCINC)$(M_INCPATH)/dyncall $(M_CCINC)$(M_INCPATH)/moar $(M_CCINC)$(M_INCPATH)/sha1 $(M_CCINC)$(M_INCPATH)/tinymt $(M_CCINC)$(M_INCPATH)/libtommath $(M_CCINC)$(M_INCPATH)/libuv \
-	    $(M_MINGW_UNICODE) @moar::ccout@main@moar::obj@ src/vm/moar/runner/main.c
-	$(M_LD) @moar::ldout@$@ $(M_LDFLAGS) main@moar::obj@ @moar::lddir@@moar::libdir@ $(M_C_RUNNER_LIBS)
+	    @moar::ccout@main@moar::obj@ src/vm/moar/runner/main.c
+	$(M_LD) @moar::ldout@$@ $(M_LDFLAGS) $(M_MINGW_UNICODE) main@moar::obj@ @moar::lddir@@moar::libdir@ $(M_C_RUNNER_LIBS)
 
 $(M_C_DEBUG_RUNNER): src/vm/moar/runner/main.c
 	$(RM_F) $(M_C_DEBUG_RUNNER)
 # Using only the pkgconfig moar includes does not work, because moar.h assumes all the specific includes below.
 	$(M_CC) @moar::ccswitch@ @static_nqp_home_define@ @static_perl6_home_define@ -DMOAR_PERL6_RUNNER_DEBUG $(M_CFLAGS) $(M_CCINC)$(M_INCPATH) $(M_CCINC)$(M_INCPATH)/moar \
 	    $(M_CCINC)$(M_INCPATH)/libatomic_ops $(M_CCINC)$(M_INCPATH)/dyncall $(M_CCINC)$(M_INCPATH)/moar $(M_CCINC)$(M_INCPATH)/sha1 $(M_CCINC)$(M_INCPATH)/tinymt $(M_CCINC)$(M_INCPATH)/libtommath $(M_CCINC)$(M_INCPATH)/libuv \
-	    $(M_MINGW_UNICODE) @moar::ccout@main@moar::obj@ src/vm/moar/runner/main.c
-	$(M_LD) @moar::ldout@$@ $(M_LDFLAGS) main@moar::obj@ @moar::lddir@@moar::libdir@ $(M_C_RUNNER_LIBS)
+	    @moar::ccout@main@moar::obj@ src/vm/moar/runner/main.c
+	$(M_LD) @moar::ldout@$@ $(M_LDFLAGS) $(M_MINGW_UNICODE) main@moar::obj@ @moar::lddir@@moar::libdir@ $(M_C_RUNNER_LIBS)
 
 
 ##  testing targets

--- a/tools/build/Makefile-Moar.in
+++ b/tools/build/Makefile-Moar.in
@@ -17,8 +17,18 @@ M_NQP  = @m_nqp@
 M_LIBDEFPATH = $(PREFIX)@slash@share@slash@nqp@slash@lib
 M_LIBPATH = $(LIBDIR)@slash@nqp@slash@lib
 M_INCPATH = $(MOAR_PREFIX)@slash@include
+M_MOAR_INC_PATHS = \
+  $(M_CCINC)"$(M_INCPATH)" \
+  $(M_CCINC)"$(M_INCPATH)/moar" \
+  $(M_CCINC)"$(M_INCPATH)/libatomic_ops" \
+  $(M_CCINC)"$(M_INCPATH)/dyncall" \
+  $(M_CCINC)"$(M_INCPATH)/moar" \
+  $(M_CCINC)"$(M_INCPATH)/sha1" \
+  $(M_CCINC)"$(M_INCPATH)/tinymt" \
+  $(M_CCINC)"$(M_INCPATH)/libtommath" \
+  $(M_CCINC)"$(M_INCPATH)/libuv"
 
-M_RUN_PERL6 = $(MOAR) --libpath="blib" --libpath="$(M_LIBPATH)" perl6.moarvm --nqp-lib=blib
+M_RUN_PERL6 = "$(MOAR)" --libpath="blib" --libpath="$(M_LIBPATH)" perl6.moarvm --nqp-lib=blib
 
 M_BAT    = @runner_suffix@
 M_BAT_RUNNER = perl6-m@runner_suffix@
@@ -115,15 +125,9 @@ check_nqp_version: tools/build/check-nqp-version.pl
 	$(PERL5) tools/build/check-nqp-version.pl $(M_NQP)
 
 $(M_PERL6_OPS_DLL): $(M_PERL6_OPS_SRC) $(M_PERL6_CONT_SRC)
-	$(M_CC) @moar::ccswitch@ @moar::ccshared@ $(M_CFLAGS) -I$(M_INCPATH)/libatomic_ops \
-	    -I$(M_INCPATH)/dyncall -I$(M_INCPATH)/moar \
-	    -I$(M_INCPATH)/sha1 -I$(M_INCPATH)/tinymt  -I$(M_INCPATH)/libtommath \
-	    -I$(M_INCPATH)/libuv -I$(M_INCPATH) @moar::cincludes@ @moar::ccout@$(M_PERL6_OPS_OBJ) $(M_PERL6_OPS_SRC)
-	$(M_CC) @moar::ccswitch@ @moar::ccshared@ $(M_CFLAGS) -I$(M_INCPATH)/libatomic_ops \
-	    -I$(M_INCPATH)/dyncall -I$(M_INCPATH)/moar \
-	    -I$(M_INCPATH)/sha1 -I$(M_INCPATH)/tinymt  -I$(M_INCPATH)/libtommath \
-	    -I$(M_INCPATH)/libuv -I$(M_INCPATH) @moar::cincludes@ @moar::ccout@$(M_PERL6_CONT_OBJ) $(M_PERL6_CONT_SRC)
-	$(M_LD) @moar::ldswitch@ -L@moar::libdir@ @moar::ldshared@ $(M_LDFLAGS) $(M_LDLIBS) @moar::ldout@$(M_PERL6_OPS_DLL) $(M_PERL6_OPS_OBJ) $(M_PERL6_CONT_OBJ) -lmoar @moarimplib@
+	$(M_CC) @moar::ccswitch@ @moar::ccshared@ $(M_CFLAGS) $(M_MOAR_INC_PATHS) @moar::ccout@$(M_PERL6_OPS_OBJ) $(M_PERL6_OPS_SRC)
+	$(M_CC) @moar::ccswitch@ @moar::ccshared@ $(M_CFLAGS) $(M_MOAR_INC_PATHS) @moar::ccout@$(M_PERL6_CONT_OBJ) $(M_PERL6_CONT_SRC)
+	$(M_LD) @moar::ldswitch@ @moar::lddir@"@moar::libdir@" @moar::ldshared@ $(M_LDFLAGS) $(M_LDLIBS) @moar::ldout@$(M_PERL6_OPS_DLL) $(M_PERL6_OPS_OBJ) $(M_PERL6_CONT_OBJ) @moar_lib@
 
 $(PERL6_ML_MOAR): src/Perl6/ModuleLoader.nqp src/vm/moar/ModuleLoaderVMConfig.nqp gen/nqp-version
 	$(M_NQP) $(M_GEN_CAT) src/vm/moar/ModuleLoaderVMConfig.nqp src/Perl6/ModuleLoader.nqp > $(M_BUILD_DIR)/ModuleLoader.nqp
@@ -228,18 +232,14 @@ $(M_VALGRIND_RUNNER): tools/build/create-moar-runner.p6 $(M_C_RUNNER) $(PERL6_MO
 $(M_C_RUNNER): src/vm/moar/runner/main.c
 	$(RM_F) $(M_C_RUNNER)
 # Using only the pkgconfig moar includes does not work, because moar.h assumes all the specific includes below.
-	$(M_CC) @moar::ccswitch@ @static_nqp_home_define@ @static_perl6_home_define@ $(M_CFLAGS) $(M_CCINC)$(M_INCPATH) $(M_CCINC)$(M_INCPATH)/moar \
-	    $(M_CCINC)$(M_INCPATH)/libatomic_ops $(M_CCINC)$(M_INCPATH)/dyncall $(M_CCINC)$(M_INCPATH)/moar $(M_CCINC)$(M_INCPATH)/sha1 $(M_CCINC)$(M_INCPATH)/tinymt $(M_CCINC)$(M_INCPATH)/libtommath $(M_CCINC)$(M_INCPATH)/libuv \
-	    @moar::ccout@main@moar::obj@ src/vm/moar/runner/main.c
-	$(M_LD) @moar::ldout@$@ $(M_LDFLAGS) $(M_MINGW_UNICODE) main@moar::obj@ @moar::lddir@@moar::libdir@ $(M_C_RUNNER_LIBS)
+	$(M_CC) @moar::ccswitch@ @static_nqp_home_define@ @static_perl6_home_define@ $(M_CFLAGS) $(M_MOAR_INC_PATHS) @moar::ccout@main@moar::obj@ src/vm/moar/runner/main.c
+	$(M_LD) @moar::ldout@$@ $(M_LDFLAGS) $(M_MINGW_UNICODE) main@moar::obj@ @moar::lddir@"@moar::libdir@" @c_runner_libs@ @moar_lib@
 
 $(M_C_DEBUG_RUNNER): src/vm/moar/runner/main.c
 	$(RM_F) $(M_C_DEBUG_RUNNER)
 # Using only the pkgconfig moar includes does not work, because moar.h assumes all the specific includes below.
-	$(M_CC) @moar::ccswitch@ @static_nqp_home_define@ @static_perl6_home_define@ -DMOAR_PERL6_RUNNER_DEBUG $(M_CFLAGS) $(M_CCINC)$(M_INCPATH) $(M_CCINC)$(M_INCPATH)/moar \
-	    $(M_CCINC)$(M_INCPATH)/libatomic_ops $(M_CCINC)$(M_INCPATH)/dyncall $(M_CCINC)$(M_INCPATH)/moar $(M_CCINC)$(M_INCPATH)/sha1 $(M_CCINC)$(M_INCPATH)/tinymt $(M_CCINC)$(M_INCPATH)/libtommath $(M_CCINC)$(M_INCPATH)/libuv \
-	    @moar::ccout@main@moar::obj@ src/vm/moar/runner/main.c
-	$(M_LD) @moar::ldout@$@ $(M_LDFLAGS) $(M_MINGW_UNICODE) main@moar::obj@ @moar::lddir@@moar::libdir@ $(M_C_RUNNER_LIBS)
+	$(M_CC) @moar::ccswitch@ @static_nqp_home_define@ @static_perl6_home_define@ -DMOAR_PERL6_RUNNER_DEBUG $(M_CFLAGS) $(M_MOAR_INC_PATHS) @moar::ccout@main@moar::obj@ src/vm/moar/runner/main.c
+	$(M_LD) @moar::ldout@$@ $(M_LDFLAGS) $(M_MINGW_UNICODE) main@moar::obj@ @moar::lddir@"@moar::libdir@" @c_runner_libs@ @moar_lib@
 
 
 ##  testing targets

--- a/tools/build/Makefile-Moar.in
+++ b/tools/build/Makefile-Moar.in
@@ -1,5 +1,6 @@
 M_CC      = @moar::cc@
 M_LD      = @moar::ld@
+M_CCINC  = @moar::ccinc@
 M_CFLAGS  = @moar::cflags@ @moar::ccmiscflags@ @moar::ccoptiflags@ @moar::ccwarnflags@
 M_LDFLAGS = @ldflags@
 M_C_RUNNER_LIBS = @c_runner_libs@
@@ -226,16 +227,18 @@ $(M_VALGRIND_RUNNER): tools/build/create-moar-runner.p6 $(M_C_RUNNER) $(PERL6_MO
 $(M_C_RUNNER): src/vm/moar/runner/main.c
 	$(RM_F) $(M_C_RUNNER)
 # Using only the pkgconfig moar includes does not work, because moar.h assumes all the specific includes below.
-	$(M_CC) @moar::ccshared@ @static_nqp_home_define@ @static_perl6_home_define@ $(M_CFLAGS) $(M_LDFLAGS) -I$(M_INCPATH) -I$(M_INCPATH)/moar \
-	    -I$(M_INCPATH)/libatomic_ops -I$(M_INCPATH)/dyncall -I$(M_INCPATH)/sha1 -I$(M_INCPATH)/tinymt -I$(M_INCPATH)/libtommath -I$(M_INCPATH)/libuv \
-	    -L@moar::libdir@ $(M_MINGW_UNICODE) @moar::ccout@$@ src/vm/moar/runner/main.c -lmoar $(M_C_RUNNER_LIBS)
+	$(M_CC) @moar::ccswitch@ @static_nqp_home_define@ @static_perl6_home_define@ $(M_CFLAGS) $(M_CCINC)$(M_INCPATH) $(M_CCINC)$(M_INCPATH)/moar \
+	    $(M_CCINC)$(M_INCPATH)/libatomic_ops $(M_CCINC)$(M_INCPATH)/dyncall $(M_CCINC)$(M_INCPATH)/moar $(M_CCINC)$(M_INCPATH)/sha1 $(M_CCINC)$(M_INCPATH)/tinymt $(M_CCINC)$(M_INCPATH)/libtommath $(M_CCINC)$(M_INCPATH)/libuv \
+	    $(M_MINGW_UNICODE) @moar::ccout@main@moar::obj@ src/vm/moar/runner/main.c
+	$(M_LD) @moar::ldout@$@ $(M_LDFLAGS) main@moar::obj@ @moar::lddir@@moar::libdir@ $(M_C_RUNNER_LIBS)
 
 $(M_C_DEBUG_RUNNER): src/vm/moar/runner/main.c
 	$(RM_F) $(M_C_DEBUG_RUNNER)
 # Using only the pkgconfig moar includes does not work, because moar.h assumes all the specific includes below.
-	$(M_CC) @moar::ccshared@ @static_nqp_home_define@ @static_perl6_home_define@ -DMOAR_PERL6_RUNNER_DEBUG $(M_CFLAGS) $(M_LDFLAGS) -I$(M_INCPATH) -I$(M_INCPATH)/moar \
-	    -I$(M_INCPATH)/libatomic_ops -I$(M_INCPATH)/dyncall -I$(M_INCPATH)/moar -I$(M_INCPATH)/sha1 -I$(M_INCPATH)/tinymt -I$(M_INCPATH)/libtommath -I$(M_INCPATH)/libuv \
-	    -L@moar::libdir@ $(M_MINGW_UNICODE) @moar::ccout@$@ src/vm/moar/runner/main.c -lmoar $(M_C_RUNNER_LIBS)
+	$(M_CC) @moar::ccswitch@ @static_nqp_home_define@ @static_perl6_home_define@ -DMOAR_PERL6_RUNNER_DEBUG $(M_CFLAGS) $(M_CCINC)$(M_INCPATH) $(M_CCINC)$(M_INCPATH)/moar \
+	    $(M_CCINC)$(M_INCPATH)/libatomic_ops $(M_CCINC)$(M_INCPATH)/dyncall $(M_CCINC)$(M_INCPATH)/moar $(M_CCINC)$(M_INCPATH)/sha1 $(M_CCINC)$(M_INCPATH)/tinymt $(M_CCINC)$(M_INCPATH)/libtommath $(M_CCINC)$(M_INCPATH)/libuv \
+	    $(M_MINGW_UNICODE) @moar::ccout@main@moar::obj@ src/vm/moar/runner/main.c
+	$(M_LD) @moar::ldout@$@ $(M_LDFLAGS) main@moar::obj@ @moar::lddir@@moar::libdir@ $(M_C_RUNNER_LIBS)
 
 
 ##  testing targets

--- a/tools/build/Makefile-Moar.in
+++ b/tools/build/Makefile-Moar.in
@@ -4,7 +4,6 @@ M_CCINC   = @moar::ccinc@
 M_CFLAGS  = @moar::cflags@
 M_LDFLAGS = @ldflags@
 M_LDLIBS  = @moar::ldlibs@
-M_C_RUNNER_LIBS = @c_runner_libs@
 M_MINGW_UNICODE = @mingw_unicode@
 
 M_GEN_CAT = tools/build/gen-cat.nqp moar

--- a/tools/build/Makefile-Moar.in
+++ b/tools/build/Makefile-Moar.in
@@ -1,8 +1,9 @@
 M_CC      = @moar::cc@
 M_LD      = @moar::ld@
-M_CCINC  = @moar::ccinc@
-M_CFLAGS  = @moar::cflags@ @moar::ccmiscflags@ @moar::ccoptiflags@ @moar::ccwarnflags@
+M_CCINC   = @moar::ccinc@
+M_CFLAGS  = @moar::cflags@
 M_LDFLAGS = @ldflags@
+M_LDLIBS  = @moar::ldlibs@
 M_C_RUNNER_LIBS = @c_runner_libs@
 M_MINGW_UNICODE = @mingw_unicode@
 
@@ -122,7 +123,7 @@ $(M_PERL6_OPS_DLL): $(M_PERL6_OPS_SRC) $(M_PERL6_CONT_SRC)
 	    -I$(M_INCPATH)/dyncall -I$(M_INCPATH)/moar \
 	    -I$(M_INCPATH)/sha1 -I$(M_INCPATH)/tinymt  -I$(M_INCPATH)/libtommath \
 	    -I$(M_INCPATH)/libuv -I$(M_INCPATH) @moar::cincludes@ @moar::ccout@$(M_PERL6_CONT_OBJ) $(M_PERL6_CONT_SRC)
-	$(M_LD) @moar::ldswitch@ -L@moar::libdir@ @moar::ldshared@ $(M_LDFLAGS) @moar::ldout@$(M_PERL6_OPS_DLL) $(M_PERL6_OPS_OBJ) $(M_PERL6_CONT_OBJ) -lmoar @moarimplib@
+	$(M_LD) @moar::ldswitch@ -L@moar::libdir@ @moar::ldshared@ $(M_LDFLAGS) $(M_LDLIBS) @moar::ldout@$(M_PERL6_OPS_DLL) $(M_PERL6_OPS_OBJ) $(M_PERL6_CONT_OBJ) -lmoar @moarimplib@
 
 $(PERL6_ML_MOAR): src/Perl6/ModuleLoader.nqp src/vm/moar/ModuleLoaderVMConfig.nqp gen/nqp-version
 	$(M_NQP) $(M_GEN_CAT) src/vm/moar/ModuleLoaderVMConfig.nqp src/Perl6/ModuleLoader.nqp > $(M_BUILD_DIR)/ModuleLoader.nqp

--- a/tools/build/Makefile-common-macros.in
+++ b/tools/build/Makefile-common-macros.in
@@ -1,7 +1,5 @@
 # Copyright (C) 2015 The Perl Foundation
 
-.NOTPARALLEL:
-
 PERL5   = @perl@
 MKPATH  = @mkpath@
 CHMOD   = @chmod@

--- a/tools/build/Makefile-common-rules.in
+++ b/tools/build/Makefile-common-rules.in
@@ -1,5 +1,7 @@
 # Copyright (C) 2015 The Perl Foundation
 
+.NOTPARALLEL:
+
 spectest_checkout : t/spec
 t/spec :
 	git clone git://github.com/perl6/roast.git t/spec


### PR DESCRIPTION
- Fix nmake default target.
- Remove duplicate compile options for dynext and the c runners.
- Rely more on the MoarVM build configuration when building dynext and the c runners.
- Replace the hardcoded`-lmoar` option with some templating that picks the correct option also on Windows.

I tested this on MinGW/gcc/gmake, MSVC/cl/nmake and linux/gcc/make.