### PR TITLE
Add a tests for `raku -V`

### DIFF
--- a/t/02-rakudo/17-cli.t
+++ b/t/02-rakudo/17-cli.t
@@ -1,0 +1,10 @@
+use Test;
+
+plan 3;
+
+{
+    my $p := run $*EXECUTABLE, '-V', :out, :err;
+    is $p.exitcode,                0,        '`raku -V` succeeds';
+    like $p.out.slurp(:close),     / 'Raku::implementation=Rakudo' /, '`raku -V` prints configuration options';
+    is $p.err.slurp(:close).chars, 0,        '`raku -V` doesn\'t print to STDERR';
+}


### PR DESCRIPTION
Make sure it succeeds and returns config options. Don't do any deep
inspection of the configuration options. (Which would be a bad idea.)

Fixes #3875