### PR TITLE
Set attribute's rw status when added to an AttributeContainer

### DIFF
--- a/src/Perl6/Metamodel/AttributeContainer.nqp
+++ b/src/Perl6/Metamodel/AttributeContainer.nqp
@@ -50,8 +50,13 @@ role Perl6::Metamodel::AttributeContainer {
     }
 
     # Makes setting the type represented by the meta-object rw mean that its
-    # attributes are rw by default.
+    # attributes are rw by default. For cases when status is late set, like
+    # with 'also is rw', fixup the previously added attributes. Note that we
+    # can safely use 'default_to_rw' because it would pay respect to `is readonly`
     method set_rw($obj) {
+        for @!attributes {
+            $_.default_to_rw();
+        }
         $!attr_rw_by_default := 1;
     }
 

--- a/src/Perl6/Metamodel/AttributeContainer.nqp
+++ b/src/Perl6/Metamodel/AttributeContainer.nqp
@@ -18,6 +18,7 @@ role Perl6::Metamodel::AttributeContainer {
             nqp::die("Package '" ~ self.name($obj) ~
                 "' already has an attribute named '$name'");
         }
+        if $!attr_rw_by_default { $meta_attr.default_to_rw() }
         @!attributes[+@!attributes] := $meta_attr;
         %!attribute_lookup{$name}   := $meta_attr;
     }
@@ -33,7 +34,6 @@ role Perl6::Metamodel::AttributeContainer {
             %orig_meths{$_.key} := 1;
         }
         for @!attributes {
-            if $!attr_rw_by_default { $_.default_to_rw() }
             if $_.has_accessor() {
                 my $acc_name := nqp::substr($_.name, 2);
                 nqp::die("Two or more attributes declared that both want an accessor method '$acc_name'")

--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -1521,6 +1521,9 @@ BEGIN {
     Attribute.HOW.add_method(Attribute, 'set_readonly', nqp::getstaticcode(sub ($self) {
             nqp::bindattr_i(nqp::decont($self),
                 Attribute, '$!ro', 1);
+            # Explicit set of readonly must reset rw as it might be a result of `is rw` trait.
+            nqp::bindattr_i(nqp::decont($self),
+                Attribute, '$!rw', 0);
             nqp::hllboolfor(1, "Raku")
         }));
     Attribute.HOW.add_method(Attribute, 'set_required', nqp::getstaticcode(sub ($self, $value) {

--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -1415,6 +1415,8 @@ BEGIN {
     #     has Attribute $!orig; # original attribute object used for instantiation
     Attribute.HOW.add_parent(Attribute, Any);
     Attribute.HOW.add_attribute(Attribute, BOOTSTRAPATTR.new(:name<$!name>, :type(str), :package(Attribute)));
+    # The existence of both $!rw and $!ro might be confusing, but they're needed for late trait application with
+    # `also is rw`. In this case we must remember the earlier applied per-attribute traits.
     Attribute.HOW.add_attribute(Attribute, BOOTSTRAPATTR.new(:name<$!rw>, :type(int), :package(Attribute)));
     Attribute.HOW.add_attribute(Attribute, BOOTSTRAPATTR.new(:name<$!ro>, :type(int), :package(Attribute)));
     Attribute.HOW.add_attribute(Attribute, BOOTSTRAPATTR.new(:name<$!required>, :type(Mu), :package(Attribute)));


### PR DESCRIPTION
It was previously set in `compose_attributes` which is called by
`ClassHOW` only. This was causing roles always ignoring the default `rw`
status and thus `is rw` trait not having effect on them. This fix
presumes that the trait is always applied before attributes are thrown
in.

Fixes #3495