### PR TITLE
Don't use add any RPATH compile flags when installing to /usr

### DIFF
--- a/tools/lib/NQP/Config/Rakudo.pm
+++ b/tools/lib/NQP/Config/Rakudo.pm
@@ -360,12 +360,14 @@ sub configure_moar_backend {
     $config->{ldflags} = $nqp_config->{'moar::ldflags'};
     $config->{ldflags} =~ s/\Q$nqp_config->{'moar::ldrpath'}\E ?//;
     $config->{ldflags} =~ s/\Q$nqp_config->{'moar::ldrpath_relocatable'}\E ?//;
-    $config->{ldflags} .= ' '
-      . (
-          $config->{relocatable} eq 'reloc'
-        ? $nqp_config->{'moar::ldrpath_relocatable'}
-        : $nqp_config->{'moar::ldrpath'}
-      );
+    if ( $config->{prefix} ne '/usr' ) {
+        $config->{ldflags} .= ' '
+          . (
+              $config->{relocatable} eq 'reloc'
+            ? $nqp_config->{'moar::ldrpath_relocatable'}
+            : $nqp_config->{'moar::ldrpath'}
+          );
+    }
     $config->{ldlibs}          = $nqp_config->{'moar::ldlibs'};
     $config->{'mingw_unicode'} = '';
 


### PR DESCRIPTION
Do it just the way MoarVM also does it. The RPATH is not necessary in that
case, as the libs will be in the library search anyways and having a
rogue RPATH is bad style and trips up some packaging tools.