### PR TITLE
Fix "unused variable" compiler warnings in C ops

### DIFF
--- a/src/vm/moar/ops/perl6_ops.c
+++ b/src/vm/moar/ops/perl6_ops.c
@@ -21,17 +21,10 @@
 #define GET_REG(tc, idx)    (*tc->interp_reg_base)[*((MVMuint16 *)(cur_op + idx))]
 #define REAL_BODY(tc, obj)  MVM_p6opaque_real_data(tc, OBJECT_BODY(obj))
 
-/* Dummy zero and one-arg callsite. */
+/* Dummy zero and one-str callsite. */
 static MVMCallsite      no_arg_callsite = { NULL, 0, 0, 0, 0, 0, NULL, NULL };
-static MVMCallsiteEntry one_arg_flags[] = { MVM_CALLSITE_ARG_OBJ };
-static MVMCallsite     one_arg_callsite = { one_arg_flags, 1, 1, 1, 0, 0, NULL, NULL };
 static MVMCallsiteEntry one_str_flags[] = { MVM_CALLSITE_ARG_STR };
 static MVMCallsite     one_str_callsite = { one_str_flags, 1, 1, 1, 0, 0, NULL, NULL };
-
-/* Assignment type check failed callsite. */
-static MVMCallsiteEntry atcf_flags[] = { MVM_CALLSITE_ARG_STR, MVM_CALLSITE_ARG_OBJ, 
-                                         MVM_CALLSITE_ARG_OBJ };
-static MVMCallsite     atcf_callsite = { atcf_flags, 3, 3, 3, 0, 0, NULL, NULL };
 
 /* Dispatcher vivify_for callsite. */
 static MVMCallsiteEntry disp_flags[] = { MVM_CALLSITE_ARG_OBJ, MVM_CALLSITE_ARG_OBJ, 


### PR DESCRIPTION
Rakudo builds ok and passes `make m-test m-spectest`.