### PR TITLE
RFC: Change PositionalBindFailover MRO

### DIFF
--- a/src/core.c/HyperSeq.pm6
+++ b/src/core.c/HyperSeq.pm6
@@ -1,7 +1,7 @@
 # A HyperSeq performs batches of work in parallel, but retains order of output
 # values relative to input values.
 #?if !js
-my class HyperSeq does Iterable does Sequence {
+my class HyperSeq does Sequence {
     has HyperConfiguration $.configuration;
     has Rakudo::Internals::HyperWorkStage $!work-stage-head;
 

--- a/src/core.c/RaceSeq.pm6
+++ b/src/core.c/RaceSeq.pm6
@@ -3,7 +3,7 @@
 # the input).
 
 #?if !js
-my class RaceSeq does Iterable does Sequence {
+my class RaceSeq does Sequence {
     has HyperConfiguration $.configuration;
     has Rakudo::Internals::HyperWorkStage $!work-stage-head;
 

--- a/src/core.c/Seq.pm6
+++ b/src/core.c/Seq.pm6
@@ -1,6 +1,6 @@
 my class X::Seq::Consumed { ... }
 my class X::Seq::NotIndexable { ... }
-my class Seq is Cool does Iterable does Sequence {
+my class Seq is Cool does Sequence {
     # The underlying iterator that iterating this sequence will work its
     # way through. Can only be obtained once.
     has Iterator $!iter;

--- a/src/core.c/Sequence.pm6
+++ b/src/core.c/Sequence.pm6
@@ -18,7 +18,7 @@
 # Sequence role, so other user-defined types can get access to this
 # functionality.
 
-my role PositionalBindFailover {
+my role PositionalBindFailover does Iterable {
     has $!list;
 
     method cache() {
@@ -36,8 +36,6 @@ my role PositionalBindFailover {
           List.from-iterator(self.iterator)
         )
     }
-
-    method iterator() { ... }
 }
 nqp::p6configposbindfailover(Positional, PositionalBindFailover); # Binder
 Routine.'!configure_positional_bind_failover'(Positional, PositionalBindFailover); # Multi-dispatch


### PR DESCRIPTION
To me it makes sense for `PositionalBindFailover` to extend `Iterable` because both require an implementation of `method iterator()`.

This PR is a proof-of-concept to invite discussion. If there are good arguments against this change I will document them.