### PR TITLE
Add 'auth-fmt' compiler arg for option '--doc'

### DIFF
--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -476,6 +476,7 @@ role STD {
 }
 
 grammar Perl6::Grammar is HLL::Grammar does STD {
+
     #================================================================
     # AMBIENT AND POD-COMMON CODE HANDLERS
     #================================================================
@@ -805,7 +806,11 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         :my $*DECLARATOR_DOCS;
         :my $*PRECEDING_DECL; # for #= comments
         :my $*PRECEDING_DECL_LINE := -1; # XXX update this when I see another comment like it?
-        :my $*keep-decl := nqp::existskey(nqp::getenvhash(), 'RAKUDO_POD_DECL_BLOCK_USER_FORMAT');
+        # Note: Implementation of the 'auth-fmt' arg to Rakudo option '--doc'
+        #       illustrates another use of compiler options to affect
+        #       grammar actions.
+        :my $*keep-decl := nqp::existskey(nqp::getenvhash(), 'RAKUDO_POD_DECL_BLOCK_USER_FORMAT')
+                        || nqp::existskey(%*COMPILING<%?OPTIONS>, 'auth-fmt');
 
         # TODO use these vars to implement S26 pod data block handling
         :my $*DATA-BLOCKS := [];
@@ -4894,7 +4899,8 @@ if $*COMPILING_CORE_SETTING {
     }
 
     method attach_leading_docs() {
-        # TODO allow some limited text layout here
+        # We now allow some limited text layout here via
+        # an environment variable or a compiler option.
         if ~$*DOC ne '' {
             my $cont;
             if $*keep-decl {

--- a/src/main.nqp
+++ b/src/main.nqp
@@ -63,6 +63,13 @@ my @clo := $comp.commandline_options();
 @clo.push('I=s');
 @clo.push('M=s');
 @clo.push('nqp-lib=s');
+# Do we need to declare an option in all cases?
+# No, at least not for the implementation of additional
+# args for, e.g., '--doc=Text|HTML,auth-fmt'.
+# See files:
+#   src/Perl6/Compiler.nqp
+#   src/Perl6/Grammar.nqp
+#@clo.push('auth-fmt=s'); # Trying to fake a valid option without it being a "normal" option
 
 #?if js
 @clo.push('beautify');


### PR DESCRIPTION
Addresses Rakudo issue GH #3701.

This commit adds the capability for the user to affect parsing of Pod
in leading declarator blocks.

The standard behavior is to extract such Pod as a single line of
normalized text. A previous commit added the capability to change such
parsing to respect the original formatting by saving the author's
newlines and other spaces, but it had to be triggered by the existence
of a special Rakudo environment variable:

  RAKUDO_POD_DECL_BLOCK_USER_FORMAT

With this commit, the user can now select the same behavior by adding
the word 'auth-fmt' after the command line option '--doc='.  The new
word can be added alone or added to the existing argument choices of
'Text' or 'HTML'. The two-word version must have the words separated
by a comma (with no spaces) and in any order.

The compiler has been modified so the '--help' option explains the new
capability.

Files modified:

+ src/Perl6/Compiler.nqp
+ src/Perl6/Grammar.nqp
+ src/main.nqp