### PR TITLE
Make X::Method::NotFound exception more user friendly

### DIFF
--- a/src/Perl6/Optimizer.nqp
+++ b/src/Perl6/Optimizer.nqp
@@ -2385,7 +2385,8 @@ class Perl6::Optimizer {
                 else {
                     $!problems.add_exception(['X', 'Method', 'NotFound'], $op,
                         :private(nqp::hllboolfor(1, "Raku")), :method($name),
-                        :typename($pkg.HOW.name($pkg)), :invocant($pkg));
+                        :typename($pkg.HOW.name($pkg)), :invocant($pkg),
+                        :in-class-call(nqp::hllboolfor(1, "Raku")));
                     return 1;
                 }
             }

--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -3933,6 +3933,7 @@ nqp::sethllconfig('Raku', nqp::hash(
         }
     },
     'method_not_found_error', -> $obj, str $name {
+        my $class := nqp::getlexcaller('$?CLASS');
         if nqp::gethllsym('Raku', 'P6EX') -> %ex {
             if $name eq 'STORE' {
                 if nqp::atkey(%ex,'X::Assignment::RO') -> $thrower {
@@ -3940,7 +3941,7 @@ nqp::sethllconfig('Raku', nqp::hash(
                 }
             }
             elsif nqp::atkey(%ex,'X::Method::NotFound') -> $thrower {
-                $thrower($obj, $name, $obj.HOW.name($obj));
+                $thrower($obj, $name, $obj.HOW.name($obj), :in-class-call(nqp::eqaddr(nqp::what($obj), $class)));
             }
         }
 

--- a/src/core.c/Exception.pm6
+++ b/src/core.c/Exception.pm6
@@ -170,11 +170,6 @@ my class X::Method::NotFound is Exception {
         my @tips;
         my $indirect-method = "";
 
-        if $.method.starts-with("!") && !$.private {
-            $indirect-method = $.method.substr(1);
-            @tips.push: "Method name starts with '!', did you mean 'self!\"$indirect-method\"()'?";
-        }
-
         my %suggestions;
         my int $max_length = do given $.method.chars {
             when 0..3 { 1 }
@@ -218,6 +213,11 @@ my class X::Method::NotFound is Exception {
                     %suggestions{"!$method_name"} = ~$dist;
                 }
             }
+        }
+
+        if $.method.starts-with("!") && !$.private && $private_suggested {
+            $indirect-method = $.method.substr(1);
+            @tips.push: "Method name starts with '!', did you mean 'self!\"$indirect-method\"()'?";
         }
 
         if +%suggestions == 1 {

--- a/src/core.c/Mu.pm6
+++ b/src/core.c/Mu.pm6
@@ -1026,6 +1026,7 @@ my class Mu { # declared in BOOTSTRAP
 
     method dispatch:<!>(Mu \SELF: \name, Mu \type, |c) is raw {
         my $meth := type.^find_private_method(name);
+        my $class := nqp::getlexcaller('$?CLASS');
         $meth ??
             $meth(SELF, |c) !!
             X::Method::NotFound.new(
@@ -1033,6 +1034,7 @@ my class Mu { # declared in BOOTSTRAP
               method   => name,
               typename => type.^name,
               :private,
+              :in-class-call(nqp::eqaddr(nqp::what(SELF), $class)),
             ).throw;
     }
 

--- a/src/core.c/Mu.pm6
+++ b/src/core.c/Mu.pm6
@@ -1026,7 +1026,6 @@ my class Mu { # declared in BOOTSTRAP
 
     method dispatch:<!>(Mu \SELF: \name, Mu \type, |c) is raw {
         my $meth := type.^find_private_method(name);
-        my $class := nqp::getlexcaller('$?CLASS');
         $meth ??
             $meth(SELF, |c) !!
             X::Method::NotFound.new(
@@ -1034,7 +1033,7 @@ my class Mu { # declared in BOOTSTRAP
               method   => name,
               typename => type.^name,
               :private,
-              :in-class-call(nqp::eqaddr(nqp::what(SELF), $class)),
+              :in-class-call(nqp::eqaddr(nqp::what(SELF), nqp::getlexcaller('$?CLASS'))),
             ).throw;
     }
 

--- a/t/05-messages/01-errors.t
+++ b/t/05-messages/01-errors.t
@@ -2,7 +2,7 @@ use lib <t/packages/>;
 use Test;
 use Test::Helpers;
 
-plan 50;
+plan 51;
 
 # https://github.com/Raku/old-issue-tracker/issues/5707
 throws-like '1++', X::Multi::NoMatch,
@@ -220,6 +220,10 @@ throws-like { Blob.splice }, X::Multi::NoMatch,
         X::Method::NotFound,
         message => all(/<<"No such private method '!bar'" \W/, /<<'RT123078_2'>>/, /<<'bar'>>/, /<<'baz'>>/),
         'a public method of the same name as the missing private method is suggested';
+    throws-like q| class RT123078_3 { method !bar { }; method baz { } }; RT123078_3.new.bar |,
+        X::Method::NotFound,
+        message => all(/<<"No such method 'bar'" \W/, /<<'RT123078_3'>>/, /\s+ Did \s+ you \s+ mean \s+ "'baz'"/),
+        'a private method of the same name as the public missing method is not suggested for out-of-class call';
     throws-like q| <a a b>.uniq |,
         X::Method::NotFound,
         message => all(/<<"No such method 'uniq'" \W/, /<<'unique'>>/),


### PR DESCRIPTION
The exception can now provide user with a few additional tips depending on the context of the method call and what kind of mistake the user possibly made. Tips include, in addition to the traditional suggestion list of like candidates, the following two:

- `self!"private"()` syntax if `self."!private"()` form is presumably used.

- If a private method invoked but all suggested candidates are public then tip the user about possibly using public method call. Same advise is given for public invocation if all suggestions are private.

No private methods are suggested if call is made outside of a class body. The condition is checked by matching invocator class to `$?CLASS`.

Measures are taken not to flood the user with surplus tips.

Should fix #3802