### PR TITLE
Improve LTA messages for incorrect declarator blocks

### DIFF
--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -1,5 +1,4 @@
-
-
+use QRegex;
 use NQPP6QRegex;
 use NQPP5QRegex;
 use Perl6::Actions;

--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -3633,18 +3633,29 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         :my $*VAR;
         :my $orig_arg_flat_ok := $*ARG_FLAT_OK;
         :dba('term')
+        # TODO try to use $/ for lookback to check for erroneous
+        #      use of pod6 trailing declarator block, e.g.:
+        #
+        #        #=!
+        #
+        #      instead of
+        #
+        #        #=(
+        #
         [
         ||  [
-            | <prefixish>+ 
-              [ <.arg_flat_nok> <term> 
-                || 
-                {} 
-                   <.panic("Prefix " ~ $<prefixish>[-1].Str 
+            | <prefixish>+
+
+
+              [ <.arg_flat_nok> <term>
+                ||
+                {}
+                   <.panic("Prefix " ~ $<prefixish>[-1].Str
                                      ~ " requires an argument, but no valid term found"
                                      ~ ".\nDid you mean "
-                                     ~ $<prefixish>[-1].Str 
+                                     ~ $<prefixish>[-1].Str
                                      ~ " to be an opening bracket for a declarator block?"
-                          )> 
+                          )>
               ]
             | <.arg_flat_nok> <term>
             ]
@@ -4699,7 +4710,7 @@ if $*COMPILING_CORE_SETTING {
     # If any character other than a space follows the first
     # two, it must be a valid opening bracketing character,
     # otherwise an exception is thrown.
-    # 
+    #
     # Note that declarator blocks retain their special handling
     # even in the one-line format.
     #==========================================================
@@ -4720,7 +4731,7 @@ if $*COMPILING_CORE_SETTING {
     #   this is an ordinary trailing one-line comment:
     #     my $a = #` some comment
     #     3;
-    #     
+    #
     #==========================================================
 
     #```````````
@@ -4733,7 +4744,7 @@ if $*COMPILING_CORE_SETTING {
         <.typed_panic: 'X::Syntax::Comment::Embedded'>
     }
     token comment:sym<#`(...)> {
-        '#`' <?opener> 
+        '#`' <?opener>
         #[ <.quibble(self.slang_grammar('Quote'))> || <.typed_panic: 'X::Syntax::Comment::Embedded'> ]
         <.quibble(self.slang_grammar('Quote'))>
     }
@@ -4759,9 +4770,9 @@ if $*COMPILING_CORE_SETTING {
                 $*POD_BLOCKS_SEEN{ self.from() } := 1;
                 if $*DECLARATOR_DOCS eq '' {
                     $*DECLARATOR_DOCS := $<attachment><nibble>;
-                } 
+                }
                 else {
-                    $*DECLARATOR_DOCS := nqp::concat($*DECLARATOR_DOCS, 
+                    $*DECLARATOR_DOCS := nqp::concat($*DECLARATOR_DOCS,
                          nqp::concat("\n", $<attachment><nibble>));
                 }
             }
@@ -4776,9 +4787,9 @@ if $*COMPILING_CORE_SETTING {
                 $*POD_BLOCKS_SEEN{ self.from() } := 1;
                 if $*DECLARATOR_DOCS eq '' {
                     $*DECLARATOR_DOCS := $<attachment>;
-                } 
+                }
                 else {
-                    $*DECLARATOR_DOCS := nqp::concat($*DECLARATOR_DOCS, 
+                    $*DECLARATOR_DOCS := nqp::concat($*DECLARATOR_DOCS,
                         nqp::concat("\n", $<attachment>));
                 }
             }

--- a/src/core/Exception.pm6
+++ b/src/core/Exception.pm6
@@ -1528,6 +1528,14 @@ my class X::Syntax::Comment::Embedded does X::Syntax {
     method message() { "Opening bracket required for #` comment" }
 }
 
+my class X::Syntax::Pod::DeclaratorLeading does X::Syntax  {
+    method message() { "Opening bracket required for #| declarator block" }
+}
+
+my class X::Syntax::Pod::DeclaratorTrailing does X::Syntax {
+    method message() { "Opening bracket required for #= declarator block" }
+}
+
 my class X::Syntax::Pod::BeginWithoutIdentifier does X::Syntax does X::Pod {
     method message() {
         '=begin must be followed by an identifier; (did you mean "=begin pod"?)'


### PR DESCRIPTION
This PR addresses issues #3144 and #3145 (and possibly others) and improves some error messages for incorrect declarator blocks such as:

1. Given an embedded comment:

```
#`!
comment
!
```

Executing it yields:

```
===SORRY!=== Error while compiling /home/tbrowde/rakudo-dev/rakudo/./d1.t
Opening bracket required for #` comment
at /home/tbrowde/rakudo-dev/rakudo/./d1.t:5
------> #`⏏!
```

2. Given  a leading declarator block:

```
#|!
comment
!
```

Executing it yields:

```
===SORRY!=== Error while compiling /home/tbrowde/rakudo-dev/rakudo/./d2.t
Opening bracket required for #| declarator block
at /home/tbrowde/rakudo-dev/rakudo/./d2.t:5
------> #|⏏!
```

3. Given a trailing declarator block:

```
#=!
comment
!
```

Executing it yields:

```
===SORRY!=== Error while compiling /home/tbrowde/rakudo-dev/rakudo/./d3.t
Prefix !
 requires an argument, but no valid term found.
Did you mean !
 to be an opening bracket for a declarator block?
at /home/tbrowde/rakudo-dev/rakudo/./d3.t:8
------> <BOL>⏏<EOL>
    expecting any of:
        prefix
```
