### PR TITLE
[WIP] Die early on a duplicate role

### DIFF
--- a/src/Perl6/Metamodel/RoleToClassApplier.nqp
+++ b/src/Perl6/Metamodel/RoleToClassApplier.nqp
@@ -42,6 +42,23 @@ my class RoleToClassApplier {
     }
 
     method apply($target, @roles) {
+
+        # Make sure the same role isn't added more than once, so that we don't
+        # get disambiguation messages on identical methods later, which can be
+        # really confusing.
+        my %seen;
+        for @roles {
+            my $name := $_.HOW.name($_);
+            if nqp::existskey(%seen,$name) {
+                nqp::die(
+                  "Can only apply role '$name' to class '"
+                  ~ $target.HOW.name($target)
+                  ~ "' once"
+                );
+            }
+            nqp::bindkey(%seen,$name,1)
+        }
+
         # If we have many things to compose, then get them into a single helper
         # role first.
         my $to_compose;


### PR DESCRIPTION
When you apply the same role to a class more than once, you wind up with
very confusing error about needing to resolve your methods because they
are being provided by more than one role.  This patch adds a check (by
name) to see whether the same role has been specified more than once.

This changes the error for:

    role A { method foo() { } }
    class B does A does A { }

from:

    Method 'foo' must be resolved by class B because it exists in multiple roles (A, A)

to:

    Can only apply role 'A' to class 'B' once

FWIW, tried to do the uniqueness check using objectid, but for some reason
identical roles still arrive in the method with different object id's, even
when deconted.