### PR TITLE
Symbol lookup optimization

### DIFF
--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -346,7 +346,7 @@ role STD {
     }
 
     token experimental($feature) {
-        <?{ try $*W.find_symbol(['EXPERIMENTAL-' ~ nqp::uc($feature)]) }>
+        <?{ try $*W.find_single_symbol('EXPERIMENTAL-' ~ nqp::uc($feature)) }>
         || <.typed_panic('X::Experimental', :$feature)>
     }
 
@@ -929,7 +929,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
             my int $line      := HLL::Compiler.lineof($orig, self.from(), :cache(1));
             my str $prematch  := nqp::substr($orig, $from > 20 ?? $from - 20 !! 0, $from > 20 ?? 20 !! $from);
             my str $postmatch := nqp::substr($orig, $to, 20);
-            my $label     := $*W.find_symbol(['Label']).new( :name($*LABEL), :$line, :$prematch, :$postmatch );
+            my $label     := $*W.find_single_symbol('Label').new( :name($*LABEL), :$line, :$prematch, :$postmatch );
             $*W.add_object_if_no_sc($label);
             $*W.install_lexical_symbol($*W.cur_lexpad(), $*LABEL, $label);
         }
@@ -1335,7 +1335,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
             self.LANG($langname, $regex, @args);
         }
         else {
-            my $Str := $*W.find_symbol(['Str']);
+            my $Str := $*W.find_single_symbol('Str');
             my $actions := self.slang_actions($langname);
             my $lang_cursor := $grammar.'!cursor_init'($Str.new( :value(self.orig())), :p(self.pos()));
             $lang_cursor.clone_braid_from(self);
@@ -1347,7 +1347,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
 
             # Build up something NQP-levelish we can return.
             my $new := NQPMatch.'!cursor_init'(self.orig(), :p(self.pos()), :shared(self.'!shared'()));
-            my $p6cursor := $*W.find_symbol(['Match']);
+            my $p6cursor := $*W.find_single_symbol('Match');
             nqp::bindattr_i($new, NQPMatch, '$!from',  nqp::getattr_i($ret, $p6cursor, '$!from'));
             nqp::bindattr_i($new, NQPMatch, '$!pos',   nqp::getattr_i($ret, $p6cursor, '$!pos'));
             my str $p6c_name := nqp::getattr_s($ret, $p6cursor, '$!name');
@@ -1617,7 +1617,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
                 );
                 nqp::iseq_i($chars-num, $pos);
             }>
-            { $*key := $<identifier>.Str; $*value := nqp::radix_I(10, $<num>, 0, 0, $*W.find_symbol(['Int']))[0]; }
+            { $*key := $<identifier>.Str; $*value := nqp::radix_I(10, $<num>, 0, 0, $*W.find_single_symbol('Int'))[0]; }
         | <identifier>
             { $*key := $<identifier>.Str; }
             [
@@ -1982,7 +1982,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
                             if $key eq 'ver' {
                                 $*VER := $*W.handle-begin-time-exceptions($/,
                                     'parsing package version',
-                                    -> { $*W.find_symbol(['Version']).new($adverb.value) });
+                                    -> { $*W.find_single_symbol('Version').new($adverb.value) });
                             }
                             elsif $key eq 'api' {
                                 $*API := $adverb.value;
@@ -2522,10 +2522,10 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
                 $*IN_DECL := '';
 
                 my $meta := $<specials> && ~$<specials> eq '^';
-                my $invocant_type := $*W.find_symbol([
+                my $invocant_type := $*W.find_single_symbol(
                     $<longname> && $*W.is_lexical('$?CLASS') && !$meta
                         ?? '$?CLASS'
-                        !! 'Mu']);
+                        !! 'Mu');
                 if $<multisig> {
                     %*SIG_INFO := $<multisig>.ast;
                     $*SIG_OBJ := $*W.create_signature_and_params($<multisig>,
@@ -2759,7 +2759,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
             my $line_no := HLL::Compiler.lineof(self.orig(), self.from(), :cache(1));
             if $*PRECEDING_DECL_LINE < $line_no {
                 $*PRECEDING_DECL_LINE := $line_no;
-                my $par_type := $*W.find_symbol(['Parameter'], :setting-only);
+                my $par_type := $*W.find_single_symbol('Parameter', :setting-only);
                 $*PRECEDING_DECL := nqp::create($par_type); # actual declarand comes later, in World::create_parameter
             }
         }
@@ -5712,7 +5712,7 @@ grammar Perl6::QGrammar is HLL::Grammar does STD {
 my role MatchPackageNibbler {
     method nibble-in-cursor($parent) {
         my $*LEAF := self;
-        my $*PACKAGE := $*W.find_symbol(['Match']); self.set_package($*PACKAGE);
+        my $*PACKAGE := $*W.find_single_symbol('Match'); self.set_package($*PACKAGE);
         my %*ATTR_USAGES;
         my $cur := nqp::findmethod($parent, 'nibbler')(self);
         for %*ATTR_USAGES {

--- a/src/Perl6/Metamodel/BUILDPLAN.nqp
+++ b/src/Perl6/Metamodel/BUILDPLAN.nqp
@@ -156,19 +156,19 @@ role Perl6::Metamodel::BUILDPLAN {
 
                 # currently compiling, so we can do typechecking now.
                 if !nqp::isnull(nqp::getlexdyn('$*W')) && $*W.in_unit_parse {
-                    if nqp::istype(nqp::decont($default), $*W.find_symbol(["Code"])) {
+                    if nqp::istype(nqp::decont($default), $*W.find_single_symbol('Code')) {
                         # cannot typecheck code to be run later
                     }
 
                     # check native attribute
                     elsif $primspec {
-                        my $destination := $*W.find_symbol([
+                        my $destination := $*W.find_single_symbol(
                           $primspec == 2
                             ?? "Num"
                             !! $primspec == 3
                               ?? "Str"
                               !! "Int"  # 1,4,5
-                        ]);
+                        );
                         nqp::istype($default,$destination)
                           ?? ($check-at-runtime := 0)
                           !! self.throw_typecheck($_, $default, $destination)
@@ -180,14 +180,14 @@ role Perl6::Metamodel::BUILDPLAN {
                     }
 
                     # associatives need to be checked at runtime
-                    elsif nqp::istype($type,$*W.find_symbol(["Associative"])) {
+                    elsif nqp::istype($type,$*W.find_single_symbol('Associative')) {
                         # cannot do type checks on associatives
                     }
 
                     # positionals could be checked now
                     elsif nqp::istype(
                       $type,
-                      my $Positional := $*W.find_symbol(["Positional"])
+                      my $Positional := $*W.find_single_symbol('Positional')
                     ) && nqp::istype($default,$Positional.of) {
                         $check-at-runtime := 0;
                     }

--- a/src/Perl6/Metamodel/LanguageRevision.nqp
+++ b/src/Perl6/Metamodel/LanguageRevision.nqp
@@ -18,7 +18,7 @@ role Perl6::Metamodel::LanguageRevision
             my $rev;
             # $*W cannot be used at optimization stage.
             if $*W && !$*OPTIMIZER-SYMBOLS {
-                $rev := $*W.find_symbol(['CORE-SETTING-REV'], :setting-only) || $*W.setting_revision;
+                $rev := $*W.find_single_symbol('CORE-SETTING-REV', :setting-only) || $*W.setting_revision;
             }
             $lang-ver := ($rev && '6.' ~ $rev)                          # compile-time if CORE is available
                           || nqp::getcomp('Raku').language_version;    # otherwise try the compiler

--- a/src/Perl6/ModuleLoader.nqp
+++ b/src/Perl6/ModuleLoader.nqp
@@ -163,7 +163,7 @@ class Perl6::ModuleLoader does Perl6::ModuleLoaderVMConfig {
             my $outer := 0;
             if !nqp::existskey(%known_symbols, $sym) {
                 try {
-                    %known_symbols{$sym} := $world.find_symbol([$sym]);
+                    %known_symbols{$sym} := $world.find_single_symbol($sym);
                     $outer := 1;
                 }
             }

--- a/src/Perl6/Pod.nqp
+++ b/src/Perl6/Pod.nqp
@@ -347,7 +347,7 @@ class Perl6::Pod {
 
     sub string_to_bigint($src, int $base, int $chars) {
         # code copied from Actions.nqp and locally modified
-        my $res := nqp::radix_I($base, ~$src, 0, 2, $*W.find_symbol(['Int']));
+        my $res := nqp::radix_I($base, ~$src, 0, 2, $*W.find_single_symbol('Int'));
         $src.panic("'$src' is not a valid number")
             unless nqp::iseq_i(nqp::unbox_i(nqp::atpos($res, 2)), $chars);
         nqp::atpos($res, 0);

--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -132,7 +132,7 @@ sub levenshtein($a, $b) {
 }
 
 sub make_levenshtein_evaluator($orig_name, @candidates) {
-    my $Str-obj := $*W.find_symbol(["Str"], :setting-only);
+    my $Str-obj := $*W.find_single_symbol("Str", :setting-only);
     my $find-count := 0;
     my $try-count := 0;
     sub inner($name, $hash) {
@@ -664,7 +664,7 @@ class Perl6::World is HLL::World {
         }
         elsif !$*COMPILING_CORE_SETTING {
             $!RAKUDO_MODULE_DEBUG :=
-              self.find_symbol(['&DYNAMIC'])('$*RAKUDO_MODULE_DEBUG')
+              self.find_single_symbol('&DYNAMIC')('$*RAKUDO_MODULE_DEBUG')
         }
         else {
             $!RAKUDO_MODULE_DEBUG := False
@@ -717,7 +717,7 @@ class Perl6::World is HLL::World {
         $!setting_loaded := 1;
 
         try {
-            my $EXPORTHOW := self.find_symbol(['EXPORTHOW']);
+            my $EXPORTHOW := self.find_single_symbol('EXPORTHOW');
             for self.stash_hash($EXPORTHOW) {
                 $*LANG.set_how($_.key, $_.value);
             }
@@ -814,7 +814,7 @@ class Perl6::World is HLL::World {
 
             unless $!have_outer {
                 self.install_lexical_symbol(
-                  $*UNIT,'$=finish',self.find_symbol(['Mu'], :setting-only));
+                  $*UNIT,'$=finish',self.find_single_symbol('Mu', :setting-only));
             }
         }
 
@@ -1093,7 +1093,7 @@ class Perl6::World is HLL::World {
             my @to_import := ['MANDATORY'];
             my @positional_imports := [];
             if nqp::defined($arglist) {
-                my $Pair := self.find_symbol(['Pair'], :setting-only);
+                my $Pair := self.find_single_symbol('Pair', :setting-only);
                 for $arglist -> $tag {
                     if nqp::istype($tag, $Pair) {
                         $tag := nqp::unbox_s($tag.key);
@@ -1121,7 +1121,7 @@ class Perl6::World is HLL::World {
             my &EXPORT := $handle.export-sub;
             if nqp::defined(&EXPORT) {
                 my $result := &EXPORT(|@positional_imports);
-                my $Map := self.find_symbol(['Map'], :setting-only);
+                my $Map := self.find_single_symbol('Map', :setting-only);
                 if nqp::istype($result, $Map) {
                     my $storage := $result.hash.FLATTENABLE_HASH();
                     self.import($/, $storage, $package_source_name, :need-decont(!(nqp::what($result) =:= $Map)));
@@ -1249,8 +1249,8 @@ class Perl6::World is HLL::World {
                 self.throw($/, 'X::Pragma::MustOneOf', :$name, :alternatives(':D, :U or :_'));
             }
 
-            my $Pair := self.find_symbol(['Pair'], :setting-only);
-            my $Bool := self.find_symbol(['Bool'], :setting-only);
+            my $Pair := self.find_single_symbol('Pair', :setting-only);
+            my $Bool := self.find_single_symbol('Bool', :setting-only);
             my $type;
             for $arglist -> $arg {
                 if $type {
@@ -1353,7 +1353,7 @@ class Perl6::World is HLL::World {
     }
 
     method DEPRECATED($/,$alternative,$from,$removed,:$what,:$line,:$file) {
-        my $DEPRECATED := self.find_symbol(['&DEPRECATED']);
+        my $DEPRECATED := self.find_single_symbol('&DEPRECATED');
         unless nqp::isnull($DEPRECATED) {
             $DEPRECATED($alternative,$from,$removed,
               :$what,
@@ -1381,7 +1381,7 @@ class Perl6::World is HLL::World {
                 }
                 else {
                     $*OFTYPE := FakeOfType.new(type => self.create_definite_type(
-                        $*W.resolve_mo($/, 'definite'), self.find_symbol(['Any'], :setting-only),
+                        $*W.resolve_mo($/, 'definite'), self.find_single_symbol('Any', :setting-only),
                         $default eq 'D'));
                 }
             }
@@ -1492,7 +1492,7 @@ class Perl6::World is HLL::World {
         $RMD("  Late loading '$module_name'") if $RMD;
 
         # Immediate loading.
-        my $true := self.find_symbol(['True'], :setting-only);
+        my $true := self.find_single_symbol('True', :setting-only);
         my $spec := self.find_symbol(['CompUnit', 'DependencySpecification'], :setting-only).new(
             :short-name($module_name),
             :from(%opts<from> // 'Perl6'),
@@ -1658,7 +1658,7 @@ class Perl6::World is HLL::World {
         my $longname := '';
         if +@parts {
             try {
-                $cur_pkg := self.find_symbol([@parts[0]], :upgrade_to_global($create_scope ne 'my'));
+                $cur_pkg := self.find_single_symbol(@parts[0], :upgrade_to_global($create_scope ne 'my'));
                 $cur_lex := 0;
                 $create_scope := 'our';
                 $longname := @parts.shift();
@@ -1691,7 +1691,7 @@ class Perl6::World is HLL::World {
         # Install final part of the symbol.
         if $create_scope eq 'my' || $cur_lex {
             # upgrade a lexically imported package stub to package scope if it exists
-            try { self.find_symbol([$name], :upgrade_to_global); }
+            try { self.find_single_symbol($name, :upgrade_to_global); }
 
             self.install_lexical_symbol($cur_lex, $name, $symbol);
         }
@@ -1837,7 +1837,7 @@ class Perl6::World is HLL::World {
 
     # Creates a new container descriptor and adds it to the SC.
     method create_container_descriptor($of, $name, $default = $of, $dynamic = is_dynamic($name)) {
-        my $cd_type_name := nqp::eqaddr($of, self.find_symbol(['Mu'], :setting-only))
+        my $cd_type_name := nqp::eqaddr($of, self.find_single_symbol('Mu', :setting-only))
             ?? ['ContainerDescriptor', 'Untyped']
             !! ['ContainerDescriptor'];
         my $cd_type := self.find_symbol($cd_type_name, :setting-only);
@@ -1865,7 +1865,7 @@ class Perl6::World is HLL::World {
         if %cont_info<build_ast> {
             $cont := $cont_type;
         }
-        elsif nqp::istype($cont_type, self.find_symbol(['Scalar'], :setting-only)) {
+        elsif nqp::istype($cont_type, self.find_single_symbol('Scalar', :setting-only)) {
             $cont := nqp::create($cont_type);
             nqp::bindattr($cont, %cont_info<container_base>, '$!descriptor', $descriptor);
             if nqp::existskey(%cont_info, 'scalar_value') {
@@ -1873,15 +1873,15 @@ class Perl6::World is HLL::World {
                     %cont_info<scalar_value>);
             }
         }
-        elsif nqp::istype($cont_type, self.find_symbol(['Array'], :setting-only)) {
+        elsif nqp::istype($cont_type, self.find_single_symbol('Array', :setting-only)) {
             $cont := nqp::create($cont_type);
             nqp::bindattr($cont, %cont_info<container_base>, '$!descriptor', $descriptor);
-            my $List := self.find_symbol(['List'], :setting-only);
-            my $Mu := self.find_symbol(['Mu'], :setting-only);
+            my $List := self.find_single_symbol('List', :setting-only);
+            my $Mu := self.find_single_symbol('Mu', :setting-only);
             nqp::bindattr($cont, $List, '$!reified', $Mu);
             nqp::bindattr($cont, $List, '$!todo', $Mu);
         }
-        elsif nqp::istype($cont_type, self.find_symbol(['Hash'], :setting-only)) {
+        elsif nqp::istype($cont_type, self.find_single_symbol('Hash', :setting-only)) {
             $cont := nqp::create($cont_type);
             nqp::bindattr($cont, %cont_info<container_base>, '$!descriptor', $descriptor);
         }
@@ -1913,7 +1913,7 @@ class Perl6::World is HLL::World {
 
         for @post -> $con {
             @value_type[0] := self.create_subset(self.resolve_mo($/, 'subset'),
-                @value_type ?? @value_type[0] !! self.find_symbol(['Mu'], :setting-only),
+                @value_type ?? @value_type[0] !! self.find_single_symbol('Mu', :setting-only),
                 $con);
         }
         if $sigil eq '@' {
@@ -1922,9 +1922,9 @@ class Perl6::World is HLL::World {
                 %info<container_base> := @cont_type[0];
             }
             else {
-                %info<bind_constraint> := self.find_symbol(['Positional'], :setting-only);
+                %info<bind_constraint> := self.find_single_symbol('Positional', :setting-only);
                 my $base_type_name     := nqp::objprimspec(@value_type[0]) ?? 'array' !! 'Array';
-                %info<container_base>  := self.find_symbol([$base_type_name], :setting-only);
+                %info<container_base>  := self.find_single_symbol($base_type_name, :setting-only);
             }
             if @value_type {
                 my $vtype              := @value_type[0];
@@ -1937,8 +1937,8 @@ class Perl6::World is HLL::World {
             }
             else {
                 %info<container_type> := %info<container_base>;
-                %info<value_type>     := self.find_symbol(['Mu'], :setting-only);
-                %info<default_value>  := self.find_symbol(['Any'], :setting-only);
+                %info<value_type>     := self.find_single_symbol('Mu', :setting-only);
+                %info<default_value>  := self.find_single_symbol('Any', :setting-only);
             }
             if $shape || @cont_type {
                 my $ast := QAST::Op.new(
@@ -1959,11 +1959,11 @@ class Perl6::World is HLL::World {
                 %info<bind_constraint> := @cont_type[0];
             }
             else {
-                %info<container_base>  := self.find_symbol(['Hash'], :setting-only);
-                %info<bind_constraint> := self.find_symbol(['Associative'], :setting-only);
+                %info<container_base>  := self.find_single_symbol('Hash', :setting-only);
+                %info<bind_constraint> := self.find_single_symbol('Associative', :setting-only);
             }
             if $shape {
-                @value_type[0] := self.find_symbol(['Any'], :setting-only) unless +@value_type;
+                @value_type[0] := self.find_single_symbol('Any', :setting-only) unless +@value_type;
                 my $shape_ast := $shape[0].ast;
                 if nqp::istype($shape_ast, QAST::Stmts) {
                     if +@($shape_ast) == 1 {
@@ -2005,8 +2005,8 @@ class Perl6::World is HLL::World {
             }
             else {
                 %info<container_type> := %info<container_base>;
-                %info<value_type>     := self.find_symbol(['Mu'], :setting-only);
-                %info<default_value>  := self.find_symbol(['Any'], :setting-only);
+                %info<value_type>     := self.find_single_symbol('Mu', :setting-only);
+                %info<default_value>  := self.find_single_symbol('Any', :setting-only);
             }
             if @cont_type {
                 %info<build_ast> := QAST::Op.new(
@@ -2019,16 +2019,16 @@ class Perl6::World is HLL::World {
             if @cont_type {
                 self.throw($/, 'X::NYI', :feature('is trait on &-sigil variable'));
             }
-            %info<container_base>  := self.find_symbol(['Scalar'], :setting-only);
+            %info<container_base>  := self.find_single_symbol('Scalar', :setting-only);
             %info<container_type>  := %info<container_base>;
-            %info<bind_constraint> := self.find_symbol(['Callable'], :setting-only);
+            %info<bind_constraint> := self.find_single_symbol('Callable', :setting-only);
             if @value_type {
                 %info<bind_constraint> := self.parameterize_type_with_args($/,
                     %info<bind_constraint>, [@value_type[0]], nqp::hash());
             }
             %info<value_type>     := %info<bind_constraint>;
-            %info<default_value>  := self.find_symbol(['Callable'], :setting-only);
-            %info<scalar_value>   := self.find_symbol(['Callable'], :setting-only);
+            %info<default_value>  := self.find_single_symbol('Callable', :setting-only);
+            %info<scalar_value>   := self.find_single_symbol('Callable', :setting-only);
         }
         else {
             if @cont_type {
@@ -2037,7 +2037,7 @@ class Perl6::World is HLL::World {
                   :did-you-mean("my {@cont_type[0].HOW.name(@cont_type[0])} $sigil{~$<variable><desigilname>}")
                 );
             }
-            %info<container_base>     := self.find_symbol(['Scalar'], :setting-only);
+            %info<container_base>     := self.find_single_symbol('Scalar', :setting-only);
             %info<container_type>     := %info<container_base>;
             if @value_type {
                 %info<bind_constraint> := @value_type[0];
@@ -2046,9 +2046,9 @@ class Perl6::World is HLL::World {
                     := self.maybe-nominalize: @value_type[0];
             }
             else {
-                %info<bind_constraint> := self.find_symbol(['Mu'], :setting-only);
-                %info<value_type>      := self.find_symbol(['Mu'], :setting-only);
-                %info<default_value>   := self.find_symbol(['Any'], :setting-only);
+                %info<bind_constraint> := self.find_single_symbol('Mu', :setting-only);
+                %info<value_type>      := self.find_single_symbol('Mu', :setting-only);
+                %info<default_value>   := self.find_single_symbol('Any', :setting-only);
             }
             %info<scalar_value> := %info<default_value>;
         }
@@ -2085,9 +2085,9 @@ class Perl6::World is HLL::World {
             self.install_lexical_container($block, $name, $mcd[0], $mcd[1], :cont($mcd[2]));
         }
         else {
-            my $Mu     := self.find_symbol(['Mu'], :setting-only);
-            my $WHAT   := self.find_symbol([ $name eq '$_' ?? 'Any' !! 'Nil' ], :setting-only);
-            my $Scalar := self.find_symbol(['Scalar'], :setting-only);
+            my $Mu     := self.find_single_symbol('Mu', :setting-only);
+            my $WHAT   := self.find_single_symbol($name eq '$_' ?? 'Any' !! 'Nil', :setting-only);
+            my $Scalar := self.find_single_symbol('Scalar', :setting-only);
 
             my %info := nqp::hash(
                 'container_base',  $Scalar,
@@ -2170,7 +2170,7 @@ class Perl6::World is HLL::World {
         self.handle_OFTYPE_for_pragma($var,'variables');
         my %cont_info  := self.container_type_info(NQPMu, $var<sigil>,
             $*OFTYPE ?? [$*OFTYPE.ast] !! [], []);
-        %cont_info<value_type> := self.find_symbol(['Any'], :setting-only);
+        %cont_info<value_type> := self.find_single_symbol('Any', :setting-only);
         my $descriptor := self.create_container_descriptor(%cont_info<value_type>, $name);
 
         nqp::die("auto_declare_var") unless nqp::objectid($*PACKAGE) == nqp::objectid($*LEAF.package);
@@ -2197,7 +2197,7 @@ class Perl6::World is HLL::World {
     # Creates a parameter object.
     method create_parameter($/, %param_info) {
         # Create parameter object now.
-        my $par_type  := self.find_symbol(['Parameter'], :setting-only);
+        my $par_type  := self.find_single_symbol('Parameter', :setting-only);
         my $parameter := nqp::create($par_type);
         self.add_object_if_no_sc($parameter);
 
@@ -2348,7 +2348,7 @@ class Perl6::World is HLL::World {
                 unless nqp::can($package.HOW, 'hidden') && $package.HOW.hidden($package) {
                     @params.push(hash(
                         variable_name => '%_',
-                        nominal_type => self.find_symbol(['Mu'], :setting-only),
+                        nominal_type => self.find_single_symbol('Mu', :setting-only),
                         named_slurpy => 1,
                         is_multi_invocant => 1,
                         sigil => '%'
@@ -2360,8 +2360,8 @@ class Perl6::World is HLL::World {
         }
 
         # Walk parameters, setting up parameter objects.
-        my $default_type := self.find_symbol([$default_type_name]);
-        my $param_type := self.find_symbol(['Parameter'], :setting-only);
+        my $default_type := self.find_single_symbol($default_type_name);
+        my $param_type := self.find_single_symbol('Parameter', :setting-only);
         my @param_objs;
         my %seen_names;
         for @params {
@@ -2449,7 +2449,7 @@ class Perl6::World is HLL::World {
     # Creates a signature object from a set of parameters.
     method create_signature(%signature_info) {
         # Create signature object now.
-        my $sig_type   := self.find_symbol(['Signature'], :setting-only);
+        my $sig_type   := self.find_single_symbol('Signature', :setting-only);
         my $signature  := nqp::create($sig_type);
         my @parameters := %signature_info<parameter_objects>;
         self.add_object_if_no_sc($signature);
@@ -2461,7 +2461,7 @@ class Perl6::World is HLL::World {
         }
 
         # Compute arity and count.
-        my $p_type    := self.find_symbol(['Parameter'], :setting-only);
+        my $p_type    := self.find_single_symbol('Parameter', :setting-only);
         my int $arity := 0;
         my int $count := 0;
         my int $i     := 0;
@@ -2533,7 +2533,7 @@ class Perl6::World is HLL::World {
 
     # Stubs a code object of the specified type.
     method stub_code_object($type) {
-        my $type_obj := self.find_symbol([$type], :setting-only);
+        my $type_obj := self.find_single_symbol($type, :setting-only);
         my $code     := nqp::create($type_obj);
         self.context().push_code_object($code);
         self.add_object_if_no_sc($code);
@@ -2543,8 +2543,8 @@ class Perl6::World is HLL::World {
     # Attaches a signature to a code object, and gives the
     # signature its backlink to the code object.
     method attach_signature($code, $signature) {
-        my $code_type := self.find_symbol(['Code'], :setting-only);
-        my $sig_type := self.find_symbol(['Signature'], :setting-only);
+        my $code_type := self.find_single_symbol('Code', :setting-only);
+        my $sig_type := self.find_single_symbol('Signature', :setting-only);
         nqp::bindattr($code, $code_type, '$!signature', $signature);
         nqp::bindattr($signature, $sig_type, '$!code', $code);
     }
@@ -2563,8 +2563,8 @@ class Perl6::World is HLL::World {
         self.context().pop_code_object();
 
         # Locate various interesting symbols.
-        my $code_type    := self.find_symbol(['Code'], :setting-only);
-        my $routine_type := self.find_symbol(['Routine'], :setting-only);
+        my $code_type    := self.find_single_symbol('Code', :setting-only);
+        my $routine_type := self.find_single_symbol('Routine', :setting-only);
 
         # Attach code object to QAST node.
         $code_past.annotate('code_object', $code);
@@ -2724,7 +2724,7 @@ class Perl6::World is HLL::World {
                     :scope<attribute>,
                     :name<$!quasi_context>,
                     QAST::WVal.new( :value($quasi_ast) ),
-                    QAST::WVal.new( :value(self.find_symbol(['AST'], :setting-only)) )
+                    QAST::WVal.new( :value(self.find_single_symbol('AST', :setting-only)) )
                 )
            )
         );
@@ -2751,7 +2751,7 @@ class Perl6::World is HLL::World {
 
     # Adds any extra code needing for handling phasers.
     method add_phasers_handling_code($code, $code_past) {
-        my $block_type := self.find_symbol(['Block'], :setting-only);
+        my $block_type := self.find_single_symbol('Block', :setting-only);
         if nqp::istype($code, $block_type) {
             my %phasers := nqp::getattr($code, $block_type, '$!phasers');
             unless nqp::isnull(%phasers) {
@@ -2807,7 +2807,7 @@ class Perl6::World is HLL::World {
             QAST::Var.new( :name($value_stash), :scope('lexical'), :decl('var') ),
             QAST::Op.new(
               :op('create'),
-              QAST::WVal.new( :value(self.find_symbol(['IterationBuffer'], :setting-only))),
+              QAST::WVal.new( :value(self.find_single_symbol('IterationBuffer', :setting-only))),
             )));
         $block.symbol($value_stash, :scope('lexical'));
 
@@ -2867,7 +2867,7 @@ class Perl6::World is HLL::World {
 
     # Wraps a value in a scalar container
     method scalar_wrap($obj) {
-        my $scalar_type := self.find_symbol(['Scalar'], :setting-only);
+        my $scalar_type := self.find_single_symbol('Scalar', :setting-only);
         my $scalar      := nqp::create($scalar_type);
         self.add_object_if_no_sc($scalar);
         nqp::bindattr($scalar, $scalar_type, '$!value', $obj);
@@ -2887,7 +2887,7 @@ class Perl6::World is HLL::World {
         # single frame and copy all the visible things into it.
         $wrapper.annotate('DYN_COMP_WRAPPER', 1);
         my %seen;
-        my $mu        := try { self.find_symbol(['Mu'], :setting-only) };
+        my $mu        := try { self.find_single_symbol('Mu', :setting-only) };
         my $cur_block := $past;
         while $cur_block {
             my %symbols := $cur_block.symtable();
@@ -3095,7 +3095,7 @@ class Perl6::World is HLL::World {
     method whatever() {
         my $the_whatever := self.context().whatever();
         unless nqp::isconcrete($the_whatever) {
-            $the_whatever := nqp::create(self.find_symbol(['Whatever'], :setting-only));
+            $the_whatever := nqp::create(self.find_single_symbol('Whatever', :setting-only));
             self.add_object_if_no_sc($the_whatever);
             self.context().set_whatever($the_whatever);
         }
@@ -3105,7 +3105,7 @@ class Perl6::World is HLL::World {
     method hyper_whatever() {
         my $the_hyper_whatever := self.context().hyper_whatever();
         unless nqp::isconcrete($the_hyper_whatever) {
-            $the_hyper_whatever := nqp::create(self.find_symbol(['HyperWhatever'], :setting-only));
+            $the_hyper_whatever := nqp::create(self.find_single_symbol('HyperWhatever', :setting-only));
             self.add_object_if_no_sc($the_hyper_whatever);
             self.context().set_hyper_whatever($the_hyper_whatever);
         }
@@ -3137,9 +3137,9 @@ class Perl6::World is HLL::World {
         # $data that's a NQP hash is wrapped in a Scalar
         if nqp::ishash($data) && $dynamic {
             my $scalar := p6ize_recursive($data);
-            my $descriptor_type := self.find_symbol(['ContainerDescriptor'], :setting-only);
+            my $descriptor_type := self.find_single_symbol('ContainerDescriptor', :setting-only);
             my $descriptor := $descriptor_type.new( :$dynamic );
-            nqp::bindattr($scalar, self.find_symbol(['Scalar'], :setting-only), '$!descriptor', $descriptor);
+            nqp::bindattr($scalar, self.find_single_symbol('Scalar', :setting-only), '$!descriptor', $descriptor);
             $scalar;
         }
         else {
@@ -3155,7 +3155,7 @@ class Perl6::World is HLL::World {
         $ast.wanted(1);
         if $ast.has_compile_time_value {
             my $value := $ast.compile_time_value;
-            if nqp::istype($value, self.find_symbol(['Str'], :setting-only)) {
+            if nqp::istype($value, self.find_single_symbol('Str', :setting-only)) {
                 return nqp::unbox_s($ast.compile_time_value);
             }
             else {
@@ -3196,7 +3196,7 @@ class Perl6::World is HLL::World {
                 while nqp::istype($inspect, QAST::Op) {
                     $inspect := $inspect[0];
                 }
-                if nqp::istype($inspect, QAST::WVal) && !nqp::istype($inspect.value, self.find_symbol(["Block"], :setting-only)) {
+                if nqp::istype($inspect, QAST::WVal) && !nqp::istype($inspect.value, self.find_single_symbol("Block", :setting-only)) {
                     $/.panic($mkerr());
                 }
                 else {
@@ -3246,7 +3246,7 @@ class Perl6::World is HLL::World {
             $/.how($declarator)
         }
         elsif $declarator ~~ /'-attr'$/ {
-            self.find_symbol(['Attribute'], :setting-only)
+            self.find_single_symbol('Attribute', :setting-only)
         }
         else {
             $/.panic("Cannot resolve meta-object for $declarator")
@@ -3348,7 +3348,7 @@ class Perl6::World is HLL::World {
         # Compile it immediately (we always compile role bodies as
         # early as possible, but then assume they don't need to be
         # re-compiled and re-fixed up at startup).
-        self.compile_in_context($past, self.find_symbol(['Code'], :setting-only));
+        self.compile_in_context($past, self.find_single_symbol('Code', :setting-only));
     }
 
     # Adds a possible role to a role group.
@@ -3935,7 +3935,7 @@ class Perl6::World is HLL::World {
                             ),
                             QAST::Op.new( :op<call>,
                               QAST::WVal.new(
-                                :value($!w.find_symbol(['&return']))),
+                                :value($!w.find_single_symbol('&return'))),
                               QAST::Var.new(:scope<local>, :name<return>)
                             )
                           )
@@ -3967,7 +3967,7 @@ class Perl6::World is HLL::World {
 
                 # Create the code object, hide it from backtraces and return it
                 my $code := $!w.create_code_object($block, 'Submethod', $sig);
-                my $trait_mod_is := $!w.find_symbol(['&trait_mod:<is>']);
+                my $trait_mod_is := $!w.find_single_symbol('&trait_mod:<is>');
                 $trait_mod_is($code,:hidden-from-backtrace);
                 $code
             }
@@ -3991,7 +3991,7 @@ class Perl6::World is HLL::World {
                 $!w.cur_lexpad()[0].push($block);
 
                 my $invocant_type := $!w.create_definite_type(
-                  $!DefiniteHOW, $!w.find_symbol(['Any'], :setting-only), 1);
+                  $!DefiniteHOW, $!w.find_single_symbol('Any', :setting-only), 1);
 
                 my $sig := $!w.create_signature_and_params(
                   NQPMu, %sig_init, $block, 'Any', :method, :$invocant_type
@@ -4027,11 +4027,11 @@ class Perl6::World is HLL::World {
                 # Set up the base object
                 my $wrapped := CompilerServices.new(
                   w           => self,
-                  Block       => self.find_symbol(['Block'], :setting-only),
+                  Block       => self.find_single_symbol('Block', :setting-only),
                   DefiniteHOW => self.find_symbol(['Metamodel','DefiniteHOW'], :setting-only),
-                  Failure     => self.find_symbol(['Failure'], :setting-only),
-                  List        => self.find_symbol(['List'], :setting-only),
-                  Map         => self.find_symbol(['Map'], :setting-only),
+                  Failure     => self.find_single_symbol('Failure', :setting-only),
+                  List        => self.find_single_symbol('List', :setting-only),
+                  Map         => self.find_single_symbol('Map', :setting-only),
                   X-Attribute-Required =>
                     self.find_symbol(['X','Attribute','Required'], :setting-only)
                 );
@@ -4080,7 +4080,7 @@ class Perl6::World is HLL::World {
             }
             my $curried := $role.HOW.parameterize($role, |@pos_args, |%named_args);
             if nqp::isconcrete($curried)
-              && nqp::istype($curried, self.find_symbol(["Str"], :setting-only)) {
+              && nqp::istype($curried, self.find_single_symbol("Str", :setting-only)) {
                 self.throw($/, 'X::AdHoc', payload => $curried)
             }
 
@@ -4181,7 +4181,7 @@ class Perl6::World is HLL::World {
 
     # Applies a trait.
     method apply_trait($/, $trait_sub_name, *@pos_args, *%named_args) {
-        my $trait_sub := self.find_symbol([$trait_sub_name]);
+        my $trait_sub := self.find_single_symbol($trait_sub_name);
         my $ex;
         try {
             self.ex-handle($/, { $trait_sub(|@pos_args, |%named_args) });
@@ -4314,10 +4314,10 @@ class Perl6::World is HLL::World {
         }
         elsif $phaser eq 'INIT' {
             unless $*UNIT.symbol('!INIT_VALUES') {
-                my $mu := self.find_symbol(['Mu'], :setting-only);
+                my $mu := self.find_single_symbol('Mu', :setting-only);
                 my %info;
-                %info<container_type> := %info<container_base> := self.find_symbol(['Hash'], :setting-only);
-                %info<bind_constraint> := self.find_symbol(['Associative'], :setting-only);
+                %info<container_type> := %info<container_base> := self.find_single_symbol('Hash', :setting-only);
+                %info<bind_constraint> := self.find_single_symbol('Associative', :setting-only);
                 %info<value_type> := $mu;
                 self.install_lexical_container($*UNIT, '!INIT_VALUES', %info,
                     self.create_container_descriptor($mu, '!INIT_VALUES'));
@@ -4382,10 +4382,10 @@ class Perl6::World is HLL::World {
                     $phaser_past[0].unshift(QAST::Var.new( :name('$_'), :scope('lexical'), :decl('var') ));
                 }
                 nqp::push(
-                    nqp::getattr($block.signature, self.find_symbol(['Signature'], :setting-only), '@!params'),
+                    nqp::getattr($block.signature, self.find_single_symbol('Signature', :setting-only), '@!params'),
                     self.create_parameter($/, hash(
                             variable_name => '$_', is_raw => 1,
-                            nominal_type => self.find_symbol(['Mu'], :setting-only)
+                            nominal_type => self.find_single_symbol('Mu', :setting-only)
                         )));
             }
 
@@ -4482,7 +4482,7 @@ class Perl6::World is HLL::World {
             return '' unless @!colonpairs;
             my $result := '';
             my $w := $*W;
-            my $Bool := $w.find_symbol(['Bool'], :setting-only);
+            my $Bool := $w.find_single_symbol('Bool', :setting-only);
             for @!colonpairs {
                 my $p := $w.compile_time_evaluate($_, $_.ast);
                 if nqp::istype($p.value,$Bool) {
@@ -4614,7 +4614,7 @@ class Perl6::World is HLL::World {
                 try {
                     my str $tname := nqp::getattr_s(
                         nqp::decont($target_package.WHO),
-                        $*W.find_symbol(['Stash'], :setting-only),
+                        $*W.find_single_symbol('Stash', :setting-only),
                         '$!longname');
                     $fullname := $tname ~ '::' ~ $fullname;
                 }
@@ -4737,7 +4737,7 @@ class Perl6::World is HLL::World {
                             $cp_str := self.canonicalize_pair('',$ast[2].value);
                         }
                         elsif nqp::istype($ast, QAST::WVal) &&
-                              nqp::istype($ast.value, $*W.find_symbol(['Str'], :setting-only)) {
+                              nqp::istype($ast.value, $*W.find_single_symbol('Str', :setting-only)) {
                             $cp_str := self.canonicalize_pair('', $ast.value);
                         }
                         else {
@@ -4854,8 +4854,8 @@ class Perl6::World is HLL::World {
     method regex_in_scope($name) {
         my $result := 0;
         try {
-            my $maybe_regex := self.find_symbol([$name]);
-            $result := nqp::istype($maybe_regex, self.find_symbol(['Regex'], :setting-only));
+            my $maybe_regex := self.find_single_symbol($name);
+            $result := nqp::istype($maybe_regex, self.find_single_symbol('Regex', :setting-only));
         }
         $result
     }
@@ -5101,7 +5101,7 @@ class Perl6::World is HLL::World {
                     # Lookups start at the :: root.
                     $lookup := QAST::Op.new(
                         :op('callmethod'), :name('new'),
-                        QAST::WVal.new( :value(self.find_symbol(['PseudoStash'], :setting-only)) )
+                        QAST::WVal.new( :value(self.find_single_symbol('PseudoStash', :setting-only)) )
                     );
                 }
                 $lookup := QAST::Op.new(
@@ -5313,7 +5313,7 @@ class Perl6::World is HLL::World {
         %opts<panic> := @panic[0] if @panic;
         %opts<sorrows> := p6ize_recursive(@*SORROWS) if @*SORROWS;
         %opts<worries> := p6ize_recursive(@*WORRIES) if @*WORRIES;
-        %opts<filename> := nqp::box_s(self.current_file,self.find_symbol(['Str'], :setting-only));
+        %opts<filename> := nqp::box_s(self.current_file,self.find_single_symbol('Str', :setting-only));
         try {
             my $group_type := self.find_symbol(['X', 'Comp', 'Group'], :setting-only);
             return $group_type.new(|%opts);
@@ -5454,7 +5454,7 @@ class Perl6::World is HLL::World {
                     %opts{$p.key} := nqp::hllizefor($p.value, 'Raku');
                 }
             }
-            %opts<filename> := nqp::box_s(self.current_file,self.find_symbol(['Str'], :setting-only));
+            %opts<filename> := nqp::box_s(self.current_file,self.find_single_symbol('Str', :setting-only));
             try { return $ex.new(|%opts) };
         }
 
@@ -5465,9 +5465,9 @@ class Perl6::World is HLL::World {
         my int $has_int;
         my int $has_list;
 
-        try { $Str := self.find_symbol(["Str"], :setting-only); $has_str := 1 }
-        try { $Int := self.find_symbol(["Int"], :setting-only); $has_int := 1 }
-        try { $List := self.find_symbol(["List"], :setting-only); $has_list := 1 }
+        try { $Str := self.find_single_symbol("Str", :setting-only); $has_str := 1 }
+        try { $Int := self.find_single_symbol("Int", :setting-only); $has_int := 1 }
+        try { $List := self.find_single_symbol("List", :setting-only); $has_list := 1 }
 
         sub safely_stringify($target) {
             if $has_str && nqp::istype($target, $Str) {
@@ -5589,7 +5589,7 @@ class Perl6::World is HLL::World {
 
         my int $success := 0;
         my $coercer;
-        try { $coercer := self.find_symbol(['&COMP_EXCEPTION'], :setting-only); ++$success; };
+        try { $coercer := self.find_single_symbol('&COMP_EXCEPTION', :setting-only); ++$success; };
         nqp::rethrow($ex) unless $success;
         my $p6ex := $coercer($ex);
 
@@ -5602,8 +5602,8 @@ class Perl6::World is HLL::World {
         if $found_xcbt {
             my $xcbt := $x_comp_bt.new(exception => $p6ex, :$use-case);
             $xcbt.SET_FILE_LINE(
-                nqp::box_s(self.current_file,self.find_symbol(['Str'], :setting-only)),
-                nqp::box_i(self.current_line($/),self.find_symbol(['Int'], :setting-only)),
+                nqp::box_s(self.current_file,self.find_single_symbol('Str', :setting-only)),
+                nqp::box_i(self.current_line($/),self.find_single_symbol('Int', :setting-only)),
             );
             $xcbt.throw;
         }
@@ -5615,7 +5615,7 @@ class Perl6::World is HLL::World {
     method rethrow($/, $err) {
         my int $success := 0;
         my $coercer;
-        try { $coercer := self.find_symbol(['&COMP_EXCEPTION'], :setting-only); ++$success; };
+        try { $coercer := self.find_single_symbol('&COMP_EXCEPTION', :setting-only); ++$success; };
         nqp::rethrow($err) unless $success;
         my $p6ex := $coercer($err);
         unless nqp::can($p6ex, 'SET_FILE_LINE') {
@@ -5626,8 +5626,8 @@ class Perl6::World is HLL::World {
         }
         if nqp::can($p6ex, 'SET_FILE_LINE') {
             $p6ex.SET_FILE_LINE(
-                nqp::box_s(self.current_file,self.find_symbol(['Str'], :setting-only)),
-                nqp::box_i(self.current_line($/),self.find_symbol(['Int'], :setting-only)),
+                nqp::box_s(self.current_file,self.find_single_symbol('Str', :setting-only)),
+                nqp::box_i(self.current_line($/),self.find_single_symbol('Int', :setting-only)),
             );
         }
         $p6ex.rethrow();

--- a/src/core.c/CompUnit/RepositoryRegistry.pm6
+++ b/src/core.c/CompUnit/RepositoryRegistry.pm6
@@ -339,7 +339,7 @@ class CompUnit::RepositoryRegistry {
                 PROCESS::<$REPO> := $head;
 
                 # Cannot just use GLOBAL.WHO here as that gives a BOOTHash
-                $*W.find_symbol(nqp::list("GLOBAL")).WHO.merge-symbols(
+                $*W.find_single_symbol("GLOBAL").WHO.merge-symbols(
                   $comp_unit.handle.globalish-package);
 
                 $repo := self.repository-for-spec($repo.path-spec, :$next-repo);

--- a/src/rakudo-debug.nqp
+++ b/src/rakudo-debug.nqp
@@ -31,7 +31,7 @@ class Perl6::DebugHooks {
 sub ps_qast() {
     QAST::Op.new(
         :op('callmethod'), :name('new'),
-        QAST::WVal.new( :value($*W.find_symbol(['PseudoStash'])) )
+        QAST::WVal.new( :value($*W.find_single_symbol('PseudoStash')) )
     )
 }
 


### PR DESCRIPTION
Since a large number of the calls to `find_symbol` are single-element lists, create a new method just for that case and call it where we can. There doesn't seem to be a noticeable change when compiling Rakudo, but I did some micro-benchmarking after the first commit where I only added the new method. Running `use nqp; BEGIN { my $w := $*W;  my $a; $a := $w.find_symbol(nqp::list("Bool")) for ^1_000_000; say $a; say now - ENTER now }; say "hi"` took ~1.1s and ~2.51b instructions. Running `use nqp; BEGIN { my $w := $*W;  my $a; $a := $w.find_single_symbol("Bool") for ^1_000_000; say $a; say now - ENTER now }; say "hi"` took ~1.0s and ~2.41b instructions.

Rakudo builds ok and passes `make m-test m-spectest`.