### PR TITLE
Provide means of preserving the decontainerization of values on Hash -> Map coercion

### DIFF
--- a/src/core.c/Hash.pm6
+++ b/src/core.c/Hash.pm6
@@ -17,7 +17,7 @@ my class Hash { # declared in BOOTSTRAP
             nqp::create(Map), Map, '$!storage',
             nqp::getattr(self,Map,'$!storage')
           ),
-          nqp::create(Map).STORE(self, :INITIALIZE)
+          nqp::create(Map).STORE(self, :INITIALIZE, :DECONT)
         )
     }
     method clone(Hash:D:) is raw {


### PR DESCRIPTION
A solution for perl6/problem-solving#99 and rakudo/rakudo#3168.

This solution provides a way to control decontainerization of values my `Map` externally by supplying `:DECONT` named argument to `STORE` method when called with `:INITALIZE`. _This would allow any other `Map`-deriving class to provide functionality similar to that of `Hash` with minimum amount of code._