### PR TITLE
Prevent rebuild of nqp without --gen-nqp.

### DIFF
--- a/Configure.pl
+++ b/Configure.pl
@@ -11,7 +11,7 @@ use Cwd;
 use FindBin;
 
 BEGIN {
-    my $set_config = ! qx{git config rakudo.initialized};
+    my $set_config = !qx{git config rakudo.initialized};
     unless ( -e '3rdparty/nqp-configure/LICENSE' ) {
         print "Updating nqp-configure submodule...\n";
         my $msg =
@@ -63,7 +63,7 @@ MAIN: {
         $cfg->options,      'help!',
         'prefix=s',         'libdir=s',
         'sysroot=s',        'sdkroot=s',
-        'relocatable',   'backends=s',
+        'relocatable',      'backends=s',
         'no-clean',         'with-nqp=s',
         'gen-nqp:s',        'gen-moar:s',
         'moar-option=s@',   'git-protocol=s',
@@ -86,8 +86,11 @@ MAIN: {
         exit(0);
     }
     if ( $cfg->opt('ignore-errors') ) {
-        print
-"===WARNING!===\nErrors are being ignored.\nIn the case of any errors the script may behave unexpectedly.\n";
+        $cfg->note(
+            "WARNING!",
+            "Errors are being ignored.\n",
+            "In the case of any errors the script may behave unexpectedly."
+        );
     }
 
     $cfg->configure_paths;

--- a/tools/lib/NQP/Config/Rakudo.pm
+++ b/tools/lib/NQP/Config/Rakudo.pm
@@ -582,10 +582,10 @@ sub gen_nqp {
         my %c        = read_config($bin);
         my $nqp_have = $c{'nqp::version'} || '';
         $self->backend_config( $b, \%c ) if %c;
-        my $nqp_ver_ok = 0 <= cmp_rev( $nqp_have, $nqp_want );
+        my $nqp_ver_ok = $nqp_have ? (0 <= cmp_rev( $nqp_have, $nqp_want )) : 0;
         my $nqp_ok = $nqp_have && $nqp_ver_ok;
 
-        unless ( $nqp_ver_ok || $options->{'ignore-errors'} ) {
+        unless ( !$nqp_have || $nqp_ver_ok || $options->{'ignore-errors'} ) {
             $self->note( "WARNING",
                 "$bin version $nqp_have is outdated, $nqp_want expected.\n" );
         }
@@ -600,6 +600,8 @@ sub gen_nqp {
             $need{$b} = 1;
         }
     }
+
+    say "need?";
 
     return unless %need;
 


### PR DESCRIPTION
Solves the case of force-checkout & rebuild of nqp when `Configure.pl` with `--expand` is called from a Makefile receipt.