### PR TITLE
Remove release and codename properties from Compiler

### DIFF
--- a/src/core/Compiler.pm6
+++ b/src/core/Compiler.pm6
@@ -1,7 +1,5 @@
 class Compiler does Systemic {
     has Str $.id;
-    has Str $.release;
-    has Str $.codename;
     my constant $id = nqp::p6box_s(nqp::sha1(
         $*W.handle.Str
         ~ nqp::atkey(nqp::getcurhllsym('$COMPILER_CONFIG'), 'source-digest')
@@ -11,8 +9,6 @@ class Compiler does Systemic {
       :$!name      = 'rakudo',
       :$!auth      = 'The Perl Foundation',
       :$version,
-      :$release,
-      :$codename
       --> Nil
     ) {
 # XXX Various issues with this stuff on JVM
@@ -23,10 +19,6 @@ class Compiler does Systemic {
         # looks like: 2018.01-50-g8afd791c1
         $!version = $version
             // Version.new(nqp::atkey($compiler, 'version'));
-        $!release =
-          $release // nqp::p6box_s(nqp::atkey($compiler, 'release-number'));
-        $!codename =
-          $codename // nqp::p6box_s(nqp::atkey($compiler, 'codename'));
     }
 
     method verbose-config(:$say) {

--- a/src/vm/js/load-compiler.nqp
+++ b/src/vm/js/load-compiler.nqp
@@ -19,8 +19,6 @@ $comp.set_language_version('6.d');
 sub hll-config($config) {
     $config<implementation>   := 'Rakudo';
     $config<version>          := '2018.03-1433-g602ca5bd3';
-    $config<release-number>   := '';
-    $config<codename>         := '';
     $config<language-version> := '6.d';
     $config<can-language-versions>
         := nqp::list('6.c', '6.d', '6.d.PREVIEW');

--- a/tools/lib/NQP/Config/Rakudo.pm
+++ b/tools/lib/NQP/Config/Rakudo.pm
@@ -243,7 +243,7 @@ sub configure_misc {
     # Get version info from VERSION template and git.
     my $VERSION = slurp( File::Spec->catfile( $self->cfg('base_dir'), 'VERSION') );
     chomp $VERSION;
-    @{$config}{qw<version release codename>} = split( ' ', $VERSION, 3 );
+    @{$config}{qw<version>} = split( ' ', $VERSION );
 
     if ( -d File::Spec->catdir( $config->{base_dir}, '.git' )
         && open( my $GIT, '-|', q|git describe --match "2*"| ) )

--- a/tools/templates/main-version.in
+++ b/tools/templates/main-version.in
@@ -1,8 +1,6 @@
 sub hll-config($config) {
     $config<implementation>   := 'Rakudo';
     $config<version>          := '@version@';
-    $config<release-number>   := '@release@';
-    $config<codename>         := '@codename@';
     $config<language-version> := '6.@lang_spec@';
     # Though language-revisions key provides more information
     # can-language-versions is used for speeding up and ordering


### PR DESCRIPTION
They're not relevant and are not used.

rakudo/rakudo#2993