### PR TITLE
Attribute $!package fix

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -3750,7 +3750,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
                 has_accessor => $twigil eq '.',
                 container_descriptor => $descriptor,
                 type => %cont_info<bind_constraint>,
-                package => $*W.find_symbol(['$?CLASS']));
+                package => $*PACKAGE);
             if %cont_info<build_ast> {
                 %config<container_initializer> := $*W.create_thunk($/,
                     %cont_info<build_ast>);

--- a/src/Perl6/Metamodel/ParametricRoleHOW.nqp
+++ b/src/Perl6/Metamodel/ParametricRoleHOW.nqp
@@ -186,7 +186,7 @@ class Perl6::Metamodel::ParametricRoleHOW
         # the concrete role.
         for self.attributes($obj, :local(1)) {
             $conc.HOW.add_attribute($conc,
-                $_.is_generic ?? $_.instantiate_generic($type_env) !! $_);
+                $_.is_generic ?? $_.instantiate_generic($type_env) !! nqp::clone($_));
         }
 
         # Go through methods and instantiate them; we always do this

--- a/src/core.c/Attribute.pm6
+++ b/src/core.c/Attribute.pm6
@@ -15,9 +15,11 @@ my class Attribute { # declared in BOOTSTRAP
     #     has Mu $!why;
     #     has $!required;
     #     has Mu $!container_initializer;
-    #     has Attribute $!original; 
+    #     has Attribute $!original;
 
     method compose(Mu $package, :$compiler_services) {
+        # If we're originating from a role then $!package has to be adjusted for the new owner.
+        nqp::bindattr(self, Attribute, '$!package', nqp::decont($package));
         # Generate accessor method, if we're meant to have one.
         if self.has_accessor {
             my str $name   = nqp::unbox_s(self.name);


### PR DESCRIPTION
This fix guarantees that traits applied to attributes can now safely use `$attr.package` if applied to an attribute in a role. This code:

```perl6
multi trait_mod:<is> (Attribute:D $a, :$foo!) {
    note $a.package.^name;
}

role R {
    has $.a is foo;
}
```

without this PR outputs `$?CLASS`. With the PR it would output `R`, as actually expected.

This PR implements the fix by using `$*PACKAGE` instead of `$?CLASS` symbol to initialize attribute `package` at compilation time. The attribute is later changed to the actual class the attribute is being installed into.

Alternative path of resolving the problem would involve introduction of an additional symbol which would resolve to either `$?ROLE` or `$?CLASS` depending on the context. The `package` would be set to that symbol then. But this path is somewhat cumbersome and would introduce additional symbol into the user namespace.