### PR TITLE
Match subst

### DIFF
--- a/src/core.c/Cool.pm6
+++ b/src/core.c/Cool.pm6
@@ -322,7 +322,7 @@ my class Cool { # declared in BOOTSTRAP
         $/ := nqp::getlexcaller('$/');
         {*}
     }
-    multi method subst(Cool:D: $original, $replacement, *%options) {
+    multi method subst(Cool:D: $original, $replacement = "", *%options) {
         $/ := nqp::getlexcaller('$/');
         self.Stringy.subst($original, $replacement, |%options);
     }

--- a/src/core.c/Cool.pm6
+++ b/src/core.c/Cool.pm6
@@ -318,9 +318,13 @@ my class Cool { # declared in BOOTSTRAP
     multi method words(Cool:D:)         { self.Str.words         }
     multi method words(Cool:D: $limit ) { self.Str.words($limit) }
 
-    method subst(|c) {
+    proto method subst(|) {
         $/ := nqp::getlexcaller('$/');
-        self.Stringy.subst(|c);
+        {*}
+    }
+    multi method subst(Cool:D: $original, $replacement, *%options) {
+        $/ := nqp::getlexcaller('$/');
+        self.Stringy.subst($original, $replacement, |%options);
     }
 
     # `$value-to-subst-mutate` will show up in errors when called on non-rw

--- a/src/core.c/Match.pm6
+++ b/src/core.c/Match.pm6
@@ -914,7 +914,7 @@ my class Match is Capture is Cool does NQPMatchRole {
         $d == 0 ?? $r.chomp !! $r;
     }
 
-    multi method replace-with(Match:D: Str() $replacement --> Str:D) {
+    method replace-with(Match:D: Str() $replacement --> Str:D) {
         self.prematch ~ $replacement ~ self.postmatch
     }
 }

--- a/src/core.c/Match.pm6
+++ b/src/core.c/Match.pm6
@@ -914,7 +914,7 @@ my class Match is Capture is Cool does NQPMatchRole {
         $d == 0 ?? $r.chomp !! $r;
     }
 
-    multi method subst(Match:D: Str() $replacement --> Str:D) {
+    multi method replace-with(Match:D: Str() $replacement --> Str:D) {
         self.prematch ~ $replacement ~ self.postmatch
     }
 }

--- a/src/core.c/Match.pm6
+++ b/src/core.c/Match.pm6
@@ -914,6 +914,9 @@ my class Match is Capture is Cool does NQPMatchRole {
         $d == 0 ?? $r.chomp !! $r;
     }
 
+    multi method subst(Match:D: Str() $replacement --> Str:D) {
+        self.prematch ~ $replacement ~ self.postmatch
+    }
 }
 
 multi sub infix:<eqv>(Match:D \a, Match:D \b) {

--- a/src/core.c/Str.pm6
+++ b/src/core.c/Str.pm6
@@ -1175,10 +1175,6 @@ my class Str does Stringy { # declared in BOOTSTRAP
             matches))
     }
 
-    proto method subst(|) {
-        $/ := nqp::getlexcaller('$/');
-        {*}
-    }
     multi method subst(Str:D: Str:D $original, Str:D $final, *%options) {
         nqp::if(
           (my $opts := nqp::getattr(%options,Map,'$!storage'))

--- a/src/core.c/Str.pm6
+++ b/src/core.c/Str.pm6
@@ -1175,7 +1175,7 @@ my class Str does Stringy { # declared in BOOTSTRAP
             matches))
     }
 
-    multi method subst(Str:D: Str:D $original, Str:D $final, *%options) {
+    multi method subst(Str:D: Str:D $original, Str:D $final = "", *%options) {
         nqp::if(
           (my $opts := nqp::getattr(%options,Map,'$!storage'))
             && nqp::isgt_i(nqp::elems($opts),1),
@@ -1195,7 +1195,7 @@ my class Str does Stringy { # declared in BOOTSTRAP
           )
         )
     }
-    multi method subst(Str:D: $matcher, $replacement, *%options) {
+    multi method subst(Str:D: $matcher, $replacement = "", *%options) {
         self!SUBST(nqp::getlexcaller('$/'), $matcher, $replacement, |%options)
     }
     method !SUBST(Str:D: \caller_dollar_slash, $matcher, $replacement,

--- a/src/core.c/core_epilogue.pm6
+++ b/src/core.c/core_epilogue.pm6
@@ -29,6 +29,9 @@ BEGIN {
     Rakudo::Internals.REGISTER-DYNAMIC: '$*PERL', {
         PROCESS::<$PERL> := Perl.new;
     }
+    Rakudo::Internals.REGISTER-DYNAMIC: '$*RAKU', {
+        PROCESS::<$RAKU> := Perl.new;
+    }
 }
 
 # temporary fix for R#2640


### PR DESCRIPTION
Add Match.subst($replacement) for easier replacing
    
Basically replace the part that matched by the replacement string and return that.  This basically allows the result of a match to be used in a condition, and then do a replacement and possibly other stuff without having to do the match again:
    
        if "foo".match( / o / ) -> $match {
            say $match.subst("x");   # fxo
            # do other stuff if we found a match
        }
