### PR TITLE
Make throws-like throw an exception on Bool:D matchers

### DIFF
--- a/lib/Test.rakumod
+++ b/lib/Test.rakumod
@@ -603,7 +603,7 @@ multi sub is-deeply(Mu $got, Mu $expected, $reason = '') is export {
 
 sub throws-like($code, $ex_type, $reason?, *%matcher) is export {
     for %matcher.kv -> $k, $v {
-        if $v === True|False {
+        if $v ~~ Bool and $v.DEFINITE {
             X::Match::Bool.new(:type(".$k")).throw;
         }
     }
@@ -650,7 +650,7 @@ sub fails-like (
     \test where Callable:D|Str:D, $ex-type, $reason?, *%matcher
 ) is export {
     for %matcher.kv -> $k, $v {
-        if $v === True|False {
+        if $v ~~ Bool and $v.DEFINITE {
             X::Match::Bool.new(:type(".$k")).throw;
         }
     }

--- a/lib/Test.rakumod
+++ b/lib/Test.rakumod
@@ -602,6 +602,11 @@ multi sub is-deeply(Mu $got, Mu $expected, $reason = '') is export {
 }
 
 sub throws-like($code, $ex_type, $reason?, *%matcher) is export {
+    for %matcher.kv -> $k, $v {
+        if $v === True|False {
+            X::Match::Bool.new(:type(".$k")).throw;
+        }
+    }
     my $caller-context = $*THROWS-LIKE-CONTEXT // CALLER::; # Don't guess our caller context, know it!
     subtest {
         plan 2 + %matcher.keys.elems;
@@ -644,6 +649,11 @@ sub throws-like($code, $ex_type, $reason?, *%matcher) is export {
 sub fails-like (
     \test where Callable:D|Str:D, $ex-type, $reason?, *%matcher
 ) is export {
+    for %matcher.kv -> $k, $v {
+        if $v === True|False {
+            X::Match::Bool.new(:type(".$k")).throw;
+        }
+    }
     my $*THROWS-LIKE-CONTEXT = CALLER::;
     subtest sub {
         plan 2;


### PR DESCRIPTION
Now, throws-like and fails-like Test subs throw an Exception in case the matcher uses Bool:D as matcher value instead of explicit Bool:D check. The behavior is similar to .grep(True).

Changes for issue: #2364
New tests: https://github.com/perl6/roast/pull/616