### PR TITLE
Add '--doc-fmt=preserve' compiler option

### DIFF
--- a/src/Perl6/Compiler.nqp
+++ b/src/Perl6/Compiler.nqp
@@ -52,6 +52,14 @@ class Perl6::Compiler is HLL::Compiler {
         if nqp::existskey(%options, 'doc') && !%options<doc> {
             %options<doc> := 'Text';
         }
+        if nqp::existskey(%options, 'doc-fmt') {
+            # check for valid arg
+            my $ok-arg := 'preserve';
+            my $arg    := %options<doc-fmt>;
+            unless nqp::iseq_s($arg,$ok-arg) {
+                self.panic("Unknown '--doc-fmt' arg '$arg', did you mean '$ok-arg'?");
+            }
+        }
 
         my $argiter := nqp::iterator(@args);
         nqp::shift($argiter) if $argiter && !nqp::defined(%options<e>);
@@ -159,6 +167,10 @@ and, by default, also executes the compiled code.
   --stagestats         display time spent in the compilation stages
   --ll-exception       display a low level backtrace on errors
   --doc=module         use Pod::To::[module] to render inline documentation
+  --doc-fmt=fmt        controls text formatting with the '--doc' option;
+                       the only fmt argument currently recognized is 
+                       'preserve' which maintains the existing formatting
+                       in leading declarator blocks
   --repl-mode=interactive|non-interactive
                        when running without "-e" or filename arguments,
                        a REPL is started. By default, if STDIN is a TTY,

--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -805,7 +805,8 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         :my $*DECLARATOR_DOCS;
         :my $*PRECEDING_DECL; # for #= comments
         :my $*PRECEDING_DECL_LINE := -1; # XXX update this when I see another comment like it?
-        :my $*keep-decl := nqp::existskey(nqp::getenvhash(), 'RAKUDO_POD_DECL_BLOCK_USER_FORMAT');
+        :my $*keep-decl := nqp::existskey(nqp::getenvhash(), 'RAKUDO_POD_DECL_BLOCK_USER_FORMAT')
+                        || nqp::existskey(%*COMPILING<%?OPTIONS>, 'doc-fmt');
 
         # TODO use these vars to implement S26 pod data block handling
         :my $*DATA-BLOCKS := [];
@@ -4894,7 +4895,7 @@ if $*COMPILING_CORE_SETTING {
     }
 
     method attach_leading_docs() {
-        # TODO allow some limited text layout here
+        # allow some limited text layout here
         if ~$*DOC ne '' {
             my $cont;
             if $*keep-decl {

--- a/src/main.nqp
+++ b/src/main.nqp
@@ -63,6 +63,7 @@ my @clo := $comp.commandline_options();
 @clo.push('I=s');
 @clo.push('M=s');
 @clo.push('nqp-lib=s');
+@clo.push('doc-fmt=s');
 
 #?if js
 @clo.push('beautify');


### PR DESCRIPTION
Addresses Rakudo issue GH #3701.

This commit adds the capability for the user to affect parsing of text
in leading declarator blocks.

The standard behavior is to extract such text as a single line of
normalized text. A previous commit added the capability to change such
parsing to respect the original formatting by saving the author's
newlines and other spaces, but it had to be triggered by the existence
of a special Rakudo environment variable:

  RAKUDO_POD_DECL_BLOCK_USER_FORMAT

With this commit, the user can now select the same behavior by adding
the new option '--doc-fmt=preserve' option along with other
'--doc' options.

The compiler has been modified so the '--help' option explains the new
option.

As an example consider this short Raku program in file 't.raku':

    #| line 1: foo
    #| line 2: bar
    sub baz() {}
    #= line 3: baz
    #= line 4: boo

Run using current usage:

    $ raku --doc t.raku
    sub baz()
    line 1: foo line 2: bar
    line 3: baz line 4: boo

Run with the new option:

    $ raku --doc --doc-fmt=preserve t.raku
    sub baz()
    line 1: foo
    line 2: bar
    line 3: baz line 4: boo

Notice the trailing declarator block hasn't been fixed yet. That is a
separate issue.

Files modified:

+ src/Perl6/Compiler.nqp
+ src/Perl6/Grammar.nqp
+ src/main.nqp