### PR TITLE
Simplify Parameter.raku, add Parameter.prefix and Parameter.suffix

### DIFF
--- a/src/core.c/Parameter.pm6
+++ b/src/core.c/Parameter.pm6
@@ -283,6 +283,28 @@ my class Parameter { # declared in BOOTSTRAP
                 ?? '*'
                 !! ''
     }
+
+    method prefix(Parameter:D: --> Str:D) {
+        nqp::bitand_i($!flags, nqp::bitor_i($SIG_ELEM_SLURPY_POS, $SIG_ELEM_SLURPY_NAMED))
+          ?? '*'
+          !! nqp::bitand_i($!flags, $SIG_ELEM_SLURPY_LOL)
+            ?? '**'
+            !! nqp::bitand_i($!flags, $SIG_ELEM_SLURPY_ONEARG)
+              ?? '+'
+              !! ''
+    }
+
+    method suffix(Parameter:D: --> Str:D) {
+        nqp::isnull(@!named_names)
+          ?? nqp::bitand_i($!flags, $SIG_ELEM_IS_OPTIONAL)
+          && nqp::not_i(nqp::bitand_i($!flags, $SIG_ELEM_HAS_DEFAULT))
+            ?? '?'
+            !! ''
+          !! nqp::bitand_i($!flags, nqp::bitor_i($SIG_ELEM_IS_OPTIONAL, $SIG_ELEM_HAS_DEFAULT))
+             ?? ''
+             !! '!'
+    }
+
     method modifier() {
         nqp::bitand_i($!flags,$SIG_ELEM_DEFINED_ONLY)
           ?? ':D'


### PR DESCRIPTION
`Parameter.raku` is somewhat complex and prone to bugs. This offloads the work it does related to slurpy, optional, and required parameters to new `prefix` and `suffix` methods, as well as parameter naming to the existing `sigil`, `twigil`, and `usage-name` methods.

This fails one test in `S06-signature/introspection.t` from Roast that checks how `:$` gets stringified; it expects the result to be `:($)`, but this is now `:$`. `make test` and the other tests in `make spectest` pass.