### PR TITLE
Revert broken master

### DIFF
--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -1499,21 +1499,15 @@ class Perl6::World is HLL::World {
         );
         self.add_object_if_no_sc($spec);
         my $registry := self.find_symbol(['CompUnit', 'RepositoryRegistry'], :setting-only);
-        my $comp_unit := $registry.head.need($spec,:first);
+        my $comp_unit := $registry.head.need($spec);
+        my $globalish := $comp_unit.handle.globalish-package;
+        nqp::gethllsym('Raku','ModuleLoader').merge_globals_lexically(self, $cur_GLOBALish, $globalish);
 
-        if $comp_unit {
-            my $globalish := $comp_unit.handle.globalish-package;
-            nqp::gethllsym('Raku','ModuleLoader').merge_globals_lexically(self, $cur_GLOBALish, $globalish);
-
-            CATCH {
-                self.rethrow($/, $_);
-            }
-            return $comp_unit;
+        CATCH {
+            self.rethrow($/, $_);
         }
 
-        self.throw($/, 'X::CompUnit::UnsatisfiedDependency',
-          specification => $spec,
-        );
+        return $comp_unit;
     }
 
     # Uses the NQP module loader to load Perl6::ModuleLoader, which

--- a/src/core.c/CompUnit/Repository.pm6
+++ b/src/core.c/CompUnit/Repository.pm6
@@ -4,7 +4,7 @@ role CompUnit::Repository {
     # Resolves a dependency specification to a concrete dependency. If the
     # dependency was not already loaded, loads it. Returns a CompUnit
     # object that represents the selected dependency. If there is no
-    # matching dependency, returns Nil
+    # matching dependency, throws X::CompUnit::UnsatisfiedDependency.
     method need(CompUnit::DependencySpecification $spec,
                 # If we're first in the chain, our precomp repo is the chosen one.
                 CompUnit::PrecompilationRepository $precomp = self.precomp-repository(),

--- a/src/core.c/CompUnit/Repository/AbsolutePath.pm6
+++ b/src/core.c/CompUnit/Repository/AbsolutePath.pm6
@@ -5,9 +5,8 @@ class CompUnit::Repository::AbsolutePath does CompUnit::Repository {
                 CompUnit::PrecompilationRepository $precomp = self.precomp-repository()
         --> CompUnit:D)
     {
-        self.next-repo
-          ?? self.next-repo.need($spec, $precomp)
-          !! Nil
+        return self.next-repo.need($spec, $precomp) if self.next-repo;
+        X::CompUnit::UnsatisfiedDependency.new(:specification($spec)).throw;
     }
 
     method load(IO::Path:D $file --> CompUnit:D) {

--- a/src/core.c/CompUnit/Repository/FileSystem.pm6
+++ b/src/core.c/CompUnit/Repository/FileSystem.pm6
@@ -68,8 +68,9 @@ class CompUnit::Repository::FileSystem
         CompUnit::DependencySpecification $spec,
         CompUnit::PrecompilationRepository $precomp = self.precomp-repository(),
         CompUnit::PrecompilationStore :@precomp-stores = self!precomp-stores(),
-        :$first,
-    --> CompUnit:D) {
+
+        --> CompUnit:D)
+    {
         return $_ with %!loaded{~$spec};
 
         with self!matching-dist($spec) {
@@ -97,20 +98,9 @@ class CompUnit::Repository::FileSystem
             );
         }
 
-        my $found := self.next-repo
+        self.next-repo
           ?? self.next-repo.need($spec, $precomp, :@precomp-stores)
-          !! Nil;
-        return $found if $found or !$first;
-
-        # set up suggestion if applicable
-        my $suggestions := $!prefix.add("META6.json").e
-          ?? "Please note that a 'META6.json' file was found in '$!prefix.relative()', of which the 'provides' section was used to determine if a dependency is available or not.  Perhaps you need to add '$spec' in the <provides> section of that file?  Or need to specify a directory that does *not* have a 'META6.json' file?"
-          !! '';
-
-        X::CompUnit::UnsatisfiedDependency.new(
-          specification => $spec,
-          suggestions   => $suggestions,
-        ).throw
+          !! Nil
     }
 
     method load(IO::Path:D $file --> CompUnit:D) {

--- a/src/core.c/CompUnit/Repository/FileSystem.pm6
+++ b/src/core.c/CompUnit/Repository/FileSystem.pm6
@@ -98,9 +98,8 @@ class CompUnit::Repository::FileSystem
             );
         }
 
-        self.next-repo
-          ?? self.next-repo.need($spec, $precomp, :@precomp-stores)
-          !! Nil
+        return self.next-repo.need($spec, $precomp, :@precomp-stores) if self.next-repo;
+        X::CompUnit::UnsatisfiedDependency.new(:specification($spec)).throw;
     }
 
     method load(IO::Path:D $file --> CompUnit:D) {

--- a/src/core.c/CompUnit/Repository/Installation.pm6
+++ b/src/core.c/CompUnit/Repository/Installation.pm6
@@ -583,10 +583,8 @@ sub MAIN(:$name, :$auth, :$ver, *@, *%) {
                 return %!loaded{$id} //= $compunit;
             }
         }
-
-        self.next-repo
-          ?? self.next-repo.need($spec, $precomp, :@precomp-stores)
-          !! Nil
+        return self.next-repo.need($spec, $precomp, :@precomp-stores) if self.next-repo;
+        X::CompUnit::UnsatisfiedDependency.new(:specification($spec)).throw;
     }
 
     method resource($dist-id, $key) {

--- a/src/core.c/CompUnit/Repository/NQP.pm6
+++ b/src/core.c/CompUnit/Repository/NQP.pm6
@@ -16,9 +16,8 @@ class CompUnit::Repository::NQP does CompUnit::Repository {
             );
         }
 
-        self.next-repo
-          ?? self.next-repo.need($spec, $precomp)
-          !! Nil
+        return self.next-repo.need($spec, $precomp) if self.next-repo;
+        X::CompUnit::UnsatisfiedDependency.new(:specification($spec)).throw;
     }
 
     method loaded() {

--- a/src/core.c/CompUnit/Repository/Perl5.pm6
+++ b/src/core.c/CompUnit/Repository/Perl5.pm6
@@ -31,9 +31,8 @@ class CompUnit::Repository::Perl5 does CompUnit::Repository {
             }
         }
 
-        self.next-repo
-          ?? self.next-repo.need($spec, $precomp)
-          !! Nil
+        return self.next-repo.need($spec, $precomp) if self.next-repo;
+        X::CompUnit::UnsatisfiedDependency.new(:specification($spec)).throw;
     }
 
     method loaded() {

--- a/src/core.c/CompUnit/Repository/Unknown.pm6
+++ b/src/core.c/CompUnit/Repository/Unknown.pm6
@@ -10,11 +10,11 @@ class CompUnit::Repository::Unknown does CompUnit::Repository {
         ),
         --> CompUnit:D)
     {
-        self.next-repo
-          ?? $precomp
+        return $precomp
             ?? self.next-repo.need($spec, $precomp, :@precomp-stores)
             !! self.next-repo.need($spec, :@precomp-stores)
-          !! Nil
+            if self.next-repo;
+        X::CompUnit::UnsatisfiedDependency.new(:specification($spec)).throw;
     }
 
     method loaded() {

--- a/src/core.c/Exception.pm6
+++ b/src/core.c/Exception.pm6
@@ -3114,7 +3114,6 @@ my class X::Proc::Unsuccessful is Exception {
 class CompUnit::DependencySpecification { ... }
 my class X::CompUnit::UnsatisfiedDependency is Exception {
     has CompUnit::DependencySpecification $.specification;
-    has $.suggestions;
 
     my sub is-core($name) {
         my @parts = $name.split("::");
@@ -3129,22 +3128,16 @@ my class X::CompUnit::UnsatisfiedDependency is Exception {
     }
 
     method message() {
-        my $name := $.specification.short-name;
-        if is-core($name) {
-            "'$name' is a builtin type (not an external module) and as such does not needs to be explicitely loaded.".naive-word-wrapper
-        }
-        else {
-            my $list := "Could not find $.specification in:\n"
-              ~ $*REPO.repo-chain.map(*.path-spec).join("\n").indent(4);
-            my $suggestions := ($.specification ~~ / $<name>=.+ '::from' /
-               ?? "If you meant to use the :from adverb, use a single colon for it: $<name>:from<...>"
-               !! $!suggestions
-            ).naive-word-wrapper;
-
-            $suggestions
-              ?? "$list\n\n$suggestions"
-              !! $list
-        }
+        my $name = $.specification.short-name;
+        is-core($name)
+            ?? "{$name} is a builtin type, not an external module"
+            !! "Could not find $.specification in:\n"
+                ~ $*REPO.repo-chain.map(*.path-spec).join("\n").indent(4)
+                ~ ($.specification ~~ / $<name>=.+ '::from' $ /
+                    ?? "\n\nIf you meant to use the :from adverb, use"
+                        ~ " a single colon for it: $<name>:from<...>\n"
+                    !! ''
+                )
     }
 }
 


### PR DESCRIPTION
This allows master to pass its tests again. Also, it reverts the interface regression where it was assumed all CURs are in the rakudo code base when the reality is there are externals CURs that were using the original interface (`MyCur.need(...)`).