### PR TITLE
Make JVM honor $PERL6_HOME env variable

### DIFF
--- a/tools/build/create-jvm-runner.pl
+++ b/tools/build/create-jvm-runner.pl
@@ -99,6 +99,7 @@ elsif ($type eq 'install') {
             $preamble_unix,
             ": \${NQP_HOME:=\"\$DIR/../share/nqp\"}",
             ": \${NQP_JARS:=\"$nqpjars\"}",
+            ": \${RAKUDO_HOME:=\"\$PERL6_HOME\"}",
             ": \${RAKUDO_HOME:=\"\$DIR/../share/perl6\"}",
             ": \${RAKUDO_JARS:=\"$rakudo_jars\"}",
             "exec "
@@ -109,6 +110,7 @@ elsif ($type eq 'install') {
             $preamble_unix,
             ": \${NQP_HOME:=\"$static_nqp_home\"}",
             ": \${NQP_JARS:=\"$nqpjars\"}",
+            ": \${RAKUDO_HOME:=\"\$PERL6_HOME\"}",
             ": \${RAKUDO_HOME:=\"$static_rakudo_home\"}",
             ": \${RAKUDO_JARS:=\"$rakudo_jars\"}",
             "exec "

--- a/tools/build/create-jvm-runner.pl
+++ b/tools/build/create-jvm-runner.pl
@@ -28,12 +28,15 @@ my $bat       = $^O eq 'MSWin32' ? '.bat' : '';
 my $nqplibdir = $^O eq 'MSWin32' ? File::Spec->catfile($static_nqp_home, 'lib') : File::Spec->catfile('${NQP_HOME}', 'lib');
 
 my $nqpjars;
-if ($^O eq 'MSWin32' || !$relocatable) {
+if ($^O eq 'MSWin32') {
     $nqpjars = $thirdpartyjars;
 }
-elsif ($relocatable) {
+else {
+    # The following is a workaround turning the third-party JARS into relative
+    # paths. The clean solution would be to pass in relative paths and only
+    # prefix those with ${NQP_HOME} here.
     my @thirdpartyjars = map { abs_path($_) } split($cpsep, $thirdpartyjars);
-    my $nqp_home       = abs_path(File::Spec->catpath($prefix, 'share', 'nqp'));
+    my $nqp_home       = File::Spec->catdir(abs_path($prefix), 'share', 'nqp');
     @thirdpartyjars    = map { $_ =~ s,$nqp_home,\${NQP_HOME},; $_ } @thirdpartyjars;
     $nqpjars           = join($cpsep, @thirdpartyjars);
 }


### PR DESCRIPTION
This PR changes the JVM runner script generator to also listen to the `$PERL6_HOME` environment variable in addition to `$RAKUDO_HOME`.

Also make sure non-relocatable builds work with a `$NQP_HOME` set.

Also clean up the generator script a bit and fix a bug that caused the NQP jars to not be made relocatable. This might actually get relocatability on the JVM backend working for the first time.

Fixes #3842 

I'm inclined to not merge this before the release as these changes are not covered by CI and have the potential to break the JVM backend.