### PR TITLE
Fix detection of current language version

### DIFF
--- a/src/Perl6/Metamodel/LanguageRevision.nqp
+++ b/src/Perl6/Metamodel/LanguageRevision.nqp
@@ -5,9 +5,22 @@ role Perl6::Metamodel::LanguageRevision
     has $!lang_rev;
 
     # The only allowed version format is 6.X
-    method set_language_version($obj, $ver) {
-        (nqp::iseq_i(nqp::chars($ver), 3) && nqp::eqat($ver, '6.', 0))
-            || nqp::die("Language version must be a string in '6.<rev>' format, got `$ver`.");
+    method set_language_version($obj, $ver = NQPMu) {
+        if nqp::isconcrete($ver) {
+            nqp::die("Language version must be a string in '6.<rev>' format, got `$ver`.")
+                unless (nqp::iseq_i(nqp::chars($ver), 3) && nqp::eqat($ver, '6.', 0))
+        }
+        else {
+            # NOTE: It turns out that nqp::getcomp path for obtaining the language version isn't reliable as sometimes
+            # language_version method report wrong version.
+            my $rev;
+            if $*W {
+                $rev := $*W.find_symbol(['CORE-SETTING-REV'], :setting-only);
+            }
+            $ver := nqp::p6clientcorever()                      # 1st: try the run-time code
+                    || ($rev && '6.' ~ $rev)                    # 2nd: compile-time if CORE is available
+                    || nqp::getcomp('perl6').language_version;  # otherwise try the compiler
+        }
         self.set_ver($obj, $ver);
         $!lang_rev := nqp::substr($ver, 2, 1);
     }

--- a/src/Perl6/Metamodel/SubsetHOW.nqp
+++ b/src/Perl6/Metamodel/SubsetHOW.nqp
@@ -31,9 +31,7 @@ class Perl6::Metamodel::SubsetHOW
         my $metasubset := self.new(:refinee($refinee), :refinement($refinement));
         my $type := nqp::settypehll(nqp::newtype($metasubset, 'Uninstantiable'), 'perl6');
         $metasubset.set_name($type, $name);
-        # TODO This only works at compile time. To support run-time creation of subsets we need to find caller's CORE.
-        # Will be possible when nqp::p6callerrevision() is implemented.
-        $metasubset.set_language_version($metasubset, nqp::getcomp('perl6').language_version);
+        $metasubset.set_language_version($metasubset);
         nqp::settypecheckmode($type, 2);
         self.add_stash($type)
     }


### PR DESCRIPTION
For unknown reason `nqp::getcomp('perl6').language_version` sometimes
returns `6.d` at compile time even though `use v6.e.PREVIEW` pragma is
used. To get around this problem `getcomp` is now last-resort path.
First `nqp::p6clientcorever` is used to work for type objects created
dynamically at run time; then `World` object is used to find
`CORE-SETTING-REV` symbol to work at compile-time.

rakudo/rakudo#3141