### PR TITLE
Never build a relocatable rakudo on OpenBSD

### DIFF
--- a/Configure.pl
+++ b/Configure.pl
@@ -145,8 +145,8 @@ MAIN: {
         close($CONFIG_STATUS);
     }
 
-    # Relocatability is not supported on AIX.
-    $options{'no-relocatable'} = 1 if $^O eq 'aix';
+    # Relocatability is not supported on AIX and OpenBSD.
+    $options{'no-relocatable'} = 1 if $^O eq 'aix' || $^O eq 'openbsd';
 
     $config{prefix} = $prefix;
     $config{libdir} = $options{libdir};
@@ -447,7 +447,8 @@ General Options:
     --libdir=<path>    Install architecture-specific files in dir; Perl6 modules included
     --no-relocatable
                        Create a perl6 with a fixed NQP and Perl6 home dir instead of dynamically identifying it
-                       (On AIX MoarVM is always built non-relocatable, since AIX misses a necessary mechanism.)
+                       (On AIX and OpenBSD rakudo is always built non-relocatable, since both OS' miss the
+                       necessary mechanism to make this work.)
     --sdkroot=<path>   When given, use for searching build tools here, e.g.
                        nqp, java, node etc.
     --sysroot=<path>   When given, use for searching runtime components here


### PR DESCRIPTION
See https://github.com/rakudo/rakudo/issues/2818

OpenBSDs implementation of $ORIGIN in rpath is unreliable. Also it misses
a mechanism to determine the executable path in general. So even at
runtime one has a hard time implementing something like this in a robust
manner.