### PR TITLE
Ensure Routine subtypes are composed before performing mixins with their instances

### DIFF
--- a/src/Perl6/Metamodel/Mixins.nqp
+++ b/src/Perl6/Metamodel/Mixins.nqp
@@ -32,15 +32,7 @@ role Perl6::Metamodel::Mixins {
             @roles[$i] := nqp::decont(@roles[$i]);
             ++$i;
         }
-        # XXX Workaround for mixing in to non-composed types; when this takes
-        # place (a bunch during CORE.setting) the mixin is missing bits. This
-        # has long been a problem, and needs a real solution (it's related to
-        # the "augment does not convey additions to subclasses" issue); mixin
-        # caching just makes the problem very visible. For now, don't cache if
-        # the current type is not yet composed.
-        my $mixin_type := self.is_composed($obj)
-            ?? nqp::parameterizetype($!mixin_cache, @roles)
-            !! self.generate_mixin($obj, @roles);
+        my $mixin_type := nqp::parameterizetype($!mixin_cache, @roles);
 
         # Ensure there's a mixin attribute, if we need it.
         if $need-mixin-attribute {

--- a/src/core.c/Code.pm6
+++ b/src/core.c/Code.pm6
@@ -1,5 +1,5 @@
-my class Code does Callable { # declared in BOOTSTRAP
-    # class Code is Any
+my class Code { # declared in BOOTSTRAP
+    # class Code is Any does Callable
     #     has Code $!do;              # Low level code object
     #     has Signature $!signature;  # Signature object
     #     has @!compstuff;            # Place for the compiler to hang stuff

--- a/src/core.c/Method.pm6
+++ b/src/core.c/Method.pm6
@@ -1,4 +1,4 @@
-my class Method { # declared in BOOTSTRAP
+augment class Method { # declared in BOOTSTRAP, composed in prologue
     # class Method is Routine
 
     multi method gist(Method:D:) { self.name }

--- a/src/core.c/Sub.pm6
+++ b/src/core.c/Sub.pm6
@@ -1,4 +1,4 @@
-my class Sub { # declared in BOOTSTRAP
+augment class Sub { # declared in BOOTSTRAP, composed in prologue
     # class Sub is Routine
 
 }

--- a/src/core.c/Submethod.pm6
+++ b/src/core.c/Submethod.pm6
@@ -1,4 +1,4 @@
-my class Submethod { # declared in BOOTSTRAP
+augment class Submethod { # declared in BOOTSTRAP, composed in prologue
     # class Submethod is Routine
 
     multi method gist(Submethod:D:) { self.name }

--- a/src/core.c/core_prologue.pm6
+++ b/src/core.c/core_prologue.pm6
@@ -39,6 +39,16 @@ my role PositionalBindFailover { ... }
 BEGIN nqp::bindhllsym('Raku', 'Iterable', Iterable);
 nqp::bindhllsym('Raku', 'Iterable', Iterable);
 
+BEGIN {
+    # Ensure routines with traits using mixins applied to them typecheck as Callable.
+    Code.^add_role: Callable;
+    # Compose routine types used in the setting so traits using mixins can be
+    # applied to them.
+    Sub.^compose;
+    Method.^compose;
+    Submethod.^compose;
+}
+
 # Set up Empty, which is a Slip created with an empty IterationBuffer (which
 # we also stub here). This is needed in a bunch of simple constructs (like if
 # with only one branch).


### PR DESCRIPTION
The only reason that pesky branch in `Metamodel::Mixins.mixin` can't be removed at the moment is because mixins of routine types get made by traits before they get composed. By applying `Callable` to `Code` and composing `Sub`/`Method`/`Submethod` in the prologue, there are no longer any mixins of uncomposed metaobjects made during the setting, which should make it possible to remove this branch.

Passes `make test` and `make spectest`.