### PR TITLE
Fix Stash'es clashing after deserialization

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -1292,7 +1292,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
         $*W.assert_stubs_defined($/);
         $*W.sort_protos();
 
-        if $*W.is_precompilation_mode {
+        if !$*COMPILING_CORE_SETTING && $*W.is_precompilation_mode {
             # Perform GLOBALish stash fixup as early as possible but after repossession conflicts are resolved. The
             # purpose is to restore correct stash in cases when two package objects with compound names share common
             # prefix. Like, for example, A::B::C::D1 and A::B::C::D2 share A::B::C. In this case sometimes when defined
@@ -1301,7 +1301,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
             my $stash-type := $*W.find_symbol(['Stash'], :setting-only);
             my $glob-stash := $*GLOBALish.WHO;
             if nqp::istype($glob-stash, $stash-type) {
-                $glob-stash.TAKE-SNAPSHOT;
+                $glob-stash.TAKE-SNAPSHOT(nqp::scgethandle($*W.context.sc));
                 $*W.add_fixup_task(
                     :deserialize_ast(
                         QAST::Stmt.new(

--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -1292,23 +1292,25 @@ class Perl6::Actions is HLL::Actions does STDActions {
         $*W.assert_stubs_defined($/);
         $*W.sort_protos();
 
-        # Perform GLOBALish stash fixup as early as possible but after repossession conflicts are resolved.
-        # The purpose is to restore correct stash in cases when two package objects with compound names share common
-        # prefix. Like, for example, A::B::C::D1 and A::B::C::D2 share A::B::C. In this case sometimes when defined in
-        # separate modules and loaded consequently the second loaded module gets the stash object on A from first
-        # loaded module.
-        my $stash-type := $*W.find_symbol(['Stash'], :setting-only);
-        my $glob-stash := $*GLOBALish.WHO;
-        if nqp::istype($glob-stash, $stash-type) {
-            $glob-stash.TAKE-SNAPSHOT;
-            $*W.add_fixup_task(
-                :deserialize_ast(
-                    QAST::Stmt.new(
-                        QAST::Op.new(
-                            :op<callmethod>,
-                            :name<RESTORE-SNAPSHOT>,
-                            QAST::WVal.new( :value($glob-stash) )
-                        ))));
+        if $*W.is_precompilation_mode {
+            # Perform GLOBALish stash fixup as early as possible but after repossession conflicts are resolved. The
+            # purpose is to restore correct stash in cases when two package objects with compound names share common
+            # prefix. Like, for example, A::B::C::D1 and A::B::C::D2 share A::B::C. In this case sometimes when defined
+            # in separate modules and loaded consequently the second loaded module gets the stash object on A from first
+            # loaded module.
+            my $stash-type := $*W.find_symbol(['Stash'], :setting-only);
+            my $glob-stash := $*GLOBALish.WHO;
+            if nqp::istype($glob-stash, $stash-type) {
+                $glob-stash.TAKE-SNAPSHOT;
+                $*W.add_fixup_task(
+                    :deserialize_ast(
+                        QAST::Stmt.new(
+                            QAST::Op.new(
+                                :op<callmethod>,
+                                :name<RESTORE-SNAPSHOT>,
+                                QAST::WVal.new( :value($glob-stash) )
+                            ))));
+            }
         }
 
         # Get the block for the unit mainline code.

--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -1292,6 +1292,25 @@ class Perl6::Actions is HLL::Actions does STDActions {
         $*W.assert_stubs_defined($/);
         $*W.sort_protos();
 
+        # Perform GLOBALish stash fixup as early as possible but after repossession conflicts are resolved.
+        # The purpose is to restore correct stash in cases when two package objects with compound names share common
+        # prefix. Like, for example, A::B::C::D1 and A::B::C::D2 share A::B::C. In this case sometimes when defined in
+        # separate modules and loaded consequently the second loaded module gets the stash object on A from first
+        # loaded module.
+        my $stash-type := $*W.find_symbol(['Stash'], :setting-only);
+        my $glob-stash := $*GLOBALish.WHO;
+        if nqp::istype($glob-stash, $stash-type) {
+            $glob-stash.TAKE-SNAPSHOT;
+            $*W.add_fixup_task(
+                :deserialize_ast(
+                    QAST::Stmt.new(
+                        QAST::Op.new(
+                            :op<callmethod>,
+                            :name<RESTORE-SNAPSHOT>,
+                            QAST::WVal.new( :value($glob-stash) )
+                        ))));
+        }
+
         # Get the block for the unit mainline code.
         my $unit := $*UNIT;
         my $mainline := QAST::Stmts.new(

--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -3476,6 +3476,7 @@ BEGIN {
 	#     has str $!longname;
     Stash.HOW.add_parent(Stash, Hash);
     Stash.HOW.add_attribute(Stash, Attribute.new(:name<$!longname>, :type(str), :package(Stash)));
+    Stash.HOW.add_attribute(Stash, Attribute.new(:name<$!snapshot>, :type(Mu), :package(Stash)));
     Stash.HOW.compose_repr(Stash);
 
     # Configure the stash type.

--- a/src/core.c/CompUnit/PrecompilationRepository.pm6
+++ b/src/core.c/CompUnit/PrecompilationRepository.pm6
@@ -300,7 +300,7 @@ class CompUnit::PrecompilationRepository::Default does CompUnit::PrecompilationR
             whenever $proc.stdout {
                 $out ~= $_
             }
-            unless $RMD {
+            unless $RMD || %*ENV<RAKUDO_DEBUG> {
                 whenever $proc.stderr {
                     $err ~= $_
                 }

--- a/src/core.c/Stash.pm6
+++ b/src/core.c/Stash.pm6
@@ -55,6 +55,45 @@ my class Stash { # declared in BOOTSTRAP
         nqp::gethllsym('perl6','ModuleLoader').merge_globals(self,$globalish)
           if $globalish.defined;
     }
+
+    # SNAPSHOT methods are only to be used in conjunction with serialization/deserialization.
+    method TAKE-SNAPSHOT(Stash:D:) is raw {
+        my \storage := nqp::getattr(self, Map, '$!storage');
+        my \iter := nqp::iterator(storage);
+        nqp::bindattr(self, Stash, '$!snapshot', nqp::list());
+        while iter {
+            nqp::shift(iter);
+            my \sym := nqp::iterkey_s(iter);
+            my \val := nqp::iterval(iter);
+            # Item is a list of 2 or 3 elements: symbol name, value, and subtable when the value is a package type.
+            my \item := nqp::list(sym, val);
+            if !nqp::isconcrete(val) && nqp::istype(val.HOW, Metamodel::PackageHOW) {
+                nqp::push(item, nqp::decont(val.WHO.TAKE-SNAPSHOT));
+            }
+            nqp::push(nqp::getattr(self, Stash, '$!snapshot'), item);
+        }
+    }
+
+    method !MERGE-SNAPSHOT(Stash:D: @table, \stash) {
+        my \storage := nqp::getattr(self, Map, '$!storage');
+        for @table -> @item {
+            my \sym := @item[0];
+            my \val := @item[1];
+            my \subtable := @item[2];
+            unless nqp::existskey(storage, sym) && nqp::atkey(storage, sym) =:= val {
+                nqp::bindkey(storage, sym, val);
+            }
+            if nqp::defined(subtable) {
+                self!MERGE-SNAPSHOT(subtable, val.WHO);
+            }
+        }
+    }
+
+    method RESTORE-SNAPSHOT(Stash:D:) {
+        self!MERGE-SNAPSHOT(nqp::getattr(self, Stash, '$!snapshot'), self);
+        # Don't keep the old records when we don't need them anymore.
+        nqp::bindattr(self, Stash, '$!snapshot', Nil);
+    }
 }
 
 # vim: ft=perl6 expandtab sw=4


### PR DESCRIPTION
When two modules are precompiled independently but then loaded by the
same process it is possible that if they share common name prefix like
in, say, `A::B::C::D1` and `A::B::C::D2` then the module loaded second
would get its Stash on `A` overriden by the module loaded first. This
would effectively result in some symbols in `A::B::...` hierarchy to be
lost to the code importing the modules. This behavior is caused by the
fact that when second module is being loaded by MoarVM from its
precompilation, symbols from parent stashes are being resolved to the
existing type objects from the first module. I.e., if `D1` is loaded
first, then upon loading `D2` it's `A` package would be resolved to the
`A` implicitly created earlier for `D1`. And that package would bear a
`Stash` object which contains `D1` but knows nothing about `D2`.

The problem is being fixed by preserving a `Stash` structure in a form
which wouldn't lost child objects after MoarVM resolves package symbols.
Currently it is done by creating a nested list of items containing
symbol name, symbol value and, optionally, subtable built from symbol's
`Stash` if it's a package. The structure is then stored in `Stash`
attribute `@!snapshot` before serialization. Then symbols from it are
merged back into the `Stash` object after deserialization.

It should also be noted that because `Stash` is Raku's level entity, it
makes sense to take care of it in Raku. Thus the solution of `Stash`
taking care of itself.

Fixes rakudo/rakudo#3075