### PR TITLE
Parse `a & a` as a conjunction, not concat

### DIFF
--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -5582,7 +5582,7 @@ grammar Perl6::RegexGrammar is QRegex::P6Regex::Grammar does STD does MatchPacka
     }
 
     token metachar:sym<rakvar> {
-        <?before <.sigil> $<twigil>=[<.alpha> | \W<.alpha> | '(']>
+        <?before <.sigil> $<twigil>=[<.alpha> | <+[\W]-[\s]><.alpha> | '(']>
         <!before <.sigil> <.rxstopper> >
         <var=.LANG('MAIN', 'variable')>
         [


### PR DESCRIPTION
Needed to fix https://github.com/rakudo/rakudo/issues/2901
jnthn++ for the actual fix.

Requires nqp patch to be accepted to fix another detected issue: https://github.com/perl6/nqp/pull/540

See https://colabti.org/irclogger/irclogger_log/perl6?date=2019-05-17#l815 and https://colabti.org/irclogger/irclogger_log/perl6?date=2019-05-18#l13 for full discussion.