### PR TITLE
[IP6NS Grant] Implement support for bind before connect with IO::Socket::INET

### DIFF
--- a/src/core.c/Exception.pm6
+++ b/src/core.c/Exception.pm6
@@ -659,6 +659,16 @@ my class X::IO::BinaryMode does X::IO {
     method message { "Cannot do '$.trying' on a handle in binary mode" }
 }
 
+my role X::IO::Socket does X::IO { }
+
+my class X::IO::Socket::Unsupported does X::IO::Socket {
+    has Str:D $.operation is required;
+    has Str:D $.family    is required;
+    method message(::?CLASS:D: --> Str:D) {
+        "Cannot $!operation with $!family sockets"
+    }
+}
+
 my role X::Comp is Exception {
     has $.filename;
     has $.pos;

--- a/src/core.c/IO/Socket/INET.pm6
+++ b/src/core.c/IO/Socket/INET.pm6
@@ -122,8 +122,8 @@ my class IO::Socket::INET does IO::Socket {
         # which is derived from the protocol, is SOCK_STREAM then connect() is called.
         if $!listening || $!localhost || $!localport {
             nqp::bindsock($PIO, nqp::unbox_s($!localhost || "0.0.0.0"),
-                                 nqp::unbox_i($!localport || 0), nqp::unbox_i($!family),
-                                 nqp::unbox_i($!backlog || 128));
+                                 nqp::unbox_i($!localport || 0), nqp::unbox_i($!family));
+            nqp::listen($PIO, nqp::unbox_i($!backlog || 128));
         }
 
         if $!listening {

--- a/src/core.c/IO/Socket/INET.pm6
+++ b/src/core.c/IO/Socket/INET.pm6
@@ -101,13 +101,17 @@ my class IO::Socket::INET does IO::Socket {
         ) unless $family == nqp::const::SOCKET_FAMILY_UNIX;
 
         with $localhost // $localport {
-            die 'Cannot set a source host or port for UNIX sockets'
-                if $family == nqp::const::SOCKET_FAMILY_UNIX;
-            ($localhost, $localport) = split-host-port(
-                :host($localhost),
-                :port($localport),
-                :$family
-            ) orelse fail $_;
+            if $family == nqp::const::SOCKET_FAMILY_UNIX {
+                fail X::IO::Socket::Unsupported.new:
+                    operation => 'bind before connect',
+                    family    => 'UNIX';
+            } else {
+                ($localhost, $localport) = split-host-port(
+                    :host($localhost),
+                    :port($localport),
+                    :$family
+                ) orelse fail $_;
+            }
         }
 
         self.bless(

--- a/src/core.c/IO/Socket/INET.pm6
+++ b/src/core.c/IO/Socket/INET.pm6
@@ -100,7 +100,7 @@ my class IO::Socket::INET does IO::Socket {
             :$family,
         ) unless $family == nqp::const::SOCKET_FAMILY_UNIX;
 
-        with $localhost {
+        with $localhost // $localport {
             die 'Cannot set a source host or port for UNIX sockets'
                 if $family == nqp::const::SOCKET_FAMILY_UNIX;
             ($localhost, $localport) = split-host-port(
@@ -127,7 +127,7 @@ my class IO::Socket::INET does IO::Socket {
     method !initialize() {
         my $PIO := nqp::socket($!listening ?? 10 !! 0);
 
-        with $!localhost {
+        with $!localhost // $!localport {
             nqp::bindsock($PIO, nqp::unbox_s($!localhost || "0.0.0.0"),
                                  nqp::unbox_i($!localport || 0), nqp::unbox_i($!family));
 #?if !js


### PR DESCRIPTION
This also helps with upcoming support for UDP sockets with `IO::Socket::INET`.

Passes `make test` and `make spectest`.

See https://github.com/MoarVM/MoarVM/pull/1231 and https://github.com/perl6/nqp/pull/597