### PR TITLE
Dispatcher revert

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -2720,11 +2720,6 @@ class Perl6::Actions is HLL::Actions does STDActions {
             :op('takedispatcher'),
             QAST::SVal.new( :value('$*DISPATCHER') )
         ));
-        $block[0].push(QAST::Var.new( :name('$*NEXT-DISPATCHER'), :scope('lexical'), :decl('var') ));
-        $block[0].push(QAST::Op.new(
-            :op('takenextdispatcher'),
-            QAST::SVal.new( :value('$*NEXT-DISPATCHER') )
-        ));
         make block_closure($ast);
     }
     method term:sym<unquote>($/) {
@@ -4006,11 +4001,6 @@ class Perl6::Actions is HLL::Actions does STDActions {
             :op('takedispatcher'),
             QAST::SVal.new( :value('$*DISPATCHER') )
         ));
-        $block[0].push(QAST::Var.new( :name('$*NEXT-DISPATCHER'), :scope('lexical'), :decl('var') ));
-        $block[0].push(QAST::Op.new(
-            :op('takenextdispatcher'),
-            QAST::SVal.new( :value('$*NEXT-DISPATCHER') )
-        ));
 
         # If it's a proto but not an onlystar, need some variables for the
         # {*} implementation to use.
@@ -4200,46 +4190,28 @@ class Perl6::Actions is HLL::Actions does STDActions {
         ).annotate_self('sink_ast', QAST::Op.new( :op('null') ));
     }
 
-    # Take next dispatcher set for the current code and set it for $code. Allows proto to transparently bypass this
-    # information to the first matching candidate.
-    sub redelegate_next_dispatcher($code) {
-        my $code_name := QAST::Node.unique("code_obj");
-        my $code_var := QAST::Var.new(:name($code_name), :scope<local>);
-        QAST::Stmts.new(
-            QAST::Op.new(:op<bind>, $code_var.decl_as('var'), $code),
-            QAST::Op.new(
-                :op<nextdispatcherfor>,
-                QAST::Var.new(:name('$*NEXT-DISPATCHER'), :scope<lexical>),
-                $code_var
-            ),
-            $code_var
-        )
-    }
-
     method autogenerate_proto($/, $name, $install_in) {
         my $p_past := $*W.push_lexpad($/);
         $p_past.name(~$name);
         $p_past.is_thunk(1);
         $p_past.push(QAST::Op.new(
             :op('invokewithcapture'),
-            redelegate_next_dispatcher(
+            QAST::Op.new(
+                :op('ifnull'),
                 QAST::Op.new(
-                    :op('ifnull'),
-                    QAST::Op.new(
-                        :op('multicachefind'),
-                        QAST::Var.new(
-                            :name('$!dispatch_cache'), :scope('attribute'),
-                            QAST::Op.new( :op('getcodeobj'), QAST::Op.new( :op('curcode') ) ),
-                            QAST::WVal.new( :value($*W.find_symbol(['Routine'], :setting-only)) ),
-                        ),
-                        QAST::Op.new( :op('usecapture') )
-                    ),
-                    QAST::Op.new(
-                        :op('callmethod'), :name('find_best_dispatchee'),
+                    :op('multicachefind'),
+                    QAST::Var.new(
+                        :name('$!dispatch_cache'), :scope('attribute'),
                         QAST::Op.new( :op('getcodeobj'), QAST::Op.new( :op('curcode') ) ),
-                        QAST::Op.new( :op('savecapture') )
+                        QAST::WVal.new( :value($*W.find_symbol(['Routine'], :setting-only)) ),
                     ),
-                )
+                    QAST::Op.new( :op('usecapture') )
+                ),
+                QAST::Op.new(
+                    :op('callmethod'), :name('find_best_dispatchee'),
+                    QAST::Op.new( :op('getcodeobj'), QAST::Op.new( :op('curcode') ) ),
+                    QAST::Op.new( :op('savecapture') )
+                ),
             ),
             QAST::Op.new( :op('usecapture') )
         ));
@@ -4300,8 +4272,8 @@ class Perl6::Actions is HLL::Actions does STDActions {
         for @($past[0]) {
             if nqp::istype($_, QAST::Var) && $_.scope eq 'lexical' {
                 my $name := $_.name;
-                return 0 if $name ne '$*DISPATCHER' && $name ne '$*NEXT-DISPATCHER'
-                    && $name ne '$_' && $name ne '$/' && $name ne '$¢' && $name ne '$!' &&
+                return 0 if $name ne '$*DISPATCHER' && $name ne '$_' &&
+                    $name ne '$/' && $name ne '$¢' && $name ne '$!' &&
                     !nqp::existskey(%arg_placeholders, $name);
             }
             elsif nqp::istype($_, QAST::Block) {
@@ -4668,11 +4640,6 @@ class Perl6::Actions is HLL::Actions does STDActions {
             :op('takedispatcher'),
             QAST::SVal.new( :value('$*DISPATCHER') )
         ));
-        $*W.install_lexical_symbol($past, '$*NEXT-DISPATCHER', $*W.find_symbol(['Nil'], :setting-only));
-        $past[0].push(QAST::Op.new(
-            :op('takenextdispatcher'),
-            QAST::SVal.new( :value('$*NEXT-DISPATCHER') )
-        ));
 
         # Finish up code object.
         $*W.attach_signature($code, $signature);
@@ -4767,23 +4734,21 @@ class Perl6::Actions is HLL::Actions does STDActions {
         # Add dispatching code.
         $BLOCK.push(QAST::Op.new(
             :op('invokewithcapture'),
-            redelegate_next_dispatcher(
+            QAST::Op.new(
+                :op('ifnull'),
                 QAST::Op.new(
-                    :op('ifnull'),
-                    QAST::Op.new(
-                        :op('multicachefind'),
-                        QAST::Var.new(
-                            :name('$!dispatch_cache'), :scope('attribute'),
-                            QAST::Op.new( :op('getcodeobj'), QAST::Op.new( :op('curcode') ) ),
-                            QAST::WVal.new( :value($*W.find_symbol(['Routine'], :setting-only)) ),
-                        ),
-                        QAST::Op.new( :op('usecapture') )
-                    ),
-                    QAST::Op.new(
-                        :op('callmethod'), :name('find_best_dispatchee'),
+                    :op('multicachefind'),
+                    QAST::Var.new(
+                        :name('$!dispatch_cache'), :scope('attribute'),
                         QAST::Op.new( :op('getcodeobj'), QAST::Op.new( :op('curcode') ) ),
-                        QAST::Op.new( :op('savecapture') )
-                    )
+                        QAST::WVal.new( :value($*W.find_symbol(['Routine'], :setting-only)) ),
+                    ),
+                    QAST::Op.new( :op('usecapture') )
+                ),
+                QAST::Op.new(
+                    :op('callmethod'), :name('find_best_dispatchee'),
+                    QAST::Op.new( :op('getcodeobj'), QAST::Op.new( :op('curcode') ) ),
+                    QAST::Op.new( :op('savecapture') )
                 )
             ),
             QAST::Op.new( :op('usecapture') )
@@ -6501,23 +6466,21 @@ class Perl6::Actions is HLL::Actions does STDActions {
             ),
             QAST::Op.new(
                 :op('invokewithcapture'),
-                redelegate_next_dispatcher(
+                QAST::Op.new(
+                    :op('ifnull'),
                     QAST::Op.new(
-                        :op('ifnull'),
-                        QAST::Op.new(
-                            :op('multicachefind'),
-                            QAST::Var.new(
-                                :name('$!dispatch_cache'), :scope('attribute'),
-                                QAST::Var.new( :name('&*CURRENT_DISPATCHER'), :scope('lexical') ),
-                                QAST::WVal.new( :value($*W.find_symbol(['Routine'], :setting-only)) ),
-                            ),
-                            QAST::Var.new( :name($dc_name), :scope('local') )
-                        ),
-                        QAST::Op.new(
-                            :op('callmethod'), :name('find_best_dispatchee'),
+                        :op('multicachefind'),
+                        QAST::Var.new(
+                            :name('$!dispatch_cache'), :scope('attribute'),
                             QAST::Var.new( :name('&*CURRENT_DISPATCHER'), :scope('lexical') ),
-                            QAST::Var.new( :name($dc_name), :scope('local') )
-                        )
+                            QAST::WVal.new( :value($*W.find_symbol(['Routine'], :setting-only)) ),
+                        ),
+                        QAST::Var.new( :name($dc_name), :scope('local') )
+                    ),
+                    QAST::Op.new(
+                        :op('callmethod'), :name('find_best_dispatchee'),
+                        QAST::Var.new( :name('&*CURRENT_DISPATCHER'), :scope('lexical') ),
+                        QAST::Var.new( :name($dc_name), :scope('local') )
                     )
                 ),
                 QAST::Var.new( :name($dc_name), :scope('local') )
@@ -6913,11 +6876,6 @@ class Perl6::Actions is HLL::Actions does STDActions {
             $block[0].push(QAST::Op.new(
                 :op('takedispatcher'),
                 QAST::SVal.new( :value('$*DISPATCHER') )
-            ));
-            $block[0].push(QAST::Var.new( :name('$*NEXT-DISPATCHER'), :scope('lexical'), :decl('var') ));
-            $block[0].push(QAST::Op.new(
-                :op('takenextdispatcher'),
-                QAST::SVal.new( :value('$*NEXT-DISPATCHER') )
             ));
             $past := block_closure($past);
             $past.annotate('bare_block', QAST::Op.new( :op('call'), $past ));

--- a/src/Perl6/Metamodel/Dispatchers.nqp
+++ b/src/Perl6/Metamodel/Dispatchers.nqp
@@ -20,12 +20,14 @@ class Perl6::Metamodel::BaseDispatcher {
     method get_call() {
         my $call := @!candidates[$!idx];
         ++$!idx;
-        if self.is_wrapper_like && self.last_candidate {
-            self.set_last_call_dispatchers($call);
+        if (nqp::can($call, 'is_dispatcher') && $call.is_dispatcher)
+            || (nqp::can($call, 'is_wrapped') && $call.is_wrapped)
+        {
+            nqp::nextdispatcherfor(self, $call);
         }
         else {
-            if (nqp::can($call, 'is_dispatcher') && $call.is_dispatcher) {
-                nqp::nextdispatcherfor(self, $call);
+            if self.is_wrapper_like && self.last_candidate {
+                nqp::setdispatcherfor($!next_dispatcher, $call) if $!next_dispatcher;
             }
             else {
                 nqp::setdispatcherfor(self, $call);
@@ -176,14 +178,11 @@ class Perl6::Metamodel::MultiDispatcher is Perl6::Metamodel::BaseDispatcher {
 }
 
 class Perl6::Metamodel::WrapDispatcher is Perl6::Metamodel::BaseDispatcher {
-    has $!stashed_dispatcher;
-
-    method new(:@candidates, :$idx, :$invocant, :$has_invocant, :$next_dispatcher, :$stashed_dispatcher) {
+    method new(:@candidates, :$idx, :$invocant, :$has_invocant, :$next_dispatcher) {
         my $disp := nqp::create(self);
         nqp::bindattr($disp, Perl6::Metamodel::BaseDispatcher, '@!candidates', @candidates);
         nqp::bindattr($disp, Perl6::Metamodel::BaseDispatcher, '$!idx', 1);
         nqp::bindattr($disp, Perl6::Metamodel::BaseDispatcher, '$!next_dispatcher', $next_dispatcher);
-        nqp::bindattr($disp, Perl6::Metamodel::WrapDispatcher, '$!stashed_dispatcher', $stashed_dispatcher);
         $disp
     }
 
@@ -192,19 +191,10 @@ class Perl6::Metamodel::WrapDispatcher is Perl6::Metamodel::BaseDispatcher {
         my $next_dispatcher := nqp::existskey($lexpad, '$*NEXT-DISPATCHER')
                                 ?? nqp::atkey($lexpad, '$*NEXT-DISPATCHER')
                                 !! nqp::null();
-        my $stashed_dispatcher := nqp::existskey($lexpad, '$*DISPATCHER')
-                                    ?? nqp::atkey($lexpad, '$*DISPATCHER')
-                                    !! nqp::null();
-        self.new(:@candidates, :idx(1), :$next_dispatcher, :$stashed_dispatcher)
+        self.new(:@candidates, :idx(1), :$next_dispatcher)
     }
 
     method has_invocant() { 0 }
     method invocant() { NQPMu }
     method is_wrapper_like() { 1 }
-
-    method set_last_call_dispatchers($call) {
-        nqp::setdispatcherfor($!stashed_dispatcher, $call) unless nqp::isnull($!stashed_dispatcher);
-        my $next_dispatcher := nqp::getattr(self, Perl6::Metamodel::BaseDispatcher, '$!next_dispatcher');
-        nqp::nextdispatcherfor($next_dispatcher, $call) unless nqp::isnull($next_dispatcher);
-    }
 }

--- a/src/Perl6/Metamodel/Dispatchers.nqp
+++ b/src/Perl6/Metamodel/Dispatchers.nqp
@@ -3,25 +3,40 @@ class Perl6::Metamodel::BaseDispatcher {
     has $!idx;
     has $!next_dispatcher; # The dispatcher we must pass control to when own queue exhausts
 
-    method candidates()     { @!candidates }
+    method candidates() { @!candidates }
 
-    method exhausted()      { $!idx >= +@!candidates && (!nqp::isconcrete($!next_dispatcher) || $!next_dispatcher.exhausted()) }
+    method exhausted() { $!idx >= +@!candidates && (!nqp::isconcrete($!next_dispatcher) || $!next_dispatcher.exhausted()) }
 
-    method last_candidate() { $!idx >= +@!candidates }
+    method last()      { @!candidates := [] }
 
-    method last()           { @!candidates := [] }
-
-    method set_next_dispatcher($next_dispatcher)
-                            { $!next_dispatcher := $next_dispatcher }
+    method set_next_dispatcher($next_dispatcher) { $!next_dispatcher := $next_dispatcher }
 
     # Wrapper-like dispatchers don't set dispatcher for the last candidate.
     method is_wrapper_like() { 0 }
 
     method get_call() { # Returns [$call, $is_dispatcher]
-        my $call := @!candidates[$!idx];
-        ++$!idx;
-        my $next_disp := self.set_call_dispatcher($call);
-        [$call, $next_disp]
+        my $call := @!candidates[$!idx++];
+
+        my $disp;
+        try {
+            # XXX Are there any better way to determine a invocation handler with own dispatcher in $!dispatcher?
+            $disp := nqp::getattr($call, nqp::what($call), '$!dispatcher'); # If $call is a handler. But there must be better way to deal with this.
+            $disp := nqp::null() unless nqp::istype($disp, Perl6::Metamodel::BaseDispatcher); # Protect from multi-Routine dispatcher attribute
+        }
+        if nqp::isconcrete($disp) {
+            return [$disp, 1];
+        }
+        else {
+            my $last_candidate := $!idx >= +@!candidates;
+            if  $last_candidate && nqp::isconcrete($!next_dispatcher) {
+                nqp::setdispatcherfor($!next_dispatcher, $call);
+                $!next_dispatcher := nqp::null();
+            }
+            else {
+                nqp::setdispatcherfor(self, $call) unless $last_candidate && self.is_wrapper_like;
+            }
+        }
+        [$call, 0]
     }
 
     # By default we just set next call dispatcher to ourselves.
@@ -40,78 +55,31 @@ class Perl6::Metamodel::BaseDispatcher {
     }
 
     method call_with_args(*@pos, *%named) {
-        if self.last_candidate {
-            if $!next_dispatcher {
-                $!next_dispatcher.call_with_args(|@pos, |%named);
-            }
-            else {
-                die(self.HOW.shortname(self) ~ " is already exhausted");
-            }
+        my @call := self.get_call;
+        if @call[1] {
+            return @call[0].enter_with_args(@pos, %named, :next_dispatcher(self));
+        }
+        if self.has_invocant {
+            my $inv := self.invocant;
+            @call[0]($inv, |@pos, |%named);
         }
         else {
-            my @call := self.get_call;
-            my $*NEXT-DISPATCHER := @call[1];
-            if self.has_invocant {
-                @call[0](self.invocant, |@pos, |%named);
-            }
-            else {
-                @call[0](|@pos, |%named);
-            }
+            @call[0](|@pos, |%named);
         }
     }
 
     method call_with_capture($capture) {
-        if self.last_candidate {
-            if $!next_dispatcher {
-                $!next_dispatcher.call_with_capture($capture)
-            }
-            else {
-                die(self.HOW.shortname(self) ~ " is already exhausted");
-            }
+        my @call := self.get_call;
+        if @call[1] { # Got a dispatcher
+            return @call[0].enter_with_capture($capture, :next_dispatcher(self));
         }
-        else {
-            my @call := self.get_call;
-            my $*NEXT-DISPATCHER := @call[1];
-            nqp::invokewithcapture(@call[0], $capture);
-        }
+        nqp::invokewithcapture(@call[0], $capture);
     }
 
     method shift_callee() {
         my $callee := @!candidates[$!idx];
-        ++$!idx;
+        $!idx := $!idx + 1;
         nqp::decont($callee)
-    }
-
-    method add_from_mro(@methods, $class, $sub, :$skip_first = 0) {
-        my @mro := nqp::can($class.HOW, 'mro_unhidden')
-                        ?? $class.HOW.mro_unhidden($class)
-                        !! $class.HOW.mro($class);
-        my $name := $sub.name;
-        my %seen;
-        for @mro {
-            my $mt := nqp::hllize($_.HOW.method_table($_));
-            if nqp::existskey($mt, $name) {
-                my $meth := nqp::atkey($mt, $name);
-                if $meth.is_dispatcher {
-                    my $proto_pkg_id := nqp::objectid($meth.package);
-                    # Skip proto if it's been seen before. Prevents from multiple dispatching over the same multi
-                    # candidates.
-                    $meth := nqp::null() if %seen{$proto_pkg_id};
-                    %seen{$proto_pkg_id} := 1
-                }
-                # Skipping the first method obtained from MRO because either it should have been handled already by
-                # vivify_for.
-                nqp::if(
-                    nqp::isgt_i($skip_first, 0),
-                    (--$skip_first),
-                    nqp::unless(
-                        nqp::isnull($meth),
-                        nqp::push(@methods, $meth)
-                    )
-                )
-            }
-        }
-        @methods
     }
 }
 
@@ -128,8 +96,17 @@ class Perl6::Metamodel::MethodDispatcher is Perl6::Metamodel::BaseDispatcher {
 
     method vivify_for($sub, $lexpad, $args) {
         my $obj      := $lexpad<self>;
-        my $class    := nqp::getlexrel($lexpad, '::?CLASS');
-        my @methods  := self.add_from_mro([], $class, $sub);
+        my $name     := $sub.name;
+        my @mro      := nqp::can($obj.HOW, 'mro_unhidden')
+            ?? $obj.HOW.mro_unhidden($obj)
+            !! $obj.HOW.mro($obj);
+        my @methods;
+        for @mro {
+            my %mt := nqp::hllize($_.HOW.method_table($_));
+            if nqp::existskey(%mt, $name) {
+                @methods.push(%mt{$name});
+            }
+        }
         self.new(:candidates(@methods), :obj($obj), :idx(1))
     }
 
@@ -141,11 +118,10 @@ class Perl6::Metamodel::MultiDispatcher is Perl6::Metamodel::BaseDispatcher {
     has $!has_invocant;
     has $!invocant;
 
-    method new(:@candidates, :$idx, :$invocant, :$has_invocant, :$next_dispatcher) {
+    method new(:@candidates, :$idx, :$invocant, :$has_invocant) {
         my $disp := nqp::create(self);
         nqp::bindattr($disp, Perl6::Metamodel::BaseDispatcher, '@!candidates', @candidates);
         nqp::bindattr($disp, Perl6::Metamodel::BaseDispatcher, '$!idx', $idx);
-        nqp::bindattr($disp, Perl6::Metamodel::BaseDispatcher, '$!next_dispatcher', $next_dispatcher);
         nqp::bindattr($disp, Perl6::Metamodel::MultiDispatcher, '$!invocant', $invocant);
         nqp::bindattr($disp, Perl6::Metamodel::MultiDispatcher, '$!has_invocant', $has_invocant);
         $disp
@@ -154,19 +130,10 @@ class Perl6::Metamodel::MultiDispatcher is Perl6::Metamodel::BaseDispatcher {
     method vivify_for($sub, $lexpad, $args) {
         my $disp         := $sub.dispatcher();
         my $has_invocant := nqp::existskey($lexpad, 'self');
-        my @cands        := $disp.find_best_dispatchee($args, 1);
         my $invocant     := $has_invocant && $lexpad<self>;
-        my $next_dispatcher := nqp::getlexreldyn($lexpad, '$*NEXT-DISPATCHER');
-        # The first candidate has already been invoked, throw it away from the list;
-        # If called in a method then only take control if MethodDispatcher is in charge.
-        if $has_invocant && !nqp::isconcrete($next_dispatcher) {
-            my $class := nqp::getlexrel($lexpad, '::?CLASS');
-            self.add_from_mro(@cands, $class, $sub, :skip_first(1));
-            Perl6::Metamodel::MethodDispatcher.new(:candidates(@cands), :idx(1), :obj($invocant))
-        }
-        else {
-            self.new(:candidates(@cands), :idx(1), :$invocant, :$has_invocant, :$next_dispatcher)
-        }
+        my @cands        := $disp.find_best_dispatchee($args, 1);
+        self.new(:candidates(@cands), :idx(1), :invocant($invocant),
+            :has_invocant($has_invocant))
     }
 
     method has_invocant() { $!has_invocant }
@@ -174,21 +141,53 @@ class Perl6::Metamodel::MultiDispatcher is Perl6::Metamodel::BaseDispatcher {
 }
 
 class Perl6::Metamodel::WrapDispatcher is Perl6::Metamodel::BaseDispatcher {
-    method new(:@candidates, :$idx, :$invocant, :$has_invocant, :$next_dispatcher) {
+    method new(:@candidates, :$idx, :$invocant, :$has_invocant) {
         my $disp := nqp::create(self);
         nqp::bindattr($disp, Perl6::Metamodel::BaseDispatcher, '@!candidates', @candidates);
         nqp::bindattr($disp, Perl6::Metamodel::BaseDispatcher, '$!idx', 1);
-        nqp::bindattr($disp, Perl6::Metamodel::BaseDispatcher, '$!next_dispatcher', $next_dispatcher);
         $disp
     }
 
-    method vivify_for($sub, $lexpad, $capture) {
-        my @candidates      := $sub.wrappers;
-        my $next_dispatcher := nqp::getlexreldyn($lexpad, '$*NEXT-DISPATCHER');
-        self.new(:@candidates, :idx(1), :$next_dispatcher)
+    method has_invocant() { 0 }
+
+    method is_wrapper_like() { 1 }
+
+    method add($wrapper) {
+        self.candidates.unshift($wrapper)
     }
 
-    method has_invocant() { 0 }
-    method invocant() { NQPMu }
-    method is_wrapper_like() { 1 }
+    method remove($wrapper) {
+        my @cands := self.candidates;
+        my $i := 0;
+        while $i < +@cands {
+            if nqp::decont(@cands[$i]) =:= nqp::decont($wrapper) {
+                nqp::splice(@cands, [], $i, 1);
+                return 1;
+            }
+            $i := $i + 1;
+        }
+        return 0;
+    }
+
+    method get_first($next_dispatcher) {
+        my $fresh := nqp::clone(self);
+        $fresh.set_next_dispatcher($next_dispatcher) if $next_dispatcher;
+        my $first := self.candidates[0];
+        nqp::setdispatcherfor($fresh, $first);
+        $first
+    }
+
+    # This method is a bridge between Perl6 and NQP.
+    method enter(*@pos, *%named) {
+        self.enter_with_args(@pos, %named);
+    }
+
+    method enter_with_args(@pos, %named, :$next_dispatcher?) {
+        self.get_first($next_dispatcher)(|@pos, |%named)
+    }
+
+    method enter_with_capture($capture, :$next_dispatcher?) {
+        my $first := self.get_first($next_dispatcher);
+        nqp::invokewithcapture($first, $capture);
+    }
 }

--- a/src/Perl6/Metamodel/Dispatchers.nqp
+++ b/src/Perl6/Metamodel/Dispatchers.nqp
@@ -39,21 +39,6 @@ class Perl6::Metamodel::BaseDispatcher {
         [$call, 0]
     }
 
-    # By default we just set next call dispatcher to ourselves.
-    # Method must return value for $*NEXT-DISPATCHER
-    method set_call_dispatcher($call) {
-        return nqp::null() if self.is_wrapper_like && self.last_candidate && !$!next_dispatcher;
-        if (nqp::can($call, 'is_dispatcher') && $call.is_dispatcher)
-            || (nqp::can($call, 'is_wrapped') && $call.is_wrapped)
-        {
-            self
-        }
-        else {
-            nqp::setdispatcherfor(self, $call);
-            nqp::null()
-        }
-    }
-
     method call_with_args(*@pos, *%named) {
         my @call := self.get_call;
         if @call[1] {

--- a/src/Perl6/Metamodel/Dispatchers.nqp
+++ b/src/Perl6/Metamodel/Dispatchers.nqp
@@ -77,16 +77,9 @@ class Perl6::Metamodel::BaseDispatcher {
     }
 
     method shift_callee() {
-        my @call := [nqp::null(), nqp::null()];
-        if self.last_candidate {
-            if $!next_dispatcher {
-                @call := $!next_dispatcher.shift_callee;
-            }
-        }
-        else {
-            @call := self.get_call;
-        }
-        @call;
+        my $callee := @!candidates[$!idx];
+        ++$!idx;
+        nqp::decont($callee)
     }
 
     method add_from_mro(@methods, $class, $sub, :$skip_first = 0) {
@@ -135,7 +128,8 @@ class Perl6::Metamodel::MethodDispatcher is Perl6::Metamodel::BaseDispatcher {
 
     method vivify_for($sub, $lexpad, $args) {
         my $obj      := $lexpad<self>;
-        my @methods  := self.add_from_mro([], $obj, $sub);
+        my $class    := nqp::getlexrel($lexpad, '::?CLASS');
+        my @methods  := self.add_from_mro([], $class, $sub);
         self.new(:candidates(@methods), :obj($obj), :idx(1))
     }
 

--- a/src/Perl6/Metamodel/MultiMethodContainer.nqp
+++ b/src/Perl6/Metamodel/MultiMethodContainer.nqp
@@ -95,7 +95,6 @@ role Perl6::Metamodel::MultiMethodContainer {
                         nqp::hash('T', $obj));
                     $proto.set_name($name);
                     $proto.add_dispatchee($code);
-                    $proto.'!set_package'($obj);
                     self.add_method($obj, $name, $proto);
                     nqp::push(@new_protos, $proto);
                 }

--- a/src/Perl6/Optimizer.nqp
+++ b/src/Perl6/Optimizer.nqp
@@ -445,7 +445,7 @@ my class BlockVarOptimizer {
     has @!autoslurpy_binds;
 
     # The takedispatcher operation.
-    has %!takedispatcher;
+    has $!takedispatcher;
 
     # If lowering is, for some reason, poisoned.
     has int $!poisoned;
@@ -516,7 +516,7 @@ my class BlockVarOptimizer {
     }
 
     method register_takedispatcher($node) {
-        %!takedispatcher{$node.op} := $node;
+        $!takedispatcher := $node;
     }
 
     method poison_lowering() { $!poisoned := 1; }
@@ -699,14 +699,9 @@ my class BlockVarOptimizer {
 
     method simplify_takedispatcher() {
         unless $!calls || $!uses_bindsig {
-            my $iter := nqp::iterator(%!takedispatcher);
-            while $iter {
-                nqp::shift($iter);
-                my $op := nqp::iterval($iter);
-                my $name := nqp::iterkey_s($iter);
-                # Replace 'take' with 'clear' in the op name.
-                $op.op(nqp::replace($name, 0, 4, 'clear'));
-                $op.shift();
+            if $!takedispatcher {
+                $!takedispatcher.op('cleardispatcher');
+                $!takedispatcher.shift();
             }
         }
     }
@@ -1310,14 +1305,13 @@ class Perl6::Optimizer {
 
     # Poisonous calls.
     my %poison_calls := nqp::hash(
-        'EVAL',       NQPMu, '&EVAL',       NQPMu,
-        'EVALFILE',   NQPMu, '&EVALFILE',   NQPMu,
-        'callwith',   NQPMu, '&callwith',   NQPMu,
-        'callsame',   NQPMu, '&callsame',   NQPMu,
-        'nextcallee', NQPMu, '&nextcallee', NQPMu,
-        'nextwith',   NQPMu, '&nextwith',   NQPMu,
-        'nextsame',   NQPMu, '&nextsame',   NQPMu,
-        'samewith',   NQPMu, '&samewith',   NQPMu,
+        'EVAL',     NQPMu, '&EVAL',     NQPMu,
+        'EVALFILE', NQPMu, '&EVALFILE', NQPMu,
+        'callwith', NQPMu, '&callwith', NQPMu,
+        'callsame', NQPMu, '&callsame', NQPMu,
+        'nextwith', NQPMu, '&nextwith', NQPMu,
+        'nextsame', NQPMu, '&nextsame', NQPMu,
+        'samewith', NQPMu, '&samewith', NQPMu,
         # This is a hack to compensate for Test.pm6 using unspecified
         # behavior. The EVAL form of it should be deprecated and then
         # removed, at which point this can go away.
@@ -1622,7 +1616,7 @@ class Perl6::Optimizer {
         }
 
         # May be able to simplify takedispatcher ops.
-        elsif $optype eq 'takedispatcher' || $optype eq 'takenextdispatcher' {
+        elsif $optype eq 'takedispatcher' {
             @!block_var_stack[nqp::elems(@!block_var_stack) - 1].register_takedispatcher($op);
         }
 
@@ -3050,13 +3044,13 @@ class Perl6::Optimizer {
                 # a symbol, do nothing (we just need it for "fallback" purposes).
                 # Otherwise, copy it and register it in the outer.
                 my $name := $_.name;
-                unless $name eq '$*DISPATCHER' || $name eq '$*NEXT-DISPATCHER' || $name eq '$_' || $outer.symbol($name) {
+                unless $name eq '$*DISPATCHER' || $name eq '$_' || $outer.symbol($name) {
                     @copy_decls.push($_);
                     $outer.symbol($name, :scope('lexical'));
                 }
             }
-            elsif nqp::istype($_, QAST::Op) && ($_.op eq 'takedispatcher' || $_.op eq 'takenextdispatcher') {
-                # Don't copy the dispatcher take, since the $*DISPATCHER and $*NEXT-DISPATCHER are
+            elsif nqp::istype($_, QAST::Op) && $_.op eq 'takedispatcher' {
+                # Don't copy the dispatcher take, since the $*DISPATCHER is
                 # also not copied.
             }
             else {

--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -2253,18 +2253,11 @@ BEGIN {
     Routine.HOW.add_attribute(Routine, Attribute.new(:name<$!onlystar>, :type(int), :package(Routine)));
     Routine.HOW.add_attribute(Routine, scalar_attr('@!dispatch_order', List, Routine, :!auto_viv_container));
     Routine.HOW.add_attribute(Routine, Attribute.new(:name<$!dispatch_cache>, :type(Mu), :package(Routine)));
-    Routine.HOW.add_attribute(Routine, Attribute.new(:name<$!wrappers>, :type(Mu), :package(Routine)));
 
     Routine.HOW.add_method(Routine, 'is_dispatcher', nqp::getstaticcode(sub ($self) {
             my $dc_self   := nqp::decont($self);
             my $disp_list := nqp::getattr($dc_self, Routine, '@!dispatchees');
             nqp::hllboolfor(nqp::defined($disp_list), "Raku");
-        }));
-    Routine.HOW.add_method(Routine, 'is_wrapped', nqp::getstaticcode(sub ($self) {
-            nqp::hllboolfor(
-                nqp::defined(
-                    nqp::getattr(nqp::decont($self), Routine, '$!wrappers')),
-                "Raku");
         }));
     Routine.HOW.add_method(Routine, 'add_dispatchee', nqp::getstaticcode(sub ($self, $dispatchee) {
             my $dc_self   := nqp::decont($self);
@@ -2298,10 +2291,6 @@ BEGIN {
     Routine.HOW.add_method(Routine, 'dispatchees', nqp::getstaticcode(sub ($self) {
             nqp::getattr(nqp::decont($self),
                 Routine, '@!dispatchees')
-        }));
-    Routine.HOW.add_method(Routine, 'wrappers', nqp::getstaticcode(sub ($self) {
-            nqp::hllize(nqp::getattr(nqp::decont($self),
-                Routine, '$!wrappers'))
         }));
     Routine.HOW.add_method(Routine, '!configure_positional_bind_failover',
         nqp::getstaticcode(sub ($self, $Positional, $PositionalBindFailover) {
@@ -3254,11 +3243,6 @@ BEGIN {
     Routine.HOW.add_method(Routine, 'set_onlystar', nqp::getstaticcode(sub ($self) {
             my $dcself := nqp::decont($self);
             nqp::bindattr_i($dcself, Routine, '$!onlystar', 1);
-            $dcself
-        }));
-    Routine.HOW.add_method(Routine, '!set_package', nqp::getstaticcode(sub ($self, $package) {
-            my $dcself := nqp::decont($self);
-            nqp::bindattr($dcself, Routine, '$!package', $package);
             $dcself
         }));
     Routine.HOW.compose_repr(Routine);

--- a/src/core.c/Deprecations.pm6
+++ b/src/core.c/Deprecations.pm6
@@ -84,7 +84,7 @@ class Rakudo::Deprecations {
 
         my $bt = Backtrace.new;
         my $deprecated =
-          $bt[ my $index = $bt.next-interesting-index(:named, :setting) // 0 ];
+          $bt[ my $index = $bt.next-interesting-index(2, :named, :setting) // 0 ];
 
         if $up ~~ Whatever {
             $index = $_ with $bt.next-interesting-index($index, :noproto);

--- a/src/core.c/Routine.pm6
+++ b/src/core.c/Routine.pm6
@@ -79,36 +79,34 @@ my class Routine { # declared in BOOTSTRAP
 
     method soft( --> Nil ) { }
 
-    my class WrapHandle {
-        has &.wrapper;
-        has &.wrappee;
-
-        method restore {
-            &.wrappee.unwrap(self)
-        }
-    }
-
     method wrap(&wrapper) {
-        my \wrp := nqp::clone(&wrapper);
-        my $handle = WrapHandle.new: :wrapper(wrp), :wrappee(self);
-
-        if $*W {
-            my sub wrp-fixup() { self!do_wrap(wrp) };
-            $*W.add_object_if_no_sc(wrp);
-            $*W.add_object_if_no_sc(&wrp-fixup);
-            $*W.add_fixup_task(
-                :fixup_ast(
-                    QAST::Op.new(:op<call>, QAST::WVal.new(:value(&wrp-fixup)))
-                ));
+        my class WrapHandle {
+            has $!dispatcher;
+            has $!wrapper;
+            method restore() {
+                nqp::hllbool($!dispatcher.remove($!wrapper));
+            }
         }
-        else {
-            self!do_wrap(wrp);
+        my role Wrapped {
+            has $!dispatcher;
+            method UNSHIFT_WRAPPER(&wrapper) {
+                # Add candidate.
+                $!dispatcher := WrapDispatcher.new()
+                    unless nqp::isconcrete($!dispatcher);
+                $!dispatcher.add(&wrapper);
+
+                # Return a handle.
+                my $handle := nqp::create(WrapHandle);
+                nqp::bindattr($handle, WrapHandle, '$!dispatcher', $!dispatcher);
+                nqp::bindattr($handle, WrapHandle, '$!wrapper', &wrapper);
+                $handle
+            }
+            method CALL-ME(|c) is raw {
+                $!dispatcher.enter(|c);
+            }
+            method soft(--> True) { }
         }
 
-        $handle
-    }
-
-    method !do_wrap(\wrp) {
         # We can't wrap a hardened routine (that is, one that's been
         # marked inlinable).
         if nqp::istype(self, HardRoutine) {
@@ -116,60 +114,22 @@ my class Routine { # declared in BOOTSTRAP
                 "use the 'soft' pragma to avoid marking routines as hard.";
         }
 
-        # Use clone to make it possible for user to use same wrapper for different routines.
-        my \wrp-do := nqp::getattr(wrp, Code, '$!do');
-        if nqp::defined($!wrappers) {
-            # Insert next to onlywrap
-            nqp::splice($!wrappers, nqp::list(wrp), 1, 0);
+        # If we're not wrapped already, do the initial dispatcher
+        # creation.
+        unless nqp::istype(self, Wrapped) {
+            my $orig = self.clone();
+            self does Wrapped;
+            $!onlystar = 0; # disable optimization if no body there
+            self.UNSHIFT_WRAPPER($orig);
         }
-        else {
-            my \onlywrap := sub onlywrap(|) is raw is hidden-from-backtrace {
-                $/ := nqp::getlexcaller('$/');
-                my Mu $dispatcher := Metamodel::WrapDispatcher.vivify_for(self, nqp::ctx(), nqp::usecapture());
-                $*DISPATCHER := $dispatcher;
-                $dispatcher.call_with_capture(nqp::usecapture())
-            };
-            # onlywrap.set_name(self.name);
-            my \me = nqp::clone(self);
-            if $*W {
-                $*W.add_object_if_no_sc(me)
-            }
-            # Make static code point to the cloned object until original is fully unwrapped. If not done we end up with
-            # static code on `me` pointing at the original Routine instance, which has $!do from onlywrap. It results in
-            # dispatchers vivified from `me` receive onlywrap as $sub parameter.
-            nqp::setcodeobj(nqp::getattr(me, Code, '$!do'), me);
-            $!wrappers := nqp::list(onlywrap, wrp, me);
-            my \onlywrap-do := nqp::getattr(onlywrap, Code, '$!do');
-            nqp::setcodeobj(onlywrap-do, self);
-            nqp::bindattr(self, Code, '$!do', onlywrap-do);
-        }
+
+        # Add this wrapper.
+        self.UNSHIFT_WRAPPER(&wrapper);
     }
 
     method unwrap($handle) {
-        X::Routine::Unwrap.new.throw unless nqp::istype($handle, WrapHandle);
-        my $succeed;
-        if $!wrappers {
-            my $idx = 0;
-            my $count = nqp::elems($!wrappers) - 1;
-            my &wrapper := nqp::decont($handle.wrapper);
-            while ++$idx < $count {
-                my &w := nqp::atpos($!wrappers, $idx);
-                if &w === &wrapper {
-                    # Also strip off all wrappers put on top of this.
-                    nqp::splice($!wrappers, nqp::list(), $idx, 1);
-                    $succeed := 1;
-                    last;
-                }
-            }
-            if $succeed && $count == 2 {
-                # We just have removed the last user wrapper, restore the original code.
-                my \orig-do := nqp::getattr(nqp::atpos($!wrappers, 1), Code, '$!do');
-                nqp::bindattr(self, Code, '$!do', orig-do);
-                nqp::setcodeobj(orig-do, self);
-                $!wrappers := nqp::null();
-            }
-        }
-        X::Routine::Unwrap.new.throw unless $succeed;
+        $handle.can('restore') && $handle.restore() ||
+            X::Routine::Unwrap.new.throw
     }
 
     method package() { $!package }


### PR DESCRIPTION
An attempt to revert dispatcher patches causing a performance loss.

1)There were new ops added to moar, but I don't know if we have to revert them as well and how that affects raw performance.
2)It does pass stresstest with https://github.com/Raku/roast/pull/638

However, when running stresstest numerous times I saw failures in random unrelated files, so the main question is: can dispatcher revert not done properly cause races?