### PR TITLE
Add definiteness constraint to convenience methods

### DIFF
--- a/src/core.c/BagHash.pm6
+++ b/src/core.c/BagHash.pm6
@@ -312,7 +312,7 @@ my class BagHash does Baggy {
     }
 
 #--- convenience methods
-    method add(\to-add --> Nil) {
+    method add(BagHash:D: \to-add --> Nil) {
         nqp::bindattr(
           self,SetHash,'$!elems',nqp::create(Rakudo::Internals::IterationSet)
         ) unless $!elems;
@@ -321,7 +321,7 @@ my class BagHash does Baggy {
         );
     }
 
-    method remove(\to-remove --> Nil) {
+    method remove(BagHash:D: \to-remove --> Nil) {
         Rakudo::QuantHash.SUB-ITERATOR-FROM-BAG(
           $!elems, to-remove.iterator
         ) if $!elems;

--- a/src/core.c/SetHash.pm6
+++ b/src/core.c/SetHash.pm6
@@ -271,7 +271,7 @@ my class SetHash does Setty {
     }
 
 #--- convenience methods
-    method set(\to-set --> Nil) {
+    method set(SetHash:D: \to-set --> Nil) {
         nqp::bindattr(
           self,SetHash,'$!elems',nqp::create(Rakudo::Internals::IterationSet)
         ) unless $!elems;
@@ -280,7 +280,7 @@ my class SetHash does Setty {
         );
     }
 
-    method unset(\to-unset --> Nil) {
+    method unset(SetHash:D: \to-unset --> Nil) {
         my \iterator := to-unset.iterator;
         nqp::until(
           nqp::eqaddr((my \pulled := iterator.pull-one),IterationEnd),


### PR DESCRIPTION
The `set`/`unset` methods on `SetHash` and the `add`/`remove` methods on `BagHash` cannot be called on type objects; there's no meaningful way to add or remove an element from a non-definite item.  However, the methods were not previously constrained to require a definite invocant, which means that invoking the methods with a type object resulted in a slightly confusing error: «Cannot look up attributes in a $Type type object».

This commit adds the missing constraints, which improves the error message to: «Invocant of method '$method' must be an object instance of type '$Type', not a type object of type '$Type'.  Did you forget a '.new'?».