### PR TITLE
Precomp store parallelism

### DIFF
--- a/src/core.c/CompUnit/PrecompilationRepository.pm6
+++ b/src/core.c/CompUnit/PrecompilationRepository.pm6
@@ -339,6 +339,14 @@ Need to re-check dependencies.")
            :$precomp-stores,
     --> Bool:D) {
 
+        my $env := nqp::clone(nqp::getattr(%*ENV,Map,'$!storage'));
+        my $rpl := nqp::atkey($env,'RAKUDO_PRECOMP_LOADING');
+        if $rpl {
+            my @modules := Rakudo::Internals::JSON.from-json: $rpl;
+            die "Circular module loading detected trying to precompile $path"
+              if $path.Str (elem) @modules;
+        }
+
         # obtain destination, lock the store for other processes
         my $store := self.store;
         my $io    := $store.destination($compiler-id, $id);
@@ -360,17 +368,14 @@ Need to re-check dependencies.")
         }
 
         # Local copy for us to tweak
-        my $env := nqp::clone(nqp::getattr(%*ENV,Map,'$!storage'));
+        $env := nqp::clone($env);
 
         my $REPO := $*REPO;
         nqp::bindkey($env,'RAKUDO_PRECOMP_WITH',
           $REPO.repo-chain.map(*.path-spec).join(',')
         );
 
-        if nqp::atkey($env,'RAKUDO_PRECOMP_LOADING') -> $rpl {
-            my @modules := Rakudo::Internals::JSON.from-json: $rpl;
-            die "Circular module loading detected trying to precompile $path"
-              if $path.Str (elem) @modules;
+        if $rpl {
             nqp::bindkey($env,'RAKUDO_PRECOMP_LOADING',
               $rpl.chop
                 ~ ','

--- a/src/core.c/CompUnit/PrecompilationRepository.pm6
+++ b/src/core.c/CompUnit/PrecompilationRepository.pm6
@@ -506,6 +506,7 @@ Need to re-check dependencies.")
         $!RMD("Writing dependencies and byte code to $io.tmp for source checksum: $source-checksum")
           if $!RMD;
 
+        $store.store-repo-id($compiler-id, $id, :repo-id($REPO.id));
         $store.store-unit(
             $compiler-id,
             $id,
@@ -517,7 +518,6 @@ Need to re-check dependencies.")
             ),
         );
         $bc.unlink;
-        $store.store-repo-id($compiler-id, $id, :repo-id($REPO.id));
         $store.unlock;
         True
     }

--- a/src/core.c/CompUnit/PrecompilationStore/File.pm6
+++ b/src/core.c/CompUnit/PrecompilationStore/File.pm6
@@ -118,7 +118,6 @@ class CompUnit::PrecompilationStore::File
     has IO::Path:D $.prefix is built(:bind) is required;
 
     has IO::Handle $!lock;
-    has int $!wont-lock;
     has int $!lock-count;
     has $!loaded;
     has $!dir-cache;
@@ -127,9 +126,6 @@ class CompUnit::PrecompilationStore::File
 
     submethod TWEAK(--> Nil) {
         $!update-lock := Lock.new;
-        if $*W -> $World {
-            $!wont-lock = 1 if $World.is_precompilation_mode;
-        }
         $!loaded         := nqp::hash;
         $!dir-cache      := nqp::hash;
         $!compiler-cache := nqp::hash;
@@ -168,31 +164,24 @@ class CompUnit::PrecompilationStore::File
         self!dir($compiler-id, $precomp-id).add($precomp-id ~ $extension)
     }
 
-    method !lock(--> Nil) {
-        unless $!wont-lock {
-            $!update-lock.lock;
-            $!lock := $.prefix.add('.lock').open(:create, :rw)
-              unless $!lock;
-            $!lock.lock if $!lock-count++ == 0;
-        }
+    method !lock($path --> Nil) {
+        $!update-lock.lock;
+        $!lock := "$path.lock".IO.open(:create, :rw)
+          unless $!lock;
+        $!lock.lock if $!lock-count++ == 0;
     }
 
     method unlock() {
-        if $!wont-lock {
-            Nil
-        }
-        else {
-            LEAVE $!update-lock.unlock;
-            die "unlock when we're not locked!" if $!lock-count == 0;
+        LEAVE $!update-lock.unlock;
+        die "unlock when we're not locked!" if $!lock-count == 0;
 
-            $!lock-count-- if $!lock-count > 0;
-            if $!lock && $!lock-count == 0 {
-                $!lock.unlock;
-                $!lock.close;
-                $!lock := IO::Handle;
-            }
-            True
+        $!lock-count-- if $!lock-count > 0;
+        if $!lock && $!lock-count == 0 {
+            $!lock.unlock;
+            $!lock.close;
+            $!lock := IO::Handle;
         }
+        True
     }
 
     method load-unit(
@@ -205,7 +194,7 @@ class CompUnit::PrecompilationStore::File
               nqp::atkey($!loaded,$key),
               do {
                   my $path := self.path($compiler-id, $precomp-id);
-                  $path.e
+                  $path.s
                     ?? nqp::bindkey($!loaded,$key,
                          CompUnit::PrecompilationUnit::File.new(
                            :id($precomp-id), :$path, :store(self)))
@@ -220,7 +209,7 @@ class CompUnit::PrecompilationStore::File
       CompUnit::PrecompilationId:D $precomp-id
     ) {
         my $path := self.path($compiler-id, $precomp-id, :extension<.repo-id>);
-        $path.e
+        $path.s
           ?? $path.slurp
           !! Nil
     }
@@ -239,7 +228,7 @@ class CompUnit::PrecompilationStore::File
 
         # have a writable prefix, assume it's a directory
         if $!prefix.w {
-            self!lock();
+            self!lock(self!file($compiler-id, $precomp-id));
             self!file($compiler-id, $precomp-id, :$extension);
         }
 

--- a/t/02-rakudo/reproducible-builds.t
+++ b/t/02-rakudo/reproducible-builds.t
@@ -1,10 +1,17 @@
-use lib 'lib';
-BEGIN my $compiler-id = CompUnit::PrecompilationId.new-without-check($*PERL.compiler.id);
-BEGIN my $id = CompUnit::PrecompilationId.new('1F3B9959EF798485A266FE735E772328311AD787');
-BEGIN my $dest = $*REPO.precomp-store.destination($compiler-id, $id); # not really used
-END { $*REPO.precomp-store.unlock }
+my constant $lib = $*TMPDIR.child("rakudo-lib" ~ (^2**128).pick.base(36));
+BEGIN {
+    $lib.child('NativeCall').mkdir;
+    $lib.child('NativeCall').child('Compiler').mkdir;
+    'lib'.IO.child('NativeCall.rakumod').copy: $lib.child('NativeCall.rakumod');
+    'lib'.IO.child('NativeCall').child('Types.rakumod').copy: $lib.child('NativeCall').child('Types.rakumod');
+    'lib'.IO.child('NativeCall').child('Compiler').child('GNU.rakumod').copy: $lib.child('NativeCall').child('Compiler').child('GNU.rakumod');
+    'lib'.IO.child('NativeCall').child('Compiler').child('MSVC.rakumod').copy: $lib.child('NativeCall').child('Compiler').child('MSVC.rakumod');
+}
+use lib $lib;
+
 use Test;
 use NativeCall; # precompile dependencies
+
 
 my $store = CompUnit::PrecompilationStore::File.new(
     :prefix($*TMPDIR.child("rakudo-precomp" ~ (^2**128).pick.base(36)))
@@ -12,6 +19,8 @@ my $store = CompUnit::PrecompilationStore::File.new(
 my $precompilation-repository = CompUnit::PrecompilationRepository::Default.new(:$store);
 my @checksums;
 my @units;
+my $compiler-id = CompUnit::PrecompilationId.new-without-check($*PERL.compiler.id);
+my constant $id = CompUnit::PrecompilationId.new-without-check('6B7A1AECF02807F30DDAD99C02C34440CA036AF6');
 for ^2 -> $run {
     $precompilation-repository.precompile(
         'lib/NativeCall.rakumod'.IO,


### PR DESCRIPTION
This PR reverts the API changes contained in https://github.com/rakudo/rakudo/pull/3785 and implements fine grained locking in `PrecompStore::File` without any changes to its or PrecompilationRepository's API.