### PR TITLE
Prioritize class attributes/method over those from roles

### DIFF
--- a/src/Perl6/Metamodel/ConcreteRoleHOW.nqp
+++ b/src/Perl6/Metamodel/ConcreteRoleHOW.nqp
@@ -63,7 +63,7 @@ class Perl6::Metamodel::ConcreteRoleHOW
     method compose($the-obj) {
         my $obj := nqp::decont($the-obj);
 
-        RoleToRoleApplier.apply($obj, self.roles_to_compose($obj));
+        Perl6::Metamodel::Configuration.role_to_role_applier_type.apply($obj, self.roles_to_compose($obj));
         for self.roles_to_compose($obj) {
             @!role_typecheck_list[+@!role_typecheck_list] := $_;
             for $_.HOW.role_typecheck_list($_) {

--- a/src/Perl6/Metamodel/Configuration.nqp
+++ b/src/Perl6/Metamodel/Configuration.nqp
@@ -25,4 +25,16 @@ class Perl6::Metamodel::Configuration {
             ?? $multi_sig_comparator($a, $b)
             !! 0
     }
+
+    my $role_to_class_applier_type := nqp::null();
+    method set_role_to_class_applier_type($rtca_type) {
+        $role_to_class_applier_type := $rtca_type;
+    }
+    method role_to_class_applier_type() { $role_to_class_applier_type }
+
+    my $role_to_role_applier_type := nqp::null();
+    method set_role_to_role_applier_type($rtra_type) {
+        $role_to_role_applier_type := $rtra_type;
+    }
+    method role_to_role_applier_type() { $role_to_role_applier_type }
 }

--- a/src/Perl6/Metamodel/MultiMethodContainer.nqp
+++ b/src/Perl6/Metamodel/MultiMethodContainer.nqp
@@ -2,6 +2,7 @@ role Perl6::Metamodel::MultiMethodContainer {
     # Set of multi-methods to incorporate. Not just the method handles;
     # each is a hash containing keys name and body.
     has @!multi_methods_to_incorporate;
+    has %!multi_candidate_names;
 
     # The proto we'll clone.
     my $autogen_proto;
@@ -26,6 +27,7 @@ role Perl6::Metamodel::MultiMethodContainer {
         my $how := MultiToIncorporate.HOW.WHAT;
         my $todo := MultiToIncorporate.new( :name($name), :code(nqp::decont($code_obj)) );
         @!multi_methods_to_incorporate[+@!multi_methods_to_incorporate] := $todo;
+        %!multi_candidate_names{$name} := 1;
         $code_obj;
     }
 
@@ -105,5 +107,10 @@ role Perl6::Metamodel::MultiMethodContainer {
             }
         }
         @!multi_methods_to_incorporate := [];
+        %!multi_candidate_names := nqp::hash();
+    }
+
+    method has_multi_candidate($obj, $name) {
+        %!multi_candidate_names{$name}
     }
 }

--- a/src/Perl6/Metamodel/ParametricRoleHOW.nqp
+++ b/src/Perl6/Metamodel/ParametricRoleHOW.nqp
@@ -186,7 +186,7 @@ class Perl6::Metamodel::ParametricRoleHOW
         # the concrete role.
         for self.attributes($obj, :local(1)) {
             $conc.HOW.add_attribute($conc,
-                $_.is_generic ?? $_.instantiate_generic($type_env) !! $_);
+                $_.is_generic ?? $_.instantiate_generic($type_env) !! nqp::clone($_));
         }
 
         # Go through methods and instantiate them; we always do this

--- a/src/Perl6/Metamodel/RoleToClassApplier.nqp
+++ b/src/Perl6/Metamodel/RoleToClassApplier.nqp
@@ -1,4 +1,9 @@
 my class RoleToClassApplier {
+    has $!target;
+    has $!to_compose;
+    has $!to_compose_meta;
+    has @!roles;
+
     sub has_method($target, $name, $local) {
         if $local {
             my %mt := nqp::hllize($target.HOW.method_table($target));
@@ -26,27 +31,27 @@ my class RoleToClassApplier {
         return nqp::existskey(%pmt, $name)
     }
 
-    method apply($target, @roles) {
+    method prepare($target, @roles) {
+        $!target := $target;
+        @!roles := @roles;
         # If we have many things to compose, then get them into a single helper
         # role first.
-        my $to_compose;
-        my $to_compose_meta;
         if +@roles == 1 {
-            $to_compose := @roles[0];
-            $to_compose_meta := $to_compose.HOW;
+            $!to_compose := @roles[0];
+            $!to_compose_meta := $!to_compose.HOW;
         }
         else {
-            $to_compose := $concrete.new_type();
-            $to_compose_meta := $to_compose.HOW;
-            $to_compose_meta.set_language_revision($to_compose, $target.HOW.language-revision($target));
+            $!to_compose := $concrete.new_type();
+            $!to_compose_meta := $!to_compose.HOW;
+            $!to_compose_meta.set_language_revision($!to_compose, $target.HOW.language-revision($target));
             for @roles {
-                $to_compose_meta.add_role($to_compose, $_);
+                $!to_compose_meta.add_role($!to_compose, $_);
             }
-            $to_compose := $to_compose_meta.compose($to_compose);
+            $!to_compose := $!to_compose_meta.compose($!to_compose);
         }
 
         # Collisions?
-        my @collisions := $to_compose_meta.collisions($to_compose);
+        my @collisions := $!to_compose_meta.collisions($!to_compose);
         for @collisions {
             if $_.private {
                 unless has_private_method($target, $_.name) {
@@ -84,11 +89,13 @@ my class RoleToClassApplier {
                 }
             }
         }
+    }
 
+    method apply() {
         my @stubs;
 
         # Starting with v6.e submethods must not be composed in from roles.
-        my $with_submethods := $target.HOW.lang-rev-before($target, 'e');
+        my $with_submethods := $!target.HOW.lang-rev-before($!target, 'e');
 
         # Compose in any methods.
         sub compose_method_table(@methods, @method_names) {
@@ -98,40 +105,40 @@ my class RoleToClassApplier {
                 my $yada := 0;
                 try { $yada := $method.yada }
                 if $yada {
-                    unless has_method($target, $name, 0)
-                            || $target.HOW.has_public_attribute($target, $name) {
+                    unless has_method($!target, $name, 0)
+                            || $!target.HOW.has_public_attribute($!target, $name) {
                         my @needed;
-                        for @roles {
+                        for @!roles {
                             for nqp::hllize($_.HOW.method_table($_)) -> $m {
                                 if $m.key eq $name {
                                     nqp::push(@needed, $_.HOW.name($_));
                                 }
                             }
                         }
-                        nqp::push(@stubs, nqp::hash('name', $name, 'needed', @needed, 'target', $target));
+                        nqp::push(@stubs, nqp::hash('name', $name, 'needed', @needed, 'target', $!target));
                     }
                 }
-                elsif !has_method($target, $name, 1)
+                elsif !has_method($!target, $name, 1)
                         && ($with_submethods
                             || !nqp::istype($method, Perl6::Metamodel::Configuration.submethod_type))
                 {
-                    $target.HOW.add_method($target, $name, $method);
+                    $!target.HOW.add_method($!target, $name, $method);
                 }
             }
         }
-        my @methods      := $to_compose_meta.method_order($to_compose);
-        my @method_names := $to_compose_meta.method_names($to_compose);
+        my @methods      := $!to_compose_meta.method_order($!to_compose);
+        my @method_names := $!to_compose_meta.method_names($!to_compose);
         compose_method_table(
             nqp::hllize(@methods),
             nqp::hllize(@method_names),
         );
-        if nqp::can($to_compose_meta, 'private_method_table') {
-            my @private_methods      := nqp::hllize($to_compose_meta.private_methods($to_compose));
-            my @private_method_names := nqp::hllize($to_compose_meta.private_method_names($to_compose));
+        if nqp::can($!to_compose_meta, 'private_method_table') {
+            my @private_methods      := nqp::hllize($!to_compose_meta.private_methods($!to_compose));
+            my @private_method_names := nqp::hllize($!to_compose_meta.private_method_names($!to_compose));
             my $i := 0;
             for @private_method_names -> str $name {
-                unless has_private_method($target, $name) {
-                    $target.HOW.add_private_method($target, $name, @private_methods[$i]);
+                unless has_private_method($!target, $name) {
+                    $!target.HOW.add_private_method($!target, $name, @private_methods[$i]);
                 }
                 $i++;
             }
@@ -139,8 +146,8 @@ my class RoleToClassApplier {
 
         # Compose in any multi-methods, looking for any requirements and
         # ensuring they are met.
-        if nqp::can($to_compose_meta, 'multi_methods_to_incorporate') {
-            my @multis := $to_compose_meta.multi_methods_to_incorporate($to_compose);
+        if nqp::can($!to_compose_meta, 'multi_methods_to_incorporate') {
+            my @multis := $!to_compose_meta.multi_methods_to_incorporate($!to_compose);
             my @required;
             for @multis -> $add {
                 my $yada := 0;
@@ -150,7 +157,7 @@ my class RoleToClassApplier {
                 }
                 else {
                     my $already := 0;
-                    for $target.HOW.multi_methods_to_incorporate($target) -> $existing {
+                    for $!target.HOW.multi_methods_to_incorporate($!target) -> $existing {
                         if $existing.name eq $add.name {
                             if Perl6::Metamodel::Configuration.compare_multi_sigs($existing.code, $add.code) {
                                 $already := 1;
@@ -159,12 +166,12 @@ my class RoleToClassApplier {
                         }
                     }
                     unless $already {
-                        $target.HOW.add_multi_method($target, $add.name, $add.code);
+                        $!target.HOW.add_multi_method($!target, $add.name, $add.code);
                     }
                 }
                 for @required -> $req {
                     my $satisfaction := 0;
-                    for $target.HOW.multi_methods_to_incorporate($target) -> $existing {
+                    for $!target.HOW.multi_methods_to_incorporate($!target) -> $existing {
                         if $existing.name eq $req.name {
                             if Perl6::Metamodel::Configuration.compare_multi_sigs($existing.code, $req.code) {
                                 $satisfaction := 1;
@@ -176,7 +183,7 @@ my class RoleToClassApplier {
                         my $name := $req.name;
                         my $sig := $req.code.signature.perl;
                         nqp::die("Multi method '$name' with signature $sig must be implemented by " ~
-                            $target.HOW.name($target) ~
+                            $!target.HOW.name($!target) ~
                             " because it is required by a role");
                     }
                 }
@@ -184,32 +191,34 @@ my class RoleToClassApplier {
         }
 
         # Compose in any role attributes.
-        my @attributes := $to_compose_meta.attributes($to_compose, :local(1));
+        my @attributes := $!to_compose_meta.attributes($!to_compose, :local(1));
         for @attributes {
-            if $target.HOW.has_attribute($target, $_.name) {
+            if $!target.HOW.has_attribute($!target, $_.name) {
                 nqp::die("Attribute '" ~ $_.name ~ "' already exists in the class '" ~
-                    $target.HOW.name($target) ~ "', but a role also wishes to compose it");
+                    $!target.HOW.name($!target) ~ "', but a role also wishes to compose it");
             }
-            $target.HOW.add_attribute($target, $_);
+            $!target.HOW.add_attribute($!target, $_);
         }
 
         # Compose in any parents.
-        if nqp::can($to_compose_meta, 'parents') {
-            my @parents := $to_compose_meta.parents($to_compose, :local(1));
+        if nqp::can($!to_compose_meta, 'parents') {
+            my @parents := $!to_compose_meta.parents($!to_compose, :local(1));
             for @parents {
-                $target.HOW.add_parent($target, $_, :hides($to_compose_meta.hides_parent($to_compose, $_)));
+                $!target.HOW.add_parent($!target, $_, :hides($!to_compose_meta.hides_parent($!to_compose, $_)));
             }
         }
 
         # Copy any array_type.
-        if nqp::can($target.HOW, 'is_array_type') && !$target.HOW.is_array_type($target) {
-            if nqp::can($to_compose_meta, 'is_array_type') {
-                if $to_compose_meta.is_array_type($to_compose) {
-                    $target.HOW.set_array_type($target, $to_compose_meta.array_type($to_compose));
+        if nqp::can($!target.HOW, 'is_array_type') && !$!target.HOW.is_array_type($!target) {
+            if nqp::can($!to_compose_meta, 'is_array_type') {
+                if $!to_compose_meta.is_array_type($!to_compose) {
+                    $!target.HOW.set_array_type($!target, $!to_compose_meta.array_type($!to_compose));
                 }
             }
         }
 
         @stubs;
     }
+
+    Perl6::Metamodel::Configuration.set_role_to_class_applier_type(RoleToClassApplier);
 }

--- a/src/Perl6/Metamodel/RoleToRoleApplier.nqp
+++ b/src/Perl6/Metamodel/RoleToRoleApplier.nqp
@@ -262,4 +262,6 @@ my class RoleToRoleApplier {
 
         1;
     }
+
+    Perl6::Metamodel::Configuration.set_role_to_role_applier_type(RoleToRoleApplier);
 }

--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -1426,6 +1426,7 @@ BEGIN {
     Attribute.HOW.add_attribute(Attribute, BOOTSTRAPATTR.new(:name<$!why>, :type(Mu), :package(Attribute)));
     Attribute.HOW.add_attribute(Attribute, BOOTSTRAPATTR.new(:name<$!container_initializer>, :type(Mu), :package(Attribute)));
     Attribute.HOW.add_attribute(Attribute, BOOTSTRAPATTR.new(:name<$!original>, :type(Attribute), :package(Attribute)));
+    Attribute.HOW.add_attribute(Attribute, BOOTSTRAPATTR.new(:name<$!composed>, :type(int), :package(Attribute)));
 
     # Need new and accessor methods for Attribute in here for now.
     Attribute.HOW.add_method(Attribute, 'new',

--- a/src/core.c/traits.pm6
+++ b/src/core.c/traits.pm6
@@ -18,7 +18,7 @@ multi sub trait_mod:<is>(Mu:U $child, Mu:U $parent) {
     }
     elsif $parent.HOW.archetypes.inheritalizable() {
         if nqp::can($parent.HOW, 'methods')
-            && my @required-methods = $parent.^methods.grep({$_.yada}) 
+            && my @required-methods = $parent.^methods.grep({$_.yada})
        {
             my $type = $child.HOW.archetypes.inheritable()
                 ?? 'Class '
@@ -425,7 +425,7 @@ multi sub trait_mod:<handles>(Attribute:D $target, $thunk) {
             $!handles := $expr;
         }
 
-        method add_delegator_method($attr: $pkg, $meth_name, $call_name) {
+        method add_delegator_method($attr: Mu $pkg, $meth_name, $call_name) {
             my $meth := method (|c) is rw {
                 $attr.get_value(self)."$call_name"(|c)
             };


### PR DESCRIPTION
When there is a name clash of a public attribute and a role method, don't let role override attribute accessor. In other words, whatever comes from a class has priority over role's stuff.

Fixes #3382 