### PR TITLE
[IP6NS Grant] Support basic usage of UNIX sockets over TCP with IO::Socket::INET

### DIFF
--- a/src/core.c/IO.pm6
+++ b/src/core.c/IO.pm6
@@ -9,6 +9,7 @@ enum SeekType (
   :SeekFromEnd(2),
 );
 enum ProtocolFamily (
+  :PF_UNSPEC(nqp::p6box_i(nqp::const::SOCKET_FAMILY_UNSPEC)),
   :PF_INET(nqp::p6box_i(nqp::const::SOCKET_FAMILY_INET)),
   :PF_INET6(nqp::p6box_i(nqp::const::SOCKET_FAMILY_INET6)),
   :PF_LOCAL(nqp::p6box_i(nqp::const::SOCKET_FAMILY_UNIX)),

--- a/src/core.c/IO/Socket/INET.pm6
+++ b/src/core.c/IO/Socket/INET.pm6
@@ -139,12 +139,12 @@ my class IO::Socket::INET does IO::Socket {
         self;
     }
 
-    method connect(IO::Socket::INET:U: Str() $host, Int() $port) {
-        self.new(:$host, :$port)
+    method connect(IO::Socket::INET:U: Str() $host, Int() $port, ProtocolFamily:D :$family = PF_UNSPEC) {
+        self.new(:$host, :$port, :family($family.value))
     }
 
-    method listen(IO::Socket::INET:U: Str() $localhost, Int() $localport) {
-        self.new(:$localhost, :$localport, :listen)
+    method listen(IO::Socket::INET:U: Str() $localhost, Int() $localport, ProtocolFamily:D :$family = PF_UNSPEC) {
+        self.new(:$localhost, :$localport, :family($family.value), :listen)
     }
 
     method accept() {

--- a/src/core.c/IO/Socket/INET.pm6
+++ b/src/core.c/IO/Socket/INET.pm6
@@ -61,6 +61,7 @@ my class IO::Socket::INET does IO::Socket {
                 $family == nqp::const::SOCKET_FAMILY_UNSPEC
              || $family == nqp::const::SOCKET_FAMILY_INET
              || $family == nqp::const::SOCKET_FAMILY_INET6
+             || $family == nqp::const::SOCKET_FAMILY_UNIX
         } = nqp::const::SOCKET_FAMILY_UNSPEC,
                *%rest,
         --> IO::Socket::INET:D) {
@@ -87,6 +88,7 @@ my class IO::Socket::INET does IO::Socket {
                $family == nqp::const::SOCKET_FAMILY_UNSPEC
             || $family == nqp::const::SOCKET_FAMILY_INET
             || $family == nqp::const::SOCKET_FAMILY_INET6
+            || $family == nqp::const::SOCKET_FAMILY_UNIX
         } = nqp::const::SOCKET_FAMILY_UNSPEC,
               *%rest,
         --> IO::Socket::INET:D) {

--- a/t/02-rakudo/03-corekeys-6c.t
+++ b/t/02-rakudo/03-corekeys-6c.t
@@ -602,6 +602,7 @@ my @expected = (
   Q{PF_LOCAL},
   Q{PF_MAX},
   Q{PF_UNIX},
+  Q{PF_UNSPEC},
   Q{PROCESS},
   Q{PROTO_TCP},
   Q{PROTO_UDP},

--- a/t/02-rakudo/03-corekeys-6d.t
+++ b/t/02-rakudo/03-corekeys-6d.t
@@ -602,6 +602,7 @@ my @expected = (
     Q{PF_LOCAL},
     Q{PF_MAX},
     Q{PF_UNIX},
+    Q{PF_UNSPEC},
     Q{PROCESS},
     Q{PROTO_TCP},
     Q{PROTO_UDP},

--- a/t/02-rakudo/03-corekeys-6e.t
+++ b/t/02-rakudo/03-corekeys-6e.t
@@ -603,6 +603,7 @@ my @expected = (
     Q{PF_LOCAL},
     Q{PF_MAX},
     Q{PF_UNIX},
+    Q{PF_UNSPEC},
     Q{PROCESS},
     Q{PROTO_TCP},
     Q{PROTO_UDP},

--- a/t/02-rakudo/03-corekeys.t
+++ b/t/02-rakudo/03-corekeys.t
@@ -604,6 +604,7 @@ my @allowed =
       Q{PF_LOCAL},
       Q{PF_MAX},
       Q{PF_UNIX},
+      Q{PF_UNSPEC},
       Q{PROCESS},
       Q{PROTO_TCP},
       Q{PROTO_UDP},

--- a/t/02-rakudo/04-settingkeys-6c.t
+++ b/t/02-rakudo/04-settingkeys-6c.t
@@ -602,6 +602,7 @@ my %allowed = (
     Q{PF_LOCAL},
     Q{PF_MAX},
     Q{PF_UNIX},
+    Q{PF_UNSPEC},
     Q{PROCESS},
     Q{PROTO_TCP},
     Q{PROTO_UDP},

--- a/t/02-rakudo/04-settingkeys-6e.t
+++ b/t/02-rakudo/04-settingkeys-6e.t
@@ -601,6 +601,7 @@ my %allowed = (
     Q{PF_LOCAL},
     Q{PF_MAX},
     Q{PF_UNIX},
+    Q{PF_UNSPEC},
     Q{PROCESS},
     Q{PROTO_TCP},
     Q{PROTO_UDP},


### PR DESCRIPTION
I mentioned on IRC that unlinking for bound sockets would be needed for this, but that can be prone to racing when other threads or processes get involved. If it's OK for people using `IO::Socket::INET` to be responsible for dealing with that problem, then MoarVM should be able to handle basic I/O with UNIX sockets on most platforms that support them with https://github.com/MoarVM/MoarVM/pull/1222.

Passes `make test` and `make spectest`. 