### PR TITLE
Perl wrapper shebang

### DIFF
--- a/src/core.c/CompUnit/Repository/Installation.pm6
+++ b/src/core.c/CompUnit/Repository/Installation.pm6
@@ -245,7 +245,6 @@ sub MAIN(:$name, :$auth, :$ver, *@, *%)
     CompUnit::RepositoryRegistry.run-script( "#name#", :$name, :$auth, :$ver );
 }
 SHELL
-
        };
 
         for %files.kv -> $name-path, $file is copy {

--- a/src/core.c/CompUnit/Repository/Installation.pm6
+++ b/src/core.c/CompUnit/Repository/Installation.pm6
@@ -201,7 +201,7 @@ __END__
 
         # bin/ scripts
 
-        my $perl-wrapper
+        state $perl-wrapper
         = do {
             # code below replaces #ext# with '-j', '-m', etc.
             #

--- a/src/core.c/CompUnit/Repository/Installation.pm6
+++ b/src/core.c/CompUnit/Repository/Installation.pm6
@@ -259,7 +259,7 @@ SHELL
                     $perl-wrapper.subst('#name#', $name, :g).subst('#ext#', $be );
                 if $is-win {
                     $.prefix.add("$withoutext$be.bat").IO.spurt:
-                        $windows_wrapper.subst('#perl#', "perl6$be", :g);
+                        $windows_wrapper.subst('#ext#', $be, :g);
                 }
                 else {
                     $.prefix.add("$withoutext$be").IO.chmod(0o755);

--- a/src/core.c/CompUnit/Repository/Installation.pm6
+++ b/src/core.c/CompUnit/Repository/Installation.pm6
@@ -202,8 +202,7 @@ __END__
         # bin/ scripts
 
         my $perl-wrapper
-        = do 
-        {
+        = do {
             # basename being dispatched is generated below, replaces '#perl#'
             # in the generated script.
             # question here is how to dispatch it: via env or the path to
@@ -213,12 +212,12 @@ __END__
             # use the literal text for now.
             # someone should clean this up in the future.
 
-            constant FIXED  = q|
+            constant FIXED  = q:to/SHELL/;
 sub MAIN(:$name, :$auth, :$ver, *@, *%)
 {
     CompUnit::RepositoryRegistry.run-script("#name#", :$name, :$auth, :$ver);
 }
-|;
+SHELL
             my $exec = gather 
             {
                 # change 'perl6' to 'rakudo' or 'raku' at some point.
@@ -226,7 +225,7 @@ sub MAIN(:$name, :$auth, :$ver, *@, *%)
 
                 with < /bin/env /usr/bin/env >.first: { .IO.e } -> $env 
                 {
-                    take "$env #perl#";
+                    take "$env rakudo";
                 }
                 else
                 {
@@ -234,21 +233,20 @@ sub MAIN(:$name, :$auth, :$ver, *@, *%)
 
                     my $curr    = $.prefix.absolute;
 
-                    loop:
+                    loop: 
                     {
-                        if $curr.add( SEARCH ).IO.ie
+                        if $curr.add( SEARCH ).IO.ie 
                         {
-                            take "$curr/bin/#perl#";
+                            take "$curr/bin/rakudo";
                             last
-                        }
-                        elsif $curr eq ( my $next = $curr.parent )
+                        } elsif $curr eq ( my $next = $curr.parent ) 
                         {
                             # one last option would be "$SHELL -e $0", but that
                             # requirs shell-speicfic arguments. rahter than open
                             # that can of worms here, it seems better to give up.
 
                             die "No '{SEARCH}' above {$.prefix}";
-                        }
+                        } 
                         else
                         {
                             $curr   = $next;


### PR DESCRIPTION
Per issue #3635 <https://github.com/rakudo/rakudo/issues/3635>: If /usr/bin/env does not exist then the perl wrappers fail. Fix is to test for both /bin/env and  /usr/bin/env, using the first existing one.

As added boilerplate, if neither is found -- old enough System7?? -- then the install prefix path is walked to locate any 'bin/rakudo' executable which is then used with an absolute path as "#!/path/to/bin/rakudo". Lacking both env and rakudo executables this dies.

This replaces the literal "#perl#" in the following loop with "#ext#" so that instead of inserting "perl6-j", etc, it simply adds the extension via  "#!/usr/bin/ext rakudo#ext#" or "#!/path/to/bin/rakudo#ext#". This avoids hardwiring "perl6" as the basename and gracefully handles both /bin/env with a basename and /path/to/bin/rakudo with an absolute path.

Note: I'm unable to test this on Windows here. 

One thing this does *not* do is deal with missing rakudo-X basenames (e.g., producing the wrapper zef-js where no rakudo-js exists on the filesystem). This seems like a useful later addition.