### PR TITLE
NativeCall: add CArray[…].new(Str:D, …) candidate

### DIFF
--- a/lib/NativeCall/Types.rakumod
+++ b/lib/NativeCall/Types.rakumod
@@ -244,6 +244,10 @@ our class CArray is repr('CArray') is array_type(Pointer) {
             nqp::create(self)
         }
     }
+    multi method new(Str:D $str, :enc(:$encoding) = 'utf8', *%encode-opts) {
+        # Add NUL terminator to the encoded C string:
+        self.new($str.encode($encoding, |%encode-opts).list, 0)
+    }
 }
 
 # duplicated code from NativeCall.pm to support Pointer.deref

--- a/t/04-nativecall/05-arrays.c
+++ b/t/04-nativecall/05-arrays.c
@@ -87,3 +87,14 @@ DLLEXPORT float SumAFloatArray(float *floats) {
 DLLEXPORT int TakeAStructArrayWithANull(Struct **structs) {
     return structs[1] == NULL;
 }
+
+static const char *the_string;
+
+DLLEXPORT size_t RememberTheString(const char *str) {
+	the_string = str;
+	return strlen(the_string);
+}
+
+DLLEXPORT const char *RetrieveTheString() {
+	return the_string;
+}


### PR DESCRIPTION
This constructor creates a CArray by first encoding the given string
and then appending a NUL byte. Its primary use would be to make a copy
of a string being passed to a native function and keeping a reference
to that copy, which the `is encoded` trait does not permit.

This came up in Raku/doc#3171 and refs Raku/doc#3169.