### PR TITLE
Box result of nqp::time_n() in DateTime.now

### DIFF
--- a/src/core.c/DateTime.pm6
+++ b/src/core.c/DateTime.pm6
@@ -253,7 +253,7 @@ my class DateTime does Dateish {
     }
 
     method now(:$timezone=$*TZ, :&formatter --> DateTime:D) {
-        self.new(nqp::time_n(), :$timezone, :&formatter)
+        self.new(nqp::p6box_n(nqp::time_n()), :$timezone, :&formatter)
     }
 
     method clone(DateTime:D: *%_ --> DateTime:D) {


### PR DESCRIPTION
This is a workaround for /issues/3459.

On Windows, `DateTime.new` multi dispatch may break if the first argument is a native `num`. I have no idea why this appears to be an issue on Windows only.