### PR TITLE
Make feed operators more compliant with the spec

### DIFF
--- a/src/core/feed.pm6
+++ b/src/core/feed.pm6
@@ -1,0 +1,28 @@
+# Rakudo::Internals.EVALUATE-FEED takes a source and a list of stages, which
+# are callbacks that make routine calls, and runs them in parallel. In the
+# following code:
+#
+# my @squares <== map { $_ ** 2 } <== 1...*;
+#
+# 1...* is the source and stages includes just one callback, which calls
+# `map { $_ ** 2 }, $source`. The result is then stored in @squares from
+# Perl6::Actions.
+
+augment class Rakudo::Internals {
+    method EVALUATE-FEED(Mu $source, @stages) {
+        my Channel $pipeline .= new;
+        $pipeline.send: $source;
+
+        await @stages.map(-> &stage {
+            start {
+                my Mu $input  := $pipeline.receive;
+                my Mu $output := nqp::decont(nqp::call(&stage, $input));
+                $pipeline.send: $output;
+            }
+        });
+
+        my Mu $result := $pipeline.receive;
+        $pipeline.close;
+        $result
+    }
+}

--- a/tools/templates/js/core_sources
+++ b/tools/templates/js/core_sources
@@ -170,6 +170,7 @@ src/core/Promise.pm6
 src/core/Channel.pm6
 src/core/Supply.pm6
 src/core/asyncops.pm6
+src/core/feed.pm6
 src/core/IO/Socket.pm6
 src/core/IO/Socket/INET.pm6
 src/core/IO/Socket/Async.pm6

--- a/tools/templates/jvm/jvm_core_sources
+++ b/tools/templates/jvm/jvm_core_sources
@@ -168,6 +168,7 @@ src/core/Channel.pm6
 src/core/Supply.pm6
 src/core/asyncops.pm6
 src/core/atomicops.pm6
+src/core/feed.pm6
 src/core/IO/Socket.pm6
 src/core/IO/Socket/INET.pm6
 src/core/IO/Socket/Async.pm6

--- a/tools/templates/moar/moar_core_sources
+++ b/tools/templates/moar/moar_core_sources
@@ -170,6 +170,7 @@ src/core/Promise.pm6
 src/core/Channel.pm6
 src/core/Supply.pm6
 src/core/asyncops.pm6
+src/core/feed.pm6
 src/core/IO/Socket.pm6
 src/core/IO/Socket/INET.pm6
 src/core/IO/Socket/Async.pm6


### PR DESCRIPTION
This speeds up use of feed operators by roughly 650%. Using feed
operators is now even faster than directly calling methods on lists.

This passes `make test`, but fails one test on `make spectest` that depends on using feed operators on lazy lists throwing.

A side effect of this is the output generated by feed operators is now `List`, not `Array`. This may break packages that depend on the output being mutable.