### PR TITLE
fixing links and improve formatting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ installation instructions.
 The general process for building is running `perl Configure.pl` with
 the desired configuration options (common options listed below), and
 then running `make` or `make install`. Optionally, you may run
-`make spectest` to test your build on [Roast](http://github.com/perl6/roast),
+`make spectest` to test your build on [Roast](http://github.com/Raku/roast),
 the Official Raku test suite. To update the test suite, run
 `make spectest_update`.
 
@@ -49,7 +49,7 @@ To automatically download, build, and install a fresh MoarVM and NQP, run:
     $ perl Configure.pl --gen-moar --gen-nqp --backends=moar
 
 Please be aware, that this will install MoarVM and NQP into your given
-`--prefix` before Configure.pl exits.
+`--prefix` before `Configure.pl` exits.
 
 Alternatively, feel free to git clone https://github.com/Raku/nqp and
 https://github.com/MoarVM/MoarVM manually and install them individually.

--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ text file.
 
 To receive important notifications from the core developer team, please
 subscribe to [the p6lert service](https://alerts.perl6.org) using the RSS feed,
-twitter, or [the p6lert commandline script](https://github.com/zoffixznet/perl6-p6lert).
+twitter, or [the p6lert commandline script](https://github.com/raku-community-modules/perl6-p6lert).
 
 ## Building and Installing Rakudo
 
 [![Build Status](https://circleci.com/gh/rakudo/rakudo.svg?style=shield)](https://circleci.com/gh/rakudo/rakudo)[![Build Status](https://travis-ci.org/rakudo/rakudo.svg?branch=master)](https://travis-ci.org/rakudo/rakudo) [![Build Status](https://ci.appveyor.com/api/projects/status/github/rakudo/rakudo?svg=true)](https://ci.appveyor.com/project/rakudo/rakudo/branch/master)
 
-See the INSTALL.txt file for detailed prerequisites and build and
+See the `INSTALL.txt` file for detailed prerequisites and build and
 installation instructions.
 
 The general process for building is running `perl Configure.pl` with
@@ -49,20 +49,20 @@ To automatically download, build, and install a fresh MoarVM and NQP, run:
     $ perl Configure.pl --gen-moar --gen-nqp --backends=moar
 
 Please be aware, that this will install MoarVM and NQP into your given
---prefix before Configure.pl exits.
+`--prefix` before Configure.pl exits.
 
-Alternatively, feel free to git clone https://github.com/perl6/nqp and
+Alternatively, feel free to git clone https://github.com/Raku/nqp and
 https://github.com/MoarVM/MoarVM manually and install them individually.
 
-Configuration flags can be passed to MoarVM's Configure.pl using the
---moar-option flag. For example, if you wish to use Clang when GCC is the
-default compiler selected for your OS, use the --compiler flag:
+Configuration flags can be passed to MoarVM's `Configure.pl` using the
+`--moar-option` flag. For example, if you wish to use Clang when GCC is the
+default compiler selected for your OS, use the `--compiler` flag:
 
     $ perl Configure.pl --gen-moar --moar-option='--compiler=clang' \
         --gen-nqp --backends=moar
 
 If the compiler you want to use isn't known by MoarVM or you have multiple
-versions of the same compiler installed, the --cc flag can be used to pass its
+versions of the same compiler installed, the `--cc` flag can be used to pass its
 exact binary:
 
     $ perl Configure.pl --gen-moar --moar-option='--cc=egcc' \
@@ -90,10 +90,10 @@ use. e.g. edit the nqp-j / nqp-j.bat executable (found wherever you installed to
 Alternatively, you can set `JAVA_OPTS` env var; e.g.
 `export JAVA_OPTS="-Xmx51200000000"`
 
-Please be aware, that this will install NQP into your given --prefix
-before Configure.pl exits.
+Please be aware, that this will install NQP into your given `--prefix`
+before `Configure.pl` exits.
 
-Alternatively, feel free to git clone https://github.com/perl6/nqp manually
+Alternatively, feel free to git clone https://github.com/Raku/nqp manually
 and install it individually.
 
 ### Multiple backends at the same time
@@ -114,16 +114,16 @@ The format for the `--backends` flag is:
 
 #### Ensure the test suite is installed
 
-The roast test suite is installed as the t/spec directory
+The roast test suite is installed as the `t/spec` directory
 under your rakudo directory. If your installed rakudo
-source directory doesn't have t/spec installed, then
+source directory doesn't have `t/spec` installed, then
 you can clone it like this:
 
     cd $YOUR_RAKUDO_SRCDIR
     git clone https://github.com/perl6/roast.git t/spec
 
-Note the rakudo code includes an entry in its .gitignore file
-so git will ignore any content under t/spec.
+Note the rakudo code includes an entry in its `.gitignore` file
+so git will ignore any content under `t/spec`.
 
 Now you can run tests in the rakudo directory.
 
@@ -178,7 +178,7 @@ list is primarily for the people who want to use Raku to write
 programs, so newbie questions are welcomed there.  Newbie questions
 are also welcome on the #raku channel; the Rakudo and Raku
 development teams tend to hang out there and are generally glad
-to help.  You can follow [@perl6org](https://twitter.com/perl6org)
+to help.  You can follow [@raku_news](https://twitter.com/raku_news)
 and on Twitter, there's a Raku news aggregator at
 [Planet Perl 6](http://pl6anet.org/).
 
@@ -198,13 +198,13 @@ See [our contribution guidelines](https://github.com/rakudo/rakudo/blob/master/C
 
 ## Line editing and tab completion
 
-If you would like simple history and tab completion in the perl6 executable,
+If you would like simple history and tab completion in the raku executable,
 you need to install the Linenoise module.  The recommended way to install
 Linenoise is via [zef](https://github.com/ugexe/zef):
 
     $ zef install Linenoise
 
-An alternative is to use a third-party program such as [rlwrap](http://utopia.knoware.nl/~hlub/uck/rlwrap/#rlwrap).
+An alternative is to use a third-party program such as [rlwrap](https://github.com/hanslub42/rlwrap).
 
 ## AUTHOR
 


### PR DESCRIPTION
Remove dead links and add working links

Changes:
==========
1. Added working link to rlwrap
2. Fix the outdated twitter link
3.  make folders look like folder  e.g t/spec to `t/spec`
4. make command line flags appear clear in markdown
5. Fix link to the p6lert commandline script
6. make markdown easy to read, add some formatting

fix changed link to Roast

The Roast repository has moved from perl6 to Raku organisation. good to reflect this change !