### PR TITLE
[WIP] Formalize what the IO role actually does and introduce IO::NativeDescriptor

### DIFF
--- a/src/core/Distribution.pm6
+++ b/src/core/Distribution.pm6
@@ -21,7 +21,7 @@ role Distribution::Locally does Distribution {
     has IO::Path $.prefix;
     method content($address) {
         my $path   = IO::Path.new($.meta<files>{$address} // $address, :CWD($!prefix.absolute // $*CWD.absolute));
-        my $handle = IO::Handle.new(:$path);
+        my $handle = IO::Handle.new(:file($path));
         $handle // $handle.throw;
     }
 }

--- a/src/core/Exception.pm6
+++ b/src/core/Exception.pm6
@@ -560,12 +560,14 @@ my class X::IO::Null does X::IO {
 
 my class X::IO::Directory does X::IO {
     has $.path;
+    has $.fd;
     has $.trying;
     has $.use;
     method message () {
-        my $x = "'$.path' is a directory, cannot do '.$.trying' on a directory";
-        if $.use { $x ~= ", try '{$.use}()' instead" }
-        $x;
+        my $x = $!path.defined ?? "'$!path'" !! "The file '$!fd' points to";
+        $x ~= " is a directory, cannot do '.$!trying' on a directory";
+        $x ~= ", try '{$.use}()' instead" if $!use;
+        $x
     }
 }
 

--- a/src/core/Exception.pm6
+++ b/src/core/Exception.pm6
@@ -576,17 +576,10 @@ my class X::IO::Null does X::IO {
 }
 
 my class X::IO::Directory does X::IO {
-    has $.at;
+    has $.path;
     has $.fd;
     has $.trying;
     has $.use;
-
-    method new(:$path, :$at = $path, :$fd, :$trying, :$use, *%named) {
-        self.bless: :$at, :$fd, :$trying, :$use, |%named
-    }
-
-    method path() { $.at }
-
     method message() {
         my $x = $!path.defined ?? "'$!path'" !! "The file '$!fd' points to";
         $x ~= " is a directory, cannot do '.$!trying' on a directory";

--- a/src/core/IO.pm6
+++ b/src/core/IO.pm6
@@ -6,6 +6,7 @@ my class Instant { ... }
 my class IO::Path         { ... }
 my class IO::Special      { ... }
 # IO::NativeDescriptor is stubbed in src/core/Int.pm6.
+# IO::Handle is stubbed in src/core/Rakudo/Internals.pm6.
 my class IO::Notification { ... }
 
 # XXX FIXME: stubbing *anything* in IO makes MoarVM throw with this error
@@ -15,9 +16,9 @@ my role IO {
     # Stringification methods
     # These *must* be implemented by whatever class is doing this role.
 
-    # multi method Str (IO:D: --> Str:D) { ... }
-    # multi method gist(IO:D: --> Str:D) { ... }
-    # multi method perl(IO:D: --> Str:D) { ... }
+    # multi method Str (::?CLASS:D: --> Str:D) { ... }
+    # multi method gist(::?CLASS:D: --> Str:D) { ... }
+    # multi method perl(::?CLASS:D: --> Str:D) { ... }
 
     # File I/O methods
 
@@ -152,6 +153,15 @@ my role IO {
     # multi method mode(IO:D: --> IntStr) { ... }
 
     # Regular file methods (i.e. files that aren't special)
+
+    # This method *must* be implemented by whatever class is doing this role.
+    # The return value must be a native file handle.
+    proto method open-native(IO:D:
+        :$mode, :$create, :$append, :$truncate, :$exclusive --> Mu
+    ) {*}
+    # multi method open-native(::?CLASS:D:
+    #     :$mode, :$create, :$append, :$truncate, :$exclusive --> Mu
+    # ) { ... }
 
     proto method open(IO:D: |c --> IO::Handle) {*}
     multi method open(IO:D: |c --> IO::Handle) {

--- a/src/core/IO.pm6
+++ b/src/core/IO.pm6
@@ -31,7 +31,7 @@ my role IO {
         )
     }
     multi method slurp(IO:D: :$enc, :$bin) {
-        Failure.new: X::IO::RegularFileRequired.new: :from(self), :trying<slurp>
+        Failure.new: X::IO::NotAFile.new: :from(self), :trying<slurp>
     }
 
     proto method spurt(IO:D: :$data, :$enc, :$append, :$createonly) {
@@ -43,7 +43,7 @@ my role IO {
         )
     }
     multi method spurt(IO:D: :$data, :$enc, :$append, :$createonly) {
-        Failure.new: X::IO::RegularFileRequired.new: :from(self), :trying<spurt>
+        Failure.new: X::IO::NotAFile.new: :from(self), :trying<spurt>
     }
 
     method lines(IO:D: :$chomp, :$enc, :$nl-in, |c) {
@@ -139,20 +139,20 @@ my role IO {
 
     proto method open(IO:D: |c --> IO::Handle) {*}
     multi method open(IO:D: |c --> IO::Handle) {
-        Failure.new: X::IO::RegularFileRequired.new: :from(self), :trying<open>
+        Failure.new: X::IO::NotAFile.new: :from(self), :trying<open>
     }
 
 #?if moar
     proto method watch(IO:D: --> IO::Notification) {*}
     multi method watch(IO:D: --> IO::Notification) {
-        Failure.new: X::IO::RegularFileRequired.new: :from(self), :trying<watch>
+        Failure.new: X::IO::NotAFile.new: :from(self), :trying<watch>
     }
 #?endif
 
     proto method rename(IO:D: IO() $to, :$createonly --> Bool) {
         nqp::unless(
           nqp::istype(nqp::decont($to), IO::Path),
-          fail X::IO::PathRequired.new: :from(self), :$to, :trying<rename>
+          fail X::IO::NotAPath.new: :from(self), :$to, :trying<rename>
         );
 
         nqp::if(
@@ -167,7 +167,7 @@ my role IO {
         } }
     }
     multi method rename(IO:D: IO() $to --> Bool) {
-        Failure.new: X::IO::RegularFileRequired.new: :from(self), :$to, :trying<rename>
+        Failure.new: X::IO::NotAFile.new: :from(self), :$to, :trying<rename>
     }
 
     proto method copy(IO:D: IO() $to, :$createonly --> Bool) {
@@ -183,12 +183,12 @@ my role IO {
         } }
     }
     multi method copy(IO:D: IO() $to, :$createonly --> Bool) {...}
-        Failure.new: X::IO::RegularFileRequired.new: :from(self), :$to, :trying<copy>
+        Failure.new: X::IO::NotAFile.new: :from(self), :$to, :trying<copy>
     }
 
     proto method move(IO:D: IO() $to --> Bool) {*}
     multi method move(IO:D: IO() $to --> Bool) {
-        Failure.new: X::IO::RegularFileRequired.new: :from(self), :$to, :trying<move>
+        Failure.new: X::IO::NotAFile.new: :from(self), :$to, :trying<move>
     }
 
     proto method chmod(IO:D: Int() $mode --> Bool) {
@@ -199,7 +199,7 @@ my role IO {
         } }
     }
     multi method chmod(IO:D: Int() $mode --> Bool) {
-        Failure.new: X::IO::RegularFileRequired.new: :from(self), :trying<chmod>
+        Failure.new: X::IO::NotAFile.new: :from(self), :trying<chmod>
     }
 
 #   proto method chown(IO:D: Str() $user --> Bool) {
@@ -210,7 +210,7 @@ my role IO {
 #       } }
 #   }
 #   multi method chown(IO:D: Str() --> Bool) {
-#       Failure.new: X::IO::RegularFileRequired.new: :from(self), :trying<chown>
+#       Failure.new: X::IO::NotAFile.new: :from(self), :trying<chown>
 #   }
 
     # Symlink methods
@@ -219,40 +219,40 @@ my role IO {
         return {*};
 
         CATCH { default {
-            fail X::IO::Unlink.new: :at(self), :os-error(.Str);
+            fail X::IO::Unlink.new: :target(self), :os-error(.Str);
         } }
     }
     multi method unlink(IO:D: --> Bool) {
-        Failure.new: X::IO::PathRequired.new: :from(self), :trying<unlink>
+        Failure.new: X::IO::NotAPath.new: :from(self), :trying<unlink>
     }
 
     proto method symlink(IO:D: IO() $to --> Bool) {
         return {*};
 
         CATCH { default {
-            fail X::IO::Symlink.new: :from(self), :$to, :os-error(.Str);
+            fail X::IO::Symlink.new: :target($to), :os-error(.Str);
         } }
     }
     multi method symlink(IO:D: IO() $to --> Bool) {
-        Failure.new: X::IO::PathRequired.new: :from(self), :$to, :trying<symlink>
+        Failure.new: X::IO::NotAPath.new: :$target, :trying<symlink>
     }
 
     proto method link(IO:D: IO() $to --> Bool) {
         return {*};
 
         CATCH { default {
-            fail X::IO::Link.new: :from(self), :$to, :os-error(.Str);
+            fail X::IO::Link.new: :target($to), :os-error(.Str);
         } }
     }
     multi method link(IO:D: IO() $to --> Bool) {
-        Failure.new: X::IO::PathRequired.new: :from(self), :$to, :trying<link>
+        Failure.new: X::IO::NotAPath.new: :from(self), :$to, :trying<link>
     }
 
     # Directory methods
 
     proto method chdir(IO:D: | --> IO) {*}
-    multi method chdir(IO:D: $to?, | --> IO) {
-        Failure.new: X::IO::PathRequired.new: :from(self), :$to, :trying<chdir>
+    multi method chdir(IO:D: $to, | --> IO) {
+        Failure.new: X::IO::NotAPath.new: :from(self), :$to, :trying<chdir>
     }
 
     proto method mkdir(IO:D: Int() --> IO) {
@@ -262,8 +262,8 @@ my role IO {
             fail X::IO::Mkdir.new: :at(self), :$mode, :os-error(.Str);
         } }
     }
-    multi method mkdir(IO:D: Int() --> IO) {
-        Failure.new: X::IO::PathRequired.new: :from(self), :trying<mkdir>
+    multi method mkdir(IO:D: Int() $to --> IO) {
+        Failure.new: X::IO::NotAPath.new: :from(self), :$to, :trying<mkdir>
     }
 
     proto method rmdir(IO:D: --> IO) {
@@ -274,7 +274,7 @@ my role IO {
         } }
     }
     multi method rmdir(IO:D: --> IO) {
-        Failure.new: X::IO::PathRequired.new: :from(self), :trying<rmdir>
+        Failure.new: X::IO::NotAPath.new: :from(self), :trying<rmdir>
     }
 
     proto method dir(IO:D: Mu :$test) {
@@ -285,7 +285,7 @@ my role IO {
         } }
     }
     multi method dir(IO:D: Mu :$test) {
-        Failure.new: X::IO::PathRequired.new: :from(self), :trying<dir>
+        Failure.new: X::IO::NotAPath.new: :from(self), :trying<dir>
     }
 }
 

--- a/src/core/IO.pm6
+++ b/src/core/IO.pm6
@@ -1,6 +1,292 @@
+# IO is done by classes representing a file in some way (as a file descriptor,
+# as a path, etc.).
+
 my role IO {
-    # This role is empty and exists so that IO() coercers
-    # that coerce to IO::Path type check the result values OK
+    multi method IO(IO: --> IO) { self }
+
+    # Stringification methods
+    # These *must* be overridden by whatever class is doing this role.
+
+    multi method Str (::?CLASS:D: --> Str) {...}
+    multi method gist(::?CLASS:D: --> Str) {...}
+    multi method perl(::?CLASS:D: --> Str) {...}
+
+    # File I/O methods
+
+    proto method slurp(IO:D: :$enc, :$bin) {
+        # We use an IO::Handle in binary mode, and then decode the string
+        # all in one go, which avoids the overhead of setting up streaming
+        # decoding.
+        nqp::if(
+          nqp::istype((my IO::Handle $handle := {*}, Failure),
+          $handle,
+          nqp::stmts(
+            (my Blob $blob := $handle.slurp: :close),
+            nqp::if(
+              $bin,
+              $blob,
+              nqp::p6box_s(nqp::join("\n", nqp::split("\r\n", $blob.decode: $enc // 'utf-8')))
+            )
+          )
+        )
+    }
+    multi method slurp(IO:D: :$enc, :$bin) {
+        Failure.new: X::IO::RegularFileRequired.new: :from(self), :trying<slurp>
+    }
+
+    proto method spurt(IO:D: :$data, :$enc, :$append, :$createonly) {
+        my IO::Handle $fh       := {*};
+        nqp::if(
+          nqp::istype($fh, Failure),
+          $fh,
+          $fh.spurt: $data, :close
+        )
+    }
+    multi method spurt(IO:D: :$data, :$enc, :$append, :$createonly) {
+        Failure.new: X::IO::RegularFileRequired.new: :from(self), :trying<spurt>
+    }
+
+    method lines(IO:D: :$chomp, :$enc, :$nl-in, |c) {
+        self.open(:$chomp, :$enc, :$nl-in).lines(|c, :close)
+    }
+    method comb (IO:D: :$chomp, :$enc, :$nl-in, |c) {
+        self.open(:$chomp, :$enc, :$nl-in).comb(|c, :close)
+    }
+    method split(IO:D: :$chomp, :$enc, :$nl-in, |c) {
+        self.open(:$chomp, :$enc, :$nl-in).split(|c, :close)
+    }
+    method words(IO:D: :$chomp, :$enc, :$nl-in, |c) {
+        self.open(:$chomp, :$enc, :$nl-in).words(|c, :close)
+    }
+
+    # Stat methods
+    # These *must* be overridden by whatever class is doing this role.
+
+    proto method e(IO:D: --> Bool) {*}
+    multi method e(IO:D: --> Bool) {...}
+
+    proto method d(IO:D: --> Bool) {
+        self.e ?? {*} !! Failure.new: X::IO::DoesNotExist.new: :at(self), :trying<d>
+    }
+    multi method d(IO:D: --> Bool) {...}
+
+    proto method f(IO:D: --> Bool) {
+        self.e ?? {*} !! Failure.new: X::IO::DoesNotExist.new: :at(self), :trying<d>
+    }
+    multi method f(IO:D: --> Bool) {...}
+
+    proto method s(IO:D: --> Int) {
+        self.e ?? {*} !! Failure.new: X::IO::DoesNotExist.new: :at(self), :trying<s>
+    }
+    multi method s(IO:D: --> Int) {...}
+
+    proto method l(IO:D: --> Bool) {
+        self.e ?? {*} !! Failure.new: X::IO::DoesNotExist.new: :at(self), :trying<l>
+    }
+    multi method l(IO:D: --> Bool) {...}
+
+    proto method z(IO:D: --> Bool) {
+        self.e ?? {*} !! Failure.new: X::IO::DoesNotExist.new: :at(self), :trying<z>
+    }
+    multi method z(IO:D: --> Bool) {...}
+
+    proto method r(IO:D: --> Bool) {
+        self.e ?? {*} !! Failure.new: X::IO::DoesNotExist.new: :at(self), :trying<r>
+    }
+    multi method r(IO:D: --> Bool) {...}
+
+    proto method w(IO:D: --> Bool) {
+        self.e ?? {*} !! Failure.new: X::IO::DoesNotExist.new: :at(self), :trying<w>
+    }
+    multi method w(IO:D: --> Bool) {...}
+
+    proto method x(IO:D: --> Bool) {
+        self.e ?? {*} !! Failure.new: X::IO::DoesNotExist.new: :at(self), :trying<x>
+    }
+    multi method x(IO:D: --> Bool) {...}
+
+    proto method rw(IO:D: --> Bool) {
+        self.e ?? {*} !! Failure.new: X::IO::DoesNotExist.new: :at(self), :trying<rw>
+    }
+    multi method rw(IO:D: --> Bool) {...}
+
+    proto method rwx(IO:D: --> Bool) {
+        self.e ?? {*} !! Failure.new: X::IO::DoesNotExist.new: :at(self), :trying<rwx>
+    }
+    multi method rwx(IO:D: --> Bool) {...}
+
+    proto method modified(IO:D: --> Instant) {
+        self.e ?? {*} !! Failure.new: X::IO::DoesNotExist.new: :at(self), :trying<modified>
+    }
+    multi method modified(IO:D: --> Instant) {...}
+
+    proto method accessed(IO:D: --> Instant) {
+        self.e ?? {*} !! Failure.new: X::IO::DoesNotExist.new: :at(self), :trying<accessed>
+    }
+    multi method accessed(IO:D: --> Instant) {...}
+
+    proto method changed(IO:D: --> Instant) {
+        self.e ?? {*} !! Failure.new: X::IO::DoesNotExist.new: :at(self), :trying<changed>
+    }
+    multi method changed(IO:D: --> Instant) {...}
+
+    proto method mode(IO:D: --> IntStr) {
+        self.e ?? {*} !! Failure.new: X::IO::DoesNotExist.new: :at(self), :trying<mode>
+    }
+    multi method mode(IO:D: --> IntStr) {...}
+
+    # Regular file methods (i.e. files that aren't special)
+
+    proto method open(IO:D: |c --> IO::Handle) {*}
+    multi method open(IO:D: |c --> IO::Handle) {
+        Failure.new: X::IO::RegularFileRequired.new: :from(self), :trying<open>
+    }
+
+#?if moar
+    proto method watch(IO:D: --> IO::Notification) {*}
+    multi method watch(IO:D: --> IO::Notification) {
+        Failure.new: X::IO::RegularFileRequired.new: :from(self), :trying<watch>
+    }
+#?endif
+
+    proto method rename(IO:D: IO() $to, :$createonly --> Bool) {
+        nqp::unless(
+          nqp::istype(nqp::decont($to), IO::Path),
+          fail X::IO::PathRequired.new: :from(self), :$to, :trying<rename>
+        );
+
+        nqp::if(
+          $createonly && $to.e,
+          fail X::IO::Rename.new: :from(self), :to($to.absolute), :os-error(':createonly specified and destination exists')
+        );
+
+        return {*};
+
+        CATCH { default {
+            fail X::IO::Rename.new: :from(self), :$to, :os-error(.Str);
+        } }
+    }
+    multi method rename(IO:D: IO() $to --> Bool) {
+        Failure.new: X::IO::RegularFileRequired.new: :from(self), :$to, :trying<rename>
+    }
+
+    proto method copy(IO:D: IO() $to, :$createonly --> Bool) {
+        nqp::if(
+          $createonly && $to.e,
+          fail X::IO::Copy.new: :from(self), :$to, :os-error(':createonly specified and destination exists')
+        );
+
+        return {*};
+
+        CATCH { default {
+            fail X::IO::Copy.new: :from(self), :$to, :os-error(.Str);
+        } }
+    }
+    multi method copy(IO:D: IO() $to, :$createonly --> Bool) {...}
+        Failure.new: X::IO::RegularFileRequired.new: :from(self), :$to, :trying<copy>
+    }
+
+    proto method move(IO:D: IO() $to --> Bool) {*}
+    multi method move(IO:D: IO() $to --> Bool) {
+        Failure.new: X::IO::RegularFileRequired.new: :from(self), :$to, :trying<move>
+    }
+
+    proto method chmod(IO:D: Int() $mode --> Bool) {
+        return {*};
+
+        CATCH { default {
+            fail X::IO::Chmod.new: :from(self), :$mode, :os-error(.Str);
+        } }
+    }
+    multi method chmod(IO:D: Int() $mode --> Bool) {
+        Failure.new: X::IO::RegularFileRequired.new: :from(self), :trying<chmod>
+    }
+
+#   proto method chown(IO:D: Str() $user --> Bool) {
+#       {*}
+#
+#       CATCH { default {
+#           fail X::IO::Chown.new: :from(self), :$user, :os-error(.Str);
+#       } }
+#   }
+#   multi method chown(IO:D: Str() --> Bool) {
+#       Failure.new: X::IO::RegularFileRequired.new: :from(self), :trying<chown>
+#   }
+
+    # Symlink methods
+
+    proto method unlink(IO:D: --> Bool) {
+        return {*};
+
+        CATCH { default {
+            fail X::IO::Unlink.new: :at(self), :os-error(.Str);
+        } }
+    }
+    multi method unlink(IO:D: --> Bool) {
+        Failure.new: X::IO::PathRequired.new: :from(self), :trying<unlink>
+    }
+
+    proto method symlink(IO:D: IO() $to --> Bool) {
+        return {*};
+
+        CATCH { default {
+            fail X::IO::Symlink.new: :from(self), :$to, :os-error(.Str);
+        } }
+    }
+    multi method symlink(IO:D: IO() $to --> Bool) {
+        Failure.new: X::IO::PathRequired.new: :from(self), :$to, :trying<symlink>
+    }
+
+    proto method link(IO:D: IO() $to --> Bool) {
+        return {*};
+
+        CATCH { default {
+            fail X::IO::Link.new: :from(self), :$to, :os-error(.Str);
+        } }
+    }
+    multi method link(IO:D: IO() $to --> Bool) {
+        Failure.new: X::IO::PathRequired.new: :from(self), :$to, :trying<link>
+    }
+
+    # Directory methods
+
+    proto method chdir(IO:D: | --> IO) {*}
+    multi method chdir(IO:D: $to?, | --> IO) {
+        Failure.new: X::IO::PathRequired.new: :from(self), :$to, :trying<chdir>
+    }
+
+    proto method mkdir(IO:D: Int() --> IO) {
+        return {*};
+
+        CATCH { default {
+            fail X::IO::Mkdir.new: :at(self), :$mode, :os-error(.Str);
+        } }
+    }
+    multi method mkdir(IO:D: Int() --> IO) {
+        Failure.new: X::IO::PathRequired.new: :from(self), :trying<mkdir>
+    }
+
+    proto method rmdir(IO:D: --> IO) {
+        return {*};
+
+        CATCH { default {
+            fail X::IO::Rmdir.new: :at(self), :os-error(.Str);
+        } }
+    }
+    multi method rmdir(IO:D: --> IO) {
+        Failure.new: X::IO::PathRequired.new: :from(self), :trying<rmdir>
+    }
+
+    proto method dir(IO:D: Mu :$test) {
+        return {*};
+
+        CATCH { default {
+            fail X::IO::Dir.new: :at(self), :os-error(.Str);
+        } }
+    }
+    multi method dir(IO:D: Mu :$test) {
+        Failure.new: X::IO::PathRequired.new: :from(self), :trying<dir>
+    }
 }
 
 enum SeekType (

--- a/src/core/IO.pm6
+++ b/src/core/IO.pm6
@@ -187,11 +187,6 @@ my role IO {
     }
 
     proto method rename(IO:D: IO() $to, :$createonly, | --> Bool) {
-        nqp::unless(
-          nqp::istype(nqp::decont($to), IO::Path),
-          fail X::IO::NotAPath.new: :from(self), :$to, :trying<rename>
-        );
-
         nqp::if(
           $createonly && $to.e,
           fail X::IO::Rename.new:
@@ -211,11 +206,6 @@ my role IO {
     }
 
     proto method copy(IO:D: IO() $to, :$createonly, | --> Bool) {
-        nqp::unless(
-          nqp::istype(nqp::decont($to), IO::Path),
-          fail X::IO::NotAPath.new: :from(self), :$to, :trying<copy>
-        );
-
         nqp::if(
           $createonly && $to.e,
           fail X::IO::Copy.new:
@@ -253,11 +243,6 @@ my role IO {
     }
 
     proto method symlink(IO:D: IO() $to, | --> Bool) {
-        nqp::unless(
-          nqp::istype(nqp::decont($to), IO::Path),
-          X::IO::NotAPath.new: :from(self), :$to, :trying<link>
-        );
-
         return {*};
 
         CATCH { default {
@@ -269,11 +254,6 @@ my role IO {
     }
 
     proto method link(IO:D: IO() $to, | --> Bool) {
-        nqp::unless(
-          nqp::istype(nqp::decont($to), IO::Path),
-          X::IO::NotAPath.new: :from(self), :$to, :trying<link>
-        );
-
         return {*};
 
         CATCH { default {

--- a/src/core/IO.pm6
+++ b/src/core/IO.pm6
@@ -1,27 +1,34 @@
-# IO is done by classes representing a file in some way (as a file descriptor,
-# as a path, etc.).
+# IO is done by classes describing files in some way (apart from IO::Handle,
+# which uses any other class describing files internally).
+
+my class Instant { ... }
+
+my class IO::Path         { ... }
+my class IO::Special      { ... }
+# IO::NativeDescriptor is stubbed in src/core/Int.pm6.
+my class IO::Notification { ... }
+
+# XXX FIXME: stubbing *anything* in IO makes MoarVM throw with this error
+# during compilation: "Cannot invoke this object (REPR: Null; VMNull)".
 
 my role IO {
-    multi method IO(IO: --> IO) { self }
-
     # Stringification methods
-    # These *must* be overridden by whatever class is doing this role.
 
-    multi method Str (::?CLASS:D: --> Str) {...}
-    multi method gist(::?CLASS:D: --> Str) {...}
-    multi method perl(::?CLASS:D: --> Str) {...}
+    # multi method Str (IO:D: --> Str:D) { ... }
+    # multi method gist(IO:D: --> Str:D) { ... }
+    # multi method perl(IO:D: --> Str:D) { ... }
 
     # File I/O methods
 
-    proto method slurp(IO:D: :$enc, :$bin) {
+    proto method slurp(IO:D: :$enc, :$bin, |) {
         # We use an IO::Handle in binary mode, and then decode the string
         # all in one go, which avoids the overhead of setting up streaming
         # decoding.
         nqp::if(
-          nqp::istype((my IO::Handle $handle := {*}, Failure),
+          nqp::istype((my $handle := {*}), Failure),
           $handle,
           nqp::stmts(
-            (my Blob $blob := $handle.slurp: :close),
+            (my $blob := $handle.slurp: :close),
             nqp::if(
               $bin,
               $blob,
@@ -34,15 +41,15 @@ my role IO {
         Failure.new: X::IO::NotAFile.new: :from(self), :trying<slurp>
     }
 
-    proto method spurt(IO:D: :$data, :$enc, :$append, :$createonly) {
-        my IO::Handle $fh       := {*};
+    proto method spurt(IO:D: $data, :$enc, :$append, :$createonly, |) {
+        my $handle := {*};
         nqp::if(
-          nqp::istype($fh, Failure),
-          $fh,
-          $fh.spurt: $data, :close
+          nqp::istype($handle, Failure),
+          $handle,
+          $handle.spurt: $data, :close
         )
     }
-    multi method spurt(IO:D: :$data, :$enc, :$append, :$createonly) {
+    multi method spurt(IO:D: $data, :$enc, :$append, :$createonly, |) {
         Failure.new: X::IO::NotAFile.new: :from(self), :trying<spurt>
     }
 
@@ -60,80 +67,81 @@ my role IO {
     }
 
     # Stat methods
-    # These *must* be overridden by whatever class is doing this role.
+    # These *must* be implemented by whatever class is doing this role.
 
     proto method e(IO:D: --> Bool) {*}
-    multi method e(IO:D: --> Bool) {...}
+    # multi method e(IO:D: --> Bool) { ... }
 
     proto method d(IO:D: --> Bool) {
         self.e ?? {*} !! Failure.new: X::IO::DoesNotExist.new: :at(self), :trying<d>
     }
-    multi method d(IO:D: --> Bool) {...}
+    # multi method d(IO:D: --> Bool) { ... }
 
     proto method f(IO:D: --> Bool) {
         self.e ?? {*} !! Failure.new: X::IO::DoesNotExist.new: :at(self), :trying<d>
     }
-    multi method f(IO:D: --> Bool) {...}
+    # multi method f(IO:D: --> Bool) { ... }
 
     proto method s(IO:D: --> Int) {
         self.e ?? {*} !! Failure.new: X::IO::DoesNotExist.new: :at(self), :trying<s>
     }
-    multi method s(IO:D: --> Int) {...}
+    # multi method s(IO:D: --> Int) { ... }
 
     proto method l(IO:D: --> Bool) {
         self.e ?? {*} !! Failure.new: X::IO::DoesNotExist.new: :at(self), :trying<l>
     }
-    multi method l(IO:D: --> Bool) {...}
+    # multi method l(IO:D: --> Bool) { ... }
 
     proto method z(IO:D: --> Bool) {
         self.e ?? {*} !! Failure.new: X::IO::DoesNotExist.new: :at(self), :trying<z>
     }
-    multi method z(IO:D: --> Bool) {...}
+    # multi method z(IO:D: --> Bool) { ... }
 
     proto method r(IO:D: --> Bool) {
         self.e ?? {*} !! Failure.new: X::IO::DoesNotExist.new: :at(self), :trying<r>
     }
-    multi method r(IO:D: --> Bool) {...}
+    # multi method r(IO:D: --> Bool) { ... }
 
     proto method w(IO:D: --> Bool) {
         self.e ?? {*} !! Failure.new: X::IO::DoesNotExist.new: :at(self), :trying<w>
     }
-    multi method w(IO:D: --> Bool) {...}
+    # multi method w(IO:D: --> Bool) { ... }
 
     proto method x(IO:D: --> Bool) {
         self.e ?? {*} !! Failure.new: X::IO::DoesNotExist.new: :at(self), :trying<x>
     }
-    multi method x(IO:D: --> Bool) {...}
+    # multi method x(IO:D: --> Bool) { ... }
 
     proto method rw(IO:D: --> Bool) {
         self.e ?? {*} !! Failure.new: X::IO::DoesNotExist.new: :at(self), :trying<rw>
     }
-    multi method rw(IO:D: --> Bool) {...}
+    # multi method rw(IO:D: --> Bool) { ... }
 
     proto method rwx(IO:D: --> Bool) {
         self.e ?? {*} !! Failure.new: X::IO::DoesNotExist.new: :at(self), :trying<rwx>
     }
-    multi method rwx(IO:D: --> Bool) {...}
+    # multi method rwx(IO:D: --> Bool) { ... }
 
     proto method modified(IO:D: --> Instant) {
         self.e ?? {*} !! Failure.new: X::IO::DoesNotExist.new: :at(self), :trying<modified>
     }
-    multi method modified(IO:D: --> Instant) {...}
+    # multi method modified(IO:D: --> Instant) { ... }
 
     proto method accessed(IO:D: --> Instant) {
         self.e ?? {*} !! Failure.new: X::IO::DoesNotExist.new: :at(self), :trying<accessed>
     }
-    multi method accessed(IO:D: --> Instant) {...}
+    # multi method accessed(IO:D: --> Instant) { ... }
 
     proto method changed(IO:D: --> Instant) {
         self.e ?? {*} !! Failure.new: X::IO::DoesNotExist.new: :at(self), :trying<changed>
     }
-    multi method changed(IO:D: --> Instant) {...}
+    # multi method changed(IO:D: --> Instant) { ... }
 
     proto method mode(IO:D: --> IntStr) {
         self.e ?? {*} !! Failure.new: X::IO::DoesNotExist.new: :at(self), :trying<mode>
     }
-    multi method mode(IO:D: --> IntStr) {...}
+    # multi method mode(IO:D: --> IntStr) { ... }
+
 
     # Regular file methods (i.e. files that aren't special)
 
@@ -143,13 +151,13 @@ my role IO {
     }
 
 #?if moar
-    proto method watch(IO:D: --> IO::Notification) {*}
-    multi method watch(IO:D: --> IO::Notification) {
+    proto method watch(IO:D: | --> IO::Notification) {*}
+    multi method watch(IO:D: | --> IO::Notification) {
         Failure.new: X::IO::NotAFile.new: :from(self), :trying<watch>
     }
 #?endif
 
-    proto method rename(IO:D: IO() $to, :$createonly --> Bool) {
+    proto method rename(IO:D: IO() $to, :$createonly, | --> Bool) {
         nqp::unless(
           nqp::istype(nqp::decont($to), IO::Path),
           fail X::IO::NotAPath.new: :from(self), :$to, :trying<rename>
@@ -157,7 +165,10 @@ my role IO {
 
         nqp::if(
           $createonly && $to.e,
-          fail X::IO::Rename.new: :from(self), :to($to.absolute), :os-error(':createonly specified and destination exists')
+          fail X::IO::Rename.new:
+              :from(self.?absolute // self),
+              :to($to.absolute),
+              :os-error(':createonly specified and destination exists')
         );
 
         return {*};
@@ -166,14 +177,22 @@ my role IO {
             fail X::IO::Rename.new: :from(self), :$to, :os-error(.Str);
         } }
     }
-    multi method rename(IO:D: IO() $to --> Bool) {
-        Failure.new: X::IO::NotAFile.new: :from(self), :$to, :trying<rename>
+    multi method rename(IO:D: IO() $to, :$createonly, | --> Bool) {
+        Failure.new: X::IO::NotAFile.new: :from(self), :trying<rename>
     }
 
-    proto method copy(IO:D: IO() $to, :$createonly --> Bool) {
+    proto method copy(IO:D: IO() $to, :$createonly, | --> Bool) {
+        nqp::unless(
+          nqp::istype(nqp::decont($to), IO::Path),
+          fail X::IO::NotAPath.new: :from(self), :$to, :trying<copy>
+        );
+
         nqp::if(
           $createonly && $to.e,
-          fail X::IO::Copy.new: :from(self), :$to, :os-error(':createonly specified and destination exists')
+          fail X::IO::Copy.new:
+              :from(self.?absolute // self),
+              :to($to.absolute),
+              :os-error(':createonly specified and destination exists')
         );
 
         return {*};
@@ -182,109 +201,108 @@ my role IO {
             fail X::IO::Copy.new: :from(self), :$to, :os-error(.Str);
         } }
     }
-    multi method copy(IO:D: IO() $to, :$createonly --> Bool) {...}
-        Failure.new: X::IO::NotAFile.new: :from(self), :$to, :trying<copy>
+    multi method copy(IO:D: IO() $to, :$createonly, | --> Bool) {
+        Failure.new: X::IO::NotAFile.new: :from(self), :trying<copy>
     }
 
-    proto method move(IO:D: IO() $to --> Bool) {*}
-    multi method move(IO:D: IO() $to --> Bool) {
-        Failure.new: X::IO::NotAFile.new: :from(self), :$to, :trying<move>
+    proto method move(IO:D: | --> Bool) {*}
+    multi method move(IO:D: | --> Bool) {
+        Failure.new: X::IO::NotAFile.new: :from(self), :trying<move>
     }
 
-    proto method chmod(IO:D: Int() $mode --> Bool) {
+    proto method chmod(IO:D: Int() $mode, | --> Bool) {
         return {*};
 
         CATCH { default {
             fail X::IO::Chmod.new: :from(self), :$mode, :os-error(.Str);
         } }
     }
-    multi method chmod(IO:D: Int() $mode --> Bool) {
+    multi method chmod(IO:D: Int() $mode, | --> Bool) {
         Failure.new: X::IO::NotAFile.new: :from(self), :trying<chmod>
     }
 
-#   proto method chown(IO:D: Str() $user --> Bool) {
-#       {*}
-#
-#       CATCH { default {
-#           fail X::IO::Chown.new: :from(self), :$user, :os-error(.Str);
-#       } }
-#   }
-#   multi method chown(IO:D: Str() --> Bool) {
-#       Failure.new: X::IO::NotAFile.new: :from(self), :trying<chown>
-#   }
+    # File link methods
 
-    # Symlink methods
-
-    proto method unlink(IO:D: --> Bool) {
+    proto method unlink(IO:D: | --> Bool) {
         return {*};
 
         CATCH { default {
             fail X::IO::Unlink.new: :target(self), :os-error(.Str);
         } }
     }
-    multi method unlink(IO:D: --> Bool) {
+    multi method unlink(IO:D: | --> Bool) {
         Failure.new: X::IO::NotAPath.new: :from(self), :trying<unlink>
     }
 
-    proto method symlink(IO:D: IO() $to --> Bool) {
+    proto method symlink(IO:D: IO() $to, | --> Bool) {
+        nqp::unless(
+          nqp::istype(nqp::decont($to), IO::Path),
+          X::IO::NotAPath.new: :from(self), :$to, :trying<link>
+        );
+
         return {*};
 
         CATCH { default {
             fail X::IO::Symlink.new: :target($to), :os-error(.Str);
         } }
     }
-    multi method symlink(IO:D: IO() $to --> Bool) {
-        Failure.new: X::IO::NotAPath.new: :$target, :trying<symlink>
+    multi method symlink(IO:D: IO() $to, | --> Bool) {
+        Failure.new: X::IO::NotAPath.new: :from(self), :trying<symlink>
     }
 
-    proto method link(IO:D: IO() $to --> Bool) {
+    proto method link(IO:D: IO() $to, | --> Bool) {
+        nqp::unless(
+          nqp::istype(nqp::decont($to), IO::Path),
+          X::IO::NotAPath.new: :from(self), :$to, :trying<link>
+        );
+
         return {*};
 
         CATCH { default {
             fail X::IO::Link.new: :target($to), :os-error(.Str);
         } }
     }
-    multi method link(IO:D: IO() $to --> Bool) {
-        Failure.new: X::IO::NotAPath.new: :from(self), :$to, :trying<link>
+    multi method link(IO:D: IO() $to, | --> Bool) {
+        Failure.new: X::IO::NotAPath.new: :from(self), :trying<link>
     }
 
     # Directory methods
 
     proto method chdir(IO:D: | --> IO) {*}
-    multi method chdir(IO:D: $to, | --> IO) {
-        Failure.new: X::IO::NotAPath.new: :from(self), :$to, :trying<chdir>
+    multi method chdir(IO:D: | --> IO) {
+        Failure.new: X::IO::NotAPath.new: :from(self), :trying<chdir>
     }
 
-    proto method mkdir(IO:D: Int() --> IO) {
+    proto method mkdir(IO:D: Int() $mode = 0o777, | --> IO) {
         return {*};
 
         CATCH { default {
-            fail X::IO::Mkdir.new: :at(self), :$mode, :os-error(.Str);
+            fail X::IO::Mkdir.new: :path(self), :$mode, :os-error(.Str);
         } }
     }
-    multi method mkdir(IO:D: Int() $to --> IO) {
-        Failure.new: X::IO::NotAPath.new: :from(self), :$to, :trying<mkdir>
+    multi method mkdir(IO:D: Int() $mode = 0o777, | --> IO) {
+        Failure.new: X::IO::NotAPath.new: :from(self), :trying<mkdir>
     }
 
-    proto method rmdir(IO:D: --> IO) {
+    proto method rmdir(IO:D: | --> IO) {
         return {*};
 
         CATCH { default {
-            fail X::IO::Rmdir.new: :at(self), :os-error(.Str);
+            fail X::IO::Rmdir.new: :path(self), :os-error(.Str);
         } }
     }
-    multi method rmdir(IO:D: --> IO) {
+    multi method rmdir(IO:D: | --> IO) {
         Failure.new: X::IO::NotAPath.new: :from(self), :trying<rmdir>
     }
 
-    proto method dir(IO:D: Mu :$test) {
+    proto method dir(IO:D: Mu :$test, |) {
         return {*};
 
         CATCH { default {
-            fail X::IO::Dir.new: :at(self), :os-error(.Str);
+            fail X::IO::Dir.new: :path(self), :os-error(.Str);
         } }
     }
-    multi method dir(IO:D: Mu :$test) {
+    multi method dir(IO:D: Mu :$test, |) {
         Failure.new: X::IO::NotAPath.new: :from(self), :trying<dir>
     }
 }

--- a/src/core/IO/FileDescriptor.pm6
+++ b/src/core/IO/FileDescriptor.pm6
@@ -1,0 +1,157 @@
+# On Windows, IO::FileDescriptor represents a pointer to a HANDLE.
+# On *NIX, take a wild guess what IO::FileDescriptor represents.
+
+my class IO::FileDescriptor is Int does IO {
+    multi method WHICH(IO::FileDescriptor:D: --> ValueObjAt) {
+        nqp::box_s(
+          nqp::concat(
+            nqp::if(
+              nqp::eqaddr(self.WHAT, IO::FileDescriptor),
+              'IO::FileDescriptor|',
+              nqp::concat(nqp::unbox_s(self.^name), '|')
+            ),
+            nqp::coerce_is(nqp::unbox_i(self))
+          ),
+          ValueObjAt
+        )
+    }
+
+    multi method ACCEPTS(IO::FileDescriptor:D: int \other --> Bool:D) {
+        nqp::hllbool(nqp::iseq_i(nqp::unbox_i(self), other))
+    }
+    multi method ACCEPTS(IO::FileDescriptor:D: Int() \other --> Bool:D) {
+        nqp::hllbool(nqp::iseq_i(nqp::unbox_i(self), nqp::unbox_i(other)))
+    }
+
+    proto method new(|) {*}
+    multi method new(int $fd) {
+        nqp::box_i($fd, IO::FileDescriptor)
+    }
+    multi method new(Int() $fd) {
+        nqp::box_i(nqp::decont_i($fd), IO::FileDescriptor)
+    }
+
+    method Int(IO::FileDescriptor:D: --> Int) {
+        nqp::p6box_i(nqp::unbox_i(self))
+    }
+
+    multi method Str (IO::FileDescriptor:D: --> Str) {
+        nqp::p6box_s(nqp::coerce_is(nqp::unbox_i(self)))
+    }
+    multi method gist(IO::FileDescriptor:D: --> Str) {
+        nqp::p6box_s(
+          nqp::concat(
+            nqp::coerce_is(nqp::unbox_i(self)),
+            '.IO'
+          )
+        )
+    }
+    multi method perl(IO::FileDescriptor:D: --> Str) {
+        nqp::p6box_s(
+          nqp::concat(
+            nqp::concat(nqp::unbox_s(self.^name), '.new('),
+            nqp::concat(nqp::coerce_is(nqp::unbox_i(self)), ')')
+          )
+        )
+    }
+
+    multi method slurp(IO::FileDescriptor:D: :$enc, :$bin --> IO::Handle)                         {
+        IO::Handle.new(:fd(self)).open(:$enc, :$bin)
+    }
+    multi method spurt(IO::FileDescriptor:D: $data, :$enc, :$append, :$createonly --> IO::Handle) {
+        my int $truncate = nqp::if(
+            nqp::isfalse(nqp::decont($append)),
+            nqp::isfalse(nqp::decont($createonly))
+        );
+        self.open:
+            :$enc,                   :bin(nqp::istype($data, Blob)),
+            :mode<wo>,               :create,
+            :exclusive($createonly), :$append,
+            :$truncate
+    }
+
+    multi method e       (IO::FileDescriptor:D: --> Bool)    {
+        ?Rakudo::Internals.FILETEST-E: self
+    }
+    multi method d       (IO::FileDescriptor:D: --> Bool)    {
+        ?Rakudo::Internals.FILETEST-D: self
+    }
+    multi method f       (IO::FileDescriptor:D: --> Bool)    {
+        ?Rakudo::Internals.FILETEST-F: self
+    }
+    multi method s       (IO::FileDescriptor:D: --> Int)     {
+        nqp::p6box_i(Rakudo::Internals.FILETEST-S: self)
+    }
+    multi method l       (IO::FileDescriptor:D: --> Bool)    {
+        ?Rakudo::Internals.FILETEST-LE(self)
+            ?? ?Rakudo::Internals.FILETEST-L(self)
+            !! Failure.new: X::IO::DoesNotExist.new: :at(self), :trying<l>
+    }
+    multi method z       (IO::FileDescriptor:D: --> Bool)    {
+        ?Rakudo::Internals.FILETEST-Z: self
+    }
+    multi method r       (IO::FileDescriptor:D: --> Bool)    {
+        ?Rakudo::Internals.FILETEST-R: self
+    }
+    multi method w       (IO::FileDescriptor:D: --> Bool)    {
+        ?Rakudo::Internals.FILETEST-W: self
+    }
+    multi method x       (IO::FileDescriptor:D: --> Bool)    {
+        ?Rakudo::Internals.FILETEST-X: self
+    }
+    multi method rw      (IO::FileDescriptor:D: --> Bool)    {
+        ?Rakudo::Internals.FILETEST-RW: self
+    }
+    multi method rwx     (IO::FileDescriptor:D: --> Bool)    {
+        ?Rakudo::Internals.FILETEST-RWX: self
+    }
+    multi method modified(IO::FileDescriptor:D: --> Instant) {
+        Instant.from-posix: Rakudo::Internals.FILETEST-MODIFIED: self
+    }
+    multi method accessed(IO::FileDescriptor:D: --> Instant) {
+        Instant.from-posix: Rakudo::Internals.FILETEST-ACCESSED: self
+    }
+    multi method changed (IO::FileDescriptor:D: --> Instant) {
+        Instant.from-posix: Rakudo::Internals.FILETEST-CHANGED: self
+    }
+    multi method mode    (IO::FileDescriptor:D: --> IntStr)  {
+        nqp::stmts(
+          (my int $mode = Rakudo::Internals.FILETEST-MODE: self),
+          IntStr.new: $mode, sprintf '%04o', $mode
+        )
+    }
+
+    multi method open  (IO::FileDescriptor:D: |c --> IO::Handle)             {
+        IO::Handle.new(:fd(self)).open(|c)
+    }
+#?if moar
+    multi method watch (IO::FileDescriptor:D: --> IO::Notification)            {
+        # TODO: implement nqp::watchfd
+        # IO::Notification.watch-file: self
+        Failure.new: X::NYI.new: :feature<watchfd>
+    }
+#?endif
+    multi method rename(IO::FileDescriptor:D: IO() $to, :$createonly --> Bool) {
+        # TODO: implement nqp::renamefd
+        # nqp::hllbool(nqp::renamefd(nqp::unbox_i(self), nqp::unbox_s($to.Str)))
+        Failure.new: X::NYI.new: :feature<renamefd>
+    }
+    multi method copy  (IO::FileDescriptor:D: IO() $to, $createonly --> Bool)  {
+        # TODO: implement nqp::copyfd
+        # nqp::hllbool(nqp::copyfd(nqp::unbox_i(self), nqp::unbox_s($to.Str)))
+        Failure.new: X::NYI.new: :feature<copyfd>
+    }
+    multi method move  (IO::FileDescriptor:D: |c --> True)                     {
+        self.copy: |c orelse fail X::IO::Move.new: :from(.exception.from),
+            :to(.exception.to), :os-error(.exception.os-error);
+        self.unlink   orelse fail X::IO::Move.new: :from(.exception.from),
+            :to(.exception.to), :os-error(.exception.os-error);
+    }
+    multi method chmod (IO::FileDescriptor:D: Int() $mode --> Bool)            {
+        # TODO: implement nqp::chmodfd
+        # nqp::hllbool(nqp::chmodfd(nqp::unbox_i(self), nqp::decont_i($mode)))
+        Failure.new: X::NYI.new: :feature<chmodfd>
+    }
+}
+
+# vim: ft=perl6 expandtab sw=4

--- a/src/core/IO/Handle.pm6
+++ b/src/core/IO/Handle.pm6
@@ -1,5 +1,6 @@
-my class IO::Path { ... }
-my class Proc { ... }
+my class IO::Path           { ... }
+my class IO::NativeDescriptor { ... }
+my class Proc               { ... }
 
 my class IO::Handle {
     has int $!fd;
@@ -856,9 +857,9 @@ my class IO::Handle {
         )
     }
 
-    method native-descriptor(IO::Handle:D: --> IO::FileDescriptor) {
+    method native-descriptor(IO::Handle:D: --> IO::NativeDescriptor) {
         nqp::defined($!PIO) or die 'File handle not open, so cannot get native descriptor';
-        IO::FileDescriptor.new: nqp::if(
+        IO::NativeDescriptor.new: nqp::if(
           nqp::isconcrete($!path) && nqp::iseq_i($!fd, -1),
           nqp::bindattr_i(self, IO::Handle, '$!fd', nqp::filenofh($!PIO)),
           nqp::getattr_i(self, IO::Handle, '$!fd')

--- a/src/core/IO/Handle.pm6
+++ b/src/core/IO/Handle.pm6
@@ -856,13 +856,13 @@ my class IO::Handle {
         )
     }
 
-    method native-descriptor(IO::Handle:D:) {
+    method native-descriptor(IO::Handle:D: --> IO::FileDescriptor) {
         nqp::defined($!PIO) or die 'File handle not open, so cannot get native descriptor';
-        nqp::if(
+        IO::FileDescriptor.new: nqp::if(
           nqp::isconcrete($!path) && nqp::iseq_i($!fd, -1),
           nqp::bindattr_i(self, IO::Handle, '$!fd', nqp::filenofh($!PIO)),
           nqp::getattr_i(self, IO::Handle, '$!fd')
-        );
+        )
     }
 }
 

--- a/src/core/IO/NativeDescriptor.pm6
+++ b/src/core/IO/NativeDescriptor.pm6
@@ -1,13 +1,13 @@
-# On Windows, IO::FileDescriptor represents a pointer to a HANDLE.
-# On *NIX, take a wild guess what IO::FileDescriptor represents.
+# On Windows, IO::NativeDescriptor represents a pointer to a HANDLE.
+# On *NIX, IO::NativeDescriptor represents a file descriptor.
 
-my class IO::FileDescriptor is Int does IO {
-    multi method WHICH(IO::FileDescriptor:D: --> ValueObjAt) {
+my class IO::NativeDescriptor is Int does IO {
+    multi method WHICH(IO::NativeDescriptor:D: --> ValueObjAt) {
         nqp::box_s(
           nqp::concat(
             nqp::if(
-              nqp::eqaddr(self.WHAT, IO::FileDescriptor),
-              'IO::FileDescriptor|',
+              nqp::eqaddr(self.WHAT, IO::NativeDescriptor),
+              'IO::NativeDescriptor|',
               nqp::concat(nqp::unbox_s(self.^name), '|')
             ),
             nqp::coerce_is(nqp::unbox_i(self))
@@ -16,29 +16,29 @@ my class IO::FileDescriptor is Int does IO {
         )
     }
 
-    multi method ACCEPTS(IO::FileDescriptor:D: int \other --> Bool:D) {
+    multi method ACCEPTS(IO::NativeDescriptor:D: int \other --> Bool:D)   {
         nqp::hllbool(nqp::iseq_i(nqp::unbox_i(self), other))
     }
-    multi method ACCEPTS(IO::FileDescriptor:D: Int() \other --> Bool:D) {
+    multi method ACCEPTS(IO::NativeDescriptor:D: Int() \other --> Bool:D) {
         nqp::hllbool(nqp::iseq_i(nqp::unbox_i(self), nqp::unbox_i(other)))
     }
 
     proto method new(|) {*}
-    multi method new(int $fd) {
-        nqp::box_i($fd, IO::FileDescriptor)
+    multi method new(int $fd)   {
+        nqp::box_i($fd, IO::NativeDescriptor)
     }
     multi method new(Int() $fd) {
-        nqp::box_i(nqp::decont_i($fd), IO::FileDescriptor)
+        nqp::box_i(nqp::decont_i($fd), IO::NativeDescriptor)
     }
 
-    method Int(IO::FileDescriptor:D: --> Int) {
+    method Int(IO::NativeDescriptor:D: --> Int) {
         nqp::p6box_i(nqp::unbox_i(self))
     }
 
-    multi method Str (IO::FileDescriptor:D: --> Str) {
+    multi method Str (IO::NativeDescriptor:D: --> Str) {
         nqp::p6box_s(nqp::coerce_is(nqp::unbox_i(self)))
     }
-    multi method gist(IO::FileDescriptor:D: --> Str) {
+    multi method gist(IO::NativeDescriptor:D: --> Str) {
         nqp::p6box_s(
           nqp::concat(
             nqp::coerce_is(nqp::unbox_i(self)),
@@ -46,7 +46,7 @@ my class IO::FileDescriptor is Int does IO {
           )
         )
     }
-    multi method perl(IO::FileDescriptor:D: --> Str) {
+    multi method perl(IO::NativeDescriptor:D: --> Str) {
         nqp::p6box_s(
           nqp::concat(
             nqp::concat(nqp::unbox_s(self.^name), '.new('),
@@ -55,99 +55,98 @@ my class IO::FileDescriptor is Int does IO {
         )
     }
 
-    multi method slurp(IO::FileDescriptor:D: :$enc, :$bin --> IO::Handle)                         {
+    multi method slurp(IO::NativeDescriptor:D: :$enc, :$bin --> IO::Handle)                         {
         IO::Handle.new(:fd(self)).open(:$enc, :$bin)
     }
-    multi method spurt(IO::FileDescriptor:D: $data, :$enc, :$append, :$createonly --> IO::Handle) {
-        my int $truncate = nqp::if(
-            nqp::isfalse(nqp::decont($append)),
-            nqp::isfalse(nqp::decont($createonly))
-        );
+    multi method spurt(IO::NativeDescriptor:D: $data, :$enc, :$append, :$createonly --> IO::Handle) {
         self.open:
             :$enc,                   :bin(nqp::istype($data, Blob)),
             :mode<wo>,               :create,
             :exclusive($createonly), :$append,
-            :$truncate
+            :truncate(nqp::if(
+                nqp::isfalse(nqp::decont($append)),
+                nqp::isfalse(nqp::decont($createonly))
+            ));
     }
 
-    multi method e       (IO::FileDescriptor:D: --> Bool)    {
+    multi method e       (IO::NativeDescriptor:D: --> Bool)    {
         ?Rakudo::Internals.FILETEST-E: self
     }
-    multi method d       (IO::FileDescriptor:D: --> Bool)    {
+    multi method d       (IO::NativeDescriptor:D: --> Bool)    {
         ?Rakudo::Internals.FILETEST-D: self
     }
-    multi method f       (IO::FileDescriptor:D: --> Bool)    {
+    multi method f       (IO::NativeDescriptor:D: --> Bool)    {
         ?Rakudo::Internals.FILETEST-F: self
     }
-    multi method s       (IO::FileDescriptor:D: --> Int)     {
+    multi method s       (IO::NativeDescriptor:D: --> Int)     {
         nqp::p6box_i(Rakudo::Internals.FILETEST-S: self)
     }
-    multi method l       (IO::FileDescriptor:D: --> Bool)    {
+    multi method l       (IO::NativeDescriptor:D: --> Bool)    {
         ?Rakudo::Internals.FILETEST-LE(self)
             ?? ?Rakudo::Internals.FILETEST-L(self)
             !! Failure.new: X::IO::DoesNotExist.new: :at(self), :trying<l>
     }
-    multi method z       (IO::FileDescriptor:D: --> Bool)    {
+    multi method z       (IO::NativeDescriptor:D: --> Bool)    {
         ?Rakudo::Internals.FILETEST-Z: self
     }
-    multi method r       (IO::FileDescriptor:D: --> Bool)    {
+    multi method r       (IO::NativeDescriptor:D: --> Bool)    {
         ?Rakudo::Internals.FILETEST-R: self
     }
-    multi method w       (IO::FileDescriptor:D: --> Bool)    {
+    multi method w       (IO::NativeDescriptor:D: --> Bool)    {
         ?Rakudo::Internals.FILETEST-W: self
     }
-    multi method x       (IO::FileDescriptor:D: --> Bool)    {
+    multi method x       (IO::NativeDescriptor:D: --> Bool)    {
         ?Rakudo::Internals.FILETEST-X: self
     }
-    multi method rw      (IO::FileDescriptor:D: --> Bool)    {
+    multi method rw      (IO::NativeDescriptor:D: --> Bool)    {
         ?Rakudo::Internals.FILETEST-RW: self
     }
-    multi method rwx     (IO::FileDescriptor:D: --> Bool)    {
+    multi method rwx     (IO::NativeDescriptor:D: --> Bool)    {
         ?Rakudo::Internals.FILETEST-RWX: self
     }
-    multi method modified(IO::FileDescriptor:D: --> Instant) {
+    multi method modified(IO::NativeDescriptor:D: --> Instant) {
         Instant.from-posix: Rakudo::Internals.FILETEST-MODIFIED: self
     }
-    multi method accessed(IO::FileDescriptor:D: --> Instant) {
+    multi method accessed(IO::NativeDescriptor:D: --> Instant) {
         Instant.from-posix: Rakudo::Internals.FILETEST-ACCESSED: self
     }
-    multi method changed (IO::FileDescriptor:D: --> Instant) {
+    multi method changed (IO::NativeDescriptor:D: --> Instant) {
         Instant.from-posix: Rakudo::Internals.FILETEST-CHANGED: self
     }
-    multi method mode    (IO::FileDescriptor:D: --> IntStr)  {
+    multi method mode    (IO::NativeDescriptor:D: --> IntStr)  {
         nqp::stmts(
           (my int $mode = Rakudo::Internals.FILETEST-MODE: self),
           IntStr.new: $mode, sprintf '%04o', $mode
         )
     }
 
-    multi method open  (IO::FileDescriptor:D: |c --> IO::Handle)             {
+    multi method open  (IO::NativeDescriptor:D: |c --> IO::Handle)               {
         IO::Handle.new(:fd(self)).open(|c)
     }
 #?if moar
-    multi method watch (IO::FileDescriptor:D: --> IO::Notification)            {
+    multi method watch (IO::NativeDescriptor:D: --> IO::Notification)            {
         # TODO: implement nqp::watchfd
         # IO::Notification.watch-file: self
         Failure.new: X::NYI.new: :feature<watchfd>
     }
 #?endif
-    multi method rename(IO::FileDescriptor:D: IO() $to, :$createonly --> Bool) {
+    multi method rename(IO::NativeDescriptor:D: IO() $to, :$createonly --> Bool) {
         # TODO: implement nqp::renamefd
         # nqp::hllbool(nqp::renamefd(nqp::unbox_i(self), nqp::unbox_s($to.Str)))
         Failure.new: X::NYI.new: :feature<renamefd>
     }
-    multi method copy  (IO::FileDescriptor:D: IO() $to, $createonly --> Bool)  {
+    multi method copy  (IO::NativeDescriptor:D: IO() $to, $createonly --> Bool)  {
         # TODO: implement nqp::copyfd
         # nqp::hllbool(nqp::copyfd(nqp::unbox_i(self), nqp::unbox_s($to.Str)))
         Failure.new: X::NYI.new: :feature<copyfd>
     }
-    multi method move  (IO::FileDescriptor:D: |c --> True)                     {
-        self.copy: |c orelse fail X::IO::Move.new: :from(.exception.from),
+    multi method move  (IO::NativeDescriptor:D: |c --> True)                     {
+        self.copy(|c) orelse fail X::IO::Move.new: :from(.exception.from),
             :to(.exception.to), :os-error(.exception.os-error);
         self.unlink   orelse fail X::IO::Move.new: :from(.exception.from),
             :to(.exception.to), :os-error(.exception.os-error);
     }
-    multi method chmod (IO::FileDescriptor:D: Int() $mode --> Bool)            {
+    multi method chmod (IO::NativeDescriptor:D: Int() $mode --> Bool)            {
         # TODO: implement nqp::chmodfd
         # nqp::hllbool(nqp::chmodfd(nqp::unbox_i(self), nqp::decont_i($mode)))
         Failure.new: X::NYI.new: :feature<chmodfd>

--- a/src/core/IO/NativeDescriptor.pm6
+++ b/src/core/IO/NativeDescriptor.pm6
@@ -8,7 +8,7 @@ my class IO::NativeDescriptor is Int does IO {
             nqp::if(
               nqp::eqaddr(self.WHAT, IO::NativeDescriptor),
               'IO::NativeDescriptor|',
-              nqp::concat(nqp::unbox_s(self.^name), '|')
+              nqp::concat(self.^name, '|')
             ),
             nqp::coerce_is(nqp::unbox_i(self))
           ),
@@ -19,26 +19,28 @@ my class IO::NativeDescriptor is Int does IO {
     multi method ACCEPTS(IO::NativeDescriptor:D: int \other --> Bool:D)   {
         nqp::hllbool(nqp::iseq_i(nqp::unbox_i(self), other))
     }
-    multi method ACCEPTS(IO::NativeDescriptor:D: Int() \other --> Bool:D) {
+    multi method ACCEPTS(IO::NativeDescriptor:D: Int:D \other --> Bool:D) {
         nqp::hllbool(nqp::iseq_i(nqp::unbox_i(self), nqp::unbox_i(other)))
     }
 
-    proto method new(|) {*}
-    multi method new(int $fd)   {
+    proto method new(IO::NativeDescriptor: |)         {*}
+    multi method new(IO::NativeDescriptor: int $fd)   {
         nqp::box_i($fd, IO::NativeDescriptor)
     }
-    multi method new(Int() $fd) {
+    multi method new(IO::NativeDescriptor: Int() $fd) {
         nqp::box_i(nqp::decont_i($fd), IO::NativeDescriptor)
     }
 
-    method Int(IO::NativeDescriptor:D: --> Int) {
+    method Int(IO::NativeDescriptor:D: --> Int:D) {
         nqp::p6box_i(nqp::unbox_i(self))
     }
 
-    multi method Str (IO::NativeDescriptor:D: --> Str) {
+    method IO(IO::NativeDescriptor:D: --> IO::NativeDescriptor:D) { self }
+
+    multi method Str (IO::NativeDescriptor:D: --> Str:D) {
         nqp::p6box_s(nqp::coerce_is(nqp::unbox_i(self)))
     }
-    multi method gist(IO::NativeDescriptor:D: --> Str) {
+    multi method gist(IO::NativeDescriptor:D: --> Str:D) {
         nqp::p6box_s(
           nqp::concat(
             nqp::coerce_is(nqp::unbox_i(self)),
@@ -46,19 +48,21 @@ my class IO::NativeDescriptor is Int does IO {
           )
         )
     }
-    multi method perl(IO::NativeDescriptor:D: --> Str) {
+    multi method perl(IO::NativeDescriptor:D: --> Str:D) {
         nqp::p6box_s(
           nqp::concat(
-            nqp::concat(nqp::unbox_s(self.^name), '.new('),
+            nqp::concat(self.^name, '.new('),
             nqp::concat(nqp::coerce_is(nqp::unbox_i(self)), ')')
           )
         )
     }
 
-    multi method slurp(IO::NativeDescriptor:D: :$enc, :$bin --> IO::Handle)                         {
-        IO::Handle.new(:fd(self)).open(:$enc, :$bin)
+    multi method slurp(IO::NativeDescriptor:D: :$enc, :$bin --> IO::Handle:D) {
+        IO::Handle.new(:file(self)).open(:$enc, :$bin)
     }
-    multi method spurt(IO::NativeDescriptor:D: $data, :$enc, :$append, :$createonly --> IO::Handle) {
+    multi method spurt(IO::NativeDescriptor:D:
+        $data, :$enc, :$append, :$createonly --> IO::Handle:D
+    ) {
         self.open:
             :$enc,                   :bin(nqp::istype($data, Blob)),
             :mode<wo>,               :create,
@@ -121,7 +125,7 @@ my class IO::NativeDescriptor is Int does IO {
     }
 
     multi method open  (IO::NativeDescriptor:D: |c --> IO::Handle)               {
-        IO::Handle.new(:fd(self)).open(|c)
+        IO::Handle.new(:file(self)).open(|c)
     }
 #?if moar
     multi method watch (IO::NativeDescriptor:D: --> IO::Notification)            {

--- a/src/core/IO/NativeDescriptor.pm6
+++ b/src/core/IO/NativeDescriptor.pm6
@@ -57,69 +57,67 @@ my class IO::NativeDescriptor is Int does IO {
         )
     }
 
-    multi method slurp(IO::NativeDescriptor:D: :$enc, :$bin --> IO::Handle:D) {
-        IO::Handle.new(:file(self)).open(:$enc, :$bin)
-    }
-    multi method spurt(IO::NativeDescriptor:D:
-        $data, :$enc, :$append, :$createonly --> IO::Handle:D
-    ) {
-        self.open:
-            :$enc,                   :bin(nqp::istype($data, Blob)),
-            :mode<wo>,               :create,
-            :exclusive($createonly), :$append,
-            :truncate(nqp::if(
-                nqp::isfalse(nqp::decont($append)),
-                nqp::isfalse(nqp::decont($createonly))
-            ));
-    }
-
     multi method e       (IO::NativeDescriptor:D: --> Bool)    {
+        # TODO: refactor RI to actually make this work.
         ?Rakudo::Internals.FILETEST-E: self
     }
     multi method d       (IO::NativeDescriptor:D: --> Bool)    {
+        # TODO: refactor RI to actually make this work.
         ?Rakudo::Internals.FILETEST-D: self
     }
     multi method f       (IO::NativeDescriptor:D: --> Bool)    {
+        # TODO: refactor RI to actually make this work.
         ?Rakudo::Internals.FILETEST-F: self
     }
     multi method s       (IO::NativeDescriptor:D: --> Int)     {
+        # TODO: refactor RI to actually make this work.
         nqp::p6box_i(Rakudo::Internals.FILETEST-S: self)
     }
     multi method l       (IO::NativeDescriptor:D: --> Bool)    {
+        # TODO: refactor RI to actually make this work.
         ?Rakudo::Internals.FILETEST-LE(self)
             ?? ?Rakudo::Internals.FILETEST-L(self)
             !! Failure.new: X::IO::DoesNotExist.new: :at(self), :trying<l>
     }
     multi method z       (IO::NativeDescriptor:D: --> Bool)    {
+        # TODO: refactor RI to actually make this work.
         ?Rakudo::Internals.FILETEST-Z: self
     }
     multi method r       (IO::NativeDescriptor:D: --> Bool)    {
+        # TODO: refactor RI to actually make this work.
         ?Rakudo::Internals.FILETEST-R: self
     }
     multi method w       (IO::NativeDescriptor:D: --> Bool)    {
+        # TODO: refactor RI to actually make this work.
         ?Rakudo::Internals.FILETEST-W: self
     }
     multi method x       (IO::NativeDescriptor:D: --> Bool)    {
+        # TODO: refactor RI to actually make this work.
         ?Rakudo::Internals.FILETEST-X: self
     }
     multi method rw      (IO::NativeDescriptor:D: --> Bool)    {
+        # TODO: refactor RI to actually make this work.
         ?Rakudo::Internals.FILETEST-RW: self
     }
     multi method rwx     (IO::NativeDescriptor:D: --> Bool)    {
+        # TODO: refactor RI to actually make this work.
         ?Rakudo::Internals.FILETEST-RWX: self
     }
     multi method modified(IO::NativeDescriptor:D: --> Instant) {
+        # TODO: refactor RI to actually make this work.
         Instant.from-posix: Rakudo::Internals.FILETEST-MODIFIED: self
     }
     multi method accessed(IO::NativeDescriptor:D: --> Instant) {
+        # TODO: refactor RI to actually make this work.
         Instant.from-posix: Rakudo::Internals.FILETEST-ACCESSED: self
     }
     multi method changed (IO::NativeDescriptor:D: --> Instant) {
+        # TODO: refactor RI to actually make this work.
         Instant.from-posix: Rakudo::Internals.FILETEST-CHANGED: self
     }
     multi method mode    (IO::NativeDescriptor:D: --> IntStr)  {
         nqp::stmts(
-          (my int $mode = Rakudo::Internals.FILETEST-MODE: self),
+          (my int $mode = nqp::fstat(nqp::unbox_i(self), nqp::const::STAT_PLATFORM_MODE) +& 0o7777),
           IntStr.new: $mode, sprintf '%04o', $mode
         )
     }
@@ -134,22 +132,6 @@ my class IO::NativeDescriptor is Int does IO {
         Failure.new: X::NYI.new: :feature<watchfd>
     }
 #?endif
-    multi method rename(IO::NativeDescriptor:D: IO() $to, :$createonly --> Bool) {
-        # TODO: implement nqp::renamefd
-        # nqp::hllbool(nqp::renamefd(nqp::unbox_i(self), nqp::unbox_s($to.Str)))
-        Failure.new: X::NYI.new: :feature<renamefd>
-    }
-    multi method copy  (IO::NativeDescriptor:D: IO() $to, $createonly --> Bool)  {
-        # TODO: implement nqp::copyfd
-        # nqp::hllbool(nqp::copyfd(nqp::unbox_i(self), nqp::unbox_s($to.Str)))
-        Failure.new: X::NYI.new: :feature<copyfd>
-    }
-    multi method move  (IO::NativeDescriptor:D: |c --> True)                     {
-        self.copy(|c) orelse fail X::IO::Move.new: :from(.exception.from),
-            :to(.exception.to), :os-error(.exception.os-error);
-        self.unlink   orelse fail X::IO::Move.new: :from(.exception.from),
-            :to(.exception.to), :os-error(.exception.os-error);
-    }
     multi method chmod (IO::NativeDescriptor:D: Int() $mode --> Bool)            {
         # TODO: implement nqp::chmodfd
         # nqp::hllbool(nqp::chmodfd(nqp::unbox_i(self), nqp::decont_i($mode)))

--- a/src/core/IO/NativeDescriptor.pm6
+++ b/src/core/IO/NativeDescriptor.pm6
@@ -122,19 +122,24 @@ my class IO::NativeDescriptor is Int does IO {
         )
     }
 
-    multi method open  (IO::NativeDescriptor:D: |c --> IO::Handle)               {
+    multi method open-native(IO::NativeDescriptor:D:
+        :$mode, :$create, :$append, :$truncate, :$exclusive --> Mu
+    ) {
+        nqp::fdopen(nqp::unbox_i(self))
+    }
+    multi method open  (IO::NativeDescriptor:D: |c --> IO::Handle)    {
         IO::Handle.new(:file(self)).open(|c)
     }
 #?if moar
-    multi method watch (IO::NativeDescriptor:D: --> IO::Notification)            {
-        # TODO: implement nqp::watchfd
+    multi method watch (IO::NativeDescriptor:D: --> IO::Notification) {
+        # TODO: implement nqp::fdwatch
         # IO::Notification.watch-file: self
         Failure.new: X::NYI.new: :feature<watchfd>
     }
 #?endif
-    multi method chmod (IO::NativeDescriptor:D: Int() $mode --> Bool)            {
-        # TODO: implement nqp::chmodfd
-        # nqp::hllbool(nqp::chmodfd(nqp::unbox_i(self), nqp::decont_i($mode)))
+    multi method chmod (IO::NativeDescriptor:D: Int() $mode --> Bool) {
+        # TODO: implement nqp::fdchmod
+        # nqp::hllbool(nqp::fdchmod(nqp::unbox_i(self), nqp::decont_i($mode)))
         Failure.new: X::NYI.new: :feature<chmodfd>
     }
 }

--- a/src/core/IO/Path.pm6
+++ b/src/core/IO/Path.pm6
@@ -531,14 +531,14 @@ my class IO::Path is Cool does IO {
         IO::Handle.new(:path(self)).open(:bin)
     }
     multi method spurt(IO::Path:D: $data, :$enc, :$append, :$createonly --> IO::Handle) {
-        my int $truncate = nqp::if(
-            nqp::isfalse(nqp::decont($append)),
-            nqp::isfalse(nqp::decont($createonly))
-        );
         self.open:
-            :$enc,     :bin(nqp::istype($data, Blob)),
-            :mode<wo>, :create, :exclusive($createonly),
-            :$append,  :$truncate
+            :$enc,                   :bin(nqp::istype($data, Blob)),
+            :mode<wo>,               :create,
+            :exclusive($createonly), :$append,
+            :truncate(nqp::if(
+                nqp::isfalse(nqp::decont($append)),
+                nqp::isfalse(nqp::decont($createonly))
+            ))
     }
 
     multi method e       (IO::Path:D: --> Bool)    {

--- a/src/core/IO/Path.pm6
+++ b/src/core/IO/Path.pm6
@@ -462,10 +462,18 @@ my class IO::Path is Cool does IO {
         nqp::chmod($.absolute, nqp::unbox_i($mode))
     }
     multi method rename (IO::Path:D: IO() $to, :$createonly --> True) {
+        nqp::unless(
+          nqp::istype(nqp::decont($to), IO::Path),
+          fail X::IO::NotAPath.new: :from(self), :$to, :trying<rename>
+        );
         nqp::rename($.absolute, nqp::unbox_s($to.absolute));
     }
     multi method copy   (IO::Path:D: IO() $to, :$createonly --> True) {
         # XXX TODO: maybe move the sameness check to the nqp OP/VM
+        nqp::unless(
+          nqp::istype(nqp::decont($to), IO::Path),
+          fail X::IO::NotAPath.new: :from(self), :$to, :trying<copy>
+        );
         nqp::if(
             nqp::iseq_s(
                 (my $from-abs :=   $.absolute),
@@ -485,9 +493,17 @@ my class IO::Path is Cool does IO {
         nqp::unlink($.absolute);
     }
     multi method symlink(IO::Path:D: IO() $to --> True) {
+        nqp::unless(
+          nqp::istype(nqp::decont($to), IO::Path),
+          X::IO::NotAPath.new: :from(self), :$to, :trying<symlink>
+        );
         nqp::symlink($.absolute, $to.absolute);
     }
     multi method link   (IO::Path:D: IO() $to --> True) {
+        nqp::unless(
+          nqp::istype(nqp::decont($to), IO::Path),
+          X::IO::NotAPath.new: :from(self), :$to, :trying<link>
+        );
         nqp::link($.absolute, $to.absolute);
     }
 

--- a/src/core/IO/Path.pm6
+++ b/src/core/IO/Path.pm6
@@ -434,6 +434,22 @@ my class IO::Path is Cool does IO {
         )
     }
 
+    multi method open-native(IO::Path:D:
+        :$mode, :$create, :$append, :$truncate, :$exclusive --> Mu
+    ) {
+        nqp::open(
+          $.absolute,
+          nqp::concat(
+            nqp::if(nqp::iseq_s($mode, 'ro'), 'r',
+            nqp::if(nqp::iseq_s($mode, 'wo'), '-',
+            nqp::if(nqp::iseq_s($mode, 'rw'), '+',
+              die "Unknown mode '$mode'"))),
+            nqp::concat(nqp::if($create,      'c', ''),
+            nqp::concat(nqp::if($append,      'a', ''),
+            nqp::concat(nqp::if($truncate,    't', ''),
+                        nqp::if($exclusive,   'x', ''))))))
+    }
+
     multi method open   (IO::Path:D: |c --> IO::Handle)               {
         IO::Handle.new(:file(self)).open(|c)
     }

--- a/src/core/IO/Socket.pm6
+++ b/src/core/IO/Socket.pm6
@@ -111,8 +111,8 @@ my role IO::Socket {
         $!PIO := nqp::null;
     }
 
-    method native-descriptor(::?CLASS:D:) {
-        nqp::filenofh($!PIO)
+    method native-descriptor(::?CLASS:D: --> IO::FileDescriptor) {
+        IO::FileDescriptor.new: nqp::filenofh($!PIO)
     }
 }
 

--- a/src/core/IO/Socket.pm6
+++ b/src/core/IO/Socket.pm6
@@ -111,8 +111,8 @@ my role IO::Socket {
         $!PIO := nqp::null;
     }
 
-    method native-descriptor(::?CLASS:D: --> IO::FileDescriptor) {
-        IO::FileDescriptor.new: nqp::filenofh($!PIO)
+    method native-descriptor(::?CLASS:D: --> IO::NativeDescriptor) {
+        IO::NativeDescriptor.new: nqp::filenofh($!PIO)
     }
 }
 

--- a/src/core/IO/Socket/Async.pm6
+++ b/src/core/IO/Socket/Async.pm6
@@ -208,8 +208,8 @@ my class IO::Socket::Async {
             self.bless(:&on-close, :$VMIO-tobe, :$socket-host, :$socket-port);
         }
 
-        method native-descriptor(--> IO::FileDescriptor) {
-            IO::FileDescriptor.new: nqp::filenofh(await $!VMIO-tobe)
+        method native-descriptor(--> IO::NativeDescriptor) {
+            IO::NativeDescriptor.new: nqp::filenofh(await $!VMIO-tobe)
         }
     }
 
@@ -309,8 +309,8 @@ my class IO::Socket::Async {
             :$host, :$port, :$backlog, :$encoding, :$scheduler
     }
 
-    method native-descriptor(--> IO::FileDescriptor) {
-        IO::FileDescriptor.new: nqp::filenofh($!VMIO)
+    method native-descriptor(--> IO::NativeDescriptor) {
+        IO::NativeDescriptor.new: nqp::filenofh($!VMIO)
     }
 
     sub setup-close(\socket --> Nil) {

--- a/src/core/IO/Socket/Async.pm6
+++ b/src/core/IO/Socket/Async.pm6
@@ -208,8 +208,8 @@ my class IO::Socket::Async {
             self.bless(:&on-close, :$VMIO-tobe, :$socket-host, :$socket-port);
         }
 
-        method native-descriptor(--> Int) {
-            nqp::filenofh(await $!VMIO-tobe)
+        method native-descriptor(--> IO::FileDescriptor) {
+            IO::FileDescriptor.new: nqp::filenofh(await $!VMIO-tobe)
         }
     }
 
@@ -309,8 +309,8 @@ my class IO::Socket::Async {
             :$host, :$port, :$backlog, :$encoding, :$scheduler
     }
 
-    method native-descriptor(--> Int) {
-        nqp::filenofh($!VMIO)
+    method native-descriptor(--> IO::FileDescriptor) {
+        IO::FileDescriptor.new: nqp::filenofh($!VMIO)
     }
 
     sub setup-close(\socket --> Nil) {

--- a/src/core/IO/Special.pm6
+++ b/src/core/IO/Special.pm6
@@ -1,6 +1,4 @@
-my class Instant { ... }
-
-class IO::Special does IO {
+my class IO::Special does IO {
     has Str $.what;
 
     multi method WHICH(IO::Special:D: --> ValueObjAt) {
@@ -9,25 +7,25 @@ class IO::Special does IO {
             nqp::if(
               nqp::eqaddr(self.WHAT, IO::Special),
               'IO::Special|',
-              nqp::concat(nqp::unbox_s(self.^name), '|')
+              nqp::concat(self.^name, '|')
             ),
-            $!what
+            nqp::unbox_s($!what)
           ),
           ValueObjAt
         )
     }
 
-    method new(Str:D \what) {
+    method new(IO::Special: Str:D \what) {
         nqp::p6bindattrinvres(nqp::create(self),self,'$!what',what)
     }
 
-    multi method Str (IO::Special:D: --> Str) {
-        $!what
-    }
-    multi method gist(IO::Special:D: --> Str) {
+    method IO(IO::Special:D: --> IO::Special:D) { self }
+
+    multi method Str (IO::Special:D: --> Str:D) { $!what }
+    multi method gist(IO::Special:D: --> Str:D) {
         nqp::p6box_s(nqp::concat(nqp::decont_s($!what), '.IO'))
     }
-    multi method perl(IO::Special:D: --> Str) {
+    multi method perl(IO::Special:D: --> Str:D) {
         nqp::p6box_s(
           nqp::concat(
             nqp::concat(nqp::unbox_s(self.^name), '.new('),
@@ -39,7 +37,7 @@ class IO::Special does IO {
     multi method e       (IO::Special:D: --> True)    {         }
     multi method d       (IO::Special:D: --> False)   {         }
     multi method f       (IO::Special:D: --> False)   {         }
-    multi method s       (IO::Special:D:--> 0)        {         }
+    multi method s       (IO::Special:D: --> 0)       {         }
     multi method l       (IO::Special:D: --> False)   {         }
     multi method r       (IO::Special:D: --> Bool)    {
         $!what eq '<STDIN>'

--- a/src/core/IO/Special.pm6
+++ b/src/core/IO/Special.pm6
@@ -52,6 +52,19 @@ my class IO::Special does IO {
     multi method accessed(IO::Special:D: --> Instant) { Instant }
     multi method changed (IO::Special:D: --> Instant) { Instant }
     multi method mode    (IO::Special:D: --> IntStr)  { IntStr  }
+
+    multi method open-native(IO::Special:D:
+        :$mode, :$create, :$append, :$truncate, :$exclusive --> Mu
+    ) {
+        given $!what {
+            when '<STDIN>'  { nqp::getstdin()  }
+            when '<STDOUT>' { nqp::getstdout() }
+            when '<STDERR>' { nqp::getstderr() }
+            default         {
+                die "Don't know how to open '$!what' especially";
+            }
+        }
+    }
 }
 
 # vim: ft=perl6 expandtab sw=4

--- a/src/core/IO/Special.pm6
+++ b/src/core/IO/Special.pm6
@@ -3,14 +3,11 @@ my class Instant { ... }
 class IO::Special does IO {
     has Str $.what;
 
-    method new(Str:D \what --> IO::Special:D) {
-        nqp::p6bindattrinvres(nqp::create(self),self,'$!what',what)
-    }
     multi method WHICH(IO::Special:D: --> ValueObjAt) {
         nqp::box_s(
           nqp::concat(
             nqp::if(
-              nqp::eqaddr(self.WHAT,IO::Special),
+              nqp::eqaddr(self.WHAT, IO::Special),
               'IO::Special|',
               nqp::concat(nqp::unbox_s(self.^name), '|')
             ),
@@ -19,27 +16,44 @@ class IO::Special does IO {
           ValueObjAt
         )
     }
-    multi method Str  (IO::Special:D:) {                    $!what         }
-    multi method perl (IO::Special:D:) { "{self.^name}.new({$!what.perl})" }
 
-    method IO(IO::Special:D: --> IO::Special:D) { self }
+    method new(Str:D \what) {
+        nqp::p6bindattrinvres(nqp::create(self),self,'$!what',what)
+    }
 
-    method e(IO::Special:D: --> True) { }
-    method d(IO::Special:D: --> False) { }
-    method f(IO::Special:D: --> False) { }
-    method s(IO::Special:D:--> 0) { }
-    method l(IO::Special:D: --> False) { }
-    method r(IO::Special:D: --> Bool:D) {
+    multi method Str (IO::Special:D: --> Str) {
+        $!what
+    }
+    multi method gist(IO::Special:D: --> Str) {
+        nqp::p6box_s(nqp::concat(nqp::decont_s($!what), '.IO'))
+    }
+    multi method perl(IO::Special:D: --> Str) {
+        nqp::p6box_s(
+          nqp::concat(
+            nqp::concat(nqp::unbox_s(self.^name), '.new('),
+            nqp::concat(nqp::unbox_s($!what.perl), ')')
+          )
+        )
+    }
+
+    multi method e       (IO::Special:D: --> True)    {         }
+    multi method d       (IO::Special:D: --> False)   {         }
+    multi method f       (IO::Special:D: --> False)   {         }
+    multi method s       (IO::Special:D:--> 0)        {         }
+    multi method l       (IO::Special:D: --> False)   {         }
+    multi method r       (IO::Special:D: --> Bool)    {
         $!what eq '<STDIN>'
     }
-    method w(IO::Special:D: --> Bool:D) {
+    multi method w       (IO::Special:D: --> Bool)    {
         $!what eq '<STDOUT>' or $!what eq '<STDERR>'
     }
-    method x(IO::Special:D: --> False) { }
-    method modified(IO::Special:D: --> Instant) { Instant }
-    method accessed(IO::Special:D: --> Instant) { Instant }
-    method changed( IO::Special:D: --> Instant) { Instant }
-    method mode(IO::Special:D: --> Nil) { }
+    multi method x       (IO::Special:D: --> False)   {         }
+    multi method rw      (IO::Special:D: --> False)   {         }
+    multi method rwx     (IO::Special:D: --> False)   {         }
+    multi method modified(IO::Special:D: --> Instant) { Instant }
+    multi method accessed(IO::Special:D: --> Instant) { Instant }
+    multi method changed (IO::Special:D: --> Instant) { Instant }
+    multi method mode    (IO::Special:D: --> IntStr)  { IntStr  }
 }
 
 # vim: ft=perl6 expandtab sw=4

--- a/src/core/Int.pm6
+++ b/src/core/Int.pm6
@@ -1,7 +1,8 @@
-my class Rat { ... }
+my class Rat                      { ... }
+my class IO::NativeDescriptor     { ... }
 my class X::Cannot::Capture       { ... }
 my class X::Numeric::DivideByZero { ... }
-my class X::NYI::BigInt { ... }
+my class X::NYI::BigInt           { ... }
 
 my class Int { ... }
 my subset UInt of Int where {
@@ -16,9 +17,9 @@ my class Int does Real { # declared in BOOTSTRAP
         nqp::box_s(
           nqp::concat(
             nqp::if(
-              nqp::eqaddr(self.WHAT,Int),
+              nqp::eqaddr(self.WHAT, Int),
               'Int|',
-              nqp::concat(nqp::unbox_s(self.^name), '|')
+              nqp::concat(self.^name, '|')
             ),
             nqp::tostr_I(self)
           ),
@@ -46,7 +47,9 @@ my class Int does Real { # declared in BOOTSTRAP
 
     method Capture() { die X::Cannot::Capture.new: :what(self) }
 
-    method IO(Int:D: --> IO::NativeDescriptor) { IO::NativeDescriptor.new: self }
+    method IO(Int:D: --> IO::NativeDescriptor:D) {
+        IO::NativeDescriptor.new: self
+    }
 
     method Int(--> Int) { self }
 

--- a/src/core/Int.pm6
+++ b/src/core/Int.pm6
@@ -46,7 +46,7 @@ my class Int does Real { # declared in BOOTSTRAP
 
     method Capture() { die X::Cannot::Capture.new: :what(self) }
 
-    method IO(Int:D: --> IO::FileDesc) { IO::FileDesc.new: self }
+    method IO(Int:D: --> IO::NativeDescriptor) { IO::NativeDescriptor.new: self }
 
     method Int(--> Int) { self }
 

--- a/src/core/Int.pm6
+++ b/src/core/Int.pm6
@@ -46,6 +46,8 @@ my class Int does Real { # declared in BOOTSTRAP
 
     method Capture() { die X::Cannot::Capture.new: :what(self) }
 
+    method IO(Int:D: --> IO::FileDesc) { IO::FileDesc.new: self }
+
     method Int(--> Int) { self }
 
     multi method Str(Int:D: --> Str:D) {

--- a/src/core/io_operators.pm6
+++ b/src/core/io_operators.pm6
@@ -81,10 +81,7 @@ multi sub dir(IO::Path:D $path, |c) { $path.dir(|c) }
 multi sub dir(IO()       $path, |c) { $path.dir(|c) }
 
 proto sub open($, |) {*}
-multi sub open(IO() $path, |c) { IO::Handle.new(:$path).open(|c) }
-
-proto sub fdopen($, |) {*}
-multi sub fdopen(Int:D $fd, |c) { IO::Handle.new(:$fd).open(|c) }
+multi sub open(IO() $file, |c) { IO::Handle.new(:$file).open(|c) }
 
 proto sub lines($?, |) {*}
 multi sub lines($what = $*ARGFILES, |c) { $what.lines(|c) }
@@ -170,11 +167,10 @@ multi sub indir(IO() $path, &what, :$d = True, :$r, :$w, :$x) {
 
     my sub setup-handle(str $what) {
         my $handle := nqp::p6bindattrinvres(
-          nqp::create(IO::Handle),IO::Handle,'$!path',nqp::p6bindattrinvres(
+          nqp::create(IO::Handle),IO::Handle,'$!file',nqp::p6bindattrinvres(
             nqp::create(IO::Special),IO::Special,'$!what',$what
           )
         );
-        nqp::bindattr_i($handle,IO::Handle,'$!fd',-1);
         nqp::getattr($handle,IO::Handle,'$!chomp')      = True;
         nqp::getattr($handle,IO::Handle,'$!nl-in')      = NL-IN;
         nqp::getattr($handle,IO::Handle,'$!nl-out')     = NL-OUT;

--- a/src/core/io_operators.pm6
+++ b/src/core/io_operators.pm6
@@ -83,6 +83,9 @@ multi sub dir(IO()       $path, |c) { $path.dir(|c) }
 proto sub open($, |) {*}
 multi sub open(IO() $path, |c) { IO::Handle.new(:$path).open(|c) }
 
+proto sub fdopen($, |) {*}
+multi sub fdopen(Int:D $fd, |c) { IO::Handle.new(:$fd).open(|c) }
+
 proto sub lines($?, |) {*}
 multi sub lines($what = $*ARGFILES, |c) { $what.lines(|c) }
 
@@ -171,10 +174,11 @@ multi sub indir(IO() $path, &what, :$d = True, :$r, :$w, :$x) {
             nqp::create(IO::Special),IO::Special,'$!what',$what
           )
         );
-        nqp::getattr($handle,IO::Handle,'$!chomp')    = True;
-        nqp::getattr($handle,IO::Handle,'$!nl-in')    = NL-IN;
-        nqp::getattr($handle,IO::Handle,'$!nl-out')   = NL-OUT;
-        nqp::getattr($handle,IO::Handle,'$!encoding') = ENCODING;
+        nqp::bindattr_i($handle,IO::Handle,'$!fd',-1);
+        nqp::getattr($handle,IO::Handle,'$!chomp')      = True;
+        nqp::getattr($handle,IO::Handle,'$!nl-in')      = NL-IN;
+        nqp::getattr($handle,IO::Handle,'$!nl-out')     = NL-OUT;
+        nqp::getattr($handle,IO::Handle,'$!encoding')   = ENCODING;
         $handle
     }
 

--- a/tools/templates/core_sources
+++ b/tools/templates/core_sources
@@ -113,6 +113,7 @@ src/core/IO/Special.pm6
 src/core/IO/Handle.pm6
 src/core/IO/Pipe.pm6
 src/core/IO/Path.pm6
+src/core/IO/NativeDescriptor.pm6
 src/core/io_operators.pm6
 src/core/IO/CatHandle.pm6
 src/core/IO/ArgFiles.pm6


### PR DESCRIPTION
Originally, this was only supposed to add support for using file descriptors/`HANDLE`s with `IO::Handle`. This alone wasn't quite good enough since `IO::Socket::INET` and `IO::Socket::Async` will also need to be able to support creating sockets given a file descriptor or path once I implement sending file descriptors over sockets as part of my networking grant work, and I want to be able to just pass an `IO` or `IO::Handle` instance to `IO::Socket::INET.new`/`IO::Socket::Async.new` and have it work without hardcoding behaviour specific to file descriptors or paths in v6.e. This requires three different changes in particular.

This starts out by formalizing what `IO` actually is: a role done by classes describing files in some way. Methods that were originally specific to `IO::Path` and `IO::Special` but are generic file operations are now stubbed in `IO`.

Second, this introduces `IO::NativeDescriptor`, an abstraction over file descriptors (`HANDLE`s on Windows). It can be used in the same way `IO::Path` and `IO::Special` are.

Finally, this makes whatever uses `IO` as a type more generic in order to make it possible to create custom file classes. `IO::Handle` no longer hardcodes logic for how `IO`-typed variables should be handled depending on their type in a way that makes that impossible; that is now implemented in the types themselves.

All of this is done while aiming to preserve compatibility with code that already uses `IO` as a type. I'll need to grep the ecosystem for cases where people specify `IO` as a type when they really mean `IO::Path` before this can be merged, as that's the only code that I know of that this may break.

This is unfinished and hasn't been fully tested past the first commit. There are still several nqp ops for dealing with native descriptors that haven't been implemented yet, as well as changes to RI necessary for `IO::NativeDescriptor`'s stat methods to work. Roast will need tests for `IO::NativeDescriptor` and the docs will need to be updated. This will need testing on Windows once it's finished.