### PR TITLE
Fix slurp error during Configure.pl

### DIFF
--- a/Configure.pl
+++ b/Configure.pl
@@ -30,7 +30,7 @@ qx{git submodule sync --quiet 3rdparty/nqp-configure && git submodule --quiet up
 
 use lib ( "$FindBin::Bin/tools/lib",
     "$FindBin::Bin/3rdparty/nqp-configure/lib" );
-use NQP::Config qw<system_or_die>;
+use NQP::Config qw<system_or_die slurp>;
 use NQP::Config::Rakudo;
 
 $| = 1;


### PR DESCRIPTION
Was getting this error:
Undefined subroutine &main::slurp called at Configure.pl line 48.
when I run:
Configure.pl --gen-moar --gen-nqp --backends=moar --make-install