### PR TITLE
Fix for spectest not seeing Inline::Perl5

### DIFF
--- a/t/harness5
+++ b/t/harness5
@@ -40,9 +40,11 @@ GetOptions(
 
 my @pass_through_options = grep m/^--?[^-]/, @ARGV;
 my @files = grep m/^[^-]/, @ARGV;
+my $build_rakudo_repo = "inst#$FindBin::Bin/../gen/build_rakudo_home/site";
 
 $ENV{'HARNESS_PERL'} = ".${slash}rakudo-" . ($js ? "js" : $moar ? "m" : $jvm ? "j" : "m");
 $ENV{'PERL6LIB'} = "./lib"; 
+$ENV{RAKULIB} = $build_rakudo_repo;
 
 my @slow;
 if ($list_file) {
@@ -52,7 +54,7 @@ if ($list_file) {
     if (!$perl5) {
         print "Inline::Perl5 not installed: not running Perl 5 integration tests\n";
         print "You can install Inline::Perl5 into the build directory with\n\n";
-        print "    zef --install-to=inst#$FindBin::Bin/../gen/build_rakudo_home/site install Inline::Perl5\n\n";
+        print "    zef --install-to=$build_rakudo_repo install Inline::Perl5\n\n";
     }
 
     open(my $f, '<', $list_file)

--- a/t/harness6
+++ b/t/harness6
@@ -24,6 +24,8 @@ constant FULL_ROAST_TEST_LIST_FILE = 't/spectest.data';
 constant ROAST_VERSION_FILE        = 't/spec/VERSION';
 
 my $vm = $*VM.name;
+my $build_rakudo_repo = "inst#{$*PROGRAM.parent}/../gen/build_rakudo_home/site";
+%*ENV<RAKULIB> = $build_rakudo_repo;
 
 sub MAIN(
     Str  :$tests-from-file is copy = Str,
@@ -49,7 +51,7 @@ sub MAIN(
             say 'Inline::Perl5 not installed: not running Perl 5 integration tests';
             say 'You can install Inline::Perl5 into the build directory with';
             say '';
-            say "    zef --install-to=inst#{$*PROGRAM.parent}/../gen/build_rakudo_home/site install Inline::Perl5";
+            say "    zef --install-to=$build_rakudo_repo install Inline::Perl5";
             say '';
         }
 


### PR DESCRIPTION
Fixes #2815. The problem occurs when the module is installed in the
system rakudo repository. Fix as suggested by @ugexe in
https://github.com/rakudo/rakudo/issues/2815#issuecomment-658270223