### PR TITLE
Add p6clientcore ops

### DIFF
--- a/docs/ops.markdown
+++ b/docs/ops.markdown
@@ -15,6 +15,10 @@
     - [p6capturelexwhere](#p6capturelexwhere)
     - [p6captureouters2](#p6captureouters2)
     - [p6clearpre](#p6clearpre)
+    - [p6clientcorectx](#p6clientcorectx)
+    - [p6clientcorerev](#p6clientcorerev)
+    - [p6clientcorever](#p6clientcorever)
+    - [p6clientctx](#p6clientctx)
     - [p6configposbindfailover](#p6configposbindfailover)
     - [p6decodelocaltime](#p6decodelocaltime)
     - [p6decontrv](#p6decontrv)
@@ -116,6 +120,28 @@ Must be called in the immediate outer scope of the block in question.
 * p6clearpre()
 
 Clears the "pre" flag in the current frame.
+
+## p6clientcorectx
+* p6clientcorectx()
+
+Returns the CORE context of our client. See [p6clientctx](#p6clientctx).
+
+Note that this returns exactly CORE, not setting, context.
+
+## p6clientcorerev
+* p6clientcorerev()
+
+Returns client's language revision letter. See [p6clientcorectx](#p6clientcorectx).
+
+## p6clientcorever
+* p6clientcorerev()
+
+Returns client's language version (`6.<rev>`). See [p6clientcorectx](#p6clientcorectx).
+
+## p6clientctx
+* p6clientctx()
+
+Returns client's, i.e. the first Perl6 caller from different package, context.
 
 ## p6configposbindfailover
 * p6configposbindfailover(Mu $type, Mu $failover-type)

--- a/src/Perl6/Ops.nqp
+++ b/src/Perl6/Ops.nqp
@@ -1,0 +1,188 @@
+
+# Registers ops so they're availabe to both NQP for Metamodel and Perl6
+sub _register_op_with_nqp($name, $desugar) {
+    register_op_desugar($name, $desugar, :compiler<nqp>);
+    register_op_desugar($name, $desugar, :compiler<perl6>);
+}
+
+# Find the nearest caller from different package with CORE as its outer and returns its context
+_register_op_with_nqp('p6clientctx', -> $qast {
+    my $ctx := QAST::Node.unique('ctx');
+    my $pkg := QAST::Node.unique('pkg');
+    QAST::Stmts.new(
+        QAST::Op.new(
+            :op<bind>,
+            QAST::Var.new( :name($ctx), :scope<local>, :decl<var> ),
+            QAST::Op.new( :op<ctx> )
+        ),
+        QAST::Op.new(
+            :op<bind>,
+            QAST::Var.new( :name($pkg), :scope<local>, :decl<var> ),
+            QAST::Op.new( :op<getlex>, QAST::SVal.new( :value<$?PACKAGE> ) )
+        ),
+        # Find first frame where CORE-SETTING-REV is visible. This is our first candidate for client context.
+        QAST::Op.new(
+            :op<while>,
+            QAST::Op.new(
+                :op<if>,
+                QAST::Op.new(
+                    :op<isnull>,
+                    QAST::Var.new( :name($ctx), :scope<local> )
+                ),
+                QAST::IVal.new( :value(0) ),
+                QAST::Op.new(
+                    :op<isnull>,
+                    QAST::Op.new(
+                        :op<getlexrel>,
+                        QAST::Var.new( :name($ctx), :scope<local> ),
+                        QAST::SVal.new( :value<CORE-SETTING-REV> )
+                    )
+                )
+            ),
+            QAST::Op.new(
+                :op<bind>,
+                QAST::Var.new( :name($ctx), :scope<local> ),
+                QAST::Op.new(
+                    :op<ctxcallerskipthunks>,
+                    QAST::Var.new( :name($ctx), :scope<local> ),
+                )
+            )
+        ),
+        # Second, find a caller with different package
+        QAST::Op.new(
+            :op<while>,
+            QAST::Op.new(
+                :op<if>,
+                QAST::Op.new(
+                    :op<isnull>,
+                    QAST::Var.new( :name($ctx), :scope<local> )
+                ),
+                QAST::IVal.new( :value(0) ),
+                QAST::Op.new(
+                    :op<eqaddr>,
+                    QAST::Op.new(
+                        :op<getlexrel>,
+                        QAST::Var.new( :name($ctx), :scope<local> ),
+                        QAST::SVal.new( :value<$?PACKAGE> )
+                    ),
+                    QAST::Var.new( :name($pkg), :scope<local> )
+                )
+            ),
+            # repeat_until body
+            QAST::Op.new(
+                :op<bind>,
+                QAST::Var.new( :name($ctx), :scope<local> ),
+                QAST::Op.new( :op<ctxcallerskipthunks>, QAST::Var.new( :name($ctx), :scope<local> ) )
+            )
+        ),
+        QAST::Var.new( :name($ctx), :scope<local> ),
+    )
+});
+# Finds client's CORE ctx. Note that it's not setting but the CORE itself.
+_register_op_with_nqp('p6clientcorectx', -> $qast {
+    my $ctx := QAST::Node.unique('ctx');
+    QAST::Stmts.new(
+        QAST::Op.new(
+            :op<bind>,
+            QAST::Var.new( :name($ctx), :scope<local>, :decl<var> ),
+            QAST::Op.new( :op<p6clientctx> )
+        ),
+        # Return VMNull unless $ctx is not null
+        QAST::Op.new(
+            :op<unless>,
+            QAST::Op.new(
+                :op<isnull>,
+                QAST::Var.new( :name($ctx), :scope<local> )
+            ),
+            QAST::Stmts.new(
+                QAST::Op.new(
+                    :op<until>,
+                    QAST::Op.new(
+                        :op<unless>,
+                        QAST::Op.new(
+                            :op<isnull>,
+                            QAST::Var.new( :name($ctx), :scope<local> ),
+                        ),
+                        QAST::Op.new(
+                            :op<existskey>,
+                            QAST::Op.new(
+                                :op<ctxlexpad>,
+                                QAST::Var.new( :name($ctx), :scope<local> )
+                            ),
+                            QAST::SVal.new( :value<CORE-SETTING-REV> )
+                        )
+                    ),
+                    QAST::Op.new(
+                        :op<bind>,
+                        QAST::Var.new( :name($ctx), :scope<local> ),
+                        QAST::Op.new( :op<ctxouterskipthunks>, QAST::Var.new( :name($ctx), :scope<local> ) )
+                    )
+                ),
+                QAST::Var.new( :name($ctx), :scope<local> ),
+            ),
+            QAST::Op.new( :op<null> )
+        )
+    )
+});
+# Similar to p6clientcorectx but returns language revision letter
+_register_op_with_nqp('p6clientcorerev', -> $qast {
+    my $ctx := QAST::Node.unique('ctx');
+    QAST::Stmts.new(
+        QAST::Op.new(
+            :op<bind>,
+            QAST::Var.new(
+                :name($ctx), :scope<local>, :decl<var>
+            ),
+            QAST::Op.new( :op<p6clientcorectx> )
+        ),
+        QAST::Op.new(
+            :op<unless>,
+            QAST::Op.new(
+                :op<isnull>,
+                QAST::Var.new( :name($ctx), :scope<local> )
+            ),
+            QAST::Op.new(
+                :op<atkey>,
+                QAST::Op.new(
+                    :op<ctxlexpad>,
+                    QAST::Var.new( :name($ctx), :scope<local> )
+                ),
+                QAST::SVal.new( :value<CORE-SETTING-REV> ),
+          ),
+          QAST::Op.new( :op<null> )
+        )
+    )
+});
+# Simialr to p6clientcorectx but returns `6.<rev>` version string
+_register_op_with_nqp('p6clientcorever', -> $qast {
+    my $ctx := QAST::Node.unique('ctx');
+    QAST::Stmts.new(
+        QAST::Op.new(
+            :op<bind>,
+            QAST::Var.new(
+                :name($ctx), :scope<local>, :decl<var>
+            ),
+            QAST::Op.new( :op<p6clientcorectx> )
+        ),
+        QAST::Op.new(
+            :op<unless>,
+            QAST::Op.new(
+                :op<isnull>,
+                QAST::Var.new( :name($ctx), :scope<local> )
+            ),
+            QAST::Op.new(
+                :op<concat>,
+                QAST::SVal.new( :value<6.> ),
+                QAST::Op.new(
+                    :op<atkey>,
+                    QAST::Op.new(
+                        :op<ctxlexpad>,
+                        QAST::Var.new( :name($ctx), :scope<local> )
+                    ),
+                    QAST::SVal.new( :value<CORE-SETTING-REV> ),
+                )
+            ),
+            QAST::Op.new( :op<null> )
+        )
+    )
+});

--- a/src/vm/js/Perl6/Ops.nqp
+++ b/src/vm/js/Perl6/Ops.nqp
@@ -1,7 +1,7 @@
 my $ops := nqp::getcomp('QAST').operations;
 
-sub register_op_desugar($op, $desugar) is export {
-    nqp::getcomp('QAST').operations.add_op(:hll<perl6>, $op, sub ($comp, $node, :$want) {
+sub register_op_desugar($op, $desugar, :$compiler = 'perl6') is export {
+    nqp::getcomp('QAST').operations.add_op(:hll($compiler), $op, sub ($comp, $node, :$want) {
         $comp.as_js($desugar($node), :$want);
     });
 }

--- a/src/vm/jvm/Perl6/Ops.nqp
+++ b/src/vm/jvm/Perl6/Ops.nqp
@@ -26,8 +26,8 @@ my $RT_VOID := -1;
 my $ALOAD_1     := JAST::Instruction.new( :op('aload_1') );
 
 # Register a de-sugar from one QAST tree to another.
-sub register_op_desugar($name, $desugar, :$inlinable = 1) is export {
-    nqp::getcomp('QAST').operations.add_hll_op('perl6', $name, :$inlinable, -> $qastcomp, $op {
+sub register_op_desugar($name, $desugar, :$inlinable = 1, :$compiler = 'perl6') is export {
+    nqp::getcomp('QAST').operations.add_hll_op($compiler, $name, :$inlinable, -> $qastcomp, $op {
         $qastcomp.as_jast($desugar($op));
     });
 }

--- a/src/vm/moar/Perl6/Ops.nqp
+++ b/src/vm/moar/Perl6/Ops.nqp
@@ -72,8 +72,8 @@ MAST::ExtOpRegistry.register_extop('p6invokeunder',
     $MVM_operand_obj   +| $MVM_operand_read_reg);
 
 # Register a de-sugar from one QAST tree to another.
-sub register_op_desugar($name, $desugar, :$inlinable = 1) is export {
-    nqp::getcomp('QAST').operations.add_hll_op('perl6', $name, :$inlinable, -> $qastcomp, $op {
+sub register_op_desugar($name, $desugar, :$inlinable = 1, :$compiler = 'perl6') is export {
+    nqp::getcomp('QAST').operations.add_hll_op($compiler, $name, :$inlinable, -> $qastcomp, $op {
         $qastcomp.as_mast($desugar($op));
     });
 }

--- a/t/02-rakudo/14-revisions.t
+++ b/t/02-rakudo/14-revisions.t
@@ -1,8 +1,9 @@
 use lib <t/packages>;
+use lib <t/packages/02-rakudo/lib>;
 use Test;
 use Test::Helpers;
 
-plan 3;
+plan 4;
 
 subtest "CORE.setting Revision", {
     plan 3;
@@ -26,6 +27,46 @@ subtest "Class Version", {
     is-run qq[use v6.c; print PseudoStash.^ver], "6.c class version", :exitcode(0), :out<6.c>;
     is-run qq[use v6.d; print PseudoStash.^ver], "6.c class version on 6.d compiler", :exitcode(0), :out<6.c>;
     is-run qq[use v6.e.PREVIEW; print PseudoStash.^ver], "6.e class version", :exitcode(0), :out<6.e>;
+}
+
+subtest "nqp::p6clientcore", {
+    plan 8;
+    use ClientLang;
+    use nqp;
+
+    for (:c<c>, :d<d>, :e<e.PREVIEW>) -> (:key($rev-char), :value($rev)) {
+        is-run
+            qq:to/TEST/,
+            use v6.$rev;
+            use ClientLang;
+            say CORE-SETTING-REV, ": ", client-core-rev, ", ", client-core-ver;
+            TEST
+            "client core revision $rev-char",
+            :compiler-args[<-It/packages/02-rakudo/lib>],
+            :exitcode(0),
+            :out(qq[$rev-char: $rev-char, 6.$rev-char\n]),
+            :err(''),
+            ;
+        is-run
+            qq:to/TEST/,
+            use v6.$rev;
+            use Foo;
+            say "foo: ", foo-rev, ", ", foo-ver;
+            TEST
+            "module core revision is d even if calling code is $rev-char",
+            :compiler-args[<-It/packages/02-rakudo/lib>],
+            :exitcode(0),
+            :out(qq[foo: d, 6.d\n]),
+            :err(''),
+            ;
+    }
+
+    # Check for client context
+    my constant THE-ANSWER = 42;
+
+    my Mu $ctx := client-ctx;
+    ok ? nqp::existskey(nqp::ctxlexpad($ctx), 'THE-ANSWER'), "constant is found in client context";
+    is nqp::atkey(nqp::ctxlexpad($ctx), 'THE-ANSWER'), 42, "constant value is as expected";
 }
 
 done-testing;

--- a/t/packages/02-rakudo/lib/ClientLang.pm6
+++ b/t/packages/02-rakudo/lib/ClientLang.pm6
@@ -1,0 +1,30 @@
+# Have this module language version differ from calling package one.
+use v6.c;
+unit module ClientLang;
+use nqp;
+
+sub client-ctx( --> Mu ) is raw is export {
+    nqp::p6clientctx()
+}
+
+sub client-core-ctx( --> Mu ) is raw is export {
+    nqp::p6clientcorectx()
+}
+
+sub client-core-rev( --> Str ) is export {
+    nqp::p6clientcorerev()
+}
+
+sub client-core-ver( --> Str ) is export {
+    nqp::p6clientcorever()
+}
+
+# The following subs are wrappers to check for CLIENT::-like behaviour of the ops
+
+sub client-rev( --> Str ) is export {
+    client-core-rev
+}
+
+sub client-ver( --> Str ) is export {
+    client-core-ver
+}

--- a/t/packages/02-rakudo/lib/Foo.pm6
+++ b/t/packages/02-rakudo/lib/Foo.pm6
@@ -1,0 +1,5 @@
+use v6.d;
+use ClientLang;
+
+sub foo-rev is export { client-rev }
+sub foo-ver is export { client-ver }

--- a/tools/build/gen-js-makefile.nqp
+++ b/tools/build/gen-js-makefile.nqp
@@ -91,7 +91,10 @@ my $ModuleLoader-nqp := combine(:sources("src/vm/js/ModuleLoaderVMConfig.nqp src
 
 
 my $Perl6-ModuleLoader := nqp($ModuleLoader-nqp, "$blib/Perl6-ModuleLoader.js");
-my $Perl6-Ops := nqp('src/vm/js/Perl6/Ops.nqp', "$blib/Perl6-Ops.js");
+
+my $Ops-nqp := combine(:sources('src/vm/js/Perl6/Ops.nqp src/Perl6/Ops.nqp'), :file<Perl6-Ops.nqp>);
+my $Perl6-Ops := nqp($Ops-nqp, "$blib/Perl6-Ops.js");
+
 my $Perl6-Pod := nqp('src/Perl6/Pod.nqp', "$blib/Perl6-Pod.js");
 my $Perl6-World := nqp('src/Perl6/World.nqp', "$blib/Perl6-World.js", :deps([$Perl6-Ops, $Perl6-Pod, $Perl6-ModuleLoader]));
 

--- a/tools/templates/jvm/Makefile.in
+++ b/tools/templates/jvm/Makefile.in
@@ -100,9 +100,9 @@ $(PERL6_ML_JAR): @nfpl(src/Perl6/ModuleLoader.nqp src/vm/jvm/ModuleLoaderVMConfi
 	$(J_NQP) --module-path=blib --target=jar --output=$(PERL6_ML_JAR) \
 	    @nfpq($(J_BUILD_DIR)/ModuleLoader.nqp)@
 
-$(PERL6_OPS_JAR): @nfpl(src/vm/jvm/Perl6/Ops.nqp gen/nqp-version)@
-	$(J_NQP) --module-path=blib --target=jar --output=$(PERL6_OPS_JAR) \
-	    @nfp(src/vm/jvm/Perl6/Ops.nqp)@
+$(PERL6_OPS_JAR): @nfpl(src/vm/jvm/Perl6/Ops.nqp src/Perl6/Ops.nqp gen/nqp-version)@
+	$(J_NQP) $(J_GEN_CAT) @nfpl(src/vm/jvm/Perl6/Ops.nqp src/Perl6/Ops.nqp )@ > @nfpq($(J_BUILD_DIR)/Perl6-Ops.nqp)@
+	$(J_NQP) --module-path=blib --target=jar --output=$(PERL6_OPS_JAR) @nfpq($(J_BUILD_DIR)/Perl6-Ops.nqp)@
 
 $(PERL6_W_JAR): $(PERL6_ML_JAR) $(PERL6_OPS_JAR) $(PERL6_P_JAR) @nfp(src/Perl6/World.nqp)@
 	$(J_NQP) --module-path=blib --target=jar --output=$(PERL6_W_JAR) \

--- a/tools/templates/moar/Makefile.in
+++ b/tools/templates/moar/Makefile.in
@@ -152,9 +152,9 @@ $(PERL6_ML_MOAR): @nfp(src/Perl6/ModuleLoader.nqp)@ @nfp(src/vm/moar/ModuleLoade
 	$(M_NQP) --module-path=blib --target=mbc --output=$(PERL6_ML_MOAR) \
 		@nfpq($(M_BUILD_DIR)/ModuleLoader.nqp)@
 
-$(PERL6_OPS_MOAR): @nfp(src/vm/moar/Perl6/Ops.nqp)@ $(M_PERL6_OPS_DLL) @nfp(gen/nqp-version)@
-	$(M_NQP) --target=mbc --output=$(PERL6_OPS_MOAR) \
-		@nfp(src/vm/moar/Perl6/Ops.nqp)@
+$(PERL6_OPS_MOAR): @nfp(src/vm/moar/Perl6/Ops.nqp src/Perl6/Ops.nqp)@ $(M_PERL6_OPS_DLL) @nfp(gen/nqp-version)@
+	$(M_NQP) $(M_GEN_CAT) @nfpl(src/vm/moar/Perl6/Ops.nqp src/Perl6/Ops.nqp)@ > @nfpq($(M_BUILD_DIR)/Perl6-Ops.nqp)@
+	$(M_NQP) --target=mbc --output=$(PERL6_OPS_MOAR) @nfpq($(M_BUILD_DIR)/Perl6-Ops.nqp)@
 
 $(PERL6_W_MOAR): $(PERL6_ML_MOAR) $(PERL6_OPS_MOAR) $(PERL6_P_MOAR) @nfp(src/Perl6/World.nqp)@
 	$(M_NQP) --module-path=blib --target=mbc --output=$(PERL6_W_MOAR) \


### PR DESCRIPTION
`nqp::p6clientctx`, `nqp::p6clientcorectx`, `nqp::p6clientcorerev`, and `nqp::p6clientcorever` ops to get Perl6 client's context, it's `CORE` context, `CORE` revision letter `<rev>`, and `CORE` version `6.<rev>`. All return `nqp::null` if no corresponding context found.

Ops are available to both NQP (for Metamodel use) and Perl6 compilers.