### PR TITLE
fix CLA URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,8 +37,7 @@ IRC channel mentioned above.
 
 If you want to contribute large amounts of code, please follow the
 [Contributor License Agreement
-process](http://www.perlfoundation.org/contributor_license_agreement) from the
-Perl Foundation.
+process](https://www.perlfoundation.org/contributor-license-agreement.html) from the Perl Foundation.
 
 For small contributions, you agree to place your code under the terms of the
 license of the code that Rakudo is under.

--- a/docs/obtaining-a-commit-bit.pod
+++ b/docs/obtaining-a-commit-bit.pod
@@ -10,7 +10,7 @@ to https://github.com/rakudo/rakudo)
 B<Step one,> if you haven't already, is to send a signed copy of the
 Contributor License Agreement (CLA) to the Perl Foundation. The CLA and the
 address it can be mailed to can
-be found at http://www.perlfoundation.org/contributor_license_agreement
+be found at https://www.perlfoundation.org/contributor-license-agreement.html
 Some contributors chose to email the CLA to C<trademark -at- perlfoundation.org>
 instead; you can speak to C<[Coke]> on
 L<our IRC chat|https://webchat.freenode.net/?channels=#perl6> for details about


### PR DESCRIPTION
The Contributor License Agreement has changed location from http://www.perlfoundation.org/contributor_license_agreement to https://www.perlfoundation.org/contributor-license-agreement.html