### PR TITLE
Allow UInt to return a failure from Int

### DIFF
--- a/src/core.c/Cool.pm6
+++ b/src/core.c/Cool.pm6
@@ -370,7 +370,7 @@ my class Cool { # declared in BOOTSTRAP
     proto method UInt(|) {*}
     multi method UInt()  {
         my $got := self.Int;
-        $got < 0
+        $got ~~ Int && $got < 0
           ?? Failure.new(X::OutOfRange.new(
                :what('Coercion to UInt'),
                :$got,


### PR DESCRIPTION
Int can give a failure for e.g. `X::Str::Numeric`, which results in an exception when used with `< 0`. This is to check that `$got` actually contains an Int before checking that it is not negative.