### PR TITLE
Give SetHash a set/unset method

### DIFF
--- a/src/core/SetHash.pm6
+++ b/src/core/SetHash.pm6
@@ -4,6 +4,23 @@ my class SetHash does Setty {
         Rakudo::Internals.PARAMETERIZE-KEYOF(base,type)
     }  
 
+    method set(\to-set --> Nil) {
+        nqp::bindattr(
+          self,SetHash,'$!elems',nqp::create(Rakudo::Internals::IterationSet)
+        ) unless $!elems;
+        Rakudo::QuantHash.ADD-ITERATOR-TO-SET(
+           $!elems, to-set.iterator, self.keyof
+        );
+    }
+
+    method unset(\to-unset --> Nil) {
+        my \iterator := to-unset.iterator;
+        nqp::until(
+          nqp::eqaddr((my \pulled := iterator.pull-one),IterationEnd),
+          nqp::deletekey($!elems,pulled.WHICH)
+        ) if $!elems
+    }
+
 #--- selector methods
 
     multi method grab(SetHash:D:) {


### PR DESCRIPTION
Inspired by seeing things like:

    %sethash{$_} = True for @to-be-added;

in the wild.  Instead, one can now do:

    %sethash.set(@to-be-added);
    %sethash.unset(@to-be-removed);

which is about 4x as fast.