### PR TITLE
Make Map method use Map class directly

### DIFF
--- a/src/core/Any.pm6
+++ b/src/core/Any.pm6
@@ -84,7 +84,7 @@ my class Any { # declared in BOOTSTRAP
     multi method Hash() { self.hash.Hash }
 
     proto method Map(|) is nodal {*}
-    multi method Map() { self.hash.Map }
+    multi method Map() { Map.new(self) }
 
     proto method elems(|) is nodal {*}
     multi method elems(Any:U: --> 1) { }


### PR DESCRIPTION
Avoid bypassing through a hash as this includes extra containerization
for the values.

Fixes spectest issue for rakudo/rakudo#3081