### PR TITLE
Parallelize feed operators and support lazy lists

### DIFF
--- a/src/core/feed.pm6
+++ b/src/core/feed.pm6
@@ -1,0 +1,28 @@
+# Rakudo::Internals.EVALUATE-FEED takes a source and a list of stages, which
+# are callbacks that make routine calls, and runs them in parallel. In the
+# following code:
+#
+# my @squares <== map { $_ ** 2 } <== 1...*;
+#
+# 1...* is the source and stages includes just one callback, which calls
+# `map { $_ ** 2 }, $source`. The result is then stored in @squares from
+# Perl6::Actions.
+
+augment class Rakudo::Internals {
+    method EVALUATE-FEED(Mu $source, @stages) {
+        my Channel $pipeline .= new;
+        $pipeline.send: nqp::decont($source);
+
+        await @stages.map(-> &stage {
+            start {
+                my Mu $input  := $pipeline.receive;
+                my Mu $output := nqp::decont(nqp::call(&stage, $input));
+                $pipeline.send: $output;
+            }
+        });
+
+        my Mu $result := $pipeline.receive;
+        $pipeline.close;
+        $result
+    }
+}

--- a/src/core/feed.pm6
+++ b/src/core/feed.pm6
@@ -6,7 +6,7 @@
 #
 # 1...* is the source and stages includes just one callback, which calls
 # `map { $_ ** 2 }, $source`. The result is then stored in @squares from
-# Perl6::Actions.
+# Perl6::Actions (by &make_feed and &make_feed_result specifically).
 
 augment class Rakudo::Internals {
     my class Pipeline is repr('ConcBlockingQueue') {}
@@ -14,13 +14,26 @@ augment class Rakudo::Internals {
     method EVALUATE-FEED(Mu $source is raw, *@stages) {
         my Pipeline $pipeline := nqp::create(Pipeline);
         nqp::push($pipeline, $source);
+
         await @stages.map(-> &stage {
             start {
                 my Mu $input  := nqp::shift($pipeline);
                 my Mu $output := &stage($input);
+
+                # If $input does Sequence and the current stage returns the
+                # same Sequence instance, its iterator will be consumed and an
+                # exception will be thrown on the call to the next stage. The
+                # solution to this is to push $output's cache to the pipeline
+                # rather than $output itself when this is the case.
+                nqp::if(
+                  nqp::istype($output, Sequence),
+                  ($output := $output.cache)
+                );
+
                 nqp::push($pipeline, $output);
             }
         });
+
         nqp::shift($pipeline)
     }
 }

--- a/tools/templates/core_sources
+++ b/tools/templates/core_sources
@@ -171,6 +171,7 @@ src/core/Promise.pm6
 src/core/Channel.pm6
 src/core/Supply.pm6
 src/core/asyncops.pm6
+src/core/feed.pm6
 src/core/IO/Socket.pm6
 src/core/IO/Socket/INET.pm6
 src/core/IO/Socket/Async.pm6

--- a/tools/templates/moar/moar_core_sources
+++ b/tools/templates/moar/moar_core_sources
@@ -164,7 +164,7 @@ src/core/Awaitable.pm6
 src/core/Awaiter.pm6
 src/core/Scheduler.pm6
 src/core/Env.pm6
-src/core/JavaScriptScheduler.pm6
+src/core/ThreadPoolScheduler.pm6
 src/core/CurrentThreadScheduler.pm6
 src/core/Promise.pm6
 src/core/Channel.pm6
@@ -175,7 +175,6 @@ src/core/IO/Socket.pm6
 src/core/IO/Socket/INET.pm6
 src/core/IO/Socket/Async.pm6
 src/core/Proc.pm6
-src/vm/js/FakeRun.pm6
 src/core/signals.pm6
 src/core/Proc/Async.pm6
 src/core/Systemic.pm6
@@ -207,12 +206,10 @@ src/core/CompUnit/Repository/AbsolutePath.pm6
 src/core/CompUnit/Repository/NQP.pm6
 src/core/CompUnit/Repository/Perl5.pm6
 src/core/CompUnit/Repository/Unknown.pm6
-src/vm/js/CompUnit/Repository/FileSystemWithRecording.pm6
 src/core/Argfiles.pm6
 src/core/Process.pm6
 src/core/Slang.pm6
 src/core/Metamodel/Primitives.pm6
 src/core/REPL.pm6
-src/core/WrappedJSObject.pm6
 src/core/Rakudo/Metaops.pm6
 src/core/core_epilogue.pm6


### PR DESCRIPTION
This brings feed operators (`==>` and `<==` at least) more in line with the spec.

Passes `make test`, fails `make spectest` since one of its tests expects trying to use lazy lists with feed operators to throw.