### PR TITLE
Better support for EXPORT with Stash

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -6677,7 +6677,18 @@ class Perl6::Actions is HLL::Actions does STDActions {
     }
 
     method circumfix:sym<( )>($/) {
-        make handle-list-semis($/, $<semilist>.ast)
+        my $past := handle-list-semis($/, $<semilist>.ast);
+        if $/<stasher> {
+            my $Stash := $*W.find_symbol: ['Stash'], :setting-only;
+            $past := QAST::Op.new:
+                        :op<callmethod>,
+                        :name<new>,
+                        :node($/),
+                        :returns($Stash),
+                        QAST::WVal.new(:value($Stash)),
+                        $past;
+        }
+        make $past
     }
 
     method circumfix:sym<[ ]>($/) {

--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -3570,7 +3570,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
     token circumfix:sym<( )> {
         :my $*FAKE_INFIX_FOUND := 0;
         :dba('parenthesized expression')
-        '(' ~ ')' <semilist>
+        [ '(' ~ ')' <semilist> ] [ $<stasher>='::' ]?
     }
     token circumfix:sym<[ ]> { :dba('array composer') '[' ~ ']' <semilist> }
     token circumfix:sym<ang> {

--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -1098,9 +1098,11 @@ class Perl6::World is HLL::World {
             if nqp::defined(&EXPORT) {
                 my $result := &EXPORT(|@positional_imports);
                 my $Map := self.find_symbol(['Map'], :setting-only);
+                my $Stash := self.find_symbol(['Stash'], :setting-only);
                 if nqp::istype($result, $Map) {
                     my $storage := $result.hash.FLATTENABLE_HASH();
-                    self.import($/, $storage, $package_source_name, :need-decont(!(nqp::what($result) =:= $Map)));
+                    my $need-decont := ! ((nqp::what($result) =:= $Map) || (nqp::what($result) =:= $Stash));
+                    self.import($/, $storage, $package_source_name, :$need-decont);
 #                    $/.check_LANG_oopsies("do_import");
                 }
                 else {

--- a/src/core/Stash.pm6
+++ b/src/core/Stash.pm6
@@ -2,6 +2,10 @@ my class Stash { # declared in BOOTSTRAP
     # class Stash is Hash
     #     has str $!longname;
 
+    method STORE_AT_KEY(|c) {
+        self.BIND-KEY(|c)
+    }
+
     multi method AT-KEY(Stash:D: Str:D $key) is raw {
         my \storage := nqp::getattr(self,Map,'$!storage');
         nqp::if(


### PR DESCRIPTION
Turn off containerization for Stash values

Also added operator (<EXPR>):: which is a shortcut for
Stash.new(<EXPR>)

Now during import values from Stash are used as-is without deconting.

perl6/problem-solving#74