### PR TITLE
Implement NativeCall wide string support

### DIFF
--- a/lib/NativeCall.pm6
+++ b/lib/NativeCall.pm6
@@ -59,7 +59,13 @@ sub string_encoding_to_nci_type(\encoding) {
         ?? "asciistr"
         !! nqp::iseq_s($enc,"utf16")
           ?? "utf16str"
-          !! die "Unknown string encoding for native call: $enc"
+          !! nqp::iseq_s($enc, 'wide')
+            ?? "widestr"
+            !! nqp::iseq_s($enc, 'u16')
+              ?? "u16str"
+              !! nqp::iseq_s($enc, 'u32')
+                ?? "u32str"
+                !! die "Unknown string encoding for native call: $enc"
 }
 
 # Builds a hash of type information for the specified parameter.
@@ -631,6 +637,24 @@ multi trait_mod:<is>(Parameter $p, :$encoded!) is export(:DEFAULT, :traits) {
 }
 multi trait_mod:<is>(Routine $p, :$encoded!) is export(:DEFAULT, :traits) {
     $p does NativeCallEncoded[$encoded];
+}
+multi trait_mod:<is>(Parameter $p, :$wide!) is export(:DEFAULT, :traits) {
+    $p does NativeCallEncoded['wide'];
+}
+multi trait_mod:<is>(Routine $p, :$wide!) is export(:DEFAULT, :traits) {
+    $p does NativeCallEncoded['wide'];
+}
+multi trait_mod:<is>(Parameter $p, :$u16!) is export(:DEFAULT, :traits) {
+    $p does NativeCallEncoded['u16'];
+}
+multi trait_mod:<is>(Routine $p, :$u16!) is export(:DEFAULT, :traits) {
+    $p does NativeCallEncoded['u16'];
+}
+multi trait_mod:<is>(Parameter $p, :$u32!) is export(:DEFAULT, :traits) {
+    $p does NativeCallEncoded['u32'];
+}
+multi trait_mod:<is>(Routine $p, :$u32!) is export(:DEFAULT, :traits) {
+    $p does NativeCallEncoded['u32'];
 }
 
 multi trait_mod:<is>(Routine $p, :$mangled!) is export(:DEFAULT, :traits) {

--- a/lib/NativeCall.pm6
+++ b/lib/NativeCall.pm6
@@ -152,10 +152,10 @@ my constant $type_map = nqp::hash(
   "num64",      "double",
   "size_t",     nqp::atpos_s($signed_ints_by_size,nativesizeof(size_t)),
   "ssize_t",    nqp::atpos_s($signed_ints_by_size,nativesizeof(ssize_t)),
-  "wchar_t",    nqp::atpos_s($signed_ints_by_size,nativesizeof(wchar_t)),
-  "wint_t",     nqp::atpos_s($signed_ints_by_size,nativesizeof(wint_t)),
-  "char16_t",   nqp::atpos_s($signed_ints_by_size,nativesizeof(char16_t)),
-  "char32_t",   nqp::atpos_s($signed_ints_by_size,nativesizeof(char32_t)),
+  "wchar_t",    "wchar_t",
+  "wint_t",     "wint_t",
+  "char16_t",   "char16_t",
+  "char32_t",   "char32_t",
   "uint",       "ulong",
   "uint16",     "ushort",
   "uint32",     "uint",
@@ -713,7 +713,7 @@ sub check_routine_sanity(Routine $r) is export(:TEST) {
       return True if nqp::existskey($repr_map,T.REPR) && T.REPR ne 'CArray' | 'CPointer';
       return True if T.^name eq 'Str' | 'str' | 'Bool';
       return False if T.REPR eq 'P6opaque';
-      return False if T.HOW.^can("nativesize") && !nqp::defined(T.^nativesize); #to disting int and int32 for example
+      return False if T.^name eq 'int' | 'uint' || (T.HOW.^can('ctype') && !nqp::defined(T.^ctype)); #to disting int and int32 for example
       return validnctype(T.of) if T.REPR eq 'CArray' | 'CPointer' and T.^can('of');
       return True;
     }

--- a/lib/NativeCall.pm6
+++ b/lib/NativeCall.pm6
@@ -23,6 +23,10 @@ my constant ulonglong     is export(:types, :DEFAULT) = NativeCall::Types::ulong
 my constant bool          is export(:types, :DEFAULT) = NativeCall::Types::bool;
 my constant size_t        is export(:types, :DEFAULT) = NativeCall::Types::size_t;
 my constant ssize_t       is export(:types, :DEFAULT) = NativeCall::Types::ssize_t;
+my constant wchar_t       is export(:types, :DEFAULT) = NativeCall::Types::wchar_t;
+my constant wint_t        is export(:types, :DEFAULT) = NativeCall::Types::wint_t;
+my constant char16_t      is export(:types, :DEFAULT) = NativeCall::Types::char16_t;
+my constant char32_t      is export(:types, :DEFAULT) = NativeCall::Types::char32_t;
 my constant void          is export(:types, :DEFAULT) = NativeCall::Types::void;
 my constant CArray        is export(:types, :DEFAULT) = NativeCall::Types::CArray;
 my constant Pointer       is export(:types, :DEFAULT) = NativeCall::Types::Pointer;
@@ -150,6 +154,10 @@ my constant $type_map = nqp::hash(
   "num64",      "double",
   "size_t",     nqp::atpos_s($signed_ints_by_size,nativesizeof(size_t)),
   "ssize_t",    nqp::atpos_s($signed_ints_by_size,nativesizeof(ssize_t)),
+  "wchar_t",    nqp::atpos_s($signed_ints_by_size,nativesizeof(wchar_t)),
+  "wint_t",     nqp::atpos_s($signed_ints_by_size,nativesizeof(wint_t)),
+  "char16_t",   "ushort",
+  "char32_t",   "uint",
   "uint",       "ulong",
   "uint16",     "ushort",
   "uint32",     "uint",

--- a/lib/NativeCall.pm6
+++ b/lib/NativeCall.pm6
@@ -698,11 +698,12 @@ class U16Str  is repr('CStr') is u16  { }
 class U32Str  is repr('CStr') is u32  { }
 
 role ExplicitlyManagedString[$encoding, $native-type] {
+    has $.native-string is rw;
     method encoding(--> Str)     { $encoding    }
     method native-type(--> Mu:U) { $native-type }
 }
 
-multi explicitly-manage(Str $str, :$encoding = 'utf8', :$type = 'c' --> Str) is export(:DEFAULT,
+multi explicitly-manage(Str $str, :$encoding = 'utf8', :$type = 'c') is export(:DEFAULT,
 :utils) {
     my Mu:U $class;
     my Mu:U $native-type;
@@ -730,9 +731,8 @@ multi explicitly-manage(Str $str, :$encoding = 'utf8', :$type = 'c' --> Str) is 
         }
     }
 
-    nqp::box_s(nqp::unbox_s(nqp::decont($str)), $class);
     $str does ExplicitlyManagedString[$encoding, $native-type];
-    $str
+    $str.native-string = nqp::box_s(nqp::unbox_s(nqp::decont($str)), $class);
 }
 
 role CPPConst {

--- a/lib/NativeCall.pm6
+++ b/lib/NativeCall.pm6
@@ -32,7 +32,6 @@ my constant CArray        is export(:types, :DEFAULT) = NativeCall::Types::CArra
 my constant Pointer       is export(:types, :DEFAULT) = NativeCall::Types::Pointer;
 my constant OpaquePointer is export(:types, :DEFAULT) = NativeCall::Types::Pointer;
 
-
 # Role for carrying extra calling convention information.
 my role NativeCallingConvention[$name] {
     method native_call_convention() { $name };
@@ -46,7 +45,6 @@ my role NativeCallEncoded[$name] {
 my role NativeCallMangled[$name] {
     method native_call_mangled() { $name }
 }
-
 
 # Throwaway type just to get us some way to get at the NativeCall
 # representation.
@@ -156,8 +154,8 @@ my constant $type_map = nqp::hash(
   "ssize_t",    nqp::atpos_s($signed_ints_by_size,nativesizeof(ssize_t)),
   "wchar_t",    nqp::atpos_s($signed_ints_by_size,nativesizeof(wchar_t)),
   "wint_t",     nqp::atpos_s($signed_ints_by_size,nativesizeof(wint_t)),
-  "char16_t",   "ushort",
-  "char32_t",   "uint",
+  "char16_t",   nqp::atpos_s($signed_ints_by_size,nativesizeof(char16_t)),
+  "char32_t",   nqp::atpos_s($signed_ints_by_size,nativesizeof(char32_t)),
   "uint",       "ulong",
   "uint16",     "ushort",
   "uint32",     "uint",

--- a/lib/NativeCall.pm6
+++ b/lib/NativeCall.pm6
@@ -641,19 +641,10 @@ multi trait_mod:<is>(Routine $p, :$encoded!) is export(:DEFAULT, :traits) {
 multi trait_mod:<is>(Parameter $p, :$wide!) is export(:DEFAULT, :traits) {
     $p does NativeCallEncoded['wide'];
 }
-multi trait_mod:<is>(Routine $p, :$wide!) is export(:DEFAULT, :traits) {
-    $p does NativeCallEncoded['wide'];
-}
 multi trait_mod:<is>(Parameter $p, :$u16!) is export(:DEFAULT, :traits) {
     $p does NativeCallEncoded['u16'];
 }
-multi trait_mod:<is>(Routine $p, :$u16!) is export(:DEFAULT, :traits) {
-    $p does NativeCallEncoded['u16'];
-}
 multi trait_mod:<is>(Parameter $p, :$u32!) is export(:DEFAULT, :traits) {
-    $p does NativeCallEncoded['u32'];
-}
-multi trait_mod:<is>(Routine $p, :$u32!) is export(:DEFAULT, :traits) {
     $p does NativeCallEncoded['u32'];
 }
 
@@ -670,6 +661,15 @@ multi trait_mod:<is>(Mu:U $type, :$u16!)  is export(:DEFAULT, :traits) {
 }
 multi trait_mod:<is>(Mu:U $type, :$u32!)  is export(:DEFAULT, :traits) {
     $type.^set_char_type('char32_t');
+}
+multi trait_mod:<is>(Attribute:D $attr, :$wide!) is export(:DEFAULT, :traits) {
+    $attr.set_char_type(nqp::const::P6STR_C_TYPE_WCHAR_T);
+}
+multi trait_mod:<is>(Attribute:D $attr, :$u16!) is export(:DEFAULT, :traits) {
+    $attr.set_char_type(nqp::const::P6STR_C_TYPE_CHAR16_T);
+}
+multi trait_mod:<is>(Attribute:D $attr, :$u32!) is export(:DEFAULT, :traits) {
+    $attr.set_char_type(nqp::const::P6STR_C_TYPE_CHAR32_T);
 }
 
 # CStr's native character type isn't set since its char_type is char by

--- a/lib/NativeCall.pm6
+++ b/lib/NativeCall.pm6
@@ -635,17 +635,26 @@ multi trait_mod:<is>(Routine $r, :$nativeconv!) is export(:DEFAULT, :traits) {
 multi trait_mod:<is>(Parameter $p, :$encoded!) is export(:DEFAULT, :traits) {
     $p does NativeCallEncoded[$encoded];
 }
-multi trait_mod:<is>(Routine $p, :$encoded!) is export(:DEFAULT, :traits) {
-    $p does NativeCallEncoded[$encoded];
+multi trait_mod:<is>(Routine $r, :$encoded!) is export(:DEFAULT, :traits) {
+    $r does NativeCallEncoded[$encoded];
 }
 multi trait_mod:<is>(Parameter $p, :$wide!) is export(:DEFAULT, :traits) {
     $p does NativeCallEncoded['wide'];
 }
+multi trait_mod:<is>(Routine $r, :$wide!) is export(:DEFAULT, :traits) {
+    $r does NativeCallEncoded['wide'];
+}
 multi trait_mod:<is>(Parameter $p, :$u16!) is export(:DEFAULT, :traits) {
     $p does NativeCallEncoded['u16'];
 }
+multi trait_mod:<is>(Routine $r, :$u16!) is export(:DEFAULT, :traits) {
+    $r does NativeCallEncoded['u16'];
+}
 multi trait_mod:<is>(Parameter $p, :$u32!) is export(:DEFAULT, :traits) {
     $p does NativeCallEncoded['u32'];
+}
+multi trait_mod:<is>(Routine $r, :$u32!) is export(:DEFAULT, :traits) {
+    $r does NativeCallEncoded['u32'];
 }
 
 multi trait_mod:<is>(Routine $p, :$mangled!) is export(:DEFAULT, :traits) {
@@ -654,13 +663,13 @@ multi trait_mod:<is>(Routine $p, :$mangled!) is export(:DEFAULT, :traits) {
 
 # Native string character type traits.
 multi trait_mod:<is>(Mu:U $type, :$wide!) is export(:DEFAULT, :traits) {
-    $type.^set_char_type('wchar_t');
+    $type.^set_char_type(nqp::const::P6STR_C_TYPE_WCHAR_T);
 }
 multi trait_mod:<is>(Mu:U $type, :$u16!)  is export(:DEFAULT, :traits) {
-    $type.^set_char_type('char16_t');
+    $type.^set_char_type(nqp::const::P6STR_C_TYPE_CHAR16_T);
 }
 multi trait_mod:<is>(Mu:U $type, :$u32!)  is export(:DEFAULT, :traits) {
-    $type.^set_char_type('char32_t');
+    $type.^set_char_type(nqp::const::P6STR_C_TYPE_CHAR32_T);
 }
 multi trait_mod:<is>(Attribute:D $attr, :$wide!) is export(:DEFAULT, :traits) {
     $attr.set_char_type(nqp::const::P6STR_C_TYPE_WCHAR_T);
@@ -700,7 +709,7 @@ multi explicitly-manage(Str $str, :$encoding = 'utf8', :$type = 'c' --> Str) is 
     given $type {
         when 'c'    {
             $class       := CStr[$encoding];
-            # XXX: this can be uint8 on certain systems but we have no way to
+            # XXX: this can be uint8 on certain platforms but we have no way to
             # tell! There needs to be a native char type.
             $native-type := int8;
         }

--- a/lib/NativeCall.pm6
+++ b/lib/NativeCall.pm6
@@ -713,8 +713,8 @@ sub check_routine_sanity(Routine $r) is export(:TEST) {
       return True if nqp::existskey($repr_map,T.REPR) && T.REPR ne 'CArray' | 'CPointer';
       return True if T.^name eq 'Str' | 'str' | 'Bool';
       return False if T.REPR eq 'P6opaque';
-      return False if T.^name eq 'int' | 'uint' || (T.HOW.^can('ctype') && !nqp::defined(T.^ctype)); #to disting int and int32 for example
-      return validnctype(T.of) if T.REPR eq 'CArray' | 'CPointer' and T.^can('of');
+      return False if T.HOW.^can('ctype') && T.^ctype eq ''; # to disting int and int32 for example
+      return validnctype(T.of) if T.REPR eq 'CArray' | 'CPointer' && T.^can('of');
       return True;
     }
     my $sig = $r.signature;

--- a/lib/NativeCall/Types.pm6
+++ b/lib/NativeCall/Types.pm6
@@ -13,8 +13,8 @@ our native ulonglong is Int is ctype("longlong") is unsigned is repr("P6int") { 
 our native size_t    is Int is ctype("size_t")   is unsigned is repr("P6int") { };
 our native ssize_t   is Int is ctype("size_t")   is repr("P6int") { };
 our native bool      is Int is ctype("bool")     is repr("P6int") { };
-our native wchar_t   is Int is ctype("wchar_t")  is repr("P6int") { };
-our native wint_t    is Int is ctype("wint_t")   is repr("P6int") { };
+our native wchar_t   is Int is ctype("wchar_t")  is unsigned(nqp::iswcharunsigned()) is repr("P6int") { };
+our native wint_t    is Int is ctype("wint_t")   is unsigned(nqp::iswintunsigned())  is repr("P6int") { };
 our native char16_t  is Int is ctype("char16_t") is unsigned is repr("P6int") { };
 our native char32_t  is Int is ctype("char32_t") is unsigned is repr("P6int") { };
 our class void                                   is repr('Uninstantiable') { };

--- a/lib/NativeCall/Types.pm6
+++ b/lib/NativeCall/Types.pm6
@@ -6,16 +6,20 @@ sub nativecast($target-type, $source) {
         nqp::decont(map_return_type($target-type)), nqp::decont($source));
 }
 
-our native long     is Int is ctype("long")     is repr("P6int") { };
-our native longlong is Int is ctype("longlong") is repr("P6int") { };
+our native long      is Int is ctype("long")     is repr("P6int") { };
+our native longlong  is Int is ctype("longlong") is repr("P6int") { };
 our native ulong     is Int is ctype("long")     is unsigned is repr("P6int") { };
 our native ulonglong is Int is ctype("longlong") is unsigned is repr("P6int") { };
 our native size_t    is Int is ctype("size_t")   is unsigned is repr("P6int") { };
-our native ssize_t   is Int is ctype("size_t")               is repr("P6int") { };
-our native bool      is Int is ctype("bool")                 is repr("P6int") { };
-our class void                                  is repr('Uninstantiable') { };
+our native ssize_t   is Int is ctype("size_t")   is repr("P6int") { };
+our native bool      is Int is ctype("bool")     is repr("P6int") { };
+our native wchar_t   is Int is ctype("wchar_t")  is repr("P6int") { };
+our native wint_t    is Int is ctype("wint_t")   is repr("P6int") { };
+our native char16_t  is Int is ctype("char16_t") is unsigned is repr("P6int") { };
+our native char32_t  is Int is ctype("char32_t") is unsigned is repr("P6int") { };
+our class void                                   is repr('Uninstantiable') { };
 # Expose a Pointer class for working with raw pointers.
-our class Pointer                               is repr('CPointer') {
+our class Pointer                                is repr('CPointer') {
     method of() { void }
 
     multi method new() {

--- a/src/Perl6/Metamodel/BOOTSTRAP.nqp
+++ b/src/Perl6/Metamodel/BOOTSTRAP.nqp
@@ -19,12 +19,14 @@ use QRegex;
 my class BOOTSTRAPATTR {
     has $!name;
     has $!type;
+    has $!char_type;
     has $!box_target;
     has $!package;
     has $!inlined;
     has $!dimensions;
     method name() { $!name }
     method type() { $!type }
+    method char_type() { $!char_type }
     method box_target() { $!box_target }
     method package() { $!package }
     method inlined() { $!inlined }
@@ -1413,6 +1415,7 @@ BEGIN {
     Attribute.HOW.add_attribute(Attribute, BOOTSTRAPATTR.new(:name<$!required>, :type(Mu), :package(Attribute)));
     Attribute.HOW.add_attribute(Attribute, BOOTSTRAPATTR.new(:name<$!has_accessor>, :type(int), :package(Attribute)));
     Attribute.HOW.add_attribute(Attribute, BOOTSTRAPATTR.new(:name<$!type>, :type(Mu), :package(Attribute)));
+    Attribute.HOW.add_attribute(Attribute, BOOTSTRAPATTR.new(:name<$!char_type>, :type(int), :package(Attribute)));
     Attribute.HOW.add_attribute(Attribute, BOOTSTRAPATTR.new(:name<$!container_descriptor>, :type(Mu), :package(Attribute)));
     Attribute.HOW.add_attribute(Attribute, BOOTSTRAPATTR.new(:name<$!auto_viv_container>, :type(Mu), :package(Attribute)));
     Attribute.HOW.add_attribute(Attribute, BOOTSTRAPATTR.new(:name<$!build_closure>, :type(Mu), :package(Attribute)));
@@ -1427,11 +1430,12 @@ BEGIN {
 
     # Need new and accessor methods for Attribute in here for now.
     Attribute.HOW.add_method(Attribute, 'new',
-        nqp::getstaticcode(sub ($self, :$name!, :$type!, :$package!, :$inlined = 0, :$has_accessor,
+        nqp::getstaticcode(sub ($self, :$name!, :$type!, :$char_type = nqp::const::P6STR_C_TYPE_CHAR, :$package!, :$inlined = 0, :$has_accessor,
                 :$positional_delegate = 0, :$associative_delegate = 0, *%other) {
             my $attr := nqp::create($self);
             nqp::bindattr_s($attr, Attribute, '$!name', $name);
             nqp::bindattr($attr, Attribute, '$!type', nqp::decont($type));
+            nqp::bindattr_i($attr, Attribute, '$!char_type', $char_type);
             nqp::bindattr_i($attr, Attribute, '$!has_accessor', $has_accessor);
             nqp::bindattr($attr, Attribute, '$!package', $package);
             nqp::bindattr_i($attr, Attribute, '$!inlined', $inlined);
@@ -1472,6 +1476,16 @@ BEGIN {
     Attribute.HOW.add_method(Attribute, 'type', nqp::getstaticcode(sub ($self) {
             nqp::getattr(nqp::decont($self),
                 Attribute, '$!type');
+        }));
+    Attribute.HOW.add_method(Attribute, 'set_char_type', nqp::getstaticcode(sub ($self, $value) {
+            $*W.add_object_if_no_sc($value);
+            nqp::bindattr_i(nqp::decont($self),
+                Attribute, '$!char_type', $value);
+            nqp::hllboolfor(1, "perl6")
+        }));
+    Attribute.HOW.add_method(Attribute, 'char_type', nqp::getstaticcode(sub ($self) {
+            nqp::getattr_i(nqp::decont($self),
+                Attribute, '$!char_type');
         }));
     Attribute.HOW.add_method(Attribute, 'container_descriptor', nqp::getstaticcode(sub ($self) {
             nqp::getattr(nqp::decont($self),

--- a/src/Perl6/Metamodel/CharType.nqp
+++ b/src/Perl6/Metamodel/CharType.nqp
@@ -9,6 +9,10 @@ role Perl6::Metamodel::CharType {
         $!is_char_type ?? 1 !! 0
     }
 
+    method raw_char_type($obj) {
+        $!char_type
+    }
+
     method char_type($obj) {
         if $!char_type == nqp::const::P6STR_C_TYPE_CHAR {
             'char'

--- a/src/Perl6/Metamodel/CharType.nqp
+++ b/src/Perl6/Metamodel/CharType.nqp
@@ -18,4 +18,3 @@ role Perl6::Metamodel::CharType {
         $!has_char_type := 1;
     }
 }
-

--- a/src/Perl6/Metamodel/CharType.nqp
+++ b/src/Perl6/Metamodel/CharType.nqp
@@ -1,0 +1,48 @@
+# Handles type declarations that really map down to string types of some kind,
+# containing information about the native type used to represent characters, so
+# they should be composed as a stringy representation.
+role Perl6::Metamodel::CharType {
+    has int $!char_type;
+    has int $!is_char_type;
+
+    method is_char_type($obj) {
+        $!is_char_type ?? 1 !! 0
+    }
+
+    method char_type($obj) {
+        if $!char_type == nqp::const::P6STR_C_TYPE_CHAR {
+            'char'
+        }
+        elsif $!char_type == nqp::const::P6STR_C_TYPE_WCHAR_T {
+            'wchar_t'
+        }
+        elsif $!char_type == nqp::const::P6STR_C_TYPE_CHAR16_T {
+            'char16_t'
+        }
+        elsif $!char_type == nqp::const::P6STR_C_TYPE_CHAR32_T {
+            'char32_t'
+        }
+        else {
+            ''
+        }
+    }
+
+    method set_char_type($obj, $type) {
+        if $type eq 'char' {
+            $!char_type := nqp::const::P6STR_C_TYPE_CHAR;
+        }
+        elsif $type eq 'wchar_t' {
+            $!char_type := nqp::const::P6STR_C_TYPE_WCHAR_T;
+        }
+        elsif $type eq 'char16_t' {
+            $!char_type := nqp::const::P6STR_C_TYPE_CHAR16_T;
+        }
+        elsif $type eq 'char32_t' {
+            $!char_type := nqp::const::P6STR_C_TYPE_CHAR32_T;
+        }
+        else {
+            nqp::die("The CharType REPR received an unknown native character type");
+        }
+    }
+}
+

--- a/src/Perl6/Metamodel/CharType.nqp
+++ b/src/Perl6/Metamodel/CharType.nqp
@@ -3,50 +3,19 @@
 # they should be composed as a stringy representation.
 role Perl6::Metamodel::CharType {
     has int $!char_type;
-    has int $!is_char_type;
+    has int $!has_char_type;
 
-    method is_char_type($obj) {
-        $!is_char_type ?? 1 !! 0
-    }
-
-    method raw_char_type($obj) {
-        $!char_type
+    method has_char_type($obj) {
+        $!has_char_type ?? 1 !! 0
     }
 
     method char_type($obj) {
-        if $!char_type == nqp::const::P6STR_C_TYPE_CHAR {
-            'char'
-        }
-        elsif $!char_type == nqp::const::P6STR_C_TYPE_WCHAR_T {
-            'wchar_t'
-        }
-        elsif $!char_type == nqp::const::P6STR_C_TYPE_CHAR16_T {
-            'char16_t'
-        }
-        elsif $!char_type == nqp::const::P6STR_C_TYPE_CHAR32_T {
-            'char32_t'
-        }
-        else {
-            ''
-        }
+        $!char_type
     }
 
     method set_char_type($obj, $type) {
-        if $type eq 'char' {
-            $!char_type := nqp::const::P6STR_C_TYPE_CHAR;
-        }
-        elsif $type eq 'wchar_t' {
-            $!char_type := nqp::const::P6STR_C_TYPE_WCHAR_T;
-        }
-        elsif $type eq 'char16_t' {
-            $!char_type := nqp::const::P6STR_C_TYPE_CHAR16_T;
-        }
-        elsif $type eq 'char32_t' {
-            $!char_type := nqp::const::P6STR_C_TYPE_CHAR32_T;
-        }
-        else {
-            nqp::die("The CharType REPR received an unknown native character type");
-        }
+        $!char_type     := $type;
+        $!has_char_type := 1;
     }
 }
 

--- a/src/Perl6/Metamodel/ClassHOW.nqp
+++ b/src/Perl6/Metamodel/ClassHOW.nqp
@@ -17,6 +17,7 @@ class Perl6::Metamodel::ClassHOW
     does Perl6::Metamodel::Trusting
     does Perl6::Metamodel::BUILDPLAN
     does Perl6::Metamodel::Mixins
+    does Perl6::Metamodel::CharType
     does Perl6::Metamodel::ArrayType
     does Perl6::Metamodel::BoolificationProtocol
     does Perl6::Metamodel::REPRComposeProtocol

--- a/src/Perl6/Metamodel/ConcreteRoleHOW.nqp
+++ b/src/Perl6/Metamodel/ConcreteRoleHOW.nqp
@@ -7,6 +7,7 @@ class Perl6::Metamodel::ConcreteRoleHOW
     does Perl6::Metamodel::AttributeContainer
     does Perl6::Metamodel::RoleContainer
     does Perl6::Metamodel::MultipleInheritance
+    does Perl6::Metamodel::CharType
     does Perl6::Metamodel::ArrayType
     does Perl6::Metamodel::Concretization
 {

--- a/src/Perl6/Metamodel/NativeHOW.nqp
+++ b/src/Perl6/Metamodel/NativeHOW.nqp
@@ -70,40 +70,40 @@ class Perl6::Metamodel::NativeHOW
         my str $reprname := nqp::reprname($obj);
         if $reprname eq 'P6int' {
             if $ctype eq 'char' {
-                $!ctype := nqp::const::C_TYPE_CHAR;
+                $!ctype := nqp::const::P6INT_C_TYPE_CHAR;
             }
             elsif $ctype eq 'short' {
-                $!ctype := nqp::const::C_TYPE_SHORT;
+                $!ctype := nqp::const::P6INT_C_TYPE_SHORT;
             }
             elsif $ctype eq 'int' {
-                $!ctype := nqp::const::C_TYPE_INT;
+                $!ctype := nqp::const::P6INT_C_TYPE_INT;
             }
             elsif $ctype eq 'long' {
-                $!ctype := nqp::const::C_TYPE_LONG;
+                $!ctype := nqp::const::P6INT_C_TYPE_LONG;
             }
             elsif $ctype eq 'longlong' {
-                $!ctype := nqp::const::C_TYPE_LONGLONG;
+                $!ctype := nqp::const::P6INT_C_TYPE_LONGLONG;
             }
             elsif $ctype eq 'bool' {
-                $!ctype := nqp::const::C_TYPE_BOOL;
+                $!ctype := nqp::const::P6INT_C_TYPE_BOOL;
             }
             elsif $ctype eq 'size_t' {
-                $!ctype := nqp::const::C_TYPE_SIZE_T;
+                $!ctype := nqp::const::P6INT_C_TYPE_SIZE_T;
             }
             elsif $ctype eq 'atomic' {
-                $!ctype := nqp::const::C_TYPE_ATOMIC_INT;
+                $!ctype := nqp::const::P6INT_C_TYPE_ATOMIC_INT;
             }
             elsif $ctype eq 'wchar_t' {
-                $!ctype := nqp::const::C_TYPE_WCHAR_T;
+                $!ctype := nqp::const::P6INT_C_TYPE_WCHAR_T;
             }
             elsif $ctype eq 'wint_t' {
-                $!ctype := nqp::const::C_TYPE_WINT_T;
+                $!ctype := nqp::const::P6INT_C_TYPE_WINT_T;
             }
             elsif $ctype eq 'char16_t' {
-                $!ctype := nqp::const::C_TYPE_CHAR16_T;
+                $!ctype := nqp::const::P6INT_C_TYPE_CHAR16_T;
             }
             elsif $ctype eq 'char32_t' {
-                $!ctype := nqp::const::C_TYPE_CHAR32_T;
+                $!ctype := nqp::const::P6INT_C_TYPE_CHAR32_T;
             }
             else {
                 nqp::die("Unhandled C type '$ctype'");
@@ -111,13 +111,13 @@ class Perl6::Metamodel::NativeHOW
         }
         elsif $reprname eq 'P6num' {
             if $ctype eq 'float' {
-                $!ctype := nqp::const::C_TYPE_FLOAT;
+                $!ctype := nqp::const::P6NUM_C_TYPE_FLOAT;
             }
             elsif $ctype eq 'double' {
-                $!ctype := nqp::const::C_TYPE_DOUBLE;
+                $!ctype := nqp::const::P6NUM_C_TYPE_DOUBLE;
             }
             elsif $ctype eq 'longdouble' {
-                $!ctype := nqp::const::C_TYPE_LONGDOUBLE;
+                $!ctype := nqp::const::P6NUM_C_TYPE_LONGDOUBLE;
             }
             else {
                 nqp::die("Unhandled C type '$ctype'");
@@ -131,40 +131,40 @@ class Perl6::Metamodel::NativeHOW
     method ctype($obj) {
         my str $reprname := nqp::reprname($obj);
         if $reprname eq 'P6int' {
-            if $!ctype == nqp::const::C_TYPE_CHAR {
+            if $!ctype == nqp::const::P6INT_C_TYPE_CHAR {
                 'char'
             }
-            elsif $!ctype == nqp::const::C_TYPE_SHORT {
+            elsif $!ctype == nqp::const::P6INT_C_TYPE_SHORT {
                 'short'
             }
-            elsif $!ctype == nqp::const::C_TYPE_INT {
+            elsif $!ctype == nqp::const::P6INT_C_TYPE_INT {
                 'int'
             }
-            elsif $!ctype == nqp::const::C_TYPE_LONG {
+            elsif $!ctype == nqp::const::P6INT_C_TYPE_LONG {
                 'long'
             }
-            elsif $!ctype == nqp::const::C_TYPE_LONGLONG {
+            elsif $!ctype == nqp::const::P6INT_C_TYPE_LONGLONG {
                 'longlong'
             }
-            elsif $!ctype == nqp::const::C_TYPE_BOOL {
+            elsif $!ctype == nqp::const::P6INT_C_TYPE_BOOL {
                 'bool'
             }
-            elsif $!ctype == nqp::const::C_TYPE_SIZE_T {
+            elsif $!ctype == nqp::const::P6INT_C_TYPE_SIZE_T {
                 'size_t'
             }
-            elsif $!ctype == nqp::const::C_TYPE_ATOMIC_INT {
+            elsif $!ctype == nqp::const::P6INT_C_TYPE_ATOMIC_INT {
                 'atomic'
             }
-            elsif $!ctype == nqp::const::C_TYPE_WCHAR_T {
+            elsif $!ctype == nqp::const::P6INT_C_TYPE_WCHAR_T {
                 'wchar_t'
             }
-            elsif $!ctype == nqp::const::C_TYPE_WINT_T {
+            elsif $!ctype == nqp::const::P6INT_C_TYPE_WINT_T {
                 'wint_t'
             }
-            elsif $!ctype == nqp::const::C_TYPE_CHAR16_T {
+            elsif $!ctype == nqp::const::P6INT_C_TYPE_CHAR16_T {
                 'char16_t'
             }
-            elsif $!ctype == nqp::const::C_TYPE_CHAR32_T {
+            elsif $!ctype == nqp::const::P6INT_C_TYPE_CHAR32_T {
                 'char32_t'
             }
             else {
@@ -172,13 +172,13 @@ class Perl6::Metamodel::NativeHOW
             }
         }
         elsif $reprname eq 'P6num' {
-            if $!ctype == nqp::const::C_TYPE_FLOAT {
+            if $!ctype == nqp::const::P6NUM_C_TYPE_FLOAT {
                 'float'
             }
-            elsif $!ctype == nqp::const::C_TYPE_DOUBLE {
+            elsif $!ctype == nqp::const::P6NUM_C_TYPE_DOUBLE {
                 'double'
             }
-            elsif $!ctype == nqp::const::C_TYPE_LONGDOUBLE {
+            elsif $!ctype == nqp::const::P6NUM_C_TYPE_LONGDOUBLE {
                 'longdouble'
             }
             else {

--- a/src/Perl6/Metamodel/NativeHOW.nqp
+++ b/src/Perl6/Metamodel/NativeHOW.nqp
@@ -9,6 +9,7 @@ class Perl6::Metamodel::NativeHOW
     does Perl6::Metamodel::MROBasedTypeChecking
 {
     has $!nativesize;
+    has int $!ctype;
     has int $!unsigned;
     has $!composed;
 
@@ -37,20 +38,24 @@ class Perl6::Metamodel::NativeHOW
         self.compute_mro($obj);
         self.publish_method_cache($obj);
         self.publish_type_cache($obj);
-        if !$!composed && ($!nativesize || $!unsigned) {
+        if !$!composed && ($!ctype || $!nativesize || $!unsigned) {
             my $info := nqp::hash();
-            $info<integer> := nqp::hash();
-            $info<integer><unsigned> := 1 if $!unsigned;
-            $info<float> := nqp::hash();
+            $info<integer>           := nqp::hash();
+            $info<float>             := nqp::hash();
+            if nqp::isconcrete($!ctype) {
+                $info<integer><type> := $!ctype;
+                $info<float><type>   := $!ctype;
+            }
             if nqp::objprimspec($!nativesize) {
                 $info<integer><bits> := $!nativesize;
                 $info<float><bits>   := $!nativesize;
             }
-            else {
-                if $!nativesize {
-                    $info<integer><bits> := nqp::unbox_i($!nativesize);
-                    $info<float><bits>   := nqp::unbox_i($!nativesize);
-                }
+            elsif $!nativesize {
+                $info<integer><bits> := nqp::unbox_i($!nativesize);
+                $info<float><bits>   := nqp::unbox_i($!nativesize);
+            }
+            if $!unsigned {
+                $info<integer><unsigned> := 1;
             }
             nqp::composetype($obj, $info);
         }
@@ -62,53 +67,126 @@ class Perl6::Metamodel::NativeHOW
     }
 
     method set_ctype($obj, $ctype) {
-        if $ctype eq 'char' {
-            $!nativesize := nqp::const::C_TYPE_CHAR;
+        my str $reprname := nqp::reprname($obj);
+        if $reprname eq 'P6int' {
+            if $ctype eq 'char' {
+                $!ctype := nqp::const::C_TYPE_CHAR;
+            }
+            elsif $ctype eq 'short' {
+                $!ctype := nqp::const::C_TYPE_SHORT;
+            }
+            elsif $ctype eq 'int' {
+                $!ctype := nqp::const::C_TYPE_INT;
+            }
+            elsif $ctype eq 'long' {
+                $!ctype := nqp::const::C_TYPE_LONG;
+            }
+            elsif $ctype eq 'longlong' {
+                $!ctype := nqp::const::C_TYPE_LONGLONG;
+            }
+            elsif $ctype eq 'bool' {
+                $!ctype := nqp::const::C_TYPE_BOOL;
+            }
+            elsif $ctype eq 'size_t' {
+                $!ctype := nqp::const::C_TYPE_SIZE_T;
+            }
+            elsif $ctype eq 'atomic' {
+                $!ctype := nqp::const::C_TYPE_ATOMIC_INT;
+            }
+            elsif $ctype eq 'wchar_t' {
+                $!ctype := nqp::const::C_TYPE_WCHAR_T;
+            }
+            elsif $ctype eq 'wint_t' {
+                $!ctype := nqp::const::C_TYPE_WINT_T;
+            }
+            elsif $ctype eq 'char16_t' {
+                $!ctype := nqp::const::C_TYPE_CHAR16_T;
+            }
+            elsif $ctype eq 'char32_t' {
+                $!ctype := nqp::const::C_TYPE_CHAR32_T;
+            }
+            else {
+                nqp::die("Unhandled C type '$ctype'");
+            }
         }
-        elsif $ctype eq 'short' {
-            $!nativesize := nqp::const::C_TYPE_SHORT;
-        }
-        elsif $ctype eq 'int' {
-            $!nativesize := nqp::const::C_TYPE_INT;
-        }
-        elsif $ctype eq 'long' {
-            $!nativesize := nqp::const::C_TYPE_LONG;
-        }
-        elsif $ctype eq 'longlong' {
-            $!nativesize := nqp::const::C_TYPE_LONGLONG;
-        }
-        elsif $ctype eq 'float' {
-            $!nativesize := nqp::const::C_TYPE_FLOAT;
-        }
-        elsif $ctype eq 'double' {
-            $!nativesize := nqp::const::C_TYPE_DOUBLE;
-        }
-        elsif $ctype eq 'longdouble' {
-            $!nativesize := nqp::const::C_TYPE_LONGDOUBLE;
-        }
-        elsif $ctype eq 'bool' {
-            $!nativesize := nqp::const::C_TYPE_BOOL;
-        }
-        elsif $ctype eq 'size_t' {
-            $!nativesize := nqp::const::C_TYPE_SIZE_T;
-        }
-        elsif $ctype eq 'atomic' {
-            $!nativesize := nqp::const::C_TYPE_ATOMIC_INT;
-        }
-        elsif $ctype eq 'wchar_t' {
-            $!nativesize := nqp::const::C_TYPE_WCHAR_T;
-        }
-        elsif $ctype eq 'wint_t' {
-            $!nativesize := nqp::const::C_TYPE_WINT_T;
-        }
-        elsif $ctype eq 'char16_t' {
-            $!nativesize := nqp::const::C_TYPE_CHAR16_T;
-        }
-        elsif $ctype eq 'char32_t' {
-            $!nativesize := nqp::const::C_TYPE_CHAR32_T;
+        elsif $reprname eq 'P6num' {
+            if $ctype eq 'float' {
+                $!ctype := nqp::const::C_TYPE_FLOAT;
+            }
+            elsif $ctype eq 'double' {
+                $!ctype := nqp::const::C_TYPE_DOUBLE;
+            }
+            elsif $ctype eq 'longdouble' {
+                $!ctype := nqp::const::C_TYPE_LONGDOUBLE;
+            }
+            else {
+                nqp::die("Unhandled C type '$ctype'");
+            }
         }
         else {
             nqp::die("Unhandled C type '$ctype'")
+        }
+    }
+
+    method ctype($obj) {
+        my str $reprname := nqp::reprname($obj);
+        if $reprname eq 'P6int' {
+            if $!ctype == nqp::const::C_TYPE_CHAR {
+                'char'
+            }
+            elsif $!ctype == nqp::const::C_TYPE_SHORT {
+                'short'
+            }
+            elsif $!ctype == nqp::const::C_TYPE_INT {
+                'int'
+            }
+            elsif $!ctype == nqp::const::C_TYPE_LONG {
+                'long'
+            }
+            elsif $!ctype == nqp::const::C_TYPE_LONGLONG {
+                'longlong'
+            }
+            elsif $!ctype == nqp::const::C_TYPE_BOOL {
+                'bool'
+            }
+            elsif $!ctype == nqp::const::C_TYPE_SIZE_T {
+                'size_t'
+            }
+            elsif $!ctype == nqp::const::C_TYPE_ATOMIC_INT {
+                'atomic'
+            }
+            elsif $!ctype == nqp::const::C_TYPE_WCHAR_T {
+                'wchar_t'
+            }
+            elsif $!ctype == nqp::const::C_TYPE_WINT_T {
+                'wint_t'
+            }
+            elsif $!ctype == nqp::const::C_TYPE_CHAR16_T {
+                'char16_t'
+            }
+            elsif $!ctype == nqp::const::C_TYPE_CHAR32_T {
+                'char32_t'
+            }
+            else {
+                ''
+            }
+        }
+        elsif $reprname eq 'P6num' {
+            if $!ctype == nqp::const::C_TYPE_FLOAT {
+                'float'
+            }
+            elsif $!ctype == nqp::const::C_TYPE_DOUBLE {
+                'double'
+            }
+            elsif $!ctype == nqp::const::C_TYPE_LONGDOUBLE {
+                'longdouble'
+            }
+            else {
+                ''
+            }
+        }
+        else {
+            ''
         }
     }
 

--- a/src/Perl6/Metamodel/NativeHOW.nqp
+++ b/src/Perl6/Metamodel/NativeHOW.nqp
@@ -95,6 +95,18 @@ class Perl6::Metamodel::NativeHOW
         elsif $ctype eq 'atomic' {
             $!nativesize := nqp::const::C_TYPE_ATOMIC_INT;
         }
+        elsif $ctype eq 'wchar_t' {
+            $!nativesize := nqp::const::C_TYPE_WCHAR_T;
+        }
+        elsif $ctype eq 'wint_t' {
+            $!nativesize := nqp::const::C_TYPE_WINT_T;
+        }
+        elsif $ctype eq 'char16_t' {
+            $!nativesize := nqp::const::C_TYPE_CHAR16_T;
+        }
+        elsif $ctype eq 'char32_t' {
+            $!nativesize := nqp::const::C_TYPE_CHAR32_T;
+        }
         else {
             nqp::die("Unhandled C type '$ctype'")
         }

--- a/src/Perl6/Metamodel/NativeHOW.nqp
+++ b/src/Perl6/Metamodel/NativeHOW.nqp
@@ -43,8 +43,8 @@ class Perl6::Metamodel::NativeHOW
             $info<integer>           := nqp::hash();
             $info<float>             := nqp::hash();
             if nqp::isconcrete($!ctype) {
-                $info<integer><type> := $!ctype;
-                $info<float><type>   := $!ctype;
+                $info<integer><nativetype> := $!ctype;
+                $info<float><nativetype>   := $!ctype;
             }
             if nqp::objprimspec($!nativesize) {
                 $info<integer><bits> := $!nativesize;
@@ -55,7 +55,7 @@ class Perl6::Metamodel::NativeHOW
                 $info<float><bits>   := nqp::unbox_i($!nativesize);
             }
             if $!unsigned {
-                $info<integer><unsigned> := 1;
+                $info<integer><unsigned> := $!unsigned;
             }
             nqp::composetype($obj, $info);
         }

--- a/src/Perl6/Metamodel/ParametricRoleHOW.nqp
+++ b/src/Perl6/Metamodel/ParametricRoleHOW.nqp
@@ -13,6 +13,7 @@ class Perl6::Metamodel::ParametricRoleHOW
     does Perl6::Metamodel::Stashing
     does Perl6::Metamodel::TypePretense
     does Perl6::Metamodel::RolePunning
+    does Perl6::Metamodel::CharType
     does Perl6::Metamodel::ArrayType
 {
     has $!composed;

--- a/src/Perl6/Metamodel/REPRComposeProtocol.nqp
+++ b/src/Perl6/Metamodel/REPRComposeProtocol.nqp
@@ -5,8 +5,13 @@ role Perl6::Metamodel::REPRComposeProtocol {
         unless $!composed_repr {
             # Is it a character type?
             if nqp::can(self, 'is_char_type') && self.is_char_type($obj) {
-                nqp::composetype(nqp::decont($obj), nqp::hash('string',
-                    nqp::hash('type', self.char_type($obj), 'length', 0)));
+                nqp::composetype(
+                  nqp::decont($obj),
+                  nqp::hash(
+                    'string',
+                    nqp::hash('type', self.raw_char_type($obj), 'length', 0),
+                  )
+                )
             }
 
             # Is it an array type?

--- a/src/Perl6/Metamodel/REPRComposeProtocol.nqp
+++ b/src/Perl6/Metamodel/REPRComposeProtocol.nqp
@@ -3,8 +3,14 @@ role Perl6::Metamodel::REPRComposeProtocol {
 
     method compose_repr($obj) {
         unless $!composed_repr {
+            # Is it a character type?
+            if nqp::can(self, 'is_char_type') && self.is_char_type($obj) {
+                nqp::composetype(nqp::decont($obj), nqp::hash('string',
+                    nqp::hash('type', self.char_type($obj), 'length', 0)));
+            }
+
             # Is it an array type?
-            if nqp::can(self, 'is_array_type') && self.is_array_type($obj) {
+            elsif nqp::can(self, 'is_array_type') && self.is_array_type($obj) {
                 if self.attributes($obj) {
                     nqp::die("Cannot have attributes on an array representation");
                 }

--- a/src/Perl6/Metamodel/REPRComposeProtocol.nqp
+++ b/src/Perl6/Metamodel/REPRComposeProtocol.nqp
@@ -4,12 +4,12 @@ role Perl6::Metamodel::REPRComposeProtocol {
     method compose_repr($obj) {
         unless $!composed_repr {
             # Is it a character type?
-            if nqp::can(self, 'is_char_type') && self.is_char_type($obj) {
+            if nqp::can(self, 'has_char_type') && self.has_char_type($obj) {
                 nqp::composetype(
                   nqp::decont($obj),
                   nqp::hash(
                     'string',
-                    nqp::hash('chartype', self.raw_char_type($obj), 'length', 0),
+                    nqp::hash('chartype', self.char_type($obj)),
                   )
                 )
             }

--- a/src/Perl6/Metamodel/REPRComposeProtocol.nqp
+++ b/src/Perl6/Metamodel/REPRComposeProtocol.nqp
@@ -9,7 +9,7 @@ role Perl6::Metamodel::REPRComposeProtocol {
                   nqp::decont($obj),
                   nqp::hash(
                     'string',
-                    nqp::hash('chartype', self.char_type($obj)),
+                    nqp::hash('nativetype', self.char_type($obj)),
                   )
                 )
             }
@@ -44,7 +44,7 @@ role Perl6::Metamodel::REPRComposeProtocol {
                         my %attr_info;
                         %attr_info<name>   := $attr.name;
                         %attr_info<type>   := $attr.type;
-                        %attr_info<string> := nqp::hash('chartype', $attr.char_type, 'length', 0);
+                        %attr_info<string> := nqp::hash('nativetype', $attr.char_type);
                         if $attr.box_target {
                             # Merely having the key serves as a "yes".
                             %attr_info<box_target> := 1;

--- a/src/Perl6/Metamodel/REPRComposeProtocol.nqp
+++ b/src/Perl6/Metamodel/REPRComposeProtocol.nqp
@@ -9,7 +9,7 @@ role Perl6::Metamodel::REPRComposeProtocol {
                   nqp::decont($obj),
                   nqp::hash(
                     'string',
-                    nqp::hash('type', self.raw_char_type($obj), 'length', 0),
+                    nqp::hash('chartype', self.raw_char_type($obj), 'length', 0),
                   )
                 )
             }
@@ -42,8 +42,9 @@ role Perl6::Metamodel::REPRComposeProtocol {
                     nqp::push(@type_info, @attrs);
                     for $type_obj.HOW.attributes(nqp::decont($type_obj), :local) -> $attr {
                         my %attr_info;
-                        %attr_info<name> := $attr.name;
-                        %attr_info<type> := $attr.type;
+                        %attr_info<name>   := $attr.name;
+                        %attr_info<type>   := $attr.type;
+                        %attr_info<string> := nqp::hash('chartype', $attr.char_type, 'length', 0);
                         if $attr.box_target {
                             # Merely having the key serves as a "yes".
                             %attr_info<box_target> := 1;

--- a/src/core/natives.pm6
+++ b/src/core/natives.pm6
@@ -1,19 +1,19 @@
 my native   int is repr('P6int') is Int { }
-my native  int8 is repr('P6int') is Int is nativesize( 8) { }
-my native int16 is repr('P6int') is Int is nativesize(16) { }
-my native int32 is repr('P6int') is Int is nativesize(32) { }
-my native int64 is repr('P6int') is Int is nativesize(64) { }
+my native  int8 is repr('P6int') is Int is ctype('char')     is nativesize( 8) { }
+my native int16 is repr('P6int') is Int is ctype('short')    is nativesize(16) { }
+my native int32 is repr('P6int') is Int is ctype('int')      is nativesize(32) { }
+my native int64 is repr('P6int') is Int is ctype('longlong') is nativesize(64) { }
 
 my native   uint is repr('P6int') is Int is unsigned { }
-my native  uint8 is repr('P6int') is Int is nativesize( 8) is unsigned { }
-my native   byte is repr('P6int') is Int is nativesize( 8) is unsigned { }
-my native uint16 is repr('P6int') is Int is nativesize(16) is unsigned { }
-my native uint32 is repr('P6int') is Int is nativesize(32) is unsigned { }
-my native uint64 is repr('P6int') is Int is nativesize(64) is unsigned { }
+my native  uint8 is repr('P6int') is Int is ctype('char')     is nativesize( 8) is unsigned { }
+my native   byte is repr('P6int') is Int is ctype('char')     is nativesize( 8) is unsigned { }
+my native uint16 is repr('P6int') is Int is ctype('short')    is nativesize(16) is unsigned { }
+my native uint32 is repr('P6int') is Int is ctype('int')      is nativesize(32) is unsigned { }
+my native uint64 is repr('P6int') is Int is ctype('longlong') is nativesize(64) is unsigned { }
 
 my native   num is repr('P6num') is Num { }
-my native num32 is repr('P6num') is Num is nativesize(32) { }
-my native num64 is repr('P6num') is Num is nativesize(64) { }
+my native num32 is repr('P6num') is Num is ctype('float')  is nativesize(32) { }
+my native num64 is repr('P6num') is Num is ctype('double') is nativesize(64) { }
 
 my native   str is repr('P6str') is Str { }
 

--- a/t/04-nativecall/02-simple-args.c
+++ b/t/04-nativecall/02-simple-args.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <string.h>
+#include <wchar.h>
 
 #ifdef _WIN32
 #define DLLEXPORT __declspec(dllexport)
@@ -109,5 +110,19 @@ DLLEXPORT int TakeSSizeT(ssize_t x)
 {
     if (x == -42)
         return 14;
+    return 0;
+}
+
+DLLEXPORT int TakeWCharT(wchar_t x)
+{
+    if (x == 42)
+        return 15;
+    return 0;
+}
+
+DLLEXPORT int TakeWIntT(wint_t x)
+{
+    if (x == 42)
+        return 16;
     return 0;
 }

--- a/t/04-nativecall/02-simple-args.t
+++ b/t/04-nativecall/02-simple-args.t
@@ -5,7 +5,7 @@ use CompileTestLib;
 use NativeCall;
 use Test;
 
-plan 14;
+plan 16;
 
 compile_test_lib('02-simple-args');
 
@@ -66,9 +66,19 @@ skip("Cannot test TakeUint16(0xFFFE) with clang without -O0");
 
 is TakeUint32(0xFFFFFFFE), 12, 'passed uint32 0xFFFFFFFE';
 
-sub TakeSizeT(size_t) returns int32 is native('./02-simple-args') { * }
-is TakeSizeT(42),     13, 'passed size_t 42';
-sub TakeSSizeT(ssize_t --> int32) is native('./02-simple-args') { * }
-is TakeSSizeT(-42),   14, 'passed ssize_t -42';
+sub TakeSizeT(size_t)   returns int32 is native('./02-simple-args') { * }
+is TakeSizeT(42),   13, 'passed size_t 42';
+sub TakeSSizeT(ssize_t) returns int32 is native('./02-simple-args') { * }
+is TakeSSizeT(-42), 14, 'passed ssize_t -42';
+
+if $*VM.name eq 'moar' {
+    sub TakeWCharT(wchar_t) returns int32 is native('./02-simple-args') { * }
+    is TakeWCharT(42), 15, 'passed wchar_t 42';
+    sub TakeWIntT(wint_t)   returns int32 is native('./02-simple-args') { * }
+    is TakeWIntT(42),  16, 'passed wint_t 42';
+}
+else {
+    skip 'Wide string support NYI on this backend', 2;
+}
 
 # vim:ft=perl6

--- a/t/04-nativecall/02-simple-args.t
+++ b/t/04-nativecall/02-simple-args.t
@@ -32,7 +32,7 @@ sub SetString(Str) returns int32 is native('./02-simple-args') { * }
 sub CheckString()  returns int32 is native('./02-simple-args') { * }
 my $str = 'ok 7 - checked previously passed string';
 explicitly-manage($str);
-SetString($str);
+SetString($str.native-string);
 is CheckString(), 7, 'checked previously passed string';
 
 # Make sure wrapped subs work

--- a/t/04-nativecall/03-simple-returns.c
+++ b/t/04-nativecall/03-simple-returns.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <string.h>
+#include <wchar.h>
 
 #ifdef _WIN32
 #define DLLEXPORT __declspec(dllexport)
@@ -62,4 +63,24 @@ DLLEXPORT unsigned short ReturnUint16()
 DLLEXPORT unsigned int ReturnUint32()
 {
     return 0xFFFFFFFE;
+}
+
+DLLEXPORT wchar_t ReturnWCharT()
+{
+    return 42;
+}
+
+DLLEXPORT wint_t ReturnWIntT()
+{
+    return 42;
+}
+
+DLLEXPORT wchar_t *ReturnWideString()
+{
+    return L"epic cuteness";
+}
+
+DLLEXPORT wchar_t *ReturnNullWideString()
+{
+    return NULL;
 }

--- a/t/04-nativecall/03-simple-returns.t
+++ b/t/04-nativecall/03-simple-returns.t
@@ -5,7 +5,7 @@ use CompileTestLib;
 use NativeCall;
 use Test;
 
-plan(11);
+plan 15;
 
 compile_test_lib('03-simple-returns');
 
@@ -28,7 +28,7 @@ sub ReturnString() returns Str is native('./03-simple-returns') { * }
 is ReturnString(), "epic cuteness", 'returning string works';
 
 sub ReturnNullString returns Str is native('./03-simple-returns') { * }
-nok ReturnNullString().defined, 'returning null string pointer';
+nok ReturnNullString().defined, 'returning null string pointer works';
 
 sub ReturnInt64() returns int64 is native('./03-simple-returns') { * }
 is ReturnInt64(), 0xFFFFFFFFFF, 'returning int64 works';
@@ -41,3 +41,20 @@ is ReturnUint16(), 0xFFFE, 'returning uint16 works';
 
 sub ReturnUint32() returns uint32 is native('./03-simple-returns') { * }
 is ReturnUint32(), 0xFFFFFFFE, 'returning uint32 works';
+
+if $*VM.name eq 'moar' {
+    sub ReturnWCharT() returns wchar_t is native('./03-simple-returns') { * }
+    is ReturnWCharT(), 42, 'returning wchar_t works';
+
+    sub ReturnWIntT() returns wint_t is native('./03-simple-returns') { * }
+    is ReturnWIntT(), 42, 'returning wint_t works';
+
+    sub ReturnWideString() returns Str is wide is native('./03-simple-returns') { * }
+    is ReturnWideString(), 'epic cuteness', 'returning wide string works';
+
+    sub ReturnNullWideString() returns Str is wide is native('./03-simple-returns') { * }
+    nok ReturnNullWideString().defined, 'returning null wide string pointer works'
+}
+else {
+    skip 'Wide string support NYI on this backend', 4;
+}

--- a/t/04-nativecall/06-struct.c
+++ b/t/04-nativecall/06-struct.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <wchar.h>
 
 #ifdef _WIN32
 #define DLLEXPORT __declspec(dllexport)
@@ -42,6 +43,11 @@ typedef struct {
     int b[3];
     int c;
 } InlinedArrayInStruct;
+
+typedef struct {
+    wchar_t *first;
+    wchar_t *second;
+} WideStringStruct;
 
 DLLEXPORT MyStruct *ReturnAStruct()
 {
@@ -148,4 +154,17 @@ DLLEXPORT InlinedArrayInStruct *ReturnAInlinedArrayInStruct() {
     iais->c    = 555;
 
     return iais;
+}
+
+DLLEXPORT WideStringStruct *ReturnAWideStringStruct() {
+    WideStringStruct *obj = malloc(sizeof(WideStringStruct));
+    obj->first  = L"OMG!";
+    obj->second = L"Strings!";
+    return obj;
+}
+
+DLLEXPORT int TakeAWideStringStruct(WideStringStruct *obj) {
+    if (wcscmp(obj->first,  L"Lorem")) return 1;
+    if (wcscmp(obj->second, L"ipsum")) return 2;
+    return 33;
 }

--- a/t/04-nativecall/09-nativecast.c
+++ b/t/04-nativecall/09-nativecast.c
@@ -72,3 +72,13 @@ DLLEXPORT char * ReturnNullString()
 {
     return NULL;
 }
+
+DLLEXPORT wchar_t * ReturnWideString()
+{
+    return L"epic cuteness";
+}
+
+DLLEXPORT wchar_t * ReturnNullWideString()
+{
+    return NULL;
+}

--- a/t/04-nativecall/09-nativecast.t
+++ b/t/04-nativecall/09-nativecast.t
@@ -5,7 +5,7 @@ use CompileTestLib;
 use NativeCall;
 use Test;
 
-plan(9);
+plan 11;
 
 compile_test_lib('09-nativecast');
 
@@ -39,3 +39,16 @@ is nativecast(str, ReturnString()), "epic cuteness", 'casting to str works';
 
 sub ReturnNullString returns Pointer is native('./09-nativecast') { * }
 nok nativecast(str, ReturnNullString()).defined, 'casting null pointer to str';
+
+if $*VM.name eq 'moar' {
+    class wstr is repr('P6str') is Str is wide { }
+
+    sub ReturnWideString() returns Pointer is native('./09-nativecast') { * }
+    is nativecast(wstr, ReturnWideString()), 'epic cuteness', 'casting to str is wide works';
+
+    sub ReturnNullWideString returns Pointer is native('./09-nativecast') { * }
+    nok nativecast(wstr, ReturnNullWideString()).defined, 'casting null pointer to str is wide';
+}
+else {
+    skip 'Wide string support NYI on this backend', 2;
+}

--- a/t/04-nativecall/10-cglobals.c
+++ b/t/04-nativecall/10-cglobals.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <string.h>
+#include <wchar.h>
 
 #ifdef _WIN32
 #define DLLEXPORT __declspec(dllexport)
@@ -27,3 +28,9 @@ char * GlobalString = "epic cuteness";
 
 DLLEXPORT char * GlobalNullString;
 char * GlobalNullString = NULL;
+
+DLLEXPORT wchar_t * GlobalWideString;
+wchar_t * GlobalWideString = L"epic cuteness";
+
+DLLEXPORT wchar_t * GlobalNullWideString;
+wchar_t * GlobalNullWideString = NULL;

--- a/t/04-nativecall/10-cglobals.t
+++ b/t/04-nativecall/10-cglobals.t
@@ -5,7 +5,7 @@ use CompileTestLib;
 use NativeCall;
 use Test;
 
-plan(7);
+plan 9;
 
 compile_test_lib('10-cglobals');
 
@@ -29,3 +29,16 @@ is $GlobalString, "epic cuteness", 'global string works';
 
 my $GlobalNullString := cglobal('./10-cglobals', 'GlobalNullString', str);
 nok $GlobalNullString.defined, 'global null string pointer';
+
+if $*VM.name eq 'moar' {
+    class wstr is repr('P6str') is Str is wide { }
+
+    my $GlobalWideString := cglobal('./10-cglobals', 'GlobalWideString', wstr);
+    is $GlobalWideString, 'epic cuteness', 'global wide string works';
+
+    my $GlobalNullWideString := cglobal('./10-cglobals', 'GlobalNullWideString', wstr);
+    nok $GlobalNullWideString.defined, 'global null wide string pointer';
+}
+else {
+    skip 'Wide string support NYI on this backend', 2;
+}

--- a/t/04-nativecall/12-sizeof.c
+++ b/t/04-nativecall/12-sizeof.c
@@ -14,6 +14,8 @@
 #endif
 
 #include <stddef.h>
+#include <stdint.h>
+#include <wchar.h>
 
 typedef struct {
     char  foo1;
@@ -87,20 +89,24 @@ struct foo8 {
     char c;
 };
 
-DLLEXPORT int SizeofFoo() { return sizeof(Foo); }
-DLLEXPORT int SizeofBar() { return sizeof(Bar); }
-DLLEXPORT int SizeofBaz() { return sizeof(Baz); }
-DLLEXPORT int SizeofBuz() { return sizeof(Buz); }
-DLLEXPORT int SizeofInt() { return sizeof(int); }
-DLLEXPORT int SizeofLng() { return sizeof(long); }
-DLLEXPORT int SizeofPtr() { return sizeof(void *); }
-DLLEXPORT int SizeofBool() { return sizeof(bool); }
-DLLEXPORT int SizeofSizeT() { return sizeof(size_t); }
-DLLEXPORT int SizeofFoo1() { return sizeof(struct foo1); }
-DLLEXPORT int SizeofFoo2() { return sizeof(struct foo2); }
-DLLEXPORT int SizeofFoo3() { return sizeof(struct foo3); }
-DLLEXPORT int SizeofFoo4() { return sizeof(struct foo4); }
-DLLEXPORT int SizeofFoo5() { return sizeof(struct foo5); }
-DLLEXPORT int SizeofFoo6() { return sizeof(struct foo6); }
-DLLEXPORT int SizeofFoo7() { return sizeof(struct foo7); }
-DLLEXPORT int SizeofFoo8() { return sizeof(struct foo8); }
+DLLEXPORT size_t SizeofFoo()     { return sizeof(Foo);            }
+DLLEXPORT size_t SizeofBar()     { return sizeof(Bar);            }
+DLLEXPORT size_t SizeofBaz()     { return sizeof(Baz);            }
+DLLEXPORT size_t SizeofBuz()     { return sizeof(Buz);            }
+DLLEXPORT size_t SizeofInt()     { return sizeof(int);            }
+DLLEXPORT size_t SizeofLng()     { return sizeof(long);           }
+DLLEXPORT size_t SizeofPtr()     { return sizeof(void *);         }
+DLLEXPORT size_t SizeofBool()    { return sizeof(bool);           }
+DLLEXPORT size_t SizeofSizeT()   { return sizeof(size_t);         }
+DLLEXPORT size_t SizeofFoo1()    { return sizeof(struct foo1);    }
+DLLEXPORT size_t SizeofFoo2()    { return sizeof(struct foo2);    }
+DLLEXPORT size_t SizeofFoo3()    { return sizeof(struct foo3);    }
+DLLEXPORT size_t SizeofFoo4()    { return sizeof(struct foo4);    }
+DLLEXPORT size_t SizeofFoo5()    { return sizeof(struct foo5);    }
+DLLEXPORT size_t SizeofFoo6()    { return sizeof(struct foo6);    }
+DLLEXPORT size_t SizeofFoo7()    { return sizeof(struct foo7);    }
+DLLEXPORT size_t SizeofFoo8()    { return sizeof(struct foo8);    }
+DLLEXPORT size_t SizeofWCharT()  { return sizeof(wchar_t);        }
+DLLEXPORT size_t SizeofWIntT()   { return sizeof(wint_t);         }
+DLLEXPORT size_t SizeofChar16T() { return sizeof(uint_least16_t); }
+DLLEXPORT size_t SizeofChar32T() { return sizeof(uint_least32_t); }

--- a/t/04-nativecall/12-sizeof.t
+++ b/t/04-nativecall/12-sizeof.t
@@ -5,7 +5,7 @@ use CompileTestLib;
 use NativeCall;
 use Test;
 
-plan 17;
+plan 21;
 
 compile_test_lib('12-sizeof');
 
@@ -81,38 +81,52 @@ class foo8 is repr<CStruct> {
     has int8 $.c;
 };
 
-sub SizeofFoo() returns int32 is native('./12-sizeof') { * }
-sub SizeofBar() returns int32 is native('./12-sizeof') { * }
-sub SizeofBaz() returns int32 is native('./12-sizeof') { * }
-sub SizeofBuz() returns int32 is native('./12-sizeof') { * }
-sub SizeofInt() returns int32 is native('./12-sizeof') { * }
-sub SizeofLng() returns int32 is native('./12-sizeof') { * }
-sub SizeofPtr() returns int32 is native('./12-sizeof') { * }
-sub SizeofBool() returns int32 is native('./12-sizeof') { * }
-sub SizeofSizeT() returns int32 is native('./12-sizeof') { * }
-sub SizeofFoo1()  returns int32 is native('./12-sizeof') { * }
-sub SizeofFoo2()  returns int32 is native('./12-sizeof') { * }
-sub SizeofFoo3()  returns int32 is native('./12-sizeof') { * }
-sub SizeofFoo4()  returns int32 is native('./12-sizeof') { * }
-sub SizeofFoo5()  returns int32 is native('./12-sizeof') { * }
-sub SizeofFoo6()  returns int32 is native('./12-sizeof') { * }
-sub SizeofFoo7()  returns int32 is native('./12-sizeof') { * }
-sub SizeofFoo8()  returns int32 is native('./12-sizeof') { * }
+sub SizeofFoo()     returns size_t is native('./12-sizeof') { * }
+sub SizeofBar()     returns size_t is native('./12-sizeof') { * }
+sub SizeofBaz()     returns size_t is native('./12-sizeof') { * }
+sub SizeofBuz()     returns size_t is native('./12-sizeof') { * }
+sub SizeofInt()     returns size_t is native('./12-sizeof') { * }
+sub SizeofLng()     returns size_t is native('./12-sizeof') { * }
+sub SizeofPtr()     returns size_t is native('./12-sizeof') { * }
+sub SizeofBool()    returns size_t is native('./12-sizeof') { * }
+sub SizeofSizeT()   returns size_t is native('./12-sizeof') { * }
+sub SizeofFoo1()    returns size_t is native('./12-sizeof') { * }
+sub SizeofFoo2()    returns size_t is native('./12-sizeof') { * }
+sub SizeofFoo3()    returns size_t is native('./12-sizeof') { * }
+sub SizeofFoo4()    returns size_t is native('./12-sizeof') { * }
+sub SizeofFoo5()    returns size_t is native('./12-sizeof') { * }
+sub SizeofFoo6()    returns size_t is native('./12-sizeof') { * }
+sub SizeofFoo7()    returns size_t is native('./12-sizeof') { * }
+sub SizeofFoo8()    returns size_t is native('./12-sizeof') { * }
+sub SizeofWCharT()  returns size_t is native('./12-sizeof') { * }
+sub SizeofWIntT()   returns size_t is native('./12-sizeof') { * }
+sub SizeofChar16T() returns size_t is native('./12-sizeof') { * }
+sub SizeofChar32T() returns size_t is native('./12-sizeof') { * }
 
-is nativesizeof(Foo),     SizeofFoo(), 'sizeof(Foo)';
-is nativesizeof(Bar),     SizeofBar(), 'sizeof(Bar)';
-is nativesizeof(Baz),     SizeofBaz(), 'sizeof(Baz)';
-is nativesizeof(Buz),     SizeofBuz(), 'sizeof(Buz)';
-is nativesizeof(int32),   SizeofInt(), 'sizeof(int)';
-is nativesizeof(long),    SizeofLng(), 'sizeof(long)';
-is nativesizeof(Pointer), SizeofPtr(), 'sizeof(Pointer)';
-is nativesizeof(bool),    SizeofBool(), 'sizeof(bool)';
-is nativesizeof(size_t),  SizeofSizeT(), 'sizeof(size_t)';
-is nativesizeof(foo1),    SizeofFoo1(),  'sizeof(foo1)';
-is nativesizeof(foo2),    SizeofFoo2(),  'sizeof(foo2)';
-is nativesizeof(foo3),    SizeofFoo3(),  'sizeof(foo3)';
-is nativesizeof(foo4),    SizeofFoo4(),  'sizeof(foo4)';
-is nativesizeof(foo5),    SizeofFoo5(),  'sizeof(foo5)';
-is nativesizeof(foo6),    SizeofFoo6(),  'sizeof(foo6)';
-is nativesizeof(foo7),    SizeofFoo7(),  'sizeof(foo7)';
-is nativesizeof(foo8),    SizeofFoo8(),  'sizeof(foo8)';
+is nativesizeof(Foo),      SizeofFoo(),     'sizeof(Foo)';
+is nativesizeof(Bar),      SizeofBar(),     'sizeof(Bar)';
+is nativesizeof(Baz),      SizeofBaz(),     'sizeof(Baz)';
+is nativesizeof(Buz),      SizeofBuz(),     'sizeof(Buz)';
+is nativesizeof(int32),    SizeofInt(),     'sizeof(int)';
+is nativesizeof(long),     SizeofLng(),     'sizeof(long)';
+is nativesizeof(Pointer),  SizeofPtr(),     'sizeof(Pointer)';
+is nativesizeof(bool),     SizeofBool(),    'sizeof(bool)';
+is nativesizeof(size_t),   SizeofSizeT(),   'sizeof(size_t)';
+is nativesizeof(foo1),     SizeofFoo1(),    'sizeof(foo1)';
+is nativesizeof(foo2),     SizeofFoo2(),    'sizeof(foo2)';
+is nativesizeof(foo3),     SizeofFoo3(),    'sizeof(foo3)';
+is nativesizeof(foo4),     SizeofFoo4(),    'sizeof(foo4)';
+is nativesizeof(foo5),     SizeofFoo5(),    'sizeof(foo5)';
+is nativesizeof(foo6),     SizeofFoo6(),    'sizeof(foo6)';
+is nativesizeof(foo7),     SizeofFoo7(),    'sizeof(foo7)';
+is nativesizeof(foo8),     SizeofFoo8(),    'sizeof(foo8)';
+
+if $*VM.name eq 'moar' {
+    is nativesizeof(wchar_t),  SizeofWCharT(),  'sizeof(wchar_t)';
+    is nativesizeof(wint_t),   SizeofWIntT(),   'sizeof(wint_t)';
+    is nativesizeof(char16_t), SizeofChar16T(), 'sizeof(char16_t)';
+    is nativesizeof(char32_t), SizeofChar32T(), 'sizeof(char32_t)';
+}
+else {
+    skip 'Wide string support NYI on this backend', 4;
+}

--- a/tools/templates/common_bootstrap_sources
+++ b/tools/templates/common_bootstrap_sources
@@ -29,6 +29,7 @@ src/Perl6/Metamodel/BUILDPLAN.nqp
 src/Perl6/Metamodel/REPRComposeProtocol.nqp
 src/Perl6/Metamodel/InvocationProtocol.nqp
 src/Perl6/Metamodel/RolePunning.nqp
+src/Perl6/Metamodel/CharType.nqp
 src/Perl6/Metamodel/ArrayType.nqp
 src/Perl6/Metamodel/RoleToRoleApplier.nqp
 src/Perl6/Metamodel/Concretization.nqp


### PR DESCRIPTION
This does two things, mainly:
- implements support for `wchar_t` and `wint_t`, as well as C++'s `char16_t` and `char32_t` types. These are accurate on MoarVM, but may be unreliable on the JVM and JS backends.
- implements wide string support for the `P6str` and `CStr` REPRs on MoarVM.

This needs testing on Windows.

Passes `make test`, `make spectest` on OpenBSD.

See https://github.com/MoarVM/MoarVM/pull/1137 and https://github.com/perl6/nqp/pull/564