### PR TITLE
fix typo,add link to linenoise,remove rlwrap link

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ source directory doesn't have t/spec installed, then
 you can clone it like this:
 
     cd $YOUR_RAKUDO_SRCDIR
-    git clone https://githb.com/perl6/roast.git t/spec
+    git clone https://github.com/perl6/roast.git t/spec
 
 Note the rakudo code includes an entry in its .gitignore file
 so git will ignore any content under t/spec.
@@ -199,12 +199,12 @@ See [our contribution guidelines](https://github.com/rakudo/rakudo/blob/master/C
 ## Line editing and tab completion
 
 If you would like simple history and tab completion in the perl6 executable,
-you need to install the Linenoise module.  The recommended way to install
+you need to install the [Linenoise](https://github.com/hoelzro/p6-linenoise) module.  The recommended way to install
 Linenoise is via [zef](https://github.com/ugexe/zef):
 
     $ zef install Linenoise
 
-An alternative is to use a third-party program such as [rlwrap](http://utopia.knoware.nl/~hlub/uck/rlwrap/#rlwrap).
+An alternative is to use a third-party program such as [rlwrap](https://github.com/hanslub42/rlwrap). Documentation on **rlwrap** can be found [here](https://linux.die.net/man/1/rlwrap).
 
 ## AUTHOR
 


### PR DESCRIPTION
1. fix typo of roast test suite
2. add link to linenoise which provides excellent binding to linenoise via native call
3.remove not working rlwrap link and insert readers to a working link