### PR TITLE
[IP6NS Grant] Make socket family handling portable

### DIFF
--- a/src/core/IO.pm6
+++ b/src/core/IO.pm6
@@ -9,11 +9,11 @@ enum SeekType (
   :SeekFromEnd(2),
 );
 enum ProtocolFamily (
-  :PF_LOCAL(0),
-  :PF_UNIX(1),
-  :PF_INET(2),
-  :PF_INET6(3),
-  :PF_MAX(4),
+  :PF_INET(nqp::p6box_i(nqp::const::SOCKET_FAMILY_INET)),
+  :PF_INET6(nqp::p6box_i(nqp::const::SOCKET_FAMILY_INET6)),
+  :PF_LOCAL(nqp::p6box_i(nqp::const::SOCKET_FAMILY_UNIX)),
+  :PF_UNIX(nqp::p6box_i(nqp::const::SOCKET_FAMILY_UNIX)),
+  :PF_MAX(nqp::p6box_i(nqp::const::SOCKET_FAMILY_UNIX + 1)),
 );
 enum SocketType (
   :SOCK_PACKET(0),

--- a/src/core/IO/Socket/INET.pm6
+++ b/src/core/IO/Socket/INET.pm6
@@ -1,10 +1,11 @@
 my class IO::Socket::INET does IO::Socket {
     my module PIO {
-        constant PF_INET        = 1;
-        constant PF_INET6       = 2;
-        constant PF_LOCAL       = 3;
-        constant PF_UNIX        = 3;
-        constant PF_MAX         = 4;
+        constant PF_UNSPEC      = nqp::const::SOCKET_FAMILY_UNSPEC;
+        constant PF_INET        = nqp::const::SOCKET_FAMILY_INET;
+        constant PF_INET6       = nqp::const::SOCKET_FAMILY_INET6;
+        constant PF_LOCAL       = nqp::const::SOCKET_FAMILY_UNIX;
+        constant PF_UNIX        = nqp::const::SOCKET_FAMILY_UNIX;
+        constant PF_MAX         = nqp::const::SOCKET_FAMILY_UNIX + 1;
         constant SOCK_PACKET    = 0;
         constant SOCK_STREAM    = 1;
         constant SOCK_DGRAM     = 2;


### PR DESCRIPTION
MoarVM and the JVM now take a separate family parameter from the port;
update use of the nqp::bind_sk and nqp::connect_sk ops accordingly and
use the same socket family constants used by MoarVM and the JVM.

Related to https://github.com/rakudo/rakudo/issues/3007

Passes `make test`, `make spectest`