### PR TITLE
Further cleanup of build subsystem.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,8 @@ perl6.rc
 /perl6-eval-server.bat
 /eval-client.pl
 /perl6.js
+/rakudo.js
+/perl6-debug.js
 /perl6-js
 /perl6-js.bat
 /perl6-m.c

--- a/tools/build/create-js-runner.pl
+++ b/tools/build/create-js-runner.pl
@@ -14,7 +14,7 @@ my $postamble = $^O eq 'MSWin32' ? ' %*' : ' "$@"';
 
 my $install_to = "perl6-js$bat";
 open my $fh, ">", $install_to or die "open: $!";
-print $fh $preamble, "node rakudo.js -Ilib --source-map", $postamble, "\n" or die "print: $!";
+print $fh $preamble, "node perl6.js -Ilib --source-map", $postamble, "\n" or die "print: $!";
 close $fh or die "close: $!";
 
 chmod 0755, $install_to if $^O ne 'MSWin32';

--- a/tools/templates/Makefile-backend-common.in
+++ b/tools/templates/Makefile-backend-common.in
@@ -5,7 +5,7 @@
 
 @bpv(BUILD_DIR)@ = @nfp(gen/@backend@)@
 @make_pp_pfx@ifndef @bpv(BLIB)@
-@bpv(BLIB)@ = @nfp(@base_dir@/blib)@
+@bpv(BLIB)@ = blib
 @make_pp_pfx@endif
 @make_pp_pfx@ifndef @bpv(BLIB_PERL6)@
 @bpv(BLIB_PERL6)@ = @nfp(blib/Perl6)@
@@ -34,7 +34,7 @@
 @bsv(PERL6_C)@   = @nfp(@bpm(BLIB_PERL6)@/Compiler.@bext@)@
 @bsv(PERL6_M)@   = @nfp(@bpm(BLIB_PERL6)@/Metamodel.@bext@)@
 @for_specs(@bsv(PERL6_BOOTSTRAP_@ucspec@)@   = @nfp(blib/Perl6/BOOTSTRAP/v6@lcspec@.@bext@)@
-@bsv(SETTING_@ucspec@)@ = CORE.@lcspec@.setting.@bext@
+@bsv(SETTING_@ucspec@)@ = @nfp(@bpm(BLIB)@/CORE.@lcspec@.setting.@bext@)@
 )@
 
 @bsv(PERL6_ML_SRC)@ =	@nfp(src/vm/@backend@/ModuleLoaderVMConfig.nqp src/Perl6/ModuleLoader.nqp)@ @bpm(ML_EXTRA)@

--- a/tools/templates/Makefile-backend-common.in
+++ b/tools/templates/Makefile-backend-common.in
@@ -94,6 +94,9 @@
 
 @bpv(HARNESS5)@ = $(PERL5) @nfp(t/harness5)@ --@backend@
 @bpv(HARNESS5_WITH_FUDGE)@ = @bpm(HARNESS5)@ --fudge --keep-exit-code
+@make_pp_pfx@ifndef @bpv(HARNESS_TYPE)@
+@bpv(HARNESS_TYPE)@ = $(HARNESS_TYPE)
+@make_pp_pfx@endif
 
 # --- Utility targets ---
 

--- a/tools/templates/Makefile.in
+++ b/tools/templates/Makefile.in
@@ -9,7 +9,7 @@ all:@for_backends( @backend_prefix@-all)@ $(LAUNCHER)
 install: @for_backends(@backend_prefix@-install )@ $(LAUNCHER)-install
 
 clean: @for_backends(@backend_prefix@-clean )@
-	$(RM_F) perl6@runner_suffix@ rakudo.js.map
+	$(RM_F) perl6@runner_suffix@
 	$(PERL5) @shquot(@script(clean-precomps.pl)@)@ @shquot(@base_dir@)@
 
 test:		@for_backends(@backend_prefix@-test$(HARNESS_TYPE))@

--- a/tools/templates/js/Makefile.in
+++ b/tools/templates/js/Makefile.in
@@ -5,9 +5,13 @@
 @bpv(NQP_FLAGS)@ = @bpm(NQP_BASE_FLAGS)@ --substagestats --stagestats --source-map
 @bpv(NQP_FLAGS_EXTRA)@ = --execname @bpm(RUNNER)@ --shebang
 @bpv(RUN_PERL6)@ = node --max-old-space-size=8192 perl6.js @bpm(NQP_BASE_FLAGS)@ --source-map
+@bpv(ALL_TARGETS)@ = rakudo.@bext@
 
 @bpv(CLEANUPS)@ = \
-	perl6.js \
+	@bsm(PERL6)@ \
+	rakudo.@bext@ \
+	@nfp(@base_dir@/*.js.map)@ \
+	@nfp(@bpm(BLIB)@/*.js.map)@ \
 	@bpm(BLIB_PERL6)@/load-compiler.js \
 	@bpm(BLIB_PERL6)@/*.js.map \
 	@bpm(BLIB_PERL6)@/BOOTSTRAP/*.js.map
@@ -22,25 +26,18 @@ js-install:: js-all
 
 # files we create
 
-#rakudo.js: @nfp(@bpm(BUILD_DIR)@/perl6.nqp)@ @bsm(PERL6_G)@ @bsm(PERL6_A)@ @bsm(PERL6_C)@ @bsm(PERL6_P)@
-#	@echo '+++ Composing\t$@'
-#	@noecho@@bpm(NQP)@ @bpm(BASE_FLAGS)@ --execname $(JS_RUNNER) --substagestats --stagestats --target=js --source-map --shebang --output=rakudo.js @nfp($(JS_BUILD_DIR)/main.nqp)@
-
 @nfp(@bpm(BUILD_DIR)@/load-compiler.nqp)@: @nfp(src/vm/js/load-compiler.nqp)@
 @nfp(@bpm(BLIB_PERL6)@/load-compiler.js)@:   @nfp(@bpm(BUILD_DIR)@/load-compiler.nqp)@ @bsm(PERL6_G)@ @bsm(PERL6_A)@ @bsm(PERL6_C)@ @bsm(PERL6_P)@
 
-#@nfp($(JS_BLIB)/load-compiler.js)@: @nfp(src/vm/js/load-compiler.nqp)@ $(PERL6_G_JS) $(PERL6_A_JS) $(PERL6_C_JS) $(PERL6_P_JS)
-#	$(MKPATH) $(JS_BLIB)
-#	$(JS_NQP) $(JS_FLAGS)  --substagestats --stagestats --target=js --source-map  --output=@nfp($(JS_BLIB)/load-compiler.js)@ @nfp(src/vm/js/load-compiler.nqp)@
-
-$(JS_RUNNER):
+@bpm(RUNNER)@:
 	$(PERL5) @script(create-js-runner.pl)@
 
-#js-all: check_nqp_version @nfp($(JS_BUILD_DIR)/ModuleLoader.nqp)@ $(PERL6_G_JS) $(PERL6_A_JS) $(PERL6_C_JS) $(PERL6_P_JS) rakudo.js @for_specs($(JS_BLIB)/CORE.@lcspec@.setting.js )@ $(JS_RUNNER) $(JS_BLIB)/load-compiler.js
+rakudo.@bext@: @bsm(PERL6)@
+	@noecho@$(CP) @bsm(PERL6)@ $@
+
 #TODO cleanup BOOTSTRAP
 js-clean:
 	$(RM_F) @bpm(CLEANUPS_ALL)@
-	#$(RM_F) @nfp(@bpm(BUILD_DIR)@/ModuleLoader.nqp)@ perl6.js BLIB)/CORE.setting.js $(JS_BUILD_DIR)/CORE.setting $(JS_BUILD_DIR)/ModuleLoader.nqp $(PERL6_ML_JS) $(JS_BUILD_DIR)/Perl6-Ops.nqp $(PERL6_OPS_JS) $(PERL6_P_JS) $(PERL6_W_JS) $(JS_BUILD_DIR)/Perl6-Actions.nqp $(PERL6_A_JS) $(PERL6_G_JS) $(JS_BUILD_DIR)/Perl6-Optimizer.nqp $(PERL6_O_JS) $(PERL6_C_JS) $(JS_BUILD_DIR)/main-version.nqp $(JS_BUILD_DIR)/main.nqp rakudo.js $(JS_BLIB)/load-compiler.js $(JS_BUILD_DIR)/Metamodel.nqp  $(PERL6_M_JS)
 
 js-lint:
 	gjslint --strict --max_line_length=200 --nojsdoc @nfp(src/vm/js/perl6-runtime/*.js)@

--- a/tools/templates/moar/Makefile.in
+++ b/tools/templates/moar/Makefile.in
@@ -77,7 +77,7 @@ R_SETTING_MOAR = RESTRICTED.setting.moarvm
 
 @bpv(NQP_FLAGS_EXTRA)@ = --vmlibs=@bpm(PERL6_OPS_DLL)@=Rakudo_ops_init
 
-@bpv(HARNESS_TYPE)@ = $(HARNESS_TYPE)
+#@bpv(HARNESS_TYPE)@ = $(HARNESS_TYPE)
 
 @bpv(HARNESS6)@ = @nfp(./@bpm(RUNNER)@)@ -Ilib @nfp(t/harness6)@
 @bpv(HARNESS6_WITH_FUDGE)@ = @bpm(HARNESS6)@ --fudge


### PR DESCRIPTION
- Unified naming by using `perl6.js` in addition to `rakudo.js`.
- `<backend>_HARNESS_TYPE` variable wasn't set.
- Move COREs compilation into `blib`