### PR TITLE
Issue #2092 | Clarify detached method error messaging.

### DIFF
--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -4046,7 +4046,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
                 $<ws> ne ''
                 ?? $¢.obs('. to concatenate strings', '~')
                 !! $pre ~~ /^\s$/
-                    ?? $¢.malformed('postfix call (only alphabetic methods may be detached)')
+                    ?? $¢.malformed('postfix call (only basic method calls that exclusively use a dot can be detached)')
                     !! $¢.malformed('postfix call')
             }
         ]?

--- a/t/05-messages/02-errors.t
+++ b/t/05-messages/02-errors.t
@@ -289,7 +289,7 @@ throws-like ｢need v6.0;｣, Exception, :message{
 
 # RT #126856
 throws-like ｢^42  .^methods.say｣, X::Syntax::Malformed,
-    :message{ .contains: 'only alphabetic methods may be detached' },
+    :message{ .contains: 'only basic method calls that exclusively use a dot can be detached' },
     'detached non-alpha method says what the problem is';
 
 #### THIS FILE ALREADY LOTS OF TESTS ADD NEW TESTS TO THE NEXT error.t FILE


### PR DESCRIPTION
Originally, this error said "only alphabetic methods may be detached"
but those aren't the only methods that can be detached. The new
messaging is a bit clearer on valid detachment candidates.

To trigger this, eval: `42 .&abs`.

Resulting error should be: `Malformed postfix call (only basic method calls that exclusively use a dot can be detached)`.