### PR TITLE
Allow use of CLIENT:: pseudo-package in code in GLOBAL

### DIFF
--- a/src/core.e/PseudoStash.pm6
+++ b/src/core.e/PseudoStash.pm6
@@ -168,7 +168,6 @@ my class PseudoStash is Map {
             my $pkg := nqp::getlexrel(
                 nqp::getattr(nqp::decont($cur), PseudoStash, '$!ctx'),
                 '$?PACKAGE');
-            die "GLOBAL can have no client package" if $pkg.^name eq "GLOBAL";
             my Mu $ctx := nqp::ctxcallerskipthunks(
                 nqp::getattr(nqp::decont($cur), PseudoStash, '$!ctx'));
             while nqp::getlexrel($ctx, '$?PACKAGE') === $pkg {

--- a/src/core/PseudoStash.pm6
+++ b/src/core/PseudoStash.pm6
@@ -173,7 +173,6 @@ my class PseudoStash is Map {
             my $pkg := nqp::getlexrel(
                 nqp::getattr(nqp::decont($cur), PseudoStash, '$!ctx'),
                 '$?PACKAGE');
-            die "GLOBAL can have no client package" if $pkg.^name eq "GLOBAL";
             my Mu $ctx := nqp::ctxcallerskipthunks(
                 nqp::getattr(nqp::decont($cur), PseudoStash, '$!ctx'));
             while nqp::getlexrel($ctx, '$?PACKAGE') === $pkg {


### PR DESCRIPTION
There is no reason for limiting its use in GLOBAL package.

rakudo/rakudo#3104