### PR TITLE
Fix parsing of Unicode brackets in interpolation

### DIFF
--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -3642,7 +3642,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         my $check     := $matches[+$matches - 1];
         my str $str   := $check.Str;
         my $last  := nqp::substr($str, nqp::chars($check) - 1, 1);
-        $last eq ')' || $last eq '}' || $last eq ']' || $last eq '>'
+        $last eq ')' || $last eq '}' || $last eq ']' || $last eq '>' || $last eq '»'
     }
 
     method EXPR(str $preclim = '') {


### PR DESCRIPTION
Add them as a possibility in postcircumfix bracket ending check.

Will be a fix for #2825 when tests are added.

Rakudo builds ok and passes `make m-test m-spectest`.