### PR TITLE
Improve error message for too many directives in routine `sprintf`

### DIFF
--- a/src/core.c/Exception.pm6
+++ b/src/core.c/Exception.pm6
@@ -2113,16 +2113,37 @@ my class X::Str::Trans::InvalidArg is Exception {
 }
 
 my class X::Str::Sprintf::Directives::Count is Exception {
-    has int $.args-used;
-    has int $.args-have;
+    has int $.args-used; # number of directives actually detected in the format string
+    has int $.args-have; # number of args supplied
     method message() {
-        "Your printf-style directives specify "
-        ~ ($.args-used == 1 ?? "1 argument, but "
-                            !! "$.args-used arguments, but ")
-        ~ ($.args-have < 1      ?? "no argument was"
-            !! $.args-have == 1 ?? "1 argument was"
-                                !! "$.args-have arguments were")
-        ~ " supplied";
+        my $msg = "Your printf-style directives specify ";
+
+        if $.args-used == 1 {
+            $msg ~= "1 argument, but ";
+        }
+        else {
+            $msg ~= "$.args-used arguments, but ";
+        }
+
+        if $.args-have < 1 {
+            $msg ~= "no argument was";
+        }
+        else {
+            if $.args-have == 1 {
+                $msg ~= "1 argument was";
+            }
+            else {
+                # too many args
+                $msg ~= "$.args-have arguments were";
+            }
+        }
+        $msg ~= " supplied.";
+
+        if $.args-used > $.args-have {
+            $msg ~= "\nAre you using an unescaped '\$'?";
+        }
+
+        $msg;
     }
 }
 

--- a/t/05-messages/02-errors.t
+++ b/t/05-messages/02-errors.t
@@ -130,11 +130,13 @@ throws-like {
 }, X::Multi::Ambiguous, :message{ .contains: 'ambigu-arg-tester' & 'IntStr' },
     'an ambiguous call includes the arguments in the error message';
 
+
 # https://github.com/Raku/old-issue-tracker/issues/3542
+# GH #3682
 throws-like { sprintf "%d" }, X::Str::Sprintf::Directives::Count,
     :message('Your printf-style directives specify 1 argument, but no '
-      ~ 'argument was supplied'),
-    'sprintf %d directive with find a corresponding argument throws';
+      ~ "argument was supplied.\nAre you using an unescaped '\$'?"),
+    'sprintf %d directive with one directive and no corresponding argument throws';
 
 { # https://github.com/perl6/roast/commit/20fe657466
     my int @arr;


### PR DESCRIPTION
Fix GH issue #3682

The problem is the erroneous use of a '$' symbol in the sprintf format
statement does not give a hint of that possibility in the original
exception code. That, coupled with incomplete sprintf documentation,
may mislead the user who makes that mistake.

The fix is to mention the possibility of the misused '$' symbol when
the args provided are less than the detected directives in the format
string.

+ modify and improve file rakudo/src/core.c/Exception.pm6
+ expand and improve core test file rakudo/t/05-messages/02-errors.t