### PR TITLE
Make a couple improvements to Metamodel::Naming

### DIFF
--- a/src/Perl6/Metamodel/Naming.nqp
+++ b/src/Perl6/Metamodel/Naming.nqp
@@ -1,38 +1,43 @@
 role Perl6::Metamodel::Naming {
     has $!name;
     has $!shortname;
-    method set_name($obj, $name) {
-        $!name := $name;
-        nqp::setdebugtypename($obj, $name);
-        if $name {
-            while (my int $colon := nqp::rindex($name, '::')) != -1 {
-                my int $paren := nqp::rindex($name, '[', $colon - 1);
-                my int $comma := nqp::rindex($name, ',', $colon - 1);
-                my int $chop-start :=
-                    ($paren < 0 && $comma < 0)
-                    ?? 0
-                    !! ($paren != -1 && $paren < $comma)
-                        ?? $comma + 1
-                        !! $paren + 1;
-                $name := nqp::concat(
-                    nqp::substr($name, 0, $chop-start),
-                    nqp::substr($name, $colon + 2)
-                );
-            }
 
-            $!shortname := $name;
-        }
-        else {
-            $!shortname := '';
-        }
-    }
-    method set_shortname($obj, $shortname) {
-        $!shortname := $shortname;
-    }
     method name($obj) {
         $!name // ($!name := '')
     }
+
+    method set_name($obj, $name) {
+        $!name      := $name;
+        $!shortname := NQPMu; # Gets set once it's needed.
+        nqp::setdebugtypename($obj, $name);
+    }
+
     method shortname($obj) {
-        $!shortname // ($!name := '')
+        sub to_shortname($name) {
+            return '' unless $name;
+
+            my $shortname := $name;
+            while (my int $colon := nqp::rindex($shortname, '::')) >= 0 {
+                my int $paren := nqp::rindex($shortname, '[', $colon - 1);
+                my int $comma := nqp::rindex($shortname, ',', $colon - 1);
+                my int $chop-start :=
+                    ($paren < 0 && $comma < 0)
+                    ?? 0
+                    !! ($paren >= 0 && $paren < $comma)
+                        ?? $comma + 1
+                        !! $paren + 1;
+                $shortname := nqp::concat(
+                    nqp::substr($shortname, 0, $chop-start),
+                    nqp::substr($shortname, $colon + 2)
+                );
+            }
+            $shortname
+        }
+
+        $!shortname // ($!shortname := to_shortname($!name))
+    }
+
+    method set_shortname($obj, $shortname) {
+        $!shortname := $shortname;
     }
 }

--- a/src/Perl6/Metamodel/Naming.nqp
+++ b/src/Perl6/Metamodel/Naming.nqp
@@ -30,9 +30,9 @@ role Perl6::Metamodel::Naming {
         $!shortname := $shortname;
     }
     method name($obj) {
-        $!name
+        $!name // ($!name := '')
     }
     method shortname($obj) {
-        $!shortname
+        $!shortname // ($!name := '')
     }
 }


### PR DESCRIPTION
The first is a bug fix. When working with the MOP directly, it's possible to end up with `NQPMu` when calling `Metamodel::Naming`'s `name` or `shortname` methods. They now set and return an empty string if none is already set.

The second is an optimization to `set_name`. When calling it, it would create and set the shortname at the same time, but this isn't necessary to do until the `shortname` method is called. Handling it from there makes creating a new role named `Foo::Bar[Baz::Qux[Quux]]` around 5% faster.

Passes `make test` and `make spectest`.