### PR TITLE
Add the Stash's name to the Failure when trying...

### DIFF
--- a/src/core.c/Stash.pm6
+++ b/src/core.c/Stash.pm6
@@ -22,7 +22,7 @@ my class Stash { # declared in BOOTSTRAP
             nqp::if(
               nqp::existskey(GLOBAL.WHO,$key),
               nqp::atkey(GLOBAL.WHO,$key),
-              Failure.new("Could not find symbol '$key'")
+              Failure.new("Could not find symbol '$key' in '{self}'")
             ),
             nqp::p6scalarfromdesc(
               ContainerDescriptor::BindHashPos.new(Mu, self, $key)


### PR DESCRIPTION
to look up a non-existent symbol in the Stash.

Rakudo builds ok and passes `make m-test m-spectest`.

Slightly improves the LTA error reported in https://github.com/Raku/old-issue-tracker/issues/1453, but I don't think it's the final solution.