### PR TITLE
Pod: allow empty config value

### DIFF
--- a/src/Perl6/Pod.nqp
+++ b/src/Perl6/Pod.nqp
@@ -486,7 +486,7 @@ class Perl6::Pod {
                 $quoted   := nqp::null();
             }
 
-            if nqp::chars($quoted) {
+            if nqp::chars($quote) || nqp::chars($quoted) {
                 $word := nqp::concat($word, $quoted);
             }
             elsif nqp::chars($unquoted) {
@@ -498,7 +498,7 @@ class Perl6::Pod {
                 @pieces.push($delim) if ($keep eq 'delimiters');
                 $word := '';
             }
-            if !nqp::chars($line) && nqp::chars($word) {
+            if !nqp::chars($line) && (nqp::chars($quote) || nqp::chars($word)) {
                 @pieces.push($word);
                 $word := '';
             }
@@ -526,13 +526,14 @@ class Perl6::Pod {
         # break into an array
         my @arr := string2array($st);
 
-        if nqp::elems(@arr) > 1 {
-            return serialize_object('Array', |@arr).compile_time_value;
-        }
-        else {
+        if nqp::elems(@arr) == 1 {
             # convert a single-element list to a single value
             my $val := @arr[0];
             return $val;
+        }
+        else {
+            # 0 or 2 or more elements are an array
+            return serialize_object('Array', |@arr).compile_time_value;
         }
     }
 


### PR DESCRIPTION
Previously a Pod block such as

``` perl6
=begin pod :config('')
=end pod
# or
=begin pod :config[]
=end pod
```

would throw a compiler error (coercing NQPMu to Str). This is because,
first, an empty quoted string was treated like nothing when compiling
the list of values of the `:config` key above, and second, an empty value
list was unexpected on the caller site.

This commit makes empty quoted strings recognized and empty value lists
supported, so that

``` perl6
=begin pod :x('') :y( )
=end pod
```

parses successfully and gives

``` perl6
dd $=pod.head.config
#= Hash %!config = {:x(""), :y($[])}
```

Fixes #3098 and closes #3101