### PR TITLE
Start to use nqp::execname on the JVM backend

### DIFF
--- a/src/Perl6/SysConfig.nqp
+++ b/src/Perl6/SysConfig.nqp
@@ -6,13 +6,7 @@ class Perl6::SysConfig is HLL::SysConfig {
         %!rakudo-build-config := nqp::hash();
 
         # Determine Rakudo home.
-#?if jvm
-        # TODO could be replaced by nqp::execname() after the next bootstrap for JVM
-        my $execname := nqp::atkey(nqp::jvmgetproperties,'perl6.execname') // '';
-#?endif
-#?if !jvm
         my $execname := nqp::execname();
-#?endif
         my $install-dir := $execname eq ''
             ?? %!rakudo-build-config<prefix>
             !! nqp::substr($execname, 0, nqp::rindex($execname, self.path-sep, nqp::rindex($execname, self.path-sep) - 1));

--- a/src/core.c/Process.pm6
+++ b/src/core.c/Process.pm6
@@ -11,17 +11,15 @@ Rakudo::Internals.REGISTER-DYNAMIC: '$*RAKUDO_MODULE_DEBUG', {
 
 Rakudo::Internals.REGISTER-DYNAMIC: '$*EXECUTABLE', {
     PROCESS::<$EXECUTABLE> := IO::Path.new(:CWD(INIT nqp::cwd()),
+      nqp::execname()
 #?if jvm
-      $*VM.properties<perl6.execname>
       // $*VM.properties<perl6.prefix> ~ '/bin/perl6-j'
 #?endif
 #?if moar
-      nqp::execname()
       || ($*VM.config<prefix> ~ '/bin/'
         ~ ($*VM.config<osname> eq 'MSWin32' ?? 'perl6-m.exe' !! 'perl6-m'))
 #?endif
 #?if js
-      nqp::execname()
       // ($*VM.config<prefix> ~ '/bin/'
         ~ ($*VM.config<osname> eq 'MSWin32' ?? 'perl6-js.bat' !! 'perl6-js'))
 #?endif


### PR DESCRIPTION
The op is now available in Rakudo (after the last NQP bump).
(It's only NQP on the JVM backend that still needs a bootstrap.)