### PR TITLE
Rakudo home env precedence

### DIFF
--- a/src/Perl6/Compiler.nqp
+++ b/src/Perl6/Compiler.nqp
@@ -115,10 +115,10 @@ class Perl6::Compiler is HLL::Compiler {
                 ?? self.config<prefix>
                 !! nqp::substr($execname, 0, nqp::rindex($execname, $sep, nqp::rindex($execname, $sep) - 1));
 
-            $!rakudo-home := self.config<static-rakudo-home>
-                || nqp::getenvhash()<RAKUDO_HOME>
+            $!rakudo-home := nqp::getenvhash()<RAKUDO_HOME>
                 // nqp::getenvhash()<PERL6_HOME>
-                // $install-dir ~ '/share/perl6';
+                // self.config<static-rakudo-home>
+                || $install-dir ~ '/share/perl6';
             if nqp::substr($!rakudo-home, nqp::chars($!rakudo-home) - 1) eq $sep {
                 $!rakudo-home := nqp::substr($!rakudo-home, 0, nqp::chars($!rakudo-home) - 1);
             }

--- a/t/harness5
+++ b/t/harness5
@@ -40,11 +40,9 @@ GetOptions(
 
 my @pass_through_options = grep m/^--?[^-]/, @ARGV;
 my @files = grep m/^[^-]/, @ARGV;
-my $build_rakudo_repo = "inst#$FindBin::Bin/../gen/build_rakudo_home/site";
 
 $ENV{'HARNESS_PERL'} = ".${slash}rakudo-" . ($js ? "js" : $moar ? "m" : $jvm ? "j" : "m");
 $ENV{'PERL6LIB'} = "./lib"; 
-$ENV{RAKULIB} = $build_rakudo_repo;
 
 my @slow;
 if ($list_file) {
@@ -54,7 +52,7 @@ if ($list_file) {
     if (!$perl5) {
         print "Inline::Perl5 not installed: not running Perl 5 integration tests\n";
         print "You can install Inline::Perl5 into the build directory with\n\n";
-        print "    zef --install-to=$build_rakudo_repo install Inline::Perl5\n\n";
+        print "    zef --install-to=inst#$FindBin::Bin/../gen/build_rakudo_home/site install Inline::Perl5\n\n";
     }
 
     open(my $f, '<', $list_file)

--- a/t/harness6
+++ b/t/harness6
@@ -24,8 +24,6 @@ constant FULL_ROAST_TEST_LIST_FILE = 't/spectest.data';
 constant ROAST_VERSION_FILE        = 't/spec/VERSION';
 
 my $vm = $*VM.name;
-my $build_rakudo_repo = "inst#{$*PROGRAM.parent}/../gen/build_rakudo_home/site";
-%*ENV<RAKULIB> = $build_rakudo_repo;
 
 sub MAIN(
     Str  :$tests-from-file is copy = Str,
@@ -51,7 +49,7 @@ sub MAIN(
             say 'Inline::Perl5 not installed: not running Perl 5 integration tests';
             say 'You can install Inline::Perl5 into the build directory with';
             say '';
-            say "    zef --install-to=$build_rakudo_repo install Inline::Perl5";
+            say "    zef --install-to=inst#{$*PROGRAM.parent}/../gen/build_rakudo_home/site install Inline::Perl5";
             say '';
         }
 


### PR DESCRIPTION
The precedence of the different RAKUDO_HOME sources was wrong. A static rakudo home set by Configure in every non-relocatable build was most dominant and thus couldn't be overridden with an environment variable anymore. That makes little sense. It also broke spec tests using Inline-Perl5 using the build runners, because the build runner relies on the RAKUDO_HOME env variable to set a different rakudo home.

This fixes #2815.