### PR TITLE
Add a parents metamethod to Metamodel::ParametricRoleGroupHOW

### DIFF
--- a/src/Perl6/Metamodel/ParametricRoleGroupHOW.nqp
+++ b/src/Perl6/Metamodel/ParametricRoleGroupHOW.nqp
@@ -182,6 +182,11 @@ class Perl6::Metamodel::ParametricRoleGroupHOW
         $c.HOW.attributes($c, |@pos, |%name);
     }
 
+    method parents($obj, *%named) {
+        my $c := self.'!get_default_candidate'($obj);
+        $c.HOW.parents($c, |%named)
+    }
+
     method roles($obj, *%named) {
         my $c := self.'!get_default_candidate'($obj);
         $c.HOW.roles($c, |%named)


### PR DESCRIPTION
In a PR for documenting `Metamodel::TypePretense` and `Metamodel::MethodDelegation` for the docs repo, I use roles as an example of how they're used. The problem is I need to pun the role I use in the examples in order to prove that they do not have `Mu` or `Any` as parents. I feel it'd be useful to know the parents of the default candidate of a role group through the role group itself.