### PR TITLE
Implement ¿? and ¡! as alternative to ""

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -8507,6 +8507,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
     method quote:sym<crnr>($/) { make $<nibble>.ast; }
     method quote:sym<question>($/){ make $<nibble>.ast; }
     method quote:sym<exclamation>($/){ make $<nibble>.ast; }
+    method quote:sym<dash>($/){ make $<nibble>.ast; }
     method quote:sym<qq>($/)   { make $<quibble>.ast; }
     method quote:sym<q>($/)    { make $<quibble>.ast; }
     method quote:sym<Q>($/)    { make $<quibble>.ast; }

--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -8505,6 +8505,8 @@ class Perl6::Actions is HLL::Actions does STDActions {
     method quote:sym<ldblq>($/){ make $<nibble>.ast; }
     method quote:sym<hdblq>($/){ make $<nibble>.ast; }
     method quote:sym<crnr>($/) { make $<nibble>.ast; }
+    method quote:sym<question>($/){ make $<nibble>.ast; }
+    method quote:sym<exclamation>($/){ make $<nibble>.ast; }
     method quote:sym<qq>($/)   { make $<quibble>.ast; }
     method quote:sym<q>($/)    { make $<quibble>.ast; }
     method quote:sym<Q>($/)    { make $<quibble>.ast; }

--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -3406,6 +3406,8 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
     token quote:sym<ldblq> { :dba('low curly double quotes') '„' ~ <[”“]> <nibble(self.quote_lang(self.slang_grammar('Quote'), '„', ['”','“'], ['qq']))> }
     token quote:sym<hdblq> { :dba('high curly double quotes') '”' ~ <[”“]> <nibble(self.quote_lang(self.slang_grammar('Quote'), '”', ['”','“'], ['qq']))> }
     token quote:sym<crnr>  { :dba('corner quotes') '｢' ~ '｣' <nibble(self.quote_lang(self.slang_grammar('Quote'), '｢', '｣'))> }
+    token quote:sym<question> { :dba('question mark quotes') '¿' ~ '?' <nibble(self.quote_lang(self.slang_grammar('Quote'), '¿', '?', ['qq']))> }
+    token quote:sym<exclamation> { :dba('exclamation mark quotes') '¡' ~ '!' <nibble(self.quote_lang(self.slang_grammar('Quote'), '¡', '!', ['qq']))> }
     token quote:sym<q> {
         :my $qm;
         'q'
@@ -5298,7 +5300,7 @@ grammar Perl6::QGrammar is HLL::Grammar does STD {
 
     role ww {
         token escape:sym<'> {
-            <?[ ' " ‘ ‚ ’ “ „ ” ｢ ]> <quote=.LANG('MAIN','quote')>
+            <?[ ' " ‘ ‚ ’ “ „ ” ｢ ¿ ¡ ]> <quote=.LANG('MAIN','quote')>
         }
         token escape:sym<colonpair> {
             <?[:]> <!RESTRICTED> <colonpair=.LANG('MAIN','colonpair')>
@@ -5602,7 +5604,7 @@ grammar Perl6::RegexGrammar is QRegex::P6Regex::Grammar does STD does MatchPacka
         <.SIGOK>
     }
 
-    token metachar:sym<'> { <?[ ' " ‘ ‚ ’ “ „ ” ｢ ]> <quote=.LANG('MAIN','quote')> <.SIGOK> }
+    token metachar:sym<'> { <?[ ' " ‘ ‚ ’ “ „ ” ｢ ¿ ¡ ]> <quote=.LANG('MAIN','quote')> <.SIGOK> }
 
     token metachar:sym<{}> { \\<[xo]>'{' <.obsbrace> }
 

--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -3408,6 +3408,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
     token quote:sym<crnr>  { :dba('corner quotes') '｢' ~ '｣' <nibble(self.quote_lang(self.slang_grammar('Quote'), '｢', '｣'))> }
     token quote:sym<question> { :dba('question mark quotes') '¿' ~ '?' <nibble(self.quote_lang(self.slang_grammar('Quote'), '¿', '?', ['qq']))> }
     token quote:sym<exclamation> { :dba('exclamation mark quotes') '¡' ~ '!' <nibble(self.quote_lang(self.slang_grammar('Quote'), '¡', '!', ['qq']))> }
+    token quote:sym<dash> { :dba('dash mark quotes') '—' ~ '—' <nibble(self.quote_lang(self.slang_grammar('Quote'), '—', '—', ['qq']))> }
     token quote:sym<q> {
         :my $qm;
         'q'
@@ -5300,7 +5301,7 @@ grammar Perl6::QGrammar is HLL::Grammar does STD {
 
     role ww {
         token escape:sym<'> {
-            <?[ ' " ‘ ‚ ’ “ „ ” ｢ ¿ ¡ ]> <quote=.LANG('MAIN','quote')>
+            <?[ ' " ‘ ‚ ’ “ „ ” ｢ ¿ ¡ — ]> <quote=.LANG('MAIN','quote')>
         }
         token escape:sym<colonpair> {
             <?[:]> <!RESTRICTED> <colonpair=.LANG('MAIN','colonpair')>
@@ -5604,7 +5605,7 @@ grammar Perl6::RegexGrammar is QRegex::P6Regex::Grammar does STD does MatchPacka
         <.SIGOK>
     }
 
-    token metachar:sym<'> { <?[ ' " ‘ ‚ ’ “ „ ” ｢ ¿ ¡ ]> <quote=.LANG('MAIN','quote')> <.SIGOK> }
+    token metachar:sym<'> { <?[ ' " ‘ ‚ ’ “ „ ” ｢ ¿ ¡ — ]> <quote=.LANG('MAIN','quote')> <.SIGOK> }
 
     token metachar:sym<{}> { \\<[xo]>'{' <.obsbrace> }
 


### PR DESCRIPTION
This is only semi-serious.  Yet, there's a lot of Spanish speaking people
in the world, that may find this feature attractive / useful.  Mostly done
to see whether the approach would work, since it did *not* work as an
external module.

The external module `Slang::SpanishQuotes` that does not work:

    module Slang::SpanishQuotes:ver<0.0.1>:auth<cpan:ELIZABETH> { }
  
    sub EXPORT(|) {
        my role SpanishQuotesGrammar {
            token quote:sym<question> {
                :dba('question mark quotes')
                '¿' ~ '?'
                <nibble(self.quote_lang(self.slang_grammar('Quote'), '¿', '?', ['qq']))>
            }
            token quote:sym<exclamation> {
                :dba('exclamation mark quotes')
                '¡' ~ '!'
                <nibble(self.quote_lang(self.slang_grammar('Quote'), '¡', '!', ['qq']))>
            }

            token metachar:sym<'> {
                <?[ ' " ‘ ‚ ’ “ „ ” ｢ ¿ ¡ ]> <quote=.LANG('MAIN','quote')> <.SIGOK>
            } 
            token escape:sym<'> {
                <?[ ' " ‘ ‚ ’ “ „ ” ｢ ¿ ¡ ]> <quote=.LANG('MAIN','quote')>
            }
        }
    
        my role SpanishQuotesActions {
            method quote:sym<question>($/){ make $<nibble>.ast; }
            method quote:sym<exclamation>($/){ make $<nibble>.ast; }
        }
    
        $*LANG.define_slang:
          'MAIN',
          $*LANG.slang_grammar('MAIN').^mixin(SpanishQuotesGrammar),
          $*LANG.actions.^mixin(SpanishQuotesActions);
    
        {}
    }
