### PR TITLE
Merge Iterable and Seq infix:<eqv> multis

### DIFF
--- a/src/core.c/Mu.pm6
+++ b/src/core.c/Mu.pm6
@@ -1099,40 +1099,6 @@ multi sub infix:<eqv>(Any:D \a, Any:D \b) {
     )
 }
 
-multi sub infix:<eqv>(Iterable:D \a, Iterable:D \b) {
-    nqp::hllbool(
-      nqp::unless(
-        nqp::eqaddr(nqp::decont(a),nqp::decont(b)),
-        nqp::if(                                 # not same object
-          nqp::eqaddr(a.WHAT,b.WHAT),
-          nqp::if(                               # same type
-            a.is-lazy,
-            nqp::if(                             # a lazy
-              b.is-lazy,
-              die(X::Cannot::Lazy.new: :action<eqv>) # a && b lazy
-            ),
-            nqp::if(                             # a NOT lazy
-              b.is-lazy,
-              0,                                 # b lazy
-              nqp::if(                           # a && b NOT lazy
-                nqp::iseq_i((my int $elems = a.elems),b.elems),
-                nqp::stmts(                      # same # elems
-                  (my int $i = -1),
-                  nqp::while(
-                    nqp::islt_i(($i = nqp::add_i($i,1)),$elems) # not exhausted
-                      && a.AT-POS($i) eqv b.AT-POS($i),         # still same
-                    nqp::null
-                  ),
-                  nqp::iseq_i($i,$elems)         # exhausted = success!
-                )
-              )
-            )
-          )
-        )
-      )
-    )
-}
-
 sub DUMP(|args (*@args, :$indent-step = 4, :%ctx?)) {
     my Mu $capture := nqp::usecapture();
     my Mu $topic   := nqp::captureposarg($capture, 0);

--- a/src/core.c/Seq.pm6
+++ b/src/core.c/Seq.pm6
@@ -180,38 +180,4 @@ my class Seq is Cool does Iterable does Sequence {
 
 sub GATHER(&block) { Seq.new(Rakudo::Iterator.Gather(&block)) }
 
-multi sub infix:<eqv>(Seq:D \a, Seq:D \b) {
-    nqp::hllbool(
-      nqp::unless(
-        nqp::eqaddr(nqp::decont(a),nqp::decont(b)),
-        nqp::if(
-          nqp::eqaddr(a.WHAT,b.WHAT),
-          nqp::if(
-            nqp::iseq_i(
-              (my \ia := a.iterator).is-lazy,
-              (my \ib := b.iterator).is-lazy
-            ),
-            nqp::if(
-              ia.is-lazy,
-              die(X::Cannot::Lazy.new: :action<eqv>),
-              nqp::stmts(
-                nqp::until(
-                  nqp::stmts(
-                    (my \pa := ia.pull-one),
-                    (my \pb := ib.pull-one),
-                    nqp::eqaddr(pa,IterationEnd)
-                      || nqp::eqaddr(pb,IterationEnd)
-                      || nqp::not_i(pa eqv pb)
-                  ),
-                  nqp::null
-                ),
-                nqp::eqaddr(pa,pb)  # exhausted if both IterationEnd
-              )
-            )
-          )
-        )
-      )
-    )
-}
-
 # vim: ft=perl6 expandtab sw=4


### PR DESCRIPTION
The old Iterable logic now applies to Positional types only. Other types are now compared using the slower but correct logic that was defined for Seq. This resolves rakudo/issues/3346.