### PR TITLE
Add a command line option `--rakudo-home` use it during build

### DIFF
--- a/src/Perl6/Compiler.nqp
+++ b/src/Perl6/Compiler.nqp
@@ -115,7 +115,8 @@ class Perl6::Compiler is HLL::Compiler {
                 ?? self.config<prefix>
                 !! nqp::substr($execname, 0, nqp::rindex($execname, $sep, nqp::rindex($execname, $sep) - 1));
 
-            $!rakudo-home := nqp::getenvhash()<RAKUDO_HOME>
+            $!rakudo-home := self.cli-options()<rakudo-home>
+                // nqp::getenvhash()<RAKUDO_HOME>
                 // nqp::getenvhash()<PERL6_HOME>
                 // self.config<static-rakudo-home>
                 || $install-dir ~ '/share/perl6';
@@ -182,6 +183,7 @@ and, by default, also executes the compiled code.
   -M module            loads the module prior to running the program
   --target=stage       specify compilation stage to emit
   --optimize=level     use the given level of optimization (0..3)
+  --rakudo-home=path   Override the path of the Rakudo runtime files
   -o, --output=name    specify name of output file
   -v, --version        display version information
   -V                   print configuration summary

--- a/src/main.nqp
+++ b/src/main.nqp
@@ -29,6 +29,7 @@ my @clo := $comp.commandline_options();
 @clo.push('I=s');
 @clo.push('M=s');
 @clo.push('nqp-lib=s');
+@clo.push('rakudo-home=s');
 
 #?if js
 @clo.push('beautify');

--- a/tools/templates/js/Makefile.in
+++ b/tools/templates/js/Makefile.in
@@ -4,7 +4,7 @@
 @bpv(NQP_BASE_FLAGS)@ = --nqp-runtime @bpm(RUNTIME)@ --perl6-runtime @perl6_runtime@ --libpath "@bpm(BLIB)@|||@nqp::libdir@@nfp(/nqp-js-on-js/)@"
 @bpv(NQP_FLAGS)@ = @bpm(NQP_BASE_FLAGS)@ --substagestats --stagestats --source-map
 @bpv(NQP_FLAGS_EXTRA)@ = --execname @bpm(RUNNER)@ --shebang
-@bpv(RUN_RAKUDO)@ = node --max-old-space-size=8192 rakudo.js @bpm(NQP_BASE_FLAGS)@ --source-map
+@bpv(RUN_RAKUDO)@ = node --max-old-space-size=8192 rakudo.js @bpm(NQP_BASE_FLAGS)@ --source-map --rakudo-home=@nfpq($(BASE_DIR)/gen/build_rakudo_home)@
 
 @bpv(CLEANUPS)@ = \
 	@bsm(RAKUDO)@ \

--- a/tools/templates/jvm/Makefile.in
+++ b/tools/templates/jvm/Makefile.in
@@ -5,7 +5,7 @@ JAR     = jar
 NQP_PREFIX  = @nqp_prefix@
 @bpv(NQP)@       = @shquot(@j_nqp@)@
 @bpv(NQP_RR)@    = $(JAVA) -Xss1m -Xms500m -Xmx3000m -cp @q(@nfp(./blib)@@cpsep@@nop($(BLD_NQP_JARS))@@cpsep@rakudo-runtime.jar@cpsep@@nop($(SYSROOT))@@abs2rel(@nqp_classpath@)@)@ nqp
-@bpv(RUN_RAKUDO)@ = $(JAVA) -Xss1m -Xms500m -Xmx3000m -cp @q(@nfp(./blib)@@cpsep@@nop($(BLD_NQP_JARS))@@cpsep@rakudo-runtime.jar@cpsep@rakudo.jar@cpsep@@nop($(SYSROOT))@@abs2rel(@nqp_classpath@)@)@ perl6
+@bpv(RUN_RAKUDO)@ = $(JAVA) -Xss1m -Xms500m -Xmx3000m -cp @q(@nfp(./blib)@@cpsep@@nop($(BLD_NQP_JARS))@@cpsep@rakudo-runtime.jar@cpsep@rakudo.jar@cpsep@@nop($(SYSROOT))@@abs2rel(@nqp_classpath@)@)@ perl6 --rakudo-home=@nfpq($(BASE_DIR)/gen/build_rakudo_home)@
 
 @bpv(DEBUG_RUNNER)@ = rakudo-debug-@backend_abbr@@bpm(RUNNER_SUFFIX)@
 

--- a/tools/templates/moar/Makefile.in
+++ b/tools/templates/moar/Makefile.in
@@ -11,7 +11,7 @@ MOAR_PREFIX = @nfp(@moar::prefix@)@
 MOAR        = @nfpq(@moar::bindir@/moar@moar::exe@)@
 @bpv(NQP)@       = @nfpq(@m_nqp@)@
 @bpv(NQP_RR)@    = @bpm(NQP)@
-@bpv(RUN_RAKUDO)@ = $(MOAR) --libpath=@nfpq($(BASE_DIR)/blib)@ --libpath=@q(@bpm(NQP_LIBDIR)@)@ @bsm(RAKUDO)@ --nqp-lib=@nfpq($(BASE_DIR)/blib)@
+@bpv(RUN_RAKUDO)@ = $(MOAR) --libpath=@nfpq($(BASE_DIR)/blib)@ --libpath=@q(@bpm(NQP_LIBDIR)@)@ @bsm(RAKUDO)@ --nqp-lib=@nfpq($(BASE_DIR)/blib)@ --rakudo-home=@nfpq($(BASE_DIR)/gen/build_rakudo_home)@
 
 @bpv(RUNNER_SUFFIX)@ = @moar::exe@
 


### PR DESCRIPTION
The precedence order of the different ways to set the Rakudo home is now:

1. Commandline option `--rakudo-home`
2. Environment variable `RAKUDO_HOME`
3. Static rakudo home set by `Configure.pl` when building a non-relocatable
   build
4. Dynamically determined by looking at the executables path - that's the
   relocatable build

During the build the first rakudo that is run (`RUN_RAKUDO` Makefile
variable) now passes the `--rakudo-home` parameter and sets the Rakudo
home to `$BUILD_DIR/gen/build_rakudo_home`. This makes sure this first
rakudo used during build does not use any files found in the install
directory.

This fixes #3798.

This PR touches the native runner script. That script is not covered by our CI yet. So still needs manual native testing. So it's a draft PR until those tests are done.