### PR TITLE
Deprecate nqp-lib

### DIFF
--- a/src/Perl6/Compiler.nqp
+++ b/src/Perl6/Compiler.nqp
@@ -54,6 +54,10 @@ class Perl6::Compiler is HLL::Compiler {
             %options<doc> := 'Text';
         }
 
+        if nqp::existskey(%options, 'nqp-lib') {
+            note('Option `--nqp-lib` is deprecated, has no effect and will be removed in 2021.06.');
+        }
+
         my $argiter := nqp::iterator(@args);
         nqp::shift($argiter) if $argiter && !nqp::defined(%options<e>);
         nqp::bindhllsym('Raku', '$!ARGITER', $argiter);

--- a/tools/build/create-jvm-runner.pl
+++ b/tools/build/create-jvm-runner.pl
@@ -8,9 +8,9 @@ use File::Spec;
 use File::Copy 'cp';
 use Cwd 'abs_path';
 
-my $USAGE = "Usage: $0 <type> <destdir> <prefix> <nqp-home> <rakudo-home> <blib> <third party jars>\n";
+my $USAGE = "Usage: $0 <type> <destdir> <prefix> <nqp-home> <rakudo-home> <third party jars>\n";
 
-my ($type, $destdir, $prefix, $static_nqp_home, $static_rakudo_home, $blib, $thirdpartyjars) = @ARGV
+my ($type, $destdir, $prefix, $static_nqp_home, $static_rakudo_home, $thirdpartyjars) = @ARGV
     or die $USAGE;
 
 my $relocatable = $static_nqp_home eq '' && $static_rakudo_home eq '';
@@ -49,7 +49,7 @@ my $rakudo_jars = join( $cpsep,
     File::Spec->catfile($jardir, 'rakudo-runtime.jar'),
     File::Spec->catfile($jardir, $debugger ? 'rakudo-debug.jar' : 'rakudo.jar'));
 
-my $NQP_LIB = $blib ? ': ${NQP_LIB:="blib"}' : '';
+my $NQP_LIB = $type eq 'install' ? '' : ': ${NQP_LIB:="blib"}';
 
 my $preamble_unix = <<'EOS';
 #!/bin/sh
@@ -156,10 +156,10 @@ if ($debugger) {
     install "perl6-debug-j", "java $jopts rakudo-debug";
 }
 else {
-    install "rakudo-j", "java $jopts perl6 $blib";
-    install "perl6-j", "java $jopts perl6 $blib";
-    install "rakudo-jdb-server", "java $jdbopts $jopts perl6 $blib";
-    install "perl6-jdb-server", "java $jdbopts $jopts perl6 $blib";
+    install "rakudo-j", "java $jopts perl6";
+    install "perl6-j", "java $jopts perl6";
+    install "rakudo-jdb-server", "java $jdbopts $jopts perl6";
+    install "perl6-jdb-server", "java $jdbopts $jopts perl6";
     install "rakudo-eval-server", "java -Xmx3000m $jopts org.raku.nqp.tools.EvalServer";
     install "perl6-eval-server", "java -Xmx3000m $jopts org.raku.nqp.tools.EvalServer";
 }

--- a/tools/templates/jvm/Makefile.in
+++ b/tools/templates/jvm/Makefile.in
@@ -45,7 +45,7 @@ $(RUNTIME_JAR): $(RUNTIME_JAVAS)
 
 $(J_RUNNER):    @@script(create-jvm-runner.pl)@@
 	@echo(+++ Setting up	$@)@
-	$(NOECHO)$(PERL5) @shquot(@script(create-jvm-runner.pl)@)@ dev . . @q(@static_nqp_home@)@ @q(@static_rakudo_home@)@ --nqp-lib=blib @q($(NQP_JARS))@
+	$(NOECHO)$(PERL5) @shquot(@script(create-jvm-runner.pl)@)@ dev . . @q(@static_nqp_home@)@ @q(@static_rakudo_home@)@ @q($(NQP_JARS))@
 
 @backend_prefix@-runner-default: @backend_prefix@-all
 	@echo(+++ Setting up @uc(@backend@)@ runner)@
@@ -54,7 +54,7 @@ $(J_RUNNER):    @@script(create-jvm-runner.pl)@@
 
 @bpm(DEBUG_RUNNER)@: @@script(create-jvm-runner.pl)@@ @bsm(RAKUDO_DEBUG)@
 	@echo(+++ Setting up	$@)@
-	$(NOECHO)$(PERL5) @shquot(@script(create-jvm-runner.pl)@)@ dev-debug . . @q(@static_nqp_home@)@ @q(@static_rakudo_home@)@ --nqp-lib=blib @q($(NQP_JARS))@
+	$(NOECHO)$(PERL5) @shquot(@script(create-jvm-runner.pl)@)@ dev-debug . . @q(@static_nqp_home@)@ @q(@static_rakudo_home@)@ @q($(NQP_JARS))@
 
 eval-client.pl:
 	@echo(+++ Setting up	$@)@
@@ -84,14 +84,14 @@ sometests: @backend_prefix@-all
 
 @backend_prefix@-runner-default-install: @backend_prefix@-install
 	@echo(+++ Installing @uc(@backend@)@ launcher)@
-	$(NOECHO)$(PERL5) @shquot(@script(create-jvm-runner.pl)@)@ install @q($(DESTDIR))@ @q($(PREFIX))@ @q(@static_nqp_home@)@ @q(@static_rakudo_home@)@ "" @q($(NQP_JARS))@
+	$(NOECHO)$(PERL5) @shquot(@script(create-jvm-runner.pl)@)@ install @q($(DESTDIR))@ @q($(PREFIX))@ @q(@static_nqp_home@)@ @q(@static_rakudo_home@)@ @q($(NQP_JARS))@
 	$(NOECHO)$(CP) @nfpq($(DESTDIR)$(PREFIX)/bin/rakudo-j$(J_BAT))@ @nfpq($(DESTDIR)$(PREFIX)/bin/rakudo$(J_BAT))@
 	$(NOECHO)$(CHMOD) 755 @nfpq($(DESTDIR)$(PREFIX)/bin/rakudo$(J_BAT))@
 
 @backend_prefix@-install-main:: $(RUNTIME_JAR) @@script(create-jvm-runner.pl)@@
 	$(NOECHO)$(CP) $(RUNTIME_JAR) @nfpq($(DESTDIR)$(RAKUDO_HOME)/runtime)@
-	$(NOECHO)$(PERL5) @shquot(@script(create-jvm-runner.pl)@)@ install @q($(DESTDIR))@ @q($(PREFIX))@ @q(@static_nqp_home@)@ @q($(NQP_PREFIX))@ "" @q($(NQP_JARS))@
-	$(NOECHO)$(PERL5) @shquot(@script(create-jvm-runner.pl)@)@ install-debug @q($(DESTDIR))@ @q($(PREFIX))@ @q(@static_nqp_home@)@ @q($(NQP_PREFIX))@ "" @q($(NQP_JARS))@
+	$(NOECHO)$(PERL5) @shquot(@script(create-jvm-runner.pl)@)@ install @q($(DESTDIR))@ @q($(PREFIX))@ @q(@static_nqp_home@)@ @q($(NQP_PREFIX))@ @q($(NQP_JARS))@
+	$(NOECHO)$(PERL5) @shquot(@script(create-jvm-runner.pl)@)@ install-debug @q($(DESTDIR))@ @q($(PREFIX))@ @q(@static_nqp_home@)@ @q($(NQP_PREFIX))@ @q($(NQP_JARS))@
 
 ##  cleaning
 @backend_prefix@-clean:

--- a/tools/templates/moar/Makefile-runner_opts.in
+++ b/tools/templates/moar/Makefile-runner_opts.in
@@ -1,1 +1,1 @@
-@shquot(--execname="\@envvar(EXEC)@" --libpath="\@envvar(DIR)@" --libpath="\@nfp(\@envvar(DIR)@/blib)@" --libpath="\@nfp(\@nqp::libdir@)@" "\@nfp(\@envvar(DIR)@/perl6.moarvm)@" --nqp-lib="\@nfp(\@envvar(DIR)@/blib)@")@
+@shquot(--execname="\@envvar(EXEC)@" --libpath="\@envvar(DIR)@" --libpath="\@nfp(\@envvar(DIR)@/blib)@" --libpath="\@nfp(\@nqp::libdir@)@" "\@nfp(\@envvar(DIR)@/perl6.moarvm)@")@

--- a/tools/templates/moar/Makefile.in
+++ b/tools/templates/moar/Makefile.in
@@ -11,7 +11,7 @@ MOAR_PREFIX = @nfp(@moar::prefix@)@
 MOAR        = @nfpq(@moar::bindir@/moar@moar::exe@)@
 @bpv(NQP)@       = @nfpq(@m_nqp@)@
 @bpv(NQP_RR)@    = @bpm(NQP)@
-@bpv(RUN_RAKUDO)@ = $(MOAR) --libpath=@nfpq($(BASE_DIR)/blib)@ --libpath=@q(@bpm(NQP_LIBDIR)@)@ @bsm(RAKUDO)@ --nqp-lib=@nfpq($(BASE_DIR)/blib)@ --rakudo-home=@nfpq($(BASE_DIR)/gen/build_rakudo_home)@
+@bpv(RUN_RAKUDO)@ = $(MOAR) --libpath=@nfpq($(BASE_DIR)/blib)@ --libpath=@q(@bpm(NQP_LIBDIR)@)@ @bsm(RAKUDO)@ --rakudo-home=@nfpq($(BASE_DIR)/gen/build_rakudo_home)@
 
 @bpv(RUNNER_SUFFIX)@ = @moar::exe@
 

--- a/tools/templates/moar/rakudo-m-build.c.in
+++ b/tools/templates/moar/rakudo-m-build.c.in
@@ -13,7 +13,7 @@ int main(int argc, char *argv[])
     char **exec_argv;
     char *moar = "@c_escape(@nfp(@MOAR@)@)@";
 
-    moar_argc = 6;
+    moar_argc = 5;
 
     // program name + moar args + passed args (without program name) + NULL pointer
     exec_argc = 1 + moar_argc + (argc - 1) + 1;
@@ -27,7 +27,6 @@ int main(int argc, char *argv[])
     exec_argv[3] = "--libpath=@c_escape(@nfp(@base_dir@/blib)@)@";
     exec_argv[4] = "--libpath=@c_escape(@nfp(@nqp_lib_dir@)@)@";
     exec_argv[5] = "@c_escape(@nfp(@base_dir@/@mbc@)@)@";
-    exec_argv[6] = "--nqp-lib=@c_escape(@nfp(@base_dir@/blib)@)@";
 
     // Copy passed args.
     for (c = 0; c < argc - 1; c++) {

--- a/tools/templates/moar/rakudo-m-build.c.windows
+++ b/tools/templates/moar/rakudo-m-build.c.windows
@@ -78,7 +78,7 @@ int wmain(int argc, wchar_t *argv[]) {
     STARTUPINFOW si;
     PROCESS_INFORMATION pi;
 
-    moar_argc = 7;
+    moar_argc = 6;
 
     // moar args + passed args (without program name) + NULL pointer
     exec_argc = moar_argc + (argc - 1) + 1;
@@ -91,7 +91,6 @@ int wmain(int argc, wchar_t *argv[]) {
     exec_argv[3] = L"--libpath=@c_escape(@nfp(@base_dir@/blib)@)@";
     exec_argv[4] = L"--libpath=@c_escape(@nfp(@nqp_lib_dir@)@)@";
     exec_argv[5] = L"@c_escape(@nfp(@base_dir@/@mbc@)@)@";
-    exec_argv[6] = L"--nqp-lib=@c_escape(@nfp(@base_dir@/blib)@)@";
 
     // Copy passed args.
     for (c = 0; c < argc - 1; c++) {


### PR DESCRIPTION
The option has been effect less for at least a year now. So remove all uses in Rakudo and add a deprecation notice.

This is for *after* the release.