### PR TITLE
Some more s/Perl 6/Raku changes

### DIFF
--- a/src/core.c/CompUnit/Repository/Perl5.pm6
+++ b/src/core.c/CompUnit/Repository/Perl5.pm6
@@ -26,7 +26,7 @@ class CompUnit::Repository::Perl5 does CompUnit::Repository {
 
             CATCH {
                 when X::CompUnit::UnsatisfiedDependency {
-                    X::NYI::Available.new(:available('Inline::Perl5'), :feature('Perl 5')).throw;
+                    X::NYI::Available.new(:available('Inline::Perl5'), :feature('Perl')).throw;
                 }
             }
         }

--- a/src/core.c/Exception.pm6
+++ b/src/core.c/Exception.pm6
@@ -850,8 +850,8 @@ my class X::Worry is Exception { }
 my class X::Worry::P5 is X::Worry { }
 my class X::Worry::P5::Reference is X::Worry::P5 {
     method message {
-q/To pass an array, hash or sub to a function in Perl 6, just pass it as is.
-For other uses of Perl 5's ref operator consider binding with ::= instead.
+q/To pass an array, hash or sub to a function in Raku, just pass it as is.
+For other uses of Perl's ref operator consider binding with ::= instead.
 Parenthesize as \\(...) if you intended a capture of a single variable./
     }
 }
@@ -1091,7 +1091,7 @@ my class X::Undeclared::Symbols does X::Comp {
             $r ~= "Undeclared routine" ~ (%.unk_routines.elems == 1 ?? "" !! "s") ~ ":\n";
             for %.unk_routines.sort(*.key) {
                 $r ~= "    $_.key() &l($_.value)";
-                $r ~= " (in Perl 6 please use " ~ $obs{$_.key()} ~ " instead)" if $obs{$_.key()};
+                $r ~= " (in Raku please use " ~ $obs{$_.key()} ~ " instead)" if $obs{$_.key()};
                 if +%.routine_suggestion{$_.key()}.list {
                     $r ~= ". " ~ s(%.routine_suggestion{$_.key()}.list);
                 }
@@ -1176,7 +1176,7 @@ my class X::Phaser::Multiple does X::Comp {
 my class X::Obsolete does X::Comp {
     has $.old;
     has $.replacement; # can't call it $.new, collides with constructor
-    has $.when = 'in Perl 6';
+    has $.when = 'in Raku';
     method message() { "Unsupported use of $.old; $.when please use $.replacement" }
 }
 
@@ -1435,7 +1435,7 @@ my class X::Syntax::ParentAsHash does X::Syntax {
 
 my class X::Syntax::Malformed::Elsif does X::Syntax {
     has $.what = 'else if';
-    method message() { qq{In Perl 6, please use "elsif' instead of "$.what"} }
+    method message() { qq{In Raku, please use "elsif' instead of "$.what"} }
 }
 
 my class X::Syntax::Reserved does X::Syntax {
@@ -1445,7 +1445,7 @@ my class X::Syntax::Reserved does X::Syntax {
 }
 
 my class X::Syntax::P5 does X::Syntax {
-    method message() { 'This appears to be Perl 5 code' }
+    method message() { 'This appears to be Perl code' }
 }
 
 my class X::Syntax::NegatedPair does X::Syntax {
@@ -1638,7 +1638,7 @@ my class X::Syntax::Perl5Var does X::Syntax {
         }
         $v
           ?? $sugg
-            ?? "Unsupported use of $name variable; in Perl 6 please use $sugg"
+            ?? "Unsupported use of $name variable; in Raku please use $sugg"
             !! "Unsupported use of $name variable"
           !! 'Weird unrecognized variable name: ' ~ $name;
     }

--- a/src/core.c/ForeignCode.pm6
+++ b/src/core.c/ForeignCode.pm6
@@ -32,7 +32,7 @@ proto sub EVAL(
   Bool()      :$check = False,
   *%_
 ) {
-    die "EVAL() in Perl 6 is intended to evaluate strings, did you mean 'try'?"
+    die "EVAL() in Raku is intended to evaluate strings, did you mean 'try'?"
       if nqp::istype($code,Callable);
     # First look in compiler registry.
     my $compiler := nqp::getcomp($lang);

--- a/src/core.c/Int.pm6
+++ b/src/core.c/Int.pm6
@@ -214,7 +214,7 @@ my class Int does Real { # declared in BOOTSTRAP
             when int32  { Range.new(         -2147483648, 2147483647         ) }
             when int16  { Range.new(              -32768, 32767              ) }
             when int8   { Range.new(                -128, 127                ) }
-            # Bring back in a future Perl 6 version, or just put on the type object
+            # Bring back in a future Raku version, or just put on the type object
             #when int4   { Range.new(                  -8, 7                  ) }
             #when int2   { Range.new(                  -2, 1                  ) }
             #when int1   { Range.new(                  -1, 0                  ) }
@@ -224,7 +224,7 @@ my class Int does Real { # declared in BOOTSTRAP
             when uint16 { Range.new( 0, 65535                ) }
             when uint8  { Range.new( 0, 255                  ) }
             when byte   { Range.new( 0, 255                  ) }
-            # Bring back in a future Perl 6 version, or just put on the type object
+            # Bring back in a future Raku version, or just put on the type object
             #when uint4  { Range.new( 0, 15                   ) }
             #when uint2  { Range.new( 0, 3                    ) }
             #when uint1  { Range.new( 0, 1                    ) }

--- a/src/core.c/IterationBuffer.pm6
+++ b/src/core.c/IterationBuffer.pm6
@@ -8,7 +8,7 @@
 # Hot-paths are free to use the nqp:: op set directly on this, and do things
 # outside the scope of the method API it exposes. This type is engineered for
 # performance over friendliness, and should not be encountered in normal use
-# of Perl 6. Do NOT add any checks and validation to methods in here. They
+# of Raku. Do NOT add any checks and validation to methods in here. They
 # need to remain trivially inlineable for performance reasons.
 my class IterationBuffer {
     method clear(IterationBuffer:D: --> Nil) {

--- a/src/core.c/Main.pm6
+++ b/src/core.c/Main.pm6
@@ -2,7 +2,7 @@
 # * Command-line parsing
 #   * Allow both = and space before argument of double-dash args
 #   * Comma-separated list values
-#   * Allow exact Perl 6 forms, quoted away from shell
+#   * Allow exact Raku forms, quoted away from shell
 # * Fix remaining XXXX
 
 my sub RUN-MAIN(&main, $mainline, :$in-as-argsfiles) {

--- a/src/core.c/Perl.pm6
+++ b/src/core.c/Perl.pm6
@@ -2,7 +2,7 @@ class Perl does Systemic {
     has Compiler $.compiler;
 
     submethod BUILD(
-      :$!name      = 'Perl 6',
+      :$!name      = 'Raku',
       :$!auth      = "The Perl Foundation",
       :$!version   = Version.new(nqp::p6box_s(nqp::getcomp('perl6').language_version())),
       :$!compiler  = Compiler.new,

--- a/src/core.c/Thread.pm6
+++ b/src/core.c/Thread.pm6
@@ -1,5 +1,5 @@
 # Thread represents an OS-level thread. While it could be used directly, it
-# is not the preferred way to work in Perl 6. It's a building block for the
+# is not the preferred way to work in Raku. It's a building block for the
 # interesting things.
 my class Thread {
     # The VM-level thread handle.

--- a/src/core.c/VM.pm6
+++ b/src/core.c/VM.pm6
@@ -23,7 +23,7 @@ class VM does Systemic {
     ) {
 #?if moar
         $!name           = 'moar';
-        $!desc           = $desc // 'Short for "Metamodel On A Runtime", MoarVM is a modern virtual machine built for the Rakudo Perl 6 compiler and the NQP Compiler Toolchain.';
+        $!desc           = $desc // 'Short for "Metamodel On A Runtime", MoarVM is a modern virtual machine built for the Rakudo Raku compiler and the NQP Compiler Toolchain.';
         $!auth           = "The MoarVM Team";
         $!version        = Version.new($!config<version> // "unknown");
         $!prefix         = $!config<prefix>;

--- a/src/core.c/asyncops.pm6
+++ b/src/core.c/asyncops.pm6
@@ -1,5 +1,5 @@
 # Waits for a promise to be kept or a channel to be able to receive a value
-# and, once it can, unwraps or returns the result. Under Perl 6.c, await will
+# and, once it can, unwraps or returns the result. Under Raku 6.c, await will
 # really block the calling thread. In 6.d, if the thread is on the thread pool
 # then a continuation will be taken, and the thread is freed up.
 

--- a/src/core.c/core_epilogue.pm6
+++ b/src/core.c/core_epilogue.pm6
@@ -27,10 +27,10 @@ BEGIN {
     # XXX TODO: https://github.com/rakudo/rakudo/issues/2433
     # my $perl := BEGIN Perl.new;
     Rakudo::Internals.REGISTER-DYNAMIC: '$*PERL', {
-        PROCESS::<$PERL> := Perl.new;
+        PROCESS::<$PERL> := Perl.new( :name<Perl> )
     }
     Rakudo::Internals.REGISTER-DYNAMIC: '$*RAKU', {
-        PROCESS::<$RAKU> := Perl.new;
+        PROCESS::<$RAKU> := Perl.new( :name<Raku> )
     }
 }
 


### PR DESCRIPTION
- $*RAKU now says "Raku" instead of "Perl", but $*PERL still says "Perl"
- Change various text references from "Perl 6" to "Raku"
- Change verious text references from "Perl 5" to "Perl"