### PR TITLE
Remove harmful stale files during build

### DIFF
--- a/Configure.pl
+++ b/Configure.pl
@@ -107,6 +107,8 @@ MAIN: {
     $cfg->gen_nqp;
     $cfg->configure_active_backends;
 
+    $cfg->clean_old_p6_libs;
+
     $cfg->expand_template;
 
     unless ( $cfg->opt('expand') ) {

--- a/tools/lib/NQP/Config/Rakudo.pm
+++ b/tools/lib/NQP/Config/Rakudo.pm
@@ -475,6 +475,32 @@ sub opts_for_configure {
     return wantarray ? @opts : join( " ", @opts );
 }
 
+sub clean_old_p6_libs {
+    my $self = shift;
+    my $is_moar  = $self->active_backend('moar');
+    if ( $is_moar ) {
+        my $nqp_config = $self->{impls}{moar}->{config};
+        my $lib_dir = File::Spec->rel2abs(File::Spec->catdir( $nqp_config->{'nqp::prefix'}, 'share', 'nqp', 'lib', 'Perl6' ));
+
+        return if !-d $lib_dir;
+
+        my @files = qw(Actions.moarvm BOOTSTRAP.moarvm Compiler.moarvm Grammar.moarvm Metamodel.moarvm ModuleLoader.moarvm Ops.moarvm Optimizer.moarvm Pod.moarvm World.moarvm);
+
+        my @notes;
+        for ( @files ) {
+            my $file = File::Spec->catdir( $lib_dir, $_ );
+            next unless -f $file;
+            push @notes, "Will remove: $file\n";
+            $self->{config}->{clean_old_p6_libs} .= "\t\$(RM_F) $file\n";
+        }
+        $self->note('NOTICE',
+            "Found stale files in $lib_dir.\n",
+            "These files were left by a previous install and cause breakage\n",
+            "in this Rakudo version. The files will be removed during install.\n",
+            "\n", @notes) if @notes;
+    }
+}
+
 # Returns all active language specification entries except for .c
 sub perl6_specs {
     my $self = shift;

--- a/tools/templates/moar/Makefile.in
+++ b/tools/templates/moar/Makefile.in
@@ -345,7 +345,7 @@ m-install: m-all @@script(install-core-dist.p6)@@ $(SETTING_MOAR)
 	@nfpq($(BASE_DIR)/$(M_BAT_RUNNER))@ @shquot(@script(upgrade-repository.p6)@)@ @nfpq($(DESTDIR)$(PERL6_HOME)/vendor)@
 	@nfpq($(BASE_DIR)/$(M_BAT_RUNNER))@ @shquot(@script(upgrade-repository.p6)@)@ @nfpq($(DESTDIR)$(PERL6_HOME)/site)@
 	@nfpq($(BASE_DIR)/$(M_BAT_RUNNER))@ @shquot(@script(install-core-dist.p6)@)@ @q($(DESTDIR)$(PERL6_HOME))@
-@expand(@m_install@)@
+@clean_old_p6_libs@@expand(@m_install@)@
 
 m-runner-default-install: m-install
 	$(CP) @nfpq($(DESTDIR)$(PREFIX)/bin/perl6-m@moar::exe@)@ @nfpq($(DESTDIR)$(PREFIX)/bin/perl6@moar::exe@)@


### PR DESCRIPTION
Files in `NQP_HOME/lib/Perl6` left there of previous installs will be loaded before files in `PERL6_HOME/lib/Perl6` and thus have precedence. Because of that these files break the install if left there. We thus check for their existence and remove them during install if necessary. The user is notified of this at Configure time.