### PR TITLE
Allow for subscripts to be used in identifiers

### DIFF
--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -566,7 +566,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
     }
 
     token identifier {
-        <.ident> [ <.apostrophe> <.ident> ]*
+        <.ident> [ [ <.apostrophe> | <[₀₁₂₃₄₅₆₇₈₉]>+ ] <.ident> ]* <[₀₁₂₃₄₅₆₇₈₉]>*
     }
 
     token name {


### PR DESCRIPTION
Just as digits.  Allows for:

    my $H₂SO₄ = 42; say $H₂SO₄;  # 42