### PR TITLE
Make sure overriding of angular associative postcircumfixes doesn't break compilation

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -6752,7 +6752,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
         make $past;
     }
 
-    method circumfix:sym<ang>($/) { make $<nibble>.ast; }
+    method circumfix:sym«< >»($/) { make $<nibble>.ast; }
 
     method circumfix:sym«<< >>»($/) { make $<nibble>.ast; }
 
@@ -8080,7 +8080,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
         make WANTED($past, '.{}');
     }
 
-    method postcircumfix:sym<ang>($/) {
+    method postcircumfix:sym«< >»($/) {
         my $past := QAST::Op.new( :name('&postcircumfix:<{ }>'), :op('call'), :node($/) );
         my $nib  := $<nibble>.ast;
         $past.push($nib)

--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -4526,7 +4526,11 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         'infix:sym<:=>', NQPMu,
         'infix:sym<::=>', NQPMu,
         'infix:sym<~~>', '(consider implementing an ACCEPTS method)',
-        'prefix:sym<|>', NQPMu);
+        'prefix:sym<|>', NQPMu,
+        'postcircumfix:sym«< >»', '(consider implementing \'&postcircumfix:<{ }>\', or method AT-KEY, or Associative role)',
+        'postcircumfix:sym«<< >>»', '(consider implementing \'&postcircumfix:<{ }>\', or method AT-KEY, or Associative role)',
+        'postcircumfix:sym<« »>', '(consider implementing \'&postcircumfix:<{ }>\', or method AT-KEY, or Associative role)',
+        );
     method add_categorical($category, $opname, $canname, $subname, $declarand?, :$defterm) {
         my $actions := self.actions;
 

--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -3636,7 +3636,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         '(' ~ ')' <semilist>
     }
     token circumfix:sym<[ ]> { :dba('array composer') '[' ~ ']' <semilist> }
-    token circumfix:sym<ang> {
+    token circumfix:sym«< >» {
         :dba('quote words')
         '<' ~ '>'
         [
@@ -3998,7 +3998,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         <O(|%methodcall)>
     }
 
-    token postcircumfix:sym<ang> {
+    token postcircumfix:sym«< >» {
         '<'
         [
         || <nibble(self.quote_lang(self.slang_grammar('Quote'), "<", ">", ['q', 'w', 'v']))> '>'


### PR DESCRIPTION
Rakudo currently fails to compile `< >` postcircumfix if code defines a `&postcirumfix:«< >»` candidate. This behavior is caused by the fact that aside from other operators, `< >` is defined using `token postcircumfix:sym<ang>` instead of `postcurcumfix:sym«< >»`, what would be the standard way.

Renaming the token and corresponding action methods results in silent ignoring of user-defined routine. Same happens with two other associative ops: `« »` and `<< >>`. With this PR all three will result in a error message like this:

```
Cannot override postcircumfix operator '< >', as it is a special form handled directly by the compiler
(consider implementing '&postcircumfix:<{ }>', or method AT-KEY, or Associative role)
```