### PR TITLE
Allow Str.(r)index searches on character classes

### DIFF
--- a/src/core.c/core_epilogue.pm6
+++ b/src/core.c/core_epilogue.pm6
@@ -34,6 +34,85 @@ BEGIN {
     }
 }
 
+enum UnicodeClass (
+  AlphabeticChar   => nqp::hllize(nqp::const::CCLASS_ALPHABETIC),
+  AlphanumericChar => nqp::hllize(nqp::const::CCLASS_ALPHANUMERIC),
+  BlankChar        => nqp::hllize(nqp::const::CCLASS_BLANK),
+  ControlChar      => nqp::hllize(nqp::const::CCLASS_CONTROL),
+  HexadecimalChar  => nqp::hllize(nqp::const::CCLASS_HEXADECIMAL),
+  LowercaseChar    => nqp::hllize(nqp::const::CCLASS_LOWERCASE),
+  NewlineChar      => nqp::hllize(nqp::const::CCLASS_NEWLINE),
+  NumericChar      => nqp::hllize(nqp::const::CCLASS_NUMERIC),
+  PrintingChar     => nqp::hllize(nqp::const::CCLASS_PRINTING),
+  PunctuationChar  => nqp::hllize(nqp::const::CCLASS_PUNCTUATION),
+  UppercaseChar    => nqp::hllize(nqp::const::CCLASS_UPPERCASE),
+  WhitespaceChar   => nqp::hllize(nqp::const::CCLASS_WHITESPACE),
+  WordChar         => nqp::hllize(nqp::const::CCLASS_WORD),
+);
+
+enum NotUnicodeClass (
+  NotAlphabeticChar   => nqp::hllize(nqp::const::CCLASS_ALPHABETIC),
+  NotAlphanumericChar => nqp::hllize(nqp::const::CCLASS_ALPHANUMERIC),
+  NotBlankChar        => nqp::hllize(nqp::const::CCLASS_BLANK),
+  NotControlChar      => nqp::hllize(nqp::const::CCLASS_CONTROL),
+  NotHexadecimalChar  => nqp::hllize(nqp::const::CCLASS_HEXADECIMAL),
+  NotLowercaseChar    => nqp::hllize(nqp::const::CCLASS_LOWERCASE),
+  NotNewlineChar      => nqp::hllize(nqp::const::CCLASS_NEWLINE),
+  NotNumericChar      => nqp::hllize(nqp::const::CCLASS_NUMERIC),
+  NotPrintingChar     => nqp::hllize(nqp::const::CCLASS_PRINTING),
+  NotPunctuationChar  => nqp::hllize(nqp::const::CCLASS_PUNCTUATION),
+  NotUppercaseChar    => nqp::hllize(nqp::const::CCLASS_UPPERCASE),
+  NotWhitespaceChar   => nqp::hllize(nqp::const::CCLASS_WHITESPACE),
+  NotWordChar         => nqp::hllize(nqp::const::CCLASS_WORD),
+);
+
+augment class Str {
+    multi method index(Str:D: UnicodeClass \cclass --> Int:D) {
+        (my int $i = nqp::findcclass(
+          cclass.value,self,0,nqp::chars(self))
+        ) == nqp::chars(self)
+          ?? Nil !! $i
+    }
+    multi method index(Str:D: UnicodeClass \cclass, Int:D \pos --> Int:D) {
+        (my int $i = nqp::findcclass(
+          cclass.value,self,pos,nqp::chars(self))
+        ) == nqp::chars(self)
+          ?? Nil !! $i
+    }
+    multi method index(Str:D: NotUnicodeClass \cclass --> Int:D) {
+        (my int $i = nqp::findnotcclass(
+          cclass.value,self,0,nqp::chars(self))
+        ) == nqp::chars(self)
+          ?? Nil !! $i
+    }
+    multi method index(Str:D: NotUnicodeClass \cclass, Int:D \pos --> Int:D) {
+        (my int $i = nqp::findnotcclass(
+          cclass.value,self,pos,nqp::chars(self))
+        ) == nqp::chars(self)
+          ?? Nil !! $i
+    }
+    multi method rindex(Str:D: UnicodeClass \cclass --> Int:D) {
+        nqp::isconcrete(
+          my $i := nqp::flip(self).index(cclass)
+        ) ?? nqp::chars(self) - $i - 1 !! Nil
+    }
+    multi method rindex(Str:D: UnicodeClass \cclass, Int:D \pos --> Int:D) {
+        nqp::isconcrete(
+          my $i := nqp::flip(self).index(cclass, nqp::chars(self) - pos - 1)
+        ) ?? nqp::chars(self) - $i - 1 !! Nil
+    }
+    multi method rindex(Str:D: NotUnicodeClass \cclass --> Int:D) {
+        nqp::isconcrete(
+          my $i := nqp::flip(self).index(cclass)
+        ) ?? nqp::chars(self) - $i - 1 !! Nil
+    }
+    multi method rindex(Str:D: NotUnicodeClass \cclass, Int:D \pos --> Int:D) {
+        nqp::isconcrete(
+          my $i := nqp::flip(self).index(cclass, nqp::chars(self) - pos - 1)
+        ) ?? nqp::chars(self) - $i - 1 !! Nil
+    }
+}
+
 {YOU_ARE_HERE}
 
 # vim: ft=perl6 expandtab sw=4


### PR DESCRIPTION
This adds 2 enums: UnicodeClass and NotUnicodeClass, and a range of
values matching the nqp::const::CCLASS_xxx constants.

It also adds some candidates to Str.index and Str.rindex, that will
dispatch on specifying a value of either of these two enums.  This
will allow you to search a string for characters (not) matching a
certain character class, e.g.

    say "foo5bar".index(NotAlphabeticChar);    # 3
    say "foo5bar".index(NotAlphanumericChar);  # Nil

This is a prove of concept.  It is implemented in core_epilogue as
an augment on the Str class, because you cannot create enums with
specific values without Pairs, and Pairs don't exist yet when Str
is being compiled.  If this is accepted, a more natural way to
implement this should be devised.