### PR TITLE
Document MoarVM specific commandline options

### DIFF
--- a/docs/running.pod
+++ b/docs/running.pod
@@ -30,6 +30,12 @@ compiled code.
   --profile            write profile information as HTML file (MoarVM)
   --profile-filename   provide a different filename (also allows .json)
   --doc=[module]       Use Pod::To::[module] to render inline documentation.
+  --dump               dump the bytecode to stdout instead of executing (MoarVM)
+  --full-cleanup       try to free all memory and exit cleanly (MoarVM)
+  --debug-port=port    listen for incoming debugger connections (MoarVM)
+  --debug-suspend      pause execution at the entry point (MoarVM)
+  --tracing            output a line to stderr on every interpreter instr (only
+                       if enabled in MoarVM)
 
 Note that only boolean single-letter options may be bundled.
 
@@ -138,6 +144,14 @@ C<IO::Spec::Cygwin> inherits this from C<IO::Spec::Unix>.
 
 C<IO::Spec::Win32.path> will read the first defined of either C<%PATH%> or C<%Path%> as a
 semicolon-delimited list.
+
+=item C<PERL6_HOME>
+
+Allows to override the Perl 6 installation path. Defaults to C<[perl6_executable_dir]/../share/perl6>.
+
+=item C<NQP_HOME>
+
+Allows to override the NQP installation path. Defaults to C<[perl6_executable_dir]/../share/nqp>.
 
 =back
 

--- a/docs/running.pod
+++ b/docs/running.pod
@@ -30,7 +30,6 @@ compiled code.
   --profile            write profile information as HTML file (MoarVM)
   --profile-filename   provide a different filename (also allows .json)
   --doc=[module]       Use Pod::To::[module] to render inline documentation.
-  --dump               dump the bytecode to stdout instead of executing (MoarVM)
   --full-cleanup       try to free all memory and exit cleanly (MoarVM)
   --debug-port=port    listen for incoming debugger connections (MoarVM)
   --debug-suspend      pause execution at the entry point (MoarVM)

--- a/src/Perl6/Compiler.nqp
+++ b/src/Perl6/Compiler.nqp
@@ -108,7 +108,6 @@ class Perl6::Compiler is HLL::Compiler {
   --profile-stage=stage
                        write profile information for the given compilation
                        stage to an HTML file
-  --dump               dump the bytecode to stdout instead of executing
   --full-cleanup       try to free all memory and exit cleanly
   --debug-port=port    listen for incoming debugger connections
   --debug-suspend      pause execution at the entry point
@@ -138,7 +137,6 @@ and, by default, also executes the compiled code.
   --stagestats         display time spent in the compilation stages
   --ll-exception       display a low level backtrace on errors
   --doc=module         use Pod::To::[module] to render inline documentation
-
   --repl-mode=interactive|non-interactive
                        when running without "-e" or filename arguments,
                        a REPL is started. By default, if STDIN is a TTY,
@@ -149,7 +147,6 @@ and, by default, also executes the compiled code.
                        loaded). This option allows to bypass TTY detection and
                        force one of the REPL modes.
 $moar-options
-
 Note that only boolean single-letter options may be bundled.
 
 The following environment variables are respected:
@@ -157,9 +154,6 @@ The following environment variables are respected:
   PERL6LIB    Modify the module search path
   PERL6_HOME  Override the path of the Perl6 runtime files
   NQP_HOME    Override the path of the NQP runtime files
-
-
-
 
 ♥); # end of usage statement
 

--- a/src/Perl6/Compiler.nqp
+++ b/src/Perl6/Compiler.nqp
@@ -86,34 +86,16 @@ class Perl6::Compiler is HLL::Compiler {
 
     method usage($name?, :$use-stderr = False) {
 	my $print-func := $use-stderr ?? &note !! &say; # RT #130760
-        $print-func(($name ?? $name !! "") ~ q♥ [switches] [--] [programfile] [arguments]
-
-With no arguments, enters a REPL (see --repl-mode option).
-With a "[programfile]" or the "-e" option, compiles the given program
-and, by default, also executes the compiled code.
-
-  -c                   check syntax only (runs BEGIN and CHECK blocks)
-  --doc                extract documentation and print it as text
-  -e program           one line of program, strict is enabled by default
-  -h, --help           display this help text
-  -n                   run program once for each line of input
-  -p                   same as -n, but also print $_ at the end of lines
-  -I path              adds the path to the module search path
-  -M module            loads the module prior to running the program
-  --target=stage       specify compilation stage to emit
-  --optimize=level     use the given level of optimization (0..3)
-  -o, --output=name    specify name of output file
-  -v, --version        display version information
-  -V                   print configuration summary
-  --stagestats         display time spent in the compilation stages
-  --ll-exception       display a low level backtrace on errors
-  --profile[=kind]     write profile information to an HTML file (MoarVM)
+    my $compiler := nqp::getcomp("perl6").backend.name;
+    my $moar-options := '';
+    if nqp::getcomp("perl6").backend.name eq 'moar' {
+        $moar-options := q♥  --profile[=kind]     write profile information to an HTML file
                          instrumented - performance measurements (default)
                          heap - record heap snapshots after every garbage
                          collector run
   --profile-compile[=kind]
                        write compile-time profile information to an HTML
-                       file (MoarVM)
+                       file
                          instrumented - performance measurements (default)
                          heap - record heap snapshots after every garbage
                          collector run
@@ -125,7 +107,36 @@ and, by default, also executes the compiled code.
                          any other extension outputs in HTML
   --profile-stage=stage
                        write profile information for the given compilation
-                       stage to an HTML file (MoarVM)
+                       stage to an HTML file
+  --dump               dump the bytecode to stdout instead of executing
+  --full-cleanup       try to free all memory and exit cleanly
+  --debug-port=port    listen for incoming debugger connections
+  --debug-suspend      pause execution at the entry point
+  --tracing            output a line to stderr on every interpreter instr (only if
+                       enabled in MoarVM)
+♥;
+    }
+    $print-func(($name ?? $name !! "") ~ qq♥ [switches] [--] [programfile] [arguments]
+
+With no arguments, enters a REPL (see --repl-mode option).
+With a "[programfile]" or the "-e" option, compiles the given program
+and, by default, also executes the compiled code.
+
+  -c                   check syntax only (runs BEGIN and CHECK blocks)
+  --doc                extract documentation and print it as text
+  -e program           one line of program, strict is enabled by default
+  -h, --help           display this help text
+  -n                   run program once for each line of input
+  -p                   same as -n, but also print \$_ at the end of lines
+  -I path              adds the path to the module search path
+  -M module            loads the module prior to running the program
+  --target=stage       specify compilation stage to emit
+  --optimize=level     use the given level of optimization (0..3)
+  -o, --output=name    specify name of output file
+  -v, --version        display version information
+  -V                   print configuration summary
+  --stagestats         display time spent in the compilation stages
+  --ll-exception       display a low level backtrace on errors
   --doc=module         use Pod::To::[module] to render inline documentation
 
   --repl-mode=interactive|non-interactive
@@ -137,6 +148,7 @@ and, by default, also executes the compiled code.
                        without any extra output (in fact, no REPL machinery is even
                        loaded). This option allows to bypass TTY detection and
                        force one of the REPL modes.
+$moar-options
 
 Note that only boolean single-letter options may be bundled.
 

--- a/src/vm/moar/runner/main.c
+++ b/src/vm/moar/runner/main.c
@@ -34,6 +34,7 @@ enum {
     UNKNOWN_FLAG = -1,
 
     FLAG_SUSPEND,
+    FLAG_FULL_CLEANUP,
     FLAG_TRACING,
 
     OPT_DEBUGPORT
@@ -154,6 +155,7 @@ int wmain(int argc, wchar_t *wargv[])
     char **argv = MVM_UnicodeToUTF8_argv(argc, wargv);
 #endif
 
+    int full_cleanup = 0;
     int argi         = 1;
     int flag;
     int new_argc     = 0;
@@ -168,6 +170,9 @@ int wmain(int argc, wchar_t *wargv[])
 
     for (; (flag = parse_flag(argv[argi])) != NOT_A_FLAG; ++argi) {
         switch (flag) {
+            case FLAG_FULL_CLEANUP:
+            full_cleanup = 1;
+            continue;
 
 #if MVM_TRACING
             case FLAG_TRACING:
@@ -342,7 +347,13 @@ int wmain(int argc, wchar_t *wargv[])
     }
 #endif
 
-    MVM_vm_exit(instance);
+    if (full_cleanup) {
+        MVM_vm_destroy_instance(instance);
+        return EXIT_SUCCESS;
+    }
+    else {
+        MVM_vm_exit(instance);
+    }
 
     free(lib_path[0]);
     free(lib_path[1]);

--- a/src/vm/moar/runner/main.c
+++ b/src/vm/moar/runner/main.c
@@ -34,7 +34,6 @@ enum {
     UNKNOWN_FLAG = -1,
 
     FLAG_SUSPEND,
-    FLAG_DUMP,
     FLAG_TRACING,
 
     OPT_DEBUGPORT
@@ -42,7 +41,6 @@ enum {
 
 static const char *const FLAGS[] = {
     "--debug-suspend",
-    "--dump",
     "--full-cleanup",
     "--tracing",
 };
@@ -156,7 +154,6 @@ int wmain(int argc, wchar_t *wargv[])
     char **argv = MVM_UnicodeToUTF8_argv(argc, wargv);
 #endif
 
-    int dump         = 0;
     int argi         = 1;
     int flag;
     int new_argc     = 0;
@@ -171,9 +168,6 @@ int wmain(int argc, wchar_t *wargv[])
 
     for (; (flag = parse_flag(argv[argi])) != NOT_A_FLAG; ++argi) {
         switch (flag) {
-            case FLAG_DUMP:
-            dump = 1;
-            continue;
 
 #if MVM_TRACING
             case FLAG_TRACING:
@@ -339,8 +333,7 @@ int wmain(int argc, wchar_t *wargv[])
         }
     }
 
-    if (dump) MVM_vm_dump_file(instance, perl6_file);
-    else MVM_vm_run_file(instance, perl6_file);
+    MVM_vm_run_file(instance, perl6_file);
 
 #ifdef HAVE_TELEMEH
     if (getenv("MVM_TELEMETRY_LOG") && telemeh_inited) {


### PR DESCRIPTION
Several perl6 commandline options are specific to MoarVM. Only show
those when running on MoarVM. Add the missing ones. Also add documentation
for PERL6_HOME and NQP_HOME.