### PR TITLE
Partial fix of mixing in a role with attributes into a NQP class

### DIFF
--- a/src/core.c/Attribute.pm6
+++ b/src/core.c/Attribute.pm6
@@ -26,7 +26,11 @@ my class Attribute { # declared in BOOTSTRAP
         if self.has_accessor {
             my str $name   = nqp::unbox_s(self.name);
             my $meth_name := nqp::substr($name, 2);
-            unless $package.^declares_method($meth_name) || $package.^has_multi_candidate($meth_name) {
+            unless nqp::existskey($package.^method_table, $meth_name)
+                    || nqp::existskey($package.^submethod_table, $meth_name)
+                    || (nqp::can($package.HOW, 'has_multi_candidate')
+                        && $package.^has_multi_candidate($meth_name))
+            {
                 my $dcpkg := nqp::decont($package);
                 my $meth;
                 my int $attr_type = nqp::objprimspec($!type);


### PR DESCRIPTION
When a Raku role with an attribute is mixed into a metamodel or NQP class rakudo throws `X::Method::NotFound`:

```raku
role Foo { has Mu $.bar }
"foo".HOW does Foo;
```

This PR is a fix. It also fixes `X::Method::NotFound` exception message code failing on `KnowHOW` objects because their `methods` method returns the method table, not a list of methods.