### PR TITLE
Make .WHY on role group delegate to default role

### DIFF
--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -2644,6 +2644,8 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         :my $*zone := 'posreq';
         :my $*multi_invocant := 1;
         :my @*seps := nqp::list();
+        :my $*PRECEDING_DECL; # for #= comments
+        :my $*PRECEDING_DECL_LINE := -1; # XXX update this when I see another comment like it?
         <.ws>
         [
         | <?before '-->' | ')' | ']' | '{' | ':'\s | ';;' >

--- a/src/Perl6/Metamodel/ParametricRoleGroupHOW.nqp
+++ b/src/Perl6/Metamodel/ParametricRoleGroupHOW.nqp
@@ -146,7 +146,7 @@ class Perl6::Metamodel::ParametricRoleGroupHOW
     }
 
     method update_role_typecheck_list($obj) {
-        my $ns := self.'!get_nonsignatured_candidate'($obj);
+        my $ns := self.'!get_nonsignatured_candidate'();
         @!role_typecheck_list := $ns.HOW.role_typecheck_list($ns) unless nqp::isnull($ns);
     }
 
@@ -169,7 +169,7 @@ class Perl6::Metamodel::ParametricRoleGroupHOW
                 return 1;
             }
         }
-        my $ns := self.'!get_nonsignatured_candidate'($obj);
+        my $ns := self.'!get_nonsignatured_candidate'();
         return $ns.HOW.type_check_parents($ns, $decont) unless nqp::isnull($ns);
         0;
     }
@@ -177,61 +177,62 @@ class Perl6::Metamodel::ParametricRoleGroupHOW
     method candidates($obj) { nqp::clone(@!candidates) }
 
     method lookup($obj, $name) {
-        my $c := self.'!get_default_candidate'($obj);
+        my $c := self.'!get_default_candidate'();
         $c.HOW.lookup($c, $name);
     }
 
     method methods($obj, *@pos, *%name) {
-        my $c := self.'!get_default_candidate'($obj);
+        my $c := self.'!get_default_candidate'();
         $c.HOW.methods($c, |@pos, |%name);
     }
 
     method attributes($obj, *@pos, *%name) {
-        my $c := self.'!get_default_candidate'($obj);
+        my $c := self.'!get_default_candidate'();
         $c.HOW.attributes($c, |@pos, |%name);
     }
 
     method parents($obj, *%named) {
-        my $c := self.'!get_default_candidate'($obj);
+        my $c := self.'!get_default_candidate'();
         $c.HOW.parents($c, |%named)
     }
 
     method roles($obj, *%named) {
-        my $c := self.'!get_default_candidate'($obj);
+        my $c := self.'!get_default_candidate'();
         $c.HOW.roles($c, |%named)
     }
 
     method ver($obj) {
-        my $c := self.'!get_default_candidate'($obj);
+        my $c := self.'!get_default_candidate'();
         $c.HOW.ver($c)
     }
 
     method auth($obj) {
-        my $c := self.'!get_default_candidate'($obj);
+        my $c := self.'!get_default_candidate'();
         $c.HOW.auth($c)
     }
 
     method language-revision($obj) {
-        my $c := self.'!get_default_candidate'($obj);
+        my $c := self.'!get_default_candidate'();
         nqp::unless(nqp::isnull($c),
                     $c.HOW.language-revision($c),
                     nqp::null())
     }
 
     method is-implementation-detail($obj) {
-        my $c := self.'!get_default_candidate'($obj);
+        my $c := self.'!get_default_candidate'();
         $c.HOW.is-implementation-detail($c)
     }
 
-    method !get_default_candidate($obj) {
-        nqp::ifnull(self.'!get_nonsignatured_candidate'($obj),
-                    nqp::if(
-                        +@!candidates,
-                        @!candidates[0],
-                        nqp::null()))
+    method WHY() {
+        my $c := self.'!get_default_candidate'();
+        $c.HOW.WHY
     }
 
-    method !get_nonsignatured_candidate($obj) {
+    method !get_default_candidate() {
+        self.'!get_nonsignatured_candidate'() || @!candidates[0]
+    }
+
+    method !get_nonsignatured_candidate() {
         return nqp::null unless +@!nonsignatured;
         @!nonsignatured[0]
     }

--- a/src/Perl6/Metamodel/ParametricRoleGroupHOW.nqp
+++ b/src/Perl6/Metamodel/ParametricRoleGroupHOW.nqp
@@ -12,7 +12,6 @@
 # a particular candidate.
 class Perl6::Metamodel::ParametricRoleGroupHOW
     does Perl6::Metamodel::Naming
-    does Perl6::Metamodel::Documenting
     does Perl6::Metamodel::Stashing
     does Perl6::Metamodel::TypePretense
     does Perl6::Metamodel::RolePunning
@@ -212,29 +211,39 @@ class Perl6::Metamodel::ParametricRoleGroupHOW
     }
 
     method language-revision($obj) {
-        my $c := self.'!get_default_candidate'();
-        nqp::unless(nqp::isnull($c),
-                    $c.HOW.language-revision($c),
-                    nqp::null())
+        nqp::isnull(my $c := self.'!get_default_candidate'())
+            ?? nqp::null()
+            !! $c.HOW.language-revision($c)
     }
 
     method is-implementation-detail($obj) {
-        my $c := self.'!get_default_candidate'();
-        $c.HOW.is-implementation-detail($c)
+        nqp::isnull(my $c := self.'!get_default_candidate'())
+            ?? nqp::null()
+            !! $c.HOW.is-implementation-detail($c)
     }
 
     method WHY() {
-        my $c := self.'!get_default_candidate'();
-        $c.HOW.WHY
+        nqp::isnull(my $c := self.'!get_default_candidate'())
+            ?? nqp::null()
+            !! $c.HOW.WHY
+    }
+
+    method set_why($why) {
+        Perl6::Metamodel::Configuration.throw_or_die(
+            'X::Role::Group::Documenting',
+            "Parametric role group cannot be documented, use one of the candidates instead for '" ~ self.name ~ "'",
+            :role-name(self.name)
+        );
     }
 
     method !get_default_candidate() {
-        self.'!get_nonsignatured_candidate'() || @!candidates[0]
+        nqp::isnull(my $c := self.'!get_nonsignatured_candidate'())
+            ?? nqp::null()
+            !! $c
     }
 
     method !get_nonsignatured_candidate() {
-        return nqp::null unless +@!nonsignatured;
-        @!nonsignatured[0]
+        +@!nonsignatured ?? @!nonsignatured[0] !! nqp::null()
     }
 
     method publish_type_cache($obj) {

--- a/src/core.c/Exception.pm6
+++ b/src/core.c/Exception.pm6
@@ -1708,6 +1708,13 @@ my class X::Role::Initialization is Exception {
     method message() { "Can only supply an initialization value for a role if it has a single public attribute, but this is not the case for '{$.role.^name}'" }
 }
 
+my class X::Role::Group::Documenting is Exception {
+    has $.role-name is required;
+    method message() {
+        "Parametric role group cannot be documented, use one of the candidates instead for '{$.role-name}'"
+    }
+}
+
 my class X::Syntax::Comment::Embedded does X::Syntax {
     method message() { "Opening bracket required for #` comment" }
 }


### PR DESCRIPTION
Roles have a two-level structure: the role name is a parametric role
group, which in turns contains the parametric role. In the case of there
being many roles of the same short name, they are within the one group.
Declarator docs correctly attach to the parametric role. However, that
means .WHY on the group doesn't actually result in those docs. You have
to extract the candidate from the group.

In many cases, however, we people ain't using parametric roles, and we
make many meta-operations delegate to the single or unsignatured role
candidate, if any. We do not currently do this for .WHY. This commit
makes us do so, BUT it turns out there are 3 current spectests that will
fail because they explicitly expect that not to happen. Thus, we need to
make a decision over whether we want this change.

Relates to #3521.