### PR TITLE
Add a CI precomp release build pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,22 @@
 version: 2.1
 
+orbs:
+    win: circleci/windows@2.2.0
+
+parameters:
+  BUILD_PRECOMP_RELEASE:
+    type: boolean
+    default: false
+  RELEASE_URL:
+    type: string
+    default: ""
+  VERSION:
+    type: string
+    default: "XXXX.YY"
+  BUILD_REV:
+    type: string
+    default: "01"
+
 variables:
   build-parameters: &build-parameters
     parameters:
@@ -9,6 +26,12 @@ variables:
       nqp-rev:
         type: string
         default: ""
+  precomp-release-environment: &precomp-release-environment
+    environment:
+      RELEASE_URL: << pipeline.parameters.RELEASE_URL >>
+      VERSION: << pipeline.parameters.VERSION >>
+      BUILD_REV: << pipeline.parameters.BUILD_REV >>
+
 
 jobs:
   test-linux:
@@ -28,6 +51,63 @@ jobs:
           nqp-rev: << parameters.nqp-rev >>
           moar-rev: << parameters.moar-rev >>
 
+  build-precomp-linux:
+    <<: *precomp-release-environment
+    docker:
+      - image: centos:6
+    steps:
+      - run:
+          name: Install basic dependencies
+          command: |
+            yum -y update
+            yum clean all
+            yum -y install git perl perl-core
+      - run:
+          name: Checkout repository
+          command: |
+            git clone `echo $CIRCLE_REPOSITORY_URL | perl -pe "s|(ssh://)?git\@github\.com:|https://github.com/|"` .
+            if [ -n "$CIRCLE_TAG" ]; then
+            git checkout -q "$CIRCLE_TAG"
+            elif [ -n "$CIRCLE_BRANCH" ]; then
+            git checkout origin/"$CIRCLE_BRANCH"
+            git branch -f "$CIRCLE_BRANCH"
+            git checkout -q "$CIRCLE_BRANCH"
+            fi
+      - run:
+          name: Run build script
+          command:
+            tools/build/binary-release/build-linux.sh
+      - store_artifacts:
+          path: rakudo-linux.tar.gz
+          destination: rakudo-moar-<< pipeline.parameters.VERSION >>-<< pipeline.parameters.BUILD_REV >>-linux-x86_64.tar.gz
+  build-precomp-macos:
+    <<: *precomp-release-environment
+    macos:
+      xcode: 10.2.0
+    steps:
+      - checkout
+      - run:
+          name: Run build script
+          command:
+            tools/build/binary-release/build-macos.sh
+      - store_artifacts:
+          path: rakudo-macos.tar.gz
+          destination: rakudo-moar-<< pipeline.parameters.VERSION >>-<< pipeline.parameters.BUILD_REV >>-macos-x86_64.tar.gz
+  build-precomp-windows:
+    <<: *precomp-release-environment
+    executor: win/default
+    working_directory: C:\rakudo
+    steps:
+      - checkout
+      - run:
+          name: Run build script
+          command:
+            tools/build/binary-release/build-windows.ps1
+      - store_artifacts:
+          path: rakudo-win.zip
+          destination: rakudo-moar-<< pipeline.parameters.VERSION >>-<< pipeline.parameters.BUILD_REV >>-win-x86_64.zip
+
+
 commands:
   build-rakudo:
     description: "Build MoarVM, NQP, and Rakudo"
@@ -44,13 +124,20 @@ commands:
 workflows:
   version: 2
   test:
+    unless: << pipeline.parameters.BUILD_PRECOMP_RELEASE >>
     jobs:
       - test-linux
       - test-linux:
           nqp-rev: HEAD
           moar-rev: HEAD
-
       - test-macos
       - test-macos:
           nqp-rev: HEAD
           moar-rev: HEAD
+  build-precomp-release:
+    when: << pipeline.parameters.BUILD_PRECOMP_RELEASE >>
+    jobs:
+      - build-precomp-linux
+      - build-precomp-macos
+      - build-precomp-windows
+

--- a/tools/build/binary-release/build-linux.sh
+++ b/tools/build/binary-release/build-linux.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env sh
+
+# This script should be run in a CentOS 6 installation (a container will do
+# just fine).
+
+set -o errexit
+set -o pipefail
+
+# Update CentOS 6
+yum -y update
+yum clean all
+
+# Install dependencies
+yum -y install curl git perl perl-core gcc make
+
+# Download release file
+curl -o rakudo.tgz $RELEASE_URL
+tar -xzf rakudo.tgz
+cd rakudo-*
+
+# Build Rakudo
+perl Configure.pl --gen-moar --gen-nqp --backends=moar --relocatable
+make
+make install
+
+# Test the build
+make test
+
+# Build Zef
+git clone https://github.com/ugexe/zef.git
+pushd zef
+../install/bin/raku -I. bin/zef install .
+popd
+
+# Prepare the package
+cp -r tools/build/binary-release/Linux/* install
+cp LICENSE install
+mv install rakudo-$VERSION
+tar -zcv --owner=0 --group=0 --numeric-owner -f ../rakudo-linux.tar.gz rakudo-$VERSION
+

--- a/tools/build/binary-release/build-macos.sh
+++ b/tools/build/binary-release/build-macos.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env sh
+
+set -o errexit
+set -o pipefail
+
+# Install Dependencies
+brew install perl
+brew install gnu-tar
+
+# Download release file
+curl -o rakudo.tgz $RELEASE_URL
+tar -xzf rakudo.tgz
+cd rakudo-*
+
+# Build Rakudo
+perl Configure.pl --gen-moar --gen-nqp --backends=moar --relocatable
+make
+make install
+
+# Test the build
+make test
+
+# Build Zef
+git clone https://github.com/ugexe/zef.git
+pushd zef
+../install/bin/raku -I. bin/zef install .
+popd
+
+# Prepare the package
+cp -r tools/build/binary-release/MacOS/* install
+cp LICENSE install
+mv install rakudo-$VERSION
+gtar -zcv --owner=0 --group=0 --numeric-owner -f ../rakudo-macos.tar.gz rakudo-$VERSION
+

--- a/tools/build/binary-release/build-windows.ps1
+++ b/tools/build/binary-release/build-windows.ps1
@@ -1,0 +1,69 @@
+$ErrorActionPreference = "Stop"
+
+# Don't display progressbars when doing Invoke-WebRequest and similar.
+# That would cause the command to fail, because in the CircleCI environment
+# one can't modify the display.
+# "Win32 internal error “Access is denied” 0x5 occurred while reading the console output buffer. Contact Microsoft Customer Support Services."
+$progressPreference = 'silentlyContinue'
+
+function CheckLastExitCode {
+    if ($LastExitCode -ne 0) {
+        $msg = @"
+Program failed with: $LastExitCode
+Callstack: $(Get-PSCallStack | Out-String)
+"@
+        throw $msg
+    }
+}
+
+
+# Install Perl
+
+mkdir download
+mkdir strawberry
+Invoke-WebRequest http://strawberryperl.com/download/5.30.0.1/strawberry-perl-5.30.0.1-64bit.zip -OutFile download/strawberry-perl-5.30.0.1-64bit.zip
+Expand-Archive -Path download/strawberry-perl-5.30.0.1-64bit.zip -DestinationPath strawberry
+strawberry\relocation.pl.bat
+$Env:PATH = (Join-Path -Path $repoPath -ChildPath "\strawberry\perl\bin") + ";" + (Join-Path -Path $repoPath -ChildPath "\strawberry\perl\site\bin") + ";" + (Join-Path -Path $repoPath -ChildPath "\strawberry\c\bin") + ";$Env:PATH"
+
+
+# Download release file
+
+Invoke-WebRequest $Env:RELEASE_URL -OutFile download/rakudo.tgz
+tar -xzf download/rakudo.tgz .
+cd rakudo-*
+
+# Build Rakudo
+
+perl Configure.pl --gen-moar --gen-nqp --backends=moar --relocatable
+CheckLastExitCode
+nmake install
+CheckLastExitCode
+
+
+# Test the build
+
+nmake test
+CheckLastExitCode
+
+
+# Build Zef
+
+git clone https://github.com/ugexe/zef.git
+CheckLastExitCode
+cd zef
+..\install\bin\raku.exe -I. bin\zef install .
+CheckLastExitCode
+
+
+# Prepare the package
+
+cp -r "tools\build\binary-release\Windows\*" install
+cp LICENSE install
+
+$version = Get-Content -Path .\VERSION -Raw
+$version = $version.Trim()
+mv install rakudo-$version
+
+Compress-Archive -Path rakudo-$version -DestinationPath ..\rakudo-win.zip
+

--- a/tools/build/binary-release/trigger-precomp-build.sh
+++ b/tools/build/binary-release/trigger-precomp-build.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env sh
+
+if [ $# -lt 4 ]; then
+    echo 'You need to pass:'
+    echo '   - version of the release, e.g. "2020.01"'
+    echo '   - build revision, typically "01"'
+    echo '   - URL of a release .tgz file'
+    echo '   - a CircleCI token'
+    exit 1
+fi
+
+curl \
+-u $4: \
+-X POST \
+-H 'Content-Type: application/json' \
+-d "{
+  \"parameters\": {
+    \"BUILD_PRECOMP_RELEASE\": true,
+    \"RELEASE_URL\": \"$3\",
+    \"VERSION\": \"$1\",
+    \"BUILD_REV\": \"$2\"
+  }
+}" \
+https://circleci.com/api/v2/project/gh/rakudo/rakudo/pipeline
+


### PR DESCRIPTION
This PR adds a CircleCI pipeline that can create precompiled release archives for Windows, MacOS and Linux.
The workflow and jobs to create a release build are not triggered automatically. They have to be started manually via an API request. The script ` tools/build/binary-release/trigger-precomp-build.sh` can send such a request. The build does not use code in the repository, but instead downloads a release archive and builds that.
The most relevant bits of the creation process is encapsulated in scripts for the respective platform. So if we should migrate to a different build infrastructure they can be reused.
After a successful build the compiled archives have to be downloaded manually via the CircleCI website.

I have tested the builds on Linux and MacOS. I wasn't able to test the Windows builds, because CircleCI seems to be confused wrt credits and refuses to run Windows builds in my clone of rakudo. I hope this won't be a problem with the official rakudo repo. Officially open source projects should have 400,000 credits/month for Linux workload, 25,000 credits/month for MacOS workloads and 2,500 credits/month for Windows workloads. That should be more than enough for the release builds.