### PR TITLE
Make listing and coercion of sequences more efficient

### DIFF
--- a/src/core.c/Sequence.pm6
+++ b/src/core.c/Sequence.pm6
@@ -44,8 +44,8 @@ Routine.'!configure_positional_bind_failover'(Positional, PositionalBindFailover
 
 my role Sequence does PositionalBindFailover {
     multi method Array(::?CLASS:D:) { Array.from-iterator(self.iterator) }
-    multi method List(::?CLASS:D:)  { List.from-iterator(self.iterator) }
-    multi method Slip(::?CLASS:D:)  { Slip.from-iterator(self.iterator) }
+    multi method List(::?CLASS:D:)  { self.list.List }
+    multi method Slip(::?CLASS:D:)  { self.list.Slip }
 
     multi method Str(::?CLASS:D:) {
         self.cache.Str

--- a/src/core.c/Sequence.pm6
+++ b/src/core.c/Sequence.pm6
@@ -28,8 +28,13 @@ my role PositionalBindFailover {
           ($!list := List.from-iterator(self.iterator))
         )
     }
+
     multi method list(::?CLASS:D:) {
-        List.from-iterator(self.iterator)
+        nqp::if(
+          nqp::isconcrete($!list),
+          $!list,
+          List.from-iterator(self.iterator)
+        )
     }
 
     method iterator() { ... }


### PR DESCRIPTION
Let `.list` return the cached list if it exists and base the `.List` and `.Slip` coercers on `.list`.