### PR TITLE
Allow capture argument to MAIN to accept arguments

### DIFF
--- a/src/core/Main.pm6
+++ b/src/core/Main.pm6
@@ -266,6 +266,7 @@ my sub RUN-MAIN(&main, $mainline, :$in-as-argsfiles) {
     }
 
     sub has-unexpected-named-arguments($signature, %named-arguments) {
+        return False if $signature.params.first: *.capture;
         my @named-params = $signature.params.grep: *.named;
         return False if @named-params.first: *.slurpy;
 


### PR DESCRIPTION
Previously RUN-MAIN would erroneously reject a sub MAIN(|capture), with this patch it will accept this. This is probably not useful for real programs, but it useful in debugging the arguments parser. e.g.
~~~~shell
perl6 -e 'sub MAIN(|capture) { dd capture }' --update=More
~~~~