### PR TITLE
Fix for failing declaration of grammar named Grammar

### DIFF
--- a/docs/ops.markdown
+++ b/docs/ops.markdown
@@ -164,9 +164,10 @@ Decodes the unix timestamp $epoch into a native int array with six fields contai
 * p6finddispatcher(str $value)
 
 ## p6getlexclient
-* p6getlexclient(str $symbol)
+* p6getlexclient(str $symbol, int $setting-only)
 
-Takes a name and finds corresponding symbol in lexical scope of [p6clientctx](#p6clientctx).
+Takes a name and finds corresponding symbol in lexical scope of [p6clientctx](#p6clientctx). If `$setting-only` is set
+to a _true_ value then lookup is performed only in client's SETTING.
 
 ## p6getouterctx
 * p6getouterctx(Mu $closure)

--- a/src/Perl6/Metamodel/ClassHOW.nqp
+++ b/src/Perl6/Metamodel/ClassHOW.nqp
@@ -1,7 +1,7 @@
 class Perl6::Metamodel::ClassHOW
     does Perl6::Metamodel::Naming
     does Perl6::Metamodel::Documenting
-    does Perl6::Metamodel::Versioning
+    does Perl6::Metamodel::LanguageRevision
     does Perl6::Metamodel::Stashing
     does Perl6::Metamodel::AttributeContainer
     does Perl6::Metamodel::MethodContainer
@@ -52,7 +52,7 @@ class Perl6::Metamodel::ClassHOW
         my $obj := nqp::settypehll($new_type, 'perl6');
         $metaclass.set_name($obj, $name // "<anon|{$anon_id++}>");
         self.add_stash($obj);
-        $metaclass.set_ver($obj, $ver);
+        $metaclass.set_ver($obj, $ver) if $ver;
         $metaclass.set_auth($obj, $auth) if $auth;
         $metaclass.set_api($obj, $api) if $api;
         $metaclass.setup_mixin_cache($obj);
@@ -91,6 +91,11 @@ class Perl6::Metamodel::ClassHOW
 
     method compose($the-obj, :$compiler_services) {
         my $obj := nqp::decont($the-obj);
+
+        # Set class language version if class belongs to the CORE
+        if $*COMPILING_CORE_SETTING {
+            self.set_language_version($the-obj);
+        }
 
         # Instantiate all of the roles we have (need to do this since
         # all roles are generic on ::?CLASS) and pass them to the

--- a/src/Perl6/Metamodel/DefaultParent.nqp
+++ b/src/Perl6/Metamodel/DefaultParent.nqp
@@ -1,10 +1,8 @@
 role Perl6::Metamodel::DefaultParent {
     my @default_parent_type;
-    my $setting_only := 0;
 
-    method set_default_parent_type($type, :$setting-only = 0) {
-        @default_parent_type[0] := nqp::isconcrete($type) ?? $type !! $type.HOW.name($type);
-        $setting_only := $setting-only;
+    method set_default_parent_type($type) {
+        @default_parent_type[0] := $type;
     }
 
     method has_default_parent_type() {
@@ -12,6 +10,6 @@ role Perl6::Metamodel::DefaultParent {
     }
 
     method get_default_parent_type() {
-        nqp::p6getlexclient( @default_parent_type[0], $setting_only );
+        @default_parent_type[0]
     }
 }

--- a/src/Perl6/Metamodel/DefaultParent.nqp
+++ b/src/Perl6/Metamodel/DefaultParent.nqp
@@ -1,8 +1,10 @@
 role Perl6::Metamodel::DefaultParent {
     my @default_parent_type;
+    my $setting_only := 0;
 
-    method set_default_parent_type($type) {
+    method set_default_parent_type($type, :$setting-only = 0) {
         @default_parent_type[0] := nqp::isconcrete($type) ?? $type !! $type.HOW.name($type);
+        $setting_only := $setting-only;
     }
 
     method has_default_parent_type() {
@@ -10,6 +12,6 @@ role Perl6::Metamodel::DefaultParent {
     }
 
     method get_default_parent_type() {
-        nqp::p6getlexclient(@default_parent_type[0]);
+        nqp::p6getlexclient( @default_parent_type[0], $setting_only );
     }
 }

--- a/src/Perl6/Metamodel/LanguageRevision.nqp
+++ b/src/Perl6/Metamodel/LanguageRevision.nqp
@@ -6,6 +6,10 @@ role Perl6::Metamodel::LanguageRevision
 
     # The only allowed version format is 6.X
     method set_language_version($obj, $ver = NQPMu) {
+        # Don't override if version is already set
+        if self.ver($obj) {
+            return
+        }
         if nqp::isconcrete($ver) {
             nqp::die("Language version must be a string in '6.<rev>' format, got `$ver`.")
                 unless (nqp::iseq_i(nqp::chars($ver), 3) && nqp::eqat($ver, '6.', 0))

--- a/src/Perl6/Metamodel/Versioning.nqp
+++ b/src/Perl6/Metamodel/Versioning.nqp
@@ -8,9 +8,6 @@ role Perl6::Metamodel::Versioning {
     method api($obj) { $!api // '' }
 
     method set_ver($obj, $ver) {
-        if $*COMPILING_CORE_SETTING && !$ver {
-            $ver := nqp::getcomp('perl6').language_version;
-        }
         $!ver := $ver if $ver
     }
     method set_auth($obj, $auth) { $!auth := $auth }

--- a/src/Perl6/Ops.nqp
+++ b/src/Perl6/Ops.nqp
@@ -192,119 +192,188 @@ _register_op_with_nqp( 'p6getlexclient', -> $qast {
         my $PseudoStash := QAST::Node.unique('$PseudoStash');
         my $Map := QAST::Node.unique('$Map');
         my $stash := QAST::Node.unique('$stash');
-        QAST::Op.new(
-            :op<if>,
+        my $setting-only := QAST::Node.unique('$setting-only');
+        my $setting-only-var := QAST::Var.new( :name($setting-only), :scope<local> );
+        my $setting-only-named := QAST::Var.new( :name($setting-only), :scope<local> );
+        $setting-only-named.named('setting-only');
+        QAST::Stmts.new(
             QAST::Op.new(
-                :op<isconcrete>,
-                QAST::VarWithFallback.new(
-                    :name<$*OPTIMIZER-SYMBOLS>,
-                    :fallback(
-                        QAST::WVal.new( :value(Mu) )
-                    ),
-                    :scope<contextual>
-                )
+                :op<bind>,
+                QAST::Var.new( :name($setting-only), :scope<local>, :decl<var> ),
+                (nqp::atpos($qast, 1) || QAST::IVal.new( :value(0) ))
             ),
-            QAST::Op.new(
-                :op<callmethod>,
-                QAST::Var.new( :name<$*OPTIMIZER-SYMBOLS>, :scope<contextual> ),
-                QAST::SVal.new( :value<find_symbol> ),
-                QAST::Op.new(
-                    :op<split>,
-                    QAST::SVal.new( :value<::> ),
-                    $qast[0]
-                )
-            ),
+            # QAST::Op.new(
+            #     :op<if>,
+            #     QAST::Op.new(:op<atkey>, QAST::Op.new(:op<getenvhash>), QAST::SVal.new(:value<RAKUDO_DEBUG>)),
+            #     QAST::Op.new(
+            #         :op<say>,
+            #         QAST::Op.new(
+            #             :op<concat>,
+            #             QAST::SVal.new( value => "p6getlexclient: "),
+            #             QAST::Op.new(
+            #                 :op<concat>,
+            #                 $qast[0],
+            #                 QAST::Op.new(
+            #                     :op<concat>,
+            #                     QAST::SVal.new(:value<, >),
+            #                     $setting-only-var
+            #                 )
+            #             )
+            #         )
+            #     ),
+            # ),
             QAST::Op.new(
                 :op<if>,
                 QAST::Op.new(
                     :op<isconcrete>,
                     QAST::VarWithFallback.new(
-                        :name<$*W>,
+                        :name<$*OPTIMIZER-SYMBOLS>,
                         :fallback(
-                            QAST::Op.new( :op<null> )
-                            # QAST::WVal.new( :value(NQPMu) )
+                            QAST::WVal.new( :value(Mu) )
                         ),
                         :scope<contextual>
                     )
                 ),
                 QAST::Op.new(
-                    :op<callmethod>,
-                    QAST::Var.new( :name<$*W>, :scope<contextual> ),
-                    QAST::SVal.new( :value<find_symbol> ),
+                    :op<if>,
+                    $setting-only-var,
                     QAST::Op.new(
-                        :op<split>,
-                        QAST::SVal.new( :value<::> ),
+                        :op<callmethod>,
+                        QAST::Var.new( :name<$*OPTIMIZER-SYMBOLS>, :scope<contextual> ),
+                        QAST::SVal.new( :value<find_in_setting> ),
                         $qast[0]
-                    )
+                    ),
+                    QAST::Op.new(
+                        :op<callmethod>,
+                        QAST::Var.new( :name<$*OPTIMIZER-SYMBOLS>, :scope<contextual> ),
+                        QAST::SVal.new( :value<find_symbol> ),
+                        QAST::Op.new(
+                            :op<split>,
+                            QAST::SVal.new( :value<::> ),
+                            $qast[0]
+                        )
+                    ),
                 ),
-                QAST::Stmts.new(
+                QAST::Op.new(
+                    :op<if>,
                     QAST::Op.new(
-                        :op<bind>,
-                        QAST::Var.new( :name($ctx), :scope<local>, :decl<var> ),
-                        QAST::Op.new( :op<p6clientctx> ),
-                    ),
-                    QAST::Op.new(
-                        :op<bind>,
-                        QAST::Var.new( :name($PseudoStash), :scope<local>, :decl<var> ),
-                        QAST::Op.new(
-                            :op<getlexrel>,
-                            QAST::Var.new( :name($ctx), :scope<local> ),
-                            QAST::SVal.new( :value<PseudoStash> )
-                        ),
-                    ),
-                    QAST::Op.new(
-                        :op<bind>,
-                        QAST::Var.new( :name($Map), :scope<local>, :decl<var> ),
-                        QAST::Op.new(
-                            :op<getlexrel>,
-                            QAST::Var.new( :name($ctx), :scope<local> ),
-                            QAST::SVal.new( :value<Map> )
-                        ),
-                    ),
-                    QAST::Op.new(
-                        :op<bind>,
-                        QAST::Var.new( :name($stash), :scope<local>, :decl<var> ),
-                        QAST::Op.new(
-                            :op<create>,
-                            QAST::Var.new( :name($PseudoStash), :scope<local> ),
+                        :op<isconcrete>,
+                        QAST::VarWithFallback.new(
+                            :name<$*W>,
+                            :fallback(
+                                QAST::Op.new( :op<null> )
+                                # QAST::WVal.new( :value(NQPMu) )
+                            ),
+                            :scope<contextual>
                         )
                     ),
                     QAST::Op.new(
-                        :op<bindattr>,
-                        QAST::Var.new( :name($stash), :scope<local> ),
-                        QAST::Var.new( :name($Map), :scope<local> ),
-                        QAST::SVal.new( :value<$!storage> ),
+                        :op<callmethod>,
+                        QAST::Var.new( :name<$*W>, :scope<contextual> ),
+                        QAST::SVal.new( :value<find_symbol> ),
                         QAST::Op.new(
-                            :op<ctxlexpad>,
+                            :op<split>,
+                            QAST::SVal.new( :value<::> ),
+                            $qast[0]
+                        ),
+                        $setting-only-named
+                    ),
+                    QAST::Stmts.new(
+                        QAST::Op.new(
+                            :op<bind>,
+                            QAST::Var.new( :name($ctx), :scope<local>, :decl<var> ),
+                            QAST::Op.new( :op<p6clientctx> ),
+                        ),
+                        QAST::Op.new(
+                            :op<bind>,
+                            QAST::Var.new( :name($PseudoStash), :scope<local>, :decl<var> ),
+                            QAST::Op.new(
+                                :op<getlexrel>,
+                                QAST::Var.new( :name($ctx), :scope<local> ),
+                                QAST::SVal.new( :value<PseudoStash> )
+                            ),
+                        ),
+                        QAST::Op.new(
+                            :op<bind>,
+                            QAST::Var.new( :name($Map), :scope<local>, :decl<var> ),
+                            QAST::Op.new(
+                                :op<getlexrel>,
+                                QAST::Var.new( :name($ctx), :scope<local> ),
+                                QAST::SVal.new( :value<Map> )
+                            ),
+                        ),
+                        QAST::Op.new(
+                            :op<bind>,
+                            QAST::Var.new( :name($stash), :scope<local>, :decl<var> ),
+                            QAST::Op.new(
+                                :op<create>,
+                                QAST::Var.new( :name($PseudoStash), :scope<local> ),
+                            )
+                        ),
+                        QAST::Op.new(
+                            :op<bindattr>,
+                            QAST::Var.new( :name($stash), :scope<local> ),
+                            QAST::Var.new( :name($Map), :scope<local> ),
+                            QAST::SVal.new( :value<$!storage> ),
+                            QAST::Op.new(
+                                :op<ctxlexpad>,
+                                QAST::Var.new( :name($ctx), :scope<local> ),
+                            ),
+                        ),
+                        QAST::Op.new(
+                            :op<bindattr>,
+                            QAST::Var.new( :name($stash), :scope<local> ),
+                            QAST::Var.new( :name($PseudoStash), :scope<local> ),
+                            QAST::SVal.new( :value<$!ctx> ),
                             QAST::Var.new( :name($ctx), :scope<local> ),
                         ),
-                    ),
-                    QAST::Op.new(
-                        :op<bindattr>,
-                        QAST::Var.new( :name($stash), :scope<local> ),
-                        QAST::Var.new( :name($PseudoStash), :scope<local> ),
-                        QAST::SVal.new( :value<$!ctx> ),
-                        QAST::Var.new( :name($ctx), :scope<local> ),
-                    ),
-                    QAST::Op.new(
-                        :op<bindattr_i>,
-                        QAST::Var.new( :name($stash), :scope<local> ),
-                        QAST::Var.new( :name($PseudoStash), :scope<local> ),
-                        QAST::SVal.new( :value<$!mode> ),
-                        QAST::IVal.new( :value(1) ) # PseudoStash::STATIC_CHAIN constant value
-                    ),
-                    QAST::Op.new(
-                        :op<call>,
                         QAST::Op.new(
-                            :op<getlexrel>,
-                            QAST::Var.new( :name($ctx), :scope<local> ),
-                            QAST::SVal.new( :value<&INDIRECT_NAME_LOOKUP> )
+                            :op<bindattr_i>,
+                            QAST::Var.new( :name($stash), :scope<local> ),
+                            QAST::Var.new( :name($PseudoStash), :scope<local> ),
+                            QAST::SVal.new( :value<$!mode> ),
+                            QAST::IVal.new( :value(1) ) # PseudoStash::STATIC_CHAIN constant value
                         ),
-                        QAST::Var.new( :name($stash), :scope<local> ),
-                        $qast[0]
-                    )
+                        QAST::Op.new(
+                            :op<if>,
+                            $setting-only-var,
+                            QAST::Op.new(
+                                :op<bind>,
+                                QAST::Var.new( :name($stash), :scope<local> ),
+                                QAST::Op.new(
+                                    :op<who>,
+                                    QAST::Op.new(
+                                        :op<callmethod>,
+                                        QAST::Var.new( :name($stash), :scope<local> ),
+                                        QAST::SVal.new( :value<AT-KEY> ),
+                                        QAST::Op.new(
+                                            :op<if>,        # If we can't 'see' '!UNIT_MARKER' then client is in CORE and SETTING cannot be used
+                                            QAST::Op.new(
+                                                :op<callmethod>,
+                                                QAST::Var.new( :name($stash), :scope<local> ),
+                                                QAST::SVal.new( :value<EXISTS-KEY> ),
+                                                QAST::SVal.new( :value<!UNIT_MARKER> )
+                                            ),
+                                            QAST::SVal.new( :value<SETTING> ),
+                                            QAST::SVal.new( :value<CORE> )
+                                        )
+                                    )
+                                )
+                            )
+                        ),
+                        QAST::Op.new(
+                            :op<call>,
+                            QAST::Op.new(
+                                :op<getlexrel>,
+                                QAST::Var.new( :name($ctx), :scope<local> ),
+                                QAST::SVal.new( :value<&INDIRECT_NAME_LOOKUP> )
+                            ),
+                            QAST::Var.new( :name($stash), :scope<local> ),
+                            $qast[0]
+                        )
+                    ),
                 ),
-            ),
+            )
         )
     }
 );

--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -3922,8 +3922,8 @@ Perl6::Metamodel::Configuration.set_stash_type(Stash, Map);
 Perl6::Metamodel::Configuration.set_submethod_type(Submethod);
 
 # Register default parent types.
-Perl6::Metamodel::ClassHOW.set_default_parent_type(Any, :setting-only);
-Perl6::Metamodel::GrammarHOW.set_default_parent_type(Grammar, :setting-only);
+Perl6::Metamodel::ClassHOW.set_default_parent_type(Any);
+Perl6::Metamodel::GrammarHOW.set_default_parent_type(Grammar);
 
 # Put PROCESS in place, and ensure it's never repossessed.
 nqp::neverrepossess(PROCESS.WHO);

--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -3922,8 +3922,8 @@ Perl6::Metamodel::Configuration.set_stash_type(Stash, Map);
 Perl6::Metamodel::Configuration.set_submethod_type(Submethod);
 
 # Register default parent types.
-Perl6::Metamodel::ClassHOW.set_default_parent_type(Any);
-Perl6::Metamodel::GrammarHOW.set_default_parent_type(Grammar);
+Perl6::Metamodel::ClassHOW.set_default_parent_type(Any, :setting-only);
+Perl6::Metamodel::GrammarHOW.set_default_parent_type(Grammar, :setting-only);
 
 # Put PROCESS in place, and ensure it's never repossessed.
 nqp::neverrepossess(PROCESS.WHO);

--- a/src/core.c/Grammar.pm6
+++ b/src/core.c/Grammar.pm6
@@ -28,9 +28,9 @@ my class Grammar is Match {
                   ),
                   $match := ($cursor := $cursor.'!cursor_next'()).MATCH
                 ),
-                $match || Nil,
+                $match || Nil
               ),
-              Nil,
+              Nil
             )
           )
         )

--- a/src/core.c/Grammar.pm6
+++ b/src/core.c/Grammar.pm6
@@ -1,62 +1,5 @@
 my class Grammar is Match {
 
-    # (oughta be down in Match or even nqp really)
-    method locprepost() {
-        my $orig = self.orig;
-        my $marked = self.?MARKED('ws');
-        my $pos = $marked && index(" }])>»", substr($orig, self.pos, 1)) < 0 ?? $marked.from !! self.pos;
-
-        my $prestart = $pos - 40;
-        $prestart = 0 if $prestart < 0;
-        my $pre = substr($orig, $prestart, $pos - $prestart);
-        $pre = $pre.subst(/.*\n/, "");
-        $pre = '<BOL>' if $pre eq '';
-
-        my $postchars = $pos + 40 > chars($orig) ?? chars($orig) - $pos !! 40;
-        my $post = substr($orig, $pos, $postchars);
-        $post = $post.subst(/\n.*/, "");
-        $post = '<EOL>' if $post eq '';
-
-        [$pre, $post]
-    }
-
-    # stolen and trimmed down from World
-    method typed_exception(X::Comp $ex, *%opts) {
-        # If the highwater is beyond the current position, force the cursor to that location.
-        my @expected;
-        my $high = self.'!highwater'();
-
-        if $high >= self.pos() {
-            self.'!cursor_pos'($high);
-            my $highexpect := self.'!highexpect'();
-            if nqp::islist($highexpect) {
-                my %seen;
-                for ^nqp::elems($highexpect) {
-                    my $x = nqp::hllizefor(nqp::shift($highexpect),'perl6');
-                    push @expected, $x unless %seen{$x}++;
-                }
-                @expected .= sort;
-            }
-        }
-
-        my @locprepost := self.locprepost();
-        # Build and throw exception object.
-        %opts<line>            = HLL::Compiler.lineof(self.orig, self.pos, :cache(1));
-        # only set <pos> if it's not already set:
-        %opts<pos>             //= self.pos;
-        %opts<pre>             = @locprepost[0];
-        %opts<post>            = @locprepost[1];
-        %opts<highexpect>      = @expected if @expected;
-        %opts<is-compile-time> = 1;
-        Failure.new($ex.new(|%opts))
-    }
-
-    method SETFAIL($failed, :$filename) {
-        return Nil unless self.defined && nqp::isge_s(CLIENT::LEXICAL::<CORE-SETTING-REV>, 'e');
-        self.'!cursor_pos'($failed.pos);
-        self.typed_exception(X::Syntax::Confused, filename => ($filename // "<anon>"))
-    }
-
     method parse(\target, :$rule, :$args, Mu :$actions, :$filename) is raw {
         my $*LINEPOSCACHE;
         nqp::stmts(
@@ -85,9 +28,9 @@ my class Grammar is Match {
                   ),
                   $match := ($cursor := $cursor.'!cursor_next'()).MATCH
                 ),
-                $match || $grammar.SETFAIL($match, :$filename),
+                $match || Nil,
               ),
-              $grammar.SETFAIL($cursor, :$filename),
+              Nil,
             )
           )
         )

--- a/src/core.c/core_prologue.pm6
+++ b/src/core.c/core_prologue.pm6
@@ -1,3 +1,7 @@
+# This constant must specify current CORE revision.
+# Must preceede class declarations to allow correct recording of their respective language version.
+my constant CORE-SETTING-REV = 'c';
+
 # Stub a few things the compiler wants to have really early on.
 my class Pair { ... }   # must be first for some reason
 my class Block { ... }
@@ -66,8 +70,5 @@ PROCESS::<$SCHEDULER> = JavaScriptScheduler.new();
 #?if jvm
 BEGIN {nqp::p6setassociativetype(Associative);}
 #?endif
-
-# This constant must specify current CORE revision
-my constant CORE-SETTING-REV = 'c';
 
 # vim: ft=perl6 expandtab sw=4

--- a/src/core.d/core_prologue.pm6
+++ b/src/core.d/core_prologue.pm6
@@ -1,6 +1,7 @@
 use nqp;
 
 # This constant must specify current CORE revision
+# Must preceede class declarations to allow correct recording of their respective language version.
 my constant CORE-SETTING-REV = 'd';
 
 # vim: ft=perl6 expandtab sw=4

--- a/src/core.e/EXPORTHOW.pm6
+++ b/src/core.e/EXPORTHOW.pm6
@@ -1,0 +1,17 @@
+# Bind the HOWs into the EXPORTHOW package under the package declarator
+# names.
+
+{
+    # Don't expose this name in CORE's namespace
+    class Perl6::Metamodel::v6e::GrammarHOW
+        is Perl6::Metamodel::ClassHOW
+        does Perl6::Metamodel::DefaultParent
+    {
+    }
+
+    # Set 6.e Grammar as the default for grammars
+    Perl6::Metamodel::v6e::GrammarHOW.set_default_parent_type(Grammar);
+    EXPORTHOW.WHO<grammar> := Perl6::Metamodel::v6e::GrammarHOW;
+}
+
+# vim: ft=perl6 expandtab sw=4

--- a/src/core.e/core_prologue.pm6
+++ b/src/core.e/core_prologue.pm6
@@ -1,6 +1,7 @@
 use nqp;
 
 # This constant must specify current CORE revision
+# Must preceede class declarations to allow correct recording of their respective language version.
 my constant CORE-SETTING-REV = 'e';
 
 # vim: ft=perl6 expandtab sw=4

--- a/tools/templates/6.e/core_sources
+++ b/tools/templates/6.e/core_sources
@@ -1,3 +1,4 @@
 src/core.e/core_prologue.pm6
 src/core.e/PseudoStash.pm6
 src/core.e/Grammar.pm6
+src/core.e/EXPORTHOW.pm6


### PR DESCRIPTION
- Re-implemented `v6.e` `Grammar` use by `grammar` using `EXPORTHOW`.
- `p6getlexclient` got second optional parameter: `$setting-only` and was
fixed for correct handling of situations where our client is in `SETTING`
or `CORE` scope.
- Fixed core classes not having their language version set.