### PR TITLE
Fix off-by-one error in infinite range subscript

### DIFF
--- a/src/core/array_slice.pm6
+++ b/src/core/array_slice.pm6
@@ -57,9 +57,9 @@ multi sub POSITIONS(
     # we can optimize `42..*` Ranges; as long as they're from core, unmodified
     my \is-pos-lazy = pos.is-lazy;
     my \pos-iter    = nqp::eqaddr(pos.WHAT,Range)
-        && nqp::eqaddr(pos.max,Inf)
+        && pos.max === Inf
         && nqp::isfalse(SELF.is-lazy)
-          ?? Range.new(pos.min, SELF.elems-1,
+          ?? Range.new(pos.min, SELF.elems,
               :excludes-min(pos.excludes-min),
               :excludes-max(pos.excludes-max)
           ).iterator


### PR DESCRIPTION
Subscripting with an infinite range was inconsistent between `0 ..^ Inf`
and `0 ..^ *`. This commit makes both behave like the former:

``` perl6
(^3)[0 ..  Inf] eqv (0,1,2)
(^3)[0 ..^ Inf] eqv (0,1,2)  # Inf-1 is Inf
(^3)[0 ..  *]   eqv (0,1,2)
(^3)[0 ..^ *]   eqv (0,1,2)  # used to be (0,1)
```

The difference came from an `nqp::eqaddr(pos.max, Inf)` condition which
the `0 .. Inf` range did *not* pass but the `0 .. *` one did. Result
of that condition was treating the range as if it had upper endpoint
`.elems - 1` which seems off-by-one. Notice that there is no behavior
specified for this in roast.

Setting it to `.elems` instead makes it at least consistent with
WhateverCode passed to the subscript:

``` perl6
(^3)[0 ..^ *].tail == (^3)[*-1]  # True with this commit
```

Closes #2872.

***

Relevant IRC: https://colabti.org/irclogger/irclogger_log/perl6?date=2019-05-02#l1027

This change in semantics is very much up to discussion. As I said in the commit message, roast does not specify the behavior of an infinite range with `:excludes-max` and the current difference between `Inf` and `*` was caused by an `nqp::eqaddr` failing for reasons I don't understand. It is also the only place where that is used to compare to `Inf`... The difference is apparent though:
``` perl6
use nqp;
say nqp::eqaddr((1..Inf).max, Inf);  #= 1
say nqp::eqaddr((1..*).max, Inf);    #= 0
say (1..*).max.WHICH;                #= Num|Inf
```
It's just that in the code this commit touches, the return values of `nqp::eqaddr` were the other way around(?).

Roast and documentation changes will follow if this is accepted.