### PR TITLE
Fix .comb(Str) to ensure non-overlapping results

### DIFF
--- a/src/core.c/Str.pm6
+++ b/src/core.c/Str.pm6
@@ -979,10 +979,12 @@ my class Str does Stringy { # declared in BOOTSTRAP
     my class CombPat does Iterator {
         has str $!str;
         has str $!pat;
+        has int $!patsz;
         has int $!pos;
         method !SET-SELF(\string, \pat) {
             $!str = nqp::unbox_s(string);
             $!pat = nqp::unbox_s(pat);
+            $!patsz = nqp::chars($!pat);
             self
         }
         method new(\string, \pat) { nqp::create(self)!SET-SELF(string,pat) }
@@ -992,7 +994,7 @@ my class Str does Stringy { # declared in BOOTSTRAP
                 IterationEnd
             }
             else {
-                $!pos = $found + 1;
+                $!pos = $found + $!patsz;
                 nqp::p6box_s($!pat)
             }
         }

--- a/src/core.c/Supply-factories.pm6
+++ b/src/core.c/Supply-factories.pm6
@@ -622,6 +622,7 @@
           ?? supply {
                  my str $str;
                  my str $needle = $the-needle;
+                 my int $len = nqp::chars($needle);
                  whenever self -> str $val {
                      $str = nqp::concat($str,$val);
 
@@ -631,7 +632,7 @@
                        nqp::isgt_i(($i = nqp::index($str,$needle,$pos)),-1),
                        nqp::stmts(
                          emit($the-needle),
-                         ($pos = $i + 1)
+                         ($pos = $i + $len)
                        )
                      );
                      $str = nqp::substr($str,$pos);


### PR DESCRIPTION
It is expected that `.comb()` returns non-overlapping results, and `.comb('aa')` should yield the same results as `.comb(/aa/)`.
