### PR TITLE
Return Failure from failed P6-level .parse on 6.e

### DIFF
--- a/src/core/Grammar.pm6
+++ b/src/core/Grammar.pm6
@@ -1,5 +1,62 @@
 my class Grammar is Match {
 
+    # (oughta be down in Match or even nqp really)
+    method locprepost() {
+        my $orig = self.orig;
+        my $marked = self.?MARKED('ws');
+        my $pos = $marked && index(" }])>»", substr($orig, self.pos, 1)) < 0 ?? $marked.from !! self.pos;
+
+        my $prestart = $pos - 40;
+        $prestart = 0 if $prestart < 0;
+        my $pre = substr($orig, $prestart, $pos - $prestart);
+        $pre = $pre.subst(/.*\n/, "");
+        $pre = '<BOL>' if $pre eq '';
+
+        my $postchars = $pos + 40 > chars($orig) ?? chars($orig) - $pos !! 40;
+        my $post = substr($orig, $pos, $postchars);
+        $post = $post.subst(/\n.*/, "");
+        $post = '<EOL>' if $post eq '';
+
+        [$pre, $post]
+    }
+
+    # stolen and trimmed down from World
+    method typed_exception(X::Comp $ex, *%opts) {
+        # If the highwater is beyond the current position, force the cursor to that location.
+        my @expected;
+        my $high = self.'!highwater'();
+
+        if $high >= self.pos() {
+            self.'!cursor_pos'($high);
+            my $highexpect := self.'!highexpect'();
+            if nqp::islist($highexpect) {
+                my %seen;
+                for ^nqp::elems($highexpect) {
+                    my $x = nqp::hllizefor(nqp::shift($highexpect),'perl6');
+                    push @expected, $x unless %seen{$x}++;
+                }
+                @expected .= sort;
+            }
+        }
+
+        my @locprepost := self.locprepost();
+        # Build and throw exception object.
+        %opts<line>            = HLL::Compiler.lineof(self.orig, self.pos, :cache(1));
+        # only set <pos> if it's not already set:
+        %opts<pos>             //= self.pos;
+        %opts<pre>             = @locprepost[0];
+        %opts<post>            = @locprepost[1];
+        %opts<highexpect>      = @expected if @expected;
+        %opts<is-compile-time> = 1;
+        Failure.new($ex.new(|%opts))
+    }
+
+    method SETFAIL($failed, :$filename) {
+        return Nil unless self.defined && nqp::isge_s(CLIENT::LEXICAL::<CORE-SETTING-REV>, 'e');
+        self.'!cursor_pos'($failed.pos);
+        self.typed_exception(X::Syntax::Confused, filename => ($filename // "<anon>"))
+    }
+
     method parse(\target, :$rule, :$args, Mu :$actions, :$filename) is raw {
         my $*LINEPOSCACHE;
         nqp::stmts(
@@ -28,9 +85,9 @@ my class Grammar is Match {
                   ),
                   $match := ($cursor := $cursor.'!cursor_next'()).MATCH
                 ),
-                $match || Nil
+                $match || $grammar.SETFAIL($match, :$filename),
               ),
-              Nil
+              $grammar.SETFAIL($cursor, :$filename),
             )
           )
         )


### PR DESCRIPTION
Cherry-pick of @9501edae4f73a970e3270e3b0336a7b3045d3329:

The `.parse` and `.parsefile` methods will now return a `Failure` object that points
to the high-water state of the parser, if available.  (The `.subparse` method
does not, since it is presumed to be for lower-level piecemeal matching that
is likelier to be success-oriented and have its own failure recovery modes.)

The behavior isn't changing for `6.c` and `6.d`.

Resolving perl6/6.d-prep#9