### PR TITLE
Make Mu.Int work the same as Mu.Numeric

### DIFF
--- a/src/core.c/Cool.pm6
+++ b/src/core.c/Cool.pm6
@@ -409,7 +409,6 @@ my class Cool { # declared in BOOTSTRAP
         )
     }
 
-    proto method Int(|) {*}
     multi method Int()  {
         nqp::if(
             nqp::istype((my $numeric := self.Numeric), Failure),

--- a/src/core.c/Mu.pm6
+++ b/src/core.c/Mu.pm6
@@ -639,14 +639,16 @@ my class Mu { # declared in BOOTSTRAP
     }
 
     proto method Numeric(|) {*}
-    multi method Numeric(Mu:U \v:) {
+    multi method Numeric(Mu:U: --> 0) {
         warn "Use of uninitialized value of type {self.^name} in numeric context";
-        0
     }
     proto method Real(|) {*}
-    multi method Real(Mu:U \v:) {
+    multi method Real(Mu:U: --> 0) {
         warn "Use of uninitialized value of type {self.^name} in numeric context";
-        0
+    }
+    proto method Int(|) {*}
+    multi method Int(Mu:U: --> 0) {
+        warn "Use of uninitialized value of type {self.^name} in numeric context";
     }
 
     proto method Str(|) {*}


### PR DESCRIPTION
Calling `Int` on a type object, fails with:

  Invocant of method 'Int' must be an object instance of type 'Str', not
  a type object of type 'Str'.  Did you forget a '.new'?

Yet, if we call `Numeric` or `Real` on a type object, we get:

  Use of uninitialized value of type Foor in numeric context

and get a 0 in return.

This commit makes `Int` on type objects act the same way.