### PR TITLE
Prevent silently swallowing errors on submodule update

### DIFF
--- a/Configure.pl
+++ b/Configure.pl
@@ -30,6 +30,12 @@ qx{git submodule sync --quiet 3rdparty/nqp-configure && git submodule --quiet up
                       . ">>> Please delete the following folder and try again:\n$1\n\n";
                     exit 1;
                 }
+                else {
+                    print "\n===SORRY=== ERROR: "
+                      . "Updating the submodule failed for an unknown reason. The error message was:\n"
+                      . $msg;
+                    exit 1;
+                }
             }
         }
         if ($set_config) {


### PR DESCRIPTION
I'm currently tracking down [this rakudobrew bug](https://github.com/tadzik/rakudobrew/issues/151) and noticed that Configure.pl seems to silently ignore nqp-configure submodule update failures. This PR should hopefully make this more vocal.

@vrurg: I'm not entirely sure the ignoring of errors wasn't on purpose. (Maybe it's totally fine for this to fail in some cases?) So can you give a quick look?