### PR TITLE
Issue 3041: Propagate laziness in KeyValue/Pair Iterators

### DIFF
--- a/src/core/Rakudo/Iterator.pm6
+++ b/src/core/Rakudo/Iterator.pm6
@@ -500,6 +500,7 @@ class Rakudo::Iterator {
               target.push(Pair.new(pulled,+($key = nqp::add_i($key,1))))
             )
         }
+        method is-lazy() { $!iter.is-lazy }
     }
     method AntiPair(\iterator) { AntiPair.new(iterator) }
 
@@ -2037,6 +2038,7 @@ class Rakudo::Iterator {
               )
             )
         }
+        method is-lazy() { $!iter.is-lazy }
     }
     method KeyValue(\iterator) { KeyValue.new(iterator) }
 
@@ -2504,6 +2506,7 @@ class Rakudo::Iterator {
               target.push(Pair.new(($key = nqp::add_i($key,1)),$pulled))
             )
         }
+        method is-lazy() { $!iter.is-lazy }
     }
     method Pair(\iterator) { PairIterator.new(iterator) }
 


### PR DESCRIPTION
Propagate the laziness value from the base iterator used.

Otherwise using .kv, .pairs, or .antipairs on a lazy list would cause it
to be eagerly evaluated.