### PR TITLE
Change URL of 3rdparty/nqp-configure submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "3rdparty/nqp-configure"]
 	path = 3rdparty/nqp-configure
-	url = https://github.com/vrurg/nqp-configure.git
+	url = https://github.com/perl6/nqp-configure.git


### PR DESCRIPTION
Ownership of nqp-configure repo has been transferred to Perl6
organization.

It is recommended to run:

git submodule sync
git submodule update --init --recursive --remote