### PR TITLE
fix error when set RAKUDO_EXCEPTIONS_HANDLER

### DIFF
--- a/src/core/Exception.pm6
+++ b/src/core/Exception.pm6
@@ -380,7 +380,7 @@ do {
             # REMOVE DEPRECATED CODE ON 201907
             Rakudo::Deprecations.DEPRECATED: "PERL6_EXCEPTIONS_HANDLER", Nil,
                 '2019.07', :file("N/A"), :line("N/A"),
-                :what<RAKUDO_EXCEPTIONS_HANDLER env var>;
+                :what<RAKUDO_EXCEPTIONS_HANDLER>;
             my $class := ::("Exceptions::$handler");
             unless nqp::istype($class,Failure) {
                 temp %*ENV<RAKUDO_EXCEPTIONS_HANDLER> = ""; # prevent looping


### PR DESCRIPTION
The instance variable `what` of `Exception` class is native string type `str`. The list input `:what<RAKUDO_EXCEPTIONS_HANDLER env var>` will cause an error:
```
> Rakudo::Deprecations.DEPRECATED: "PERL6_EXCEPTIONS_HANDLER", Nil,'2019.07', :file("N/A"), :line("N/A"),:what<RAKUDO_EXCEPTIONS_HANDLER env var>;
This type cannot unbox to a native string: P6opaque, List
  in block <unit> at <unknown file> line 1
```