### PR TITLE
Releaseable tweaks

### DIFF
--- a/tools/releasable/Sakefile
+++ b/tools/releasable/Sakefile
@@ -23,8 +23,8 @@ use File::Directory::Tree;
 my $THREADS  = 7;
 
 # These are used so that you can run tests on a faster machine.
-my $SSH      = ‘alex@localhost’; # TODO make it configurable
-my $SSH-PATH = ‘/home/alex/git/Releasable/’; # TODO make it configurable
+my $SSH      = %*ENV<RELEASE_SSH> // "{qx{whoami}.trim}@localhost";
+my $SSH-PATH = %*ENV<RELEASE_HOME>;
 my $RSYNC    = “$SSH:$SSH-PATH”;
 
 my $WIKIPEDIA-NAME = %*ENV<WIKIPEDIA-NAME>; # currently not used
@@ -66,6 +66,7 @@ spurt ‘BRANCH_MOAR’,    $branch-moar;
 spurt ‘BRANCH_NQP’,     $branch-nqp;
 spurt ‘BRANCH_RAKUDO’,  $branch-rakudo;
 spurt ‘BRANCH_ROAST’,   $branch-roast;
+
 
 my $temp = “temp”.IO;
 my $nqp-archive    = “$NQP-PATH/nqp-{$version-nqp}.tar.gz”;

--- a/tools/releasable/Sakefile
+++ b/tools/releasable/Sakefile
@@ -210,14 +210,14 @@ task ‘rakudo-push’, { # Step ??? (rakudo release guide)
 
 task ‘nqp-upload’, { # Step ❽ (nqp release guide)
     for @tarball-distributors {
-        run ‘scp’, $nqp-archive, “{$nqp-archive}.asc”, “$_/nqp/”
+        run ‘scp -p 2222’, $nqp-archive, “{$nqp-archive}.asc”, “$_/nqp/”
     }
     True
 }
 
 task ‘rakudo-upload’, { # Step ⓲ (rakudo release guide)
     for @tarball-distributors {
-        run ‘scp’, $rakudo-archive, “{$rakudo-archive}.asc”, “$_/rakudo/”
+        run ‘scp -p 2222’, $rakudo-archive, “{$rakudo-archive}.asc”, “$_/rakudo/”
     }
     True
 }

--- a/tools/releasable/Sakefile
+++ b/tools/releasable/Sakefile
@@ -74,8 +74,7 @@ my $rakudo-archive = “$RAKUDO-PATH/rakudo-{$version-rakudo}.tar.gz”;
 my $nqp-test-dir    = $temp.add: ‘nqp-test’;
 my $rakudo-test-dir = $temp.add: ‘rakudo-test’;
 
-my @tarball-distributors = ‘rakudo@rakudo.org:public_html/downloads/’,
-                           ‘rakudo@www.p6c.org:public_html/downloads/’;
+my @tarball-distributors = 'rakudo.org@lavm-perl6infra-1.atikon.io:public_html/downloads/';
 
 my @canary-distributors  = ‘rakudo@www.p6c.org:public_html/downloads/’;
 


### PR DESCRIPTION
SSH is not configurable via envvars. We have plenty of them already and it won't hurt to add some more, but makes the script more robust.
Also update tarball distributors to use a working one.