### PR TITLE
Clear signature before parsing block

### DIFF
--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -1038,6 +1038,8 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
     token block($*IMPLICIT = 0) {
         :my $*DECLARAND := $*W.stub_code_object('Block');
         :my $*CODE_OBJECT := $*DECLARAND;
+        :my $*SIG_OBJ;
+        :my %*SIG_INFO;
         :dba('scoped block')
         :my $borg := $*BORG;
         :my $has_mystery := $*MYSTERY ?? 1 !! 0;


### PR DESCRIPTION
Fixes https://github.com/rakudo/rakudo/issues/3070.
Fudged test at https://github.com/perl6/roast/pull/562/files.

If we do not do this then the block takes on the signature of the enclosing routine, leaking %*SIG_INFO<returns> into the block and causing the block to return any declared return value of the enclosing sub.

The token pblock also resets $*POD_BLOCK, $*DOC, and $*LINE_NO, but the token block does not. I don't know if that's necessary.

I'm also not entirely sure why the issue only seems to occur for return values and only inside string interpolation (see the linked issue). Do all other places use pblock instead?