### PR TITLE
Don't special case OpenBSD in relocatability handling

### DIFF
--- a/src/main.nqp
+++ b/src/main.nqp
@@ -23,26 +23,13 @@ my $config := nqp::backendconfig();
 my $sep := $config<osname> eq 'MSWin32' ?? '\\' !! '/';
 #?if jvm
 my $execname := nqp::atkey(nqp::jvmgetproperties,'perl6.execname');
-my $install-dir := $execname ne ''
-    ?? nqp::substr($execname, 0, nqp::rindex($execname, $sep, nqp::rindex($execname, $sep) - 1))
-    !! $comp.config<prefix>;
 #?endif
-#?if moar
+#?if !jvm
 my $execname := nqp::execname();
-my $install-dir := $config<osname> eq 'openbsd'
-    ?? $comp.config<prefix>
-    !! $execname ne ''
-        ?? nqp::substr($execname, 0, nqp::rindex($execname, $sep, nqp::rindex($execname, $sep) - 1))
-        !! $comp.config<prefix>;
 #?endif
-#?if js
-my $execname := nqp::execname();
-my $install-dir := $config<osname> eq 'openbsd'
+my $install-dir := $execname eq ''
     ?? $comp.config<prefix>
-    !! $execname ne ''
-        ?? nqp::substr($execname, 0, nqp::rindex($execname, $sep, nqp::rindex($execname, $sep) - 1))
-        !! $comp.config<prefix>;
-#?endif
+    !! nqp::substr($execname, 0, nqp::rindex($execname, $sep, nqp::rindex($execname, $sep) - 1));
 
 my $perl6-home := $comp.config<static_perl6_home>
     // nqp::getenvhash()<PERL6_HOME>

--- a/src/main.nqp
+++ b/src/main.nqp
@@ -25,7 +25,7 @@ my $sep := $config<osname> eq 'MSWin32' ?? '\\' !! '/';
 my $execname := nqp::atkey(nqp::jvmgetproperties,'perl6.execname');
 #?endif
 #?if !jvm
-my $execname := nqp::execname();
+my $execname := $config<osname> eq 'openbsd' ?? '' !! nqp::execname();
 #?endif
 my $install-dir := $execname eq ''
     ?? $comp.config<prefix>

--- a/src/perl6-debug.nqp
+++ b/src/perl6-debug.nqp
@@ -471,26 +471,13 @@ sub MAIN(*@ARGS) {
     my $sep := $config<osname> eq 'MSWin32' ?? '\\' !! '/';
 #?if jvm
     my $execname := nqp::atkey(nqp::jvmgetproperties,'perl6.execname');
-    my $install-dir := $execname ne ''
-        ?? nqp::substr($execname, 0, nqp::rindex($execname, $sep, nqp::rindex($execname, $sep) - 1))
-        !! $comp.config<prefix>;
 #?endif
-#?if moar
+#?if !jvm
     my $execname := nqp::execname();
-    my $install-dir := $config<osname> eq 'openbsd'
-        ?? $config<prefix> ~ '/bin/perl6-m'
-        !! $execname ne ''
-            ?? nqp::substr($execname, 0, nqp::rindex($execname, $sep, nqp::rindex($execname, $sep) - 1))
-            !! $comp.config<prefix>;
 #?endif
-#?if js
-    my $execname := nqp::execname();
-    my $install-dir := $config<osname> eq 'openbsd'
-        ?? $config<prefix> ~ '/bin/perl6-js'
-        !! $execname ne ''
-            ?? nqp::substr($execname, 0, nqp::rindex($execname, $sep, nqp::rindex($execname, $sep) - 1))
-            !! $comp.config<prefix>;
-#?endif
+    my $install-dir := $execname eq ''
+        ?? $comp.config<prefix>
+        !! nqp::substr($execname, 0, nqp::rindex($execname, $sep, nqp::rindex($execname, $sep) - 1));
 
     my $perl6-home := $comp.config<static_perl6_home>
         // nqp::getenvhash()<PERL6_HOME>

--- a/src/perl6-debug.nqp
+++ b/src/perl6-debug.nqp
@@ -473,7 +473,7 @@ sub MAIN(*@ARGS) {
     my $execname := nqp::atkey(nqp::jvmgetproperties,'perl6.execname');
 #?endif
 #?if !jvm
-    my $execname := nqp::execname();
+    my $execname := $config<osname> eq 'openbsd' ?? '' !! nqp::execname();
 #?endif
     my $install-dir := $execname eq ''
         ?? $comp.config<prefix>


### PR DESCRIPTION
Relocatability is disabled entirely on OpenBSD, because of technical
difficulties. So no need to put hacks in to make it work in relocatable
mode.
Also simplify logic a bit more. Should still do the same as before.