### PR TITLE
Fix dispatchers and make them interact and chain properly, reconsider wrapping

### DIFF
--- a/src/Perl6/Metamodel/Dispatchers.nqp
+++ b/src/Perl6/Metamodel/Dispatchers.nqp
@@ -3,68 +3,115 @@ class Perl6::Metamodel::BaseDispatcher {
     has $!idx;
     has $!next_dispatcher; # The dispatcher we must pass control to when own queue exhausts
 
-    method candidates() { @!candidates }
+    method candidates()     { @!candidates }
 
-    method exhausted() { $!idx >= +@!candidates && (!nqp::isconcrete($!next_dispatcher) || $!next_dispatcher.exhausted()) }
+    method exhausted()      { $!idx >= +@!candidates && (!nqp::isconcrete($!next_dispatcher) || $!next_dispatcher.exhausted()) }
 
-    method last()      { @!candidates := [] }
+    method last_candidate() { $!idx >= +@!candidates }
 
-    method set_next_dispatcher($next_dispatcher) { $!next_dispatcher := $next_dispatcher }
+    method last()           { @!candidates := [] }
+
+    method set_next_dispatcher($next_dispatcher)
+                            { $!next_dispatcher := $next_dispatcher }
 
     # Wrapper-like dispatchers don't set dispatcher for the last candidate.
     method is_wrapper_like() { 0 }
 
     method get_call() { # Returns [$call, $is_dispatcher]
-        my $call := @!candidates[$!idx++];
+        my $call := @!candidates[$!idx];
+        ++$!idx;
+        my $next_disp := self.set_call_dispatcher($call);
+        [$call, $next_disp]
+    }
 
-        my $disp;
-        try {
-            # XXX Are there any better way to determine a invocation handler with own dispatcher in $!dispatcher?
-            $disp := nqp::getattr($call, nqp::what($call), '$!dispatcher'); # If $call is a handler. But there must be better way to deal with this.
-            $disp := nqp::null() unless nqp::istype($disp, Perl6::Metamodel::BaseDispatcher); # Protect from multi-Routine dispatcher attribute
-        }
-        if nqp::isconcrete($disp) {
-            return [$disp, 1];
+    # By default we just set next call dispatcher to ourselves.
+    # Method must return value for $*NEXT-DISPATCHER
+    method set_call_dispatcher($call) {
+        return nqp::null() if self.is_wrapper_like && self.last_candidate && !$!next_dispatcher;
+        if (nqp::can($call, 'is_dispatcher') && $call.is_dispatcher)
+            || (nqp::can($call, 'is_wrapped') && $call.is_wrapped)
+        {
+            self
         }
         else {
-            my $last_candidate := $!idx >= +@!candidates;
-            if  $last_candidate && nqp::isconcrete($!next_dispatcher) {
-                nqp::setdispatcherfor($!next_dispatcher, $call);
-                $!next_dispatcher := nqp::null();
-            }
-            else {
-                nqp::setdispatcherfor(self, $call) unless $last_candidate && self.is_wrapper_like;
-            }
+            nqp::setdispatcherfor(self, $call);
+            nqp::null()
         }
-        [$call, 0]
     }
 
     method call_with_args(*@pos, *%named) {
-        my @call := self.get_call;
-        if @call[1] {
-            return @call[0].enter_with_args(@pos, %named, :next_dispatcher(self));
-        }
-        if self.has_invocant {
-            my $inv := self.invocant;
-            @call[0]($inv, |@pos, |%named);
+        if self.last_candidate {
+            if $!next_dispatcher {
+                $!next_dispatcher.call_with_args(|@pos, |%named);
+            }
+            else {
+                die(self.HOW.shortname(self) ~ " is already exhausted");
+            }
         }
         else {
-            @call[0](|@pos, |%named);
+            my @call := self.get_call;
+            my $*NEXT-DISPATCHER := @call[1];
+            if self.has_invocant {
+                @call[0](self.invocant, |@pos, |%named);
+            }
+            else {
+                @call[0](|@pos, |%named);
+            }
         }
     }
 
     method call_with_capture($capture) {
-        my @call := self.get_call;
-        if @call[1] { # Got a dispatcher
-            return @call[0].enter_with_capture($capture, :next_dispatcher(self));
+        if self.last_candidate {
+            if $!next_dispatcher {
+                $!next_dispatcher.call_with_capture($capture)
+            }
+            else {
+                die(self.HOW.shortname(self) ~ " is already exhausted");
+            }
         }
-        nqp::invokewithcapture(@call[0], $capture);
+        else {
+            my @call := self.get_call;
+            my $*NEXT-DISPATCHER := @call[1];
+            nqp::invokewithcapture(@call[0], $capture);
+        }
     }
 
     method shift_callee() {
         my $callee := @!candidates[$!idx];
-        $!idx := $!idx + 1;
+        ++$!idx;
         nqp::decont($callee)
+    }
+
+    method add_from_mro(@methods, $class, $sub, :$skip_first = 0) {
+        my @mro := nqp::can($class.HOW, 'mro_unhidden')
+                        ?? $class.HOW.mro_unhidden($class)
+                        !! $class.HOW.mro($class);
+        my $name := $sub.name;
+        my %seen;
+        for @mro {
+            my $mt := nqp::hllize($_.HOW.method_table($_));
+            if nqp::existskey($mt, $name) {
+                my $meth := nqp::atkey($mt, $name);
+                if $meth.is_dispatcher {
+                    my $proto_pkg_id := nqp::objectid($meth.package);
+                    # Skip proto if it's been seen before. Prevents from multiple dispatching over the same multi
+                    # candidates.
+                    $meth := nqp::null() if %seen{$proto_pkg_id};
+                    %seen{$proto_pkg_id} := 1
+                }
+                # Skipping the first method obtained from MRO because either it should have been handled already by
+                # vivify_for.
+                nqp::if(
+                    nqp::isgt_i($skip_first, 0),
+                    (--$skip_first),
+                    nqp::unless(
+                        nqp::isnull($meth),
+                        nqp::push(@methods, $meth)
+                    )
+                )
+            }
+        }
+        @methods
     }
 }
 
@@ -81,17 +128,8 @@ class Perl6::Metamodel::MethodDispatcher is Perl6::Metamodel::BaseDispatcher {
 
     method vivify_for($sub, $lexpad, $args) {
         my $obj      := $lexpad<self>;
-        my $name     := $sub.name;
-        my @mro      := nqp::can($obj.HOW, 'mro_unhidden')
-            ?? $obj.HOW.mro_unhidden($obj)
-            !! $obj.HOW.mro($obj);
-        my @methods;
-        for @mro {
-            my %mt := nqp::hllize($_.HOW.method_table($_));
-            if nqp::existskey(%mt, $name) {
-                @methods.push(%mt{$name});
-            }
-        }
+        my $class    := nqp::getlexrel($lexpad, '::?CLASS');
+        my @methods  := self.add_from_mro([], $class, $sub);
         self.new(:candidates(@methods), :obj($obj), :idx(1))
     }
 
@@ -103,10 +141,11 @@ class Perl6::Metamodel::MultiDispatcher is Perl6::Metamodel::BaseDispatcher {
     has $!has_invocant;
     has $!invocant;
 
-    method new(:@candidates, :$idx, :$invocant, :$has_invocant) {
+    method new(:@candidates, :$idx, :$invocant, :$has_invocant, :$next_dispatcher) {
         my $disp := nqp::create(self);
         nqp::bindattr($disp, Perl6::Metamodel::BaseDispatcher, '@!candidates', @candidates);
         nqp::bindattr($disp, Perl6::Metamodel::BaseDispatcher, '$!idx', $idx);
+        nqp::bindattr($disp, Perl6::Metamodel::BaseDispatcher, '$!next_dispatcher', $next_dispatcher);
         nqp::bindattr($disp, Perl6::Metamodel::MultiDispatcher, '$!invocant', $invocant);
         nqp::bindattr($disp, Perl6::Metamodel::MultiDispatcher, '$!has_invocant', $has_invocant);
         $disp
@@ -115,10 +154,19 @@ class Perl6::Metamodel::MultiDispatcher is Perl6::Metamodel::BaseDispatcher {
     method vivify_for($sub, $lexpad, $args) {
         my $disp         := $sub.dispatcher();
         my $has_invocant := nqp::existskey($lexpad, 'self');
-        my $invocant     := $has_invocant && $lexpad<self>;
         my @cands        := $disp.find_best_dispatchee($args, 1);
-        self.new(:candidates(@cands), :idx(1), :invocant($invocant),
-            :has_invocant($has_invocant))
+        my $invocant     := $has_invocant && $lexpad<self>;
+        my $next_dispatcher := nqp::getlexreldyn($lexpad, '$*NEXT-DISPATCHER');
+        # The first candidate has already been invoked, throw it away from the list;
+        # If called in a method then only take control if MethodDispatcher is in charge.
+        if $has_invocant && !nqp::isconcrete($next_dispatcher) {
+            my $class := nqp::getlexrel($lexpad, '::?CLASS');
+            self.add_from_mro(@cands, $class, $sub, :skip_first(1));
+            Perl6::Metamodel::MethodDispatcher.new(:candidates(@cands), :idx(1), :obj($invocant))
+        }
+        else {
+            self.new(:candidates(@cands), :idx(1), :$invocant, :$has_invocant, :$next_dispatcher)
+        }
     }
 
     method has_invocant() { $!has_invocant }
@@ -126,53 +174,21 @@ class Perl6::Metamodel::MultiDispatcher is Perl6::Metamodel::BaseDispatcher {
 }
 
 class Perl6::Metamodel::WrapDispatcher is Perl6::Metamodel::BaseDispatcher {
-    method new(:@candidates, :$idx, :$invocant, :$has_invocant) {
+    method new(:@candidates, :$idx, :$invocant, :$has_invocant, :$next_dispatcher) {
         my $disp := nqp::create(self);
         nqp::bindattr($disp, Perl6::Metamodel::BaseDispatcher, '@!candidates', @candidates);
         nqp::bindattr($disp, Perl6::Metamodel::BaseDispatcher, '$!idx', 1);
+        nqp::bindattr($disp, Perl6::Metamodel::BaseDispatcher, '$!next_dispatcher', $next_dispatcher);
         $disp
     }
 
+    method vivify_for($sub, $lexpad, $capture) {
+        my @candidates      := $sub.wrappers;
+        my $next_dispatcher := nqp::getlexreldyn($lexpad, '$*NEXT-DISPATCHER');
+        self.new(:@candidates, :idx(1), :$next_dispatcher)
+    }
+
     method has_invocant() { 0 }
-
+    method invocant() { NQPMu }
     method is_wrapper_like() { 1 }
-
-    method add($wrapper) {
-        self.candidates.unshift($wrapper)
-    }
-
-    method remove($wrapper) {
-        my @cands := self.candidates;
-        my $i := 0;
-        while $i < +@cands {
-            if nqp::decont(@cands[$i]) =:= nqp::decont($wrapper) {
-                nqp::splice(@cands, [], $i, 1);
-                return 1;
-            }
-            $i := $i + 1;
-        }
-        return 0;
-    }
-
-    method get_first($next_dispatcher) {
-        my $fresh := nqp::clone(self);
-        $fresh.set_next_dispatcher($next_dispatcher) if $next_dispatcher;
-        my $first := self.candidates[0];
-        nqp::setdispatcherfor($fresh, $first);
-        $first
-    }
-
-    # This method is a bridge between Perl6 and NQP.
-    method enter(*@pos, *%named) {
-        self.enter_with_args(@pos, %named);
-    }
-
-    method enter_with_args(@pos, %named, :$next_dispatcher?) {
-        self.get_first($next_dispatcher)(|@pos, |%named)
-    }
-
-    method enter_with_capture($capture, :$next_dispatcher?) {
-        my $first := self.get_first($next_dispatcher);
-        nqp::invokewithcapture($first, $capture);
-    }
 }

--- a/src/Perl6/Metamodel/MultiMethodContainer.nqp
+++ b/src/Perl6/Metamodel/MultiMethodContainer.nqp
@@ -95,6 +95,7 @@ role Perl6::Metamodel::MultiMethodContainer {
                         nqp::hash('T', $obj));
                     $proto.set_name($name);
                     $proto.add_dispatchee($code);
+                    $proto.'!set_package'($obj);
                     self.add_method($obj, $name, $proto);
                     nqp::push(@new_protos, $proto);
                 }

--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -2250,11 +2250,18 @@ BEGIN {
     Routine.HOW.add_attribute(Routine, Attribute.new(:name<$!onlystar>, :type(int), :package(Routine)));
     Routine.HOW.add_attribute(Routine, scalar_attr('@!dispatch_order', List, Routine, :!auto_viv_container));
     Routine.HOW.add_attribute(Routine, Attribute.new(:name<$!dispatch_cache>, :type(Mu), :package(Routine)));
+    Routine.HOW.add_attribute(Routine, Attribute.new(:name<$!wrappers>, :type(Mu), :package(Routine)));
 
     Routine.HOW.add_method(Routine, 'is_dispatcher', nqp::getstaticcode(sub ($self) {
             my $dc_self   := nqp::decont($self);
             my $disp_list := nqp::getattr($dc_self, Routine, '@!dispatchees');
             nqp::hllboolfor(nqp::defined($disp_list), "Raku");
+        }));
+    Routine.HOW.add_method(Routine, 'is_wrapped', nqp::getstaticcode(sub ($self) {
+            nqp::hllboolfor(
+                nqp::defined(
+                    nqp::getattr(nqp::decont($self), Routine, '$!wrappers')),
+                "Raku");
         }));
     Routine.HOW.add_method(Routine, 'add_dispatchee', nqp::getstaticcode(sub ($self, $dispatchee) {
             my $dc_self   := nqp::decont($self);
@@ -2288,6 +2295,10 @@ BEGIN {
     Routine.HOW.add_method(Routine, 'dispatchees', nqp::getstaticcode(sub ($self) {
             nqp::getattr(nqp::decont($self),
                 Routine, '@!dispatchees')
+        }));
+    Routine.HOW.add_method(Routine, 'wrappers', nqp::getstaticcode(sub ($self) {
+            nqp::hllize(nqp::getattr(nqp::decont($self),
+                Routine, '$!wrappers'))
         }));
     Routine.HOW.add_method(Routine, '!configure_positional_bind_failover',
         nqp::getstaticcode(sub ($self, $Positional, $PositionalBindFailover) {

--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -3242,6 +3242,11 @@ BEGIN {
             nqp::bindattr_i($dcself, Routine, '$!onlystar', 1);
             $dcself
         }));
+    Routine.HOW.add_method(Routine, '!set_package', nqp::getstaticcode(sub ($self, $package) {
+            my $dcself := nqp::decont($self);
+            nqp::bindattr($dcself, Routine, '$!package', $package);
+            $dcself
+        }));
     Routine.HOW.compose_repr(Routine);
     Routine.HOW.set_multi_invocation_attrs(Routine, Routine, '$!onlystar', '$!dispatch_cache');
     Routine.HOW.compose_invocation(Routine);

--- a/src/core.c/Routine.pm6
+++ b/src/core.c/Routine.pm6
@@ -79,34 +79,36 @@ my class Routine { # declared in BOOTSTRAP
 
     method soft( --> Nil ) { }
 
+    my class WrapHandle {
+        has &.wrapper;
+        has &.wrappee;
+
+        method restore {
+            &.wrappee.unwrap(self)
+        }
+    }
+
     method wrap(&wrapper) {
-        my class WrapHandle {
-            has $!dispatcher;
-            has $!wrapper;
-            method restore() {
-                nqp::hllbool($!dispatcher.remove($!wrapper));
-            }
-        }
-        my role Wrapped {
-            has $!dispatcher;
-            method UNSHIFT_WRAPPER(&wrapper) {
-                # Add candidate.
-                $!dispatcher := WrapDispatcher.new()
-                    unless nqp::isconcrete($!dispatcher);
-                $!dispatcher.add(&wrapper);
+        my \wrp := nqp::clone(&wrapper);
+        my $handle = WrapHandle.new: :wrapper(wrp), :wrappee(self);
 
-                # Return a handle.
-                my $handle := nqp::create(WrapHandle);
-                nqp::bindattr($handle, WrapHandle, '$!dispatcher', $!dispatcher);
-                nqp::bindattr($handle, WrapHandle, '$!wrapper', &wrapper);
-                $handle
-            }
-            method CALL-ME(|c) is raw {
-                $!dispatcher.enter(|c);
-            }
-            method soft(--> True) { }
+        if $*W {
+            my sub wrp-fixup() { self!do_wrap(wrp) };
+            $*W.add_object_if_no_sc(wrp);
+            $*W.add_object_if_no_sc(&wrp-fixup);
+            $*W.add_fixup_task(
+                :fixup_ast(
+                    QAST::Op.new(:op<call>, QAST::WVal.new(:value(&wrp-fixup)))
+                ));
+        }
+        else {
+            self!do_wrap(wrp);
         }
 
+        $handle
+    }
+
+    method !do_wrap(\wrp) {
         # We can't wrap a hardened routine (that is, one that's been
         # marked inlinable).
         if nqp::istype(self, HardRoutine) {
@@ -114,22 +116,60 @@ my class Routine { # declared in BOOTSTRAP
                 "use the 'soft' pragma to avoid marking routines as hard.";
         }
 
-        # If we're not wrapped already, do the initial dispatcher
-        # creation.
-        unless nqp::istype(self, Wrapped) {
-            my $orig = self.clone();
-            self does Wrapped;
-            $!onlystar = 0; # disable optimization if no body there
-            self.UNSHIFT_WRAPPER($orig);
+        # Use clone to make it possible for user to use same wrapper for different routines.
+        my \wrp-do := nqp::getattr(wrp, Code, '$!do');
+        if nqp::defined($!wrappers) {
+            # Insert next to onlywrap
+            nqp::splice($!wrappers, nqp::list(wrp), 1, 0);
         }
-
-        # Add this wrapper.
-        self.UNSHIFT_WRAPPER(&wrapper);
+        else {
+            my \onlywrap := sub onlywrap(|) is raw is hidden-from-backtrace {
+                $/ := nqp::getlexcaller('$/');
+                my Mu $dispatcher := Metamodel::WrapDispatcher.vivify_for(self, nqp::ctx(), nqp::usecapture());
+                $*DISPATCHER := $dispatcher;
+                $dispatcher.call_with_capture(nqp::usecapture())
+            };
+            # onlywrap.set_name(self.name);
+            my \me = nqp::clone(self);
+            if $*W {
+                $*W.add_object_if_no_sc(me)
+            }
+            # Make static code point to the cloned object until original is fully unwrapped. If not done we end up with
+            # static code on `me` pointing at the original Routine instance, which has $!do from onlywrap. It results in
+            # dispatchers vivified from `me` receive onlywrap as $sub parameter.
+            nqp::setcodeobj(nqp::getattr(me, Code, '$!do'), me);
+            $!wrappers := nqp::list(onlywrap, wrp, me);
+            my \onlywrap-do := nqp::getattr(onlywrap, Code, '$!do');
+            nqp::setcodeobj(onlywrap-do, self);
+            nqp::bindattr(self, Code, '$!do', onlywrap-do);
+        }
     }
 
     method unwrap($handle) {
-        $handle.can('restore') && $handle.restore() ||
-            X::Routine::Unwrap.new.throw
+        X::Routine::Unwrap.new.throw unless nqp::istype($handle, WrapHandle);
+        my $succeed;
+        if $!wrappers {
+            my $idx = 0;
+            my $count = nqp::elems($!wrappers) - 1;
+            my &wrapper := nqp::decont($handle.wrapper);
+            while ++$idx < $count {
+                my &w := nqp::atpos($!wrappers, $idx);
+                if &w === &wrapper {
+                    # Also strip off all wrappers put on top of this.
+                    nqp::splice($!wrappers, nqp::list(), $idx, 1);
+                    $succeed := 1;
+                    last;
+                }
+            }
+            if $succeed && $count == 2 {
+                # We just have removed the last user wrapper, restore the original code.
+                my \orig-do := nqp::getattr(nqp::atpos($!wrappers, 1), Code, '$!do');
+                nqp::bindattr(self, Code, '$!do', orig-do);
+                nqp::setcodeobj(orig-do, self);
+                $!wrappers := nqp::null();
+            }
+        }
+        X::Routine::Unwrap.new.throw unless $succeed;
     }
 
     method package() { $!package }


### PR DESCRIPTION
A fix turned into a next revamp. This time it's about dispatchers and wrapping.

- Dispatchers now chain to each other. I.e. it is possible to wrap a
  candidate of a multi-dispatch method in the middle of inheritance chain.
  In turn, the wrapping routine can be a multi on its own and its
  candidates can be wrapped too, etc., etc.
- Wrapping is done using manipulations with `$!do` attribute. Whan a
  routine is completely unwrapped it's no different from its original
  state. Avoidance of use of `CALL-ME` invocation also fixes a few cases
  of 'Cannot invoke object with invocation handler in this context' error.
- `Routine` got attribute and accessor `wrappers` which is initialized
  with a list of routine wrappers, including a clone of the original
  routine itself.
- `Routine` got method `is_wrapped`.

Fixes #3499 