### PR TITLE
Add an iterator multi candidate to Supply

### DIFF
--- a/src/core.c/Supply-coercers.pm6
+++ b/src/core.c/Supply-coercers.pm6
@@ -41,12 +41,22 @@
             nqp::stmts(
               (my $got := nqp::shift($!queue)),
               nqp::if(
-                nqp::eqaddr($got, ConcQueue),
+                nqp::eqaddr($got,ConcQueue),
                 nqp::if(
                   nqp::isconcrete($!exception),
                   $!exception.throw,
                   IterationEnd),
                 $got))
+        }
+
+        method push-all(\target --> IterationEnd) {
+            nqp::stmts(
+              nqp::while(
+                nqp::not_i(nqp::eqaddr((my $got := nqp::shift($!queue)),ConcQueue)),
+                target.push($got)),
+              nqp::if(
+                nqp::isconcrete($!exception),
+                $!exception.throw))
         }
 
         # method is-lazy(--> Bool:D) { ... }

--- a/src/core.c/Supply-coercers.pm6
+++ b/src/core.c/Supply-coercers.pm6
@@ -51,8 +51,8 @@
 
         method push-all(\target --> IterationEnd) {
             nqp::stmts(
-              nqp::while(
-                nqp::not_i(nqp::eqaddr((my $got := nqp::shift($!queue)),ConcQueue)),
+              nqp::until(
+                nqp::eqaddr((my $got := nqp::shift($!queue)),ConcQueue),
                 target.push($got)),
               nqp::if(
                 nqp::isconcrete($!exception),

--- a/src/core.c/Supply-coercers.pm6
+++ b/src/core.c/Supply-coercers.pm6
@@ -15,30 +15,51 @@
         $c
     }
 
-    my class ConcQueue is repr('ConcBlockingQueue') { }
+    my class SupplyIterator does Iterator {
+        my class ConcQueue is repr('ConcBlockingQueue') { }
+        has $!queue;
+        has $!exception;
+
+        method new($supply) {
+            nqp::create(self)!SET-SELF($supply)
+        }
+        method !SET-SELF($supply) {
+            $!queue     := nqp::create(ConcQueue);
+            $!exception := Nil;
+            $supply.tap: {
+                nqp::push($!queue, $_)
+            }, done => -> {
+                nqp::push($!queue, ConcQueue); # Sentinel value.
+            }, quit => {
+                $!exception := $_;
+                nqp::push($!queue, ConcQueue); # Sentinel value.
+            };
+            self
+        }
+
+        method pull-one() is raw {
+            nqp::stmts(
+              (my $got := nqp::shift($!queue)),
+              nqp::if(
+                nqp::eqaddr($got, ConcQueue),
+                nqp::if(
+                  nqp::isconcrete($!exception),
+                  $!exception.throw,
+                  IterationEnd),
+                $got))
+        }
+
+        # method is-lazy(--> Bool:D) { ... }
+    }
+
+    multi method iterator(Supply:D:) {
+        SupplyIterator.new: self
+    }
     multi method list(Supply:D:) {
-        self.Seq.list
+        List.from-iterator: self.iterator
     }
     method Seq(Supply:D:) {
-        gather {
-            my Mu \queue = nqp::create(ConcQueue);
-            my $exception;
-            self.tap(
-                -> \val { nqp::push(queue, val) },
-                done => -> { nqp::push(queue, ConcQueue) }, # type obj as sentinel
-                quit => -> \ex { $exception := ex; nqp::push(queue, ConcQueue) });
-            loop {
-                my \got = nqp::shift(queue);
-                if got =:= ConcQueue {
-                    $exception.DEFINITE
-                        ?? $exception.throw
-                        !! last
-                }
-                else {
-                    take got;
-                }
-            }
-        }
+        Seq.new: self.iterator
     }
 
     method Promise(Supply:D:) {


### PR DESCRIPTION
A problem with `Seq` and `List` supply coercions was that `take` could be used
inside of them, which would mix values taken with those that are
actually emitted by the supply in the coercion. Instead of using `gather`
to handle coercions in the first place, this adds an `iterator` method to
`Supply` to handle that for these two methods. Because of this,
`Supply.list` no longer needs to create a throwaway `Seq` to coerce to a
`List`.

Passes `make test` and `make spectest`.