### PR TITLE
Move the core comp unit repo to a separate folder

### DIFF
--- a/src/core/CompUnit/RepositoryRegistry.pm6
+++ b/src/core/CompUnit/RepositoryRegistry.pm6
@@ -109,7 +109,7 @@ class CompUnit::RepositoryRegistry {
         # set up custom libs
         my str $site   = "inst#{$prefix}{$sep}site";
         my str $vendor = "inst#{$prefix}{$sep}vendor";
-        my str $perl   = "inst#$prefix";
+        my str $perl   = "inst#{$prefix}{$sep}core";
 
         # your basic repo chain
         my CompUnit::Repository $next-repo :=
@@ -142,7 +142,7 @@ class CompUnit::RepositoryRegistry {
         unless $precomp-specs {
             nqp::bindkey($custom-lib, 'perl', $next-repo := self!register-repository(
                 $perl,
-                CompUnit::Repository::Installation.new(:prefix($prefix), :$next-repo)
+                CompUnit::Repository::Installation.new(:prefix("$prefix/core"), :$next-repo)
             )) unless nqp::existskey($unique, $perl);
             nqp::bindkey($custom-lib, 'vendor', $next-repo := self!register-repository(
                 $vendor,

--- a/src/core/CompUnit/RepositoryRegistry.pm6
+++ b/src/core/CompUnit/RepositoryRegistry.pm6
@@ -109,7 +109,7 @@ class CompUnit::RepositoryRegistry {
         # set up custom libs
         my str $site   = "inst#{$prefix}{$sep}site";
         my str $vendor = "inst#{$prefix}{$sep}vendor";
-        my str $perl   = "inst#{$prefix}{$sep}core";
+        my str $core   = "inst#{$prefix}{$sep}core";
 
         # your basic repo chain
         my CompUnit::Repository $next-repo :=
@@ -140,10 +140,10 @@ class CompUnit::RepositoryRegistry {
         }
 
         unless $precomp-specs {
-            nqp::bindkey($custom-lib, 'perl', $next-repo := self!register-repository(
-                $perl,
+            nqp::bindkey($custom-lib, 'core', $next-repo := self!register-repository(
+                $core,
                 CompUnit::Repository::Installation.new(:prefix("$prefix/core"), :$next-repo)
-            )) unless nqp::existskey($unique, $perl);
+            )) unless nqp::existskey($unique, $core);
             nqp::bindkey($custom-lib, 'vendor', $next-repo := self!register-repository(
                 $vendor,
                 CompUnit::Repository::Installation.new(:prefix("$prefix/vendor"), :$next-repo)
@@ -169,13 +169,13 @@ class CompUnit::RepositoryRegistry {
         }
 
         # register manually set custom-lib repos
-        unless nqp::existskey($custom-lib, 'perl') {
-            my $repo := nqp::atkey($repos, $perl);
+        unless nqp::existskey($custom-lib, 'core') {
+            my $repo := nqp::atkey($repos, $core);
             if nqp::isnull($repo) {
-                nqp::deletekey($custom-lib, 'perl');
+                nqp::deletekey($custom-lib, 'core');
             }
             else {
-                nqp::bindkey($custom-lib, 'perl', $repo);
+                nqp::bindkey($custom-lib, 'core', $repo);
             }
         }
         unless nqp::existskey($custom-lib, 'vendor') {

--- a/tools/build/install-core-dist.p6
+++ b/tools/build/install-core-dist.p6
@@ -22,16 +22,16 @@ PROCESS::<$REPO> := CompUnit::Repository::Staging.new(
         # Make CompUnit::Repository::Staging available to precomp processes
         CompUnit::Repository::Installation.new(
             :prefix(@*ARGS[0]),
-            :next-repo(CompUnit::RepositoryRegistry.repository-for-name('perl')),
+            :next-repo(CompUnit::RepositoryRegistry.repository-for-name('core')),
         )
     ),
-    :name('perl'),
+    :name('core'),
 );
 $*REPO.install(
     Distribution::Hash.new(
         {
-            name     => "CORE",
-            auth     => "perl",
+            name     => 'CORE',
+            auth     => 'perl',
             ver      => $*PERL.version.Str,
             provides => %provides,
         },
@@ -50,7 +50,7 @@ my $source-file = $source.relative($*REPO.prefix);
 $*REPO.precomp-repository.precompile(
         $source,
         CompUnit::PrecompilationId.new($source-id),
-        :source-name("perl#$source-file (CompUnit::Repository::Staging)"),
+        :source-name("core#$source-file (CompUnit::Repository::Staging)"),
         :force,
     );
 

--- a/tools/templates/moar/Makefile.in
+++ b/tools/templates/moar/Makefile.in
@@ -363,10 +363,10 @@ m-install: m-all @@script(install-core-dist.p6)@@ $(SETTING_MOAR)
 	$(CP) $(M_PERL6_OPS_DLL) @nfpq($(DESTDIR)$(PERL6_HOME)/runtime/dynext)@
 	$(CP) $(M_INST_PERL6_M) @nfpq($(DESTDIR)$(PREFIX)/bin/$(M_PERL6_M))@
 	$(CP) $(M_INST_PERL6_DEBUG_M) @nfpq($(DESTDIR)$(PREFIX)/bin/$(M_PERL6_DEBUG_M))@
-	@nfpq($(BASE_DIR)/$(M_BAT_RUNNER))@ @shquot(@script(upgrade-repository.p6)@)@ @q($(DESTDIR)$(PERL6_HOME))@
+	@nfpq($(BASE_DIR)/$(M_BAT_RUNNER))@ @shquot(@script(upgrade-repository.p6)@)@ @nfpq($(DESTDIR)$(PERL6_HOME)/core)@
 	@nfpq($(BASE_DIR)/$(M_BAT_RUNNER))@ @shquot(@script(upgrade-repository.p6)@)@ @nfpq($(DESTDIR)$(PERL6_HOME)/vendor)@
 	@nfpq($(BASE_DIR)/$(M_BAT_RUNNER))@ @shquot(@script(upgrade-repository.p6)@)@ @nfpq($(DESTDIR)$(PERL6_HOME)/site)@
-	@nfpq($(BASE_DIR)/$(M_BAT_RUNNER))@ @shquot(@script(install-core-dist.p6)@)@ @q($(DESTDIR)$(PERL6_HOME))@
+	@nfpq($(BASE_DIR)/$(M_BAT_RUNNER))@ @shquot(@script(install-core-dist.p6)@)@ @q($(DESTDIR)$(PERL6_HOME)/core)@
 @clean_old_p6_libs@@expand(@m_install@)@
 
 m-runner-default-install: m-install

--- a/tools/templates/moar/Makefile.in
+++ b/tools/templates/moar/Makefile.in
@@ -366,7 +366,7 @@ m-install: m-all @@script(install-core-dist.p6)@@ $(SETTING_MOAR)
 	@nfpq($(BASE_DIR)/$(M_BAT_RUNNER))@ @shquot(@script(upgrade-repository.p6)@)@ @nfpq($(DESTDIR)$(PERL6_HOME)/core)@
 	@nfpq($(BASE_DIR)/$(M_BAT_RUNNER))@ @shquot(@script(upgrade-repository.p6)@)@ @nfpq($(DESTDIR)$(PERL6_HOME)/vendor)@
 	@nfpq($(BASE_DIR)/$(M_BAT_RUNNER))@ @shquot(@script(upgrade-repository.p6)@)@ @nfpq($(DESTDIR)$(PERL6_HOME)/site)@
-	@nfpq($(BASE_DIR)/$(M_BAT_RUNNER))@ @shquot(@script(install-core-dist.p6)@)@ @q($(DESTDIR)$(PERL6_HOME)/core)@
+	@nfpq($(BASE_DIR)/$(M_BAT_RUNNER))@ @shquot(@script(install-core-dist.p6)@)@ @nfpq($(DESTDIR)$(PERL6_HOME)/core)@
 @clean_old_p6_libs@@expand(@m_install@)@
 
 m-runner-default-install: m-install


### PR DESCRIPTION
As proposed [in this issue comment](https://github.com/rakudo/rakudo/issues/2919#issuecomment-496417006), move the core compilation unit repository previously installed directly into `<Perl6 home>/` to `<Perl6 home>/core`. This should continue to work as before, but does not attempt to remove any old stale comp unit repository a previous install might have put there. So some cruft might be left behind.