### PR TITLE
Move RUN_CLEAN_TARGET_FILES to separate script

### DIFF
--- a/tools/build/clean-target-files.raku
+++ b/tools/build/clean-target-files.raku
@@ -1,0 +1,11 @@
+#!/usr/bin/env raku
+
+unit sub MAIN(Str $folder, *@files where @files.so, Bool :$v);
+
+for @files {
+    given ( $folder.IO.add($_) ) {
+        say 'rm -f ' ~ .Str if $v;
+        .unlink if .e;
+    }
+}
+

--- a/tools/templates/Makefile-common-macros.in
+++ b/tools/templates/Makefile-common-macros.in
@@ -1,13 +1,20 @@
 # Copyright (C) 2015 The Perl Foundation
 
-@if(silent_build==on NOECHO = @
-@make_pp_pfx@ifdef VERBOSE_BUILD 
+@if(silent_build==on @make_pp_pfx@ifdef VERBOSE_BUILD
 NOECHO = 
+VERBOSE = -v
 @make_pp_pfx@endif
-)@@if(silent_build!=on
-NOECHO = 
-@make_pp_pfx@ifdef SILENT_BUILD
+@make_pp_pfx@ifndef VERBOSE_BUILD
 NOECHO = @
+VERBOSE = 
+@make_pp_pfx@endif
+)@@if(silent_build!=on @make_pp_pfx@ifdef SILENT_BUILD
+NOECHO = @
+VERBOSE = 
+@make_pp_pfx@endif
+@make_pp_pfx@ifndef SILENT_BUILD
+NOECHO = 
+VERBOSE = -v
 @make_pp_pfx@endif
 )@
 PERL5   = @shquot(@perl@)@ -I@nfpq(@base_dir@/tools/lib)@ -I@nfpq(@base_dir@/3rdparty/nqp-configure/lib)@

--- a/tools/templates/moar/Makefile.in
+++ b/tools/templates/moar/Makefile.in
@@ -93,7 +93,7 @@ R_SETTING_MOAR = RESTRICTED.setting.moarvm
 @bpv(HARNESS6)@ = @nfp(@base_dir@/@bpm(RUNNER)@)@ -Ilib @nfp(t/harness6)@
 @bpv(HARNESS6_WITH_FUDGE)@ = @bpm(HARNESS6)@ --fudge
 
-@bpv(RUN_CLEAN_TARGET_FILES)@ = @bpm(RUN_RAKUDO)@ -e "for @*ARGS.head(*-1) { given (@*ARGS[*-1] ~ '.'.IO.SPEC.dir-sep ~ .IO.basename.Str) { say 'rm -f ' ~ .Str if '@verbose@' eq '@'; .IO.unlink if .IO.e } }"
+@bpv(RUN_CLEAN_TARGET_FILES)@ = @nfp(@base_dir@/@bpm(RUNNER)@)@ @script(clean-target-files.raku)@ $(VERBOSE)
 
 @include(Makefile-backend-common)@
 
@@ -205,11 +205,10 @@ $(R_SETTING_MOAR): @bsm(RAKUDO)@@for_specs( @bsm(SETTING_@ucspec@)@)@ $(R_SETTIN
 
 @backend_prefix@-install-pre::
 	@echo(+++ Removing old files)@
-	$(NOECHO)@bpm(RUN_CLEAN_TARGET_FILES)@ @bpm(RAKUDO_PRECOMPS)@ @nfpq(@nop($(DESTDIR))@@bpm(LIBDIR)@/Perl6)@
-	$(NOECHO)@bpm(RUN_CLEAN_TARGET_FILES)@ @bpm(RAKUDO_BOOTSTRAP_PRECOMPS)@ @nfpq(@nop($(DESTDIR))@@bpm(LIBDIR)@/Perl6/BOOTSTRAP)@
-	$(NOECHO)@bpm(RUN_CLEAN_TARGET_FILES)@ @for_specs($(SETTING_@ucspec@_MOAR) )@$(R_SETTING_MOAR) @nfpq($(DESTDIR)$(RAKUDO_HOME)/runtime)@
-	$(NOECHO)@bpm(RUN_CLEAN_TARGET_FILES)@ @bsm(PERL6)@ @bsm(PERL6_DEBUG)@
-	$(NOECHO)@bpm(RUN_CLEAN_TARGET_FILES)@ @bsm(RAKUDO)@ @bsm(RAKUDO_DEBUG)@ @nfpq($(DESTDIR)$(RAKUDO_HOME)/runtime)@
+	$(NOECHO)@bpm(RUN_CLEAN_TARGET_FILES)@ @nfpq(@nop($(DESTDIR))@@bpm(LIBDIR)@/Perl6)@ @bpm(RAKUDO_PRECOMPS)@
+	$(NOECHO)@bpm(RUN_CLEAN_TARGET_FILES)@ @nfpq(@nop($(DESTDIR))@@bpm(LIBDIR)@/Perl6/BOOTSTRAP)@ @bpm(RAKUDO_BOOTSTRAP_PRECOMPS)@
+	$(NOECHO)@bpm(RUN_CLEAN_TARGET_FILES)@ @nfpq($(DESTDIR)$(RAKUDO_HOME)/runtime)@ @for_specs($(SETTING_@ucspec@_MOAR) )@$(R_SETTING_MOAR)
+	$(NOECHO)@bpm(RUN_CLEAN_TARGET_FILES)@ @nfpq($(DESTDIR)$(PREFIX)/bin)@ @bsm(RAKUDO)@ @bsm(RAKUDO_DEBUG)@ @bsm(PERL6)@ @bsm(PERL6_DEBUG)@
 
 @backend_prefix@-install-main:: @@bpm(RAKUDO_OPS_DLL)@@ $(R_SETTING_MOAR) @@bpm(INST_RAKUDO_M)@@ @@bpm(INST_RAKUDO_DEBUG_M)@@
 	$(NOECHO)$(CP) @bpm(RAKUDO_OPS_DLL)@ @nfpq($(DESTDIR)$(RAKUDO_HOME)/runtime/dynext)@


### PR DESCRIPTION
And clean up the logic a lot. The way it looked before it was probably
broken in multiple ways:
- PERL6 and PERL6_DEBUG were never deleted, the line was missing a folder.
- The 'verbose' logic didn't work. There is no 'verbose' variable specified
  anywhere. I just removed the respective logic as I didn't find an obvious
  way to turn the NOECHO variable into a '-v' argument.