### PR TITLE
Make Parameter's BUILD use named args

### DIFF
--- a/src/core.c/Parameter.pm6
+++ b/src/core.c/Parameter.pm6
@@ -90,15 +90,15 @@ my class Parameter { # declared in BOOTSTRAP
     }
 
     submethod BUILD(
-       Str:D $name      is copy = "",
-       Int:D $flags     is copy = 0,
-      Bool:D $named     is copy = False,
-      Bool:D $optional  is copy = False,
-      Bool:D $mandatory is copy = False,
-      Bool:D $is-copy = False,
-      Bool:D $is-raw = False,
-      Bool:D $is-rw = False,
-      Bool:D $multi-invocant = True,
+       Str:D :$name      is copy = "",
+       Int:D :$flags     is copy = 0,
+      Bool:D :$named     is copy = False,
+      Bool:D :$optional  is copy = False,
+      Bool:D :$mandatory is copy = False,
+      Bool:D :$is-copy = False,
+      Bool:D :$is-raw = False,
+      Bool:D :$is-rw = False,
+      Bool:D :$multi-invocant = True,
              *%args  # type / default / where / sub_signature captured through %_
       ) {
 

--- a/t/02-rakudo/99-misc.t
+++ b/t/02-rakudo/99-misc.t
@@ -2,7 +2,7 @@ use lib <t/packages/>;
 use Test;
 use Test::Helpers;
 
-plan 10;
+plan 11;
 
 subtest '.lang-ver-before method on Perl6::World' => {
     plan 5;
@@ -154,3 +154,5 @@ class ParameterChild is Parameter {
     has $.foobar
 }
 is ParameterChild.new(foobar => 'Baz').foobar, 'Baz', 'Subclassing of Parameter works';
+
+is Parameter.new(:name('$a'), :type(Int), :optional).perl, 'Int $a?', 'Parameter takes by-name parameters itself';


### PR DESCRIPTION
Between 3d3578 and d31fb2, the by-name marker has been lost.
This commit restores it, allowing a Parameter to be constructed
manually.