### PR TITLE
De-containerize Junction values.

### DIFF
--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -4055,14 +4055,14 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
     token infix:sym<∘>   { <sym>  <O(|%concatenation)> }
     token infix:sym<o>   { <sym>  <O(|%concatenation)> }
 
-    token infix:sym<&>   { <sym> <O(|%junctive_and, :iffy(1))> }
+    token infix:sym<&>   { <sym> <O(|%junctive_and, :iffy(1), :diffy(1))> }
     token infix:sym<(&)> { <sym> <O(|%junctive_and)> }
     token infix:sym«∩»   { <sym> <O(|%junctive_and)> }
     token infix:sym<(.)> { <sym> <O(|%junctive_and)> }
     token infix:sym«⊍»   { <sym> <O(|%junctive_and)> }
 
-    token infix:sym<|>    { <sym> <O(|%junctive_or, :iffy(1))> }
-    token infix:sym<^>    { <sym> <O(|%junctive_or, :iffy(1))> }
+    token infix:sym<|>    { <sym> <O(|%junctive_or, :iffy(1), :diffy(1))> }
+    token infix:sym<^>    { <sym> <O(|%junctive_or, :iffy(1), :diffy(1))> }
     token infix:sym<(|)>  { <sym> <O(|%junctive_or)> }
     token infix:sym«∪»    { <sym> <O(|%junctive_or)> }
     token infix:sym<(^)>  { <sym> <O(|%junctive_or)> }

--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -4055,14 +4055,14 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
     token infix:sym<∘>   { <sym>  <O(|%concatenation)> }
     token infix:sym<o>   { <sym>  <O(|%concatenation)> }
 
-    token infix:sym<&>   { <sym> <O(|%junctive_and, :iffy(1), :diffy(1))> }
+    token infix:sym<&>   { <sym> <O(|%junctive_and, :iffy(1))> }
     token infix:sym<(&)> { <sym> <O(|%junctive_and)> }
     token infix:sym«∩»   { <sym> <O(|%junctive_and)> }
     token infix:sym<(.)> { <sym> <O(|%junctive_and)> }
     token infix:sym«⊍»   { <sym> <O(|%junctive_and)> }
 
-    token infix:sym<|>    { <sym> <O(|%junctive_or, :iffy(1), :diffy(1))> }
-    token infix:sym<^>    { <sym> <O(|%junctive_or, :iffy(1), :diffy(1))> }
+    token infix:sym<|>    { <sym> <O(|%junctive_or, :iffy(1))> }
+    token infix:sym<^>    { <sym> <O(|%junctive_or, :iffy(1))> }
     token infix:sym<(|)>  { <sym> <O(|%junctive_or)> }
     token infix:sym«∪»    { <sym> <O(|%junctive_or)> }
     token infix:sym<(^)>  { <sym> <O(|%junctive_or)> }

--- a/src/core.c/Junction.pm6
+++ b/src/core.c/Junction.pm6
@@ -16,7 +16,7 @@ my class Junction { # declared in BOOTSTRAP
             nqp::stmts(
               ($!storage := nqp::if(
                 nqp::isconcrete(
-                  $_ := nqp::getattr(values.eager.list,List,'$!reified')),
+                  $_ := nqp::getattr(values.map({nqp::decont($_)}).eager.list,List,'$!reified')),
                 $_,
                 nqp::create(IterationBuffer))),
               self


### PR DESCRIPTION
Junctions are about values, not containers. Allowing containers inside a junction allows actions at distance in cases like:

```
my @a = 1,2;
my $j = any @a;
@a[0] = 3;
say 1 ~~ $j; # False
```