### PR TITLE
Fix Baggy.pickpairs with a Callable

### DIFF
--- a/src/core.c/Baggy.pm6
+++ b/src/core.c/Baggy.pm6
@@ -381,7 +381,7 @@ my role Baggy does QuantHash {
         )
     }
     multi method pickpairs(Baggy:D: Callable:D $calculate) {
-        self.pickpairs( $calculate(self.total) )
+        self.pickpairs( $calculate(self.elems) )
     }
     multi method pickpairs(Baggy:D: Whatever $) {
         self.pickpairs(Inf)


### PR DESCRIPTION
Baggy.pickpairs' Callable should be invoked with the Baggy number of
elements as the pairs are picked independently of the elements' weight
in the Baggy object.

See proposed test included in Raku/roast#668