### PR TITLE
Better error message when calling a star proto without declared multi 

### DIFF
--- a/src/core.c/Exception.pm6
+++ b/src/core.c/Exception.pm6
@@ -2633,6 +2633,14 @@ my class X::Item is Exception {
     method message { "Cannot index {$.aggregate.^name} with $.index" }
 }
 
+my class X::Multi::Undefined is Exception {
+    has $.objname;
+    method message {
+        my ($red,$clear,$green,$,$eject) = Rakudo::Internals.error-rcgye;
+        "Multi dispatch has not been declared for $red$!objname$clear";
+    }
+}
+
 my class X::Multi::Ambiguous is Exception {
     has $.dispatcher;
     has @.ambiguous;
@@ -2819,6 +2827,10 @@ nqp::bindcurhllsym('P6EX', BEGIN nqp::hash(
   'X::Method::NotFound',
   -> Mu $invocant, $method, $typename, $private = False {
       X::Method::NotFound.new(:$invocant, :$method, :$typename, :$private).throw
+  },
+  'X::Multi::Undefined',
+  -> $objname {
+      X::Multi::Undefined.new(:$objname).throw
   },
   'X::Multi::Ambiguous',
   -> $dispatcher, @ambiguous, $capture {

--- a/src/core.c/Exception.pm6
+++ b/src/core.c/Exception.pm6
@@ -2362,12 +2362,12 @@ my class X::TypeCheck::Argument is X::TypeCheck {
     has $.objname;
     has $.signature;
     method message {
-            my $multi = $!signature ~~ /\n/ // '';
-            "Calling {$!objname}({ join(', ', @!arguments) }) will never work with " ~ (
-                $!protoguilt ?? 'signature of the proto ' !!
-                $multi       ?? 'any of these multi signatures:' !!
-                                'declared signature '
-            ) ~ $!signature;
+        my $multi = $!signature ~~ /\n/ // '';
+        "Calling {$!objname}({ join(', ', @!arguments) }) will never work with " ~ (
+            $!protoguilt ?? 'signature of the proto ' !!
+            $multi       ?? 'any of these multi signatures:' !!
+                            'declared signature '
+        ) ~ $!signature;
     }
 }
 


### PR DESCRIPTION
Fix: #1746

__Problem:__ Error message whencalling a star proto linked to an bad signature but it was impossible to call with any signature.
__Solution:__ New Error message `X::Multi::Undefined`

In comment the before then after messages

```bash
perl6 -e 'proto z(Int $) {*}; say z 3'
# Calling z(Int) will never work with declared signature 
# Multi dispatch has not been declared for star proto z(Int)

perl6 -e 'proto z($ where rand) {*}; say z "x"'
# Multi dispatch has not been declared for star proto z($ where { ... })
# Calling z(Str) will never work with declared signature 

perl6 -e 'sub z(Int) {}; z "x"'
# Calling z(Str) will never work with declared signature (Int)
# Same

perl6 -e 'proto z(Int $) {*}; say z "x"'
# Calling z(Str) will never work with signature of the proto (Int)
# Same

perl6 -e 'proto z(Int $a) {say "proto"}; say z "eaz"'
# Type check failed in binding to parameter '$a'; expected Int but got Str ("eaz")
# Same

perl6 -e 'proto z(Int $) {*}; multi z(Int $int where {$int > 0} ) {42}; say z "Int"'
# Calling z(Str) will never work with signature of the proto (Int)
# Same

perl6 -e 'proto z(Int $) {*}; multi z(Int $int where {$int > 0} ) {42}; say z -1'
# Cannot resolve caller z(-1); none of these signatures match:
#    (Int $int where { ... })
# Same
```