### PR TITLE
Typecheck Attribute's build attribute against Code

### DIFF
--- a/src/Perl6/Metamodel/BUILDPLAN.nqp
+++ b/src/Perl6/Metamodel/BUILDPLAN.nqp
@@ -133,7 +133,7 @@ role Perl6::Metamodel::BUILDPLAN {
 
                 # compile check constants for correct type
                 if nqp::isconcrete($default) {
-                    if $default.HOW.name($default) eq 'Method' {
+                    if nqp::istype($default, $*W.find_symbol(["Code"])) {
                         # cannot typecheck code to be run later
                     }
                     elsif $primspec {


### PR DESCRIPTION
Attrbiute `build` of `Attrbiute` class can not only be set to a method
but to any kind of generic code. This fixes a breakage in `Red` ORM.

Related to FCO/Red#422