### PR TITLE
use libdir instead of rebuilding path from prefix

### DIFF
--- a/src/main.nqp
+++ b/src/main.nqp
@@ -33,7 +33,7 @@ my $install-dir := $execname eq ''
 
 my $perl6-home := $comp.config<static_perl6_home>
     // nqp::getenvhash()<PERL6_HOME>
-    // $install-dir ~ '/share/perl6';
+    // $comp.config<libdir> ~ '/perl6';
 if nqp::substr($perl6-home, nqp::chars($perl6-home) - 1) eq $sep {
     $perl6-home := nqp::substr($perl6-home, 0, nqp::chars($perl6-home) - 1);
 }

--- a/tools/lib/NQP/Config/Rakudo.pm
+++ b/tools/lib/NQP/Config/Rakudo.pm
@@ -348,7 +348,7 @@ sub configure_moar_backend {
           );
         $nqp_config->{static_perl6_home} =
           File::Spec->rel2abs(
-            File::Spec->catdir( $config->{prefix}, 'share', 'perl6' ) );
+            File::Spec->catdir( $config->{libdir}, 'perl6' ) );
         $nqp_config->{static_nqp_home_define} =
           '-DSTATIC_NQP_HOME='
           . $qchar . $self->c_escape_string( $nqp_config->{static_nqp_home} ) . $qchar;


### PR DESCRIPTION
Currently when building with a custom `--libdir` it will place all runtime files in there, but the rest of rakudo rebuilds the path from only the prefix so starts searching in `$PREFIX/share/perl6` which results in the following error if you run `perl6`

```
[docker:f33e5790e49e /]$ perl6
Unhandled exception: While looking for '/usr/share/perl6/runtime/perl6.moarvm': no such file or directory
```

With this fix it should respect libdir and run as expected.

Current patch originates from https://github.com/void-linux/void-packages/pull/14073