### PR TITLE
Perl6 to Raku and many more

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -147,7 +147,7 @@
         Result: PASS
 
     If you want to run the tests in parallel, you need to install a fairly
-    recent version of the Perl 5 module Test::Harness (3.16 works for sure).
+    recent version of the Perl module Test::Harness (3.16 works for sure).
 
   Spectest smolder requirements (Windows)
     You need recent version of either Strawberry Perl or ActiveState Perl.

--- a/docs/Building-Rakudo.md
+++ b/docs/Building-Rakudo.md
@@ -20,12 +20,12 @@ development via following command line options:
 
 - `--github-user=<user>` defines the GitHub account where cloned repositories of `MoarVM`, `NQP`, and `Rakudo` are all
   located. With this option sources of `NQP` will be cloned from `git@github.com:<user>/nqp` instead of the default
-  `git@github.com:perl6/nqp`.
+  `git@github.com:Raku/nqp`.
 - `--[rakudo|moar|nqp|roast]-repo` command line options allow to define particular URL for each individual repository.
 
 ### nqp-configure submodule
 
-`Configure.pl` is based on modules implemented by [nqp-configure](https://github.com/perl6/nqp-configure) repository.
+`Configure.pl` is based on modules implemented by [nqp-configure](https://github.com/Raku/nqp-configure) repository.
 This repo is included as a submodule into `rakudo` source repository. To set a user free of manual update of submodules
 upon each update of `nqp-configure` `Configure.pl` does a few things under the hood upon startup:
 
@@ -44,11 +44,11 @@ upon each update of `nqp-configure` `Configure.pl` does a few things under the h
 _... needs documenting ..._
 
 See documentation on macros in
-[nqp-configure repository](https://github.com/perl6/nqp-configure/blob/master/doc/Macros.md).
+[nqp-configure repository](https://github.com/Raku/nqp-configure/blob/master/doc/Macros.md).
 
 ## Language Revisions
 
-Language revisions supported by current `Rakudo` version are defined in `tools/templates/PERL6_SPECS` file. At the
+Language revisions supported by current `Rakudo` version are defined in `tools/templates/RAKU_SPECS` file. At the
 moment of writing this section it has the following look:
 
 ```
@@ -67,7 +67,7 @@ The life cycle of a release modifier `PREVIEW` must follow these rules:
 
 1. For a revision being developed it has to be marked as required. In this status use of the revision letter in a
    language version is not possible without the modifier. With the file in the example if we try `use v6.e;` the
-   compiler must die with _'Perl v6.e requires modifier PREVIEW'_ message.
+   compiler must die with _'Raku v6.e requires modifier PREVIEW'_ message.
 1. When revision gets released the modifier status changes into normal status for a couple of monthly releases of
    `Rakudo` to allow graceful transition for modules which were built specifically for the just released revision.
 
@@ -75,18 +75,18 @@ The life cycle of a release modifier `PREVIEW` must follow these rules:
 1. When the transition period is considered over the `PREVIEW` modifier must be marked as _deprecated_. With this
    status it's still possible to use it. But the compiler will generate a warning message.
 1. The _deprecation_ period should be over after another few releases and followed by complete removal of `PREVIEW`
-   modifier from `PERL6_SPECS` file. At this point its use is considered illegal and compiler will be dying whenever
+   modifier from `RAKU_SPECS` file. At this point its use is considered illegal and compiler will be dying whenever
    find it in a code.
 
 ### Steps to add a new revision
 
-1. Edit `PERL6_SPECS` to add a line containing the new revision letter similar to this:
+1. Edit `RAKU_SPECS` to add a line containing the new revision letter similar to this:
 
    ```<revision letter> !PREVIEW```
 
    _Note_ that here and below `<revision letter>` must be replaced with the next letter to be used.
 
-1. Change the status of `PREVIEW` modifier of the previous release from _required_ to _normal_. Save `PERL6_SPECS`.
+1. Change the status of `PREVIEW` modifier of the previous release from _required_ to _normal_. Save `RAKU_SPECS`.
 1. Create `src/core.<revision letter>` directory.
 1. Create file `src/core.<revision letter>/core_prologue.pm6` with the following lines in it:
 
@@ -96,9 +96,9 @@ The life cycle of a release modifier `PREVIEW` must follow these rules:
    # This dynamic is purely for testing support.
    PROCESS::<$CORE-SETTING-REV> := '<revision letter>';
 
-   # vim: ft=perl6 expandtab sw=4
+   # vim: ft=raku expandtab sw=4
    ```
 
-1. Edit file `t/02-rakudo/14-revisions.t` to reflect all changes done in `PERL6_SPECS` on the previous steps: add one
+1. Edit file `t/02-rakudo/14-revisions.t` to reflect all changes done in `RAKU_SPECS` on the previous steps: add one
    more test for the new revision, remove `PREVIEW` from the previous revision, etc.
 1. Change `VERSION` file in `roast` repository.

--- a/docs/ROADMAP
+++ b/docs/ROADMAP
@@ -60,7 +60,7 @@ Language Features
 2 **    module versioning (lizmat,FROGGS)
 2 ***   new syntax/semantics for coercion (jnthn)
 3 ***   domain specific languages -- slang and grammar tweaks (FROGGS)
-3 ****  more advanced Perl 5 interop (lexical embedding, etc.) (FROGGS)
+3 ****  more advanced Perl interop (lexical embedding, etc.) (FROGGS)
 2 **    label handling using goto
 2 ?     leave for leading blocks
 

--- a/docs/S11-Modules-proposal.pod
+++ b/docs/S11-Modules-proposal.pod
@@ -58,7 +58,7 @@ If you want to use Unicode in your module names, your file system must
 support Unicode as well.  If you want users without Unicode file names
 to use your modules, don't use Unicode in your module names.
 
-=head2 Retain @*INC to specify where searching begins
+=head2 Retain C<@*INC> to specify where searching begins
 
 Rakudo effectively gives the following output to C<-e '.say for @*INC'>
 
@@ -82,11 +82,11 @@ exists.
 =head2 Room for wriggling on file names
 
 If multiple instances of a module exist, they may be distributed among
-all the @*INC directories.  Folders correspond to packages (aka
-namespaces) and they are not allowed to have :ver and :auth name parts.
+all the C<@*INC> directories.  Folders correspond to packages (aka
+namespaces) and they are not allowed to have C<:ver> and C<:auth> name parts.
 
 In every directory, file name collisions are avoided by optionally
-inserting a unique .infix in the name before the .pm extension.  The
+inserting a unique C<.infix> in the name before the C<.pm> extension.  The
 following would all match a C<use Foo;> command:
 
     Foo.pm
@@ -96,38 +96,38 @@ following would all match a C<use Foo;> command:
 Currently only digits are being considered, but anything within reason
 between the two dots should be allowed, and is under the control of the
 module installer.  The infix characters are meaningless.  Only the code
-inside the file specifies :ver and :auth.
+inside the file specifies C<:ver> and C<:auth>.
 
 =head1 Searches in C<use>, C<need> and C<require> commands
 
-In commands such as C<use>, the :auth and :ver name parts are
-independently optional.  Rakudo * will do only exact matches on :auth
-and :ver name parts, because the alternative gives headaches...
+In commands such as C<use>, the C<:auth> and C<:ver> name parts are
+independently optional.  Rakudo * will do only exact matches on C<:auth>
+and C<:ver> name parts, because the alternative gives headaches...
 
-Consider the example "use Foo::Bar:ver<1.2.3>:auth<baz>"
+Consider the example C<"use Foo::Bar:ver<1.2.3>:auth<baz>">
 
-Rakudo * will look for files matching Foo/Bar.pm and Foo/Bar.*.pm from
-every starting point listed in @*INC.  Rakudo will then open each file
-in turn and partially (how?) parse the content to extract the first :ver
-and :auth values, building a list of the results.  Caching will
+Rakudo * will look for files matching C<Foo/Bar.pm> and C<Foo/Bar.*.pm> from
+every starting point listed in C<@*INC>.  Rakudo will then open each file
+in turn and partially (how?) parse the content to extract the first C<:ver>
+and C<:auth> values, building a list of the results.  Caching will
 probably be added soon after the initial implementation works, in order to
 reduce the obvious overheads.
 
 If the C<use> specified an C<:auth> or a C<:ver>, the values must match,
 and non-matching files are disqualified.
 
-Rakudo will consider files in the user's local directories (. and
-~/.perl6/lib) that omit :auth and :ver values.  Modules in the
-parrot_install tree should all have :auth and :ver.
+Rakudo will consider files in the user's local directories (C<.> and
+C<~/.perl6/lib>) that omit C<:auth> and C<:ver> values.  Modules in the
+parrot_install tree should all have C<:auth> and C<:ver>.
 
-If the :ver is not specified, Rakudo must select the file containing the
-highest :ver value.  Files without :ver are considered as having the
-lowest possible :ver value.  Multiple files without :ver, or multiple
-files with the same :ver, will result in an arbitrary selection.
+If the C<:ver> is not specified, Rakudo must select the file containing the
+highest C<:ver> value.  Files without C<:ver> are considered as having the
+lowest possible C<:ver> value.  Multiple files without C<:ver>, or multiple
+files with the same C<:ver>, will result in an arbitrary selection.
 
 =head1 Implementation notes
 
 There is a Perl stub implementation of the module finding algorithm in the
 rmp repository L<http://github.com/moritz/rmp> in the file
 C<loader-fulllist.pl>. Commit bits to that repo are handed out freely; just
-ask HUG-me on #raku :-).
+ask HUG-me on #raku https://webchat.freenode.net/?channels=#raku :-).

--- a/docs/S11-Modules-proposal.pod
+++ b/docs/S11-Modules-proposal.pod
@@ -1,19 +1,19 @@
 =head1 S11-Modules proposal for Rakudo * implementation
 
-The aim will be to implement it all in NQP if possible.
+The aim will be to implement it all in C<NQP> if possible.
 
 =head1 Overriding Principle
 
 The source code must always be the absolute source of all information.
-Everything else should act as a cache.  That means *.pir files and
+Everything else should act as a cache.  That means C<*.pir> files and
 databases of metadata may be automatically or manually derived from the
-*.pm files, but they may not add information (from the command line, for
+C<*.rakumod> files, but they may not add information (from the command line, for
 example).
 
 If there is to be cached metadata in future, it should be stored in
 files as close to the corresponding source files as possible.
-If modules are precompiled to *.pir files, those files will be stored
-in the same directories as their corresponding *.pm source files, with
+If modules are precompiled to C<*.pir> files, those files will be stored
+in the same directories as their corresponding C<*.rakumod> source files, with
 identical names apart from the extension.
 
 =head1 Restrictions and limitations
@@ -32,7 +32,7 @@ file, in order to keep the implementation simple.  In order to keep
 users sane, multiple C<:ver> or C<:auth> name parts in the same source
 file will make the using program die with a NYI error.
 
-The following is ok (loaded by "use Foo::Bar:ver<1.2.3>:auth<baz>"):
+The following is ok (loaded by C<"use Foo::Bar:ver<1.2.3>:auth<baz>">):
 
     # in Foo/Bar.pm
     class Foo::Bar:ver<1.2.3>:auth<baz> {       # or module, grammar etc
@@ -60,19 +60,19 @@ to use your modules, don't use Unicode in your module names.
 
 =head2 Retain @*INC to specify where searching begins
 
-Rakudo effectively gives the following output to -e'.say for @*INC'
+Rakudo effectively gives the following output to C<-e '.say for @*INC'>
 
     ~/.perl6/lib
     parrot_install/lib/2.1.0-devel/share/perl6/lib
     .
 
-The . entry may be removed from the default @*INC because it creates a
+The . entry may be removed from the default C<@*INC> because it creates a
 security risk, but it is needed in the medium term for the build process
 to conveniently find F<Test.pm>.
 
-Unlike the Perl 5 case, all matching candidate files in all applicable
+Unlike the Perl case, all matching candidate files in all applicable
 directories will be considered, so in most cases the order of
-directories in @*INC is not significant.  If copies of the same module
+directories in C<@*INC> is not significant.  If copies of the same module
 name with the same C<:auth> and C<:ver> name parts exist in the same or
 even different directories, Rakudo may arbitrarily use any one of those
 files and ignore the others.  The module installer utility should try to
@@ -127,7 +127,7 @@ files with the same :ver, will result in an arbitrary selection.
 
 =head1 Implementation notes
 
-There is a Perl 5 stub implementation of the module finding algorithm in the
+There is a Perl stub implementation of the module finding algorithm in the
 rmp repository L<http://github.com/moritz/rmp> in the file
 C<loader-fulllist.pl>. Commit bits to that repo are handed out freely; just
-ask hugme on #perl6 :-).
+ask HUG-me on #raku :-).

--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -1,12 +1,12 @@
 <html>
 <head>
-    <title>How Rakudo compiles a Perl 6 program</title>
+    <title>How Rakudo compiles a Raku program</title>
 </head>
 <body style="margin:2ex">
 
-<h1>How Rakudo compiles a Perl 6 program</h1>
+<h1>How Rakudo compiles a Raku program</h1>
 
-<object 
+<object
     style="margin:2ex; float:left"
     data="architecture.svg"
     type="image/svg+xml"
@@ -17,11 +17,11 @@
 <a id="action-methods" />
 <h2 id="parser" >Parser and Action Methods</h2>
 
-<p>The Perl 6 source code is transformed in various stages, of which the first two are the Parser and Action Method stages. The Parser creates a parse tree out of the Perl 6 source code and then gives control to appropriate action methods that annotate the parse tree, incrementally turning it into an Abstract Syntax Tree (AST). When an action method is done annotating, control is handed back to the parser, which then continues parsing the Perl 6 code and "fire off" new action methods as it goes.</p>
+<p>The Raku source code is transformed in various stages, of which the first two are the Parser and Action Method stages. The Parser creates a parse tree out of the Raku source code and then gives control to appropriate action methods that annotate the parse tree, incrementally turning it into an Abstract Syntax Tree (AST). When an action method is done annotating, control is handed back to the parser, which then continues parsing the Raku code and "fire off" new action methods as it goes.</p>
 
 <p>The result of these two stages interacting is an "improved PAST" (Perl 6 Abstract Syntax Tree) called QAST. This tree is then passed on to the QAST compiler.</p>
 
-<p>The parser and action methods are implemented in "Not Quite Perl 6" (NQP) and are part of Rakudo and hosted in the Rakudo repository at <a href="../src/Perl6/Grammar.pm">src/Perl6/Grammar.pm</a> and <a href="../src/Perl6/Actions.pm">src/Perl6/Actions.pm</a>.</p>
+<p>The parser and action methods are implemented in "Not Quite Perl" (NQP) and are part of Rakudo and hosted in the Rakudo repository at <a href="../src/Perl6/Grammar.nqp">src/Perl6/Grammar.nqp</a> and <a href="../src/Perl6/Actions.nqp">src/Perl6/Actions.nqp</a>.</p>
 
 <h2 id="the-world">The World</h2>
 
@@ -54,17 +54,17 @@
 
 <h2 id="pmc-dynops">PMCs and dynops</h2>
 
-<p>There are also some supporting custom types and operations in Rakudo called <em>dynamic PMCs</em> and <em>dynamic ops</em> (dynops) which are written in C, and helper functions written in NQP and PIR. These supporting libraries exist for adding features to Parrot that are needed to handle special features in Perl 6.</p>
+<p>There are also some supporting custom types and operations in Rakudo called <em>dynamic PMCs</em> and <em>dynamic ops</em> (dynops) which are written in C, and helper functions written in NQP and PIR. These supporting libraries exist for adding features to Parrot that are needed to handle special features in Raku.</p>
 
 <h2 id="core-setting">Core setting library</h2>
 
-<p>The core settings library is the library containing the methods, classes and almost all other features that make up the Rakudo Perl 6 implementation. This library is tightly coupled with the <code>perl6</code> binary, and loaded by default every time <code>perl6</code> is run.</p>
+<p>The core settings library is the library containing the methods, classes and almost all other features that make up the Rakudo Raku implementation. This library is tightly coupled with the <code>raku</code> binary, and loaded by default every time <code>raku</code> is run.</p>
 
 <h2 id="glossary">Glossary</h2>
 
 <dl>
     <dt>NQP</dt>
-    <dd>Not Quite Perl 6, a small subset of Perl 6 that is used for tree transformations in compilers.</dd>
+    <dd>Not Quite Perl, a small subset of Raku that is used for tree transformations in compilers.</dd>
 
     <dt>PIR</dt>
     <dd>Parrot Intermediate Representation, the most commonly used for of parrot assembly (which is still high-level enough to be written by humans).</dd>
@@ -76,10 +76,10 @@
     <dd>Parrot Byte Code, the binary form to which all parrot programs are compiled in the end.</dd>
 
     <dt>Core setting</dt>
-    <dd>The core setting is the Perl 6 standard library. It is part of the perl6 executable, and contains all the standard features available in Perl 6.</dd>
+    <dd>The core setting is the Raku standard library. It is part of the raku executable, and contains all the standard features available in Raku.</dd>
 
     <dt>QAST</dt>
-    <dd>The "improved" Abstract Syntax Tree used in Rakudo Perl 6. It contains information about how the program is structured, and what it is supposed to do.</dd>
+    <dd>The "improved" Abstract Syntax Tree used in Rakudo. It contains information about how the program is structured, and what it is supposed to do.</dd>
 
     <dt>PIRT</dt>
     <dd>Parrot Intermediate Representation Tree.</dd>
@@ -88,6 +88,6 @@
 
 </body>
 </html>
-<!-- 
+<!--
     vim: ft=html spell sw=4 ts=4 expandtab tw=75
 -->

--- a/docs/architecture.svg
+++ b/docs/architecture.svg
@@ -578,7 +578,7 @@ There are also some supporting custom types and operations in Rakudo called dyna
        sodipodi:role="line"
        id="tspan3982"
        x="-122.32886"
-       y="328.75763">Raku::World</tspan><tspan
+       y="328.75763">Perl6::World</tspan><tspan
        sodipodi:role="line"
        x="-122.32886"
        y="343.75763"

--- a/docs/architecture.svg
+++ b/docs/architecture.svg
@@ -19,7 +19,7 @@
    sodipodi:docname="architecture.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape">
   <title
-     id="title3260">Rakudo Perl 6 Architecture</title>
+     id="title3260">Rakudo Raku Architecture</title>
   <metadata
      id="metadata106">
     <rdf:RDF>
@@ -28,7 +28,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title>Rakudo Perl 6 Architecture</dc:title>
+        <dc:title>Rakudo Raku Architecture</dc:title>
         <cc:license
            rdf:resource="http://opensource.org/licenses/artistic-license-2.0" />
         <dc:subject>
@@ -104,7 +104,7 @@
          id="tspan2573">Core setting</tspan><tspan
          x="78.422783"
          y="272.36749"
-         id="tspan2577">(Perl 6)</tspan></text>
+         id="tspan2577">(Raku)</tspan></text>
   </a>
   <a
      xlink:href="architecture.html#the-world"
@@ -138,9 +138,9 @@
      target="_top"
      transform="matrix(0.5,0,0,0.5,12.2667,-77.083296)">
     <desc
-       id="desc3046">The Perl 6 source code is transformed in various stages. The first one is the parser stage, which creates a parse tree out of the Perl 6 source code.
+       id="desc3046">The Raku source code is transformed in various stages. The first one is the parser stage, which creates a parse tree out of the Raku source code.
 
-The parser stage is implemented in &quot;Not Quite Perl 6&quot; (NQP) and is part of Rakudo and hosted in the Rakudo repository.
+The parser stage is implemented in &quot;Not Quite Perl&quot; (NQP) and is part of Rakudo and hosted in the Rakudo repository.
 
 </desc>
     <title
@@ -217,7 +217,7 @@ The parser stage is implemented in &quot;Not Quite Perl 6&quot; (NQP) and is par
      style="font-size:12.36547184px;font-style:normal;font-weight:normal;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;font-family:Bitstream Vera Sans"><tspan
        x="206.18925"
        y="16.676073"
-       id="tspan2475">Perl 6</tspan><tspan
+       id="tspan2475">Raku</tspan><tspan
        x="206.18925"
        y="32.132919"
        id="tspan2483">source</tspan></text>
@@ -578,7 +578,7 @@ There are also some supporting custom types and operations in Rakudo called dyna
        sodipodi:role="line"
        id="tspan3982"
        x="-122.32886"
-       y="328.75763">Perl6::World</tspan><tspan
+       y="328.75763">Raku::World</tspan><tspan
        sodipodi:role="line"
        x="-122.32886"
        y="343.75763"

--- a/docs/compiler_overview.pod
+++ b/docs/compiler_overview.pod
@@ -5,10 +5,10 @@
 F<Please note: Parts of this overview are outdated since Rakudo does
 no longer run on the Parrot Virtual Machine.>
 
-=head2 How the Rakudo Perl 6 compiler works
+=head2 How the Rakudo compiler works
 
 This document describes the architecture and operation of the Rakudo
-Perl 6 (or simply Rakudo) compiler.  The F<README> describes how to
+Raku (or simply Rakudo) compiler.  The F<README> describes how to
 build and run Rakudo.
 
 Rakudo has six main parts summarized below.  Source code paths are
@@ -19,7 +19,7 @@ extensions such as F<.exe> are sometimes omitted for brevity.
 
 =item 1.
 
-Not Quite Perl builds Perl 6 source code parts into Rakudo
+Not Quite Perl builds Raku source code parts into Rakudo
 
 =item 2.
 
@@ -36,7 +36,7 @@ Action methods build a Parrot Abstract Syntax Tree (F<Perl6/Actions.nqp>)
 
 =item 5.
 
-Parrot extensions provide Perl 6 run time behavior (F<ops/perl6.ops>,
+Parrot extensions provide Raku run time behavior (F<Perl6/Ops.nqp>,
 F<pmc/*.pmc>, F<binder/*>)
 
 =item 6.
@@ -48,7 +48,7 @@ F<core/*.pm>, F<glue/*.pir>, F<metamodel/*>)
 
 The F<Makefile> (generated from F<../tools/build/Makefile.in> by
 F<../Configure.pl>) compiles all the parts to form the F<perl6.pbc>
-executable and the F<perl6> or F<perl6.exe> "fake executable".  We call
+executable and the F<perl6> or F<raku.exe> "fake executable".  We call
 it fake because it has only a small stub of code to start the Parrot
 virtual machine, and passes itself as a chunk of bytecode for Parrot to
 execute.  The source code of the "fakecutable" is generated as
@@ -59,17 +59,17 @@ string called C<program_code>.  What a hack!
 =head2 1. NQP
 
 The source files of Rakudo are preferably and increasingly written in
-Perl 6, the remainder in Parrot Intermediate Representation (PIR) or C.
+Perl, the remainder in Parrot Intermediate Representation (PIR) or C.
 Not Quite Perl (nqp) provides the bootstrap step of compiling compiler
-code (yes!) written in a subset of Perl 6, into PIR.
+code (yes!) written in a subset of Perl, into PIR.
 
 The latest version of NQP includes the I<6model> library, which is the
-building block for all Perl 6 object. It also comes with a regex engine
+building block for all Raku objects. It also comes with a regex engine
 that Rakudo uses.
 
 NQP is a bootstrapped compiler, it is mostly written in NQP.
 The source code of NQP is in a separate repository at
-L<http://github.com/perl6/nqp/>.  Note, NQPx only
+L<http://github.com/Raku/nqp/>.  Note, NQPx only
 I<builds> the Rakudo compiler, and does not compile or run user programs.
 
 =head3 Stages
@@ -83,14 +83,14 @@ The bare-bones compiler then loads the compiled metamodel, and compiles
 the I<core files> found in F<core/*.pm>. Those core files provide the runtime
 library (like the C<Array> and C<Complex> classes). But note that many
 of these classes are also used when the final compiler processes your
-Perl 6 scripts.
+Raku scripts.
 
 
 =head2 2. Compiler main program
 
 A subroutine called C<'MAIN'>, in F<main.nqp>, starts the
 source parsing and bytecode generation work.  It creates a
-C<Perl6::Compiler> object for the C<'perl6'> source type.
+C<Perl6::Compiler> object for the C<'raku'> source type.
 
 Before tracing Rakudo's execution further, a few words about Parrot
 process and library initialization.
@@ -119,16 +119,16 @@ between PCT, grammar and actions.
 =head2 3. Grammar
 
 Using C<parrot-nqp>, C<make> target C<PERL6_G> uses F<parrot-nqp> to
-compile F<Perl6/Grammar.pm> to F<gen/perl6-grammar.pir>.
+compile F<Perl6/Grammar.nqp> to F<gen/perl6-grammar.pir>.
 
-The compiler works by calling C<TOP> method in F<Perl6/Grammar.pm>.
+The compiler works by calling C<TOP> method in F<Perl6/Grammar.nqp>.
 After some initialization, TOP matches the user program to the comp_unit
 (meaning compilation unit) token.  That triggers a series of matches to
 other tokens and rules (two kinds of regex) depending on the source in
 the user program.
 
 For example, here's the parse rule for Rakudo's C<unless> statement
-(in F<Perl6/Grammar.pm>):
+(in F<Perl6/Grammar.nqp>):
 
  token statement_control:sym<unless> {
    <sym> :s
@@ -145,13 +145,13 @@ syntax is almost exactly the same as in F<STD.pm>, described below.
 
 Remember that for a match, not only must the C<< <sym> >> match the word
 C<unless>, the C<< <xblock> >> must also match the C<xblock> token.  If
-you read more of F<Perl6/Grammar.pm>, you will learn that C<xblock> in
+you read more of F<Perl6/Grammar.nqp>, you will learn that C<xblock> in
 turn tries to match an C<< <EXPR> >> and a C<< <pblock>  >>, which in
 turn tries to match .....
 
 That is why this parsing algorithm is called Recursive Descent.
 
-The top-level portion of the grammar is written using Perl 6 rules
+The top-level portion of the grammar is written using Raku rules
 (Synopsis 5) and is based on the STD.pm grammar in the C<perl6/std>
 repository (L<https://github.com/perl6/std/>).  There are a few
 places where Rakudo's grammar deviates from STD.pm, but the ultimate
@@ -178,7 +178,7 @@ matches a named regex in the grammar, it automatically invokes the same
 named method in the actions class.
 
 Back to the C<unless> example, here's the action method for the
-C<unless> statement (from F<Perl6/Actions.pm>):
+C<unless> statement (from F<Perl6/Actions.nqp>):
 
  method statement_control:sym<unless>($/) {
    my $past := xblock_immediate( $<xblock>.ast );
@@ -188,10 +188,10 @@ C<unless> statement (from F<Perl6/Actions.pm>):
 
 When the parser invokes this action method, the current match object
 containing the parsed statement is passed into the method as C<$/>.
-In Perl 6, this means that the expression C<< $<xblock> >> refers to
+In Raku, this means that the expression C<< $<xblock> >> refers to
 whatever the parser matched to the C<xblock> token.  Similarly there
 are C<< $<EXPR> >> and C<< $<pblock> >> objects etc until the end of the
-recursive descent.  By the way, C<< $<xblock> >> is Perl 6 syntactic
+recursive descent.  By the way, C<< $<xblock> >> is Raku syntactic
 sugar for C< $/{'xblock'} >.
 
 The magic occurs in the C<< $<xblock>.ast >> and C<make> expressions in
@@ -221,7 +221,7 @@ machine code instructions, and 9 dynamic PMCs ("dynpmcs") (PolyMorphic
 Container, remember?) which are are Parrot's equivalent of class
 definitions.
 
-The dynops source is in F<ops/perl6.ops>, which looks like C, apart from
+The dynops source is in F<Perl6/Ops.nqp>, which looks like C, apart from
 some Perlish syntactic sugar.
 A F<../parrot_install/bin/ops2c> desugars
 that to F<build/perl6.c> which your C compiler turns into a library.
@@ -280,7 +280,7 @@ in F<parrot/src/ops/math.ops>)
 =head2 6. Builtin functions and runtime support
 
 The last component of the compiler are the various builtin functions and
-libraries that a Perl 6 program expects to have available when it is
+libraries that a Raku program expects to have available when it is
 running.  These include functions for the basic operations
 (C<< infix:<+> >>, C<< prefix:<abs> >>) as well as common global
 functions such as C<say> and C<print>.

--- a/docs/language_versions.md
+++ b/docs/language_versions.md
@@ -54,7 +54,7 @@ afterwards).
 
 ## Spectests
 
-The Perl 6 language is defined by its test suite. A particular release of the
+The Raku language is defined by its test suite. A particular release of the
 language is, therefore, a release of the test suite. To make sure we don't
 regress on things that we decided are part of the 6.c language, we need to
 make sure that we don't unknowingly change such tests.
@@ -79,20 +79,20 @@ to pass this test any more).
 
 ## Language versioning
 
-The Perl 6 language has version numbers v6.c, v6.d, v6.e, and so forth. These
+The Raku language has version numbers v6.c, v6.d, v6.e, and so forth. These
 are very much like C has C89, C99, and C11. Each language version is defined
 by its test suite.
 
-Rakudo is a Perl 6 implementation, as GCC, Clang, and MSVC are implementations
+Rakudo is a Raku implementation, as GCC, Clang, and MSVC are implementations
 of the C language. Rakudo has monthly releases (2015.12, 2016.01, etc.) For
 the moment, we don't make any distinction between these releases; they are all
 equally "supported".
 
-Each Rakudo release must indicate the maximum version of Perl 6 it supports,
+Each Rakudo release must indicate the maximum version of Raku it supports,
 and this should be included prominently in the release announcement, for
-example in the title, such as: "Rakudo 2016.01 (implements Perl 6.c)".
+example in the title, such as: "Rakudo 2020.05.1 (implements Raku 6.d)".
 
-A Perl 6 source file without a "use v???" line will be run at the latest
+A Raku source file without a "use v???" line will be run at the latest
 language version that the current implementation supports (as will -e and
 the REPL). A source file with "use v6.X" (where X is meta) should be
 treated as follows:
@@ -120,7 +120,7 @@ we'll do something like this:
 
 To facilitate this, for now at least, we'll require that a "use v6.X" is the
 first non-comment, non-whitespace declaration in a file. Anything later will
-trigger a "too late to switch Perl 6 language version".
+trigger a "too late to switch Raku language version".
 
 ## Experimental features
 

--- a/docs/module_management.md
+++ b/docs/module_management.md
@@ -97,7 +97,7 @@ the point they were formed.
 Furthermore, precompilations are statically linked against the precompilations
 of their transitive dependencies as well as against a particular compilation
 of the Raku compiler and its `CORE.setting`. Therefore, the identity of the
-Raku compiler - obtained through `$*PERL.compiler.id` - should also be
+Raku compiler - obtained through `$*RAKU.compiler.id` - should also be
 considered part of the environment the precompilation was formed in. This will
 also support `rakubrew` style tools, which enable switching between different
 versions and backends.
@@ -129,7 +129,7 @@ to another. A repository can always provide its unique identity, which must
 incorporate the identity of any repository it refers to. In normal startup, the
 `PROCESS::<$REPO>` symbol will be set to a default repository that supports the
 installation of distributions (a `CompUnit::Repository::Installation`). Any
-`-I` includes, or any paths in a `PERL6LIB` environment variable, will cause
+`-I` includes, or any paths in a `RAKULIB` environment variable, will cause
 `PROCESS::<$REPO>` to instead point to a chain of repositories that ends with
 the default `CompUnit::Repository::Installation` that is normally there.
 
@@ -426,7 +426,7 @@ should implement the following role:
     role CompUnit::Repository::Installable does CompUnit::Repository {
         # Installs a distribution into the repository.
         method install(
-            # A Distribution object 
+            # A Distribution object
             Distribution $dist,
             # A hash mapping entries in `provides` to a disk location that
             # holds the source files; they will be copied (and may also be
@@ -560,7 +560,7 @@ versioning or authority.
 
     class CompUnit::Repository::FileSystem does CompUnit::Repository {
         has $.prefix is required;
-        
+
         ...
     }
 

--- a/docs/obtaining-a-commit-bit.pod
+++ b/docs/obtaining-a-commit-bit.pod
@@ -2,7 +2,7 @@
 
 Firstly, what's a "commit bit"? If you don't know what it is, you
 probably don't need one :-) But, in any case, a "commit bit" is the
-colloquial way that L<#perl6|https://webchat.freenode.net/?channels=#perl6>
+colloquial way that L<#raku|https://webchat.freenode.net/?channels=#raku>
 describes how you obtain access to make commits directly to the rakudo
 repository. (i.e., not via a fork and pull request, but directly
 to https://github.com/rakudo/rakudo)
@@ -13,7 +13,7 @@ address it can be mailed to can
 be found at https://www.perlfoundation.org/contributor-license-agreement.html
 Some contributors chose to email the CLA to C<trademark -at- perlfoundation.org>
 instead; you can speak to C<[Coke]> on
-L<our IRC chat|https://webchat.freenode.net/?channels=#perl6> for details about
+L<our IRC chat|https://webchat.freenode.net/?channels=#raku> for details about
 the process as well as follow up on whether your CLA has been received by
 The Perl Foundation.
 
@@ -34,12 +34,12 @@ as far as you are aware, your contributions are yours alone to give.
 
 B<Once you send off your signed CLA,> and it's received by The Perl Foundation
 you can then inquire on
-L<irc://freenode.net/#perl6|https://webchat.freenode.net/?channels=#perl6>
+L<irc://freenode.net/#raku|https://webchat.freenode.net/?channels=#raku>
 about getting commit access to the Rakudo
 repository. The main source code repository for Rakudo is administered
 on GitHub, so it would be a good idea to have a github account before
 you request a commit bit. There is at least one officer of the Perl
-Foundation on #perl6 who can verify the reception of your signed CLA and
+Foundation on #raku who can verify the reception of your signed CLA and
 several people that can then add you to the Rakudo project.
 
 Typically a commit bit is granted after a new contributor has submitted

--- a/docs/ops.markdown
+++ b/docs/ops.markdown
@@ -82,27 +82,27 @@ This desugars to:
 ## p6bool
 * p6bool(Mu $value)
 
-Create a Perl 6 Bool from $value.
+Create a Raku Bool from $value.
 
 ## p6box_i
 * p6box_i(int $value)
 
-Box a native int into a Perl 6 Int.
+Box a native int into a Raku Int.
 
 ## p6box_n
 * p6box_n(num $value)
 
-Box a native num into a Perl 6 Num.
+Box a native num into a Raku Num.
 
 ## p6box_s
 * p6box_s(str $value)
 
-Box a native str into a Perl 6 Str.
+Box a native str into a Raku Str.
 
 ## p6box_u
 * p6box_u(uint $value)
 
-Box a native uint into a Perl 6 UInt.
+Box a native uint into a Raku UInt.
 
 ## p6capturelex
 * p6capturelex(Mu $closure)
@@ -141,7 +141,7 @@ Returns client's language version (`6.<rev>`). See [p6clientcorectx](#p6clientco
 ## p6clientctx
 * p6clientctx()
 
-Returns client's, i.e. the first Perl6 caller from different package, context.
+Returns client's, i.e. the first Raku caller from different package, context.
 
 ## p6configposbindfailover
 * p6configposbindfailover(Mu $type, Mu $failover-type)
@@ -169,7 +169,7 @@ to a _true_ value then lookup is performed only in client's SETTING.
 ## p6init
 * p6init()
 
-Initializes the GlobalContext extensions for Perl 6.
+Initializes the GlobalContext extensions for Raku.
 
 ## p6inpre
 * p6inpre()

--- a/docs/rakudo-nqp-and-pod-notes.md
+++ b/docs/rakudo-nqp-and-pod-notes.md
@@ -172,13 +172,13 @@ process for later developers.
 Following is the start of a table to show the grammar tokens that have
 action methods and their resulting `.ast` values.
 
-| Actions method           | `made` (`ast`) value 
+| Actions method           | `made` (`ast`) value
 | ---                      | ---            
-| pod_textcontent          | 
-| pod_block:sym\<delimited> | QAST node [instance of Pod::Heading] 
-| pod_block:sym\<delimited> | QAST node [instance of Pod::Item] 
-| pod_block:sym\<delimited> | QAST node [instance of Pod::Defn] 
-| pod_block:sym\<delimited> | QAST node [instance of Pod::Block::Named] 
+| pod_textcontent          |
+| pod_block:sym\<delimited> | QAST node [instance of Pod::Heading]
+| pod_block:sym\<delimited> | QAST node [instance of Pod::Item]
+| pod_block:sym\<delimited> | QAST node [instance of Pod::Defn]
+| pod_block:sym\<delimited> | QAST node [instance of Pod::Block::Named]
 | pod_content:sym\<block>   | $<pod_block>.ast;
 | pod_content_toplevel     | $<pod_block>.ast
 

--- a/docs/release-guide-binary.md
+++ b/docs/release-guide-binary.md
@@ -37,14 +37,14 @@ Windows
 =======
 
 - Create a fresh Windows 10 VM as described in [the Windows guide](windows.md) if you don't have an up to date Windows 10 available (the download is 20GB and turns unusable after ~ 2 months).
-- Install Git, Perl 5, and the C/C+ development tools as described in that guide.
+- Install Git, Perl, and the C/C+ development tools as described in that guide.
 - Download the [latest release](http://rakudo.org/files/rakudo) and extract it to `C:\rakudo`. The path will end up in the finished build, so if you don't want some other path to end up persisted in the build in some buildsystem variable put it in `C:\rakudo`.
 - Open the 'Developer Command Prompt for VS 20XX'.
 - Navigate to `C:\rakudo\`.
 - `perl Configure.pl --gen-moar --gen-nqp --backends=moar --relocatable`
 - `nmake install`
 - `nmake test`
-- In `C:\rakudo` do `git clone https://github.com/ugexe/zef.git` and `cd zef` and `C:\rakudo\install\bin\perl6.exe -I. bin\zef install .`
+- In `C:\rakudo` do `git clone https://github.com/ugexe/zef.git` and `cd zef` and `C:\rakudo\install\bin\raku.exe -I. bin\zef install .`
 - Copy all files in the `tools\build\binary-release\Windows` folder into the `install` folder.
 - Rename the `install` folder to `rakudo-20XX.XX`.
 - Create a `.zip` archive. Name it `rakudo-moar-20XX.XX-01-win-x86_64.zip`.
@@ -66,21 +66,21 @@ As of 2019-07-08 CentOS 6 (using glibc 2.12) is a good pick.
 
     yum -y update && yum clean all
     yum install git perl perl-core gcc make
-    curl -L -o rakudo-2019.03.1.tar.gz https://rakudo.org/dl/rakudo/rakudo-2019.03.1.tar.gz
-    tar -xzf rakudo-2019.03.1.tar.gz
-    cd rakudo-2019.03.1
+    curl -L -o rakudo-2020.01.tar.gz https://rakudo.org/dl/rakudo/rakudo-2020.01.tar.gz
+    tar -xzf rakudo-2020.01.tar.gz
+    cd rakudo-2020.01
     perl Configure.pl --gen-moar --gen-nqp --backends=moar --relocatable
     make install
     make test
     git clone https://github.com/ugexe/zef.git
     cd zef
-    /rakudo-2019.03.1/install/bin/raku -I. bin/zef install .
-    cd /rakudo-2019.03.1
+    /rakudo-2020.01/install/bin/raku -I. bin/zef install .
+    cd /rakudo-2020.01
     cp -r tools/build/binary-release/Linux/* install
-    mv install rakudo-2019.03.1
-    tar -zcv --owner=0 --group=0 --numeric-owner -f /rakudo-moar-2019.03.1-01-linux-x86_64.tar.gz rakudo-2019.03.1
+    mv install rakudo-2020.01
+    tar -zcv --owner=0 --group=0 --numeric-owner -f /rakudo-moar-2020.01-01-linux-x86_64.tar.gz rakudo-2020.01
 
-- On the host linux (not inside the container) run `docker cp rakudo-build:/rakudo-moar-2019.03.1-01-linux-x86_64.tar.gz .` to copy the archive out of the container. If you happended to stop the container by exitting the console, type `docker start rakudo-build` to start it again and allow copying files out.
+- On the host linux (not inside the container) run `docker cp rakudo-build:/rakudo-moar-2020.01-01-linux-x86_64.tar.gz .` to copy the archive out of the container. If you happended to stop the container by exitting the console, type `docker start rakudo-build` to start it again and allow copying files out.
 - Sign the tarball archive as described in `release_guide.pod`.
 - Upload the tarball and signature as described in `release_guide.pod`.
 
@@ -91,20 +91,20 @@ Mac OS
 - Install XCode from the App Store.
 - Open a terminal and do the following:
 
-    curl -L -o /Applications/rakudo-2019.03.1.tar.gz https://rakudo.org/dl/rakudo/rakudo-2019.03.1.tar.gz
+    curl -L -o /Applications/rakudo-2020.01.tar.gz https://rakudo.org/dl/rakudo/rakudo-2020.01.tar.gz
     cd /Applications
-    tar -xzf rakudo-2019.03.1.tar.gz
-    cd rakudo-2019.03.1
+    tar -xzf rakudo-2020.01.tar.gz
+    cd rakudo-2020.01
     perl Configure.pl --gen-moar --gen-nqp --backends=moar --relocatable
     make install
     make test
     git clone https://github.com/ugexe/zef.git
     cd zef
-    /Applications/rakudo-2019.03.1/install/bin/raku -I. bin/zef install .
-    cd /Applications/rakudo-2019.03.1
+    /Applications/rakudo-2020.01/install/bin/raku -I. bin/zef install .
+    cd /Applications/rakudo-2020.01
     cp -r tools/build/binary-release/MacOS/* install
-    mv install rakudo-2019.03.1
-    tar -zcv --owner=0 --group=0 --numeric-owner -f /rakudo-moar-2019.03.1-01-macos-x86_64.tar.gz rakudo-2019.03.1
+    mv install rakudo-2020.01
+    tar -zcv --owner=0 --group=0 --numeric-owner -f /rakudo-moar-2020.01-01-macos-x86_64.tar.gz rakudo-2020.01
 
 - Sign the tarball archive as described in `release_guide.pod`.
 - Upload the tarball and signature as described in `release_guide.pod`.

--- a/docs/release_guide.pod
+++ b/docs/release_guide.pod
@@ -35,7 +35,7 @@ Currently there are two tools:
 =item *
 L<Release Sakefile|https://github.com/rakudo/rakudo/blob/master/tools/releasable/Sakefile>
 which is meant to be used together with
-L<Releasable|https://github.com/perl6/whateverable/wiki/Releasable> bot
+L<Releasable|https://github.com/Raku/whateverable/wiki/Releasable> bot
 
 =item *
 L<NeuralAnomaly|https://github.com/zoffixznet/na> bot
@@ -92,13 +92,13 @@ etc. as appropriate.
   git add docs/announce/YYYY.MM.md
   git commit docs
 
-There is a helper script C<tools/create-release-announcement.p6> that
+There is a helper script C<tools/create-release-announcement.raku> that
 will create a basic release announcement for you based on the state
 of the repository and the current date.  Feel free to use it to
 save yourself some time, but please look over its output if you decide
 to use it:
 
-    ./perl6 tools/create-release-announcement.p6 > docs/announce/YYYY.MM.md
+    ./raku tools/create-release-announcement.raku > docs/announce/YYYY.MM.md
 
 =item *
 
@@ -114,7 +114,7 @@ To spot more regressions, it’s a good idea to test the ecosystem and see
 if there are any modules that were working correctly (e.g. passing their
 tests) on the previous release but no longer work on HEAD. One of the
 tools to do that is
-L<Blin|https://github.com/perl6/Blin>.
+L<Blin|https://github.com/Raku/Blin>.
 
 Generally, any kind of breakage in modules is unwanted, but there are
 exceptions. Submit Pull Requests to anything that is affected and file
@@ -140,7 +140,7 @@ Update Rakudo’s leap-second tables:
 
   perl tools/update-tai-utc.pl
 
-If a new leap second has been announced, F<src/core/Rakudo/Internals.pm>
+If a new leap second has been announced, F<src/core.c/Rakudo/Internals.pm6>
 will be modified, so commit the new version. B<Note:> be sure to double
 check the modifications are correct before committing.
 
@@ -172,14 +172,14 @@ new release is significant.
 Include a list of contributors since the last release in the announcement.
 You can get an automatically generated list by running
 
-  ./perl6 tools/contributors.p6
+  ./raku tools/contributors.raku
 
 To obtain all contributors, ensure you have all supporting repositories
 checked out, before running (this can be achieved by building rakudo
 and running a spectest). Please check the result manually for duplicates
-and other errors. Note that you may not be able to run your system perl6
+and other errors. Note that you may not be able to run your system raku
 in a local checkout, you may have to wait until you build in this
-directory and use C<./perl6>.
+directory and use C<./raku>.
 
   git add docs/announce/YYYY.MM.md
   git commit docs
@@ -205,7 +205,7 @@ status). It is also a good idea to look for JVM issues at this point.
 
 Create an NQP release with the same C<YYYY.MM> version number
 as Rakudo. Follow NQP’s
-L<docs/release_guide.pod|https://github.com/perl6/nqp/blob/master/docs/release_guide.pod>
+L<docs/release_guide.pod|https://github.com/Raku/nqp/blob/master/docs/release_guide.pod>
 file to do that.
 
 =item 8.
@@ -245,7 +245,7 @@ Install Inline::Perl5 so stresstest can use it.
 
   git clone https://github.com/ugexe/zef
   export PATH=`pwd`/install/bin:$PATH
-  cd zef; perl6 -Ilib bin/zef install .
+  cd zef; raku -Ilib bin/zef install .
   cd ..
   export PATH=`pwd`/install/share/perl6/site/bin:$PATH
   zef install Inline::Perl5
@@ -331,17 +331,15 @@ Sign the tarball with your PGP key:
 
 =item 18.
 
-Upload the tarball and the signature to L<http://rakudo.org/downloads/rakudo>
-and L<https://rakudo.perl6.org/downloads/rakudo/>:
+Upload the tarball and the signature to L<http://rakudo.org/downloads/rakudo>:
 
   scp rakudo-YYYY.MM.tar.gz rakudo-YYYY.MM.tar.gz.asc \
        rakudo@rakudo.org:public_html/downloads/rakudo/
-  scp rakudo-YYYY.MM.tar.gz rakudo-YYYY.MM.tar.gz.asc \
-       rakudo@www.p6c.org:public_html/downloads/rakudo/
+
 
 If you do not have permissions for that, ask one of (jnthn,
 masak, tadzik, moritz, [Coke], lizmat, timotimo,
- AlexDaniel) on #perl6 or #perl6-dev to do it for you.
+ AlexDaniel) on #raku or #raku-dev to do it for you.
 
 =item 19.
 

--- a/docs/running.pod
+++ b/docs/running.pod
@@ -61,11 +61,11 @@ attempts to document all those currently in use.
 
 =over
 
-=item C<RAKUDOLIB>, C<PERL6LIB> (I<Str>; F<src/core/Inc.pm>)
+=item C<RAKUDOLIB>, C<RAKULIB> (I<Str>; F<src/core/Inc.pm>)
 
 Appends a comma-delimited list of paths to C<@INC>. C<RAKUDOLIB> is evaluated first.
 
-=item C<RAKUDO_MODULE_DEBUG> (I<Bool>; F<src/Perl6/ModuleLoader.pm>)
+=item C<RAKUDO_MODULE_DEBUG> (I<Bool>; F<src/Perl6/ModuleLoader.nqp>)
 
 Causes the module loader to print debugging information to standard error.
 
@@ -75,19 +75,19 @@ Causes the module loader to print debugging information to standard error.
 
 =over
 
-=item C<RAKUDO_NO_DEPRECATIONS> (I<Bool>; F<src/core/Deprecations.pm>)
+=item C<RAKUDO_NO_DEPRECATIONS> (I<Bool>; F<src/core.c/Deprecations.pm6>)
 
 If true, suppresses deprecation warnings triggered by the C<is DEPRECATED> trait.
 
-=item C<RAKUDO_DEPRECATIONS_FATAL> (I<Bool>; F<src/core/Deprecations.pm>)
+=item C<RAKUDO_DEPRECATIONS_FATAL> (I<Bool>; F<src/core.c/Deprecations.pm6>)
 
 If true, deprecation warnings become thrown exceptions.
 
-=item C<RAKUDO_VERBOSE_STACKFRAME> (I<UInt>; F<src/core/Backtrace.pm>)
+=item C<RAKUDO_VERBOSE_STACKFRAME> (I<UInt>; F<src/core.c/Backtrace.pm6>)
 
 Displays source code in stack frames surrounded by the specified number of lines of context.
 
-=item C<RAKUDO_BACKTRACE_SETTING> (I<Bool>; F<src/core/Backtrace.pm>)
+=item C<RAKUDO_BACKTRACE_SETTING> (I<Bool>; F<src/core.c/Backtrace.pm6>)
 
 Controls whether .setting files are included in backtraces.
 
@@ -97,18 +97,18 @@ Controls whether .setting files are included in backtraces.
 
 =over
 
-=item C<RAKUDO_PREFIX> (I<Str>; F<src/core/CompUnit/RepositoryRegistry.pm>)
+=item C<RAKUDO_PREFIX> (I<Str>; F<src/core.c/CompUnit/RepositoryRegistry.pm6>)
 
 When this is set, Rakudo will look for the standard repositories (perl, vendor, site) in the
 specified directory. This is intended as an escape hatch for build-time bootstrapping issues,
 where Rakudo may be built as an unprivileged user without write access to the runtime paths
 in NQP's config.
 
-=item C<RAKUDO_PRECOMP_DIST> (F<src/core/CompUnit/PrecompilationRepository.pm>)
+=item C<RAKUDO_PRECOMP_DIST> (F<src/core.c/CompUnit/PrecompilationRepository.pm6>)
 
-=item C<RAKUDO_PRECOMP_LOADING> (F<src/core/CompUnit/PrecompilationRepository.pm>)
+=item C<RAKUDO_PRECOMP_LOADING> (F<src/core.c/CompUnit/PrecompilationRepository.pm6>)
 
-=item C<RAKUDO_PRECOMP_WITH> (F<src/core/CompUnit/PrecompilationRepository.pm>)
+=item C<RAKUDO_PRECOMP_WITH> (F<src/core.c/CompUnit/PrecompilationRepository.pm6>)
 
 These are internal variables for passing serialized state to precompilation jobs in child processes.
 Please do not set them manually.
@@ -119,16 +119,16 @@ Please do not set them manually.
 
 =over
 
-=item C<RAKUDO_ERROR_COLOR> (I<Bool>; F<src/core/Exception.pm>)
+=item C<RAKUDO_ERROR_COLOR> (I<Bool>; F<src/core.c/Exception.pm6>)
 
 Controls whether to emit ANSI codes for error highlighting. Defaults to true if unset, except on
 Win32.
 
-=item C<RAKUDO_MAX_THREADS> (I<UInt>; F<src/core/ThreadPoolScheduler.pm>)
+=item C<RAKUDO_MAX_THREADS> (I<UInt>; F<src/core.c/ThreadPoolScheduler.pm6>)
 
 Override the default maximum number of threads used by a thread pool.
 
-=item C<TMPDIR>, C<TEMP>, C<TMP> (I<Str>; F<src/core/IO/Spec/>)
+=item C<TMPDIR>, C<TEMP>, C<TMP> (I<Str>; F<src/core.c/IO/Spec/>)
 
 The C<IO::Spec::Unix.tmpdir> method will return C<$TMPDIR> if it points to a directory with full
 access permissions for the current user, with a fallback default of C<'/tmp'>.
@@ -136,7 +136,7 @@ access permissions for the current user, with a fallback default of C<'/tmp'>.
 C<IO::Spec::Cygwin> and C<IO::Spec::Win32> use more Win32-appropriate lists which also include the
 C<%TEMP%> and C<%TMP%> environment variables.
 
-=item C<PATH>, C<Path> (I<Str>; F<src/core/IO/Spec/>)
+=item C<PATH>, C<Path> (I<Str>; F<src/core.c/IO/Spec/>)
 
 The C<IO::Spec::Unix.path> method splits C<$PATH> as a shell would; i.e. as a colon-separated list.
 C<IO::Spec::Cygwin> inherits this from C<IO::Spec::Unix>.
@@ -146,11 +146,11 @@ semicolon-delimited list.
 
 =item C<RAKU_HOME>
 
-Allows to override the Raku installation path. Defaults to C<[perl6_executable_dir]/../share/perl6>.
+Allows to override the Raku installation path. Defaults to C<[rakudo_executable_dir]/../share/perl6>.
 
 =item C<NQP_HOME>
 
-Allows to override the NQP installation path. Defaults to C<[perl6_executable_dir]/../share/nqp>.
+Allows to override the NQP installation path. Defaults to C<[rakudo_executable_dir]/../share/nqp>.
 
 =back
 

--- a/docs/val.pod6
+++ b/docs/val.pod6
@@ -1,7 +1,7 @@
 =begin pod
 
 This document is meant to describe in some detail what's going on in C<val()>
-(found in C<src/core/allomorphs.pm>), since it's quite a big function. It
+(found in C<src/core.c/allomorphs.pm6>), since it's quite a big function. It
 contains a bunch of inner subs to make the process as sane as possible without
 resorting to a grammar.
 
@@ -17,7 +17,7 @@ part of the error reporting process.
 =head2 C<ProtoFailure>
 
 The C<ProtoFailure> class is just a hack, because using C<Failure>s in a similar
-way will cause Perl 6 to hang and likely eat all your memory (including on
+way will cause Raku to hang and likely eat all your memory (including on
 compiling C<RESTRICTED>, the next step after C<CORE>).
 
 Its only similarity to a C<Failure> is that it always comes out as undefined (so

--- a/lib/MoarVM/Profiler.rakumod
+++ b/lib/MoarVM/Profiler.rakumod
@@ -2,17 +2,17 @@
 # nqp::mvmendprofile, when started with mvmstartprofile({:instrumented})
 
 # The nqp::mvmendprofile returns an nqp::list that needs to be nqp::hllize'd
-# before you can iterate over it in Perl 6.  The documentation of this
+# before you can iterate over it in Raku.  The documentation of this
 # structure can be found in the nqp repository, docs/ops.markdown (or on
 # github at:
 #
-#  https://github.com/perl6/nqp/blob/master/docs/ops.markdown#mvmendprofile
+#  https://github.com/Raku/nqp/blob/master/docs/ops.markdown#mvmendprofile-moar
 
 # To reduce any additional memory pressure, the objects created by this class
 # are just shims around the arrays / hashes that have been returned.  This
 # means that access to attributes is slightly more expensive CPU-wise then
 # they could be.  On the other hand, no additional CPU was spent to create
-# "proper" Perl 6 objects to begin with, so when inspecting only parts of a
+# "proper" Raku objects to begin with, so when inspecting only parts of a
 # big profile, will only cause addtional overhead in accessing those parts,
 # rather than using a lot of CPU and additional memory on the whole structure.
 

--- a/lib/NativeCall.rakumod
+++ b/lib/NativeCall.rakumod
@@ -132,7 +132,7 @@ sub nativesizeof($obj) is export(:DEFAULT) {
 my constant $signed_ints_by_size =
   nqp::list_s( "", "char", "short", "", "int", "", "", "", "longlong" );
 
-# Gets the NCI type code to use based on a given Perl 6 type.
+# Gets the NCI type code to use based on a given Raku type.
 my constant $type_map = nqp::hash(
   "Bool",       nqp::atpos_s($signed_ints_by_size,nativesizeof(bool)),
   "bool",       nqp::atpos_s($signed_ints_by_size,nativesizeof(bool)),

--- a/lib/Spesh.rakumod
+++ b/lib/Spesh.rakumod
@@ -10,8 +10,8 @@
 # When used as a script, it will accept the name of a spesh file and output
 # a list of all of the opcodes that caused a bail, ordered by number of bails.
 #
-#   $ MVM_SPESH_LOG=spesh perl6 yourcode
-#   $ perl6 lib/Spesh.pm6 spesh
+#   $ MVM_SPESH_LOG=spesh raku yourcode
+#   $ raku lib/Spesh.rakumod spesh
 
 class Spesh {
     has @.parts;

--- a/lib/Test.rakumod
+++ b/lib/Test.rakumod
@@ -871,7 +871,7 @@ Test - Rakudo Testing Library
 Please check the section Language/testing of the doc repository.
 If you have 'p6doc' installed, you can do 'p6doc Language/testing'.
 
-You can also check the documentation about testing in Perl 6 online on:
+You can also check the documentation about testing in Raku online on:
 
   https://doc.raku.org/language/testing
 

--- a/src/Perl6/ModuleLoader.nqp
+++ b/src/Perl6/ModuleLoader.nqp
@@ -303,6 +303,6 @@ class Perl6::ModuleLoader does Perl6::ModuleLoaderVMConfig {
     }
 }
 
-# We stash this in the perl6 HLL namespace, just so it's easy to
-# locate. Note this makes it invisible inside Perl 6 itself.
+# We stash this in the raku HLL namespace, just so it's easy to
+# locate. Note this makes it invisible inside Raku itself.
 nqp::bindhllsym('Raku', 'ModuleLoader', Perl6::ModuleLoader);

--- a/src/Perl6/Ops.nqp
+++ b/src/Perl6/Ops.nqp
@@ -1,5 +1,5 @@
 
-# Registers ops so they're availabe to both NQP for Metamodel and Perl6
+# Registers ops so they're availabe to both NQP for Metamodel and Raku
 sub _register_op_with_nqp($name, $desugar) {
     register_op_desugar($name, $desugar, :compiler<nqp>);
     register_op_desugar($name, $desugar, :compiler<Raku>);

--- a/src/Perl6/Optimizer.nqp
+++ b/src/Perl6/Optimizer.nqp
@@ -737,7 +737,7 @@ my class BlockVarOptimizer {
             unless nqp::existskey(%!usages_inner, $name) ||
                     nqp::existskey(%!used_in_handle_handler, $name) {
                 # Lowerable if it's a normal variable, including $_ if we're in a
-                # Perl 6 version that allows lowering that.
+                # Raku version that allows lowering that.
                 next if nqp::chars($name) < 1;
                 unless nqp::iscclass(nqp::const::CCLASS_ALPHABETIC, $name, 0) {
                     my str $sigil := nqp::substr($name, 0, 1);
@@ -2750,7 +2750,7 @@ class Perl6::Optimizer {
                 $type.HOW.archetypes.nominal();
             unless $ok_type {
                 # nqp::ops end up labeled with nqp primitive types; we swap
-                # those out for their Perl 6 equivalents.
+                # those out for their Raku equivalents.
                 my int $ps := nqp::objprimspec($type);
                 if $ps >= 1 && $ps <= 3 {
                     $type := $!symbols.find_lexical(@prim_names[$ps]);

--- a/src/Perl6/Pod.nqp
+++ b/src/Perl6/Pod.nqp
@@ -187,7 +187,7 @@ class Perl6::Pod {
     }
 
     our sub defn($/, $blocktype) {
-        # produces a Perl 6 instance of Pod::Defn
+        # produces a Raku instance of Pod::Defn
 
         my $config := add-numbered-to-config($/);
 
@@ -195,7 +195,7 @@ class Perl6::Pod {
         die("FATAL: the incoming object is NOT a =defn block, type: $type")
             if $type !~~ /^defn/;
 
-        # the final Perl 6 type
+        # the final Raku type
         my $p6type := 'Pod::Defn';
 
         # Get all content lines.  The first line is the term for all
@@ -401,9 +401,9 @@ class Perl6::Pod {
                      :$Delimiter?,
                      :$keep?,
                     ) {
-        # Based on the 'parse_line' function in CPAN Perl 5 module
-        # Text::ParseString, but with many changes due to Perl 6 and
-        # nqp differences from Perl 5.
+        # Based on the 'parse_line' function in CPAN Perl module
+        # Text::ParseString, but with many changes due to Raku and
+        # nqp differences from Perl.
 
         # Options:
         #   $hash      - set true for a hash (default: array)
@@ -458,7 +458,7 @@ class Perl6::Pod {
             $line := subst($line, $regex, '');
             say("DEBUG pass $pass, postmatch:\n  \$line    = |$line|") if $debugp;
 
-            # As opposed to the Perl 5 version, only two match vars are recognized:
+            # As opposed to the Perl version, only two match vars are recognized:
             # $m[0] and $m[1].
             my $quote    := $m[0];
             my $quoted   := $m[1];
@@ -994,7 +994,7 @@ class Perl6::Pod {
             elsif $st.inkey {
                 if nqp::existskey(%endkeychar, $c) {
                     # we've collected the key name, check validity
-                    # look at emacs perl6 mode for ident regex
+                    # look at emacs raku mode for ident regex
                     my $rx := /<[a..zA..Z]>/;
 
                     $endchar := nqp::atkey(%endkeychar, $c);

--- a/src/core.c/Dateish.pm6
+++ b/src/core.c/Dateish.pm6
@@ -199,9 +199,9 @@ my role Dateish {
 # =begin pod
 #
 # =head1 SEE ALSO
-# Perl 6 spec <S32-Temporal|http://design.perl6.org/S32/Temporal.html>.
-# The Perl 5 DateTime Project home page L<http://datetime.perl.org>.
-# Perl 5 perldoc L<doc:DateTime> and L<doc:Time::Local>.
+# Raku spec <S32-Temporal|https://design.raku.org/S32/Temporal.html>.
+# The Perl DateTime Project home page L<http://datetime.perl.org>.
+# Perl perldoc L<doc:DateTime> and L<doc:Time::Local>.
 #
 # The best yet seen explanation of calendars, by Claus Tøndering
 # L<Calendar FAQ|http://www.tondering.dk/claus/calendar.html>.

--- a/src/rakudo-debug.nqp
+++ b/src/rakudo-debug.nqp
@@ -466,7 +466,7 @@ sub MAIN(*@ARGS) {
     nqp::bindhllsym('Raku', '$COMPILER_CONFIG', $comp.config);
 
 
-    # Determine Perl6 and NQP dirs.
+    # Determine Raku and NQP dirs.
 #?if jvm
     my $sep := nqp::atkey(nqp::jvmgetproperties,'os.name') eq 'MSWin32' ?? '\\' !! '/';
     my $execname := nqp::atkey(nqp::jvmgetproperties,'perl6.execname');

--- a/src/vm/js/README.md
+++ b/src/vm/js/README.md
@@ -63,7 +63,7 @@ A Raku Mu when passed to JS land ends up as null
 
 To pass values to Raku land the executed code needs a return.
 
-```perl6
+```raku
 EVAL(:lang<JavaScript>, '123') # This returns Mu
 EVAL(:lang<JavaScript>, 'return 123') # This returns 123
 ```
@@ -93,7 +93,7 @@ offer some methods that Raku expects.
 
   Uses the JavaScript new operator to create an new instance
 
-  ```perl6
+  ```raku
   my $Date = EVAL(:lang<JavaScript>, 'return Date');
   my $instance = $Date.new('December 17, 1995 03:24:00');
   say($instance.getFullYear()); # 1995


### PR DESCRIPTION
+ in docs/architecture.svg, change references to Raku.
+ in docs/architecture.html change file extensions .pm to .nqp as per the rakudo source code
+ There is no /nqp/src/QAST/PIRT.nqp, I think PIRT serializer can be removed from architecture.html
+ language_versions.md change Perl 6 to Raku, "Rakudo 2020.05.1 (implements Raku 6.d)"
+ perl6 to raku in docs/ops.markdown
+ change file extensions in docs/release_guide
+ remove redundant link https://rakudo.perl6.org/downloads/rakudo/ because this link and https://rakudo.org/downloads/rakudo points to same site
+ reflect the change in file extensions .p6 to raku in helper scripts in tools folder in rakudo
+ Perl 5 is Perl only now, there is no ambiguity now so change Perl 5 to Perl
+ update release guide binary with more recent version of rakudo
+ rakudo is the executable as mentioned in https://github.com/Raku/problem-solving/blob/master/solutions/language/Path-to-Raku.md#executables, so perl6_executable_dir to rakudo_executable_dir in docs/running.pod
+ make src/core/CompUnit/PrecompilationRepository.pm to src/core.c/CompUnit/PrecompilationRepository.pm6 and other similar changes in docs/running.pod
+ change hugme in S11-Modules-proposal.pod to HUG-me to reflect "	Help Understand and Guide Me"
+ more cleanup
+ more formatting the docs
+ add working link https://github.com/Raku/nqp/blob/master/docs/ops.markdown#mvmendprofile-moar to `lib/MoarVM/Profiler.rakumod`