### PR TITLE
Azure pipelines

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,20 +3,6 @@ version: 2.1
 orbs:
     win: circleci/windows@2.2.0
 
-parameters:
-  BUILD_PRECOMP_RELEASE:
-    type: boolean
-    default: false
-  RELEASE_URL:
-    type: string
-    default: ""
-  VERSION:
-    type: string
-    default: "XXXX.YY"
-  BUILD_REV:
-    type: string
-    default: "01"
-
 variables:
   build-parameters: &build-parameters
     parameters:
@@ -26,12 +12,6 @@ variables:
       nqp-rev:
         type: string
         default: ""
-  precomp-release-environment: &precomp-release-environment
-    environment:
-      RELEASE_URL: << pipeline.parameters.RELEASE_URL >>
-      VERSION: << pipeline.parameters.VERSION >>
-      BUILD_REV: << pipeline.parameters.BUILD_REV >>
-
 
 jobs:
   test-linux:
@@ -51,63 +31,6 @@ jobs:
           nqp-rev: << parameters.nqp-rev >>
           moar-rev: << parameters.moar-rev >>
 
-  build-precomp-linux:
-    <<: *precomp-release-environment
-    docker:
-      - image: centos:6
-    steps:
-      - run:
-          name: Install basic dependencies
-          command: |
-            yum -y update
-            yum clean all
-            yum -y install git perl perl-core
-      - run:
-          name: Checkout repository
-          command: |
-            git clone `echo $CIRCLE_REPOSITORY_URL | perl -pe "s|(ssh://)?git\@github\.com:|https://github.com/|"` .
-            if [ -n "$CIRCLE_TAG" ]; then
-            git checkout -q "$CIRCLE_TAG"
-            elif [ -n "$CIRCLE_BRANCH" ]; then
-            git checkout origin/"$CIRCLE_BRANCH"
-            git branch -f "$CIRCLE_BRANCH"
-            git checkout -q "$CIRCLE_BRANCH"
-            fi
-      - run:
-          name: Run build script
-          command:
-            tools/build/binary-release/build-linux.sh
-      - store_artifacts:
-          path: rakudo-linux.tar.gz
-          destination: rakudo-moar-<< pipeline.parameters.VERSION >>-<< pipeline.parameters.BUILD_REV >>-linux-x86_64.tar.gz
-  build-precomp-macos:
-    <<: *precomp-release-environment
-    macos:
-      xcode: 10.2.0
-    steps:
-      - checkout
-      - run:
-          name: Run build script
-          command:
-            tools/build/binary-release/build-macos.sh
-      - store_artifacts:
-          path: rakudo-macos.tar.gz
-          destination: rakudo-moar-<< pipeline.parameters.VERSION >>-<< pipeline.parameters.BUILD_REV >>-macos-x86_64.tar.gz
-  build-precomp-windows:
-    <<: *precomp-release-environment
-    executor: win/default
-    working_directory: C:\rakudo
-    steps:
-      - checkout
-      - run:
-          name: Run build script
-          command:
-            tools/build/binary-release/build-windows.ps1
-      - store_artifacts:
-          path: rakudo-win.zip
-          destination: rakudo-moar-<< pipeline.parameters.VERSION >>-<< pipeline.parameters.BUILD_REV >>-win-x86_64.zip
-
-
 commands:
   build-rakudo:
     description: "Build MoarVM, NQP, and Rakudo"
@@ -124,7 +47,6 @@ commands:
 workflows:
   version: 2
   test:
-    unless: << pipeline.parameters.BUILD_PRECOMP_RELEASE >>
     jobs:
       - test-linux
       - test-linux:
@@ -134,10 +56,4 @@ workflows:
       - test-macos:
           nqp-rev: HEAD
           moar-rev: HEAD
-  build-precomp-release:
-    when: << pipeline.parameters.BUILD_PRECOMP_RELEASE >>
-    jobs:
-      - build-precomp-linux
-      - build-precomp-macos
-      - build-precomp-windows
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,120 @@
+# This is the Azure Pipelines configuration to create the precompiled release
+# archives that are made available at <https://rakudo.org>.
+#
+# To trigger a build, go to <https://dev.azure.com/infra0037/raku/...> and
+# start a run of the precompile-release pipeline.
+#
+# The following pipeline variables are required:
+#
+# RELEASE_URL: Release archive to build. e.g. "https://rakudo.org/dl/rakudo/rakudo-2020.05.tar.gz"
+# VERSION: The version that you are building. e.g. "2020.05"
+# REVISION: Usually "01"
+#
+
+trigger:
+- none
+
+jobs:
+  - job: linux
+    displayName: Linux x86_64 build
+    pool:
+      vmImage: 'ubuntu-18.04'
+    container:
+      image: centos:6
+      options: "--name raku-build-container -v /usr/bin/docker:/tmp/docker:ro"
+    workspace:
+      clean: all
+    steps:
+      - script: /tmp/docker exec -t -u 0 raku-build-container sh -c "yum -y update && yum -y install sudo"
+        displayName: Set up sudo (see https://github.com/microsoft/azure-pipelines-agent/issues/2043)
+
+      - checkout: self
+        path: source
+        fetchDepth: 1
+        displayName: Checkout repository
+
+      - script: $(Agent.BuildDirectory)/source/tools/build/binary-release/build-linux.sh
+        failOnStderr: false
+        displayName: Run build script
+
+      - publish: rakudo-linux.tar.gz
+        artifact: rakudo-linux
+
+  - job: macos
+    displayName: MacOS x86_64 build
+    pool:
+      vmImage: 'macOS-10.15'
+    workspace:
+      clean: all
+    steps:
+      - checkout: self
+        path: source
+        fetchDepth: 1
+
+      - script: $(Agent.BuildDirectory)/source/tools/build/binary-release/build-macos.sh
+        failOnStderr: false
+        displayName: Run build script
+
+      - publish: rakudo-macos.tar.gz
+        artifact: rakudo-macos
+
+  - job: windows
+    displayName: Windows x86_64 build
+    pool:
+      vmImage: 'windows-2019'
+    workspace:
+      clean: all
+    steps:
+      - checkout: self
+        path: source
+        fetchDepth: 1
+
+      # Turn this Powershell console into a developer powershell console.
+      # https://intellitect.com/enter-vsdevshell-powershell/
+      - pwsh: |
+          $installPath = &"C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationpath
+          $devShell    = &"C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -latest -find **\Microsoft.VisualStudio.DevShell.dll
+          Import-Module $devShell
+          Enter-VsDevShell -VsInstallPath $installPath -SkipAutomaticLocation -DevCmdArguments "-arch=amd64"
+          $(Agent.BuildDirectory)/source/tools/build/binary-release/build-windows.ps1
+        failOnStderr: false
+        displayName: Run build script
+
+      - publish: rakudo-win.zip
+        artifact: rakudo-win
+
+  - job: zip
+    displayName: Package results
+    dependsOn:
+    - linux
+    - macos
+    - windows
+    pool:
+      vmImage: 'ubuntu-18.04'
+    workspace:
+      clean: all
+    steps:
+    - checkout: none
+
+    - download: current
+      artifact: rakudo-linux
+      displayName: Download Linux build artifacts
+
+    - download: current
+      artifact: rakudo-macos
+      displayName: Download MacOS build artifacts
+
+    - download: current
+      artifact: rakudo-win
+      displayName: Download Windows build artifacts
+
+    - script: |
+        OUT_DIR=rakudo-builds-$(VERSION)-$(REVISION)
+        mkdir $OUT_DIR
+        cp $(Pipeline.Workspace)/rakudo-linux/rakudo-linux.tar.gz $OUT_DIR/rakudo-moar-$(VERSION)-$(REVISION)-linux-x86_64.tar.gz
+        cp $(Pipeline.Workspace)/rakudo-macos/rakudo-macos.tar.gz $OUT_DIR/rakudo-moar-$(VERSION)-$(REVISION)-linux-x86_64.tar.gz
+        cp $(Pipeline.Workspace)/rakudo-win/rakudo-win.zip        $OUT_DIR/rakudo-moar-$(VERSION)-$(REVISION)-win-x86_64.zip
+        tar -czf rakudo-moar-builds-$(VERSION)-$(REVISION).tar.gz $OUT_DIR
+
+    - publish: rakudo-moar-builds-$(VERSION)-$(REVISION).tar.gz
+      artifact: build-result

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,120 +1,282 @@
-# This is the Azure Pipelines configuration to create the precompiled release
-# archives that are made available at <https://rakudo.org>.
+# This is the Azure Pipelines configuration is also used to create the
+# precompiled release archives that are made available at <https://rakudo.org>.
 #
 # To trigger a build, go to <https://dev.azure.com/infra0037/raku/...> and
-# start a run of the precompile-release pipeline.
+# manually start a run of this pipeline.
 #
 # The following pipeline variables are required:
 #
+# BUILD_PRECOMP_RELEASE: Set this to "yes".
 # RELEASE_URL: Release archive to build. e.g. "https://rakudo.org/dl/rakudo/rakudo-2020.05.tar.gz"
 # VERSION: The version that you are building. e.g. "2020.05"
 # REVISION: Usually "01"
 #
 
 trigger:
-- none
+- master
 
-jobs:
-  - job: linux
-    displayName: Linux x86_64 build
-    pool:
-      vmImage: 'ubuntu-18.04'
-    container:
-      image: centos:6
-      options: "--name raku-build-container -v /usr/bin/docker:/tmp/docker:ro"
-    workspace:
-      clean: all
-    steps:
-      - script: /tmp/docker exec -t -u 0 raku-build-container sh -c "yum -y update && yum -y install sudo"
-        displayName: Set up sudo (see https://github.com/microsoft/azure-pipelines-agent/issues/2043)
+pr:
+- master
 
-      - checkout: self
-        path: source
-        fetchDepth: 1
-        displayName: Checkout repository
+variables:
+  # Turn this Powershell console into a developer powershell console.
+  # https://intellitect.com/enter-vsdevshell-powershell/
+  PWSH_DEV: |
+    $installPath = &"C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationpath
+    $devShell    = &"C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -latest -find **\Microsoft.VisualStudio.DevShell.dll
+    Import-Module $devShell
+    Enter-VsDevShell -VsInstallPath $installPath -SkipAutomaticLocation -DevCmdArguments "-arch=amd64"
 
-      - script: $(Agent.BuildDirectory)/source/tools/build/binary-release/build-linux.sh
-        failOnStderr: false
-        displayName: Run build script
 
-      - publish: rakudo-linux.tar.gz
+stages:
+- stage: Test
+  condition: ne( variables['BUILD_PRECOMP_RELEASE'], 'yes' )
+  jobs:
+    - job: Test
+      strategy:
+       matrix:
+         Windows_MoarVM:
+          IMAGE_NAME: 'windows-2019'
+          RAKUDO_OPTIONS: '--backends=moar --gen-nqp --gen-moar'
+         Windows_MoarVM_NQP_master:
+          IMAGE_NAME: 'windows-2019'
+          RAKUDO_OPTIONS: '--backends=moar --gen-nqp=master --gen-moar'
+         Windows_MoarVM_NQP_master_MoarVM_master:
+          IMAGE_NAME: 'windows-2019'
+          RAKUDO_OPTIONS: '--backends=moar --gen-nqp=master --gen-moar=master'
+         Windows_JVM:
+          IMAGE_NAME: 'windows-2019'
+          BACKEND: 'JVM'
+          RAKUDO_OPTIONS: '--backends=jvm  --gen-nqp'
+         Windows_JVM_NQP_master:
+          IMAGE_NAME: 'windows-2019'
+          BACKEND: 'JVM'
+          RAKUDO_OPTIONS: '--backends=jvm  --gen-nqp=master'
+         Windows_MoarVM_relocatable:
+          IMAGE_NAME: 'windows-2019'
+          RELOCATABLE: 'yes'
+          RAKUDO_OPTIONS: '--backends=moar --gen-nqp --gen-moar --relocatable'
+
+         MacOS_MoarVM:
+          IMAGE_NAME: 'macOS-10.15'
+          RAKUDO_OPTIONS: '--backends=moar --gen-nqp --gen-moar'
+         MacOS_MoarVM_NQP_master:
+          IMAGE_NAME: 'macOS-10.15'
+          RAKUDO_OPTIONS: '--backends=moar --gen-nqp=master --gen-moar'
+         MacOS_MoarVM_NQP_master_MoarVM_master:
+          IMAGE_NAME: 'macOS-10.15'
+          RAKUDO_OPTIONS: '--backends=moar --gen-nqp=master --gen-moar=master'
+         MacOS_JVM:
+          IMAGE_NAME: 'macOS-10.15'
+          BACKEND: 'JVM'
+          RAKUDO_OPTIONS: '--backends=jvm  --gen-nqp'
+         MacOS_JVM_NQP_master:
+          IMAGE_NAME: 'macOS-10.15'
+          BACKEND: 'JVM'
+          RAKUDO_OPTIONS: '--backends=jvm  --gen-nqp=master'
+         MacOS_MoarVM_relocatable:
+          IMAGE_NAME: 'macOS-10.15'
+          RELOCATABLE: 'yes'
+          RAKUDO_OPTIONS: '--backends=moar --gen-nqp --gen-moar --relocatable'
+
+         Linux_MoarVM:
+          IMAGE_NAME: 'ubuntu-18.04'
+          RAKUDO_OPTIONS: '--backends=moar --gen-nqp --gen-moar'
+         Linux_MoarVM_NQP_master:
+          IMAGE_NAME: 'ubuntu-18.04'
+          RAKUDO_OPTIONS: '--backends=moar --gen-nqp=master --gen-moar'
+         Linux_MoarVM_NQP_master_MoarVM_master:
+          IMAGE_NAME: 'ubuntu-18.04'
+          RAKUDO_OPTIONS: '--backends=moar --gen-nqp=master --gen-moar=master'
+         Linux_JVM:
+          IMAGE_NAME: 'ubuntu-18.04'
+          BACKEND: 'JVM'
+          RAKUDO_OPTIONS: '--backends=jvm  --gen-nqp'
+         Linux_JVM_NQP_master:
+          IMAGE_NAME: 'ubuntu-18.04'
+          BACKEND: 'JVM'
+          RAKUDO_OPTIONS: '--backends=jvm  --gen-nqp=master'
+         Linux_MoarVM_relocatable:
+          IMAGE_NAME: 'ubuntu-18.04'
+          RELOCATABLE: 'yes'
+          RAKUDO_OPTIONS: '--backends=moar --gen-nqp --gen-moar --relocatable'
+
+      pool:
+        vmImage: $(IMAGE_NAME)
+      workspace:
+        clean: all
+      steps:
+
+        - script: |
+            echo "##vso[task.setvariable variable=JAVA_HOME]$(JAVA_HOME_11_X64)"
+            echo "##vso[task.setvariable variable=PATH]$(JAVA_HOME_11_X64)/bin:$(PATH)"
+          displayName: "Set java version (non-Windows)"
+          condition: and( eq( variables['BACKEND'], 'JVM'), ne( variables['Agent.OS'], 'Windows_NT' ) )
+        - script: |
+            echo "##vso[task.setvariable variable=JAVA_HOME]$(JAVA_HOME_11_X64)"
+            echo "##vso[task.setvariable variable=PATH]$(JAVA_HOME_11_X64)\bin;$(PATH)"
+          displayName: "Set java version (Windows)"
+          condition: and( eq( variables['BACKEND'], 'JVM'), eq( variables['Agent.OS'], 'Windows_NT' ) )
+
+        - checkout: self
+          fetchDepth: 1
+          displayName: Checkout repository
+
+        - script: |
+            perl Configure.pl $(RAKUDO_OPTIONS)
+          condition: ne( variables['Agent.OS'], 'Windows_NT' )
+          displayName: Build (non-Windows)
+        - pwsh: |
+            ${{ variables.PWSH_DEV }}
+            perl Configure.pl $(RAKUDO_OPTIONS)
+          failOnStderr: false
+          condition: eq( variables['Agent.OS'], 'Windows_NT' )
+          displayName: Build (Windows)
+        
+        - script: make install
+          condition: ne( variables['Agent.OS'], 'Windows_NT' )
+          displayName: Install (non-Windows)
+        - pwsh: |
+            ${{ variables.PWSH_DEV }}
+            nmake install
+          failOnStderr: false
+          condition: eq( variables['Agent.OS'], 'Windows_NT' )
+          displayName: Install (Windows)
+        
+        # TODO: Should use "install moved" instead of "install-moved". But `prove` currently fails with an executable path that contains a space.
+        - script: mv install install-moved
+          condition: and( eq( variables['RELOCATABLE'], 'yes' ), ne( variables['Agent.OS'], 'Windows_NT' ) )
+          displayName: Move installation (non-Windows)
+        - pwsh: mv install install-moved
+          condition: and( eq( variables['RELOCATABLE'], 'yes' ), eq( variables['Agent.OS'], 'Windows_NT' ) )
+          displayName: Move installation (Windows)
+
+        - script: prove -e install/bin/perl6 -vlr t
+          condition: and( ne( variables['RELOCATABLE'], 'yes' ), ne( variables['BACKEND'], 'JVM'), ne( variables['Agent.OS'], 'Windows_NT' ) )
+          displayName: Test (non-Windows)
+        - pwsh: |
+            ${{ variables.PWSH_DEV }}
+            prove -e install/bin/perl6 -vlr t
+          condition: and( ne( variables['RELOCATABLE'], 'yes' ), ne( variables['BACKEND'], 'JVM'), eq( variables['Agent.OS'], 'Windows_NT' ) )
+          displayName: Test (Windows)
+
+        - script: prove -e install-moved/bin/perl6 -vlr t
+          condition: and( eq( variables['RELOCATABLE'], 'yes' ), ne( variables['BACKEND'], 'JVM'), ne( variables['Agent.OS'], 'Windows_NT' ) )
+          displayName: Test with moved installation (non-Windows)
+        - pwsh: |
+            ${{ variables.PWSH_DEV }}
+            prove -e install-moved\bin\perl6 -vlr t
+          condition: and( eq( variables['RELOCATABLE'], 'yes' ), ne( variables['BACKEND'], 'JVM'), eq( variables['Agent.OS'], 'Windows_NT' ) )
+          displayName: Test with moved installation (Windows)
+
+        - publish: install-moved
+          artifact: relocatable-build
+          condition: eq( variables['RELOCATABLE'], 'yes' )
+          displayName: Publish build artifact
+
+- stage: Build_Precomp_Release
+  condition: eq( variables['BUILD_PRECOMP_RELEASE'], 'yes' )
+  jobs:
+    - job: linux
+      displayName: Linux x86_64 build
+      pool:
+        vmImage: 'ubuntu-18.04'
+      container:
+        image: centos:6
+        options: "--name raku-build-container -v /usr/bin/docker:/tmp/docker:ro"
+      workspace:
+        clean: all
+      steps:
+        - script: /tmp/docker exec -t -u 0 raku-build-container sh -c "yum -y update && yum -y install sudo"
+          displayName: Set up sudo (see https://github.com/microsoft/azure-pipelines-agent/issues/2043)
+
+        - checkout: self
+          path: source
+          fetchDepth: 1
+          displayName: Checkout repository
+
+        - script: $(Agent.BuildDirectory)/source/tools/build/binary-release/build-linux.sh
+          failOnStderr: false
+          displayName: Run build script
+
+        - publish: rakudo-linux.tar.gz
+          artifact: rakudo-linux
+
+    - job: macos
+      displayName: MacOS x86_64 build
+      pool:
+        vmImage: 'macOS-10.15'
+      workspace:
+        clean: all
+      steps:
+        - checkout: self
+          path: source
+          fetchDepth: 1
+
+        - script: $(Agent.BuildDirectory)/source/tools/build/binary-release/build-macos.sh
+          failOnStderr: false
+          displayName: Run build script
+
+        - publish: rakudo-macos.tar.gz
+          artifact: rakudo-macos
+
+    - job: windows
+      displayName: Windows x86_64 build
+      pool:
+        vmImage: 'windows-2019'
+      workspace:
+        clean: all
+      steps:
+        - checkout: self
+          path: source
+          fetchDepth: 1
+
+        # Turn this Powershell console into a developer powershell console.
+        # https://intellitect.com/enter-vsdevshell-powershell/
+        - pwsh: |
+            $installPath = &"C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationpath
+            $devShell    = &"C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -latest -find **\Microsoft.VisualStudio.DevShell.dll
+            Import-Module $devShell
+            Enter-VsDevShell -VsInstallPath $installPath -SkipAutomaticLocation -DevCmdArguments "-arch=amd64"
+            $(Agent.BuildDirectory)/source/tools/build/binary-release/build-windows.ps1
+          failOnStderr: false
+          displayName: Run build script
+
+        - publish: rakudo-win.zip
+          artifact: rakudo-win
+
+    - job: zip
+      displayName: Package results
+      dependsOn:
+      - linux
+      - macos
+      - windows
+      pool:
+        vmImage: 'ubuntu-18.04'
+      workspace:
+        clean: all
+      steps:
+      - checkout: none
+
+      - download: current
         artifact: rakudo-linux
+        displayName: Download Linux build artifacts
 
-  - job: macos
-    displayName: MacOS x86_64 build
-    pool:
-      vmImage: 'macOS-10.15'
-    workspace:
-      clean: all
-    steps:
-      - checkout: self
-        path: source
-        fetchDepth: 1
-
-      - script: $(Agent.BuildDirectory)/source/tools/build/binary-release/build-macos.sh
-        failOnStderr: false
-        displayName: Run build script
-
-      - publish: rakudo-macos.tar.gz
+      - download: current
         artifact: rakudo-macos
+        displayName: Download MacOS build artifacts
 
-  - job: windows
-    displayName: Windows x86_64 build
-    pool:
-      vmImage: 'windows-2019'
-    workspace:
-      clean: all
-    steps:
-      - checkout: self
-        path: source
-        fetchDepth: 1
-
-      # Turn this Powershell console into a developer powershell console.
-      # https://intellitect.com/enter-vsdevshell-powershell/
-      - pwsh: |
-          $installPath = &"C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationpath
-          $devShell    = &"C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -latest -find **\Microsoft.VisualStudio.DevShell.dll
-          Import-Module $devShell
-          Enter-VsDevShell -VsInstallPath $installPath -SkipAutomaticLocation -DevCmdArguments "-arch=amd64"
-          $(Agent.BuildDirectory)/source/tools/build/binary-release/build-windows.ps1
-        failOnStderr: false
-        displayName: Run build script
-
-      - publish: rakudo-win.zip
+      - download: current
         artifact: rakudo-win
+        displayName: Download Windows build artifacts
 
-  - job: zip
-    displayName: Package results
-    dependsOn:
-    - linux
-    - macos
-    - windows
-    pool:
-      vmImage: 'ubuntu-18.04'
-    workspace:
-      clean: all
-    steps:
-    - checkout: none
+      - script: |
+          OUT_DIR=rakudo-builds-$(VERSION)-$(REVISION)
+          mkdir $OUT_DIR
+          cp $(Pipeline.Workspace)/rakudo-linux/rakudo-linux.tar.gz $OUT_DIR/rakudo-moar-$(VERSION)-$(REVISION)-linux-x86_64.tar.gz
+          cp $(Pipeline.Workspace)/rakudo-macos/rakudo-macos.tar.gz $OUT_DIR/rakudo-moar-$(VERSION)-$(REVISION)-linux-x86_64.tar.gz
+          cp $(Pipeline.Workspace)/rakudo-win/rakudo-win.zip        $OUT_DIR/rakudo-moar-$(VERSION)-$(REVISION)-win-x86_64.zip
+          tar -czf rakudo-moar-builds-$(VERSION)-$(REVISION).tar.gz $OUT_DIR
 
-    - download: current
-      artifact: rakudo-linux
-      displayName: Download Linux build artifacts
-
-    - download: current
-      artifact: rakudo-macos
-      displayName: Download MacOS build artifacts
-
-    - download: current
-      artifact: rakudo-win
-      displayName: Download Windows build artifacts
-
-    - script: |
-        OUT_DIR=rakudo-builds-$(VERSION)-$(REVISION)
-        mkdir $OUT_DIR
-        cp $(Pipeline.Workspace)/rakudo-linux/rakudo-linux.tar.gz $OUT_DIR/rakudo-moar-$(VERSION)-$(REVISION)-linux-x86_64.tar.gz
-        cp $(Pipeline.Workspace)/rakudo-macos/rakudo-macos.tar.gz $OUT_DIR/rakudo-moar-$(VERSION)-$(REVISION)-linux-x86_64.tar.gz
-        cp $(Pipeline.Workspace)/rakudo-win/rakudo-win.zip        $OUT_DIR/rakudo-moar-$(VERSION)-$(REVISION)-win-x86_64.zip
-        tar -czf rakudo-moar-builds-$(VERSION)-$(REVISION).tar.gz $OUT_DIR
-
-    - publish: rakudo-moar-builds-$(VERSION)-$(REVISION).tar.gz
-      artifact: build-result
+      - publish: rakudo-moar-builds-$(VERSION)-$(REVISION).tar.gz
+        artifact: build-result

--- a/docs/release-guide-binary.md
+++ b/docs/release-guide-binary.md
@@ -1,25 +1,23 @@
 Binary release guide
 ====================
 
-The process of building a release on the different platforms is largely automated. There is a build pipeline setup utilizing the CircleCI infrastructure.
-The process of building is not started automatically though, but has to be triggered manually. To do so one needs to call a special script.
+The process of building a release on the different platforms is largely automated. There is a build pipeline setup utilizing the Azure Pipelines infrastructure.
+The process of building is not started automatically, but has to be triggered manually. To do so do:
 
-    tools/build/binary-release/trigger-precomp-build.sh 2020.01 01 https://rakudo.org/dl/rakudo/rakudo-2020.01.tar.gz 19234ae87f78787c87e7887fe877b78c7878d8fb
-
-The parameters are:
-
-- The version to build, e.g. 2020.01
-- The build revision, usually 01 (except when doing a second binary release for the same rakudo release)
-- The download URL for the rakudo source in tar.gz format
-- A CircleCI personal API token. One can be created here: <https://circleci.com/account/api>
-  Do not confuse the personal API token with project specific API tokens! The project specific API tokens will not work and result in a "Permission denied" error.
-
-After calling the above script accordingly a message with some JSON indicating successful start of the build procedure should be printed.
-Navigate to <https://circleci.com/gh/rakudo/workflows/rakudo/tree/master> and select the latest workflow named "build-precomp-release". Three build jobs should be running. One for Windows, one for Linux and one for MacOS. After successful completion of the jobs click on each of them, select the "Artifacts" tab and download the shown file.
-
-For some reason the Linux and MacOS `.tar.gz` files are double compressed. So you need to rename them, adding an additional `.gz` and call `gunzip` on them.
-
-Verify all three files decompress successfully.
+- Visit the [Azure Pipelines website](https://dev.azure.com/rakudo/rakudo/_build?definitionId=1&_a=summary)
+- Click on the blue 'Run pipeline' button at the top right.
+- Under 'Advanced options' click on 'Variables'.
+- Click on 'BUILD_PRECOMP_RELEASE' and change to 'yes'.
+- Click the blue 'Update' button at the bottom.
+- Change the 'RELEASE_URL', 'VERSION' and 'REVISION' variables with the same procedure as necessary.
+- Click the back arrow next to the 'Variables' heading.
+- Click on the blue 'Run' button at the bottom.
+- Wait for the build to finish. All the Jobs will have a green tick next to them once the build is finished.
+- In the upper box below the grey 'Related' heading click on '4 published'.
+- Download the 'rakudo-moar-builds-*.tar.gz' file.
+- Extract the archive.
+- Verify all three archives have a size >10MB.
+- Verify all three archives decompress successfully.
 
 Sign the files:
 

--- a/tools/build/binary-release/build-linux.sh
+++ b/tools/build/binary-release/build-linux.sh
@@ -1,40 +1,55 @@
 #!/usr/bin/env sh
 
-# This script should be run in a CentOS 6 installation (a container will do
-# just fine).
+# This script should be allowed to run sudo in a CentOS 6 installation (a
+# container will do just fine).
+# For some strange reason the environment variables are lost when running this
+# script with `sudo` in azure pipelines. So we just do sudo our selves for the
+# dependency install part.
 
 set -o errexit
 set -o pipefail
 
-# Update CentOS 6
-yum -y update
-yum clean all
+echo "========= Starting build"
 
-# Install dependencies
-yum -y install curl git perl perl-core gcc make
+echo "========= Updating CentOS 6"
+sudo yum -y update
+sudo yum clean all
 
-# Download release file
+echo "========= Downloading dependencies"
+sudo yum -y install curl git perl perl-core gcc make
+
+echo "========= Downloading release"
 curl -o rakudo.tgz $RELEASE_URL
+
+echo "========= Extracting release"
 tar -xzf rakudo.tgz
 cd rakudo-*
 
-# Build Rakudo
+echo "========= Configuring Rakudo (includes building MoarVM and NQP)"
 perl Configure.pl --gen-moar --gen-nqp --backends=moar --moar-option='--toolchain=gnu' --relocatable
+
+echo "========= Building Rakudo"
 make
+
+echo "========= Installing Rakudo"
 make install
 
-# Test the build
+echo "========= Testing Rakudo"
 make test
 
-# Build Zef
+echo "========= Cloning Zef"
 git clone https://github.com/ugexe/zef.git
+
+echo "========= Installing Zef"
 pushd zef
 ../install/bin/raku -I. bin/zef install .
 popd
 
-# Prepare the package
+echo "========= Copying auxiliary files"
 cp -r tools/build/binary-release/Linux/* install
 cp LICENSE install
+
+echo "========= Preparing archive"
 mv install rakudo-$VERSION
 tar -zcv --owner=0 --group=0 --numeric-owner -f ../rakudo-linux.tar.gz rakudo-$VERSION
 

--- a/tools/build/binary-release/build-macos.sh
+++ b/tools/build/binary-release/build-macos.sh
@@ -3,32 +3,44 @@
 set -o errexit
 set -o pipefail
 
-# Install Dependencies
+echo "========= Starting build"
+
+echo "========= Downloading dependencies"
 brew install perl
 brew install gnu-tar
 
-# Download release file
+echo "========= Downloading release"
 curl -o rakudo.tgz $RELEASE_URL
+
+echo "========= Extracting release"
 tar -xzf rakudo.tgz
 cd rakudo-*
 
-# Build Rakudo
+echo "========= Configuring Rakudo (includes building MoarVM and NQP)"
 perl Configure.pl --gen-moar --gen-nqp --backends=moar --relocatable
+
+echo "========= Building Rakudo"
 make
+
+echo "========= Installing Rakudo"
 make install
 
-# Test the build
+echo "========= Testing Rakudo"
 make test
 
-# Build Zef
+echo "========= Cloning Zef"
 git clone https://github.com/ugexe/zef.git
+
+echo "========= Installing Zef"
 pushd zef
 ../install/bin/raku -I. bin/zef install .
 popd
 
-# Prepare the package
+echo "========= Copying auxiliary files"
 cp -r tools/build/binary-release/MacOS/* install
 cp LICENSE install
+
+echo "========= Preparing archive"
 mv install rakudo-$VERSION
 gtar -zcv --owner=0 --group=0 --numeric-owner -f ../rakudo-macos.tar.gz rakudo-$VERSION
 


### PR DESCRIPTION
Switch over to using Microsoft Azure Pipelines instead of CircleCI for creating the binary release builds.
The reason that motivated this move was CircleCI having a bug in their billing which prevented us from doing any Windows builds at all even though their documentation stated this should be possible. Azure Pipelines have unlimited builds on all three platforms. So with this change it should finally be possible to automatically build the binary release builds automatically on all platforms we currently provide builds for.
I have developed and tested this in my clone of the rakudo repository.
A bug in libtommath prevents successful compilation on Windows at the moment though. But that's a separate issue.

This PR also serves as a test whether the changes in the CircleCI config broke anything.