### PR TITLE
Fix return code of perl6 build runners

### DIFF
--- a/src/core/Process.pm6
+++ b/src/core/Process.pm6
@@ -18,7 +18,7 @@ Rakudo::Internals.REGISTER-DYNAMIC: '$*EXECUTABLE', {
 #?if moar
       nqp::execname()
       || ($*VM.config<prefix> ~ '/bin/'
-        ~ ($*VM.config<osname> eq 'MSWin32' ?? 'perl6-m.bat' !! 'perl6-m'))
+        ~ ($*VM.config<osname> eq 'MSWin32' ?? 'perl6-m.exe' !! 'perl6-m'))
 #?endif
 #?if js
       nqp::execname()

--- a/tools/templates/moar/Makefile.in
+++ b/tools/templates/moar/Makefile.in
@@ -242,7 +242,7 @@ $(M_BUILD_RUNNER): @@configure_script@@ $(PERL6_MOAR) $(SETTING_MOAR) @@nfp(@tem
 		--set-var=exec_name=@shquot(@nfp(@base_dir@/$(M_BUILD_RUNNER))@)@ \
 		--set-var=mbc=perl6.moarvm
 	$(M_CC) @moar::ccswitch@ $(M_CFLAGS) @moar::ccout@perl6-m@moar::obj@ perl6-m.c
-	$(M_LD) @moar::ldout@$@ perl6-m@moar::obj@
+	$(M_LD) @moar::ldout@$@ $(M_LDFLAGS) perl6-m@moar::obj@
 
 @perl(
     my %execs = (

--- a/tools/templates/moar/perl6-m-build.c.windows
+++ b/tools/templates/moar/perl6-m-build.c.windows
@@ -1,11 +1,10 @@
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
-#include <errno.h>
-#include <process.h>
+#include <windows.h>
+#include <WinDef.h>
 
 // Loosely according to https://blogs.msdn.microsoft.com/twistylittlepassagesallalike/2011/04/23/everyone-quotes-command-line-arguments-the-wrong-way/
-size_t argvQuote(wchar_t *in, wchar_t *out) {
+int argvQuote(wchar_t *in, wchar_t *out) {
     int ipos;
     int opos;
     int bs_count;
@@ -16,7 +15,7 @@ size_t argvQuote(wchar_t *in, wchar_t *out) {
 
     if (!wcschr(in, L' ') && !wcschr(in, L'\\"') && !wcschr(in, L'\\t') && !wcschr(in, L'\\n') && !wcschr(in, L'\\v')) {
         if (out) wcscpy(out, in);
-        return (wcslen(in) + 1) * sizeof(wchar_t);
+        return wcslen(in) + 1;
     }
 
     if (out) out[opos] = L'\\"';
@@ -61,28 +60,32 @@ size_t argvQuote(wchar_t *in, wchar_t *out) {
     if (out) out[opos] = 0;
     opos++;
 
-    return opos * sizeof(wchar_t);
+    return opos;
 }
 
-int wmain(int argc, wchar_t *argv[])
-{
+
+int wmain(int argc, wchar_t *argv[]) {
     int moar_argc;
     int exec_argc;
     int c;
     wchar_t **exec_argv;
-    wchar_t *moar = L"@c_escape(@nfp(@MOAR@)@)@";
-    wchar_t *buf;
-    size_t buf_size;
+    size_t arg_size;
+    wchar_t *moar;
+    size_t cmd_line_size;
+    wchar_t *cmd_line;
+    DWORD exit_code;
+    BOOL success;
+    STARTUPINFOW si;
+    PROCESS_INFORMATION pi;
 
-    moar_argc = 6;
+    moar_argc = 7;
 
-    // program name + moar args + passed args (without program name) + NULL pointer
-    exec_argc = 1 + moar_argc + (argc - 1) + 1;
+    // moar args + passed args (without program name) + NULL pointer
+    exec_argc = moar_argc + (argc - 1) + 1;
     exec_argv = malloc(exec_argc * sizeof(void*));
 
-    exec_argv[0] = L"@c_escape(@nfp(@MOAR@)@)@";
-
     // Set up moar args.
+    exec_argv[0] = L"@c_escape(@nfp(@MOAR@)@)@";
     exec_argv[1] = L"--execname=@c_escape(@nfp(@exec_name@)@)@";
     exec_argv[2] = L"--libpath=@c_escape(@nfp(@base_dir@)@)@";
     exec_argv[3] = L"--libpath=@c_escape(@nfp(@base_dir@/blib)@)@";
@@ -92,20 +95,65 @@ int wmain(int argc, wchar_t *argv[])
 
     // Copy passed args.
     for (c = 0; c < argc - 1; c++) {
-        exec_argv[1 + moar_argc + c] = argv[c + 1];
+        exec_argv[moar_argc + c] = argv[c + 1];
     }
 
     exec_argv[exec_argc - 1] = NULL;
 
+    // Encode program name
+    arg_size = argvQuote(exec_argv[0], NULL);
+    moar = malloc(arg_size * sizeof(wchar_t));
+    argvQuote(exec_argv[0], moar);
+
+    // Size of the final command line string.
+    // cmd_line_size = size of each argument + one space each - the last space + the trailing \0
+    cmd_line_size = 0;
+    cmd_line = NULL;
+
     for (c = 0; c < exec_argc - 1; c++) {
-        buf_size = argvQuote(exec_argv[c], NULL);
-        buf = malloc(buf_size);
-        argvQuote(exec_argv[c], buf);
-        exec_argv[c] = buf;
+        // argvQuote leaves space for a trailing \0
+        arg_size = argvQuote(exec_argv[c], NULL);
+        cmd_line = realloc(cmd_line, (cmd_line_size + arg_size) * sizeof(wchar_t));
+        argvQuote(exec_argv[c], cmd_line + cmd_line_size);
+        cmd_line_size += arg_size;
+        cmd_line[cmd_line_size - 1] = L' ';
+    }
+    cmd_line[cmd_line_size - 1] = 0;
+
+    // Execute the command and wait for it to finish.
+    ZeroMemory(&si, sizeof(si));
+    si.cb = sizeof(si);
+
+    ZeroMemory(&pi, sizeof(pi));
+
+    success = CreateProcessW(
+        moar,     // ApplicationName
+        cmd_line, // CommandLine
+        NULL,     // ProcessAttributes
+        NULL,     // ThreadAttributes
+        FALSE,    // InheritHandles
+        0,        // CreationFlags
+        NULL,     // Environment
+        NULL,     // CurrentDirectory
+        &si,      // StartupInfo
+        &pi);     // ProcessInformation
+
+    if (!success) {
+        fprintf(stderr, "ERROR: Failed to execute moar. Error code: %ld\n", GetLastError());
+        return EXIT_FAILURE;
     }
 
-    _wexecv(moar, exec_argv);
-    // execv doesn't return on successful exec.
-    fprintf(stderr, "ERROR: Failed to execute moar. Error code: %i\n", errno);
-    return EXIT_FAILURE;
+    // I guess processes only signal when they are done. So no need to check the return value.
+    WaitForSingleObject(pi.hProcess, INFINITE);
+    success = GetExitCodeProcess(pi.hProcess, &exit_code);
+
+    CloseHandle(pi.hProcess);
+    CloseHandle(pi.hThread);
+
+    if (!success) {
+        fprintf(stderr, "Couldn't retrieve exit code. Error code: %ld\n", GetLastError());
+        return EXIT_FAILURE;
+    }
+
+    return exit_code;
 }


### PR DESCRIPTION
Don't use `exec()` as that's broken on Windows. Directly use
`CreateProcess()`, wait for it to finish, retrieve the exit code and
exit with that ourselves.