### PR TITLE
Protect class Perl version method with Lock

### DIFF
--- a/src/core/Perl.pm6
+++ b/src/core/Perl.pm6
@@ -15,9 +15,12 @@ class Perl does Systemic {
     method KERNELnames { <darwin linux freebsd openbsd netbsd  dragonfly win32 browser>  }
 
     my %version-cache;
+    my Lock $version-cache-lock .= new;
     method version {
-        my $comp-ver = nqp::p6box_s(nqp::getcomp('perl6').language_version());
-        %version-cache{$comp-ver} //= Version.new($comp-ver);
+        $version-cache-lock.protect: {
+            my $comp-ver = nqp::p6box_s(nqp::getcomp('perl6').language_version());
+            %version-cache{$comp-ver} //= Version.new($comp-ver);
+        }
     }
 }
 


### PR DESCRIPTION
Make it thread-safe, as noticed by Jonathan: https://github.com/rakudo/rakudo/commit/65207879172e6203dde3b40d2b8eb75d8e7c7978#r34296824