### PR TITLE
Add tests for catching error at compile time

### DIFF
--- a/t/02-rakudo/13-exceptions.t
+++ b/t/02-rakudo/13-exceptions.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 1;
+plan 3;
 
 # GH #2739
 # Prior to the fix the original exception would be lost hidden under 'no handler found' error.
@@ -8,5 +8,14 @@ throws-like q<sub foo ( ::T $val ) { my T $a is default($val); }; foo(42)>,
         X::Parameter::Default::TypeCheck,
         "exception isn't lost",
         message => q<Default value '(Mu)' will never bind to a parameter of type T>;
+
+# RT #129812
+throws-like q[multi sub f(int $foo is rw) { }; f(42)],
+        X::Comp,
+        'calling multi sub that expects a rw native argument with a literal is caught at compile time';
+
+throws-like q[multi sub f(Int $foo is rw) { }; f(42)],
+        X::Comp,
+        'calling multi sub that expects a rw non-native argument with a literal is caught at compile time';
 
 done-testing;


### PR DESCRIPTION
The second new test refers to a change introduced with
https://github.com/rakudo/rakudo/pull/3231 (to fix RT #129812
on the JVM backend). The first new test only serves to
show that the native and the non-native case behaves identically.