### PR TITLE
#3751 Fix vcs conflict marker detection

### DIFF
--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -685,6 +685,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         | [\r\n || \v] <.heredoc>
         | <.unv>
         | <.unsp>
+        | <.vcs-conflict>
         ]*
         <?MARKER('ws')>
         :my $stub := self.'!fresh_highexpect'();
@@ -705,10 +706,16 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         [
             [
             | \v
-            | '<<<<<<<' {} <?before [.*? \v '=======']: .*? \v '>>>>>>>' > <.sorry: 'Found a version control conflict marker'> \V* \v
-            | '=======' {} .*? \v '>>>>>>>' \V* \v   # ignore second half
+            | <.vcs-conflict>
             ]
         ]+
+    }
+
+    token vcs-conflict {
+        [
+        | '<<<<<<<' {} <?before [.*? \v '=======']: .*? \v '>>>>>>>' > <.sorry: 'Found a version control conflict marker'> \V* \v
+        | '=======' {} .*? \v '>>>>>>>' \V* \v   # ignore second half
+        ]
     }
 
     token unv {


### PR DESCRIPTION
Previously vcs conflict marker detection work only after unspace.
Now the marker can be detected as after unspace as without it.

Changes for issue: #3751
New tests: https://github.com/Raku/roast/pull/647