### PR TITLE
Make default degree for hyper/batch make more sense

### DIFF
--- a/src/core.c/Iterable.pm6
+++ b/src/core.c/Iterable.pm6
@@ -28,7 +28,7 @@ my role Iterable {
         Seq.new(Rakudo::Iterator.Lazy(self))
     }
 
-    method hyper(Int(Cool) :$batch = 64, Int(Cool) :$degree = 4) {
+    method hyper(Int(Cool) :$batch = 64, Int(Cool) :$degree = $*DEGREE // nqp::cpucores) {
 #?if !js
         HyperSeq.new:
           configuration =>
@@ -41,7 +41,7 @@ my role Iterable {
 #?endif
     }
 
-    method race(Int(Cool) :$batch = 64, Int(Cool) :$degree = 4) {
+    method race(Int(Cool) :$batch = 64, Int(Cool) :$degree = $*DEGREE // nqp::cpucores) {
 #?if !js
         RaceSeq.new:
           configuration =>

--- a/src/core.c/Iterable.pm6
+++ b/src/core.c/Iterable.pm6
@@ -28,7 +28,10 @@ my role Iterable {
         Seq.new(Rakudo::Iterator.Lazy(self))
     }
 
-    method hyper(Int(Cool) :$batch = 64, Int(Cool) :$degree = $*DEGREE // nqp::cpucores) {
+    method hyper(
+      Int(Cool) :$batch = 64,
+      Int(Cool) :$degree = $*DEGREE // min(nqp::cpucores() - 1,1)
+    ) {
 #?if !js
         HyperSeq.new:
           configuration =>
@@ -41,7 +44,10 @@ my role Iterable {
 #?endif
     }
 
-    method race(Int(Cool) :$batch = 64, Int(Cool) :$degree = $*DEGREE // nqp::cpucores) {
+    method race(
+      Int(Cool) :$batch = 64,
+      Int(Cool) :$degree = $*DEGREE // min(nqp::cpucores() - 1,1)
+    ) {
 #?if !js
         RaceSeq.new:
           configuration =>

--- a/src/core.c/Iterable.pm6
+++ b/src/core.c/Iterable.pm6
@@ -30,7 +30,7 @@ my role Iterable {
 
     method hyper(
       Int(Cool) :$batch = 64,
-      Int(Cool) :$degree = $*DEGREE // min(nqp::cpucores() - 1,1)
+      Int(Cool) :$degree = min(nqp::cpucores() - 1,1)
     ) {
 #?if !js
         HyperSeq.new:
@@ -46,7 +46,7 @@ my role Iterable {
 
     method race(
       Int(Cool) :$batch = 64,
-      Int(Cool) :$degree = $*DEGREE // min(nqp::cpucores() - 1,1)
+      Int(Cool) :$degree = min(nqp::cpucores() - 1,1)
     ) {
 #?if !js
         RaceSeq.new:


### PR DESCRIPTION
Currently, the default :degree for .hyper / .race is set to 4.  This may be too high for small single core CPU's, and to small for bigger beasts (such as my MBP with 2x8 cores).  Set the default to the number of CPU cores available, and introduce the $*DEGREE dynamic variable for setting the default for a given scope.