### PR TITLE
Fix a wrong reference

### DIFF
--- a/tools/templates/jvm/Makefile.in
+++ b/tools/templates/jvm/Makefile.in
@@ -84,7 +84,7 @@ sometests: @backend_prefix@-all
 
 @backend_prefix@-runner-default-install: @backend_prefix@-install
 	@echo(+++ Installing @uc(@backend@)@ launcher)@
-	@noecho@$(PERL5) @shquot(@script(create-jvm-runner.pl)@)@ install @q($(DESTDIR))@ @q($(PREFIX))@ @q($(NQP_HOME))@ @q($(PERL6_HOME))@ "" @q($(NQP_JARS))@
+	@noecho@$(PERL5) @shquot(@script(create-jvm-runner.pl)@)@ install @q($(DESTDIR))@ @q($(PREFIX))@ @q(@bpm(NQP_HOME)@)@ @q($(PERL6_HOME))@ "" @q($(NQP_JARS))@
 	@noecho@$(CP) @nfpq($(DESTDIR)$(PREFIX)/bin/perl6-j$(J_BAT))@ @nfpq($(DESTDIR)$(PREFIX)/bin/perl6$(J_BAT))@
 	@noecho@$(CHMOD) 755 @nfpq($(DESTDIR)$(PREFIX)/bin/perl6$(J_BAT))@
 


### PR DESCRIPTION
otherwise we end up with an empty pattern in a split call later which breaks stuff.

To expand on that commit message, `$(NQP_HOME)` doesn't seem to be defined in that spot in the Makefile, which results in an empty string being passed to `create-jvm-runner.pl`, which in turn results in an empty string being used as the pattern in a perl `split` call, which resulted in the classpath in *installed* `perl6-j` to be a lot of letters separated by `:`, which doesn't work.

