### PR TITLE
Suggest method names without checking for capitalization

### DIFF
--- a/src/core.c/Exception.pm6
+++ b/src/core.c/Exception.pm6
@@ -217,8 +217,10 @@ my class X::Method::NotFound is Exception {
                     %suggestions{$method_name} = "";  # assume identity
                 }
                 else {
-                    my $dist =
-                      StrDistance.new(:before($.method), :after($method_name));
+                    my $dist = StrDistance.new(
+                      before => $.method.fc,
+                      after  => $method_name.fc
+                    );
                     if $dist <= $max_length {
                         $public_suggested = 1;
                         %suggestions{$method_name} = ~$dist;
@@ -230,7 +232,10 @@ my class X::Method::NotFound is Exception {
         my $private_suggested = 0;
         if $.in-class-call && nqp::can($!invocant.HOW, 'private_method_table') {
             for $!invocant.^private_method_table.keys -> $method_name {
-                my $dist = StrDistance.new(:before($.method), :after(~$method_name));
+                my $dist = StrDistance.new(
+                  before => $.method.fc,
+                  after  => $method_name.fc
+                );
                 if $dist <= $max_length {
                     $private_suggested = 1;
                     %suggestions{"!$method_name"} = ~$dist

--- a/t/05-messages/01-errors.t
+++ b/t/05-messages/01-errors.t
@@ -222,7 +222,7 @@ throws-like { Blob.splice }, X::Multi::NoMatch,
         'a public method of the same name as the missing private method is suggested';
     throws-like q| class RT123078_3 { method !bar { }; method baz { } }; RT123078_3.new.bar |,
         X::Method::NotFound,
-        message => all(/<<"No such method 'bar'" \W/, /<<'RT123078_3'>>/, /\s+ Did \s+ you \s+ mean \s+ "'baz'"/),
+        message => all(/<<"No such method 'bar'" \W/, /<<'RT123078_3'>>/, /\s+ Did \s+ you \s+ mean/),
         'a private method of the same name as the public missing method is not suggested for out-of-class call';
     throws-like q| <a a b>.uniq |,
         X::Method::NotFound,

--- a/t/05-messages/01-errors.t
+++ b/t/05-messages/01-errors.t
@@ -223,6 +223,7 @@ throws-like { Blob.splice }, X::Multi::NoMatch,
     throws-like q| class RT123078_3 { method !bar { }; method baz { } }; RT123078_3.new.bar |,
         X::Method::NotFound,
         message => all(/<<"No such method 'bar'" \W/, /<<'RT123078_3'>>/, /\s+ Did \s+ you \s+ mean/),
+        suggestions => <Bag baz>,
         'a private method of the same name as the public missing method is not suggested for out-of-class call';
     throws-like q| <a a b>.uniq |,
         X::Method::NotFound,


### PR DESCRIPTION
Currently, an expression like `say 42.which` will fail with:

  No such method 'which' for invocant of type 'Int'

*without* suggesting .WHICH.  This patch changes that to:

  No such method 'which' for invocant of type 'Int'.  Did you mean 'WHICH'?