### PR TITLE
Fix build runners

### DIFF
--- a/tools/build/Makefile-Moar.in
+++ b/tools/build/Makefile-Moar.in
@@ -211,21 +211,21 @@ $(PERL6_DEBUG_MOAR): src/perl6-debug.nqp $(PERL6_MOAR)
 	    --vmlibs=$(M_PERL6_OPS_DLL)=Rakudo_ops_init $(M_BUILD_DIR)/perl6-debug.nqp
 
 $(M_BAT_DEBUG_RUNNER): tools/build/create-moar-runner.p6 $(M_C_DEBUG_RUNNER) $(PERL6_DEBUG_MOAR) $(SETTING_MOAR)
-	$(M_RUN_PERL6) tools/build/create-moar-runner.p6 moar "$(MOAR)" perl6-debug-m ~SCRIPT_DIR~/perl6-debug.moarvm "" --nqp-lib=\$$DIR/blib ~SCRIPT_DIR~ ~SCRIPT_DIR~/blib $(M_LIBPATH)
+	$(M_RUN_PERL6) tools/build/create-moar-runner.p6 moar "$(MOAR)" perl6-debug-m ~SCRIPT_DIR~/perl6-debug.moarvm "" --nqp-lib=~SCRIPT_DIR~/blib ~SCRIPT_DIR~ ~SCRIPT_DIR~/blib $(M_LIBPATH)
 
 $(M_GDB_RUNNER): tools/build/create-moar-runner.p6 $(M_C_RUNNER) $(PERL6_MOAR) $(SETTING_MOAR)
 	$(RM_F) $(M_GDB_RUNNER)
-	$(M_RUN_PERL6) tools/build/create-moar-runner.p6 moar "$(MOAR)" perl6-gdb-m ~SCRIPT_DIR~/perl6.moarvm "gdb" --nqp-lib=\$$DIR/blib ~SCRIPT_DIR~ ~SCRIPT_DIR~/blib $(M_LIBPATH)
+	$(M_RUN_PERL6) tools/build/create-moar-runner.p6 moar "$(MOAR)" perl6-gdb-m ~SCRIPT_DIR~/perl6.moarvm "gdb" --nqp-lib=~SCRIPT_DIR~/blib ~SCRIPT_DIR~ ~SCRIPT_DIR~/blib $(M_LIBPATH)
 	-$(CHMOD) 755 $(M_GDB_RUNNER)
 
 $(M_LLDB_RUNNER): tools/build/create-moar-runner.p6 $(M_C_RUNNER) $(PERL6_MOAR) $(SETTING_MOAR)
 	$(RM_F) $(M_LLDB_RUNNER)
-	$(M_RUN_PERL6) tools/build/create-moar-runner.p6 moar "$(MOAR)" perl6-lldb-m ~SCRIPT_DIR~/perl6.moarvm "lldb" --nqp-lib=\$$DIR/blib ~SCRIPT_DIR~ ~SCRIPT_DIR~/blib $(M_LIBPATH)
+	$(M_RUN_PERL6) tools/build/create-moar-runner.p6 moar "$(MOAR)" perl6-lldb-m ~SCRIPT_DIR~/perl6.moarvm "lldb" --nqp-lib=~SCRIPT_DIR~/blib ~SCRIPT_DIR~ ~SCRIPT_DIR~/blib $(M_LIBPATH)
 	-$(CHMOD) 755 $(M_LLDB_RUNNER)
 
 $(M_VALGRIND_RUNNER): tools/build/create-moar-runner.p6 $(M_C_RUNNER) $(PERL6_MOAR) $(SETTING_MOAR)
 	$(RM_F) $(M_VALGRIND_RUNNER)
-	$(M_RUN_PERL6) tools/build/create-moar-runner.p6 moar "$(MOAR)" perl6-valgrind-m ~SCRIPT_DIR~/perl6.moarvm "valgrind" --nqp-lib=\$$DIR/blib ~SCRIPT_DIR~ ~SCRIPT_DIR~/blib $(M_LIBPATH)
+	$(M_RUN_PERL6) tools/build/create-moar-runner.p6 moar "$(MOAR)" perl6-valgrind-m ~SCRIPT_DIR~/perl6.moarvm "valgrind" --nqp-lib=~SCRIPT_DIR~/blib ~SCRIPT_DIR~ ~SCRIPT_DIR~/blib $(M_LIBPATH)
 	-$(CHMOD) 755 $(M_VALGRIND_RUNNER)
 
 $(M_C_RUNNER): src/vm/moar/runner/main.c

--- a/tools/build/Makefile-Moar.in
+++ b/tools/build/Makefile-Moar.in
@@ -197,7 +197,7 @@ $(R_SETTING_MOAR): $(PERL6_MOAR) $(SETTING_MOAR) $(R_SETTING_SRC) $(SETTING_MOAR
 
 $(M_BAT_RUNNER): tools/build/create-moar-runner.p6 $(M_C_RUNNER) $(PERL6_MOAR) $(SETTING_MOAR)
 	$(RM_F) $(M_BAT_RUNNER)
-	$(M_RUN_PERL6) tools/build/create-moar-runner.p6 moar "$(MOAR)" perl6-m perl6.moarvm . "" $(PERL6_HOME) $(NQP_HOME) --nqp-lib=blib $(M_LIBPATH) . blib
+	$(M_RUN_PERL6) tools/build/create-moar-runner.p6 moar "$(MOAR)" perl6-m perl6.moarvm \$$DIR "" $(PERL6_HOME) $(NQP_HOME) --nqp-lib=\$$DIR/blib $(M_LIBPATH) \$$DIR \$$DIR/blib
 	-$(CHMOD) 755 $(M_BAT_RUNNER)
 
 m-runner-default: $(M_BAT_RUNNER)
@@ -211,21 +211,21 @@ $(PERL6_DEBUG_MOAR): src/perl6-debug.nqp $(PERL6_MOAR)
 	    --vmlibs=$(M_PERL6_OPS_DLL)=Rakudo_ops_init $(M_BUILD_DIR)/perl6-debug.nqp
 
 $(M_BAT_DEBUG_RUNNER): tools/build/create-moar-runner.p6 $(M_C_DEBUG_RUNNER) $(PERL6_DEBUG_MOAR) $(SETTING_MOAR)
-	$(M_RUN_PERL6) tools/build/create-moar-runner.p6 moar "$(MOAR)" perl6-debug-m perl6-debug.moarvm . "" $(PERL6_HOME) $(NQP_HOME) --nqp-lib=blib $(M_LIBPATH) . blib
+	$(M_RUN_PERL6) tools/build/create-moar-runner.p6 moar "$(MOAR)" perl6-debug-m perl6-debug.moarvm \$$DIR "" $(PERL6_HOME) $(NQP_HOME) --nqp-lib=\$$DIR/blib $(M_LIBPATH) \$$DIR \$$DIR/blib
 
 $(M_GDB_RUNNER): tools/build/create-moar-runner.p6 $(M_C_RUNNER) $(PERL6_MOAR) $(SETTING_MOAR)
 	$(RM_F) $(M_GDB_RUNNER)
-	$(M_RUN_PERL6) tools/build/create-moar-runner.p6 moar "$(MOAR)" perl6-gdb-m perl6.moarvm . "gdb" $(PERL6_HOME) $(NQP_HOME) --nqp-lib=blib $(M_LIBPATH) . blib
+	$(M_RUN_PERL6) tools/build/create-moar-runner.p6 moar "$(MOAR)" perl6-gdb-m perl6.moarvm \$$DIR "gdb" $(PERL6_HOME) $(NQP_HOME) --nqp-lib=\$$DIR/blib $(M_LIBPATH) \$$DIR \$$DIR/blib
 	-$(CHMOD) 755 $(M_GDB_RUNNER)
 
 $(M_LLDB_RUNNER): tools/build/create-moar-runner.p6 $(M_C_RUNNER) $(PERL6_MOAR) $(SETTING_MOAR)
 	$(RM_F) $(M_LLDB_RUNNER)
-	$(M_RUN_PERL6) tools/build/create-moar-runner.p6 moar "$(MOAR)" perl6-lldb-m perl6.moarvm . "lldb" $(PERL6_HOME) $(NQP_HOME) --nqp-lib=blib $(M_LIBPATH) . blib
+	$(M_RUN_PERL6) tools/build/create-moar-runner.p6 moar "$(MOAR)" perl6-lldb-m perl6.moarvm \$$DIR "lldb" $(PERL6_HOME) $(NQP_HOME) --nqp-lib=\$$DIR/blib $(M_LIBPATH) \$$DIR \$$DIR/blib
 	-$(CHMOD) 755 $(M_LLDB_RUNNER)
 
 $(M_VALGRIND_RUNNER): tools/build/create-moar-runner.p6 $(M_C_RUNNER) $(PERL6_MOAR) $(SETTING_MOAR)
 	$(RM_F) $(M_VALGRIND_RUNNER)
-	$(M_RUN_PERL6) tools/build/create-moar-runner.p6 moar "$(MOAR)" perl6-valgrind-m perl6.moarvm . "valgrind" $(PERL6_HOME) $(NQP_HOME) --nqp-lib=blib $(M_LIBPATH) . blib
+	$(M_RUN_PERL6) tools/build/create-moar-runner.p6 moar "$(MOAR)" perl6-valgrind-m perl6.moarvm \$$DIR "valgrind" $(PERL6_HOME) $(NQP_HOME) --nqp-lib=\$$DIR/blib $(M_LIBPATH) \$$DIR \$$DIR/blib
 	-$(CHMOD) 755 $(M_VALGRIND_RUNNER)
 
 $(M_C_RUNNER): src/vm/moar/runner/main.c

--- a/tools/build/Makefile-Moar.in
+++ b/tools/build/Makefile-Moar.in
@@ -197,7 +197,7 @@ $(R_SETTING_MOAR): $(PERL6_MOAR) $(SETTING_MOAR) $(R_SETTING_SRC) $(SETTING_MOAR
 
 $(M_BAT_RUNNER): tools/build/create-moar-runner.p6 $(M_C_RUNNER) $(PERL6_MOAR) $(SETTING_MOAR)
 	$(RM_F) $(M_BAT_RUNNER)
-	$(M_RUN_PERL6) tools/build/create-moar-runner.p6 moar "$(MOAR)" perl6-m perl6.moarvm \$$DIR "" $(PERL6_HOME) $(NQP_HOME) --nqp-lib=\$$DIR/blib \$$DIR \$$DIR/blib $(M_LIBPATH)
+	$(M_RUN_PERL6) tools/build/create-moar-runner.p6 moar "$(MOAR)" perl6-m ~SCRIPT_DIR~/perl6.moarvm "" --nqp-lib=~SCRIPT_DIR~/blib ~SCRIPT_DIR~ ~SCRIPT_DIR~/blib $(M_LIBPATH)
 	-$(CHMOD) 755 $(M_BAT_RUNNER)
 
 m-runner-default: $(M_BAT_RUNNER)
@@ -211,21 +211,21 @@ $(PERL6_DEBUG_MOAR): src/perl6-debug.nqp $(PERL6_MOAR)
 	    --vmlibs=$(M_PERL6_OPS_DLL)=Rakudo_ops_init $(M_BUILD_DIR)/perl6-debug.nqp
 
 $(M_BAT_DEBUG_RUNNER): tools/build/create-moar-runner.p6 $(M_C_DEBUG_RUNNER) $(PERL6_DEBUG_MOAR) $(SETTING_MOAR)
-	$(M_RUN_PERL6) tools/build/create-moar-runner.p6 moar "$(MOAR)" perl6-debug-m perl6-debug.moarvm \$$DIR "" $(PERL6_HOME) $(NQP_HOME) --nqp-lib=\$$DIR/blib \$$DIR \$$DIR/blib $(M_LIBPATH)
+	$(M_RUN_PERL6) tools/build/create-moar-runner.p6 moar "$(MOAR)" perl6-debug-m ~SCRIPT_DIR~/perl6-debug.moarvm "" --nqp-lib=\$$DIR/blib ~SCRIPT_DIR~ ~SCRIPT_DIR~/blib $(M_LIBPATH)
 
 $(M_GDB_RUNNER): tools/build/create-moar-runner.p6 $(M_C_RUNNER) $(PERL6_MOAR) $(SETTING_MOAR)
 	$(RM_F) $(M_GDB_RUNNER)
-	$(M_RUN_PERL6) tools/build/create-moar-runner.p6 moar "$(MOAR)" perl6-gdb-m perl6.moarvm \$$DIR "gdb" $(PERL6_HOME) $(NQP_HOME) --nqp-lib=\$$DIR/blib \$$DIR \$$DIR/blib $(M_LIBPATH)
+	$(M_RUN_PERL6) tools/build/create-moar-runner.p6 moar "$(MOAR)" perl6-gdb-m ~SCRIPT_DIR~/perl6.moarvm "gdb" --nqp-lib=\$$DIR/blib ~SCRIPT_DIR~ ~SCRIPT_DIR~/blib $(M_LIBPATH)
 	-$(CHMOD) 755 $(M_GDB_RUNNER)
 
 $(M_LLDB_RUNNER): tools/build/create-moar-runner.p6 $(M_C_RUNNER) $(PERL6_MOAR) $(SETTING_MOAR)
 	$(RM_F) $(M_LLDB_RUNNER)
-	$(M_RUN_PERL6) tools/build/create-moar-runner.p6 moar "$(MOAR)" perl6-lldb-m perl6.moarvm \$$DIR "lldb" $(PERL6_HOME) $(NQP_HOME) --nqp-lib=\$$DIR/blib \$$DIR \$$DIR/blib $(M_LIBPATH)
+	$(M_RUN_PERL6) tools/build/create-moar-runner.p6 moar "$(MOAR)" perl6-lldb-m ~SCRIPT_DIR~/perl6.moarvm "lldb" --nqp-lib=\$$DIR/blib ~SCRIPT_DIR~ ~SCRIPT_DIR~/blib $(M_LIBPATH)
 	-$(CHMOD) 755 $(M_LLDB_RUNNER)
 
 $(M_VALGRIND_RUNNER): tools/build/create-moar-runner.p6 $(M_C_RUNNER) $(PERL6_MOAR) $(SETTING_MOAR)
 	$(RM_F) $(M_VALGRIND_RUNNER)
-	$(M_RUN_PERL6) tools/build/create-moar-runner.p6 moar "$(MOAR)" perl6-valgrind-m perl6.moarvm \$$DIR "valgrind" $(PERL6_HOME) $(NQP_HOME) --nqp-lib=\$$DIR/blib \$$DIR \$$DIR/blib $(M_LIBPATH)
+	$(M_RUN_PERL6) tools/build/create-moar-runner.p6 moar "$(MOAR)" perl6-valgrind-m ~SCRIPT_DIR~/perl6.moarvm "valgrind" --nqp-lib=\$$DIR/blib ~SCRIPT_DIR~ ~SCRIPT_DIR~/blib $(M_LIBPATH)
 	-$(CHMOD) 755 $(M_VALGRIND_RUNNER)
 
 $(M_C_RUNNER): src/vm/moar/runner/main.c

--- a/tools/build/Makefile-Moar.in
+++ b/tools/build/Makefile-Moar.in
@@ -197,7 +197,7 @@ $(R_SETTING_MOAR): $(PERL6_MOAR) $(SETTING_MOAR) $(R_SETTING_SRC) $(SETTING_MOAR
 
 $(M_BAT_RUNNER): tools/build/create-moar-runner.p6 $(M_C_RUNNER) $(PERL6_MOAR) $(SETTING_MOAR)
 	$(RM_F) $(M_BAT_RUNNER)
-	$(M_RUN_PERL6) tools/build/create-moar-runner.p6 moar "$(MOAR)" perl6-m perl6.moarvm \$$DIR "" $(PERL6_HOME) $(NQP_HOME) --nqp-lib=\$$DIR/blib $(M_LIBPATH) \$$DIR \$$DIR/blib
+	$(M_RUN_PERL6) tools/build/create-moar-runner.p6 moar "$(MOAR)" perl6-m perl6.moarvm \$$DIR "" $(PERL6_HOME) $(NQP_HOME) --nqp-lib=\$$DIR/blib \$$DIR \$$DIR/blib $(M_LIBPATH)
 	-$(CHMOD) 755 $(M_BAT_RUNNER)
 
 m-runner-default: $(M_BAT_RUNNER)
@@ -211,21 +211,21 @@ $(PERL6_DEBUG_MOAR): src/perl6-debug.nqp $(PERL6_MOAR)
 	    --vmlibs=$(M_PERL6_OPS_DLL)=Rakudo_ops_init $(M_BUILD_DIR)/perl6-debug.nqp
 
 $(M_BAT_DEBUG_RUNNER): tools/build/create-moar-runner.p6 $(M_C_DEBUG_RUNNER) $(PERL6_DEBUG_MOAR) $(SETTING_MOAR)
-	$(M_RUN_PERL6) tools/build/create-moar-runner.p6 moar "$(MOAR)" perl6-debug-m perl6-debug.moarvm \$$DIR "" $(PERL6_HOME) $(NQP_HOME) --nqp-lib=\$$DIR/blib $(M_LIBPATH) \$$DIR \$$DIR/blib
+	$(M_RUN_PERL6) tools/build/create-moar-runner.p6 moar "$(MOAR)" perl6-debug-m perl6-debug.moarvm \$$DIR "" $(PERL6_HOME) $(NQP_HOME) --nqp-lib=\$$DIR/blib \$$DIR \$$DIR/blib $(M_LIBPATH)
 
 $(M_GDB_RUNNER): tools/build/create-moar-runner.p6 $(M_C_RUNNER) $(PERL6_MOAR) $(SETTING_MOAR)
 	$(RM_F) $(M_GDB_RUNNER)
-	$(M_RUN_PERL6) tools/build/create-moar-runner.p6 moar "$(MOAR)" perl6-gdb-m perl6.moarvm \$$DIR "gdb" $(PERL6_HOME) $(NQP_HOME) --nqp-lib=\$$DIR/blib $(M_LIBPATH) \$$DIR \$$DIR/blib
+	$(M_RUN_PERL6) tools/build/create-moar-runner.p6 moar "$(MOAR)" perl6-gdb-m perl6.moarvm \$$DIR "gdb" $(PERL6_HOME) $(NQP_HOME) --nqp-lib=\$$DIR/blib \$$DIR \$$DIR/blib $(M_LIBPATH)
 	-$(CHMOD) 755 $(M_GDB_RUNNER)
 
 $(M_LLDB_RUNNER): tools/build/create-moar-runner.p6 $(M_C_RUNNER) $(PERL6_MOAR) $(SETTING_MOAR)
 	$(RM_F) $(M_LLDB_RUNNER)
-	$(M_RUN_PERL6) tools/build/create-moar-runner.p6 moar "$(MOAR)" perl6-lldb-m perl6.moarvm \$$DIR "lldb" $(PERL6_HOME) $(NQP_HOME) --nqp-lib=\$$DIR/blib $(M_LIBPATH) \$$DIR \$$DIR/blib
+	$(M_RUN_PERL6) tools/build/create-moar-runner.p6 moar "$(MOAR)" perl6-lldb-m perl6.moarvm \$$DIR "lldb" $(PERL6_HOME) $(NQP_HOME) --nqp-lib=\$$DIR/blib \$$DIR \$$DIR/blib $(M_LIBPATH)
 	-$(CHMOD) 755 $(M_LLDB_RUNNER)
 
 $(M_VALGRIND_RUNNER): tools/build/create-moar-runner.p6 $(M_C_RUNNER) $(PERL6_MOAR) $(SETTING_MOAR)
 	$(RM_F) $(M_VALGRIND_RUNNER)
-	$(M_RUN_PERL6) tools/build/create-moar-runner.p6 moar "$(MOAR)" perl6-valgrind-m perl6.moarvm \$$DIR "valgrind" $(PERL6_HOME) $(NQP_HOME) --nqp-lib=\$$DIR/blib $(M_LIBPATH) \$$DIR \$$DIR/blib
+	$(M_RUN_PERL6) tools/build/create-moar-runner.p6 moar "$(MOAR)" perl6-valgrind-m perl6.moarvm \$$DIR "valgrind" $(PERL6_HOME) $(NQP_HOME) --nqp-lib=\$$DIR/blib \$$DIR \$$DIR/blib $(M_LIBPATH)
 	-$(CHMOD) 755 $(M_VALGRIND_RUNNER)
 
 $(M_C_RUNNER): src/vm/moar/runner/main.c

--- a/tools/build/create-moar-runner.p6
+++ b/tools/build/create-moar-runner.p6
@@ -28,21 +28,20 @@ multi sub MAIN("perl6", $perl6, $install-to, $toolchain, $ld-lib-path, $perl6-ho
     chmod(0o755, $install-to) if $*DISTRO ne 'mswin32';
 }
 
-multi sub MAIN("moar", $moar, $install-to is copy, $mbc, $p6-mbc-path, $toolchain, $perl6-home is copy, $nqp-home is copy, $blib is copy, *@libpaths) {
-    $perl6-home = "PERL6_HOME=$perl6-home" if $perl6-home;
-    $nqp-home = "NQP_HOME=$nqp-home" if $nqp-home;
-    my $env-vars = join(' ', $nqp-home, $perl6-home).trim;
+multi sub MAIN("moar", $moar, $install-to is copy, $mbc, $toolchain, $blib is copy, *@libpaths) {
 
     $blib = ' ' ~ $blib if $blib;
     my $libpaths = '--libpath="%s"'.sprintf: @libpaths.join('" --libpath="');
-    my $libpath-line = '%s %s/%s%s'.sprintf: $libpaths, $p6-mbc-path, $mbc, $blib;
+    my $libpath-line = "%s %s%s".sprintf: $libpaths, $mbc, $blib;
+    $libpath-line ~~ s:g/\~SCRIPT_DIR\~/\$DIR/ if $*DISTRO ne 'mswin32';
+    $libpath-line ~~ s:g/\~SCRIPT_DIR\~/%DIR%/ if $*DISTRO eq 'mswin32';
     
     $install-to ~= '.bat' if $*DISTRO eq 'mswin32';
 
     my $fh = open $install-to, :w;
 
     if $*DISTRO eq 'mswin32' {
-        $fh.print(get-moar-win-runner($moar, $libpaths, $p6-mbc-path, $mbc, $blib));
+        $fh.print(get-moar-win-runner($moar, $libpath-line));
     }
     elsif $toolchain eq any('gdb','lldb') {
         $fh.print(get-moar-debug-runner($toolchain, $moar, $libpath-line));
@@ -92,9 +91,12 @@ my $sh-prelude = q:to/EOS/;
     DIR=$(dirname -- "$(rreadlink "$0")")
     EOS
 
-sub get-moar-win-runner($moar, $libpaths, $p6-mbc-path, $mbc, $blib) {
-    return sprintf(qq[@ "%s" --execname="%%\~dpf0" %s %s\\%s%s %%*\n],
-            $moar, $libpaths, $p6-mbc-path, $mbc, $blib);
+sub get-moar-win-runner($moar, $libpath-line) {
+    return sprintf(q:to/EOS/, $moar, $libpath-line);
+    @ SET DIR=%%~dp0
+    @ SET DIR=%%DIR:~0,-1%%
+    @ "%s" --execname="%%~dpf0" %s %%*
+    EOS
 }
 
 sub get-perl6-runner($perl6, $env-vars) {

--- a/tools/build/create-moar-runner.p6
+++ b/tools/build/create-moar-runner.p6
@@ -106,8 +106,9 @@ sub get-perl6-runner($perl6, $env-vars) {
 }
 
 sub get-moar-runner($moar, $libpath-line) {
-    return sprintf(q:to/EOS/, $moar, $libpath-line);
-    #!/bin/sh
+    return sprintf(q:to/EOS/, $sh-prelude, $moar, $libpath-line);
+    %s
+
     exec %s --execname="$0" %s "$@"
     EOS
 }
@@ -145,8 +146,9 @@ sub get-perl6-debug-runner($toolchain, $perl6, $env-vars) {
 sub get-moar-debug-runner($toolchain, $moar, $libpath-line) {
     my $cmdline = $toolchain eq 'gdb'  ?? 'gdb --quiet --ex=run --args %s --execname="$0" %s "$@"'.sprintf($moar, $libpath-line)
                !! $toolchain eq 'lldb' ?? 'lldb %s -- --execname="$0" %s "$@"'.sprintf($moar, $libpath-line) !! die;
-    return sprintf(q:to/EOS/, $moar, $libpath-line, get-debugger-text($toolchain), $cmdline);
-    #!/bin/sh
+    return sprintf(q:to/EOS/, $sh-prelude, $moar, $libpath-line, get-debugger-text($toolchain), $cmdline);
+    %s
+
     %s --execname="$0" %s -e '%s'
     %s
     EOS


### PR DESCRIPTION
Change the runners in the build directory so they work irrespective of CWD. Also change the libpath include order, so the files in the build dir take precedence over the ones in the install location. (We can't just leave the install location out, because the NQP that's installed there is needed.)