### PR TITLE
Add an "is accessible" attribute to Attribute

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -3747,6 +3747,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
             my $metaattr := $*W.resolve_mo($/, $*PKGDECL ~ '-attr');
             my %config := hash(
                 name => $attrname,
+                is_settable => $twigil eq '.',
                 has_accessor => $twigil eq '.',
                 container_descriptor => $descriptor,
                 type => %cont_info<bind_constraint>,

--- a/src/Perl6/Metamodel/BUILDPLAN.nqp
+++ b/src/Perl6/Metamodel/BUILDPLAN.nqp
@@ -99,7 +99,7 @@ role Perl6::Metamodel::BUILDPLAN {
                 $primspec := $is_oversized_int ?? 0 !! $primspec;
 #?endif
 
-                if $_.has_accessor {
+                if $_.is_settable {
                     nqp::push(@plan,[
                       0 + $primspec,
                       $obj,

--- a/src/Perl6/Metamodel/Mixins.nqp
+++ b/src/Perl6/Metamodel/Mixins.nqp
@@ -103,7 +103,7 @@ role Perl6::Metamodel::Mixins {
         # if there is one.
         my $found;
         for $new_type.HOW.attributes($new_type, :local) {
-            if $_.has_accessor {
+            if $_.is_settable {
                 if $found {
                     $found := NQPMu;
                     last;

--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -29,6 +29,7 @@ my class BOOTSTRAPATTR {
     method package() { $!package }
     method inlined() { $!inlined }
     method dimensions() { $!dimensions }
+    method is_settable() { 0 }
     method has_accessor() { 0 }
     method positional_delegate() { 0 }
     method associative_delegate() { 0 }
@@ -1395,6 +1396,7 @@ BEGIN {
     # class Attribute is Any {
     #     has str $!name;
     #     has int $!rw;
+    #     has int $!is_settable;
     #     has int $!has_accessor;
     #     has Mu $!type;
     #     has Mu $!container_descriptor;
@@ -1413,6 +1415,7 @@ BEGIN {
     Attribute.HOW.add_attribute(Attribute, BOOTSTRAPATTR.new(:name<$!rw>, :type(int), :package(Attribute)));
     Attribute.HOW.add_attribute(Attribute, BOOTSTRAPATTR.new(:name<$!ro>, :type(int), :package(Attribute)));
     Attribute.HOW.add_attribute(Attribute, BOOTSTRAPATTR.new(:name<$!required>, :type(Mu), :package(Attribute)));
+    Attribute.HOW.add_attribute(Attribute, BOOTSTRAPATTR.new(:name<$!is_settable>, :type(int), :package(Attribute)));
     Attribute.HOW.add_attribute(Attribute, BOOTSTRAPATTR.new(:name<$!has_accessor>, :type(int), :package(Attribute)));
     Attribute.HOW.add_attribute(Attribute, BOOTSTRAPATTR.new(:name<$!type>, :type(Mu), :package(Attribute)));
     Attribute.HOW.add_attribute(Attribute, BOOTSTRAPATTR.new(:name<$!container_descriptor>, :type(Mu), :package(Attribute)));
@@ -1431,11 +1434,12 @@ BEGIN {
 
     # Need new and accessor methods for Attribute in here for now.
     Attribute.HOW.add_method(Attribute, 'new',
-        nqp::getstaticcode(sub ($self, :$name!, :$type!, :$package!, :$inlined = 0, :$has_accessor,
+        nqp::getstaticcode(sub ($self, :$name!, :$type!, :$package!, :$inlined = 0, :$is_settable, :$has_accessor,
                 :$positional_delegate = 0, :$associative_delegate = 0, *%other) {
             my $attr := nqp::create($self);
             nqp::bindattr_s($attr, Attribute, '$!name', $name);
             nqp::bindattr($attr, Attribute, '$!type', nqp::decont($type));
+            nqp::bindattr_i($attr, Attribute, '$!is_settable', $is_settable);
             nqp::bindattr_i($attr, Attribute, '$!has_accessor', $has_accessor);
             nqp::bindattr($attr, Attribute, '$!package', $package);
             nqp::bindattr_i($attr, Attribute, '$!inlined', $inlined);
@@ -1485,6 +1489,10 @@ BEGIN {
     Attribute.HOW.add_method(Attribute, 'auto_viv_container', nqp::getstaticcode(sub ($self) {
             nqp::getattr(nqp::decont($self),
                 Attribute, '$!auto_viv_container');
+        }));
+    Attribute.HOW.add_method(Attribute, 'is_settable', nqp::getstaticcode(sub ($self) {
+            nqp::hllboolfor(nqp::getattr_i(nqp::decont($self),
+                Attribute, '$!is_settable'), "perl6");
         }));
     Attribute.HOW.add_method(Attribute, 'has_accessor', nqp::getstaticcode(sub ($self) {
             nqp::hllboolfor(nqp::getattr_i(nqp::decont($self),

--- a/src/core.c/Attribute.pm6
+++ b/src/core.c/Attribute.pm6
@@ -2,6 +2,7 @@ my class Attribute { # declared in BOOTSTRAP
     # class Attribute is Any
     #     has str $!name;
     #     has int $!rw;
+    #     has int $!is_settable;
     #     has int $!has_accessor;
     #     has Mu $!type;
     #     has Mu $!container_descriptor;
@@ -240,6 +241,10 @@ multi sub trait_mod:<does>(Attribute:D $a, Mu:U $role) {
             composer    => $role,
         ).throw;
     }
+}
+
+multi sub trait_mod:<is>(Attribute:D $a, :$accessible!) {
+    nqp::bindattr_i($a,Attribute,'$!has_accessor',1)
 }
 
 # vim: ft=perl6 expandtab sw=4

--- a/src/core.c/Attribute.pm6
+++ b/src/core.c/Attribute.pm6
@@ -243,8 +243,15 @@ multi sub trait_mod:<does>(Attribute:D $a, Mu:U $role) {
     }
 }
 
-multi sub trait_mod:<is>(Attribute:D $a, :$accessible!) {
-    nqp::bindattr_i($a,Attribute,'$!has_accessor',1)
+multi sub trait_mod:<is>(Attribute:D $a, :$init!) {
+    if nqp::istype($init,Bool) {
+        nqp::bindattr_i($a,Attribute,'$!is_settable',+$init);
+    }
+#    elsif nqp::istype($init,Pair) {
+#    }
+    else {
+        die "Don't know how to handle 'is init($init)' trait";
+    }
 }
 
 # vim: ft=perl6 expandtab sw=4

--- a/src/core.c/Enumeration.pm6
+++ b/src/core.c/Enumeration.pm6
@@ -102,7 +102,7 @@ Metamodel::EnumHOW.set_composalizer(-> $type, $name, @enum_values {
     my Mu $r := Metamodel::ParametricRoleHOW.new_type(:name($name));
     $r.^add_attribute(Attribute.new(
         :name('$!' ~ $name), :type(nqp::decont($type)),
-        :has_accessor(1), :package($r)));
+        :is_settable(1), :has_accessor(1), :package($r)));
     for @enum_values {
         my $key   = $_.key;
         my $value = $_.value;

--- a/src/core.c/Mu.pm6
+++ b/src/core.c/Mu.pm6
@@ -645,7 +645,7 @@ Perhaps it can be found at https://docs.raku.org/type/$name"
             nqp::decont(self).raku,
             self.rakuseen: self.^name, {
                 my @attrs;
-                for self.^attributes().flat.grep: { .has_accessor } -> $attr {
+                for self.^attributes().flat.grep: { .is_settable } -> $attr {
                     my $name := substr($attr.Str,2);
                     @attrs.push: $name ~ ' => ' ~ $attr.get_value(self).raku
                 }


### PR DESCRIPTION
This allows you to define a private attribute in a class, yet have
an accessor automatically created for it (without it being settable
with .new):

    class A {
        has $!a is accessible = 42;
    }
    dd A.new(a => 666).a;   # 42