### PR TITLE
Make attribute defaults typecheck work at run-time too.

### DIFF
--- a/src/core.c/core_epilogue.pm6
+++ b/src/core.c/core_epilogue.pm6
@@ -34,6 +34,12 @@ BEGIN {
     }
 }
 
+# Provide symbols for attribute defaults typechecking by create_BUILDPLAN.
+nqp::bindhllsym('Raku', 'Code', Code);
+nqp::bindhllsym('Raku', 'Associative', Associative);
+nqp::bindhllsym('Raku', 'Positional', Positional);
+nqp::bindhllsym('Raku', 'X::TypeCheck::Attribute::Default', X::TypeCheck::Attribute::Default);
+
 {YOU_ARE_HERE}
 
 # vim: ft=perl6 expandtab sw=4


### PR DESCRIPTION
Follow-up to #3452.

This PR turns on `create_BUILDPLAN` typechecking on attribute defaults for run-time. If a type is created by user code dynamically, any type mismatch could be detected as early as `compose` is called.