### PR TITLE
Properly support generic types in Signature 'returns' attribute.

### DIFF
--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -1853,6 +1853,11 @@ BEGIN {
                 }
             }
             nqp::bindattr($ins, Signature, '@!params', @ins_params);
+            my $returns := nqp::getattr($self, Signature, '$!returns');
+            if !nqp::isnull($returns) && $returns.HOW.archetypes.generic {
+                nqp::bindattr($ins, Signature, '$!returns',
+                    $returns.HOW.instantiate_generic($returns, $type_environment));
+            }
             $ins
         }));
     Signature.HOW.add_method(Signature, 'returns', nqp::getstaticcode(sub ($self) {

--- a/src/core.c/Signature.pm6
+++ b/src/core.c/Signature.pm6
@@ -134,7 +134,7 @@ my class Signature { # declared in BOOTSTRAP
             }
         }
         if !nqp::isnull($!returns) && !($!returns =:= Mu) {
-            $text = $text ~ ' --> ' ~ $!returns.raku
+            $text = $text ~ ' --> ' ~ (nqp::can($!returns, 'raku') ?? $!returns.raku !! $!returns.^name)
         }
         # Closer.
         $text ~ ')'


### PR DESCRIPTION
First, stringification must not use `raku` method on the type in `$!returns` if the type doesn't have the method. Fixes LTA error message as reported by #3483.

Also, instantiate a return type in `Signature`'s `instantiate_generic` method.