### PR TITLE
Fix for Configure.pl options when only --gen-moar is used

### DIFF
--- a/tools/lib/NQP/Config/Rakudo.pm
+++ b/tools/lib/NQP/Config/Rakudo.pm
@@ -327,6 +327,7 @@ sub ignorable_opt {
                     | make-install
                     | expand
                     | out
+                    | backends
                   ) 
                   $
             )

--- a/tools/templates/Makefile-common-macros.in
+++ b/tools/templates/Makefile-common-macros.in
@@ -1,7 +1,7 @@
 # Copyright (C) 2015 The Perl Foundation
 
 PERL5   = @shquot(@perl@)@ -I@nfpq(@base_dir@/tools/lib)@ -I@nfpq(@base_dir@/3rdparty/nqp-configure/lib)@
-CONFIGURE = $(PERL5) @shquot(@configure_script@)@ @configure_opts@
+CONFIGURE = $(PERL5) @shquot(@configure_script@)@ @configure_opts()@
 MKPATH  = @mkpath@
 CHMOD   = @chmod@
 CP      = @cp@


### PR DESCRIPTION
Since `--gen-moar` is not passed down to Configure.pl calls used to expand templates, they require explicit `--backends=moar` 