### PR TITLE
Add Mu.WHAT for introspection

### DIFF
--- a/src/core.c/Mu.pm6
+++ b/src/core.c/Mu.pm6
@@ -11,6 +11,10 @@ my class Mu { # declared in BOOTSTRAP
 
     method sink(--> Nil) { }
 
+    # This method is only here so that it can be introspected.  The codegen
+    # will actually generate an nqp::what in all cases.
+    method WHAT() { self.WHAT }
+
     proto method perl(|) {*}
     multi method perl(Mu \SELF: |c) { SELF.raku(|c) }
     # although technically not a documented method, some module authors have


### PR DESCRIPTION
Yes, foo.WHAT will be codegenned without actually calling any method.
But to not have a method Mu.WHAT also means it won't show up in any
introspection or error messages.

Together with b7ff282fc5, this will suggest WHAT for "say 42.what".