### PR TITLE
Preserve compiler version in EVALs

### DIFF
--- a/src/Perl6/Compiler.nqp
+++ b/src/Perl6/Compiler.nqp
@@ -31,7 +31,7 @@ class Perl6::Compiler is HLL::Compiler {
             $!language_version
         }
         else {
-            $!language_version := self.config<language-version>
+            $!language_version := %*COMPILING<%?OPTIONS><language_version> || self.config<language-version>
         }
     }
     method language_modifier() {

--- a/src/core.c/ForeignCode.pm6
+++ b/src/core.c/ForeignCode.pm6
@@ -64,6 +64,7 @@ proto sub EVAL(
         :outer_ctx($eval_ctx),
         :global(GLOBAL),
         :mast_frames(mast_frames),
+        :language_version(nqp::getcomp('perl6').language_version),
         |(:optimize($_) with nqp::getcomp('perl6').cli-options<optimize>),
         |(%(:grammar($LANG<MAIN>), :actions($LANG<MAIN-actions>)) if $LANG);
 


### PR DESCRIPTION
Previously it was always reset to the default one.

Fixes #3263