### PR TITLE
Implement dispatchers using nextdispatcherfor/takenextdispatcher

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -4286,8 +4286,8 @@ class Perl6::Actions is HLL::Actions does STDActions {
         for @($past[0]) {
             if nqp::istype($_, QAST::Var) && $_.scope eq 'lexical' {
                 my $name := $_.name;
-                return 0 if $name ne '$*DISPATCHER' && $name ne '$_' &&
-                    $name ne '$/' && $name ne '$¢' && $name ne '$!' &&
+                return 0 if $name ne '$*DISPATCHER' && $name ne '$*NEXT-DISPATCHER'
+                    && $name ne '$_' && $name ne '$/' && $name ne '$¢' && $name ne '$!' &&
                     !nqp::existskey(%arg_placeholders, $name);
             }
             elsif nqp::istype($_, QAST::Block) {

--- a/src/Perl6/Metamodel/Dispatchers.nqp
+++ b/src/Perl6/Metamodel/Dispatchers.nqp
@@ -5,7 +5,7 @@ class Perl6::Metamodel::BaseDispatcher {
 
     method candidates()     { @!candidates }
 
-    method exhausted()      { $!idx >= +@!candidates && (!nqp::isconcrete($!next_dispatcher) || $!next_dispatcher.exhausted()) }
+    method exhausted()      { $!idx >= +@!candidates && (!nqp::defined($!next_dispatcher) || $!next_dispatcher.exhausted()) }
 
     method last_candidate() { $!idx >= +@!candidates }
 
@@ -14,34 +14,31 @@ class Perl6::Metamodel::BaseDispatcher {
     method set_next_dispatcher($next_dispatcher)
                             { $!next_dispatcher := $next_dispatcher }
 
-    # Wrapper-like dispatchers don't set dispatcher for the last candidate.
+    # Wrapper-like dispatchers handle their last candidate differently.
     method is_wrapper_like() { 0 }
 
-    method get_call() { # Returns [$call, $is_dispatcher]
+    method get_call() {
         my $call := @!candidates[$!idx];
         ++$!idx;
-        my $next_disp := self.set_call_dispatcher($call);
-        [$call, $next_disp]
-    }
-
-    # By default we just set next call dispatcher to ourselves.
-    # Method must return value for $*NEXT-DISPATCHER
-    method set_call_dispatcher($call) {
-        return nqp::null() if self.is_wrapper_like && self.last_candidate && !$!next_dispatcher;
         if (nqp::can($call, 'is_dispatcher') && $call.is_dispatcher)
             || (nqp::can($call, 'is_wrapped') && $call.is_wrapped)
         {
-            self
+            nqp::nextdispatcherfor(self, $call);
         }
         else {
-            nqp::setdispatcherfor(self, $call);
-            nqp::null()
+            if self.is_wrapper_like && self.last_candidate {
+                nqp::setdispatcherfor($!next_dispatcher, $call) if $!next_dispatcher;
+            }
+            else {
+                nqp::setdispatcherfor(self, $call);
+            }
         }
+        $call
     }
 
     method call_with_args(*@pos, *%named) {
         if self.last_candidate {
-            if $!next_dispatcher {
+            if nqp::defined($!next_dispatcher) {
                 $!next_dispatcher.call_with_args(|@pos, |%named);
             }
             else {
@@ -49,20 +46,19 @@ class Perl6::Metamodel::BaseDispatcher {
             }
         }
         else {
-            my @call := self.get_call;
-            my $*NEXT-DISPATCHER := @call[1];
+            my $call := self.get_call;
             if self.has_invocant {
-                @call[0](self.invocant, |@pos, |%named);
+               $call(self.invocant, |@pos, |%named);
             }
             else {
-                @call[0](|@pos, |%named);
+                $call(|@pos, |%named);
             }
         }
     }
 
     method call_with_capture($capture) {
         if self.last_candidate {
-            if $!next_dispatcher {
+            if nqp::defined($!next_dispatcher) {
                 $!next_dispatcher.call_with_capture($capture)
             }
             else {
@@ -70,23 +66,23 @@ class Perl6::Metamodel::BaseDispatcher {
             }
         }
         else {
-            my @call := self.get_call;
-            my $*NEXT-DISPATCHER := @call[1];
-            nqp::invokewithcapture(@call[0], $capture);
+            my $call := self.get_call;
+            nqp::invokewithcapture($call, $capture);
         }
     }
 
     method shift_callee() {
-        my @call := [nqp::null(), nqp::null()];
         if self.last_candidate {
-            if $!next_dispatcher {
-                @call := $!next_dispatcher.shift_callee;
+            if nqp::defined($!next_dispatcher) {
+                $!next_dispatcher.shift_callee;
+            }
+            else {
+                nqp::null()
             }
         }
         else {
-            @call := self.get_call;
+            self.get_call;
         }
-        @call;
     }
 
     method add_from_mro(@methods, $class, $sub, :$skip_first = 0) {
@@ -106,8 +102,7 @@ class Perl6::Metamodel::BaseDispatcher {
                     $meth := nqp::null() if %seen{$proto_pkg_id};
                     %seen{$proto_pkg_id} := 1
                 }
-                # Skipping the first method obtained from MRO because either it should have been handled already by
-                # vivify_for.
+                # Skipping the first method obtained from MRO because it should have been invoked already
                 nqp::if(
                     nqp::isgt_i($skip_first, 0),
                     (--$skip_first),
@@ -134,8 +129,9 @@ class Perl6::Metamodel::MethodDispatcher is Perl6::Metamodel::BaseDispatcher {
     }
 
     method vivify_for($sub, $lexpad, $args) {
-        my $obj      := $lexpad<self>;
-        my @methods  := self.add_from_mro([], $obj, $sub);
+        my $obj      := nqp::decont($lexpad<self>);
+        my @methods  := [];
+        self.add_from_mro(@methods, $obj, $sub);
         self.new(:candidates(@methods), :obj($obj), :idx(1))
     }
 
@@ -163,11 +159,11 @@ class Perl6::Metamodel::MultiDispatcher is Perl6::Metamodel::BaseDispatcher {
         my @cands        := $disp.find_best_dispatchee($args, 1);
         my $invocant     := $has_invocant && $lexpad<self>;
         my $next_dispatcher := nqp::getlexreldyn($lexpad, '$*NEXT-DISPATCHER');
+
         # The first candidate has already been invoked, throw it away from the list;
         # If called in a method then only take control if MethodDispatcher is in charge.
-        if $has_invocant && !nqp::isconcrete($next_dispatcher) {
-            my $class := nqp::getlexrel($lexpad, '::?CLASS');
-            self.add_from_mro(@cands, $class, $sub, :skip_first(1));
+        if $has_invocant && !nqp::defined($next_dispatcher) {
+            self.add_from_mro(@cands, $invocant, $sub, :skip_first(1));
             Perl6::Metamodel::MethodDispatcher.new(:candidates(@cands), :idx(1), :obj($invocant))
         }
         else {

--- a/src/Perl6/Metamodel/Dispatchers.nqp
+++ b/src/Perl6/Metamodel/Dispatchers.nqp
@@ -158,7 +158,9 @@ class Perl6::Metamodel::MultiDispatcher is Perl6::Metamodel::BaseDispatcher {
         my $has_invocant := nqp::existskey($lexpad, 'self');
         my @cands        := $disp.find_best_dispatchee($args, 1);
         my $invocant     := $has_invocant && $lexpad<self>;
-        my $next_dispatcher := nqp::getlexreldyn($lexpad, '$*NEXT-DISPATCHER');
+        my $next_dispatcher := nqp::existskey($lexpad, '$*NEXT-DISPATCHER')
+                                ?? nqp::atkey($lexpad, '$*NEXT-DISPATCHER')
+                                !! nqp::null();
 
         # The first candidate has already been invoked, throw it away from the list;
         # If called in a method then only take control if MethodDispatcher is in charge.
@@ -186,7 +188,9 @@ class Perl6::Metamodel::WrapDispatcher is Perl6::Metamodel::BaseDispatcher {
 
     method vivify_for($sub, $lexpad, $capture) {
         my @candidates      := $sub.wrappers;
-        my $next_dispatcher := nqp::getlexreldyn($lexpad, '$*NEXT-DISPATCHER');
+        my $next_dispatcher := nqp::existskey($lexpad, '$*NEXT-DISPATCHER')
+                                ?? nqp::atkey($lexpad, '$*NEXT-DISPATCHER')
+                                !! nqp::null();
         self.new(:@candidates, :idx(1), :$next_dispatcher)
     }
 

--- a/src/Perl6/Optimizer.nqp
+++ b/src/Perl6/Optimizer.nqp
@@ -703,7 +703,9 @@ my class BlockVarOptimizer {
             while $iter {
                 nqp::shift($iter);
                 my $op := nqp::iterval($iter);
-                $op.op('cleardispatcher');
+                my $name := nqp::iterkey_s($iter);
+                # Replace 'take' with 'clear' in the op name.
+                $op.op(nqp::replace($name, 0, 4, 'clear'));
                 $op.shift();
             }
         }

--- a/src/Perl6/Optimizer.nqp
+++ b/src/Perl6/Optimizer.nqp
@@ -1305,13 +1305,14 @@ class Perl6::Optimizer {
 
     # Poisonous calls.
     my %poison_calls := nqp::hash(
-        'EVAL',     NQPMu, '&EVAL',     NQPMu,
-        'EVALFILE', NQPMu, '&EVALFILE', NQPMu,
-        'callwith', NQPMu, '&callwith', NQPMu,
-        'callsame', NQPMu, '&callsame', NQPMu,
-        'nextwith', NQPMu, '&nextwith', NQPMu,
-        'nextsame', NQPMu, '&nextsame', NQPMu,
-        'samewith', NQPMu, '&samewith', NQPMu,
+        'EVAL',       NQPMu, '&EVAL',       NQPMu,
+        'EVALFILE',   NQPMu, '&EVALFILE',   NQPMu,
+        'callwith',   NQPMu, '&callwith',   NQPMu,
+        'callsame',   NQPMu, '&callsame',   NQPMu,
+        'nextcallee', NQPMu, '&nextcallee', NQPMu,
+        'nextwith',   NQPMu, '&nextwith',   NQPMu,
+        'nextsame',   NQPMu, '&nextsame',   NQPMu,
+        'samewith',   NQPMu, '&samewith',   NQPMu,
         # This is a hack to compensate for Test.pm6 using unspecified
         # behavior. The EVAL form of it should be deprecated and then
         # removed, at which point this can go away.
@@ -3041,13 +3042,13 @@ class Perl6::Optimizer {
                 # a symbol, do nothing (we just need it for "fallback" purposes).
                 # Otherwise, copy it and register it in the outer.
                 my $name := $_.name;
-                unless $name eq '$*DISPATCHER' || $name eq '$_' || $outer.symbol($name) {
+                unless $name eq '$*DISPATCHER' || $name eq '$*NEXT-DISPATCHER' || $name eq '$_' || $outer.symbol($name) {
                     @copy_decls.push($_);
                     $outer.symbol($name, :scope('lexical'));
                 }
             }
-            elsif nqp::istype($_, QAST::Op) && $_.op eq 'takedispatcher' {
-                # Don't copy the dispatcher take, since the $*DISPATCHER is
+            elsif nqp::istype($_, QAST::Op) && ($_.op eq 'takedispatcher' || $_.op eq 'takenextdispatcher') {
+                # Don't copy the dispatcher take, since the $*DISPATCHER and $*NEXT-DISPATCHER are
                 # also not copied.
             }
             else {

--- a/src/core.c/Backtrace.pm6
+++ b/src/core.c/Backtrace.pm6
@@ -90,17 +90,42 @@ my class Backtrace {
         $!frames := nqp::list;
         self
     }
+
+    # The purpose of SKIP-OWN-COUNT is to find the first frame which lies above any of our own frames. This method makes
+    # backtracing much less context and optimization dependent.
+    # This method is only needed while we depend on exceptions to produce a backtrace. If we ever get nqp::backtrace()
+    # or nqp::backtrace(nqp::ctx) implemented then this method could be obsoleted as then we would know exactly how many
+    # frames belong to Backtrace.
+    method !SKIP-OWN-COUNT(Mu \bt) {
+        my $cnt = 0;
+        my $found-self := 0;
+        my $i = 0;
+        my $elems := bt.elems;
+        nqp::while(
+            nqp::if(nqp::islt_i($i, $elems), nqp::iseq_i($cnt, 0)),
+            nqp::stmts(
+                (my $own := nqp::isge_i(nqp::rindex(%(bt[$i])<annotations><file>, 'Backtrace.pm6'), 0)),
+                nqp::if(
+                    $found-self,
+                    nqp::unless($own, ($cnt = $i)),
+                    nqp::if($own, ($found-self := 1))
+                ),
+                ++$i
+            )
+        );
+        $cnt
+    }
     multi method new() {
         try X::AdHoc.new(:payload("Died")).throw;
         nqp::create(self)!SET-SELF(
-          nqp::backtrace(nqp::getattr(nqp::decont($!),Exception,'$!ex')),
-          1)
+          (my \bt = nqp::backtrace(nqp::getattr(nqp::decont($!),Exception,'$!ex'))),
+          self!SKIP-OWN-COUNT(bt))
     }
     multi method new(Int:D $offset) {
         try X::AdHoc.new(:payload("Died")).throw;
         nqp::create(self)!SET-SELF(
-          nqp::backtrace(nqp::getattr(nqp::decont($!),Exception,'$!ex')),
-          1 + $offset)
+          (my \bt = nqp::backtrace(nqp::getattr(nqp::decont($!),Exception,'$!ex'))),
+          self!SKIP-OWN-COUNT(bt) + $offset)
     }
     multi method new(Mu \ex) {
         nqp::create(self)!SET-SELF(

--- a/src/core.c/Deprecations.pm6
+++ b/src/core.c/Deprecations.pm6
@@ -81,7 +81,7 @@ class Rakudo::Deprecations {
 
         my $bt = Backtrace.new;
         my $deprecated =
-          $bt[ my $index = $bt.next-interesting-index(2, :named, :setting) // 0 ];
+          $bt[ my $index = $bt.next-interesting-index(:named, :setting) // 0 ];
 
         if $up ~~ Whatever {
             $index = $_ with $bt.next-interesting-index($index, :noproto);

--- a/src/core.c/Routine.pm6
+++ b/src/core.c/Routine.pm6
@@ -96,6 +96,9 @@ my class Routine { # declared in BOOTSTRAP
             $*W.add_object_if_no_sc(&wrapper);
             $*W.add_object_if_no_sc(&wrapper-fixup);
             $*W.add_fixup_task(
+                :deserialize_ast(
+                    QAST::Op.new(:op<call>, QAST::WVal.new(:value(&wrapper-fixup)))
+                ),
                 :fixup_ast(
                     QAST::Op.new(:op<call>, QAST::WVal.new(:value(&wrapper-fixup)))
                 ));

--- a/src/core.c/Routine.pm6
+++ b/src/core.c/Routine.pm6
@@ -123,13 +123,11 @@ my class Routine { # declared in BOOTSTRAP
             nqp::splice($!wrappers, nqp::list(wrapper), 1, 0);
         }
         else {
-            my \onlywrap := sub onlywrap(|) is raw is hidden-from-backtrace {
+            my \onlywrap := my sub onlywrap(|) is raw is hidden-from-backtrace {
                 $/ := nqp::getlexcaller('$/');
                 my Mu $dispatcher := Metamodel::WrapDispatcher.vivify_for(self, nqp::ctx(), nqp::usecapture());
-                $*DISPATCHER := $dispatcher;
                 $dispatcher.call_with_capture(nqp::usecapture())
             };
-            # onlywrap.set_name(self.name);
             my \me = nqp::clone(self);
             if $*W {
                 $*W.add_object_if_no_sc(me)

--- a/src/core.c/control.pm6
+++ b/src/core.c/control.pm6
@@ -149,20 +149,7 @@ sub lastcall(--> True) {
 
 sub nextcallee() {
     my Mu $dispatcher := nqp::p6finddispatcher('nextsame');
-    if $dispatcher.exhausted {
-        Nil
-    }
-    else {
-        # XXX Until there is a nqp op which would repace $*NEXT-DISPATCHER, this is the only way for nextcallee to
-        # support chaining of dispatchers.
-        my @call = $dispatcher.shift_callee;
-        @call[0]
-            ?? -> |args {
-                my $*NEXT-DISPATCHER := @call[1];
-                @call[0]( |args )
-            }
-            !! Nil
-    }
+    $dispatcher.exhausted ?? Nil !! $dispatcher.shift_callee()
 }
 
 sub samewith(|c) {


### PR DESCRIPTION
It is the correct way to do chaining of dispatchers.

This PR fixes a problem which is covered by a new test in perl6/roast#627.

This depends on MoarVM/MoarVM#1252 and perl6/nqp#601.