### PR TITLE
Improve introspection of anonymous parameters

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -1724,7 +1724,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
                 if $*IMPLICIT {
                     my $optional := $*IMPLICIT == 1;
                     @params.push(hash(
-                        :variable_name('$_'), :$optional,
+                        :variable_name('$_'), :sigil('$'), :$optional,
                         :nominal_type($*W.find_symbol(['Mu'])),
                         :default_from_outer($optional), :is_raw(1),
                     ));
@@ -9708,7 +9708,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
             });
         }
         ($*W.cur_lexpad())[0].push($block);
-        my $param := hash( :variable_name('$_'), :nominal_type($*W.find_symbol(['Mu'])));
+        my $param := hash( :variable_name('$_'), :sigil('$'), :nominal_type($*W.find_symbol(['Mu'])) );
         if $copy {
             $param<container_descriptor> := $*W.create_container_descriptor(
                 $*W.find_symbol(['Mu']), '$_');
@@ -9745,9 +9745,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
         ($*W.cur_lexpad())[0].push($past);
 
         # Give it a signature and create code object.
-        my $param := hash(
-            variable_name => '$_',
-            nominal_type => $*W.find_symbol(['Mu']));
+        my $param := hash( variable_name => '$_', sigil => '$', nominal_type => $*W.find_symbol(['Mu']) );
         my $sig := $*W.create_signature(nqp::hash('parameter_objects',
             [$*W.create_parameter($/, $param)]));
         add_signature_binding_code($past, $sig, [$param]);
@@ -9913,8 +9911,8 @@ class Perl6::Actions is HLL::Actions does STDActions {
 
         # Need to construct and install an initializer method
         my @params := [
-          hash( is_invocant => 1, nominal_type => $/.package),
-          hash( variable_name => '$_', nominal_type => $*W.find_symbol(['Mu']))
+          hash( is_invocant => 1, nominal_type => $/.package ),
+          hash( variable_name => '$_', sigil => '$', nominal_type => $*W.find_symbol(['Mu']) )
         ];
         my $sig := $*W.create_signature(nqp::hash('parameter_objects', [
           $*W.create_parameter($/, @params[0]),
@@ -10144,6 +10142,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
                             $curry[0].push: $_;
                             @params.push: hash(
                               :variable_name($_.name),
+                              :sigil(nqp::substr($_.name, 0, 1)),
                               :nominal_type(
                                   $*W.find_symbol: ['Mu'], :setting-only),
                               :is_raw(1))
@@ -10169,6 +10168,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
                   ).annotate_self: 'whatever-var', 1;
                 @params.push: hash(
                     :variable_name($param.name),
+                    :sigil('$'),
                     :nominal_type($*W.find_symbol: ['Mu'], :setting-only),
                     :is_raw(1));
                 $curry[0].push: $param.decl_as: <var>;

--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -32,6 +32,7 @@ my $SIG_ELEM_NATIVE_STR_VALUE    := 8388608;
 my $SIG_ELEM_SLURPY_ONEARG       := 16777216;
 my $SIG_ELEM_CODE_SIGIL          := 33554432;
 my $SIG_ELEM_SCALAR_SIGIL        := 67108864;
+my $SIG_ELEM_NO_VARIABLE         := 134217728;
 
 sub p6ize_recursive($x) {
     if nqp::islist($x) {
@@ -2204,8 +2205,49 @@ class Perl6::World is HLL::World {
 
         # Calculate flags.
         my int $flags := 0;
-        if %param_info<optional> {
-            $flags := $flags + $SIG_ELEM_IS_OPTIONAL;
+        if %param_info<no_variable> {
+            $flags := $flags + $SIG_ELEM_NO_VARIABLE;
+        }
+        else {
+            if %param_info<pos_slurpy> {
+                $flags := $flags + $SIG_ELEM_SLURPY_POS;
+            }
+            if %param_info<pos_lol> {
+                $flags := $flags + $SIG_ELEM_SLURPY_LOL;
+            }
+            if %param_info<pos_onearg> {
+                $flags := $flags + $SIG_ELEM_SLURPY_ONEARG;
+            }
+            if %param_info<named_slurpy> {
+                $flags := $flags + $SIG_ELEM_SLURPY_NAMED;
+            }
+            if %param_info<sigil> eq '$' {
+                $flags := $flags + $SIG_ELEM_SCALAR_SIGIL;
+            }
+            elsif %param_info<sigil> eq '@' {
+                $flags := $flags + $SIG_ELEM_ARRAY_SIGIL;
+            }
+            elsif %param_info<sigil> eq '%' {
+                $flags := $flags + $SIG_ELEM_HASH_SIGIL;
+            }
+            elsif %param_info<sigil> eq '&' {
+                $flags := $flags + $SIG_ELEM_CODE_SIGIL;
+            }
+            if %param_info<bind_attr> {
+                $flags := $flags + $SIG_ELEM_BIND_PRIVATE_ATTR;
+            }
+            if %param_info<bind_accessor> {
+                $flags := $flags + $SIG_ELEM_BIND_PUBLIC_ATTR;
+            }
+            if %param_info<is_rw> {
+                $flags := $flags + $SIG_ELEM_IS_RW;
+            }
+            if %param_info<is_raw> {
+                $flags := $flags + $SIG_ELEM_IS_RAW;
+            }
+            if %param_info<is_capture> {
+                $flags := $flags + $SIG_ELEM_IS_CAPTURE + $SIG_ELEM_IS_RAW;
+            }
         }
         if %param_info<is_invocant> {
             $flags := $flags + $SIG_ELEM_INVOCANT;
@@ -2213,56 +2255,20 @@ class Perl6::World is HLL::World {
         if %param_info<is_multi_invocant> {
             $flags := $flags + $SIG_ELEM_MULTI_INVOCANT;
         }
-        if %param_info<is_rw> {
-            $flags := $flags + $SIG_ELEM_IS_RW;
-        }
-        if %param_info<is_raw> {
-            $flags := $flags + $SIG_ELEM_IS_RAW;
-        }
-        if %param_info<pos_onearg> {
-            $flags := $flags + $SIG_ELEM_SLURPY_ONEARG;
-        }
-        if %param_info<is_capture> {
-            $flags := $flags + $SIG_ELEM_IS_CAPTURE + $SIG_ELEM_IS_RAW;
-        }
         if %param_info<undefined_only> {
             $flags := $flags + $SIG_ELEM_UNDEFINED_ONLY;
         }
         if %param_info<defined_only> {
             $flags := $flags + $SIG_ELEM_DEFINED_ONLY;
         }
-        if %param_info<pos_slurpy> {
-            $flags := $flags + $SIG_ELEM_SLURPY_POS;
+        if %param_info<nominal_generic> {
+            $flags := $flags + $SIG_ELEM_NOMINAL_GENERIC;
         }
-        if %param_info<named_slurpy> {
-            $flags := $flags + $SIG_ELEM_SLURPY_NAMED;
-        }
-        if %param_info<pos_lol> {
-            $flags := $flags + $SIG_ELEM_SLURPY_LOL;
-        }
-        if %param_info<bind_attr> {
-            $flags := $flags + $SIG_ELEM_BIND_PRIVATE_ATTR;
-        }
-        if %param_info<bind_accessor> {
-            $flags := $flags + $SIG_ELEM_BIND_PUBLIC_ATTR;
-        }
-        if %param_info<sigil> eq '$' {
-            $flags := $flags + $SIG_ELEM_SCALAR_SIGIL;
-        }
-        elsif %param_info<sigil> eq '@' {
-            $flags := $flags + $SIG_ELEM_ARRAY_SIGIL;
-        }
-        elsif %param_info<sigil> eq '%' {
-            $flags := $flags + $SIG_ELEM_HASH_SIGIL;
-        }
-        elsif %param_info<sigil> eq '&' {
-            $flags := $flags + $SIG_ELEM_CODE_SIGIL;
+        if %param_info<optional> {
+            $flags := $flags + $SIG_ELEM_IS_OPTIONAL;
         }
         if %param_info<default_from_outer> {
             $flags := $flags + $SIG_ELEM_DEFAULT_FROM_OUTER;
-        }
-        if %param_info<nominal_generic> {
-            $flags := $flags + $SIG_ELEM_NOMINAL_GENERIC;
         }
         if %param_info<default_is_literal> {
             $flags := $flags + $SIG_ELEM_DEFAULT_IS_LITERAL;

--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -31,6 +31,7 @@ my $SIG_ELEM_NATIVE_NUM_VALUE    := 4194304;
 my $SIG_ELEM_NATIVE_STR_VALUE    := 8388608;
 my $SIG_ELEM_SLURPY_ONEARG       := 16777216;
 my $SIG_ELEM_CODE_SIGIL          := 33554432;
+my $SIG_ELEM_SCALAR_SIGIL        := 67108864;
 
 sub p6ize_recursive($x) {
     if nqp::islist($x) {
@@ -2245,7 +2246,10 @@ class Perl6::World is HLL::World {
         if %param_info<bind_accessor> {
             $flags := $flags + $SIG_ELEM_BIND_PUBLIC_ATTR;
         }
-        if %param_info<sigil> eq '@' {
+        if %param_info<sigil> eq '$' {
+            $flags := $flags + $SIG_ELEM_SCALAR_SIGIL;
+        }
+        elsif %param_info<sigil> eq '@' {
             $flags := $flags + $SIG_ELEM_ARRAY_SIGIL;
         }
         elsif %param_info<sigil> eq '%' {

--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -2351,7 +2351,8 @@ class Perl6::World is HLL::World {
                 @params.unshift(hash(
                     nominal_type => $invocant_type,
                     is_invocant => 1,
-                    is_multi_invocant => 1
+                    is_multi_invocant => 1,
+                    no_variable => 1
                 ));
             }
             unless has_named_slurpy_or_capture(@params) {

--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -137,6 +137,8 @@ my class Binder {
     my int $SIG_ELEM_SLURPY_ONEARG       := 16777216;
     my int $SIG_ELEM_SLURPY              := ($SIG_ELEM_SLURPY_POS +| $SIG_ELEM_SLURPY_NAMED +| $SIG_ELEM_SLURPY_LOL +| $SIG_ELEM_SLURPY_ONEARG);
     my int $SIG_ELEM_CODE_SIGIL          := 33554432;
+    my int $SIG_ELEM_SCALAR_SIGIL        := 67108864;
+    my int $SIG_ELEM_NO_VARIABLE         := 134217728;
 
     # Binding result flags.
     my int $BIND_RESULT_OK       := 0;
@@ -483,7 +485,7 @@ my class Binder {
                     # If it's a scalar, we always need to wrap it into a new
                     # container and store it; the container descriptor will be
                     # provided and make it rw if it's an `is copy`.
-                    else {
+                    elsif $flags +& ($SIG_ELEM_SCALAR_SIGIL +| $SIG_ELEM_CODE_SIGIL) {
                         my $new_cont := nqp::create(Scalar);
                         nqp::bindattr($new_cont, Scalar, '$!descriptor',
                             nqp::getattr($param, Parameter, '$!container_descriptor'));
@@ -1035,7 +1037,8 @@ my class Binder {
                     $SIG_ELEM_MULTI_INVOCANT +| $SIG_ELEM_IS_RAW +|
                     $SIG_ELEM_IS_COPY +| $SIG_ELEM_ARRAY_SIGIL +|
                     $SIG_ELEM_HASH_SIGIL +| $SIG_ELEM_NATIVE_VALUE +|
-                    $SIG_ELEM_IS_OPTIONAL) || $flags +& $SIG_ELEM_IS_RW {
+                    $SIG_ELEM_IS_OPTIONAL +| $SIG_ELEM_SCALAR_SIGIL +|
+                    $SIG_ELEM_NO_VARIABLE) || $flags +& $SIG_ELEM_IS_RW {
                 return $TRIAL_BIND_NOT_SURE;
             }
             unless nqp::isnull(nqp::getattr($param, Parameter, '@!named_names')) {

--- a/src/core.c/Parameter.pm6
+++ b/src/core.c/Parameter.pm6
@@ -36,6 +36,7 @@ my class Parameter { # declared in BOOTSTRAP
     my constant $SIG_ELEM_SLURPY_ONEARG      = 1 +< 24;
     my constant $SIG_ELEM_CODE_SIGIL         = 1 +< 25;
     my constant $SIG_ELEM_SCALAR_SIGIL       = 1 +< 26;
+    my constant $SIG_ELEM_NO_VARIABLE        = 1 +< 27;
 
     my constant $SIG_ELEM_IS_NOT_POSITIONAL = $SIG_ELEM_SLURPY_POS
                                            +| $SIG_ELEM_SLURPY_NAMED
@@ -175,6 +176,9 @@ my class Parameter { # declared in BOOTSTRAP
 
             set-sigil-bits($sigil, $flags);
             $name = $name.substr(1) if $sigil eq Q/\/ || $sigil eq Q/|/;
+        }
+        else {
+            $flags +|= $SIG_ELEM_NO_VARIABLE;
         }
 
         if %args.EXISTS-KEY('type') {
@@ -564,6 +568,7 @@ my class Parameter { # declared in BOOTSTRAP
                 !nqp::eqaddr($!nominal_type, nqp::decont($elide-type)) {
             $perl ~= $type ~ $modifier;
         }
+        return $perl if nqp::bitand_i($!flags, $SIG_ELEM_NO_VARIABLE);
 
         my $prefix     = $.prefix;
         my $sigil      = $.sigil;

--- a/src/core.c/Signature.pm6
+++ b/src/core.c/Signature.pm6
@@ -123,10 +123,6 @@ my class Signature { # declared in BOOTSTRAP
             my $sep = '';
             for @params.kv -> $i, $param {
                 $text ~= $sep ~ $_ with $param.raku(:$elide-type);
-
-                # Remove sigils from anon typed scalars, leaving type only
-                $text .= subst(/» ' $'$/,'') unless $perl;
-
                 $sep = $param.multi-invocant && !@params[$i+1].?multi-invocant
                   ?? ';; '
                   !! ', '


### PR DESCRIPTION
`+` currently gets stringified as `+$ is raw`, likewise `\` as `$ is raw` and `Callable` as `Callable $`. The first two are bugs, the third is behaviour that Roast tests for, but is behaviour I disagree with.

Since `$ is raw` and `\` are impossible to differentiate otherwise, this adds the `SIG_ELEM_SCALAR_SIGIL` parameter flag. This also adds the `SIG_ELEM_NO_VARIABLE` flag to make it possible to differentiate between `Callable` and `Callable $`, which should also have the bonus of making compilation slightly faster, though I don't know exactly how to benchmark this.

Passes `make test`, passes all tests in `make spectest` apart from a handful in `S06-currying/positional.t` and `S06-signature/introspection.t` that expect the old behaviour with `Callable $`.