### PR TITLE
Correct eqv between non-Positional Iterables

### DIFF
--- a/src/core.c/Mu.pm6
+++ b/src/core.c/Mu.pm6
@@ -1015,40 +1015,6 @@ multi sub infix:<eqv>(Any:D \a, Any:D \b) {
     )
 }
 
-multi sub infix:<eqv>(Iterable:D \a, Iterable:D \b) {
-    nqp::hllbool(
-      nqp::unless(
-        nqp::eqaddr(nqp::decont(a),nqp::decont(b)),
-        nqp::if(                                 # not same object
-          nqp::eqaddr(a.WHAT,b.WHAT),
-          nqp::if(                               # same type
-            a.is-lazy,
-            nqp::if(                             # a lazy
-              b.is-lazy,
-              die(X::Cannot::Lazy.new: :action<eqv>) # a && b lazy
-            ),
-            nqp::if(                             # a NOT lazy
-              b.is-lazy,
-              0,                                 # b lazy
-              nqp::if(                           # a && b NOT lazy
-                nqp::iseq_i((my int $elems = a.elems),b.elems),
-                nqp::stmts(                      # same # elems
-                  (my int $i = -1),
-                  nqp::while(
-                    nqp::islt_i(($i = nqp::add_i($i,1)),$elems) # not exhausted
-                      && a.AT-POS($i) eqv b.AT-POS($i),         # still same
-                    nqp::null
-                  ),
-                  nqp::iseq_i($i,$elems)         # exhausted = success!
-                )
-              )
-            )
-          )
-        )
-      )
-    )
-}
-
 sub DUMP(|args (*@args, :$indent-step = 4, :%ctx?)) {
     my Mu $capture := nqp::usecapture();
     my Mu $topic   := nqp::captureposarg($capture, 0);


### PR DESCRIPTION
This resolves rakudo/issues/3346.

Note that I moved the `eqv` candidate to `Iterable` because `constant IterationEnd` is not defined inside `Mu`. It's also a more appropriate location from an architectural perspective.

Furthermore I did not modify the existing implementation for `Positional` iterables becomes some iterators appeared to be buggy.