### PR TITLE
Submethod resolution fix

### DIFF
--- a/src/Perl6/Metamodel/ParametricRoleHOW.nqp
+++ b/src/Perl6/Metamodel/ParametricRoleHOW.nqp
@@ -168,7 +168,7 @@ class Perl6::Metamodel::ParametricRoleHOW
             }
             if $error {
                 nqp::die("Could not instantiate role '" ~ self.name($obj)
-                         ~ "':\n" ~ nqp::getmessage($error))
+                         ~ "':\n" ~ (nqp::getpayload($error) || nqp::getmessage($error)))
             }
 
             # Use it to build a concrete role.

--- a/src/Perl6/Metamodel/ParametricRoleHOW.nqp
+++ b/src/Perl6/Metamodel/ParametricRoleHOW.nqp
@@ -168,10 +168,10 @@ class Perl6::Metamodel::ParametricRoleHOW
             }
             if $error {
                 nqp::die("Could not instantiate role '" ~ self.name($obj)
-                         ~ "':\n" ~ nqp::getpayload($error))
+                         ~ "':\n" ~ nqp::getmessage($error))
             }
 
-            # Use it to build concrete role.
+            # Use it to build a concrete role.
             $conc := self.specialize_with($obj, $conc, $type_env, @pos_args);
             nqp::if(
                 nqp::can($class.HOW, 'add_conc_to_cache'),

--- a/src/Perl6/Metamodel/RoleToClassApplier.nqp
+++ b/src/Perl6/Metamodel/RoleToClassApplier.nqp
@@ -38,6 +38,7 @@ my class RoleToClassApplier {
         else {
             $to_compose := $concrete.new_type();
             $to_compose_meta := $to_compose.HOW;
+            $to_compose_meta.set_language_revision($to_compose, $target.HOW.language-revision($target));
             for @roles {
                 $to_compose_meta.add_role($to_compose, $_);
             }

--- a/src/Perl6/Metamodel/RoleToRoleApplier.nqp
+++ b/src/Perl6/Metamodel/RoleToRoleApplier.nqp
@@ -157,6 +157,7 @@ my class RoleToRoleApplier {
                 for $how.multi_methods_to_incorporate($role) {
                     my $name := $_.name;
                     my $to_add := $_.code;
+                    next if !$with_submethods && nqp::istype($to_add, $submethod_type);
                     my $yada := 0;
                     try { $yada := $to_add.yada; }
                     if $yada {


### PR DESCRIPTION
Fix for `RoleToClassApplier` detecting submethods as conflicting in `6.e` despite of them not being composed into the target.