### PR TITLE
Check type before looking for qualified method

### DIFF
--- a/src/core.c/Mu.pm6
+++ b/src/core.c/Mu.pm6
@@ -810,7 +810,8 @@ Perhaps it can be found at https://docs.perl6.org/type/$name"
                 }
                 $ctx := nqp::ctxouterskipthunks($ctx);
             } while $ctx && !$sym-found;
-            $meth = $caller-type.^find_method_qualified($type, $name) if $sym-found;
+            $meth = $caller-type.^find_method_qualified($type, $name)
+                if $sym-found && nqp::istype($caller-type, $type);
             $meth = self.^find_method_qualified($type, $name) unless $meth;
         }
 


### PR DESCRIPTION
This fixes a failing test in S12-methods/qualified.t on the JVM
backend. The code in src/vm/moar/spesh-plugins.nqp does a similiar
check before calling 'find_method_qualified'.

A somewhat golfed version of the failing test would be:

  role R  { method x { 'R::x'  } }
  class C { method x { self does R; self.R::x } }
  say C.new.x;

Running this code fails with

  No concretization found for R

instead of printing 'R::x' on the JVM backend.