### PR TITLE
Remove relative elements from NQP_HOME and PERL6_HOME

### DIFF
--- a/src/main.nqp
+++ b/src/main.nqp
@@ -7,17 +7,19 @@ my $config := nqp::backendconfig();
 my $sep := $config<osname> eq 'MSWin32' ?? '\\' !! '/';
 #?if jvm
 my $execname := nqp::atkey(nqp::jvmgetproperties,'perl6.execname');
-my $exec-dir := nqp::substr($execname, 0, nqp::rindex($execname, $sep));
+my $install-dir := nqp::substr($execname, 0, nqp::rindex($execname, $sep, nqp::rindex($execname, $sep) - 1));
 #?endif
 #?if moar
-my $exec-dir := $config<osname> eq 'openbsd'
+my $execname := nqp::execname();
+my $install-dir := $config<osname> eq 'openbsd'
     ?? $config<prefix> ~ '/bin/perl6-m'
-    !! nqp::substr(nqp::execname(), 0, nqp::rindex(nqp::execname(), $sep));
+    !! nqp::substr($execname, 0, nqp::rindex($execname, $sep, nqp::rindex($execname, $sep) - 1));
 #?endif
 #?if js
-my $exec-dir := $config<osname> eq 'openbsd'
+my $execname := nqp::execname();
+my $install-dir := $config<osname> eq 'openbsd'
     ?? $config<prefix> ~ '/bin/perl6-js'
-    !! nqp::substr(nqp::execname(), 0, nqp::rindex(nqp::execname(), $sep))
+    !! nqp::substr($execname, 0, nqp::rindex($execname, $sep, nqp::rindex($execname, $sep) - 1));
 #?endif
 
 
@@ -29,14 +31,14 @@ my $comp := Perl6::Compiler.new();
 
 my $perl6-home := $comp.config<static_perl6_home>
     // nqp::getenvhash()<PERL6_HOME>
-    // $exec-dir ~ '/../share/perl6';
+    // $install-dir ~ '/share/perl6';
 if nqp::substr($perl6-home, nqp::chars($perl6-home) - 1) eq $sep {
     $perl6-home := nqp::substr($perl6-home, 0, nqp::chars($perl6-home) - 1);
 }
 
 my $nqp-home := $comp.config<static_nqp_home>
     // nqp::getenvhash()<NQP_HOME>
-    // $exec-dir ~ '/../share/nqp';
+    // $install-dir ~ '/share/nqp';
 if nqp::substr($nqp-home, nqp::chars($nqp-home) - 1) eq $sep {
     $nqp-home := nqp::substr($nqp-home, 0, nqp::chars($nqp-home) - 1);
 }

--- a/src/perl6-debug.nqp
+++ b/src/perl6-debug.nqp
@@ -461,28 +461,30 @@ sub MAIN(*@ARGS) {
     my $sep    := $config<osname> eq 'MSWin32' ?? '\\' !! '/';
 #?if jvm
     my $execname := nqp::atkey(nqp::jvmgetproperties,'perl6.execname');
-    my $exec-dir := nqp::substr($execname, 0, nqp::rindex($execname, $sep));
+    my $install-dir := nqp::substr($execname, 0, nqp::rindex($execname, $sep, nqp::rindex($execname, $sep) - 1));
 #?endif
 #?if moar
-    my $exec-dir := $config<osname> eq 'openbsd'
+    my $execname := nqp::execname();
+    my $install-dir := $config<osname> eq 'openbsd'
         ?? $config<prefix> ~ '/bin/perl6-m'
-        !! nqp::substr(nqp::execname(), 0, nqp::rindex(nqp::execname(), $sep));
+        !! nqp::substr($execname, 0, nqp::rindex($execname, $sep, nqp::rindex($execname, $sep) - 1));
 #?endif
 #?if js
-    my $exec-dir := $config<osname> eq 'openbsd'
+    my $execname := nqp::execname();
+    my $install-dir := $config<osname> eq 'openbsd'
         ?? $config<prefix> ~ '/bin/perl6-js'
-        !! nqp::substr(nqp::execname(), 0, nqp::rindex(nqp::execname(), $sep));
+        !! nqp::substr($execname, 0, nqp::rindex($execname, $sep, nqp::rindex($execname, $sep) - 1));
 #?endif
     my $perl6-home := $comp.config<static_perl6_home>
         // nqp::getenvhash()<PERL6_HOME>
-        // $exec-dir ~ '/../share/perl6';
+        // $install-dir ~ '/share/perl6';
     if nqp::substr($perl6-home, nqp::chars($perl6-home) - 1) eq $sep {
         $perl6-home := nqp::substr($perl6-home, 0, nqp::chars($perl6-home) - 1);
     }
 
     my $nqp-home := $comp.config<static_nqp_home>
         // nqp::getenvhash()<NQP_HOME>
-        // $exec-dir ~ '/../share/nqp';
+        // $install-dir ~ '/share/nqp';
     if nqp::substr($nqp-home, nqp::chars($nqp-home) - 1) eq $sep {
         $nqp-home := nqp::substr($nqp-home, 0, nqp::chars($nqp-home) - 1);
     }


### PR DESCRIPTION
This in turn results in the repository path specs to not contain any relative path elements. Fixes #2840 