### PR TITLE
Removes full directory lock on .precomp, allowing for faster parallel compilation

### DIFF
--- a/src/core.c/CompUnit/PrecompilationRepository.pm6
+++ b/src/core.c/CompUnit/PrecompilationRepository.pm6
@@ -161,10 +161,7 @@ class CompUnit::PrecompilationRepository::Default does CompUnit::PrecompilationR
         }
 
         if $resolve {
-            if self.store.destination($compiler-id, $precomp-unit.id, :extension<.repo-id>) {
-                self.store.store-repo-id($compiler-id, $precomp-unit.id, :repo-id($repo.id));
-                self.store.unlock;
-            }
+            self.store.store-repo-id($compiler-id, $precomp-unit.id, :repo-id($repo.id));
         }
         True
     }
@@ -259,6 +256,8 @@ class CompUnit::PrecompilationRepository::Default does CompUnit::PrecompilationR
         }
         my $source-checksum = nqp::sha1($path.slurp(:enc<iso-8859-1>));
         my $bc = "$io.bc".IO;
+
+        #LEAVE { self.store.unlock }
 
         $lle     //= Rakudo::Internals.LL-EXCEPTION;
         $profile //= Rakudo::Internals.PROFILE;


### PR DESCRIPTION
This is by -no means- intended to be a complete PR. I would like comments and assistance before I would even consider this ready for merging into master.

What I would like are thoughts on the changes herein.

Some numbers:

[p6-GLib](https://github.com/Xliff/p6-GLib)
- Non-parallel compile:
> real 342.19
> user 425.71
> sys 18.44
- Parallel compile: 
> Total compile time: 78.40569049s

[p6-GIO](https://github.com/Xliff/p6-GIO)
- Non-parallel compile:
> real 886.80
> user 1097.50
> sys 52.87
- Parallel compile:
> Total compile time: 179.515837s

[p6-Pango](https://github.com/Xliff/p6-Pango)
- Non-parallel compile:
> real 167.37
> user 207.07
> sys 9.63
- Parallel compile:
> Total compile time: 55.9401686s

[p6-GDK](https://github.com/Xliff/p6-GDK)
- Non-parallel compile:
> real 268.98
> user 323.06
> sys 13.92
- Parallel compile:
> Total compile time: 68.391482s

...and finally...

[o6-GtkPlus](https://github.com/Xliff/p6-GDK)
- Non parallel compile:
> real 1918.10
> user 2270.30
> sys 107.15
- Parallel compile:
> Total compile time: 432.639475s

The code has been commented, and if anyone has questions, I'll be more than happy to answer.

This code would not have been possible without the help of niner++ and the folks in ##raku-dev. Thank you so much for your help!
