### PR TITLE
Actually return found method

### DIFF
--- a/src/Perl6/Metamodel/ConcreteRoleHOW.nqp
+++ b/src/Perl6/Metamodel/ConcreteRoleHOW.nqp
@@ -152,7 +152,7 @@ class Perl6::Metamodel::ConcreteRoleHOW
                     || nqp::null();
         } elsif nqp::istype($obj, $qtype) {
             # Non-parametric, so just locate it from the already concrete type.
-            nqp::findmethod($qtype, $name)
+            return nqp::findmethod($qtype, $name)
         }
         nqp::null()
     }


### PR DESCRIPTION
I have to admit that I don't know what code would trigger this code.
But the missing 'return' was obviously an oversight (cmp. also
https://colabti.org/irclogger/irclogger_log/raku-dev?date=2020-01-02#l302).