### PR TITLE
Add read-from-input option, closes #3743

### DIFF
--- a/src/Perl6/Compiler.nqp
+++ b/src/Perl6/Compiler.nqp
@@ -143,6 +143,7 @@ With no arguments, enters a REPL (see --repl-mode option).
 With a "[programfile]" or the "-e" option, compiles the given program
 and, by default, also executes the compiled code.
 
+  -                    read program source from standard input until EOF is found
   -c                   check syntax only (runs BEGIN and CHECK blocks)
   --doc                extract documentation and print it as text
   -e program           one line of program, strict is enabled by default


### PR DESCRIPTION
This option was, apparently, not documented, but works as expected.