### PR TITLE
Fix incorrect method call

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -6169,7 +6169,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
         }
         my $ast_class := $*W.find_single_symbol('AST');
         unless istype($macro_ast, $ast_class) {
-            $*W.throw('X::TypeCheck::Splice',
+            $*W.throw($/, 'X::TypeCheck::Splice',
                 got         => $macro_ast,
                 expected    => $ast_class,
                 symbol      => $name,


### PR DESCRIPTION
`World::throw` needs grammar object as the first parameter