### PR TITLE
Fix build runner comp repos

### DIFF
--- a/tools/templates/Makefile-common-macros.in
+++ b/tools/templates/Makefile-common-macros.in
@@ -14,7 +14,6 @@ SYSROOT    = @nfp(@sysroot@)@
 SDKROOT    = @nfp(@sdkroot@)@
 PREFIX     = @nfp(@prefix@)@
 LIBDIR     = @nfp(@libdir@)@
-NQP_HOME   = $(LIBDIR)@nfp(/nqp)@
 PERL6_HOME = $(LIBDIR)@nfp(/perl6)@
 BASE_DIR   = @base_dir@
 

--- a/tools/templates/moar/Makefile.in
+++ b/tools/templates/moar/Makefile.in
@@ -227,7 +227,8 @@ $(M_BAT_RUNNER): @@configure_script@@ @@template(@backend_subdir@/perl6-m)@@ $(P
 		--set-var=mbc=perl6.moarvm \
 		--set-var=ctx_subdir=@backend_subdir@ \
 		--set-var=nqp_libdir=@shquot(@nqp::libdir@)@ \
-		--set-var=runner_opts=@chomp(@insert(Makefile-runner_opts)@)@
+		--set-var=runner_opts=@chomp(@insert(Makefile-runner_opts)@)@ \
+		--set-var=nqp_prefix=@nqp::prefix@
 	-$(CHMOD) 755 $(M_BAT_RUNNER)
 
 $(M_BAT_DEBUG_RUNNER): @@configure_script@@ @@template(@backend_subdir@/perl6-m)@@ $(PERL6_DEBUG_MOAR) $(SETTING_MOAR)
@@ -237,7 +238,8 @@ $(M_BAT_DEBUG_RUNNER): @@configure_script@@ @@template(@backend_subdir@/perl6-m)
 		--set-var=mbc=perl6-debug.moarvm \
 		--set-var=ctx_subdir=@backend_subdir@ \
 		--set-var=nqp_libdir=@shquot(@nqp::libdir@)@ \
-		--set-var=runner_opts=@chomp(@insert(Makefile-runner_opts)@)@
+		--set-var=runner_opts=@chomp(@insert(Makefile-runner_opts)@)@ \
+		--set-var=nqp_prefix=@nqp::prefix@
 	-$(CHMOD) 755 $(M_BAT_DEBUG_RUNNER)
 
 $(M_C_RUNNER): @nfp(src/vm/moar/runner/main.c)@

--- a/tools/templates/moar/Makefile.in
+++ b/tools/templates/moar/Makefile.in
@@ -220,7 +220,7 @@ $(PERL6_DEBUG_MOAR): @nfp(src/perl6-debug.nqp)@ $(PERL6_MOAR)
 		$out .= $macros->expand('@insert(Makefile-gen-runner)@');
 	}
 )@
-$(M_BAT_RUNNER): @@configure_script@@ $(M_C_RUNNER) $(PERL6_MOAR) $(SETTING_MOAR)
+$(M_BAT_RUNNER): @@configure_script@@ @@template(@backend_subdir@/perl6-m)@@ $(PERL6_MOAR) $(SETTING_MOAR)
 	$(RM_F) @q($(M_BAT_RUNNER))@
 	$(CONFIGURE) --expand @nfpq(@backend_subdir@/perl6-m)@ --out @q($(M_BAT_RUNNER))@ \
 		--set-var=MOAR=$(MOAR) \
@@ -230,7 +230,7 @@ $(M_BAT_RUNNER): @@configure_script@@ $(M_C_RUNNER) $(PERL6_MOAR) $(SETTING_MOAR
 		--set-var=runner_opts=@chomp(@insert(Makefile-runner_opts)@)@
 	-$(CHMOD) 755 $(M_BAT_RUNNER)
 
-$(M_BAT_DEBUG_RUNNER): @@configure_script@@ $(M_C_DEBUG_RUNNER) $(PERL6_DEBUG_MOAR) $(SETTING_MOAR)
+$(M_BAT_DEBUG_RUNNER): @@configure_script@@ @@template(@backend_subdir@/perl6-m)@@ $(PERL6_DEBUG_MOAR) $(SETTING_MOAR)
 	$(RM_F) @q($(M_BAT_DEBUG_RUNNER))@
 	$(CONFIGURE) --expand @nfpq(@backend_subdir@/perl6-m)@ --out @q($(M_BAT_DEBUG_RUNNER))@ \
 		--set-var=MOAR=$(MOAR) \

--- a/tools/templates/moar/perl6-m.in
+++ b/tools/templates/moar/perl6-m.in
@@ -1,3 +1,3 @@
 @insert(sh-prelude)@
 
-exec "@expand(@MOAR@)@" @expand(@runner_opts@)@ "$@"
+NQP_HOME="@nfp(@nqp_prefix@/share/nqp)@" PERL6_HOME="@nfp(@prefix@/share/perl6)@" exec "@expand(@MOAR@)@" @expand(@runner_opts@)@ "$@"

--- a/tools/templates/moar/perl6-m.windows
+++ b/tools/templates/moar/perl6-m.windows
@@ -1,4 +1,6 @@
 @ SET DIR=%~dp0
 @ SET DIR=%DIR:~0,-1%
 @ SET EXEC=%~dpf0
+@ SET NQP_HOME=@nfp(@nqp_prefix@/share/nqp)@
+@ SET PERL6_HOME=@nfp(@prefix@/share/perl6)@
 @ "@expand(@MOAR@)@" @expand(@runner_opts@)@ %*


### PR DESCRIPTION
As discussed in #2969 this PR passes `NQP_HOME` and `PERL6_HOME` in the build runners, which gets them working again when an installation exists.