### PR TITLE
fix install-dist

### DIFF
--- a/tools/install-dist.p6
+++ b/tools/install-dist.p6
@@ -52,7 +52,7 @@ multi sub MAIN(:from(:$dist-prefix) = '.', :to(:$repo-prefix)!, :for(:$repo-name
         :name($repo-name),
     ).install($dist);
 
-    $_.unlink for <version repo.lock precomp/.lock>.map: {$repo-prefix.IO.child($_)};
+    $_.unlink for <repo.lock precomp/.lock>.map: {$repo-prefix.IO.child($_)};
 }
 
 multi sub MAIN(:from(:$dist-prefix) = '.', :to(:$repo-id) = 'site', Bool :$force) {


### PR DESCRIPTION
It was deleting the `version` file from the installed dist, rendering it
impossible to import (because CompUnitRepo::Installation.candidates
assumes a dist without a version file is version 0 and tries to
.lines its short/ directory, which does not go well).