### PR TITLE
Add BuildTools installation assistant

### DIFF
--- a/tools/build/binary-release/Windows/README.md
+++ b/tools/build/binary-release/Windows/README.md
@@ -1,11 +1,13 @@
-# Rakudo Perl 6
+Rakudo Perl 6
+==============
 
 This is a pre-built package of Rakudo Perl 6, a Perl 6 compiler.
 
 This package includes the Rakudo Perl 6 compiler and the module installer Zef.
 
 
-## Running Perl 6
+Running Perl 6
+--------------
 
 To run a Perl 6 program, open a command prompt and type
 
@@ -15,7 +17,8 @@ or start a REPL by calling `perl6.exe` without an argument
 
     C:\path\to\this\folder\bin\perl6.exe
 
-To add the relevant paths to your environment so you don't have to type the full path execute the following script in CMD:
+To add the relevant paths to your environment so you don't have to type the
+full path execute the following script in CMD:
 
     C:\path\to\this\folder\scripts\set-env.bat
 
@@ -24,21 +27,47 @@ or when using Powershell (note the dot at the beginning):
     . C:\path\to\this\folder\scripts\set-env.ps1
 
 
-## Installing modules
+Installing modules
+------------------
 
 To install Perl 6 modules you can use the Zef module installer.
 
     C:\path\to\this\folder\bin\perl6.exe C:\path\to\this\folder\share\perl6\site\bin\zef install JSON::Fast
 
-Modules will be installed into this Perl 6 package and will thus be available even when moving this package.
+Modules will be installed into this Perl 6 package and will thus be available
+even when moving this package.
 
 
 ### Native code modules
 
-To install modules that require a compiler toolchain, you have to have the Microsoft Visual C compiler installed. It's included in the Microsoft BuildTools which can be freely downloaded [here](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=BuildTools).
+To install modules that require a compiler toolchain, you need to have the
+Microsoft Visual C compiler installed. The freely available
+Microsoft BuildTools contain that compiler. You can use the installer script
+
+    C:\path\to\this\folder\bin\vs_build_tools_install_assistant.ps1
+
+to guide you through the installation.
+
+Alternatively you can install the BuildTools manually. They can be downloaded
+[here](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=BuildTools).
+You'll need to select the `C++ build tools` and recommended components.
+
+The compiler is only usable in special Build Tools CMD / PowerShell windows.
+
+To make use of the Build Tools in Rakudo using CMD:
+- start a CMD window using
+    Start Menu -> Visual Studio 2019 ->
+    x86 / x64 Native Tools Command Prompt for VS 2019
+- Execute $scriptPath\set-env.bat
+
+To make use of the Build Tools in Rakudo using PowerShell:
+- start a PowerShell window using
+    Start Menu -> Visual Studio 2019 -> Developer PowerShell for VS 2019
+- Execute $scriptPath\set-env.ps1
 
 
-## Changes
+Changes
+-------
 
 Recent changes and feature additions are documented in the `docs/ChangeLog`
 text file.
@@ -48,7 +77,8 @@ subscribe to [the p6lert service](https://alerts.perl6.org) using the RSS feed,
 twitter, or [the p6lert commandline script](https://github.com/zoffixznet/perl6-p6lert).
 
 
-## Where to get help or answers to questions
+Where to get help or answers to questions
+-----------------------------------------
 
 There are several mailing lists, IRC channels, and wikis available with
 help for Perl 6 and Rakudo. Figuring out the right one to use
@@ -73,27 +103,32 @@ Questions about NQP can also be posted to the #perl6 IRC channel.
 For questions about MoarVM, you can join #moarvm on freenode.
 
 
-## Reporting bugs
+Reporting bugs
+--------------
 
 See https://rakudo.org/bugs
 
 
-## Submitting patches
+Submitting patches
+------------------
 
 If you have a patch that fixes a bug or adds a new feature, please
 create a pull request using github's pull request infrastructure.
 
-See [our contribution guidelines](https://github.com/rakudo/rakudo/blob/master/CONTRIBUTING.md) for more information.
+See [our contribution guidelines](https://github.com/rakudo/rakudo/blob/master/CONTRIBUTING.md)
+for more information.
 
 
-## License
+License
+-------
 
 Rakudo Perl 6 is Copyright © 2008-2019, The Perl Foundation. Rakudo Perl 6
 is distributed under the terms of the Artistic License 2.0. For more
 details, see the full text of the license in the file LICENSE.
 
 
-## AUTHOR
+AUTHOR
+------
 
 See CREDITS for the many people that have contributed
 to the development of the Rakudo compiler.

--- a/tools/build/binary-release/Windows/bin/vs_build_tools_install_assistant.ps1
+++ b/tools/build/binary-release/Windows/bin/vs_build_tools_install_assistant.ps1
@@ -1,0 +1,86 @@
+$url = "https://download.visualstudio.microsoft.com/download/pr/02aebac1-9464-4473-9af5-710a97b8f023/92c237448ec5563948a83f2f9e01d3050755a15eb473c9e7ffefd735bf7474f1/vs_BuildTools.exe"
+
+$scriptPath = split-path -parent $MyInvocation.MyCommand.Definition
+
+function getTmpDir {
+    $parent = [System.IO.Path]::GetTempPath()
+    [string] $name = [System.Guid]::NewGuid()
+    return New-Item -ItemType Directory -Path (Join-Path $parent $name)
+}
+
+function download {
+    $outDir = getTmpDir
+    $output = "$outDir\vs_BuildTools.exe"
+    Invoke-WebRequest -Uri $url -OutFile $output
+    return $output
+}
+
+function runInstaller($installer) {
+    Start-Process -Wait -FilePath $installer -ArgumentList "--norestart --wait --includeRecommended --add Microsoft.VisualStudio.Workload.VCTools"
+    #--quiet --installPath="C:\raku_vs_buildtools"
+}
+
+function getInput($prompt) {
+    Write-Host -NoNewline $prompt
+    $Host.UI.ReadLine()
+}
+
+Write-Host @"
+================================================================================
+Welcome to Rakudos Visual Studio Build Tools 2019 installation assistant.
+The installation
+- needs approximately 4.5 GB of disk space
+- downloads ~1.2 GB of data
+- might take 30 minutes or longer with a 10 MBit/s connection
+================================================================================
+
+"@
+
+$response = getInput "Shall we start? [Y] / N ? "
+if (($response -ne '') -and ($response -ne 'y') -and ($response -ne 'Y')) {
+    Write-Host "Aborting ... "
+    exit
+}
+
+Write-Host -NoNewline "Downloading the installer stub (1.3 MB) ... "
+$installer = download
+
+Write-Host @"
+done
+
+================================================================================
+We are about to start the graphical installer. After some dialogs, downloading
+the actuall installer and more dialogs you will be presented with a component
+selection interface. The required components will already be selected. Just
+click the "Install" button on the bottom right. You are free to select
+additional components or change the installation location.
+================================================================================
+
+"@
+
+Write-Host -NoNewline "Press Return to start. "
+Read-Host
+
+Write-Output "Starting installer ..."
+runInstaller $installer
+
+Write-Host @"
+
+================================================================================
+Installation finished.
+To make use of the Build Tools in Rakudo using CMD:
+- start a CMD window using
+    Start Menu -> Visual Studio 2019 ->
+    x86 / x64 Native Tools Command Prompt for VS 2019
+- Execute $scriptPath\set-env.bat
+
+To make use of the Build Tools in Rakudo using PowerShell:
+- start a PowerShell window using
+    Start Menu -> Visual Studio 2019 -> Developer PowerShell for VS 2019
+- Execute $scriptPath\set-env.ps1
+================================================================================
+
+"@
+
+Write-Host -NoNewline "Press Return to close this installation assistant. "
+Read-Host


### PR DESCRIPTION
Add a script to help with installing the MSVC compiler needed to install
binary packages on Windows. Also adapt the documentation to explain when
a compiler is needed and how to install it.