### PR TITLE
Streamline X::Multi::Ambiguous listing

### DIFF
--- a/src/core.c/Exception.pm6
+++ b/src/core.c/Exception.pm6
@@ -2772,7 +2772,7 @@ my class X::Multi::Ambiguous is Exception {
         @priors.join ~ join "\n",
             "Ambiguous call to '$.dispatcher.name()$cap'; these signatures all match:",
             @.ambiguous.map: {
-                my $sig := .signature.raku.substr(1);
+                my $sig := .signature.raku.substr(1).subst(/ \s* "-->" <-[)]>+ /);
                 .?default ?? "  $sig is default" !! "  $sig"
             }
     }

--- a/src/core.c/Exception.pm6
+++ b/src/core.c/Exception.pm6
@@ -2771,7 +2771,10 @@ my class X::Multi::Ambiguous is Exception {
         @priors = flat "Earlier failures:\n", @priors, "\nFinal error:\n " if @priors;
         @priors.join ~ join "\n",
             "Ambiguous call to '$.dispatcher.name()$cap'; these signatures all match:",
-            @.ambiguous.map(*.signature.raku)
+            @.ambiguous.map: {
+                my $sig := .signature.raku.substr(1);
+                .?default ?? "  $sig is default" !! "  $sig"
+            }
     }
 }
 


### PR DESCRIPTION
- remove ":", it does not convey any information, clear it's a signature
- add two spaces to set it off the first line
- add "is default" status of the candidate when applicable