### PR TITLE
add IO::Handle.do-not-close-at-exit() method

### DIFF
--- a/src/core.c/IO/Handle.pm6
+++ b/src/core.c/IO/Handle.pm6
@@ -37,7 +37,7 @@ my class IO::Handle {
             )
         }
     }
-    method forget-about-closing(int $fileno --> Nil) {
+    method !forget-about-closing(int $fileno --> Nil) {
         $opened-locker.protect: {
             nqp::bindpos($opened,$fileno,nqp::null)
         }
@@ -232,7 +232,7 @@ my class IO::Handle {
             (my int $fileno = nqp::filenofh($!PIO)),
             nqp::closefh($!PIO), # TODO: catch errors
             ($!PIO := nqp::null),
-            self.forget-about-closing($fileno)
+            self!forget-about-closing($fileno)
 #?endif
           )
         )
@@ -631,7 +631,7 @@ my class IO::Handle {
         Bool:D :$non-blocking = False, Bool:D :$shared = False --> True
     ) {
 #?if moar
-        self.forget-about-closing(nqp::filenofh($!PIO));
+        self!forget-about-closing(nqp::filenofh($!PIO));
 #?endif
         nqp::lockfh($!PIO, 0x10*$non-blocking + $shared);
         CATCH { default {
@@ -885,7 +885,7 @@ my class IO::Handle {
 #?endif
 #?if moar
             ($!PIO := nqp::null),
-            self.forget-about-closing($fileno)
+            self!forget-about-closing($fileno)
 #?endif
           )
         )

--- a/src/core.c/IO/Handle.pm6
+++ b/src/core.c/IO/Handle.pm6
@@ -37,7 +37,7 @@ my class IO::Handle {
             )
         }
     }
-    method !forget-about-closing(int $fileno --> Nil) {
+    method forget-about-closing(int $fileno --> Nil) {
         $opened-locker.protect: {
             nqp::bindpos($opened,$fileno,nqp::null)
         }
@@ -232,7 +232,7 @@ my class IO::Handle {
             (my int $fileno = nqp::filenofh($!PIO)),
             nqp::closefh($!PIO), # TODO: catch errors
             ($!PIO := nqp::null),
-            self!forget-about-closing($fileno)
+            self.forget-about-closing($fileno)
 #?endif
           )
         )
@@ -631,7 +631,7 @@ my class IO::Handle {
         Bool:D :$non-blocking = False, Bool:D :$shared = False --> True
     ) {
 #?if moar
-        self!forget-about-closing(nqp::filenofh($!PIO));
+        self.forget-about-closing(nqp::filenofh($!PIO));
 #?endif
         nqp::lockfh($!PIO, 0x10*$non-blocking + $shared);
         CATCH { default {
@@ -885,7 +885,7 @@ my class IO::Handle {
 #?endif
 #?if moar
             ($!PIO := nqp::null),
-            self!forget-about-closing($fileno)
+            self.forget-about-closing($fileno)
 #?endif
           )
         )


### PR DESCRIPTION
Which is currently a private method. For when file-handles are closed outside of Raku

```
     my UInt $fd = $ioh.native-descriptor();
     $ioh.forget-about-closing($fd);
```
Easiest solution to solving failing t/12html.t tests in latest LibXML https://github.com/libxml-raku/LibXML-raku/commit/cf4ea76fd3adb45962bc49fc062972e5069ce9e5

After some bug-fixes `LibXML.parse(:$fd)` and `LibXML::parse(:$io)` are being closed by libxml2. Causing errors because Rakudo is also trying to close the same file-handles.

Hoping this is a suitable fix and others might find this method handy.