### PR TITLE
Improve smartmatching against Mu/Any/Junction

### DIFF
--- a/src/core.c/Any.pm6
+++ b/src/core.c/Any.pm6
@@ -15,13 +15,10 @@ my role  Numeric { ... }
 my class Any { # declared in BOOTSTRAP
     # my class Any is Mu
 
-    multi method ACCEPTS(Any:D: Mu:D \a) { self === a }
-    multi method ACCEPTS(Any:D: Mu:U $ --> False) { }
-
-    # use of Any on topic to force autothreading
-    # so that all(@foo) ~~ Type works as expected
-    multi method ACCEPTS(Any:U: Any \topic --> Bool:D) {
-        nqp::hllbool(nqp::istype(topic, self))
+    multi method ACCEPTS(Any:D: Mu:U --> False) { }
+    multi method ACCEPTS(Any:D: Mu:D \topic) {
+        # XXX: &[===] works with Any, not Mu!
+        self === topic
     }
 
     proto method EXISTS-KEY(|) is nodal {*}

--- a/src/core.c/Junction.pm6
+++ b/src/core.c/Junction.pm6
@@ -176,12 +176,7 @@ my class Junction { # declared in BOOTSTRAP
         )
     }
 
-    multi method ACCEPTS(Junction:U: Mu:D \topic) {
-        nqp::hllbool(nqp::istype(topic, Junction));
-    }
-    multi method ACCEPTS(Junction:U: Any \topic) {
-        nqp::hllbool(nqp::istype(topic, Junction));
-    }
+    multi method ACCEPTS(Junction:U: Junction:D --> True) { }
     multi method ACCEPTS(Junction:D: Mu \topic) {
         nqp::hllbool(
           nqp::stmts(
@@ -343,7 +338,6 @@ my class Junction { # declared in BOOTSTRAP
         my int $elems = nqp::elems(positionals);
         my int $i     = -1;
         while nqp::islt_i(++$i,$elems) {
-
             # Junctional positional argument?
             my Mu $arg := nqp::atpos(positionals, $i);
             if nqp::istype($arg,Junction) {

--- a/src/core.c/Mu.pm6
+++ b/src/core.c/Mu.pm6
@@ -18,10 +18,7 @@ my class Mu { # declared in BOOTSTRAP
     method perlseen(Mu \SELF: |c) { SELF.rakuseen(|c) }
 
     proto method ACCEPTS(|) {*}
-    multi method ACCEPTS(Mu:U: Any \topic) {
-        nqp::hllbool(nqp::istype(topic, self))
-    }
-    multi method ACCEPTS(Mu:U: Mu:U \topic) {
+    multi method ACCEPTS(Mu:U: Mu \topic) {
         nqp::hllbool(nqp::istype(topic, self))
     }
 

--- a/src/core.c/Mu.pm6
+++ b/src/core.c/Mu.pm6
@@ -21,6 +21,15 @@ my class Mu { # declared in BOOTSTRAP
     multi method ACCEPTS(Mu:U: Mu \topic) {
         nqp::hllbool(nqp::istype(topic, self))
     }
+    # Typically, junctions shouldn't be typechecked literally. There are
+    # exceptions though, such as Junction in particular, so this probably
+    # shouldn't be handled by the compiler itself. Having a default ACCEPTS
+    # candidate to handle junctions allows them to get threaded as they should
+    # while preserving compatibility with existing code that has any ACCEPTS
+    # candidates for Mu or Junction.
+    multi method ACCEPTS(Mu:U \SELF: Junction:D \topic) is default {
+        topic.THREAD: { SELF.ACCEPTS: $_ }
+    }
 
     method WHERE() {
         nqp::p6box_i(nqp::where(self))


### PR DESCRIPTION
This allows any instance to typecheck against any type object by giving `Mu` an `ACCEPTS` candidate for `Mu`. This alone breaks smartmatching with junctions, though. To fix this, rather than implicitly autothreading junctions with an `Any:U` candidate, threading of junctions is now explicitly handled from a `Mu:U` candidate. While it's not strictly necessary for this to reside in `Mu`, this allows `any(Mu, Any) ~~ Mu` to return `True` instead of `False`, which I feel is more correct. A bonus to doing all this is smartmatching with junctions is now around twice as fast, and there should be a speedup of some form for *all* smartmatches since some `ACCEPTS` candidates in `Mu`, `Any`, and `Junction` are no longer necessary!

Passes `make test` and `make spectest`.