### PR TITLE
Force publish type cache if found in the MRO

### DIFF
--- a/src/Perl6/Metamodel/MROBasedTypeChecking.nqp
+++ b/src/Perl6/Metamodel/MROBasedTypeChecking.nqp
@@ -17,11 +17,13 @@ role Perl6::Metamodel::MROBasedTypeChecking {
         # Just hunt through MRO.
         for self.mro($obj) {
             if $_ =:= $checkee {
+                self.publish_type_cache($obj);
                 return 1;
             }
             if nqp::can($_.HOW, 'role_typecheck_list') {
                 for $_.HOW.role_typecheck_list($_) {
                     if $_ =:= $checkee {
+                        self.publish_type_cache($obj);
                         return 1;
                     }
                 }


### PR DESCRIPTION
Before, `constant N = 1_000_000; my int @a[N]; @a[$_] = $_ for ^N; say @a[N-1]; say now - INIT now` would take ~3s. After, it takes ~1s. Before, a profile showed 2m calls to `type_check` (https://github.com/rakudo/rakudo/blob/master/src/Perl6/Metamodel/MROBasedTypeChecking.nqp#L14). After, there is only 1.

Rakudo builds ok and passes `make m-test m-spectest`. Helps out #3532 a bit, but I suspect there is a much smarter way to do this.