### PR TITLE
Simplify binary release instructions a little

### DIFF
--- a/docs/release-guide-binary.md
+++ b/docs/release-guide-binary.md
@@ -63,22 +63,24 @@ As of 2019-07-08 CentOS 6 (using glibc 2.12) is a good pick.
 - Use a 64 bit Linux.
 - Install docker.
 - `docker run -it --name=rakudo-build centos:6 bash`
-
-    yum -y update && yum clean all
-    yum install git perl perl-core gcc make
-    curl -L -o rakudo-2020.01.tar.gz https://rakudo.org/dl/rakudo/rakudo-2020.01.tar.gz
-    tar -xzf rakudo-2020.01.tar.gz
-    cd rakudo-2020.01
-    perl Configure.pl --gen-moar --gen-nqp --backends=moar --relocatable
-    make install
-    make test
-    git clone https://github.com/ugexe/zef.git
-    cd zef
-    /rakudo-2020.01/install/bin/raku -I. bin/zef install .
-    cd /rakudo-2020.01
-    cp -r tools/build/binary-release/Linux/* install
-    mv install rakudo-2020.01
-    tar -zcv --owner=0 --group=0 --numeric-owner -f /rakudo-moar-2020.01-01-linux-x86_64.tar.gz rakudo-2020.01
+- In the container
+```bash
+yum -y update && yum clean all
+yum install git perl perl-core gcc make
+curl -sSL -o rakudo.tar.gz https://rakudo.org/dl/rakudo/rakudo-2020.01.tar.gz
+tar -xzf rakudo.tar.gz
+cd rakudo-*
+perl Configure.pl --gen-moar --gen-nqp --backends=moar --relocatable
+make test
+make install
+git clone https://github.com/ugexe/zef.git
+cd zef
+/rakudo-*/install/bin/raku -I. bin/zef install .
+cd /rakudo-*
+cp -r tools/build/binary-release/Linux/* install
+mv install rakudo-2020.01
+tar -zcv --owner=0 --group=0 --numeric-owner -f /rakudo-moar-2020.01-01-linux-x86_64.tar.gz rakudo-2020.01
+```
 
 - On the host linux (not inside the container) run `docker cp rakudo-build:/rakudo-moar-2020.01-01-linux-x86_64.tar.gz .` to copy the archive out of the container. If you happended to stop the container by exitting the console, type `docker start rakudo-build` to start it again and allow copying files out.
 - Sign the tarball archive as described in `release_guide.pod`.


### PR DESCRIPTION
- They can now be copied more easily by using wildcards for some filenams.
- Also the code is now highlighted correctly.
- Some smaller changes to the commands.

In adapted form this pulls in the changes of PR#3287.