### PR TITLE
Fix problems with nextcallee

### DIFF
--- a/src/Perl6/Metamodel/Dispatchers.nqp
+++ b/src/Perl6/Metamodel/Dispatchers.nqp
@@ -72,9 +72,16 @@ class Perl6::Metamodel::BaseDispatcher {
     }
 
     method shift_callee() {
-        my $callee := @!candidates[$!idx];
-        ++$!idx;
-        nqp::decont($callee)
+        my @call := [nqp::null(), nqp::null()];
+        if self.last_candidate {
+            if $!next_dispatcher {
+                @call := $!next_dispatcher.shift_callee;
+            }
+        }
+        else {
+            @call := self.get_call;
+        }
+        @call;
     }
 
     method add_from_mro(@methods, $class, $sub, :$skip_first = 0) {

--- a/src/Perl6/Metamodel/Dispatchers.nqp
+++ b/src/Perl6/Metamodel/Dispatchers.nqp
@@ -130,8 +130,7 @@ class Perl6::Metamodel::MethodDispatcher is Perl6::Metamodel::BaseDispatcher {
 
     method vivify_for($sub, $lexpad, $args) {
         my $obj      := $lexpad<self>;
-        my $class    := nqp::getlexrel($lexpad, '::?CLASS');
-        my @methods  := self.add_from_mro([], $class, $sub);
+        my @methods  := self.add_from_mro([], $obj, $sub);
         self.new(:candidates(@methods), :obj($obj), :idx(1))
     }
 

--- a/src/core.c/control.pm6
+++ b/src/core.c/control.pm6
@@ -149,7 +149,20 @@ sub lastcall(--> True) {
 
 sub nextcallee() {
     my Mu $dispatcher := nqp::p6finddispatcher('nextsame');
-    $dispatcher.exhausted ?? Nil !! $dispatcher.shift_callee()
+    if $dispatcher.exhausted {
+        Nil
+    }
+    else {
+        # XXX Until there is a nqp op which would repace $*NEXT-DISPATCHER, this is the only way for nextcallee to
+        # support chaining of dispatchers.
+        my @call = $dispatcher.shift_callee;
+        @call[0]
+            ?? -> |args {
+                my $*NEXT-DISPATCHER := @call[1];
+                @call[0]( |args )
+            }
+            !! Nil
+    }
 }
 
 sub samewith(|c) {


### PR DESCRIPTION
Two causes were identified:

- Use of `::?CLASS` for obtaining MRO fails for dynamically produced methods engrafted onto another class as they preserve `::?CLASS` of the package they were created in.
- `nextcallee` was breaking dispatcher chain because subsequent dispatcher had no way to know where to re-dispatch when exhausted. Until  MoarVM/MoarVM#1274 is implemented, use a workaround with a stub which would set `$*NEXT-DISPATCHER` and then call the actual callee.