### PR TITLE
see:rakudo/rakudo#2826; add HALF-[UP|DOWN|EVEN|ODD] | [TO|FROM]-ZERO …

### DIFF
--- a/src/core/Rational.pm6
+++ b/src/core/Rational.pm6
@@ -354,7 +354,6 @@ my role Rational[::NuT = Int, ::DeT = ::("NuT")] does Real {
             :details('when calling .round on Rational')
           )
         ) unless $!denominator;
-        my ($numerator, $denominator);
         if ($!numerator < 0 && $!denominator < 0) || ($!numerator > 0 && $!denominator > 0) {
             return floor(
               nqp::add_I(nqp::mul_I($!numerator, 2, Int), $!denominator, Int).Int /

--- a/src/core/Real.pm6
+++ b/src/core/Real.pm6
@@ -38,30 +38,8 @@ my role Real does Numeric {
     method ceiling() { self.Bridge.ceiling }
 
     proto method round(|) {*}
-    multi method round(Real:D: :$HALF-UP!) {
-        (self + 1/2).floor; # Rat NYI here, so no .5
-    }
-    multi method round(Real:D: Bool:D :$HALF-DOWN!) {
-        (self - 1/2).ceiling;
-    }
-    multi method round(Real:D: :$HALF-EVEN!) {
-        (self - self.floor == 1/2
-                  ?? (self.floor %% 2 ?? self.floor !! self.ceiling)
-                  !! self.round(:HALF-UP));
-    }
-    multi method round(Real:D: :$HALF-ODD!) {
-        (self - self.floor == 1/2
-                  ?? (self.floor %% 2 ?? self.ceiling !! self.floor)
-                  !! self.round(:HALF-UP));
-    }
-    multi method round(Real:D: :$TO-ZERO!) {
-        (self + (self < 0 ?? 1/2 !! -1/2))."{self < 0 ?? 'floor' !! 'ceiling'}"();
-    }
-    multi method round(Real:D: :$FROM-ZERO!) {
-        (self + (self > 0 ?? 1/2 !! -1/2))."{self > 0 ?? 'floor' !! 'ceiling'}"();
-    }
     multi method round(Real:D:) {
-        self.round(:HALF-UP);
+        (self + 1/2).floor; # Rat NYI here, so no .5
     }
     multi method round(Real:D: Real() $scale) {
         (self / $scale + 1/2).floor * $scale;

--- a/src/core/Real.pm6
+++ b/src/core/Real.pm6
@@ -38,8 +38,30 @@ my role Real does Numeric {
     method ceiling() { self.Bridge.ceiling }
 
     proto method round(|) {*}
-    multi method round(Real:D:) {
+    multi method round(Real:D: :$HALF-UP!) {
         (self + 1/2).floor; # Rat NYI here, so no .5
+    }
+    multi method round(Real:D: Bool:D :$HALF-DOWN!) {
+        (self - 1/2).ceiling;
+    }
+    multi method round(Real:D: :$HALF-EVEN!) {
+        (self - self.floor == 1/2
+                  ?? (self.floor %% 2 ?? self.floor !! self.ceiling)
+                  !! self.round(:HALF-UP));
+    }
+    multi method round(Real:D: :$HALF-ODD!) {
+        (self - self.floor == 1/2
+                  ?? (self.floor %% 2 ?? self.ceiling !! self.floor)
+                  !! self.round(:HALF-UP));
+    }
+    multi method round(Real:D: :$TO-ZERO!) {
+        (self + (self < 0 ?? 1/2 !! -1/2))."{self < 0 ?? 'floor' !! 'ceiling'}"();
+    }
+    multi method round(Real:D: :$FROM-ZERO!) {
+        (self + (self > 0 ?? 1/2 !! -1/2))."{self > 0 ?? 'floor' !! 'ceiling'}"();
+    }
+    multi method round(Real:D:) {
+        self.round(:HALF-UP);
     }
     multi method round(Real:D: Real() $scale) {
         (self / $scale + 1/2).floor * $scale;


### PR DESCRIPTION
for the issue see:rakudo/rakudo#2826
for the related tests see:perl6/roast#527

this commit adds HALF-[UP|DOWN|EVEN|ODD] | [TO|FROM]-ZERO rounding options as adverbs on `.round` for `Real` and `Rat` and maintains the default `HALF-UP` when no adverb is applied.