### PR TITLE
Remove special handling of ne and != wrt Junctions

### DIFF
--- a/src/core.c/Numeric.pm6
+++ b/src/core.c/Numeric.pm6
@@ -308,9 +308,9 @@ multi sub infix:<=~=>(\a, \b, :$tolerance = $*TOLERANCE)    {
 # U+2245 APPROXIMATELY EQUAL TO
 my constant &infix:<≅> = &infix:<=~=>;
 
-proto sub infix:<!=>(Mu $?, Mu $?, *%) is pure  {*}
+proto sub infix:<!=>($?, $?, *%) is pure  {*}
 multi sub infix:<!=>($?)                    { Bool::True }
-multi sub infix:<!=>(Mu \a, Mu \b)          { not a == b }
+multi sub infix:<!=>(\a, \b)                { not a == b }
 # U+2260 NOT EQUAL TO
 my constant &infix:<≠> := &infix:<!=>;
 

--- a/src/core.c/Numeric.pm6
+++ b/src/core.c/Numeric.pm6
@@ -308,9 +308,13 @@ multi sub infix:<=~=>(\a, \b, :$tolerance = $*TOLERANCE)    {
 # U+2245 APPROXIMATELY EQUAL TO
 my constant &infix:<≅> = &infix:<=~=>;
 
-proto sub infix:<!=>($?, $?, *%) is pure  {*}
-multi sub infix:<!=>($?)                    { Bool::True }
-multi sub infix:<!=>(\a, \b)                { not a == b }
+proto sub infix:<!=>(Mu $?, Mu $?, *%) is pure  {*}
+multi sub infix:<!=>($?) { Bool::True }
+multi sub infix:<!=>(Mu \a, Mu \b) {
+    nqp::istype(($_ := a == b),Junction)
+      ?? $_ but .not
+      !! $_.not
+}
 # U+2260 NOT EQUAL TO
 my constant &infix:<≠> := &infix:<!=>;
 

--- a/src/core.c/Stringy.pm6
+++ b/src/core.c/Stringy.pm6
@@ -36,9 +36,8 @@ proto sub infix:<eq>($?, $?, *%)  is pure {*}
 multi sub infix:<eq>($x?)          { Bool::True }
 multi sub infix:<eq>(\a, \b)       { a.Stringy eq b.Stringy }
 
-proto sub infix:<ne>(Mu $?, Mu $?, *%) is pure {*}
+proto sub infix:<ne>($?, $?, *%) is pure {*}
 multi sub infix:<ne>($x?)            { Bool::True }
-multi sub infix:<ne>(Mu \a, Mu \b)   { a !eq b }
 multi sub infix:<ne>(Any \a, Any \b) { a.Stringy ne b.Stringy }
 
 proto sub infix:<lt>($?, $?, *%) is pure {*}

--- a/src/core.c/Stringy.pm6
+++ b/src/core.c/Stringy.pm6
@@ -36,9 +36,13 @@ proto sub infix:<eq>($?, $?, *%)  is pure {*}
 multi sub infix:<eq>($x?)          { Bool::True }
 multi sub infix:<eq>(\a, \b)       { a.Stringy eq b.Stringy }
 
-proto sub infix:<ne>($?, $?, *%) is pure {*}
-multi sub infix:<ne>($x?)            { Bool::True }
-multi sub infix:<ne>(Any \a, Any \b) { a.Stringy ne b.Stringy }
+proto sub infix:<ne>(Mu $?, Mu $?, *%) is pure {*}
+multi sub infix:<ne>($x?) { Bool::True }
+multi sub infix:<ne>(Mu \a, Mu \b) {
+    nqp::istype(($_ := a.Stringy eq b.Stringy),Junction)
+      ?? $_ but .not
+      !! .not
+}
 
 proto sub infix:<lt>($?, $?, *%) is pure {*}
 multi sub infix:<lt>($x?)          { Bool::True }


### PR DESCRIPTION
This is a proof of concept.  It breaks the following tests:

t/spec/S03-junctions/boolean-context.t                          (Wstat: 256 Tests: 74 Failed: 1)
  Failed test:  72
t/spec/S03-junctions/autothreading.t                            (Wstat: 768 Tests: 106 Failed: 3)
  Failed tests:  79-80, 85
t/spec/S03-operators/misc.rakudo.moar                           (Wstat: 256 Tests: 78 Failed: 1)
  Failed test:  74

t/04-nativecall/18-routine-sig-sanity.t                       (Wstat: 512 Tests: 35 Failed: 2)
  Failed tests:  3, 7

Should we decide to do this, we will probably need a version check for this.
So this will have to wait for the newdisp branch to be merged.