### PR TITLE
Truncate .gist output for multidim arrays

### DIFF
--- a/src/core.c/Rakudo/Internals.pm6
+++ b/src/core.c/Rakudo/Internals.pm6
@@ -535,12 +535,25 @@ implementation detail and has no serviceable parts inside"
             self.gistseen('Array', { self!gist(nqp::create(Array),self.shape) })
         }
         method !gist(@path, @dims) {
-            if @dims.elems == 1 {
-                 '[' ~ (^@dims[0]).map({ self.AT-POS(|@path, $_).gist }).join(' ') ~ ']';
-            }
-            else {
+            if @dims.elems == 1  {
+                '[' ~ (^@dims[0]).map(
+                    -> $elem {
+                        given ++$ {
+                            when 11 { '...' }
+                            when 12 { last }
+                            default { self.AT-POS(|@path, $elem).gist }
+	                }
+                    }).join(' ') ~ ']';
+            } else {
                 my @nextdims = @dims[1..^@dims.elems];
-                '[' ~ (^@dims[0]).map({ self!gist((flat @path, $_), @nextdims) }).join(' ') ~ ']';
+                '[' ~ (^@dims[0]).map(
+                    -> $elem {
+                        given ++$ {
+                            when 11 { '...' }
+                            when 12 { last }
+                            default { self!gist((flat @path, $elem), @nextdims) }
+                        }
+                    }).join("\n" ~ (' ' x @path.elems + 1)) ~ ']';
             }
         }
 

--- a/src/core.c/Rakudo/Internals.pm6
+++ b/src/core.c/Rakudo/Internals.pm6
@@ -542,8 +542,9 @@ implementation detail and has no serviceable parts inside"
                             when 11 { '...' }
                             when 12 { last }
                             default { self.AT-POS(|@path, $elem).gist }
-	                }
-                    }).join(' ') ~ ']';
+                        }
+                    }
+                ).join(' ') ~ ']';
             } else {
                 my @nextdims = @dims[1..^@dims.elems];
                 '[' ~ (^@dims[0]).map(
@@ -553,7 +554,8 @@ implementation detail and has no serviceable parts inside"
                             when 12 { last }
                             default { self!gist((flat @path, $elem), @nextdims) }
                         }
-                    }).join("\n" ~ (' ' x @path.elems + 1)) ~ ']';
+                    }
+                ).join("\n" ~ (' ' x @path.elems + 1)) ~ ']';
             }
         }
 


### PR DESCRIPTION
Example output here:
https://gist.github.com/donaldh/b947e78324541a14ebd784da9ddd86a3

Some minimal spectest updates to follow for the modified .gist output:

https://github.com/Raku/roast/blob/bc69ad8bf4964f85bdbbe4825a5b98e11d4b3886/S09-multidim/methods.t#L62
https://github.com/Raku/roast/blob/bc69ad8bf4964f85bdbbe4825a5b98e11d4b3886/S09-multidim/methods.t#L129