### PR TITLE
2019.12 release

### DIFF
--- a/docs/ChangeLog
+++ b/docs/ChangeLog
@@ -1,3 +1,110 @@
+New in 2019.12:
+  + Changes:
+    + A big overhaul of role applying rules and behavior or
+      submethods, constructors and destructors
+      [38c72649][a8f61882][cddcd46a][61d3aef2][27147ed0][cbc4b839]
+      [3f7caf57][f242bcfa][cd74a3a7][51055d0e][9369c68e][ad92abc3]
+      [00fec7c3][6f0dd1ea][c9ac15cb][cb903667][d89a0c92][a08e1ff5]
+      [c674a1d3][0654d3e5][fffb5c9c][232382f8][b47be208][44648fbe]
+      [c2d5c20c][48fc44c2][7afffd61][17537ab5][b1e288c3][32e210cd]
+      [fc4a5a3b][1e166e41][7a94c4e0][3eb63b3d][a4ad1a8e][526d38d4]
+      [9e4087e1][aeb10ef5][c4f1cff0][940bf4d8][1f620408][b83e069d]
+      [4d69fda5][c7a87053][13ae9298][0fb7a697][86b1ccbd][ca2cb4ab]
+      [e843fd20][a92ade48][bdcf3149][93d0575c][23191207][595e0ca3]
+      [2c4fa983][b51c1fc5][afcbeb59][eadc1582][548dea5f][1aad3481]
+      [4a962e07][1d1678a8][0b6a9343][bb2600d9][5d10e91c][139d528b]
+  + Deprecations:
+    + Made `PERL6_EXCEPTIONS_HANDLER` env variable deprecated and
+      scheduled for removal in 2020.11. `RAKU_EXCEPTIONS_HANDLER` must
+      be used instead [90408d18]
+  + Fixes:
+    + Fixed compile-time subroutine candidate matching when `is rw`
+      trait is used on JVM [12d4514a][fae105b0][73d5e74d][d81212b2]
+    + Improved error message for invalid Pod6 leading and trailing
+      declarator blocks [26f63ff7]
+    + Prevented `ASSIGN-POS` method on `Any` from decontainerizing,
+      allowing its correct overloading in roles [ed8f5141]
+    + Prevent `name` MOP method from returning a `NQPMu` when no name
+      is set by returning an empty string instead [dabf83a2]
+    + Fixed relocatability of bundled native libraries
+      [55b3ed56][0e4f8351]
+    + Made `Range.int-bounds(from,to)` always return correct result
+      [8c3f2927]
+    + Fixed a precompilation bug related to determining class language
+      version [15a55801]
+  + Additions:
+    + Allow user to retain formatting of Pod6 leading declarator
+      blocks (`#|`) using RAKUDO_POD_DECL_BLOCK_USER_FORMAT env var,
+      instead of always collapsing them into a single string. The
+      latter remains the default behavior [9a4c83af]
+    + Made `.perl` method call on signature of {...} display `$_`
+      variable from outer scope [e7c20386]
+    + Add `$*RAKU` variable [a05e169e]
+    + `Raku` is now allowed to be used as a language in EVAL
+      [1c5d010f]
+    + Add `:$match` named parameter to `comb` subroutine when called
+      on `Cool` object when the `$matcher` argument is a `Regex`
+      [dd2f072d][a9cd6404]
+    + Add `log2` subroutine, which accepts `Cool` and `Numeric`
+      arguments, as well as its method form (`Numeric.log2`)
+      [f6254be1]
+    + Allowed colon syntax on `$.foo` method, making `$.foo: 42` work
+      as well as equivalent `self.foo: 42`
+      does [4a1323ed][6abdf27a][0f86e49f]
+  + Removals:
+    + Removed deprecated `RAKUDO_EXCEPTIONS_HANDLER` env variable,
+      instead `RAKU_EXCEPTIONS_HANDLER` has to be used [90408d18]
+  + Build system:
+    + Renamed `PERL6_HOME` env var into `RAKUDO_HOME`, preserving
+      backward compatibility. Rakudo `Configure.pl` now accepts
+      `--rakudo-home` in addition to `--perl6-home` [7cfdd598]
+    + Add `--force-rebuild` command line option. Together with
+      `--gen-*` options is causes corresponding components to
+      recompile irrelevant to their existence and version
+      conformance [15255b0a][2022b9cd][1945b9d2]
+    + Fix `set-env.sh` script [0b8ede6c]
+    + Fix `raku` symlinks relocability [a00628e0]
+    + Prevent silently swallowing errors on submodule update
+      [db43d134]
+    + Use Visual Studio 2017 in AppVeyor [7ecc5bfd][7ce49472]
+    + Various tweaks and small improvements
+      [75056dfa][8b7d0651][52a7bab9][d7d9a2f4][470c9b7e]
+  + Efficiency:
+    + Made `Str.chomp` between 10x and 100x faster [b9c0196f]
+    + Made `Str.chop(N)` between 3x and 17x faster [b569e112]
+    + Made `Str.chop` between 1.8x and 30x faster [f1963623]
+    + Made `Str.trim-trailing` up to 2x as fast [657d36f1]
+    + Made `Str.trim` between 1.5x and 3x faster [0d0d419f]
+    + Made `Str.substr(N)` between 1.5 and 3x faster [4252a8c9]
+    + Made `Str.substr(N,M)` about 1.5x faster [908dd251]
+    + Made `Str.substr(N, Inf)` about 15% faster [25a29987]
+    + Made `Str.trim-leading` between 20x and 90x faster [3941fef0]
+    + Made `Str.parse-base` between 7x (with decimal point) and 12x
+      (without) faster, decreased its memory pressure
+      [74c8017c][3ce92453][9b8ce733]
+    + Made `Str.Numeric` a few percent faster and 13x faster for an
+      empty string [37474a7a]
+    + Made Str.Int a few percent faster [b42957cc]
+    + Made DateTime.new(epoch) about 20% faster [9d895914]
+    + Made DateTime.new($epoch) about 50% faster [cd321254]
+    + Made the decont operator about 20x faster [872cb7c0]
+    + Improved efficiency of JIT for `split` subroutine [3e2cfb4d]
+    + Fix regression in performance of async socket [4e9487ce]
+    + Micro-optimize `set_name` MOP method [88741d94]
+    + Numerous micro-optimizations
+      [f5583de4][05aff922][488f21a6][9c15d717][6c85e691][60a9ff62]
+  + Internal:
+    + Removed SUBSTR-(START|CHARS)-OOR from Rakudo::Internals, they
+      are now `Str` private methods [ab99c2dd]
+    + Simplify `Str.substr` implementation
+      [99a0610a][1a891062][e3426579][f79102fa]
+    + Fixed some regressions related to `v6.e.PREVIEW` usage
+      [6c251f27][8d03bdff][94b4ca96][466f7de4][65847f71][a59fec7f][755c8030][0d2eb1cb]
+    + Numerous small codebase improvements
+      [8f30cc76][fc309419][540162c1][6a129499][1003bb93][1d8d62d4]
+      [68cee0dd][2652d9c5][f9e30a02][ee66a6b1][a04af365][11808277]
+      [0e2485a8]
+
 New in 2019.11:
   + SPECIAL NOTES:
     + Perl 6 is now Raku! This release comes with initial changes

--- a/docs/announce/2019.12.md
+++ b/docs/announce/2019.12.md
@@ -128,7 +128,7 @@ This release implements 6.c and 6.d versions of the Raku specification.
 6.c version of the language is available if you use the `use v6.c`
 version pragma, otherwise 6.d is the default.
 
-Upcoming releases in 2019 will include new functionality that is not
+Upcoming releases in 2020 will include new functionality that is not
 part of 6.c or 6.d specifications, available with a lexically scoped
 pragma. Our goal is to ensure that anything that is tested as part of
 6.c and 6.d specifications will continue to work unchanged. There may

--- a/docs/announce/2019.12.md
+++ b/docs/announce/2019.12.md
@@ -1,0 +1,159 @@
+# Announce: Rakudo compiler, Release #133 (2019.12)
+
+On behalf of the Rakudo development team, I’m very happy to announce the
+December 2019 release of Rakudo #133. Rakudo is an implementation of
+the Raku[^1] language.
+
+The source tarball for this release is available from
+<https://rakudo.org/files/rakudo>.
+Pre-compiled archives will be available shortly.
+
+New in 2019.12:
+  + Changes:
+    + A big overhaul of role applying rules and behavior or
+      submethods, constructors and destructors
+      [38c72649][a8f61882][cddcd46a][61d3aef2][27147ed0][cbc4b839]
+      [3f7caf57][f242bcfa][cd74a3a7][51055d0e][9369c68e][ad92abc3]
+      [00fec7c3][6f0dd1ea][c9ac15cb][cb903667][d89a0c92][a08e1ff5]
+      [c674a1d3][0654d3e5][fffb5c9c][232382f8][b47be208][44648fbe]
+      [c2d5c20c][48fc44c2][7afffd61][17537ab5][b1e288c3][32e210cd]
+      [fc4a5a3b][1e166e41][7a94c4e0][3eb63b3d][a4ad1a8e][526d38d4]
+      [9e4087e1][aeb10ef5][c4f1cff0][940bf4d8][1f620408][b83e069d]
+      [4d69fda5][c7a87053][13ae9298][0fb7a697][86b1ccbd][ca2cb4ab]
+      [e843fd20][a92ade48][bdcf3149][93d0575c][23191207][595e0ca3]
+      [2c4fa983][b51c1fc5][afcbeb59][eadc1582][548dea5f][1aad3481]
+      [4a962e07][1d1678a8][0b6a9343][bb2600d9][5d10e91c][139d528b]
+  + Deprecations:
+    + Made `PERL6_EXCEPTIONS_HANDLER` env variable deprecated and
+      scheduled for removal in 2020.11. `RAKU_EXCEPTIONS_HANDLER` must
+      be used instead [90408d18]
+  + Fixes:
+    + Fixed compile-time subroutine candidate matching when `is rw`
+      trait is used on JVM [12d4514a][fae105b0][73d5e74d][d81212b2]
+    + Improved error message for invalid Pod6 leading and trailing
+      declarator blocks [26f63ff7]
+    + Prevented `ASSIGN-POS` method on `Any` from decontainerizing,
+      allowing its correct overloading in roles [ed8f5141]
+    + Prevent `name` MOP method from returning a `NQPMu` when no name
+      is set by returning an empty string instead [dabf83a2]
+    + Fixed relocatability of bundled native libraries
+      [55b3ed56][0e4f8351]
+    + Made `Range.int-bounds(from,to)` always return correct result
+      [8c3f2927]
+    + Fixed a precompilation bug related to determining class language
+      version [15a55801]
+  + Additions:
+    + Allow user to retain formatting of Pod6 leading declarator
+      blocks (`#|`) using RAKUDO_POD_DECL_BLOCK_USER_FORMAT env var,
+      instead of always collapsing them into a single string. The
+      latter remains the default behavior [9a4c83af]
+    + Made `.perl` method call on signature of {...} display `$_`
+      variable from outer scope [e7c20386]
+    + Add `$*RAKU` variable [a05e169e]
+    + `Raku` is now allowed to be used as a language in EVAL
+      [1c5d010f]
+    + Add `:$match` named parameter to `comb` subroutine when called
+      on `Cool` object when the `$matcher` argument is a `Regex`
+      [dd2f072d][a9cd6404]
+    + Add `log2` subroutine, which accepts `Cool` and `Numeric`
+      arguments, as well as its method form (`Numeric.log2`)
+      [f6254be1]
+    + Allowed colon syntax on `$.foo` method, making `$.foo: 42` work
+      as well as equivalent `self.foo: 42`
+      does [4a1323ed][6abdf27a][0f86e49f]
+  + Removals:
+    + Removed deprecated `RAKUDO_EXCEPTIONS_HANDLER` env variable,
+      instead `RAKU_EXCEPTIONS_HANDLER` has to be used [90408d18]
+  + Build system:
+    + Renamed `PERL6_HOME` env var into `RAKUDO_HOME`, preserving
+      backward compatibility. Rakudo `Configure.pl` now accepts
+      `--rakudo-home` in addition to `--perl6-home` [7cfdd598]
+    + Add `--force-rebuild` command line option. Together with
+      `--gen-*` options is causes corresponding components to
+      recompile irrelevant to their existence and version
+      conformance [15255b0a][2022b9cd][1945b9d2]
+    + Fix `set-env.sh` script [0b8ede6c]
+    + Fix `raku` symlinks relocability [a00628e0]
+    + Prevent silently swallowing errors on submodule update
+      [db43d134]
+    + Use Visual Studio 2017 in AppVeyor [7ecc5bfd][7ce49472]
+    + Various tweaks and small improvements
+      [75056dfa][8b7d0651][52a7bab9][d7d9a2f4][470c9b7e]
+  + Efficiency:
+    + Made `Str.chomp` between 10x and 100x faster [b9c0196f]
+    + Made `Str.chop(N)` between 3x and 17x faster [b569e112]
+    + Made `Str.chop` between 1.8x and 30x faster [f1963623]
+    + Made `Str.trim-trailing` up to 2x as fast [657d36f1]
+    + Made `Str.trim` between 1.5x and 3x faster [0d0d419f]
+    + Made `Str.substr(N)` between 1.5 and 3x faster [4252a8c9]
+    + Made `Str.substr(N,M)` about 1.5x faster [908dd251]
+    + Made `Str.substr(N, Inf)` about 15% faster [25a29987]
+    + Made `Str.trim-leading` between 20x and 90x faster [3941fef0]
+    + Made `Str.parse-base` between 7x (with decimal point) and 12x
+      (without) faster, decreased its memory pressure
+      [74c8017c][3ce92453][9b8ce733]
+    + Made `Str.Numeric` a few percent faster and 13x faster for an
+      empty string [37474a7a]
+    + Made Str.Int a few percent faster [b42957cc]
+    + Made DateTime.new(epoch) about 20% faster [9d895914]
+    + Made DateTime.new($epoch) about 50% faster [cd321254]
+    + Made the decont operator about 20x faster [872cb7c0]
+    + Improved efficiency of JIT for `split` subroutine [3e2cfb4d]
+    + Fix regression in performance of async socket [4e9487ce]
+    + Micro-optimize `set_name` MOP method [88741d94]
+    + Numerous micro-optimizations
+      [f5583de4][05aff922][488f21a6][9c15d717][6c85e691][60a9ff62]
+  + Internal:
+    + Removed SUBSTR-(START|CHARS)-OOR from Rakudo::Internals, they
+      are now `Str` private methods [ab99c2dd]
+    + Simplify `Str.substr` implementation
+      [99a0610a][1a891062][e3426579][f79102fa]
+    + Fixed some regressions related to `v6.e.PREVIEW` usage
+      [6c251f27][8d03bdff][94b4ca96][466f7de4][65847f71][a59fec7f][755c8030][0d2eb1cb]
+    + Numerous small codebase improvements
+      [8f30cc76][fc309419][540162c1][6a129499][1003bb93][1d8d62d4]
+      [68cee0dd][2652d9c5][f9e30a02][ee66a6b1][a04af365][11808277]
+      [0e2485a8]
+
+
+The following people contributed to this release:
+
+Vadim Belman, Stefan Seifert, Elizabeth Mattijsen, Daniel Green,
+Patrick Böker, Aleks-Daniel Jakimenko-Aleksejev, Juan Julián Merelo
+Guervós, Stoned Elipot, Will "Coke" Coleda, Tom Browder, Paweł Murias,
+Alexander Kiryuhin, Ben Davies, Bahtiar Gadimov, Timo Paulssen,
+Jan-Olof Hendig, Nguyễn Gia Phong, Richard Hainsworth
+
+This release implements 6.c and 6.d versions of the Raku specification.
+6.c version of the language is available if you use the `use v6.c`
+version pragma, otherwise 6.d is the default.
+
+Upcoming releases in 2019 will include new functionality that is not
+part of 6.c or 6.d specifications, available with a lexically scoped
+pragma. Our goal is to ensure that anything that is tested as part of
+6.c and 6.d specifications will continue to work unchanged. There may
+be incremental spec releases this year as well.
+
+If you would like to contribute or find out more information, visit
+<https://raku.org>, <https://rakudo.org/how-to-help>, ask on the
+<perl6-compiler@perl.org> mailing list, or ask on IRC #raku on freenode.
+
+Additionally, we invite you to make a donation to The Perl Foundation
+to sponsor Raku development: <https://donate.perlfoundation.org/>
+(put “Raku Core Development Fund” in the ‘Purpose’ text field)
+
+The next release of Rakudo (#134), is tentatively scheduled for 2020-01-18.
+
+A list of the other planned release dates is available in the
+“docs/release_guide.pod” file.
+
+The development team appreciates feedback! If you’re using Rakudo, do
+get back to us. Questions, comments, suggestions for improvements, cool
+discoveries, incredible hacks, or any other feedback – get in touch with
+us through (the above-mentioned) mailing list or IRC channel. Enjoy!
+
+Please note that recent releases have known issues running on the JVM.
+We are working to get the JVM backend working again but do not yet have
+an estimated delivery date.
+
+[^1]: See <https://raku.org/>


### PR DESCRIPTION
So what we have here:
* An announcement
* A changelog
* I can build and sign all artifacts just fine with `VERSION=2019.12 VERSION_MOAR=2019.11-94-g0e0f5bf6d BRANCH_ROAST=master BRANCH_RAKUDO=master BRANCH_NQP=master sake all`

We need:
* Blin started today still has 140 modules to check, no Fails yet. 237 ZefFailures so.
* A moarvm release.
* I haven't actually tested that, but I think I don't have scp access to `rakudo@rakudo.org` and `rakudo@www.p6c.org`. @rba?

The question is:

* How to describe the "big roles overhaul" more nicely? I don't think that linking to a blog post is a wise idea, yet I am not sure how to describe all the changes in a concise way. @vrurg?