### PR TITLE
Try matching parameters by their addresses

### DIFF
--- a/src/Perl6/Metamodel/CurriedRoleHOW.nqp
+++ b/src/Perl6/Metamodel/CurriedRoleHOW.nqp
@@ -224,7 +224,9 @@ class Perl6::Metamodel::CurriedRoleHOW
                     my int $i := -1;
                     my int $ok := 1;
                     while ($i := $i + 1) < $num_args {
-                        unless @!pos_args[$i].ACCEPTS(@try_args[$i]) {
+                        unless    nqp::eqaddr(nqp::decont(@!pos_args[$i]), nqp::decont(@try_args[$i]))
+                               || @!pos_args[$i].ACCEPTS(@try_args[$i])
+                        {
                             $ok := 0;
                             $i := $num_args;
                         }


### PR DESCRIPTION
Thus we can match a definite to itself and have `R[T:D] ~~ R[T:D]` in
cases where lhs comes from a class as a consumed role and has different
object id from rhs. For example, this solves `Array[Str:D] ~~
`Positional[Str:D]`.

rakudo/rakudo#3383