### PR TITLE
Improve Capture positional methods

### DIFF
--- a/src/core.c/Capture.pm6
+++ b/src/core.c/Capture.pm6
@@ -59,6 +59,13 @@ my class Capture { # declared in BOOTSTRAP
                :what($*INDEX // 'Index'),:got(pos),:range<0..^Inf>))
           !! nqp::ifnull(nqp::atpos(@!list,$pos),Nil)
     }
+    multi method AT-POS(Capture:D: \pos) is raw {
+        my int $pos = nqp::unbox_i(pos.Int);
+        nqp::islt_i($pos,0)
+          ?? Failure.new(X::OutOfRange.new(
+               :what($*INDEX // 'Index'),:got(pos),:range<0..^Inf>))
+          !! nqp::ifnull(nqp::atpos(@!list,$pos),Nil)
+    }
 
     method hash(Capture:D:) {
         nqp::if(

--- a/src/core.c/Capture.pm6
+++ b/src/core.c/Capture.pm6
@@ -52,12 +52,6 @@ my class Capture { # declared in BOOTSTRAP
           Nil)
     }
 
-    multi method AT-POS(Capture:D: int \pos) is raw {
-        nqp::islt_i(pos,0)
-          ?? Failure.new(X::OutOfRange.new(
-               :what($*INDEX // 'Index'),:got(pos),:range<0..^Inf>))
-          !! nqp::ifnull(nqp::atpos(@!list,pos),Nil)
-    }
     multi method AT-POS(Capture:D: Int:D \pos) is raw {
         my int $pos = nqp::unbox_i(pos);
         nqp::islt_i($pos,0)

--- a/src/core.c/Capture.pm6
+++ b/src/core.c/Capture.pm6
@@ -87,6 +87,19 @@ my class Capture { # declared in BOOTSTRAP
           False)
     }
 
+    multi method EXISTS-POS(Capture:D: Int:D \pos) {
+        nqp::if(
+          nqp::isconcrete(@!list),
+          nqp::hllbool(nqp::existspos(@!list, nqp::unbox_i(pos))),
+          False)
+    }
+    multi method EXISTS-POS(Capture:D: \pos) {
+        nqp::if(
+          nqp::isconcrete(@!list),
+          nqp::hllbool(nqp::existspos(@!list, nqp::unbox_i(pos.Int))),
+          False)
+    }
+
     method list(Capture:D:) {
         nqp::if(
           (nqp::defined(@!list) && nqp::elems(@!list)),


### PR DESCRIPTION
The commits should speak for themselves (apart from the second, but the reasoning is explained in its commit message).

Passes `make test` and `make spectest`.