### PR TITLE
Add missing label support for some loop constructs

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -157,10 +157,18 @@ sub wanted($ast,$by) {
                 $block := Perl6::Actions::make_thunk_ref($body, $body.node);
                 $block-closure := block_closure($block);
             }
+
+            # make sure from-loop knows about existing label
+            my $label := QAST::WVal.new( :value($*W.find_symbol(['Any'])), :named('label') );
+            for @($ast) {
+                $label := $_ if nqp::istype($_, QAST::WVal) && nqp::istype($_.value, $*W.find_symbol(['Label']));
+            }
+
             my $past := QAST::Op.new: :node($body.node),
                 :op<callmethod>, :name<from-loop>,
                 QAST::WVal.new(:value($*W.find_symbol(['Seq']))),
-                $block-closure;
+                $block-closure,
+                $label;
 
             # Elevate statevars to enclosing thunk
             if $body.has_ann('has_statevar') && $block.has_ann('past_block') {

--- a/src/core.c/Seq.pm6
+++ b/src/core.c/Seq.pm6
@@ -125,20 +125,20 @@ my class Seq is Cool does Iterable does Sequence {
     }
 
     proto method from-loop(|) {*}
-    multi method from-loop(&body) {
-        Seq.new(Rakudo::Iterator.Loop(&body))
+    multi method from-loop(&body, :$label) {
+        Seq.new(Rakudo::Iterator.Loop(&body, :$label))
     }
-    multi method from-loop(&body, &cond, :$repeat!) {
+    multi method from-loop(&body, &cond, :$repeat!, :$label) {
         Seq.new($repeat
-          ?? Rakudo::Iterator.RepeatLoop(&body, &cond)
-          !! Rakudo::Iterator.WhileLoop(&body, &cond)
+          ?? Rakudo::Iterator.RepeatLoop(&body, &cond, :$label)
+          !! Rakudo::Iterator.WhileLoop(&body, &cond, :$label)
         )
     }
-    multi method from-loop(&body, &cond) {
-        Seq.new(Rakudo::Iterator.WhileLoop(&body, &cond))
+    multi method from-loop(&body, &cond, :$label) {
+        Seq.new(Rakudo::Iterator.WhileLoop(&body, &cond, :$label))
     }
-    multi method from-loop(&body, &cond, &afterwards) {
-        Seq.new(Rakudo::Iterator.CStyleLoop(&body, &cond, &afterwards))
+    multi method from-loop(&body, &cond, &afterwards, :$label) {
+        Seq.new(Rakudo::Iterator.CStyleLoop(&body, &cond, &afterwards, :$label))
     }
 
     multi method ACCEPTS(Seq:D: Iterable:D \iterable --> Bool:D) {


### PR DESCRIPTION
A couple of loop constructs were missing support for labels. Probably
this went unnoticed, because 'for' loops were not affected and a lot
of iterating is handled by optimized code in
src/core.c/Any-iterable-methods.pm6 (IterateOneWithPhasers and friends).

This should fix the problem described in #3622.