### PR TITLE
Enable env var RAKULIB

### DIFF
--- a/src/Perl6/Compiler.nqp
+++ b/src/Perl6/Compiler.nqp
@@ -174,18 +174,20 @@ Note that only boolean single-letter options may be bundled.
 The following environment variables are respected:
 
   RAKUDOLIB   Modify the module search path
-  PERL6LIB    Modify the module search path
+  RAKULIB     Modify the module search path
+  PERL6LIB    Modify the module search path # to be deprecated
   RAKUDO_HOME Override the path of the Rakudo runtime files
-  PERL6_HOME  Override the path of the Rakudo runtime files
+  RAKU_HOME   Override the path of the Rakudo runtime files
+  PERL6_HOME  Override the path of the Rakudo runtime files # to be deprecated
   NQP_HOME    Override the path of the NQP runtime files
 
 ♥); # end of usage statement
 
         nqp::exit(0);
 
-        # TODO: create and install a man page for Perl 6; then add the following
+        # TODO: create and install a man page for Raku; then add the following
         #       line to the end of the usage text above:
         #
-        #  For more information, see the perl6(1) man page.\n");
+        #  For more information, see the raku(1) man page.\n");
     }
 }

--- a/src/Perl6/Compiler.nqp
+++ b/src/Perl6/Compiler.nqp
@@ -177,8 +177,6 @@ The following environment variables are respected:
   RAKULIB     Modify the module search path
   PERL6LIB    Modify the module search path # to be deprecated
   RAKUDO_HOME Override the path of the Rakudo runtime files
-  RAKU_HOME   Override the path of the Rakudo runtime files
-  PERL6_HOME  Override the path of the Rakudo runtime files # to be deprecated
   NQP_HOME    Override the path of the NQP runtime files
 
 ♥); # end of usage statement

--- a/src/Perl6/Compiler.nqp
+++ b/src/Perl6/Compiler.nqp
@@ -173,7 +173,6 @@ Note that only boolean single-letter options may be bundled.
 
 The following environment variables are respected:
 
-  RAKUDOLIB   Modify the module search path
   RAKULIB     Modify the module search path
   PERL6LIB    Modify the module search path # to be deprecated
   RAKUDO_HOME Override the path of the Rakudo runtime files

--- a/src/core.c/CompUnit/RepositoryRegistry.pm6
+++ b/src/core.c/CompUnit/RepositoryRegistry.pm6
@@ -76,15 +76,15 @@ class CompUnit::RepositoryRegistry {
                  for parse-include-specS($specs);
             }
 
+            if nqp::existskey($ENV,'RAKUDOLIB') {
+                nqp::push($raw-specs,$_)
+                  for parse-include-specS(nqp::atkey($ENV,'RAKUDOLIB'));
+            }
             if nqp::existskey($ENV,'RAKULIB') {
                 nqp::push($raw-specs,$_)
                   for parse-include-specS(nqp::atkey($ENV,'RAKULIB'));
             }
-            elsif nqp::existskey($ENV,'RAKUDOLIB') {
-                nqp::push($raw-specs,$_)
-                  for parse-include-specS(nqp::atkey($ENV,'RAKUDOLIB'));
-            }
-            elsif nqp::existskey($ENV,'PERL6LIB') {
+            if nqp::existskey($ENV,'PERL6LIB') {
                 nqp::push($raw-specs,$_)
                   for parse-include-specS(nqp::atkey($ENV,'PERL6LIB'));
             }

--- a/src/core.c/CompUnit/RepositoryRegistry.pm6
+++ b/src/core.c/CompUnit/RepositoryRegistry.pm6
@@ -80,7 +80,7 @@ class CompUnit::RepositoryRegistry {
                 nqp::push($raw-specs,$_)
                   for parse-include-specS(nqp::atkey($ENV,'RAKUDOLIB'));
             }
-            elsif nqp::existskey($ENV,'RAKULIB') {
+            if nqp::existskey($ENV,'RAKULIB') {
                 nqp::push($raw-specs,$_)
                   for parse-include-specS(nqp::atkey($ENV,'RAKULIB'));
             }

--- a/src/core.c/CompUnit/RepositoryRegistry.pm6
+++ b/src/core.c/CompUnit/RepositoryRegistry.pm6
@@ -80,11 +80,11 @@ class CompUnit::RepositoryRegistry {
                 nqp::push($raw-specs,$_)
                   for parse-include-specS(nqp::atkey($ENV,'RAKUDOLIB'));
             }
-            if nqp::existskey($ENV,'RAKULIB') {
+            elsif nqp::existskey($ENV,'RAKULIB') {
                 nqp::push($raw-specs,$_)
                   for parse-include-specS(nqp::atkey($ENV,'RAKULIB'));
             }
-            if nqp::existskey($ENV,'PERL6LIB') {
+            elsif nqp::existskey($ENV,'PERL6LIB') {
                 nqp::push($raw-specs,$_)
                   for parse-include-specS(nqp::atkey($ENV,'PERL6LIB'));
             }

--- a/src/core.c/CompUnit/RepositoryRegistry.pm6
+++ b/src/core.c/CompUnit/RepositoryRegistry.pm6
@@ -76,13 +76,13 @@ class CompUnit::RepositoryRegistry {
                  for parse-include-specS($specs);
             }
 
-            if nqp::existskey($ENV,'RAKUDOLIB') {
-                nqp::push($raw-specs,$_)
-                  for parse-include-specS(nqp::atkey($ENV,'RAKUDOLIB'));
-            }
             if nqp::existskey($ENV,'RAKULIB') {
                 nqp::push($raw-specs,$_)
                   for parse-include-specS(nqp::atkey($ENV,'RAKULIB'));
+            }
+            elsif nqp::existskey($ENV,'RAKUDOLIB') {
+                nqp::push($raw-specs,$_)
+                  for parse-include-specS(nqp::atkey($ENV,'RAKUDOLIB'));
             }
             elsif nqp::existskey($ENV,'PERL6LIB') {
                 nqp::push($raw-specs,$_)

--- a/src/core.c/CompUnit/RepositoryRegistry.pm6
+++ b/src/core.c/CompUnit/RepositoryRegistry.pm6
@@ -80,6 +80,10 @@ class CompUnit::RepositoryRegistry {
                 nqp::push($raw-specs,$_)
                   for parse-include-specS(nqp::atkey($ENV,'RAKUDOLIB'));
             }
+            if nqp::existskey($ENV,'RAKULIB') {
+                nqp::push($raw-specs,$_)
+                  for parse-include-specS(nqp::atkey($ENV,'RAKULIB'));
+            }
             if nqp::existskey($ENV,'PERL6LIB') {
                 nqp::push($raw-specs,$_)
                   for parse-include-specS(nqp::atkey($ENV,'PERL6LIB'));

--- a/src/main.nqp
+++ b/src/main.nqp
@@ -32,6 +32,7 @@ my $install-dir := $execname eq ''
     !! nqp::substr($execname, 0, nqp::rindex($execname, $sep, nqp::rindex($execname, $sep) - 1));
 
 my $rakudo-home := $comp.config<static_rakudo_home>
+    // nqp::getenvhash()<PERL6_HOME>
     // nqp::getenvhash()<RAKUDO_HOME>
     // $install-dir ~ '/share/perl6';
 if nqp::substr($rakudo-home, nqp::chars($rakudo-home) - 1) eq $sep {

--- a/src/main.nqp
+++ b/src/main.nqp
@@ -32,8 +32,8 @@ my $install-dir := $execname eq ''
     !! nqp::substr($execname, 0, nqp::rindex($execname, $sep, nqp::rindex($execname, $sep) - 1));
 
 my $rakudo-home := $comp.config<static_rakudo_home>
-    // nqp::getenvhash()<PERL6_HOME>
     // nqp::getenvhash()<RAKUDO_HOME>
+    // nqp::getenvhash()<PERL6_HOME>
     // $install-dir ~ '/share/perl6';
 if nqp::substr($rakudo-home, nqp::chars($rakudo-home) - 1) eq $sep {
     $rakudo-home := nqp::substr($rakudo-home, 0, nqp::chars($rakudo-home) - 1);

--- a/src/main.nqp
+++ b/src/main.nqp
@@ -32,7 +32,6 @@ my $install-dir := $execname eq ''
     !! nqp::substr($execname, 0, nqp::rindex($execname, $sep, nqp::rindex($execname, $sep) - 1));
 
 my $rakudo-home := $comp.config<static_rakudo_home>
-    // nqp::getenvhash()<PERL6_HOME>
     // nqp::getenvhash()<RAKUDO_HOME>
     // $install-dir ~ '/share/perl6';
 if nqp::substr($rakudo-home, nqp::chars($rakudo-home) - 1) eq $sep {

--- a/src/rakudo-debug.nqp
+++ b/src/rakudo-debug.nqp
@@ -481,6 +481,7 @@ sub MAIN(*@ARGS) {
 
     my $rakudo-home := $comp.config<static_rakudo_home>
         // nqp::getenvhash()<RAKUDO_HOME>
+        // nqp::getenvhash()<PERL6_HOME>
         // $install-dir ~ '/share/perl6';
     if nqp::substr($rakudo-home, nqp::chars($rakudo-home) - 1) eq $sep {
         $rakudo-home := nqp::substr($rakudo-home, 0, nqp::chars($rakudo-home) - 1);

--- a/src/rakudo-debug.nqp
+++ b/src/rakudo-debug.nqp
@@ -480,7 +480,6 @@ sub MAIN(*@ARGS) {
         !! nqp::substr($execname, 0, nqp::rindex($execname, $sep, nqp::rindex($execname, $sep) - 1));
 
     my $rakudo-home := $comp.config<static_rakudo_home>
-        // nqp::getenvhash()<PERL6_HOME>
         // nqp::getenvhash()<RAKUDO_HOME>
         // $install-dir ~ '/share/perl6';
     if nqp::substr($rakudo-home, nqp::chars($rakudo-home) - 1) eq $sep {


### PR DESCRIPTION
Enable the compiler to respect the new environment variable RAKULIB for module paths to supersede the existing environment variable PERL6LIB.

Change is required for the name change from Perl 6 to Raku.

The existing test for the change is ready to be comited to roast and it was used to successfully test this change. See roast PR #625.