### PR TITLE
Fix for 'Missing or wrong version of dependency' 

### DIFF
--- a/tools/lib/NQP/Config/Rakudo.pm
+++ b/tools/lib/NQP/Config/Rakudo.pm
@@ -6,7 +6,6 @@ package NQP::Config::Rakudo;
 use Cwd;
 use POSIX qw<strftime>;
 use Digest::SHA;
-use File::Find;
 use NQP::Config qw<slurp read_config cmp_rev system_or_die run_or_die>;
 use IPC::Cmd qw<run>;
 use NQP::Macros;
@@ -473,6 +472,7 @@ sub gen_nqp {
 package NQP::Macros::Rakudo;
 use strict;
 use warnings;
+use File::Find;
 
 # --- Rakudo-specific macro methods.
 sub _specs_iterate {
@@ -560,7 +560,7 @@ sub _m_source_digest {
 
 NQP::Macros->register_macro( 'for_specs',     \&_m_for_specs );
 NQP::Macros->register_macro( 'for_specmods',  \&_m_for_specmods );
-NQP::Macros->register_macro( 'source_digest', \&_m_for_specmods );
+NQP::Macros->register_macro( 'source_digest', \&_m_source_digest );
 
 1;
 

--- a/tools/templates/Makefile-common-macros.in
+++ b/tools/templates/Makefile-common-macros.in
@@ -16,7 +16,7 @@ PREFIX     = @nfp(@prefix@)@
 LIBDIR     = @nfp(@libdir@)@
 NQP_HOME   = $(LIBDIR)@nfp(/nqp)@
 PERL6_HOME = $(LIBDIR)@nfp(/perl6)@
-BASE_DIR   = @@base_dir@@
+BASE_DIR   = @base_dir@
 
 BOOTSTRAP_SOURCES = \
   @nfp(src/Perl6/Metamodel/BOOTSTRAP.nqp)@ \
@@ -25,12 +25,12 @@ BOOTSTRAP_SOURCES = \
 COMMON_BOOTSTRAP_SOURCES = \
     @insert_filelist(common_bootstrap_sources)@
 
-NQP_CONF_DIR = @@nfp($(BASE_DIR)/3rdparty/nqp-configure/lib)@@
+NQP_CONFIG_DIR = @nfp(3rdparty/nqp-configure/lib)@
 
 CONFIGURE_SOURCES = \
-	@nfp($(BASE_DIR)/Configure.pl)@ \
-	@nfp($(BASE_DIR)/tools/lib/NQP/Config/Rakudo.pm)@ \
-	@nfp($(NQP_CONF_DIR)/NQP/Config.pm)@ \
-	@nfp($(NQP_CONF_DIR)/NQP/Macros.pm)@ 
+	Configure.pl \
+	@nfp(tools/lib/NQP/Config/Rakudo.pm)@ \
+	@nfp($(NQP_CONFIG_DIR)/NQP/Config.pm)@ \
+	@nfp($(NQP_CONFIG_DIR)/NQP/Macros.pm)@ 
 
 R_SETTING_SRC = @nfp(src/RESTRICTED.setting)@

--- a/tools/templates/Makefile-common-macros.in
+++ b/tools/templates/Makefile-common-macros.in
@@ -16,7 +16,7 @@ PREFIX     = @nfp(@prefix@)@
 LIBDIR     = @nfp(@libdir@)@
 NQP_HOME   = $(LIBDIR)@nfp(/nqp)@
 PERL6_HOME = $(LIBDIR)@nfp(/perl6)@
-BASE_DIR   = @base_dir@
+BASE_DIR   = @@base_dir@@
 
 BOOTSTRAP_SOURCES = \
   @nfp(src/Perl6/Metamodel/BOOTSTRAP.nqp)@ \
@@ -24,5 +24,13 @@ BOOTSTRAP_SOURCES = \
 
 COMMON_BOOTSTRAP_SOURCES = \
     @insert_filelist(common_bootstrap_sources)@
+
+NQP_CONF_DIR = @@nfp($(BASE_DIR)/3rdparty/nqp-configure/lib)@@
+
+CONFIGURE_SOURCES = \
+	@nfp($(BASE_DIR)/Configure.pl)@ \
+	@nfp($(BASE_DIR)/tools/lib/NQP/Config/Rakudo.pm)@ \
+	@nfp($(NQP_CONF_DIR)/NQP/Config.pm)@ \
+	@nfp($(NQP_CONF_DIR)/NQP/Macros.pm)@ 
 
 R_SETTING_SRC = @nfp(src/RESTRICTED.setting)@

--- a/tools/templates/moar/Makefile.in
+++ b/tools/templates/moar/Makefile.in
@@ -166,13 +166,13 @@ $(PERL6_C_MOAR): @nfp(src/Perl6/Compiler.nqp)@ $(PERL6_O_MOAR)
 	$(M_NQP) --module-path=blib --target=mbc --output=$(PERL6_C_MOAR) \
 		@nfp(src/Perl6/Compiler.nqp)@
 
-@@nfp($(M_BUILD_DIR)/main-version.nqp)@@: @@template(main-version)@@ $(CONFIGURE_SOURCES) $(M_METAMODEL_SOURCES) $(M_BOOTSTRAP_SOURCES) $(M_CORE_SOURCES)@for_specs( $(M_CORE_@ucspec@_SOURCES))@
+@nfp($(M_BUILD_DIR)/main-version.nqp)@: @@template(main-version)@@ $(CONFIGURE_SOURCES) $(M_METAMODEL_SOURCES) $(M_BOOTSTRAP_SOURCES) $(M_CORE_SOURCES)@for_specs( $(M_CORE_@ucspec@_SOURCES))@
 	$(CONFIGURE) --expand main-version --out @nfpq($(M_BUILD_DIR)/main-version.nqp)@
 
-@@nfp($(M_BUILD_DIR)/main.nqp)@@: @@nfp($(M_BUILD_DIR)/main-version.nqp)@@ @@nfp($(BASE_DIR)/src/main.nqp)@@
+@nfp($(M_BUILD_DIR)/main.nqp)@: @nfp($(M_BUILD_DIR)/main-version.nqp)@ @nfp(src/main.nqp)@
 	$(M_NQP) $(M_GEN_CAT) @nfpl(src/main.nqp $(M_BUILD_DIR)/main-version.nqp > $(M_BUILD_DIR)/main.nqp)@
 
-$(PERL6_MOAR): @@nfp($(M_BUILD_DIR)/main.nqp)@@ $(PERL6_G_MOAR) $(PERL6_A_MOAR) $(PERL6_C_MOAR) $(PERL6_P_MOAR)
+$(PERL6_MOAR): @nfp($(M_BUILD_DIR)/main.nqp)@ $(PERL6_G_MOAR) $(PERL6_A_MOAR) $(PERL6_C_MOAR) $(PERL6_P_MOAR)
 	$(M_NQP) --module-path=blib --target=mbc --output=$(PERL6_MOAR) \
 		--vmlibs=$(M_PERL6_OPS_DLL)=Rakudo_ops_init @nfpq($(M_BUILD_DIR)/main.nqp)@
 

--- a/tools/templates/moar/Makefile.in
+++ b/tools/templates/moar/Makefile.in
@@ -166,9 +166,13 @@ $(PERL6_C_MOAR): @nfp(src/Perl6/Compiler.nqp)@ $(PERL6_O_MOAR)
 	$(M_NQP) --module-path=blib --target=mbc --output=$(PERL6_C_MOAR) \
 		@nfp(src/Perl6/Compiler.nqp)@
 
-$(PERL6_MOAR): @nfp(src/main.nqp)@ $(PERL6_G_MOAR) $(PERL6_A_MOAR) $(PERL6_C_MOAR) $(PERL6_P_MOAR) $(M_METAMODEL_SOURCES) $(M_BOOTSTRAP_SOURCES) $(M_CORE_SOURCES)@for_specs( $(M_CORE_@ucspec@_SOURCES))@
+@@nfp($(M_BUILD_DIR)/main-version.nqp)@@: @@template(main-version)@@ $(CONFIGURE_SOURCES) $(M_METAMODEL_SOURCES) $(M_BOOTSTRAP_SOURCES) $(M_CORE_SOURCES)@for_specs( $(M_CORE_@ucspec@_SOURCES))@
 	$(CONFIGURE) --expand main-version --out @nfpq($(M_BUILD_DIR)/main-version.nqp)@
+
+@@nfp($(M_BUILD_DIR)/main.nqp)@@: @@nfp($(M_BUILD_DIR)/main-version.nqp)@@ @@nfp($(BASE_DIR)/src/main.nqp)@@
 	$(M_NQP) $(M_GEN_CAT) @nfpl(src/main.nqp $(M_BUILD_DIR)/main-version.nqp > $(M_BUILD_DIR)/main.nqp)@
+
+$(PERL6_MOAR): @@nfp($(M_BUILD_DIR)/main.nqp)@@ $(PERL6_G_MOAR) $(PERL6_A_MOAR) $(PERL6_C_MOAR) $(PERL6_P_MOAR)
 	$(M_NQP) --module-path=blib --target=mbc --output=$(PERL6_MOAR) \
 		--vmlibs=$(M_PERL6_OPS_DLL)=Rakudo_ops_init @nfpq($(M_BUILD_DIR)/main.nqp)@
 


### PR DESCRIPTION
source_digest macro was incorrectly registered.

Improved moar/Makefile to rebuild main-version.nqp and main.nqp when
necessary.