### PR TITLE
Improve X::Syntax::Variable::MissingInitializer's message

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -3422,13 +3422,13 @@ class Perl6::Actions is HLL::Actions does STDActions {
                 if nqp::istype($past, QAST::Var) {
                     if $*W.cur_lexpad.symbol($past.name) -> %sym {
                         if %sym<descriptor> {
-                            check_default_value_type($/, %sym<descriptor>, %sym<type>, 'variables');
+                            check_default_value_type($/, %sym<descriptor>, %sym<type>, 'variable');
                         }
                     }
                 }
                 elsif $past.ann('metaattr') -> $attr {
                     if !$attr.required && !$attr.type.HOW.archetypes.generic {
-                        check_default_value_type($/, $attr.container_descriptor, $attr.type, 'attributes');
+                        check_default_value_type($/, $attr.container_descriptor, $attr.type, 'attribute');
                     }
                 }
             }
@@ -3592,10 +3592,11 @@ class Perl6::Actions is HLL::Actions does STDActions {
         }
         unless $matches {
             $/.typed_sorry('X::Syntax::Variable::MissingInitializer',
-                type => nqp::how($bind_constraint).name($bind_constraint),
-                :$maybe,
+                what     => $what,
+                type     => nqp::how($bind_constraint).name($bind_constraint),
+                maybe    => $maybe,
                 implicit => !nqp::istype($*OFTYPE, NQPMatch) || !$*OFTYPE<colonpairs> || $*OFTYPE<colonpairs> && !$*OFTYPE<colonpairs>.ast<D> && !$*OFTYPE<colonpairs>.ast<U>
-                         ?? ':' ~ $/.pragma($what) ~ ' by pragma'
+                         ?? ':' ~ $/.pragma($what ~ 's') ~ ' by pragma'
                          !! 0
             );
         }

--- a/src/core.c/Exception.pm6
+++ b/src/core.c/Exception.pm6
@@ -1808,14 +1808,17 @@ my class X::Syntax::Term::MissingInitializer does X::Syntax {
 }
 
 my class X::Syntax::Variable::MissingInitializer does X::Syntax {
+    has $.what;
     has $.type;
     has $.implicit;
     has $.maybe;
     method message {
-        my $modality = $.maybe ?? "may need" !! "requires";
-        $.implicit ??
-            "Variable definition of type $.type (implicit $.implicit) $modality an initializer" !!
-            "Variable definition of type $.type $modality an initializer"
+        my $modality    = $.maybe ?? "may need" !! "needs";
+        my $type        = $.implicit ?? "$.type (implicit $.implicit)" !! "$.type";
+        my $requirement = $.what eq 'attribute'
+                      ?? 'to be marked as required or given an initializer'
+                      !! 'to be given an initializer';
+        "$.what.tc() definition of type $type $modality $requirement"
     }
 }
 


### PR DESCRIPTION
This makes the messages it can give more consistent. On top of that,
attributes now get referred to as attributes instead of variables and
the "is required" trait now gets mentioned with them.

Passes `make test`, fails a few tests in `S02-types/subset-6e.t` that expect the old messages but passes all others.