### PR TITLE
Temporarily disable CircleCI building

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,7 +124,8 @@ commands:
 workflows:
   version: 2
   test:
-    unless: << pipeline.parameters.BUILD_PRECOMP_RELEASE >>
+      #    unless: << pipeline.parameters.BUILD_PRECOMP_RELEASE >>
+      when: False
     jobs:
       - test-linux
       - test-linux:


### PR DESCRIPTION
This is for debugging purposes with respect to why CircleCI is not building on Windows.
Per request of the CircleCI support team.