### PR TITLE
Revert "Work around existing bug exposed by mixin caching."

### DIFF
--- a/src/Perl6/Metamodel/Mixins.nqp
+++ b/src/Perl6/Metamodel/Mixins.nqp
@@ -32,15 +32,7 @@ role Perl6::Metamodel::Mixins {
             @roles[$i] := nqp::decont(@roles[$i]);
             ++$i;
         }
-        # XXX Workaround for mixing in to non-composed types; when this takes
-        # place (a bunch during CORE.setting) the mixin is missing bits. This
-        # has long been a problem, and needs a real solution (it's related to
-        # the "augment does not convey additions to subclasses" issue); mixin
-        # caching just makes the problem very visible. For now, don't cache if
-        # the current type is not yet composed.
-        my $mixin_type := self.is_composed($obj)
-            ?? nqp::parameterizetype($!mixin_cache, @roles)
-            !! self.generate_mixin($obj, @roles);
+        my $mixin_type := nqp::parameterizetype($!mixin_cache, @roles);
 
         # Ensure there's a mixin attribute, if we need it.
         if $need-mixin-attribute {


### PR DESCRIPTION
This reverts commit 8ec84b608d0b3c21ec465352eef617581ed5af41.

Adding some logging showed that `self.is_composed($obj)` is always true
when building Rakudo.

Rakudo builds ok and passes `make m-test m-spectest`.