### PR TITLE
Hack to fix "any" Junction inlining optimization

### DIFF
--- a/src/Perl6/Optimizer.nqp
+++ b/src/Perl6/Optimizer.nqp
@@ -2960,6 +2960,10 @@ class Perl6::Optimizer {
         my $qast-block := nqp::getattr($wv-block.value,
             $!symbols.find_symbol(['Code']), '@!compstuff')[0];
 
+        if nqp::istype($qast-block[1], QAST::Stmts) && @($qast-block[1]) == 1 {
+            $qast-block[1] := $qast-block[1][0];
+        }
+
         # do we have an "any" Junction we can inline?
         if nqp::istype($qast-block[1], QAST::Op)
         && $qast-block[1].op eq 'callmethod' && $qast-block[1].name eq 'ACCEPTS'


### PR DESCRIPTION
Most of the time there as a QAST::Stmts with only one sub-element in the
QAST that we're trying to optimize. This means that the giant
conditional that's attempting to match the structure of the QAST is
failing. In these cases, just get rid of the wrapping QAST::Stmts.

Rakudo builds ok and passes `make m-test m-spectest`. Furthermore, `sub a($a where Str|Rat|Complex|Array|Hash|Encoding|Int) { $a }; my $b; my $s = now; $b = a(2) for ^500_000; say now - $s; say $b` takes ~1.8s before, ~0.12s after. Putting the `Int` first in the list drops the before time to 0.39s, but the after time is unchanged (so still faster at ~0.12s).

I'm unsure exactly how safe this change is, or if it's a more general optimization (remove QAST::Stmts if there's only one sub-element) that should be moved elsewhere.