### PR TITLE
Make v6.* work again.

### DIFF
--- a/src/Perl6/Compiler.nqp
+++ b/src/Perl6/Compiler.nqp
@@ -4,6 +4,7 @@ use Perl6::Optimizer;
 
 class Perl6::Compiler is HLL::Compiler {
     has $!language_version;  # Default language version in form 6.c
+    has $!language_modifier; # Active language modifier; PREVIEW mostly.
     has $!language_revisions; # Hash of language revision letters. See gen/<vm>/main-version.nqp
     has $!can_language_versions; # List of valid language version
 
@@ -17,9 +18,13 @@ class Perl6::Compiler is HLL::Compiler {
     method language_name()    { 'Perl' }
     method reset_language_version() {
         $!language_version := NQPMu;
+        $!language_modifier := NQPMu;
     }
     method set_language_version($version) {
         $!language_version := $version;
+    }
+    method set_language_modifier($modifier) {
+        $!language_modifier := $modifier;
     }
     method language_version() {
         if nqp::defined($!language_version) {
@@ -28,6 +33,9 @@ class Perl6::Compiler is HLL::Compiler {
         else {
             $!language_version := self.config<language-version>
         }
+    }
+    method language_modifier() {
+        $!language_modifier
     }
     method    can_language_versions() {
             $!can_language_versions

--- a/tools/templates/main-version.in
+++ b/tools/templates/main-version.in
@@ -5,7 +5,7 @@ sub hll-config($config) {
     $config<codename>         := '@codename@';
     $config<language-version> := '6.@lang_spec@';
     # Though language-revisions key provides more information
-    # can-language-versions is kept for speeding up
+    # can-language-versions is used for speeding up and ordering
     # Perl6::Compiler.can_langauge_versions method
     $config<can-language-versions>
         := nqp::list( '6.c'@for_specmods(, '6.@spec_with_mod@')@ );


### PR DESCRIPTION
- Also modifications like `v6.*.*`, or `v6.a+`, or `v6.e.*` or anything else
what `Version` accepts would work as expected. Contrary to incorrect
behavior of older releases now the highest version available will be
used. So that

  ```
  use v6.*;
  ```

  loads v6.e.PREVIEW now.

- Added `whatever` attribute to `Version` object. Similarly to `plus` it
indicates that version has a `Whatever` part.

- Added `language_modifier` attribute to `Perl6::Compiler`

rakudo/rakudo#2952