### PR TITLE
nativecall: Allow Callable arg to return List or IO::Path

### DIFF
--- a/lib/NativeCall.rakumod
+++ b/lib/NativeCall.rakumod
@@ -209,19 +209,20 @@ my role NativeCallSymbol[Str $name] {
     method native_symbol()  { $name }
 }
 
-multi guess_library_name(IO::Path $lib) is export(:TEST) {
+multi guess_library_name(IO::Path $lib) returns Str is export(:TEST) {
     guess_library_name($lib.absolute)
 }
-multi guess_library_name(Distribution::Resource $lib) is export(:TEST) {
+multi guess_library_name(Distribution::Resource $lib) returns Str is export(:TEST) {
     $lib.platform-library-name.Str;
 }
-multi guess_library_name(Callable $lib) is export(:TEST) {
-    $lib();
+multi guess_library_name(Callable $lib) returns Str is export(:TEST) {
+    my \ret := $lib();
+    nqp::istype(ret, Str) ?? ret !! guess_library_name(ret)
 }
-multi guess_library_name(List $lib) is export(:TEST) {
+multi guess_library_name(List $lib) returns Str is export(:TEST) {
     guess_library_name($lib[0], $lib[1])
 }
-multi guess_library_name(Str $libname, $apiversion='') is export(:TEST) {
+multi guess_library_name(Str $libname, $apiversion='') returns Str is export(:TEST) {
     $libname.DEFINITE
         ?? $libname ~~ /[\.<.alpha>+ | \.so [\.<.digit>+]+ ] $/
             ?? $libname #Already a full name?

--- a/t/04-nativecall/17-libnames.t
+++ b/t/04-nativecall/17-libnames.t
@@ -4,22 +4,19 @@ use lib <lib>;
 use NativeCall :TEST;
 use Test;
 
+plan :skip-all<Non-linux tests NYI> unless $*KERNEL ~~ 'linux';
 plan 11;
 
-if $*KERNEL ~~ 'linux' {
-	is guess_library_name("foo"), "libfoo.so", "foo is libfoo.so and should warn";
-	is guess_library_name(("foo", Version.new(1))), "libfoo.so.1", "foo , 1  is libfoo.so.1";
-	is guess_library_name(("foo", v1.2.3)), "libfoo.so.1.2.3", "foo , v1.2.3  is libfoo.so.1.2.3";
-	is guess_library_name("libfoo.so"), "libfoo.so", "libfoo.so is libfoo.so";
-	is guess_library_name("./foo"), "$*CWD/libfoo.so", "./foo is ./libfoo.so";
-	is guess_library_name("./libfoo.so"), "./libfoo.so", "./libfoo.so is ./libfoo.so";
-	is guess_library_name("/libfoo.so"), "/libfoo.so", "/libfoo.so is /libfoo.so";
+is guess_library_name("foo"), "libfoo.so", "foo is libfoo.so and should warn";
+is guess_library_name(("foo", Version.new(1))), "libfoo.so.1", "foo , 1  is libfoo.so.1";
+is guess_library_name(("foo", v1.2.3)), "libfoo.so.1.2.3", "foo , v1.2.3  is libfoo.so.1.2.3";
+is guess_library_name("libfoo.so"), "libfoo.so", "libfoo.so is libfoo.so";
+is guess_library_name("./foo"), "$*CWD/libfoo.so", "./foo is ./libfoo.so";
+is guess_library_name("./libfoo.so"), "./libfoo.so", "./libfoo.so is ./libfoo.so";
+is guess_library_name("/libfoo.so"), "/libfoo.so", "/libfoo.so is /libfoo.so";
 
-	is guess_library_name(IO::Path.new: "libfoo.so", :CWD</lib>), "/lib/libfoo.so", 'IO::Path("foo.so", :CWD</lib>) is resolved correctly';
+is guess_library_name(IO::Path.new: "libfoo.so", :CWD</lib>), "/lib/libfoo.so", 'IO::Path("foo.so", :CWD</lib>) is resolved correctly';
 
-	is guess_library_name(-> { './foo' }), './foo', 'Callable --> Str is used unconditionally';
-	is guess_library_name(-> { ("foo", v1.2.3) }), "libfoo.so.1.2.3", 'Callable --> List is resolved correctly';
-	is guess_library_name(-> { IO::Path.new: "libfoo.so", :CWD</lib> }), '/lib/libfoo.so', 'Callable --> IO::Path is resolved correctly';
-} else {
-	skip-rest;
-}
+is guess_library_name(-> { './foo' }), './foo', 'Callable --> Str is used unconditionally';
+is guess_library_name(-> { ("foo", v1.2.3) }), "libfoo.so.1.2.3", 'Callable --> List is resolved correctly';
+is guess_library_name(-> { IO::Path.new: "libfoo.so", :CWD</lib> }), '/lib/libfoo.so', 'Callable --> IO::Path is resolved correctly';

--- a/t/04-nativecall/17-libnames.t
+++ b/t/04-nativecall/17-libnames.t
@@ -4,7 +4,7 @@ use lib <lib>;
 use NativeCall :TEST;
 use Test;
 
-plan 7;
+plan 11;
 
 if $*KERNEL ~~ 'linux' {
 	is guess_library_name("foo"), "libfoo.so", "foo is libfoo.so and should warn";
@@ -14,6 +14,12 @@ if $*KERNEL ~~ 'linux' {
 	is guess_library_name("./foo"), "$*CWD/libfoo.so", "./foo is ./libfoo.so";
 	is guess_library_name("./libfoo.so"), "./libfoo.so", "./libfoo.so is ./libfoo.so";
 	is guess_library_name("/libfoo.so"), "/libfoo.so", "/libfoo.so is /libfoo.so";
+
+	is guess_library_name(IO::Path.new: "libfoo.so", :CWD</lib>), "/lib/libfoo.so", 'IO::Path("foo.so", :CWD</lib>) is resolved correctly';
+
+	is guess_library_name(-> { './foo' }), './foo', 'Callable --> Str is used unconditionally';
+	is guess_library_name(-> { ("foo", v1.2.3) }), "libfoo.so.1.2.3", 'Callable --> List is resolved correctly';
+	is guess_library_name(-> { IO::Path.new: "libfoo.so", :CWD</lib> }), '/lib/libfoo.so', 'Callable --> IO::Path is resolved correctly';
 } else {
 	skip-rest;
 }


### PR DESCRIPTION
This is needed to facilitate something like:

```perl6
sub find-foo() {
    %*ENV<FOO_LIBRARY> // ('foo', v1)
}

sub foo() is native(&find-foo) { * }
```

Without this change, `find-foo` must:

- use `guess_library_name()` directly (ugly, it should be an implementation detail),
- reproduce its functionality (error prone and onerous),
- give up and return a simple library name string (not portable or maintainable), or
- switch from `is native(&find-foo)` to `is native(find-foo)` (buggy, ENV value gets baked in during precompilation)