### PR TITLE
Make COREs compile with their respective language revision

### DIFF
--- a/src/Perl6/Metamodel/ClassHOW.nqp
+++ b/src/Perl6/Metamodel/ClassHOW.nqp
@@ -52,7 +52,7 @@ class Perl6::Metamodel::ClassHOW
         my $obj := nqp::settypehll($new_type, 'perl6');
         $metaclass.set_name($obj, $name // "<anon|{$anon_id++}>");
         self.add_stash($obj);
-        $metaclass.set_ver($obj, $ver) if $ver;
+        $metaclass.set_ver($obj, $ver);
         $metaclass.set_auth($obj, $auth) if $auth;
         $metaclass.set_api($obj, $api) if $api;
         $metaclass.setup_mixin_cache($obj);

--- a/src/Perl6/Metamodel/ConcreteRoleHOW.nqp
+++ b/src/Perl6/Metamodel/ConcreteRoleHOW.nqp
@@ -47,7 +47,7 @@ class Perl6::Metamodel::ConcreteRoleHOW
         my $metarole := self.new(:roles(@roles));
         my $obj := nqp::settypehll(nqp::newtype($metarole, 'Uninstantiable'), 'perl6');
         $metarole.set_name($obj, $name);
-        $metarole.set_ver($obj, $ver) if $ver;
+        $metarole.set_ver($obj, $ver);
         $metarole.set_auth($obj, $auth) if $auth;
         $metarole.set_api($obj, $api) if $api;
         $obj;

--- a/src/Perl6/Metamodel/ModuleHOW.nqp
+++ b/src/Perl6/Metamodel/ModuleHOW.nqp
@@ -22,7 +22,7 @@ class Perl6::Metamodel::ModuleHOW
         my $metaclass := self.new();
         my $obj := nqp::settypehll(nqp::newtype($metaclass, 'Uninstantiable'), 'perl6');
         $metaclass.set_name($obj, $name);
-        $metaclass.set_ver($obj, $ver) if $ver;
+        $metaclass.set_ver($obj, $ver);
         $metaclass.set_auth($obj, $auth) if $auth;
         $metaclass.set_api($obj, $api) if $api;
         self.add_stash($obj);

--- a/src/Perl6/Metamodel/NativeHOW.nqp
+++ b/src/Perl6/Metamodel/NativeHOW.nqp
@@ -25,7 +25,7 @@ class Perl6::Metamodel::NativeHOW
         my $metaclass := self.new();
         my $obj := nqp::settypehll(nqp::newtype($metaclass, $repr), 'perl6');
         $metaclass.set_name($obj, $name);
-        $metaclass.set_ver($obj, $ver) if $ver;
+        $metaclass.set_ver($obj, $ver);
         $metaclass.set_auth($obj, $auth) if $auth;
         $metaclass.set_api($obj, $api) if $api;
         self.add_stash($obj);

--- a/src/Perl6/Metamodel/NativeRefHOW.nqp
+++ b/src/Perl6/Metamodel/NativeRefHOW.nqp
@@ -26,7 +26,7 @@ class Perl6::Metamodel::NativeRefHOW
         my $metaclass := self.new();
         my $obj := nqp::settypehll(nqp::newtype($metaclass, 'NativeRef'), 'perl6');
         $metaclass.set_name($obj, $name);
-        $metaclass.set_ver($obj, $ver) if $ver;
+        $metaclass.set_ver($obj, $ver);
         $metaclass.set_auth($obj, $auth) if $auth;
         $metaclass.set_api($obj, $api) if $api;
         self.add_stash($obj);

--- a/src/Perl6/Metamodel/ParametricRoleHOW.nqp
+++ b/src/Perl6/Metamodel/ParametricRoleHOW.nqp
@@ -37,7 +37,7 @@ class Perl6::Metamodel::ParametricRoleHOW
         my $metarole := self.new(:signatured($signatured), :specialize_lock(NQPLock.new));
         my $type := nqp::settypehll(nqp::newtype($metarole, 'Uninstantiable'), 'perl6');
         $metarole.set_name($type, $name // "<anon|{$anon_id++}>");
-        $metarole.set_ver($type, $ver) if $ver;
+        $metarole.set_ver($type, $ver);
         $metarole.set_auth($type, $auth) if $auth;
         $metarole.set_api($type, $api) if $api;
         $metarole.set_pun_repr($type, $repr) if $repr;

--- a/src/Perl6/Metamodel/Versioning.nqp
+++ b/src/Perl6/Metamodel/Versioning.nqp
@@ -7,7 +7,12 @@ role Perl6::Metamodel::Versioning {
     method auth($obj) { $!auth // '' }
     method api($obj) { $!api // '' }
 
-    method set_ver($obj, $ver) { $!ver := $ver }
+    method set_ver($obj, $ver) {
+        if $*COMPILING_CORE_SETTING && !$ver {
+            $ver := nqp::getcomp('perl6').language_version;
+        }
+        $!ver := $ver if $ver
+    }
     method set_auth($obj, $auth) { $!auth := $auth }
     method set_api($obj, $api) { $!api := $api }
 }

--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -683,8 +683,12 @@ class Perl6::World is HLL::World {
             if nqp::eqat($!setting_name, 'NULL', 0) {
                 $*COMPILING_CORE_SETTING := 1;
                 $*SET_DEFAULT_LANG_VER := 0;
+                my $lang_ver := nqp::iseq_s($!setting_name, 'NULL')
+                                    ?? '6.c'
+                                    !! '6.' ~ nqp::substr($!setting_name, 5, 1);
+                nqp::getcomp('perl6').set_language_version: $lang_ver;
+
             }
-            # self.load_setting($/,$!setting_name);
             $*UNIT.annotate('IN_DECL', 'mainline');
         }
     }

--- a/src/core/Rakudo/Internals.pm6
+++ b/src/core/Rakudo/Internals.pm6
@@ -15,6 +15,8 @@ my class X::Str::Sprintf::Directives::Count { ... }
 my class X::Str::Sprintf::Directives::Unsupported { ... }
 my class X::TypeCheck { ... }
 
+# Marker symbol for 6.c-mode regex boolification.
+my class Rakudo::Internals::RegexBoolification6cMarker { }
 
 my class Rakudo::Internals {
 
@@ -39,9 +41,6 @@ my class Rakudo::Internals {
     class LoweredAwayLexical {
         method dynamic() { False }
     }
-
-    # Marker symbol for 6.c-mode regex boolification.
-    class RegexBoolification6cMarker { }
 
     # rotate nqp list to another given list without using push/pop
     method RotateListToList(\from,\n,\to) {

--- a/src/core/core_prologue.pm6
+++ b/src/core/core_prologue.pm6
@@ -9,6 +9,8 @@ my class Failure { ... }
 my class Rakudo::Deprecations { ... }
 my class Rakudo::Internals { ... }
 my class Rakudo::Internals::JSON { ... }
+my class Rakudo::Internals::RegexBoolification6cMarker { ... }
+my class Rakudo::Internals::HyperWorkBatch { ... }
 my class Rakudo::Iterator { ... }
 #?if !js
 my class ThreadPoolScheduler { ... }

--- a/t/02-rakudo/14-revisions.t
+++ b/t/02-rakudo/14-revisions.t
@@ -2,7 +2,7 @@ use lib <t/packages>;
 use Test;
 use Test::Helpers;
 
-plan 2;
+plan 3;
 
 subtest "CORE.setting Revision", {
     plan 3;
@@ -19,6 +19,13 @@ subtest "Modifiers", {
     is-run q[use v6.d.TEST; print CORE-SETTING-REV], "v6.d.TEST loads CORE.d.setting", :out<d>;
     is-run q[use v6.d.TESTDEPR; print CORE-SETTING-REV], "Deprecated modifier generates a warning", :out<d>, :err(rx:s/TESTDEPR modifier is deprecated for Perl 6'.'d/);
     is-run q[use v6.d.NOMOD; print CORE-SETTING-REV], "Deprecated modifier generates a warning", :exitcode(1), :err(rx:s/No compiler available for Perl v6'.'d'.'NOMOD/);
+}
+
+subtest "Class Version", {
+    plan 3;
+    is-run qq[use v6.c; print PseudoStash.^ver], "6.c class version", :exitcode(0), :out<6.c>;
+    is-run qq[use v6.d; print PseudoStash.^ver], "6.c class version on 6.d compiler", :exitcode(0), :out<6.c>;
+    is-run qq[use v6.e.PREVIEW; print PseudoStash.^ver], "6.e class version", :exitcode(0), :out<6.e>;
 }
 
 done-testing;


### PR DESCRIPTION
This is a preparation work to assign language version to core classes.
I.e. PseudoStash.^ver would report back either `6.c` or `6.e` depending
from which `CORE` the class was imported.

rakudo/rakudo#3107