### PR TITLE
Fix for use of parametrics instead concretizations in BUILDPLAN

### DIFF
--- a/src/Perl6/Metamodel/BUILDPLAN.nqp
+++ b/src/Perl6/Metamodel/BUILDPLAN.nqp
@@ -201,14 +201,10 @@ role Perl6::Metamodel::BUILDPLAN {
 
     method ins_roles($obj, :$with-submethods-only = 0) {
         my @ins_roles;
-        my @target_roles := self.c3_merge([self.roles($obj, :local)]);
-        for @target_roles {
-            my @res := self.concretization_lookup($obj, $_, :local, :transitive);
-            my $conc := @res[0] ?? @res[1] !! $_;
-            my @croles := $conc.HOW.roles($conc, :!transitive);
-            for @croles -> $cr {
-                next if $with-submethods-only && !nqp::can($cr.HOW, 'submethod_table');
-                @ins_roles.push($cr);
+        if nqp::can(self, 'concretizations') {
+            for self.concretizations($obj, :local) {
+                next if $with-submethods-only && !nqp::can($_.HOW, 'submethod_table');
+                @ins_roles.push($_);
             }
         }
         @ins_roles

--- a/src/Perl6/Metamodel/ClassHOW.nqp
+++ b/src/Perl6/Metamodel/ClassHOW.nqp
@@ -95,7 +95,7 @@ class Perl6::Metamodel::ClassHOW
     method compose($the-obj, :$compiler_services) {
         my $obj := nqp::decont($the-obj);
 
-        self.set_language_version($the-obj);
+        self.set_language_version($obj);
 
         # Instantiate all of the roles we have (need to do this since
         # all roles are generic on ::?CLASS) and pass them to the

--- a/src/Perl6/Metamodel/Concretization.nqp
+++ b/src/Perl6/Metamodel/Concretization.nqp
@@ -25,8 +25,10 @@ role Perl6::Metamodel::Concretization {
         @conc := self.c3_merge(@conc) if $transitive;
         unless $local {
             for self.parents($obj, :local) {
-                for $_.HOW.concretizations($_, :$local, :$transitive) {
-                    nqp::push(@conc, $_)
+                if nqp::can($_.HOW, 'concretizations') {
+                    for $_.HOW.concretizations($_, :$local, :$transitive) {
+                        nqp::push(@conc, $_)
+                    }
                 }
             }
         }

--- a/src/Perl6/Metamodel/LanguageRevision.nqp
+++ b/src/Perl6/Metamodel/LanguageRevision.nqp
@@ -14,7 +14,7 @@ role Perl6::Metamodel::LanguageRevision
         }
         elsif nqp::getcomp('perl6') {
             # NOTE: It turns out that nqp::getcomp path for obtaining the language version isn't reliable as sometimes
-            # language_version method report wrong version.
+            # language_version method reports wrong version.
             my $rev;
             # $*W cannot be used at optimization stage.
             if $*W && !$*OPTIMIZER-SYMBOLS {


### PR DESCRIPTION
Wrong closures were causing `$?CLASS` and other typecaptures to be lost.

Fixes rakudo/rakudo#3365