### PR TITLE
Add Cool.contains(Regex) candidates

### DIFF
--- a/src/core.c/Cool.pm6
+++ b/src/core.c/Cool.pm6
@@ -230,6 +230,9 @@ my class Cool { # declared in BOOTSTRAP
     multi method contains(Cool:D: Cool:D $needle --> Bool:D) {
         self.Str.contains: $needle.Str
     }   
+    multi method contains(Cool:D: Regex:D $needle --> Bool:D) {
+        self.Str.contains: $needle
+    }
 
     multi method contains(Cool:D:
       Cool:D $needle, Cool:D $pos, :i(:$ignorecase)!, :m(:$ignoremark)
@@ -242,6 +245,9 @@ my class Cool { # declared in BOOTSTRAP
     }
     multi method contains(Cool:D: Cool:D $needle, Cool:D $pos --> Bool:D) {
         self.Str.contains($needle.Str, $pos.Int)
+    }
+    multi method contains(Cool:D: Regex:D $needle, Cool:D $pos --> Bool:D) {
+        self.Str.contains($needle, $pos)
     }
 
     proto method indices(|) {*}


### PR DESCRIPTION
Commit c3c5dae123 added Str.contains candidates for a Regex $needle.
The Cool class also has a contains method which implicitly converts the
Cool to a Str and calls Str.contains on it. But the new candidates were
not mirrored in Cool, so the OO loop wasn't as convenient. This commit
fixes this oversight.

[uzl++](https://colabti.org/irclogger/irclogger_log/raku?date=2020-03-01#l152) for discovery.