### PR TITLE
Make core setting name mapping more consise

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "3rdparty/nqp-configure"]
 	path = 3rdparty/nqp-configure
-	url = https://github.com/perl6/nqp-configure.git
+	url = https://github.com/Raku/nqp-configure.git

--- a/src/Perl6/ModuleLoader.nqp
+++ b/src/Perl6/ModuleLoader.nqp
@@ -213,18 +213,10 @@ class Perl6::ModuleLoader does Perl6::ModuleLoaderVMConfig {
         }
     }
 
-    my %previous_setting_name := nqp::hash(
-      'NULL.c',  'NULL.c',    # identity
-      'CORE.c',  'CORE.c',
-      'NULL.d',  'CORE.c',
-      'CORE.d',  'CORE.d',
-      'NULL.e',  'CORE.d',
-      'CORE.e',  'CORE.e'
-    );
-
-    # Transforms NULL.<release> into CORE.<previous-release>
+    # Transforms NULL.<release> into CORE.<previous-release>, CORE.<release> into CORE.<previous-release>
     method previous_setting_name ($setting_name, :$base = 'CORE') {
-        %previous_setting_name{$setting_name} // nqp::die("Don't know setting $setting_name")
+        nqp::getcomp('Raku').config()<prev-setting-name>{$setting_name}
+            // nqp::die("Don't know setting $setting_name")
     }
 
     method transform_setting_name ($setting_name) {
@@ -236,7 +228,6 @@ class Perl6::ModuleLoader does Perl6::ModuleLoaderVMConfig {
 
         if $setting_name ne 'NULL.c' {
             DEBUG("Requested for settings $setting_name") if $DEBUG;
-            # XXX TODO: see https://github.com/rakudo/rakudo/issues/2432
             $setting_name := self.transform_setting_name($setting_name);
 
             # First, pre-load previous setting.

--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -572,8 +572,6 @@ class Perl6::World is HLL::World {
         }
     }
 
-    # NOTE: Revision .c has special meaning because it doesn't have own dedicated CORE setting and serves as the base
-    # for all other revisions.
     method load-lang-ver($ver-match, $comp) {
         if $*INSIDE-EVAL && $!have_outer {
             # XXX Calling typed_panic is the desirable behavior. But it breaks some code. Just ignore version change for
@@ -697,7 +695,7 @@ class Perl6::World is HLL::World {
                 nqp::getcomp('Raku').set_language_version( nqp::isgt_s($!setting_revision, $default_revision)
                                                             ?? $!setting_revision
                                                             !! $default_revision );
-                                            }
+            }
             $*UNIT.annotate('IN_DECL', 'mainline');
         }
 
@@ -955,7 +953,6 @@ class Perl6::World is HLL::World {
         }
         # Do nothing for the NULL.c setting.
         if $setting_name ne 'NULL.c' {
-            # XXX TODO: see https://github.com/rakudo/rakudo/issues/2432
             $setting_name := Perl6::ModuleLoader.transform_setting_name($setting_name);
             # Load it immediately, so the compile time info is available.
             # Once it's loaded, set it as the outer context of the code

--- a/tools/lib/NQP/Config/Rakudo.pm
+++ b/tools/lib/NQP/Config/Rakudo.pm
@@ -726,8 +726,10 @@ sub _specs_iterate {
 
     $self->not_in_context( specs => 'spec' );
 
+    my $prev_spec_char;
     for my $spec ( $cfg->raku_specs ) {
         my $spec_char   = $spec->[0];
+        $prev_spec_char //= $spec_char; # Map c -> c
         my $spec_subdir = "6.$spec_char";
         my %config      = (
             ctx_subdir    => $spec_subdir,
@@ -736,6 +738,9 @@ sub _specs_iterate {
             spec_with_mod => $spec_char,
             ucspec        => uc $spec_char,
             lcspec        => lc $spec_char,
+            prevspec      => $prev_spec_char,
+            ucprevspec    => uc $prev_spec_char,
+            lcprevspec    => lc $prev_spec_char,
         );
         my $spec_ctx = {
             spec    => $spec,
@@ -758,6 +763,7 @@ sub _specs_iterate {
                 $cb->(@_);
             }
         }
+        $prev_spec_char = $spec_char;
     }
 }
 

--- a/tools/templates/main-version.in
+++ b/tools/templates/main-version.in
@@ -1,9 +1,11 @@
 sub hll-config($config) {
+    ### Language
     $config<implementation>   := 'Rakudo';
     $config<version>          := '@version@';
     $config<release-number>   := '@release@';
     $config<codename>         := '@codename@';
     $config<language-version> := '6.@lang_spec@';
+
     # Though language-revisions key provides more information
     # can-language-versions is used for speeding up and ordering
     # Perl6::Compiler.can_langauge_versions method
@@ -33,9 +35,22 @@ sub hll-config($config) {
     }
 )@
     );
+
+    # This mapping is for handling custom settings
+    $config<prev-revision>      := nqp::hash(@for_specs(
+        '@lcspec@', '@lcprevspec@',)@
+    );
+    # This mapping is for quick-transforming of core setting name
+    $config<prev-setting-name>  := nqp::hash(@for_specs(
+        'NULL.@lcspec@', '@if(lcspec==c NULL)@@if(lcspec!=c CORE)@.@lcprevspec@',
+        'CORE.@lcspec@', 'CORE.@lcspec@',)@
+    );
+
+    ### Location
     $config<prefix>             := '@prefix@';
     $config<static-nqp-home>    := '@static_nqp_home@';
     $config<static-rakudo-home> := '@static_rakudo_home@';
+
     $config<source-digest>      := '@source_digest()@';
 }
 


### PR DESCRIPTION
Replace a manually handled hash deep inside the `ModuleLoader` to a pre-generated compiler configuration key in _gen/<backend>/main-version.nqp_.