### PR TITLE
Pass relaxed flag further up to parent lookup

### DIFF
--- a/src/Perl6/Metamodel/Concretization.nqp
+++ b/src/Perl6/Metamodel/Concretization.nqp
@@ -77,7 +77,7 @@ role Perl6::Metamodel::Concretization {
         }
         unless $local {
             for self.parents($obj, :local) {
-                @result := $_.HOW.concretization_lookup($_, $ptype, :local(0), :$transitive);
+                @result := $_.HOW.concretization_lookup($_, $ptype, :local(0), :$transitive, :$relaxed);
                 return @result if @result[0];
             }
         }


### PR DESCRIPTION
Fix for parameterized roles not found for FQN lookup if applied to a
parent class.