### PR TITLE
Change the way compiler version is chosen for COREs

### DIFF
--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -784,7 +784,6 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         :my $*NEXT_STATEMENT_ID := 1;              # to give each statement an ID
         :my $*IN_STMT_MOD := 0;                    # are we inside a statement modifier?
         :my $*COMPILING_CORE_SETTING := 0;         # are we compiling CORE.setting?
-        # TODO XXX: see https://github.com/rakudo/rakudo/issues/2432
         :my $*SET_DEFAULT_LANG_VER := 1;
         :my %*SIG_INFO;                            # information about recent signature
         :my $*CAN_LOWER_TOPIC := 1;                # true if we optimize the $_ lexical away

--- a/src/Perl6/Metamodel/LanguageRevision.nqp
+++ b/src/Perl6/Metamodel/LanguageRevision.nqp
@@ -19,7 +19,7 @@ role Perl6::Metamodel::LanguageRevision
             # language_version method report wrong version.
             my $rev;
             if $*W {
-                $rev := $*W.find_symbol(['CORE-SETTING-REV'], :setting-only);
+                $rev := $*W.find_symbol(['CORE-SETTING-REV'], :setting-only) || $*W.setting_revision;
             }
             $ver := nqp::p6clientcorever()                      # 1st: try the run-time code
                     || ($rev && '6.' ~ $rev)                    # 2nd: compile-time if CORE is available


### PR DESCRIPTION
Compiling a CORE with version lower than default can cause performance
degradation because not all current optimizations would be used. Thus,
the previous decision of compiling each core with corresponding compiler
considered erroneous.

On the other hand, the next revision core is better be compiled with
its respective compiler version to have additional testing.

For these reasons, compiler version is now set using core revision if
it's higher than the default language version; and set to the default
otherwise.

Additionally, `World` now remembers the revision of the currently
compiled `CORE` to provide correct versioning for core classes.

Should fix rakudo/rakudo#3326