### PR TITLE
Handle revision in names of settings files

### DIFF
--- a/src/core.c/Backtrace.pm6
+++ b/src/core.c/Backtrace.pm6
@@ -63,10 +63,10 @@ my class Backtrace::Frame {
     method is-setting(Backtrace::Frame:D:) {
         $!file.starts-with("SETTING::")
 #?if jvm
-          || $!file.ends-with("CORE.setting")
+          || $!file ~~ / "CORE." \w+ ".setting" $ /
 #?endif
 #?if !jvm
-          || $!file.ends-with("CORE.setting." ~ Rakudo::Internals.PRECOMP-EXT)
+          || $!file ~~ / "CORE." \w+ ".setting.{ Rakudo::Internals.PRECOMP-EXT }" $ /
 #?endif
           || $!file.ends-with(".nqp")
     }


### PR DESCRIPTION
With the recently improved multi-revision support (PR #3138) the
revision is part of the settings file names.