### PR TITLE
Make X::Method::NotFound case-insensitive

### DIFF
--- a/src/core.c/Exception.pm6
+++ b/src/core.c/Exception.pm6
@@ -208,7 +208,7 @@ my class X::Method::NotFound is Exception {
                 my $method_name = code-name($method_candidate);
                 # GH#1758 do not suggest a submethod from a parent
                 next if $method_candidate.^name eq 'Submethod' && !@invocant_methods.first($method_name, :k).defined;
-                my $dist = StrDistance.new(:before($.method), :after(~$method_name));
+                my $dist = StrDistance.new(:before($.method.fc), :after(~$method_name.fc));
                 if $dist <= $max_length {
                     $public_suggested = 1;
                     %suggestions{$method_name} = ~$dist;
@@ -219,7 +219,7 @@ my class X::Method::NotFound is Exception {
         my $private_suggested = 0;
         if $.in-class-call && nqp::can($!invocant.HOW, 'private_method_table') {
             for $!invocant.^private_method_table.keys -> $method_name {
-                my $dist = StrDistance.new(:before($.method), :after(~$method_name));
+                my $dist = StrDistance.new(:before($.method.fc), :after(~$method_name.fc));
                 if $dist <= $max_length {
                     $private_suggested = 1;
                     %suggestions{"!$method_name"} = ~$dist

--- a/t/05-messages/01-errors.t
+++ b/t/05-messages/01-errors.t
@@ -222,7 +222,7 @@ throws-like { Blob.splice }, X::Multi::NoMatch,
         'a public method of the same name as the missing private method is suggested';
     throws-like q| class RT123078_3 { method !bar { }; method baz { } }; RT123078_3.new.bar |,
         X::Method::NotFound,
-        message => all(/<<"No such method 'bar'" \W/, /<<'RT123078_3'>>/, /\s+ Did \s+ you \s+ mean \s+ "'baz'"/),
+        message => all(/<<"No such method 'bar'" \W/, /<<'RT123078_3'>>/, /<<'baz'>>/,  none(/<<'!bar'>>/)),
         'a private method of the same name as the public missing method is not suggested for out-of-class call';
     throws-like q| <a a b>.uniq |,
         X::Method::NotFound,


### PR DESCRIPTION
When an `X::Method::NotFound` exception is thrown, it's `.message` method suggests up to four similar methods that the user might have meant.  However, it computes "similar" methods based on a case-sensitive comparison of the user-supplied method and methods available on the object.

This case sensitivity can result in methods not being suggested even though they are largely similar (or even identical) to
the method the user supplied, apart from case. This can be a particular problem for methods that new users may have forgotten are all uppercase.  For example, `why` and `WHY` share no letters when compared in a case-sensitive way.

This commit resolves this issue by calling `.fc` before performing the comparison.  This may *very* slightly slow the comparison, but I am not concerned – when generating the message from `X::Method::NotFound`, the program is very likely to be in an unrecoverable state, where extremely slight performance issues are unlikely to have an impact.

This commit updates the corresponding test, and hopefully makes it slightly less fragile – it no longer tests against the suggested
methods being an exact match, but just tests that private methods are correctly excluded.

Solves #3859