### PR TITLE
Only pass on capture in `sub split` if it's there

### DIFF
--- a/src/core.c/Cool.pm6
+++ b/src/core.c/Cool.pm6
@@ -492,7 +492,7 @@ proto sub samecase($, $, *%) {*}
 multi sub samecase(Cool:D $string, Cool:D $pattern) { $string.samecase($pattern) }
 
 proto sub split($, $, |) {*}
-multi sub split($pat, Cool:D $target, |c) { $target.split($pat, |c) }
+multi sub split($pat, Cool:D $target, |c) { c ?? $target.split($pat, |c) !! $target.split($pat) }
 
 proto sub chars($, *%) is pure {*}
 multi sub chars(Cool $x)  { $x.Str.chars }


### PR DESCRIPTION
Otherwise spesh can't intern the callsite and then the jit bails. Other
attempts (i.e., adding a new `multi sub split($pat, Cool:D $target)`, or
adding that and also changing the `|c` in the other multi to `*%h`)
caused errors like `Unexpected named argument 'v' passed` and `Ambiguous
call to 'split(Str, Str, :v)'; these signatures all match::($pat,
Cool:D $target):($pat, Cool:D $target, *%h)`. Found when playing around
with the code referenced in #3281 and makes it slightly faster.

Rakudo builds ok and passes `make m-test m-spectest`.