### PR TITLE
Try fixing closed handle operations error

### DIFF
--- a/src/core.c/Exception.pm6
+++ b/src/core.c/Exception.pm6
@@ -745,6 +745,11 @@ my class X::IO::BinaryMode does X::IO {
     method message { "Cannot do '$.trying' on a handle in binary mode" }
 }
 
+my class X::IO::ClosedHandle does X::IO {
+    has $.trying;
+    method message { "Cannot do '$.trying' on a closed handle" }
+}
+
 my role X::Comp is Exception {
     has $.filename;
     has $.pos;

--- a/t/05-messages/03-errors.t
+++ b/t/05-messages/03-errors.t
@@ -64,7 +64,7 @@ throws-like {
         .bind-stdout: IO::Handle.new;
         .start;
     }
-}, Exception, :message{.contains: 'handle not open'},
+}, Exception, :message{.contains: 'closed handle'},
   'trying to bind Proc::Async to unopened handle gives useful error';
 
 # https://github.com/Raku/old-issue-tracker/issues/6580


### PR DESCRIPTION
This tries solving the problem described in bug #3073.

It has not been thoroughly tested, there are a few problems with this:
- new method naming
- race condition when closing/destroying handle: `$!decoder` is `Encoding::Decoder`, `$!PIO` is not null
- wrong exception because of race condition: `$!decoder` is not null (set by seek), `$!PIO` is null
- missing "closed handle" errors for a few methods