### PR TITLE
Allow debuggers to be specified by environment variables

### DIFF
--- a/tools/templates/moar/rakudo-gdb-m.in
+++ b/tools/templates/moar/rakudo-gdb-m.in
@@ -5,5 +5,13 @@
 GDB="gdb"
 if [ -n "$RAKUDO_GDB" ]; then
     GDB="$RAKUDO_GDB"
+else
+    case "$(uname)" in
+        OpenBSD)
+            if which egdb >/dev/null; then
+                GDB="egdb"
+            fi
+    esac
 fi
+
 "$GDB" --quiet --ex=run --args "@expand(@MOAR@)@" @expand(@runner_opts@)@ "$@"

--- a/tools/templates/moar/rakudo-gdb-m.in
+++ b/tools/templates/moar/rakudo-gdb-m.in
@@ -2,4 +2,8 @@
 
 @insert(rakudo-debug-notice)@
 
-gdb --quiet --ex=run --args "@expand(@MOAR@)@" @expand(@runner_opts@)@ "$@"
+GDB="gdb"
+if [ -n "$RAKUDO_GDB" ]; then
+    GDB="$RAKUDO_GDB"
+fi
+"$GDB" --quiet --ex=run --args "@expand(@MOAR@)@" @expand(@runner_opts@)@ "$@"

--- a/tools/templates/moar/rakudo-lldb-m.in
+++ b/tools/templates/moar/rakudo-lldb-m.in
@@ -2,4 +2,8 @@
 
 @insert(rakudo-debug-notice)@
 
-lldb -o run "@expand(@MOAR@)@" -- @expand(@runner_opts@)@ "$@"
+LLDB="lldb"
+if [ -n "$RAKUDO_LLDB" ]; then
+    LLDB="$RAKUDO_LLDB"
+fi
+"$LLDB" -o run "@expand(@MOAR@)@" -- @expand(@runner_opts@)@ "$@"

--- a/tools/templates/moar/rakudo-valgrind-m.in
+++ b/tools/templates/moar/rakudo-valgrind-m.in
@@ -15,4 +15,8 @@ say "running on $*DISTRO.gist() / $*KERNEL.gist()";
 say "-" x 96;
 )@
 
-valgrind ${MVM_VALGRIND_OPTS} "@expand(@MOAR@)@" @expand(@runner_opts@)@ "$@"
+VALGRIND="valgrind"
+if [ -n "$RAKUDO_VALGRIND" ]; then
+    VALGRIND="$RAKUDO_VALGRIND"
+fi
+"$VALGRIND" ${MVM_VALGRIND_OPTS} "@expand(@MOAR@)@" @expand(@runner_opts@)@ "$@"


### PR DESCRIPTION
This makes it so gdb/lldb/valgrind are used by default, but may be
overridden by RAKUDO_GDB/RAKUDO_LLDB/RAKUDO_VALGRIND environment
variables.