### PR TITLE
Temporary: Fix PERL6/NQP_HOME broken without --execpath

### DIFF
--- a/src/main.nqp
+++ b/src/main.nqp
@@ -2,32 +2,47 @@ use Perl6::Grammar;
 use Perl6::Actions;
 use Perl6::Compiler;
 
-my $config := nqp::backendconfig();
-# Determine Perl6 and NQP dirs.
-my $sep := $config<osname> eq 'MSWin32' ?? '\\' !! '/';
-#?if jvm
-my $execname := nqp::atkey(nqp::jvmgetproperties,'perl6.execname');
-my $install-dir := nqp::substr($execname, 0, nqp::rindex($execname, $sep, nqp::rindex($execname, $sep) - 1));
-#?endif
-#?if moar
-my $execname := nqp::execname();
-my $install-dir := $config<osname> eq 'openbsd'
-    ?? $config<prefix> ~ '/bin/perl6-m'
-    !! nqp::substr($execname, 0, nqp::rindex($execname, $sep, nqp::rindex($execname, $sep) - 1));
-#?endif
-#?if js
-my $execname := nqp::execname();
-my $install-dir := $config<osname> eq 'openbsd'
-    ?? $config<prefix> ~ '/bin/perl6-js'
-    !! nqp::substr($execname, 0, nqp::rindex($execname, $sep, nqp::rindex($execname, $sep) - 1));
-#?endif
-
 
 # Initialize Rakudo runtime support.
 nqp::p6init();
 
 # Create and configure compiler object.
 my $comp := Perl6::Compiler.new();
+
+$comp.language('perl6');
+$comp.parsegrammar(Perl6::Grammar);
+$comp.parseactions(Perl6::Actions);
+$comp.addstage('syntaxcheck', :before<ast>);
+$comp.addstage('optimize', :after<ast>);
+hll-config($comp.config);
+nqp::bindhllsym('perl6', '$COMPILER_CONFIG', $comp.config);
+
+
+# Determine Perl6 and NQP dirs.
+my $config := nqp::backendconfig();
+my $sep := $config<osname> eq 'MSWin32' ?? '\\' !! '/';
+#?if jvm
+my $execname := nqp::atkey(nqp::jvmgetproperties,'perl6.execname');
+my $install-dir := $execname ne ''
+    ?? nqp::substr($execname, 0, nqp::rindex($execname, $sep, nqp::rindex($execname, $sep) - 1))
+    !! $comp.config<prefix>;
+#?endif
+#?if moar
+my $execname := nqp::execname();
+my $install-dir := $config<osname> eq 'openbsd'
+    ?? $config<prefix> ~ '/bin/perl6-m'
+    !! $execname ne ''
+        ?? nqp::substr($execname, 0, nqp::rindex($execname, $sep, nqp::rindex($execname, $sep) - 1))
+        !! $comp.config<prefix>;
+#?endif
+#?if js
+my $execname := nqp::execname();
+my $install-dir := $config<osname> eq 'openbsd'
+    ?? $config<prefix> ~ '/bin/perl6-js'
+    !! $execname ne ''
+        ?? nqp::substr($execname, 0, nqp::rindex($execname, $sep, nqp::rindex($execname, $sep) - 1))
+        !! $comp.config<prefix>;
+#?endif
 
 my $perl6-home := $comp.config<static_perl6_home>
     // nqp::getenvhash()<PERL6_HOME>
@@ -46,13 +61,6 @@ if nqp::substr($nqp-home, nqp::chars($nqp-home) - 1) eq $sep {
 nqp::bindhllsym('perl6', '$PERL6_HOME', $perl6-home);
 nqp::bindhllsym('perl6', '$NQP_HOME', $nqp-home);
 
-$comp.language('perl6');
-$comp.parsegrammar(Perl6::Grammar);
-$comp.parseactions(Perl6::Actions);
-$comp.addstage('syntaxcheck', :before<ast>);
-$comp.addstage('optimize', :after<ast>);
-hll-config($comp.config);
-nqp::bindhllsym('perl6', '$COMPILER_CONFIG', $comp.config);
 
 # Add extra command line options.
 my @clo := $comp.commandline_options();


### PR DESCRIPTION
The previous behavior broke comma debugging, because comma directly calls moar but did not pass an --execpath parameter, thus breaking PERL6_HOME and NQP_HOME detection.
This temporary fix adds a fallback when exec-path is empty to then use the hard coded install path of the configure config. This breaks relocatability in this specific case, but better than not working at all.
Should fix #2850.
I have not tested this with comma yet. Will try to install it now and see how it goes.