### PR TITLE
New coercion semantics

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -9219,12 +9219,14 @@ class Perl6::Actions is HLL::Actions does STDActions {
 
             # Handle coercion.
             my $param_type := nqp::getattr($param_obj, $Param, '$!type');
+            my $ptype_archetypes := $param_type.HOW.archetypes;
             if nqp::getenvhash<RAKUDO_DEBUG> {
-                if !$param_obj.coercive && $param_type.HOW.archetypes.coercive {
-                    nqp::say("!!! Parameter " ~ $param_obj.name ~ " doesn't have coercive flag");
+                note("!!! Parameter(", ($param_obj.name || '*unnamed*'), ") type: ", $param_type.HOW.name($param_type), ", generic? ", $param_type.HOW.archetypes.generic);
+                if !$param_obj.coercive && nqp::can($ptype_archetypes, 'coercive') && $ptype_archetypes.coercive {
+                    note("!!! Parameter " ~ $param_obj.name ~ " doesn't have coercive flag");
                 }
             }
-            if $param_type.HOW.archetypes.generic {
+            if $ptype_archetypes.generic {
                 # For a generic-typed parameter get its instantiated clone and see if its type is a coercion.
                 nqp::say("Generic param type on " ~ $param_obj.name) if nqp::getenvhash<RAKUDO_DEBUG>;
                 $decont_name_invalid := 1;
@@ -9289,7 +9291,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
                                     QAST::Var.new(:name($low_param_type), :scope('local')),
                                     QAST::Var.new(:name($name), :scope('local')))))));
             }
-            elsif $param_type.HOW.archetypes.coercive {
+            elsif nqp::can($ptype_archetypes, 'coercive') && $ptype_archetypes.coercive {
                 # if $param_type.HOW.archetypes.generic {
                 #     return 0;
                 # }

--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -18,7 +18,7 @@ my int $?BITS := nqp::isgt_i(nqp::add_i(2147483648, 1), 0) ?? 64 !! 32;
 sub block_closure($code, :$regex) {
     my $clone := QAST::Op.new( :op('callmethod'), :name('clone'), $code );
     if $regex {
-        if $*W.lang-ver-before('d') {
+        if $*W.lang-rev-before('d') {
             my $marker := $*W.find_symbol(['Rakudo', 'Internals', 'RegexBoolification6cMarker']);
             $clone.push(QAST::WVal.new( :value($marker), :named('topic') ));
         }
@@ -1362,7 +1362,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
               QAST::WVal.new(:value($main<value>)),
               $mainline             # run the mainline and get its result
             );
-            unless $*W.lang-ver-before('d') {
+            unless $*W.lang-rev-before('d') {
                 $mainline.push(
                   QAST::WVal.new( # $*IN as $*ARGSFILES
                     value => $*W.find_symbol(['Bool','True'], :setting-only),
@@ -1553,7 +1553,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
                 my $ast := $statements[0].ast;
 
                 # an op and 6e or higher?
-                if nqp::istype($ast,QAST::Op) && !$*W.lang-ver-before("e") {
+                if nqp::istype($ast,QAST::Op) && !$*W.lang-rev-before("e") {
                     sub is-pipe-pipe($ast) {
                         nqp::istype($ast,QAST::Op)
                           && $ast.name eq '&prefix:<|>'
@@ -2546,7 +2546,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
             QAST::WVal.new( :value($*W.find_single_symbol('Promise')) ),
             $<blorst>.ast
         );
-        unless $*W.lang-ver-before('d') {
+        unless $*W.lang-rev-before('d') {
             $qast.push(QAST::WVal.new(
                 :value($*W.find_symbol(['Bool', 'True'])),
                 :named('report-broken-if-sunk')
@@ -2902,7 +2902,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
 
     method contextualizer($/) {
         my $past := $<coercee>.ast;
-        my $has_magic := $*W.lang-ver-before('d') && $<coercee> eq '';
+        my $has_magic := $*W.lang-rev-before('d') && $<coercee> eq '';
 
         if $has_magic && $<sigil> eq '$' { # for '$()'
             my $result_var := $past.unique('sm_result');
@@ -3969,7 +3969,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
     method routine_declarator:sym<submethod>($/) { make $<method_def>.ast; }
 
     sub decontrv_op() {
-        $*W.lang-ver-before('d') && nqp::getcomp('Raku').backend.name eq 'moar'
+        $*W.lang-rev-before('d') && nqp::getcomp('Raku').backend.name eq 'moar'
             ?? 'p6decontrv_6c'
             !! 'p6decontrv'
     }
@@ -5259,7 +5259,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
         }
         if $sigil eq '%' {
             nqp::defined($*OFTYPE) && $W.throw: $/, 'X::ParametricConstant';
-            $W.lang-ver-before('d')
+            $W.lang-rev-before('d')
               ?? check-type($W.find_symbol: ['Associative'])
               !! check-type-maybe-coerce('Map', $W.find_symbol: ['Associative'])
         }

--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -9222,16 +9222,8 @@ class Perl6::Actions is HLL::Actions does STDActions {
 
             # Handle coercion.
             my $ptype_archetypes := $param_type.HOW.archetypes;
-            if nqp::getenvhash<RAKUDO_DEBUG> {
-                note("!!! Parameter(", ($param_obj.name || '*unnamed*'), ") type: ", $param_type.HOW.name($param_type), ", generic? ", $param_type.HOW.archetypes.generic);
-                note("!!! nomtype: ", $nomtype.HOW.name($nomtype)) if nqp::getenvhash<RAKUDO_DEBUG>;
-                if !$param_obj.coercive && nqp::can($ptype_archetypes, 'coercive') && $ptype_archetypes.coercive {
-                    note("!!! Parameter " ~ $param_obj.name ~ " doesn't have coercive flag");
-                }
-            }
             if $ptype_archetypes.generic {
                 # For a generic-typed parameter get its instantiated clone and see if its type is a coercion.
-                nqp::say("Generic param type on " ~ $param_obj.name) if nqp::getenvhash<RAKUDO_DEBUG>;
                 $decont_name_invalid := 1;
                 unless $instantiated_code {
                     # Produce current code object variable with the first generic-typed parameter encountered. Any
@@ -9295,10 +9287,6 @@ class Perl6::Actions is HLL::Actions does STDActions {
                                     QAST::Var.new(:name($name), :scope('local')))))));
             }
             elsif nqp::can($ptype_archetypes, 'coercive') && $ptype_archetypes.coercive {
-                # if $param_type.HOW.archetypes.generic {
-                #     return 0;
-                # }
-                nqp::say("Coercive param type on " ~ $param_obj.name ~ " ") if nqp::getenvhash<RAKUDO_DEBUG>;
                 $decont_name_invalid := 1;
                 my $target_type := $param_type.HOW.target_type($param_type);
                 $*W.add_object_if_no_sc($param_type.HOW);

--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -3701,7 +3701,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
         if $*OFTYPE {
             $of_type := $*OFTYPE.ast;
             my $archetypes := $of_type.HOW.archetypes;
-            unless $archetypes.nominal || $archetypes.nominalizable || $archetypes.generic || $archetypes.definite {
+            unless $archetypes.nominal || $archetypes.nominalizable || $archetypes.generic || $archetypes.definite || $archetypes.coercive {
                 $*OFTYPE.typed_sorry('X::Syntax::Variable::BadType', type => $of_type);
             }
         }
@@ -8994,6 +8994,8 @@ class Perl6::Actions is HLL::Actions does STDActions {
         my @result;
         my $clear_topic_bind;
         my $saw_slurpy;
+        my $instantiated_code;
+        my $Code     := $*W.find_single_symbol('Code', :setting-only);
         my $Sig      := $*W.find_single_symbol('Signature', :setting-only);
         my $Param    := $*W.find_single_symbol('Parameter', :setting-only);
         my $Iterable := $*W.find_single_symbol('Iterable');
@@ -9211,7 +9213,83 @@ class Perl6::Actions is HLL::Actions does STDActions {
 
             # Handle coercion.
             my $coerce_to := nqp::getattr($param_obj, $Param, '$!coerce_type');
-            unless nqp::isnull($coerce_to) {
+            my $nominal_type := nqp::getattr($param_obj, $Param, '$!nominal_type');
+            if nqp::getenvhash<RAKUDO_DEBUG> {
+                say("<<< Parameter ", $name, " type: ", $nominal_type.HOW.name($nominal_type), ", generic: ", $nominal_type.HOW.archetypes.generic);
+            }
+            if $nominal_type.HOW.archetypes.generic {
+                # For a generic-typed parameter get its instantiated clone and see if its type is a coercion.
+                $decont_name_invalid := 1;
+                unless $instantiated_code {
+                    # Produce current code object variable with the first generic-typed parameter encountered. Any
+                    # next generic paramter would re-use the variable sparing a few CPU cycles per call.
+                    $instantiated_code := QAST::Node.unique('__lowered_code_obj_');
+                    $var.push(
+                        QAST::Op.new(
+                            :op('bind'),
+                            QAST::Var.new(:name($instantiated_code), :scope('local'), :decl('var')),
+                            QAST::Op.new(
+                                :op('getcodeobj'),
+                                QAST::Op.new(
+                                    :op('ctxcode'),
+                                    QAST::Op.new(:op('ctx')))
+                            )
+                        ));
+                }
+                my $inst_param := QAST::Node.unique('__lowered_param_obj_');
+                $var.push(
+                    QAST::Op.new(
+                        :op('bind'),
+                        QAST::Var.new( :name($inst_param), :scope('local'), :decl('var') ),
+                        QAST::Op.new(
+                            :op('atpos'),
+                            QAST::Op.new(
+                                :op('getattr'),
+                                QAST::Op.new(
+                                    :op('getattr'),
+                                    QAST::Var.new(:name($instantiated_code), :scope('local')),
+                                    QAST::WVal.new(:value($Code)),
+                                    QAST::SVal.new(:value('$!signature'))
+                                ),
+                                QAST::WVal.new(:value($Sig)),
+                                QAST::SVal.new(:value('@!params'))
+                            ),
+                            QAST::IVal.new(:value($i)))));
+                my $nominal_type := QAST::Node.unique('__lowered_nominal_type_');
+                $var.push(
+                    QAST::Op.new(
+                        :op('if'),
+                        QAST::Op.new(
+                            :op('callmethod'),
+                            :name('coercive'),
+                            QAST::Var.new(:name($inst_param), :scope('local'))
+                        ),
+                        QAST::Op.new(
+                            :op('bind'),
+                            QAST::Var.new( :name($name), :scope('local') ),
+                            QAST::Stmts.new(
+                                QAST::Op.new(
+                                    :op('bind'),
+                                    QAST::Var.new(:name($nominal_type), :scope('local'), :decl('var')),
+                                    QAST::Op.new(
+                                        :op('getattr'),
+                                        QAST::Var.new(:name($inst_param), :scope('local')),
+                                        QAST::WVal.new(:value($Param)),
+                                        QAST::SVal.new(:value('$!nominal_type'))
+                                    )
+                                ),
+                                QAST::Op.new(
+                                    :op('callmethod'),
+                                    :name('coerce'),
+                                    QAST::Op.new(
+                                        :op('how'),
+                                        QAST::Var.new(:name($nominal_type), :scope('local')),
+                                    ),
+                                    QAST::Var.new(:name($nominal_type), :scope('local')),
+                                    QAST::Var.new(:name($name), :scope('local'))
+                                )))));
+            }
+            elsif !nqp::isnull($coerce_to) {
                 if $coerce_to.HOW.archetypes.generic {
                     return 0;
                 }

--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -1758,7 +1758,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
                     my $optional := $*IMPLICIT == 1;
                     @params.push(hash(
                         :variable_name('$_'), :$optional,
-                        :nominal_type($*W.find_single_symbol('Mu')),
+                        :type($*W.find_single_symbol('Mu')),
                         :default_from_outer($optional), :is_raw(1),
                     ));
                 }
@@ -4255,7 +4255,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
         ));
         $*W.pop_lexpad();
         $install_in.push(QAST::Stmt.new($p_past));
-        my @p_params := [hash(is_capture => 1, nominal_type => $*W.find_single_symbol('Mu') )];
+        my @p_params := [hash(is_capture => 1, type => $*W.find_single_symbol('Mu') )];
         my $p_sig := $*W.create_signature(nqp::hash('parameter_objects',
             [$*W.create_parameter($/, @p_params[0])]));
         add_signature_binding_code($p_past, $p_sig, @p_params);
@@ -4295,7 +4295,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
         my %arg_placeholders;
         while $i < $n {
             my %info := @params[$i];
-            return 0 unless nqp::objprimspec(%info<nominal_type>); # non-native
+            return 0 unless nqp::objprimspec(%info<type>); # non-native
             return 0 if %info<optional> || %info<post_constraints> ||  %info<bind_attr> ||
                 %info<bind_accessor> || %info<named_names> || %info<type_captures>;
             my $param_obj := @p_objs[$i];
@@ -5441,8 +5441,8 @@ class Perl6::Actions is HLL::Actions does STDActions {
     }
 
     sub check_param_default_type($/, $value) {
-        if nqp::existskey(%*PARAM_INFO, 'nominal_type') {
-            my $expected := %*PARAM_INFO<nominal_type>;
+        if nqp::existskey(%*PARAM_INFO, 'type') {
+            my $expected := %*PARAM_INFO<type>;
             if nqp::objprimspec($expected) == 0 {
                 unless nqp::istype($value, $expected) {
                     # Ensure both types are composed before complaining,
@@ -5454,7 +5454,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
                         $<default_value>[0].typed_sorry(
                             'X::Parameter::Default::TypeCheck',
                             got => $value,
-                            expected => %*PARAM_INFO<nominal_type>);
+                            expected => %*PARAM_INFO<type>);
                     }
                 }
             }
@@ -5469,7 +5469,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
             %*PARAM_INFO<sub_signature_params> := $<signature>.ast;
             if nqp::eqat(~$/, '[', 0) {
                 %*PARAM_INFO<sigil> := '@';
-                %*PARAM_INFO<nominal_type> := $*W.find_single_symbol('Positional');
+                %*PARAM_INFO<type> := $*W.find_single_symbol('Positional');
             }
         }
         else {
@@ -5496,12 +5496,12 @@ class Perl6::Actions is HLL::Actions does STDActions {
                 $need_role := 1;
             }
             if $need_role {
-                if nqp::existskey(%*PARAM_INFO, 'nominal_type') {
-                    %*PARAM_INFO<nominal_type> := $*W.parameterize_type_with_args($/,
-                        $role_type, [%*PARAM_INFO<nominal_type>], nqp::hash());
+                if nqp::existskey(%*PARAM_INFO, 'type') {
+                    %*PARAM_INFO<type> := $*W.parameterize_type_with_args($/,
+                        $role_type, [%*PARAM_INFO<type>], nqp::hash());
                 }
                 else {
-                    %*PARAM_INFO<nominal_type> := $role_type;
+                    %*PARAM_INFO<type> := $role_type;
                 }
             }
 
@@ -5640,10 +5640,10 @@ class Perl6::Actions is HLL::Actions does STDActions {
         if $cur_pad.symbol($name) {
             $*W.throw($/, ['X', 'Redeclaration'], symbol => $name);
         }
-        if nqp::existskey(%*PARAM_INFO, 'nominal_type') {
+        if nqp::existskey(%*PARAM_INFO, 'type') {
             $cur_pad[0].push(QAST::Var.new( :$name, :scope('lexical'),
-                :decl('var'), :returns(%*PARAM_INFO<nominal_type>) ));
-            $cur_pad.symbol(%*PARAM_INFO<variable_name>, :type(%*PARAM_INFO<nominal_type>));
+                :decl('var'), :returns(%*PARAM_INFO<type>) ));
+            $cur_pad.symbol(%*PARAM_INFO<variable_name>, :type(%*PARAM_INFO<type>));
         } else {
             $cur_pad[0].push(QAST::Var.new( :name($name), :scope('lexical'), :decl('var') ));
         }
@@ -5679,7 +5679,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
                     $<typename>.ast);
             }
             else {
-                if nqp::existskey(%*PARAM_INFO, 'nominal_type') {
+                if nqp::existskey(%*PARAM_INFO, 'type') {
                     $*W.throw($/, ['X', 'Parameter', 'MultipleTypeConstraints'],
                         parameter => (%*PARAM_INFO<variable_name> // ''),
                     );
@@ -5688,7 +5688,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
             }
         }
         elsif $<value> {
-            if nqp::existskey(%*PARAM_INFO, 'nominal_type') {
+            if nqp::existskey(%*PARAM_INFO, 'type') {
                 $*W.throw($/, ['X', 'Parameter', 'MultipleTypeConstraints'],
                         parameter => (%*PARAM_INFO<variable_name> // ''),
                 );
@@ -5704,7 +5704,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
                 $*W.add_object_if_no_sc($val);
             }
 
-            %*PARAM_INFO<nominal_type> := $val.WHAT;
+            %*PARAM_INFO<type> := $val.WHAT;
             unless %*PARAM_INFO<post_constraints> {
                 %*PARAM_INFO<post_constraints> := [];
             }
@@ -5728,29 +5728,30 @@ class Perl6::Actions is HLL::Actions does STDActions {
             }
 
             # Actual a value that parses type-ish.
-            %*PARAM_INFO<nominal_type> := $type.WHAT;
+            %*PARAM_INFO<type> := $type.WHAT;
             unless %*PARAM_INFO<post_constraints> {
                 %*PARAM_INFO<post_constraints> := [];
             }
             %*PARAM_INFO<post_constraints>.push($type);
         }
         elsif $type.HOW.archetypes.nominal {
-            %*PARAM_INFO<nominal_type> := $type;
+            %*PARAM_INFO<type> := $type;
         }
         elsif $type.HOW.archetypes.coercive {
-            %*PARAM_INFO<nominal_type> := $type.HOW.constraint_type($type);
-            %*PARAM_INFO<coerce_type>  := $type.HOW.target_type($type);
+            %*PARAM_INFO<type> := $type;
+            %*PARAM_INFO<type_coercive> := 1;
         }
         elsif $type.HOW.archetypes.definite {
             dissect_type_into_parameter($/, $type.HOW.base_type($type));
         }
         elsif $type.HOW.archetypes.generic {
-            %*PARAM_INFO<nominal_type> := $type;
-            %*PARAM_INFO<nominal_generic> := 1;
+            %*PARAM_INFO<type> := $type;
+            %*PARAM_INFO<type_generic> := 1;
         }
         elsif $type.HOW.archetypes.nominalizable {
+            # XXX The actual nominalization is likely to be done by Parameter class itself.
             my $nom := $type.HOW.nominalize($type);
-            %*PARAM_INFO<nominal_type> := $nom;
+            %*PARAM_INFO<type> := $nom;
             unless %*PARAM_INFO<post_constraints> {
                 %*PARAM_INFO<post_constraints> := [];
             }
@@ -5759,7 +5760,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
         else {
             $<typename>.typed_sorry('X::Parameter::BadType', :$type);
         }
-        %*PARAM_INFO<of_type> := %*PARAM_INFO<nominal_type>;
+        %*PARAM_INFO<of_type> := %*PARAM_INFO<type>;
         %*PARAM_INFO<of_type_match> := $<typename>;
         %*PARAM_INFO<defined_only>   := 1 if $<typename><colonpairs> && $<typename><colonpairs>.ast<D>;
         %*PARAM_INFO<undefined_only> := 1 if $<typename><colonpairs> && $<typename><colonpairs>.ast<U>;
@@ -8966,7 +8967,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
             if $only<is_capture> && !nqp::existskey($only, 'variable_name')
                                  && !nqp::existskey($only, 'sub_signature')
                                  && !nqp::existskey($only, 'post_constraints') {
-                if !nqp::istype($*W.find_single_symbol('Capture'), $only<nominal_type>) {
+                if !nqp::istype($*W.find_single_symbol('Capture'), $only<type>) {
                     $only<node>.panic("Capture parameter must have a type accepting a Capture");
                 }
                 else {
@@ -8980,7 +8981,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
         if nqp::elems(@params) == 1 {
             my $only := @params[0];
             if $only<is_raw> && $only<variable_name> eq '$_' &&
-                    $only<nominal_type> =:= $*W.find_single_symbol('Mu') {
+                    $only<type> =:= $*W.find_single_symbol('Mu') {
                 return $only<default_from_outer> ?? 'optional' !! 'required';
             }
         }
@@ -9021,7 +9022,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
                 return 0 if $saw_slurpy;
                 return 0 unless $i + 1 == $n ||
                                 $i + 2 == $n && @params[$i + 1]<named_slurpy>;
-                if !nqp::istype($*W.find_single_symbol('Capture'), %info<nominal_type>) {
+                if !nqp::istype($*W.find_single_symbol('Capture'), %info<type>) {
                     %info<node>.panic("Capture parameter must have a type accepting a Capture");
                 }
                 $var.slurpy(1);
@@ -9105,8 +9106,8 @@ class Perl6::Actions is HLL::Actions does STDActions {
             }
 
             # Add type checks.
-            my $nomtype   := %info<nominal_type>;
-            my int $is_generic := %info<nominal_generic>;
+            my $nomtype   := %info<type>;
+            my int $is_generic := %info<type_generic>;
             my int $is_rw := $flags +& $SIG_ELEM_IS_RW;
             my int $spec  := nqp::objprimspec($nomtype);
             my $decont_name;
@@ -9127,7 +9128,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
                 }
                 return $decont_name;
             }
-            if $spec && !%info<nominal_generic> {
+            if $spec && !%info<type_generic> {
                 if $is_rw {
                     $var.push(QAST::ParamTypeCheck.new(QAST::Op.new(
                         :op(@iscont_ops[$spec]),
@@ -9212,12 +9213,13 @@ class Perl6::Actions is HLL::Actions does STDActions {
             }
 
             # Handle coercion.
-            my $coerce_to := nqp::getattr($param_obj, $Param, '$!coerce_type');
-            my $nominal_type := nqp::getattr($param_obj, $Param, '$!nominal_type');
+            my $param_type := nqp::getattr($param_obj, $Param, '$!type');
             if nqp::getenvhash<RAKUDO_DEBUG> {
-                say("<<< Parameter ", $name, " type: ", $nominal_type.HOW.name($nominal_type), ", generic: ", $nominal_type.HOW.archetypes.generic);
+                if !$param_obj.coercive && $param_type.HOW.archetypes.coercive {
+                    nqp::say("!!! Parameter " ~ $param_obj.name ~ " doesn't have coercive flag");
+                }
             }
-            if $nominal_type.HOW.archetypes.generic {
+            if $param_type.HOW.archetypes.generic {
                 # For a generic-typed parameter get its instantiated clone and see if its type is a coercion.
                 $decont_name_invalid := 1;
                 unless $instantiated_code {
@@ -9255,7 +9257,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
                                 QAST::SVal.new(:value('@!params'))
                             ),
                             QAST::IVal.new(:value($i)))));
-                my $nominal_type := QAST::Node.unique('__lowered_nominal_type_');
+                my $low_param_type := QAST::Node.unique('__lowered_param_type_');
                 $var.push(
                     QAST::Op.new(
                         :op('if'),
@@ -9270,45 +9272,51 @@ class Perl6::Actions is HLL::Actions does STDActions {
                             QAST::Stmts.new(
                                 QAST::Op.new(
                                     :op('bind'),
-                                    QAST::Var.new(:name($nominal_type), :scope('local'), :decl('var')),
+                                    QAST::Var.new(:name($low_param_type), :scope('local'), :decl('var')),
                                     QAST::Op.new(
                                         :op('getattr'),
                                         QAST::Var.new(:name($inst_param), :scope('local')),
                                         QAST::WVal.new(:value($Param)),
-                                        QAST::SVal.new(:value('$!nominal_type'))
+                                        QAST::SVal.new(:value('$!type'))
                                     )
                                 ),
                                 QAST::Op.new(
                                     :op('callmethod'),
-                                    :name('coerce'),
+                                    :name('!coerce'),
                                     QAST::Op.new(
                                         :op('how'),
-                                        QAST::Var.new(:name($nominal_type), :scope('local')),
+                                        QAST::Var.new(:name($low_param_type), :scope('local')),
                                     ),
-                                    QAST::Var.new(:name($nominal_type), :scope('local')),
+                                    QAST::Var.new(:name($low_param_type), :scope('local')),
                                     QAST::Var.new(:name($name), :scope('local'))
                                 )))));
             }
-            elsif !nqp::isnull($coerce_to) {
-                if $coerce_to.HOW.archetypes.generic {
-                    return 0;
-                }
+            elsif $param_obj.coercive {
+                # if $param_type.HOW.archetypes.generic {
+                #     return 0;
+                # }
+                nqp::say("Coercive param type on " ~ $param_obj.name) if nqp::getenvhash<RAKUDO_DEBUG>;
                 $decont_name_invalid := 1;
+                my $target_type := $param_type.HOW.target_type($param_type);
+                $*W.add_object_if_no_sc($param_type.HOW);
+                $*W.add_object_if_no_sc($target_type);
                 $var.push(QAST::Op.new(
                     :op('unless'),
                     QAST::Op.new(
                         :op('istype'),
                         QAST::Var.new( :name($name), :scope('local') ),
-                        QAST::WVal.new( :value($coerce_to) )
+                        QAST::WVal.new( :value($target_type) )
                     ),
                     QAST::Op.new(
                         :op('bind'),
                         QAST::Var.new( :name($name), :scope('local') ),
                         QAST::Op.new(
                             :op('callmethod'),
-                            :name(nqp::getattr_s($param_obj, $Param, '$!coerce_method')),
-                            QAST::Var.new( :name($name), :scope('local') )
-                        ))));
+                            :name('coerce'),
+                            QAST::WVal.new(:value($param_type.HOW)),
+                            QAST::WVal.new(:value($param_type)),
+                            QAST::Var.new( :name($name), :scope('local') ))))
+                );
             }
 
             # If it's optional, do any default handling.
@@ -9470,13 +9478,11 @@ class Perl6::Actions is HLL::Actions does STDActions {
                     # we need not wrap it in a read-only scalar.
                     my $wrap := $flags +& $SIG_ELEM_IS_COPY;
                     unless $wrap {
-                        if nqp::isnull($coerce_to) {
+                        if !$param_obj.coercive {
                             $wrap := nqp::istype($nomtype, $Iterable) || nqp::istype($Iterable, $nomtype);
                         }
                         else {
-                            my $coerce_nom := $coerce_to.HOW.archetypes.nominalizable
-                                ?? $coerce_to.HOW.nominalize($coerce_to)
-                                !! $coerce_to;
+                            my $coerce_nom := $param_type.HOW.nominal_target($param_type);
                             $wrap := nqp::istype($coerce_nom, $Iterable) || nqp::istype($Iterable, $coerce_nom);
                         }
                     }
@@ -9578,7 +9584,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
                         # Some optimizations we must handle specially if no
                         # autothreading of Junctions will happen:
                         $param.annotate: 'no-autothread', 1
-                          unless nqp::istype(%info<nominal_type>,
+                          unless nqp::istype(%info<type>,
                             $*W.find_symbol: ['Any'], :setting-only);
                     }
 
@@ -9701,13 +9707,13 @@ class Perl6::Actions is HLL::Actions does STDActions {
 
         # Apply any type implied by the sigil.
         if $sigil eq '@' {
-            %param_info<nominal_type> := $*W.find_single_symbol('Positional');
+            %param_info<type> := $*W.find_single_symbol('Positional');
         }
         elsif $sigil eq '%' {
-            %param_info<nominal_type> := $*W.find_single_symbol('Associative');
+            %param_info<type> := $*W.find_single_symbol('Associative');
         }
         elsif $sigil eq '&' {
-            %param_info<nominal_type> := $*W.find_single_symbol('Callable');
+            %param_info<type> := $*W.find_single_symbol('Callable');
         }
 
         # If it's slurpy, just goes on the end.
@@ -9793,7 +9799,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
             });
         }
         ($*W.cur_lexpad())[0].push($block);
-        my $param := hash( :variable_name('$_'), :nominal_type($*W.find_single_symbol('Mu')));
+        my $param := hash( :variable_name('$_'), :type($*W.find_single_symbol('Mu')));
         if $copy {
             $param<container_descriptor> := $*W.create_container_descriptor(
                 $*W.find_single_symbol('Mu'), '$_');
@@ -9832,7 +9838,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
         # Give it a signature and create code object.
         my $param := hash(
             variable_name => '$_',
-            nominal_type => $*W.find_single_symbol('Mu'));
+            type => $*W.find_single_symbol('Mu'));
         my $sig := $*W.create_signature(nqp::hash('parameter_objects',
             [$*W.create_parameter($/, $param)]));
         add_signature_binding_code($past, $sig, [$param]);
@@ -9998,8 +10004,8 @@ class Perl6::Actions is HLL::Actions does STDActions {
 
         # Need to construct and install an initializer method
         my @params := [
-          hash( is_invocant => 1, nominal_type => $/.package),
-          hash( variable_name => '$_', nominal_type => $*W.find_single_symbol('Mu'))
+          hash( is_invocant => 1, type => $/.package),
+          hash( variable_name => '$_', type => $*W.find_single_symbol('Mu'))
         ];
         my $sig := $*W.create_signature(nqp::hash('parameter_objects', [
           $*W.create_parameter($/, @params[0]),
@@ -10233,7 +10239,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
                             $curry[0].push: $_;
                             @params.push: hash(
                               :variable_name($_.name),
-                              :nominal_type(
+                              :type(
                                   $*W.find_symbol: ['Mu'], :setting-only),
                               :is_raw(1))
                         }
@@ -10258,7 +10264,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
                   ).annotate_self: 'whatever-var', 1;
                 @params.push: hash(
                     :variable_name($param.name),
-                    :nominal_type($*W.find_symbol: ['Mu'], :setting-only),
+                    :type($*W.find_symbol: ['Mu'], :setting-only),
                     :is_raw(1));
                 $curry[0].push: $param.decl_as: <var>;
                 $qast[$i] := $param;

--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -3701,7 +3701,11 @@ class Perl6::Actions is HLL::Actions does STDActions {
         if $*OFTYPE {
             $of_type := $*OFTYPE.ast;
             my $archetypes := $of_type.HOW.archetypes;
-            unless $archetypes.nominal || $archetypes.nominalizable || $archetypes.generic || $archetypes.definite || $archetypes.coercive {
+            unless $archetypes.nominal
+                || $archetypes.nominalizable
+                || $archetypes.generic
+                || $archetypes.definite
+                || $archetypes.coercive {
                 $*OFTYPE.typed_sorry('X::Syntax::Variable::BadType', type => $of_type);
             }
         }
@@ -5746,7 +5750,6 @@ class Perl6::Actions is HLL::Actions does STDActions {
         }
         elsif $type.HOW.archetypes.generic {
             %*PARAM_INFO<type> := $type;
-            %*PARAM_INFO<type_generic> := 1;
         }
         elsif $type.HOW.archetypes.nominalizable {
             # XXX The actual nominalization is likely to be done by Parameter class itself.
@@ -5760,8 +5763,9 @@ class Perl6::Actions is HLL::Actions does STDActions {
         else {
             $<typename>.typed_sorry('X::Parameter::BadType', :$type);
         }
-        %*PARAM_INFO<of_type> := %*PARAM_INFO<type>;
-        %*PARAM_INFO<of_type_match> := $<typename>;
+        %*PARAM_INFO<type_generic>   := 1 if $type.HOW.archetypes.generic;
+        %*PARAM_INFO<of_type>        := %*PARAM_INFO<type>;
+        %*PARAM_INFO<of_type_match>  := $<typename>;
         %*PARAM_INFO<defined_only>   := 1 if $<typename><colonpairs> && $<typename><colonpairs>.ast<D>;
         %*PARAM_INFO<undefined_only> := 1 if $<typename><colonpairs> && $<typename><colonpairs>.ast<U>;
     }
@@ -9108,6 +9112,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
             # Add type checks.
             my $nomtype   := %info<type>;
             my int $is_generic := %info<type_generic>;
+            my int $is_coercive := %info<type_coercive>;
             my int $is_rw := $flags +& $SIG_ELEM_IS_RW;
             my int $spec  := nqp::objprimspec($nomtype);
             my $decont_name;
@@ -9150,7 +9155,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
                     )));
 
                 # Type-check, unless it's Mu, in which case skip it.
-                if $is_generic {
+                if $is_generic && !$is_coercive {
                     my $genericname := $nomtype.HOW.name(%info<attr_package>);
                     $var.push(QAST::ParamTypeCheck.new(QAST::Op.new(
                         :op('istype_nd'),
@@ -9221,6 +9226,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
             }
             if $param_type.HOW.archetypes.generic {
                 # For a generic-typed parameter get its instantiated clone and see if its type is a coercion.
+                nqp::say("Generic param type on " ~ $param_obj.name) if nqp::getenvhash<RAKUDO_DEBUG>;
                 $decont_name_invalid := 1;
                 unless $instantiated_code {
                     # Produce current code object variable with the first generic-typed parameter encountered. Any
@@ -9234,9 +9240,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
                                 :op('getcodeobj'),
                                 QAST::Op.new(
                                     :op('ctxcode'),
-                                    QAST::Op.new(:op('ctx')))
-                            )
-                        ));
+                                    QAST::Op.new(:op('ctx'))))));
                 }
                 my $inst_param := QAST::Node.unique('__lowered_param_obj_');
                 $var.push(
@@ -9251,8 +9255,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
                                     :op('getattr'),
                                     QAST::Var.new(:name($instantiated_code), :scope('local')),
                                     QAST::WVal.new(:value($Code)),
-                                    QAST::SVal.new(:value('$!signature'))
-                                ),
+                                    QAST::SVal.new(:value('$!signature'))),
                                 QAST::WVal.new(:value($Sig)),
                                 QAST::SVal.new(:value('@!params'))
                             ),
@@ -9264,8 +9267,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
                         QAST::Op.new(
                             :op('callmethod'),
                             :name('coercive'),
-                            QAST::Var.new(:name($inst_param), :scope('local'))
-                        ),
+                            QAST::Var.new(:name($inst_param), :scope('local'))),
                         QAST::Op.new(
                             :op('bind'),
                             QAST::Var.new( :name($name), :scope('local') ),
@@ -9277,25 +9279,21 @@ class Perl6::Actions is HLL::Actions does STDActions {
                                         :op('getattr'),
                                         QAST::Var.new(:name($inst_param), :scope('local')),
                                         QAST::WVal.new(:value($Param)),
-                                        QAST::SVal.new(:value('$!type'))
-                                    )
-                                ),
+                                        QAST::SVal.new(:value('$!type')))),
                                 QAST::Op.new(
                                     :op('callmethod'),
-                                    :name('!coerce'),
+                                    :name('coerce'),
                                     QAST::Op.new(
                                         :op('how'),
-                                        QAST::Var.new(:name($low_param_type), :scope('local')),
-                                    ),
+                                        QAST::Var.new(:name($low_param_type), :scope('local'))),
                                     QAST::Var.new(:name($low_param_type), :scope('local')),
-                                    QAST::Var.new(:name($name), :scope('local'))
-                                )))));
+                                    QAST::Var.new(:name($name), :scope('local')))))));
             }
-            elsif $param_obj.coercive {
+            elsif $param_type.HOW.archetypes.coercive {
                 # if $param_type.HOW.archetypes.generic {
                 #     return 0;
                 # }
-                nqp::say("Coercive param type on " ~ $param_obj.name) if nqp::getenvhash<RAKUDO_DEBUG>;
+                nqp::say("Coercive param type on " ~ $param_obj.name ~ " ") if nqp::getenvhash<RAKUDO_DEBUG>;
                 $decont_name_invalid := 1;
                 my $target_type := $param_type.HOW.target_type($param_type);
                 $*W.add_object_if_no_sc($param_type.HOW);

--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -4588,7 +4588,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
             self.typed_panic(
                 'X::Syntax::Extension::Category', :$category
             ) if nqp::iseq_s($subname, "$category:<$opname>")
-              || nqp::iseq_s($subname, "$category:sym<$opname>") && $*W.lang-ver-before('d');
+              || nqp::iseq_s($subname, "$category:sym<$opname>") && $*W.lang-rev-before('d');
 
             self.typed_panic(
                 'X::Syntax::Reserved', :reserved(':sym<> colonpair')

--- a/src/Perl6/Metamodel/CoercionHOW.nqp
+++ b/src/Perl6/Metamodel/CoercionHOW.nqp
@@ -4,63 +4,144 @@
 # This means we get cross-compilation-unit interning "for free", as well as
 # avoiding a meta-object instance per coercion type created.
 class Perl6::Metamodel::CoercionHOW
-    does Perl6::Metamodel::MethodDelegation
-    does Perl6::Metamodel::TypePretense
+    # does Perl6::Metamodel::MethodDelegation
+    # does Perl6::Metamodel::TypePretense
 {
-    my $archetypes := Perl6::Metamodel::Archetypes.new(:coercive);
+    has $!composed;
+    has $!target_type;
+    has $!constraint_type;
+
+    my $archetypes := Perl6::Metamodel::Archetypes.new(:coercive, :nominalizable);
     method archetypes() {
         $archetypes
     }
 
+    method new(*%named) {
+        nqp::findmethod(NQPMu, 'BUILDALL')(nqp::create(self), |%named)
+    }
+
     method new_type($target, $constraint) {
-        my $root := nqp::parameterizetype((Perl6::Metamodel::CoercionHOW.WHO)<root>,
+        my $coercion_type := nqp::parameterizetype((Perl6::Metamodel::CoercionHOW.WHO)<root>,
             [$target, $constraint]);
-        nqp::setdebugtypename($root, self.name($root));
+        nqp::setdebugtypename($coercion_type, $coercion_type.HOW.name($coercion_type));
+        $coercion_type
+    }
+
+    method compose($coercion_type) {
+        if $!composed {
+            return $coercion_type;
+        }
+        my $tt := $coercion_type.HOW.target_type($coercion_type);
+        my $ct := $coercion_type.HOW.constraint_type($coercion_type);
+        note("CoercionHOW.compose(", $coercion_type.HOW.name($coercion_type), "|", nqp::objectid($coercion_type), ") ", $tt.HOW.name($tt), " ", $ct.HOW.name($ct));
+        # TODO typecache must iterate over MRO with roles
+        nqp::settypecache($coercion_type,
+            nqp::list(
+                $coercion_type.HOW.target_type($coercion_type),
+                $coercion_type.HOW.constraint_type($coercion_type)));
+        $!composed := 1;
+        $coercion_type
+    }
+
+    method set_target_type($target_type) {
+        $!target_type := $target_type;
+    }
+
+    method set_constraint_type($constraint_type) {
+        $!constraint_type := $constraint_type;
     }
 
     method name($coercion_type) {
-        if nqp::isnull(nqp::typeparameterized($coercion_type)) {
-            '?(?)'
-        }
-        else {
-            my $target := nqp::typeparameterat($coercion_type, 0);
-            my $constraint := nqp::typeparameterat($coercion_type, 1);
-            $target.HOW.name($target) ~ '(' ~ $constraint.HOW.name($constraint) ~ ')'
-        }
+        $!target_type.HOW.name($!target_type) ~ '(' ~ $!constraint_type.HOW.name($!constraint_type) ~ ')'
     }
 
     method shortname($coercion_type) {
-        if nqp::isnull(nqp::typeparameterized($coercion_type)) {
-            '?(?)'
-        }
-        else {
-            my $target := nqp::typeparameterat($coercion_type, 0);
-            my $constraint := nqp::typeparameterat($coercion_type, 1);
-            $target.HOW.shortname($target) ~ '(' ~ $constraint.HOW.shortname($constraint) ~ ')'
-        }
-    }
-
-    sub check_instantiated($coercion_type) {
-        nqp::die('Cannot perform this operation on an uninstantiated coercion type')
-            if nqp::isnull(nqp::typeparameterized($coercion_type));
+        $!target_type.HOW.shortname($!target_type) ~ '(' ~ $!constraint_type.HOW.shortname($!constraint_type) ~ ')'
     }
 
     method target_type($coercion_type) {
-        check_instantiated($coercion_type);
-        nqp::typeparameterat($coercion_type, 0)
+        $!target_type
     }
 
     method constraint_type($coercion_type) {
-        check_instantiated($coercion_type);
-        nqp::typeparameterat($coercion_type, 1)
+        $!constraint_type
+    }
+
+    method nominalize($coercion_type) {
+        my $target_type := $coercion_type.HOW.target_type($coercion_type);
+        $target_type.HOW.archetypes.nominalizable
+            ?? $target_type.HOW.nominalize($target_type)
+            !! $target_type
+    }
+
+    method find_method($coercion_type, $name, *%c) {
+        say('find_method(', $coercion_type.HOW.name($coercion_type), ", ", $name, ')') if nqp::getenvhash<RAKUDO_DEBUG>;
+        my $target_type := $coercion_type.HOW.target_type($coercion_type);
+        $target_type.HOW.find_method($target_type, $name, |%c)
+    }
+
+    method type_check($obj, $checkee) {
+        say("type_check, obj:", $obj.HOW.name($obj), ", checkee:", $checkee.HOW.name($checkee)) if nqp::getenvhash<RAKUDO_DEBUG>;
+        if $obj =:= $checkee {
+            return 1;
+        }
+        my $target_type := $obj.HOW.target_type($obj);
+        my $rc := $target_type.HOW.type_check($target_type, $checkee);
+        say("type checked: ", $rc) if nqp::getenvhash<RAKUDO_DEBUG>;
+        $rc
+    }
+
+    method accepts_type($coercion_type, $checkee) {
+        say("accepts_type, obj:", $coercion_type.HOW.name($coercion_type), ", checkee:", $checkee.HOW.name($checkee)) if nqp::getenvhash<RAKUDO_DEBUG>;
+        my $target_type := $coercion_type.HOW.target_type($coercion_type);
+        my $constraint_type := $coercion_type.HOW.constraint_type($coercion_type);
+        my $rc := nqp::istype($checkee, $target_type) || nqp::istype($checkee, $constraint_type);
+        say("accepted: ", $rc) if nqp::getenvhash<RAKUDO_DEBUG>;
+        $rc
+    }
+
+    # Coercion protocol method.
+    method coerce($obj, $value) {
+        my $value_type := nqp::what($value);
+        if nqp::istype($value_type, $!target_type) {
+            return $value
+        }
+
+        # First we try $value.TargetType() approach
+        my $method := $value_type.HOW.find_method($value_type, $!target_type.HOW.name($!target_type), :no_fallback);
+        unless nqp::isnull($method) {
+            return $method($value)
+        }
+
+        # Next we try $value.COERCE-INTO(TargetType). This would make possible coercion into types with compound names
+        # like MyPackage::TargetType.
+        $method := $value_type.HOW.find_method($value_type, 'COERCE-INTO');
+        if nqp::defined($method) {
+            return $method($value, $!target_type);
+        }
+
+        # As the last resort we fallback to TargetType.COERCE-FROM($value). This is the worst possible variant because
+        # the best possible coercion may require access to source calss private data. Yet, this may work for many simple
+        # cases like TargetType(Str), for example.
+        $method := $!target_type.HOW.find_method($!target_type, 'COERCE-FROM');
+        if nqp::defined($method) {
+            return $method($!target_type, $value);
+        }
+
+        # TODO To be replaced with a proper Exception throwing.
+        nqp::die("Impossible coercion of " ~ $value_type.HOW.name($value_type)
+                    ~ " into " ~ $!target_type.HOW.name($!target_type));
     }
 }
 BEGIN {
-    my $root := nqp::newtype(Perl6::Metamodel::CoercionHOW, 'Uninstantiable');
+    my $root := nqp::newtype(Perl6::Metamodel::CoercionHOW.new, 'Uninstantiable');
     nqp::settypehll($root, 'Raku');
     nqp::setparameterizer($root, sub ($type, $params) {
-        # Re-use same HOW.
-        nqp::settypehll(nqp::newtype($type.HOW, 'Uninstantiable'), 'Raku');
+        my $metaclass := $type.HOW.new();
+        $metaclass.set_target_type($params[0]);
+        $metaclass.set_constraint_type($params[1]);
+        my $coercion_type := nqp::settypehll(nqp::newtype($metaclass, 'Uninstantiable'), 'Raku');
+        nqp::settypecheckmode($coercion_type, 2)
     });
     (Perl6::Metamodel::CoercionHOW.WHO)<root> := $root;
 }

--- a/src/Perl6/Metamodel/CoercionHOW.nqp
+++ b/src/Perl6/Metamodel/CoercionHOW.nqp
@@ -11,10 +11,18 @@ class Perl6::Metamodel::CoercionHOW
     has $!target_type;
     has $!nominal_target;
     has $!constraint_type;
+    has $!archetypes;
 
-    my $archetypes := Perl6::Metamodel::Archetypes.new(:coercive, :nominalizable);
+    my $archetypes_g := Perl6::Metamodel::Archetypes.new(:coercive, :nominalizable, :generic);
+    my $archetypes_ng := Perl6::Metamodel::Archetypes.new(:coercive, :nominalizable);
+
     method archetypes() {
-        $archetypes
+        unless nqp::isconcrete($!archetypes) {
+            $!archetypes := $!target_type.HOW.archetypes.generic || $!constraint_type.HOW.archetypes.generic
+                            ?? $archetypes_g
+                            !! $archetypes_ng;
+        }
+        $!archetypes
     }
 
     method new(*%named) {
@@ -77,6 +85,20 @@ class Perl6::Metamodel::CoercionHOW
             !! $target_type
     }
 
+    method instantiate_generic($coercion_type, $type_env) {
+        return self unless self.archetypes.generic;
+        my $ins_target :=
+            $!target_type.HOW.archetypes.generic
+                ?? $!target_type.HOW.instantiate_generic($!target_type, $type_env)
+                !! $!target_type;
+        my $ins_constraint :=
+            $!constraint_type.HOW.archetypes.generic
+                ?? $!constraint_type.HOW.instantiate_generic($!constraint_type, $type_env)
+                !! $!constraint_type;
+        my $ins := self.new_type($ins_target, $ins_constraint);
+        $ins.HOW.compose($ins)
+    }
+
     method find_method($coercion_type, $name, *%c) {
         if nqp::getenvhash<RAKUDO_DEBUG> {
             say("&&& find_method on ", $coercion_type.HOW.name($coercion_type), " for ", $name);
@@ -90,40 +112,45 @@ class Perl6::Metamodel::CoercionHOW
         $target_type.HOW.find_method_qualified($target_type, $qtype, $name)
     }
 
-    method type_check($obj, $checkee) {
-        say("type_check, obj:", $obj.HOW.name($obj), ", checkee:", $checkee.HOW.name($checkee)) if nqp::getenvhash<RAKUDO_DEBUG>;
-        if $obj =:= $checkee {
+    method type_check($coercion_type, $checkee) {
+        say("??? type_check(", $coercion_type.HOW.name($coercion_type), " vs. ", $checkee.HOW.name($checkee), ")") if nqp::getenvhash<RAKUDO_DEBUG>;
+        if $coercion_type =:= $checkee {
+            say("??? types are full match") if nqp::getenvhash<RAKUDO_DEBUG>;
             return 1;
         }
-        my $target_type := $obj.HOW.target_type($obj);
+        my $target_type := $coercion_type.HOW.target_type($coercion_type);
         my $rc := $target_type.HOW.type_check($target_type, $checkee);
-        say("type checked: ", $rc) if nqp::getenvhash<RAKUDO_DEBUG>;
+        say("??? checks? ", $rc) if nqp::getenvhash<RAKUDO_DEBUG>;
         $rc
     }
 
     method accepts_type($coercion_type, $checkee) {
-        say("accepts_type, obj:", $coercion_type.HOW.name($coercion_type), ", checkee:", $checkee.HOW.name($checkee)) if nqp::getenvhash<RAKUDO_DEBUG>;
+        say("??? accepts_type(", $coercion_type.HOW.name($coercion_type), " vs. ", $checkee.HOW.name($checkee), ")") if nqp::getenvhash<RAKUDO_DEBUG>;
         my $target_type := $coercion_type.HOW.target_type($coercion_type);
         my $constraint_type := $coercion_type.HOW.constraint_type($coercion_type);
         my $rc := nqp::istype($checkee, $target_type) || nqp::istype($checkee, $constraint_type);
-        say("accepted: ", $rc) if nqp::getenvhash<RAKUDO_DEBUG>;
+        say("??? accepts? ", $rc) if nqp::getenvhash<RAKUDO_DEBUG>;
         $rc
     }
 
     # Coercion protocol method.
     method !coerce($target_type, $value) {
         say("!!! coerce ", $value.HOW.name($value), " into ", $target_type.HOW.name($target_type)) if nqp::getenvhash<RAKUDO_DEBUG>;
-        my $value_type := nqp::what($value);
-        if nqp::istype($value_type, $target_type) {
+        if nqp::istype($value, $target_type) {
+            say("!!! ... coerce isn't needed") if nqp::getenvhash<RAKUDO_DEBUG>;
             return $value
         }
 
+        my $value_type := nqp::what($value);
+
+        say("!!! ... try target type method first") if nqp::getenvhash<RAKUDO_DEBUG>;
         # First we try $value.TargetType() approach
         my $method := $value_type.HOW.find_method($value_type, $!nominal_target.HOW.name($!nominal_target), :no_fallback);
         unless nqp::isnull($method) {
             return $method($value)
         }
 
+        say("!!! ... try COERCE-INTO") if nqp::getenvhash<RAKUDO_DEBUG>;
         # Next we try $value.COERCE-INTO(TargetType). This would make possible coercion into types with compound names
         # like MyPackage::TargetType.
         # XXX COERCE-* methods can only be of type Routine now. Does it ever makes sense for them to be of some other
@@ -133,6 +160,7 @@ class Perl6::Metamodel::CoercionHOW
             return $method($value, $target_type);
         }
 
+        say("!!! ... try COERCE-FROM") if nqp::getenvhash<RAKUDO_DEBUG>;
         # As the last resort we fallback to TargetType.COERCE-FROM($value). This is the worst possible variant because
         # the best possible coercion may require access to source calss private data. Yet, this may work for many simple
         # cases like TargetType(Str), for example.
@@ -141,12 +169,15 @@ class Perl6::Metamodel::CoercionHOW
             return $method($target_type, $value);
         }
 
+        say("!!! ... failed") if nqp::getenvhash<RAKUDO_DEBUG>;
         my %ex := nqp::gethllsym('Raku', 'P6EX');
+        my $target_type_name := $target_type.HOW.name($target_type);
+        my $value_type_name := $value_type.HOW.name($value_type);
         if %ex {
-            %ex<X::Coerce::Impossible>($target_type, $value_type)
+            %ex<X::Coerce::Impossible>($target_type_name, $value_type_name)
         }
-        nqp::die("Impossible coercion from " ~ $value_type.HOW.name($value_type)
-                    ~ " into " ~ $target_type.HOW.name($target_type));
+        nqp::die("Impossible coercion from " ~ $value_type.HOW.name($value_type_name)
+                    ~ " into " ~ $target_type.HOW.name($target_type_name));
     }
 
     method coerce($obj, $value) {

--- a/src/Perl6/Metamodel/CoercionHOW.nqp
+++ b/src/Perl6/Metamodel/CoercionHOW.nqp
@@ -206,7 +206,7 @@ class Perl6::Metamodel::CoercionHOW
                 %ex<X::Coerce::Impossible>($target_type_name, $value_type_name, $hint)
             }
             nqp::die("Impossible coercion from " ~ $value_type.HOW.name($value_type_name)
-                        ~ " into " ~ $target_type_name) ~ ": " ~ $hint;
+                        ~ " into " ~ $target_type_name ~ ": " ~ $hint);
         }
 
         $coerced_value

--- a/src/Perl6/Metamodel/CoercionHOW.nqp
+++ b/src/Perl6/Metamodel/CoercionHOW.nqp
@@ -4,8 +4,7 @@
 # This means we get cross-compilation-unit interning "for free", as well as
 # avoiding a meta-object instance per coercion type created.
 class Perl6::Metamodel::CoercionHOW
-    # does Perl6::Metamodel::MethodDelegation
-    # does Perl6::Metamodel::TypePretense
+    does Perl6::Metamodel::LanguageRevision
 {
     has $!composed;
     has $!target_type;
@@ -40,6 +39,7 @@ class Perl6::Metamodel::CoercionHOW
         if $!composed {
             return $coercion_type;
         }
+        self.set_language_version($coercion_type, :force);
         my $tt := $coercion_type.HOW.target_type($coercion_type);
         my $ct := $coercion_type.HOW.constraint_type($coercion_type);
         nqp::settypecheckmode($coercion_type, 2);
@@ -49,9 +49,9 @@ class Perl6::Metamodel::CoercionHOW
 
     method set_target_type($target_type) {
         $!target_type := $target_type;
-        $!nominal_target := nqp::if($!target_type.HOW.archetypes.nominalizable,
-                                    $!target_type.HOW.nominalize($!target_type),
-                                    $!target_type);
+        $!nominal_target := $!target_type.HOW.archetypes.nominalizable
+                                ?? $!target_type.HOW.nominalize($!target_type)
+                                !! $!target_type;
     }
 
     method set_constraint_type($constraint_type) {
@@ -112,6 +112,14 @@ class Perl6::Metamodel::CoercionHOW
         $target_type.HOW.find_method_qualified($target_type, $qtype, $name)
     }
 
+    method isa($obj, $type) {
+        $!nominal_target.HOW.isa($obj, $type)
+    }
+
+    method does($obj, $type) {
+        $!nominal_target.HOW.does($obj, $type)
+    }
+
     method type_check($coercion_type, $checkee) {
         say("??? type_check(", $coercion_type.HOW.name($coercion_type), " vs. ", $checkee.HOW.name($checkee), ")") if nqp::getenvhash<RAKUDO_DEBUG>;
         if $coercion_type =:= $checkee {
@@ -134,52 +142,92 @@ class Perl6::Metamodel::CoercionHOW
     }
 
     # Coercion protocol method.
-    method !coerce($target_type, $value) {
-        say("!!! coerce ", $value.HOW.name($value), " into ", $target_type.HOW.name($target_type)) if nqp::getenvhash<RAKUDO_DEBUG>;
-        if nqp::istype($value, $target_type) {
+    method coerce($obj, $value) {
+        say("!!! coerce ", $value.HOW.name($value), " into ", $!target_type.HOW.name($!target_type)) if nqp::getenvhash<RAKUDO_DEBUG>;
+        if nqp::istype($value, $!target_type) {
             say("!!! ... coerce isn't needed") if nqp::getenvhash<RAKUDO_DEBUG>;
             return $value
         }
 
         my $value_type := nqp::what($value);
+        my $coerced_value := nqp::null();
+        my $coercion_method;
+        my $method;
 
         say("!!! ... try target type method first") if nqp::getenvhash<RAKUDO_DEBUG>;
         # First we try $value.TargetType() approach
-        my $method := $value_type.HOW.find_method($value_type, $!nominal_target.HOW.name($!nominal_target), :no_fallback);
-        unless nqp::isnull($method) {
-            return $method($value)
+        $coercion_method := $!nominal_target.HOW.name($!nominal_target);
+        $method := nqp::tryfindmethod($value_type, $coercion_method);
+        if nqp::defined($method) {
+            $coerced_value := $method($value)
         }
 
-        say("!!! ... try COERCE") if nqp::getenvhash<RAKUDO_DEBUG>;
-        # As the last resort we fallback to TargetType.COERCE($value). This is the worst possible variant because
-        # the best possible coercion may require access to source calss private data. Yet, this may work for many simple
-        # cases like TargetType(Str), for example.
-        # $method := $target_type.HOW.find_method($target_type, 'COERCE');
-        my $target_how := $target_type.HOW;
-        my $target_nominal := $target_how.archetypes.nominalizable
-                                    ?? $target_how.nominalize($target_type)
-                                    !! $target_type;
-        my $submethod_table := $target_nominal.HOW.submethod_table($target_nominal);
-        if nqp::existskey($submethod_table, 'COERCE') {
-            my $method := nqp::atkey($submethod_table, 'COERCE');
-            if nqp::can($method, 'cando') && $method.cando($target_nominal, $value) {
-                return $method($target_nominal, $value);
+        # Then try TargetType.COERCE($value).
+        if nqp::isnull($coerced_value) {
+            say("!!! ... try COERCE") if nqp::getenvhash<RAKUDO_DEBUG>;
+            $method := nqp::tryfindmethod($!nominal_target, $coercion_method := 'COERCE');
+            say("!!! ... got: ", $method.HOW.name($method)) if nqp::getenvhash<RAKUDO_DEBUG>;
+            if nqp::defined($method) && nqp::can($method, 'cando') && $method.cando($!nominal_target, $value) {
+                $coerced_value := $method($!nominal_target, $value);
             }
         }
 
-        say("!!! ... failed") if nqp::getenvhash<RAKUDO_DEBUG>;
-        my %ex := nqp::gethllsym('Raku', 'P6EX');
-        my $target_type_name := $target_type.HOW.name($target_type);
-        my $value_type_name := $value_type.HOW.name($value_type);
-        if %ex {
-            %ex<X::Coerce::Impossible>($target_type_name, $value_type_name)
-        }
-        nqp::die("Impossible coercion from " ~ $value_type.HOW.name($value_type_name)
-                    ~ " into " ~ $target_type.HOW.name($target_type_name));
-    }
+        # And eventually fall back to new. Note that it is invoked on the coercion type invokee to let the method know
+        # it's context.
+        if nqp::isnull($coerced_value) {
+            $method := nqp::tryfindmethod($!nominal_target, $coercion_method := 'new');
+            if nqp::defined($method) && nqp::can($method, 'cando') && $method.cando($!nominal_target, $value) {
+                # There should be no signifacnt performance penalty on this path because if method call ever throws
+                # then this is gonna result in an exception one way or another.
+                my $exception;
+                try {
+                    $coerced_value := $method($obj, $value);
+                    CATCH {
+                        my $exception_obj := nqp::getpayload($!);
 
-    method coerce($obj, $value) {
-        self."!coerce"($!target_type, $value)
+                        unless $exception_obj.HOW.name($exception_obj) eq 'X::Constructor::Positional' {
+                            $exception := $!;
+                        }
+                    }
+                }
+                if nqp::defined($exception) {
+                    nqp::rethrow($exception);
+                }
+            }
+        }
+
+        say("!!! ... ... coerced into ", nqp::what(nqp::decont($coerced_value)).HOW.name(nqp::what(nqp::decont($coerced_value))), "; subtype of ",
+            $!target_type.HOW.name($!target_type), "? ", nqp::istype(nqp::decont($coerced_value), $!target_type)
+        ) if nqp::getenvhash<RAKUDO_DEBUG>;
+        my $coerced_decont := nqp::decont($coerced_value);
+        # Fail for either no coercion method found or wrong type returned, except for Failure kind of return which we
+        # must bypass as it carries some useful information about another error.
+        if nqp::isnull($coerced_value)
+            || !(nqp::istype($coerced_decont, $!target_type)
+                || nqp::istype($coerced_decont, nqp::gethllsym('Raku', 'Failure')))
+        {
+            say("!!! ... failed") if nqp::getenvhash<RAKUDO_DEBUG>;
+            my %ex := nqp::gethllsym('Raku', 'P6EX');
+            my $target_type_name := $!target_type.HOW.name($!target_type);
+            my $value_type_name := $value_type.HOW.name($value_type);
+            my $hint;
+            if nqp::isnull($coerced_value) {
+                $hint := "no acceptable coercion method found";
+            }
+            else {
+                my $coerced_name := $coerced_decont.HOW.name($coerced_decont);
+                $hint := "method " ~ $coercion_method ~ " returned "
+                            ~ (nqp::defined($coerced_decont) ?? "an instance of" !! "a type object")
+                            ~ " " ~ $coerced_name;
+            }
+            if %ex {
+                %ex<X::Coerce::Impossible>($target_type_name, $value_type_name, $hint)
+            }
+            nqp::die("Impossible coercion from " ~ $value_type.HOW.name($value_type_name)
+                        ~ " into " ~ $target_type_name) ~ ": " ~ $hint;
+        }
+
+        $coerced_value
     }
 }
 BEGIN {

--- a/src/Perl6/Metamodel/CoercionHOW.nqp
+++ b/src/Perl6/Metamodel/CoercionHOW.nqp
@@ -111,7 +111,7 @@ class Perl6::Metamodel::CoercionHOW
         # Next we try $value.COERCE-INTO(TargetType). This would make possible coercion into types with compound names
         # like MyPackage::TargetType.
         $method := $value_type.HOW.find_method($value_type, 'COERCE-INTO');
-        if nqp::defined($method) {
+        if nqp::defined($method) && $method.cando($value, $!target_type) {
             return $method($value, $!target_type);
         }
 
@@ -119,7 +119,7 @@ class Perl6::Metamodel::CoercionHOW
         # the best possible coercion may require access to source calss private data. Yet, this may work for many simple
         # cases like TargetType(Str), for example.
         $method := $!target_type.HOW.find_method($!target_type, 'COERCE-FROM');
-        if nqp::defined($method) {
+        if nqp::defined($method) && $method.cando($!target_type, $value) {
             return $method($!target_type, $value);
         }
 

--- a/src/Perl6/Metamodel/CoercionHOW.nqp
+++ b/src/Perl6/Metamodel/CoercionHOW.nqp
@@ -110,8 +110,10 @@ class Perl6::Metamodel::CoercionHOW
 
         # Next we try $value.COERCE-INTO(TargetType). This would make possible coercion into types with compound names
         # like MyPackage::TargetType.
+        # XXX COERCE-* methods can only be of type Routine now. Does it ever makes sense for them to be of some other
+        # base class?
         $method := $value_type.HOW.find_method($value_type, 'COERCE-INTO');
-        if nqp::defined($method) && $method.cando($value, $!target_type) {
+        if nqp::defined($method) && nqp::can($method, 'cando') && $method.cando($value, $!target_type) {
             return $method($value, $!target_type);
         }
 
@@ -119,7 +121,7 @@ class Perl6::Metamodel::CoercionHOW
         # the best possible coercion may require access to source calss private data. Yet, this may work for many simple
         # cases like TargetType(Str), for example.
         $method := $!target_type.HOW.find_method($!target_type, 'COERCE-FROM');
-        if nqp::defined($method) && $method.cando($!target_type, $value) {
+        if nqp::defined($method) && nqp::can($method, 'cando') && $method.cando($!target_type, $value) {
             return $method($!target_type, $value);
         }
 

--- a/src/Perl6/Metamodel/CoercionHOW.nqp
+++ b/src/Perl6/Metamodel/CoercionHOW.nqp
@@ -66,6 +66,10 @@ class Perl6::Metamodel::CoercionHOW
         $!constraint_type
     }
 
+    method nominal_target($coercion_type) {
+        $!nominal_target
+    }
+
     method nominalize($coercion_type) {
         my $target_type := $coercion_type.HOW.target_type($coercion_type);
         $target_type.HOW.archetypes.nominalizable
@@ -74,9 +78,16 @@ class Perl6::Metamodel::CoercionHOW
     }
 
     method find_method($coercion_type, $name, *%c) {
-        say('find_method(', $coercion_type.HOW.name($coercion_type), ", ", $name, ')') if nqp::getenvhash<RAKUDO_DEBUG>;
+        if nqp::getenvhash<RAKUDO_DEBUG> {
+            say("&&& find_method on ", $coercion_type.HOW.name($coercion_type), " for ", $name);
+        }
         my $target_type := $coercion_type.HOW.target_type($coercion_type);
         $target_type.HOW.find_method($target_type, $name, |%c)
+    }
+
+    method find_method_qualified($coercion_type, $qtype, $name) {
+        my $target_type := $coercion_type.HOW.target_type($coercion_type);
+        $target_type.HOW.find_method_qualified($target_type, $qtype, $name)
     }
 
     method type_check($obj, $checkee) {
@@ -140,6 +151,9 @@ class Perl6::Metamodel::CoercionHOW
 
     method coerce($obj, $value) {
         self."!coerce"($!target_type, $value)
+    }
+    method no-coerce($obj) {
+        say("Not coercing ", $obj.HOW.name($obj)) if nqp::getenvhash<RAKUDO_DEBUG>;
     }
 }
 BEGIN {

--- a/src/Perl6/Metamodel/CoercionHOW.nqp
+++ b/src/Perl6/Metamodel/CoercionHOW.nqp
@@ -40,8 +40,6 @@ class Perl6::Metamodel::CoercionHOW
             return $coercion_type;
         }
         self.set_language_version($coercion_type, :force);
-        my $tt := $coercion_type.HOW.target_type($coercion_type);
-        my $ct := $coercion_type.HOW.constraint_type($coercion_type);
         nqp::settypecheckmode($coercion_type, 2);
         $!composed := 1;
         $coercion_type
@@ -86,7 +84,7 @@ class Perl6::Metamodel::CoercionHOW
     }
 
     method instantiate_generic($coercion_type, $type_env) {
-        return self unless self.archetypes.generic;
+        return $coercion_type unless $!archetypes.generic;
         my $ins_target :=
             $!target_type.HOW.archetypes.generic
                 ?? $!target_type.HOW.instantiate_generic($!target_type, $type_env)

--- a/src/Perl6/Metamodel/CoercionHOW.nqp
+++ b/src/Perl6/Metamodel/CoercionHOW.nqp
@@ -202,11 +202,13 @@ class Perl6::Metamodel::CoercionHOW
                             ~ (nqp::defined($coerced_decont) ?? "an instance of" !! "a type object")
                             ~ " " ~ $coerced_name;
             }
-            if %ex {
+            unless nqp::isnull(%ex) {
                 %ex<X::Coerce::Impossible>($target_type_name, $value_type_name, $hint)
             }
-            nqp::die("Impossible coercion from " ~ $value_type.HOW.name($value_type_name)
-                        ~ " into " ~ $target_type_name ~ ": " ~ $hint);
+            nqp::die("Impossible coercion from "
+                        ~ $value_type_name
+                        ~ " into " ~ $target_type_name
+                        ~ ": " ~ $hint);
         }
 
         $coerced_value

--- a/src/Perl6/Metamodel/CoercionHOW.nqp
+++ b/src/Perl6/Metamodel/CoercionHOW.nqp
@@ -152,9 +152,6 @@ class Perl6::Metamodel::CoercionHOW
     method coerce($obj, $value) {
         self."!coerce"($!target_type, $value)
     }
-    method no-coerce($obj) {
-        say("Not coercing ", $obj.HOW.name($obj)) if nqp::getenvhash<RAKUDO_DEBUG>;
-    }
 }
 BEGIN {
     my $root := nqp::newtype(Perl6::Metamodel::CoercionHOW.new, 'Uninstantiable');

--- a/src/Perl6/Metamodel/CoercionHOW.nqp
+++ b/src/Perl6/Metamodel/CoercionHOW.nqp
@@ -33,12 +33,7 @@ class Perl6::Metamodel::CoercionHOW
         }
         my $tt := $coercion_type.HOW.target_type($coercion_type);
         my $ct := $coercion_type.HOW.constraint_type($coercion_type);
-        note("CoercionHOW.compose(", $coercion_type.HOW.name($coercion_type), "|", nqp::objectid($coercion_type), ") ", $tt.HOW.name($tt), " ", $ct.HOW.name($ct));
-        # TODO typecache must iterate over MRO with roles
-        nqp::settypecache($coercion_type,
-            nqp::list(
-                $coercion_type.HOW.target_type($coercion_type),
-                $coercion_type.HOW.constraint_type($coercion_type)));
+        nqp::settypecheckmode($coercion_type, 2);
         $!composed := 1;
         $coercion_type
     }
@@ -140,8 +135,7 @@ BEGIN {
         my $metaclass := $type.HOW.new();
         $metaclass.set_target_type($params[0]);
         $metaclass.set_constraint_type($params[1]);
-        my $coercion_type := nqp::settypehll(nqp::newtype($metaclass, 'Uninstantiable'), 'Raku');
-        nqp::settypecheckmode($coercion_type, 2)
+        nqp::settypehll(nqp::newtype($metaclass, 'Uninstantiable'), 'Raku');
     });
     (Perl6::Metamodel::CoercionHOW.WHO)<root> := $root;
 }

--- a/src/Perl6/Metamodel/CoercionHOW.nqp
+++ b/src/Perl6/Metamodel/CoercionHOW.nqp
@@ -179,7 +179,8 @@ class Perl6::Metamodel::CoercionHOW
                 # then this is gonna result in an exception one way or another.
                 my $exception;
                 try {
-                    $coerced_value := $method($obj, $value);
+                    my $*COERCION-TYPE := $obj; # Provide context information to the method 'new'
+                    $coerced_value := $method($!nominal_target, $value);
                     CATCH {
                         my $exception_obj := nqp::getpayload($!);
 

--- a/src/Perl6/Metamodel/CoercionHOW.nqp
+++ b/src/Perl6/Metamodel/CoercionHOW.nqp
@@ -123,8 +123,11 @@ class Perl6::Metamodel::CoercionHOW
             return $method($!target_type, $value);
         }
 
-        # TODO To be replaced with a proper Exception throwing.
-        nqp::die("Impossible coercion of " ~ $value_type.HOW.name($value_type)
+        my %ex := nqp::gethllsym('Raku', 'P6EX');
+        if %ex {
+            %ex<X::Coerce::Impossible>($!target_type, $value_type)
+        }
+        nqp::die("Impossible coercion from " ~ $value_type.HOW.name($value_type)
                     ~ " into " ~ $!target_type.HOW.name($!target_type));
     }
 }

--- a/src/Perl6/Metamodel/Configuration.nqp
+++ b/src/Perl6/Metamodel/Configuration.nqp
@@ -3,6 +3,7 @@
 class Perl6::Metamodel::Configuration {
     my $stash_type := nqp::null();
     my $stash_attr_type := nqp::null();
+
     method set_stash_type($type, $attr_type) {
         $stash_type := $type;
         $stash_attr_type := $attr_type;

--- a/src/Perl6/Metamodel/DefiniteHOW.nqp
+++ b/src/Perl6/Metamodel/DefiniteHOW.nqp
@@ -106,6 +106,11 @@ class Perl6::Metamodel::DefiniteHOW
         $base_type.HOW.find_method($base_type, $name)
     }
 
+    method find_method_qualified($definite_type, $qtype, $name) {
+        my $base_type := self.base_type($definite_type);
+        $base_type.HOW.find_method_qualified($base_type, $qtype, $name)
+    }
+
     # Do check when we're on LHS of smartmatch (e.g. Even ~~ Int).
     method type_check($definite_type, $checkee) {
         my $base_type := self.base_type($definite_type);

--- a/src/Perl6/Metamodel/RolePunning.nqp
+++ b/src/Perl6/Metamodel/RolePunning.nqp
@@ -58,7 +58,7 @@ role Perl6::Metamodel::RolePunning {
     }
 
     # Do a pun-based dispatch. If we pun, return a thunk that will delegate.
-    method find_method($obj, $name) {
+    method find_method($obj, $name, *%c) {
         if nqp::existskey(%exceptions, $name) {
             return nqp::findmethod(%exceptions{$name}, $name);
         }

--- a/src/Perl6/Ops.nqp
+++ b/src/Perl6/Ops.nqp
@@ -202,26 +202,6 @@ _register_op_with_nqp( 'p6getlexclient', -> $qast {
                 QAST::Var.new( :name($setting-only), :scope<local>, :decl<var> ),
                 (nqp::atpos($qast, 1) || QAST::IVal.new( :value(0) ))
             ),
-            # QAST::Op.new(
-            #     :op<if>,
-            #     QAST::Op.new(:op<atkey>, QAST::Op.new(:op<getenvhash>), QAST::SVal.new(:value<RAKUDO_DEBUG>)),
-            #     QAST::Op.new(
-            #         :op<say>,
-            #         QAST::Op.new(
-            #             :op<concat>,
-            #             QAST::SVal.new( value => "p6getlexclient: "),
-            #             QAST::Op.new(
-            #                 :op<concat>,
-            #                 $qast[0],
-            #                 QAST::Op.new(
-            #                     :op<concat>,
-            #                     QAST::SVal.new(:value<, >),
-            #                     $setting-only-var
-            #                 )
-            #             )
-            #         )
-            #     ),
-            # ),
             QAST::Op.new(
                 :op<if>,
                 QAST::Op.new(

--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -2256,9 +2256,6 @@ class Perl6::World is HLL::World {
             $flags := $flags + $SIG_ELEM_TYPE_GENERIC;
         }
         if %param_info<type_coercive> {
-            if nqp::getenvhash<RAKUDO_DEBUG> {
-                nqp::say("??? ... adding " ~ $SIG_ELEM_IS_COERCIVE ~ " (is coercive) flag, name: " ~ (%param_info<variable_name> // '*WTF?*'));
-            }
             $flags := $flags + $SIG_ELEM_IS_COERCIVE;
         }
         if %param_info<default_is_literal> {
@@ -2281,9 +2278,6 @@ class Perl6::World is HLL::World {
         }
         nqp::bindattr($parameter, $par_type, '$!type', %param_info<type>);
         nqp::bindattr_i($parameter, $par_type, '$!flags', $flags);
-        if nqp::getenvhash<RAKUDO_DEBUG> {
-            nqp::say("??? ... flags " ~ nqp::sprintf('%08x', [$flags // -1]));
-        }
         if %param_info<named_names> {
             nqp::bindattr($parameter, $par_type, '@!named_names', %param_info<named_names>);
         }
@@ -2366,16 +2360,9 @@ class Perl6::World is HLL::World {
         my @param_objs;
         my %seen_names;
         for @params {
-            if nqp::getenvhash<RAKUDO_DEBUG> {
-                nqp::say("??? Param " ~ ($_<variable_name> // '*unnamed*'));
-            }
             # Set default nominal type, if we lack one.
             unless nqp::existskey($_, 'type') {
                 $_<type> := $default_type;
-            }
-
-            if nqp::getenvhash<RAKUDO_DEBUG> {
-                nqp::say("??? ... type " ~ $_<type>.HOW.name($_<type>) ~ ", coercive: " ~ ($_<type_coercive> ?? "YES" !! "NO"));
             }
 
             # Default to rw if needed.

--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -4127,7 +4127,7 @@ class Perl6::World is HLL::World {
         self.ex-handle($/, {
             my $type := $/.how('coercion').new_type($target, $constraint);
             if nqp::isnull(nqp::getobjsc($type)) { self.add_object_if_no_sc($type); }
-            $type
+            $type.HOW.compose($type)
         })
     }
 

--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -4015,8 +4015,6 @@ Perl6::Metamodel::PackageHOW.pretend_to_be([Any, Mu]);
 Perl6::Metamodel::PackageHOW.delegate_methods_to(Any);
 Perl6::Metamodel::ModuleHOW.pretend_to_be([Any, Mu]);
 Perl6::Metamodel::ModuleHOW.delegate_methods_to(Any);
-# Perl6::Metamodel::CoercionHOW.pretend_to_be([Any, Mu]);
-# Perl6::Metamodel::CoercionHOW.delegate_methods_to(Any);
 
 # Let ClassHOW and EnumHOW know about the invocation handler.
 Perl6::Metamodel::ClassHOW.set_default_invoke_handler(

--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -1925,7 +1925,8 @@ BEGIN {
                     nqp::bindattr_i($ins, Parameter, '$!flags', $flags - $SIG_ELEM_TYPE_GENERIC);
                 }
             }
-            if $ins_type.HOW.archetypes.coercive {
+            my $archetypes := $ins_type.HOW.archetypes;
+            if nqp::can($archetypes, 'coercive') && $archetypes.coercive {
                 nqp::bindattr_i($ins, Parameter, '$!flags', $flags +| $SIG_ELEM_IS_COERCIVE);
             }
             nqp::bindattr($ins, Parameter, '$!type', $ins_type);

--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -1656,7 +1656,12 @@ BEGIN {
                 $val := $desc.default if nqp::eqaddr($val.WHAT, Nil);
                 my $type := $desc.of;
                 if nqp::eqaddr($type, Mu) || nqp::istype($val, $type) {
-                    nqp::bindattr($cont, Scalar, '$!value', $val);
+                    if $type.HOW.archetypes.coercive {
+                        nqp::bindattr($cont, Scalar, '$!value', $type.HOW.coerce($type, $val));
+                    }
+                    else {
+                        nqp::bindattr($cont, Scalar, '$!value', $val);
+                    }
                     unless nqp::eqaddr($desc.WHAT, ContainerDescriptor) ||
                            nqp::eqaddr($desc.WHAT, ContainerDescriptor::Untyped) {
                         $desc.assigned($cont);

--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -296,7 +296,6 @@ my class Binder {
                 # can happen in (::T, T) where we didn't learn about the type until
                 # during the signature bind).
                 if $flags +& $SIG_ELEM_TYPE_GENERIC {
-                    nqp::say("Instantiating " ~ $param_type.HOW.name($param_type) ~ " on " ~ $param.gist) if nqp::getenvhash<RAKUDO_DEBUG>;
                     $param_type := $param_type.HOW.instantiate_generic($param_type, $lexpad);
                 }
 

--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -296,7 +296,7 @@ my class Binder {
                 # can happen in (::T, T) where we didn't learn about the type until
                 # during the signature bind).
                 if $flags +& $SIG_ELEM_TYPE_GENERIC {
-                    nqp::say("Instantiating " ~ $param_type.HOW.name($param_type) ~ " on " ~ $param.gist);
+                    nqp::say("Instantiating " ~ $param_type.HOW.name($param_type) ~ " on " ~ $param.gist) if nqp::getenvhash<RAKUDO_DEBUG>;
                     $param_type := $param_type.HOW.instantiate_generic($param_type, $lexpad);
                 }
 

--- a/src/core.c/Capture.pm6
+++ b/src/core.c/Capture.pm6
@@ -116,7 +116,7 @@ my class Capture { # declared in BOOTSTRAP
                 nqp::push_s($str, nqp::unbox_s((nqp::p6box_s(nqp::iterkey_s($kv)) => nqp::iterval($kv).Str).Str));
             }
         }
-        nqp::join(' ', $str)
+        nqp::p6box_s(nqp::join(' ', $str))
     }
 
     multi method gist(Capture:D:) { self.Capture::raku }
@@ -158,7 +158,7 @@ my class Capture { # declared in BOOTSTRAP
                 nqp::push_s($raku, ')');
             }
         }
-        nqp::join('', $raku)
+        nqp::p6box_s(nqp::join('', $raku))
     }
 
     multi method Bool(Capture:D:) {

--- a/src/core.c/Code.pm6
+++ b/src/core.c/Code.pm6
@@ -55,14 +55,17 @@ my class Code { # declared in BOOTSTRAP
         # A ::() that does not throw.  Also does not need to deal
         # with chunks or sigils.
         my sub soft_indirect_name_lookup($name) {
-            my @parts    = $name.split('::');
+            my @subtypes = ($name ~~ /^ (.*?) [ \( (.*) \) ]? $/).list;
+            for @subtypes -> $subtype {
+                my @parts    = $subtype.split('::');
 
-            my Mu $thing := ::.EXISTS-KEY(@parts[0]);
-            return False unless $thing;
-            $thing := ::.AT-KEY(@parts.shift);
-            for @parts {
-                return False unless $thing.WHO.EXISTS-KEY($_);
-                $thing := $thing.WHO{$_};
+                my Mu $thing := ::.EXISTS-KEY(@parts[0]);
+                return False unless $thing;
+                $thing := ::.AT-KEY(@parts.shift);
+                for @parts {
+                    return False unless $thing.WHO.EXISTS-KEY($_);
+                    $thing := $thing.WHO{$_};
+                }
             }
             True;
         }
@@ -73,35 +76,46 @@ my class Code { # declared in BOOTSTRAP
         # "?", removing type captures, subsignatures, and undeclared types
         # (e.g. types set to or parameterized by captured types.)
         my sub strip_parm (Parameter:D $parm, :$make_optional = False) {
-            my $type = $parm.type.^name;
-            my $raku = $type;
+            my $type := $parm.type;
+            my $type_coercive := $type.HOW.archetypes.coercive;
+            my @types = $type_coercive
+                            ?? ($type.^target_type.^name, $type.^constraint_type.^name)
+                            !! $type.^name;
+            my @raku_names;
+            my $raku;
             my $rest = '';
             my $sigil = $parm.sigil;
-            my $elide_agg_cont= so ($sigil eqv '@'
-                                    or $sigil eqv '%'
-                                    or $type ~~ /^^ Callable >> /);
+            for @types -> $type_name is copy {
+                my $out_name = $type_name;
+                my $elide_agg_cont = so ($sigil eqv '@'
+                                        or $sigil eqv '%'
+                                        or $type_name ~~ /^^ Callable >> /);
 
-            $raku = '' if $elide_agg_cont;
-            unless $type eq "Any" {
-                my int $FIRST = 1; # broken FIRST workaround
-                while $type ~~ / (.*?) \[ (.*) \] $$/ {
-#                   FIRST {  # seems broken in setting
-                    if $FIRST { # broken FIRST workaround
-                        $raku = $elide_agg_cont
-                          ?? ~$1
-                          !! ~$/;
-                        $FIRST = 0;
+                $out_name = '' if $elide_agg_cont;
+                unless $type_name eq "Any" {
+                    my int $FIRST = 1; # broken FIRST workaround
+                    while $type_name ~~ / (.*?) \[ (.*?) \] $$/ {
+    #                   FIRST {  # seems broken in setting
+                        if $FIRST { # broken FIRST workaround
+                            $out_name = $elide_agg_cont
+                              ?? ~$1
+                              !! ~$/;
+                            $FIRST = 0;
+                        }
+                        $type_name = ~$1;
+                        unless soft_indirect_name_lookup(~$0) {
+                            $out_name = '';
+                            last
+                        };
                     }
-                    $type = ~$1;
-                    unless soft_indirect_name_lookup(~$0) {
-                        $raku = '';
-                        last
-                    };
+                    $out_name = '' unless soft_indirect_name_lookup($type_name);
                 }
-                $raku = '' unless soft_indirect_name_lookup($type);
+                @raku_names.push: $out_name;
             }
-            $raku = $parm.coerce_type.^name ~ "($raku)"
-              unless nqp::eqaddr($parm.coerce_type,Mu);
+            $raku = @raku_names[0];
+            if $type_coercive {
+                $raku ~= "(" ~ @raku_names[1] ~ ")";
+            }
             $raku ~= $parm.modifier if $raku ne '';
 
             my $name = $parm.name;

--- a/src/core.c/Duration.pm6
+++ b/src/core.c/Duration.pm6
@@ -13,7 +13,7 @@ my class Duration is Cool does Real {
           !! nqp::p6bindattrinvres(nqp::create(Duration),Duration,'$!tai',tai)
     }
 
-    method Bridge(Duration:D: --> Num:D) { $!tai.Num    }
+    method Bridge(Duration:   --> Num:D) { self.defined ?? $!tai.Num !! self.Real::Bridge }
     method Num   (Duration:D: --> Num:D) { $!tai.Num    }
     method Rat   (Duration:D: --> Rat:D) { $!tai        }
     method narrow(Duration:D:          ) { $!tai.narrow }

--- a/src/core.c/Enumeration.pm6
+++ b/src/core.c/Enumeration.pm6
@@ -32,13 +32,18 @@ my role Enumeration {
 
     multi method ACCEPTS(::?CLASS:D: ::?CLASS:D \v) { self === v }
 
-    proto method CALL-ME(|) {*}
-    multi method CALL-ME(|) {
+    method !FROM-VALUE(|) {
         my $x := nqp::atpos(nqp::p6argvmarray(), 1).AT-POS(0);
         nqp::istype($x, ::?CLASS)
             ?? $x
             !! self.^enum_from_value($x)
     }
+
+    proto method CALL-ME(|) {*}
+    multi method CALL-ME(|c) { self!FROM-VALUE(|c) }
+
+    proto method COERCE(|) {*}
+    multi method COERCE(|c) { self!FROM-VALUE(|c) }
 
     method pred(::?CLASS:D:) {
         nqp::getattr_i(self,::?CLASS,'$!index')

--- a/src/core.c/Exception.pm6
+++ b/src/core.c/Exception.pm6
@@ -2758,6 +2758,11 @@ my class X::Numeric::Underflow is Exception {
     method message() { "Numeric underflow" }
 }
 
+my class X::Numeric::Uninitialized is Exception {
+    has Numeric $.type;
+    method message() { "Use of uninitialized value of type " ~ $!type.^name ~ " in numeric context" }
+}
+
 my class X::Numeric::Confused is Exception {
     has $.num;
     has $.base;

--- a/src/core.c/Exception.pm6
+++ b/src/core.c/Exception.pm6
@@ -877,13 +877,14 @@ my class X::Coerce is Exception {
     has str $.target-type;
     has str $.from-type;
     method message() {
-        "from " ~ $!from-type ~ " into " ~ $!target-type
+        "from '" ~ $!from-type ~ "' into '" ~ $!target-type ~ "'"
     }
 }
 
 my class X::Coerce::Impossible is X::Coerce {
+    has Str:D $.hint is required;
     method message() {
-        "Impossible coercion " ~ callsame
+        "Impossible coercion " ~ callsame() ~ ": " ~ $!hint
     }
 }
 
@@ -2970,8 +2971,8 @@ nqp::bindcurhllsym('P6EX', BEGIN nqp::hash(
       X::TypeCheck::Return.new(:$got, :$expected).throw;
   },
   'X::Coerce::Impossible',
-  -> str $target-type is raw, str $from-type is raw {
-      X::Coerce::Impossible.new(:$target-type, :$from-type).throw;
+  -> str $target-type is raw, str $from-type is raw, str $hint is raw {
+      X::Coerce::Impossible.new(:$target-type, :$from-type, :$hint).throw;
   },
   'X::Assignment::RO',
   -> $value is raw = "value" {

--- a/src/core.c/Exception.pm6
+++ b/src/core.c/Exception.pm6
@@ -873,6 +873,20 @@ my class X::Comp::BeginTime does X::Comp {
     }
 }
 
+my class X::Coerce is Exception {
+    has Mu:U $.target-type;
+    has Mu:U $.from-type;
+    method message() {
+        "from " ~ $!from-type.^name ~ " into " ~ $!target-type.^name
+    }
+}
+
+my class X::Coerce::Impossible is X::Coerce {
+    method message() {
+        "Impossible coercion " ~ callsame
+    }
+}
+
 # XXX a hack for getting line numbers from exceptions from the metamodel
 my class X::Comp::AdHoc is X::AdHoc does X::Comp {
     method is-compile-time(--> True) { }
@@ -2954,6 +2968,10 @@ nqp::bindcurhllsym('P6EX', BEGIN nqp::hash(
   'X::TypeCheck::Return',
   -> Mu $got is raw, Mu $expected is raw {
       X::TypeCheck::Return.new(:$got, :$expected).throw;
+  },
+  'X::Coerce::Impossible',
+  -> Mu $target-type is raw, Mu $from-type is raw {
+      X::Coerce::Impossible.new(:$target-type, :$from-type).throw;
   },
   'X::Assignment::RO',
   -> $value is raw = "value" {

--- a/src/core.c/Exception.pm6
+++ b/src/core.c/Exception.pm6
@@ -874,10 +874,10 @@ my class X::Comp::BeginTime does X::Comp {
 }
 
 my class X::Coerce is Exception {
-    has Mu:U $.target-type;
-    has Mu:U $.from-type;
+    has str $.target-type;
+    has str $.from-type;
     method message() {
-        "from " ~ $!from-type.^name ~ " into " ~ $!target-type.^name
+        "from " ~ $!from-type ~ " into " ~ $!target-type
     }
 }
 
@@ -2970,7 +2970,7 @@ nqp::bindcurhllsym('P6EX', BEGIN nqp::hash(
       X::TypeCheck::Return.new(:$got, :$expected).throw;
   },
   'X::Coerce::Impossible',
-  -> Mu $target-type is raw, Mu $from-type is raw {
+  -> str $target-type is raw, str $from-type is raw {
       X::Coerce::Impossible.new(:$target-type, :$from-type).throw;
   },
   'X::Assignment::RO',

--- a/src/core.c/Instant.pm6
+++ b/src/core.c/Instant.pm6
@@ -37,7 +37,7 @@ my class Instant is Cool does Real {
         my ($posix,$flag) = self.to-posix;
         'Instant.from-posix(' ~ $posix.raku ~ ($flag ?? ',True)' !! ')')
     }
-    method Bridge(Instant:D:          ) { $!tai.Bridge }
+    method Bridge(Instant:   --> Num:D) { self.defined ?? $!tai.Bridge !! self.Real::Bridge }
     method Num   (Instant:D: --> Num:D) { $!tai.Num    }
     method Rat   (Instant:D: --> Rat:D) { $!tai        }
     method Int   (Instant:D: --> Int:D) { $!tai.Int    }

--- a/src/core.c/Int.pm6
+++ b/src/core.c/Int.pm6
@@ -33,11 +33,11 @@ my class Int does Real { # declared in BOOTSTRAP
     multi method new(Any:D \value --> Int:D) { self.new: value.Int }
     multi method new(int   \value --> Int:D) {
         # rebox the value, so we get rid of any potential mixins
-        nqp::fromI_I(nqp::decont(value), self)
+        nqp::fromI_I(nqp::decont(value), self.HOW.archetypes.nominalizable ?? self.^nominalize !! self)
     }
     multi method new(Int:D \value = 0 --> Int:D) {
         # rebox the value, so we get rid of any potential mixins
-        nqp::fromI_I(nqp::decont(value), self)
+        nqp::fromI_I(nqp::decont(value), self.HOW.archetypes.nominalizable ?? self.^nominalize !! self)
     }
 
     multi method raku(Int:D: --> Str:D) {

--- a/src/core.c/Int.pm6
+++ b/src/core.c/Int.pm6
@@ -33,11 +33,11 @@ my class Int does Real { # declared in BOOTSTRAP
     multi method new(Any:D \value --> Int:D) { self.new: value.Int }
     multi method new(int   \value --> Int:D) {
         # rebox the value, so we get rid of any potential mixins
-        nqp::fromI_I(nqp::decont(value), self.HOW.archetypes.nominalizable ?? self.^nominalize !! self)
+        nqp::fromI_I(nqp::decont(value), self)
     }
     multi method new(Int:D \value = 0 --> Int:D) {
         # rebox the value, so we get rid of any potential mixins
-        nqp::fromI_I(nqp::decont(value), self.HOW.archetypes.nominalizable ?? self.^nominalize !! self)
+        nqp::fromI_I(nqp::decont(value), self)
     }
 
     multi method raku(Int:D: --> Str:D) {

--- a/src/core.c/Int.pm6
+++ b/src/core.c/Int.pm6
@@ -80,8 +80,10 @@ my class Int does Real { # declared in BOOTSTRAP
         nqp::abs_I(self, Int)
     }
 
-    method Bridge(Int:D: --> Num:D) {
-        nqp::p6box_n(nqp::tonum_I(self));
+    method Bridge(Int: --> Num:D) {
+        self.defined
+            ?? nqp::p6box_n(nqp::tonum_I(self))
+            !! self.Real::Bridge
     }
 
     method chr(Int:D: --> Str:D) {

--- a/src/core.c/Match.pm6
+++ b/src/core.c/Match.pm6
@@ -29,6 +29,8 @@ my class Match is Capture is Cool does NQPMatchRole {
 
     method Int(--> Int:D) { self.Str.Int }
 
+    method Str { nqp::p6box_s(self.NQPMatchRole::Str) }
+
     method STR() is implementation-detail {
         nqp::eqaddr(nqp::getattr(self,Match,'$!match'),NQPdidMATCH)
           ?? self.Str

--- a/src/core.c/Mu.pm6
+++ b/src/core.c/Mu.pm6
@@ -114,12 +114,10 @@ my class Mu { # declared in BOOTSTRAP
 
     proto method new(|) {*}
     multi method new(*%attrinit) {
-        my Mu $nself := self.HOW.archetypes.nominalizable ?? self.^nominalize !! self;
-        nqp::eqaddr(
-          (my $bless := nqp::findmethod($nself,'bless')),
-          nqp::findmethod(Mu,'bless')
-        ) ?? nqp::create($nself).BUILDALL(Empty, %attrinit)
-          !! $bless($nself,|%attrinit)
+        nqp::eqaddr((my $bless := nqp::findmethod(self,'bless')),
+                    nqp::findmethod(Mu,'bless'))
+                ?? nqp::create(self).BUILDALL(Empty, %attrinit)
+                !! $bless(self,|%attrinit)
     }
     multi method new($, *@) {
         X::Constructor::Positional.new(:type( self )).throw();

--- a/src/core.c/Mu.pm6
+++ b/src/core.c/Mu.pm6
@@ -114,11 +114,12 @@ my class Mu { # declared in BOOTSTRAP
 
     proto method new(|) {*}
     multi method new(*%attrinit) {
+        my Mu $nself := self.HOW.archetypes.nominalizable ?? self.^nominalize !! self;
         nqp::eqaddr(
-          (my $bless := nqp::findmethod(self,'bless')),
+          (my $bless := nqp::findmethod($nself,'bless')),
           nqp::findmethod(Mu,'bless')
-        ) ?? nqp::create(self).BUILDALL(Empty, %attrinit)
-          !! $bless(self,|%attrinit)
+        ) ?? nqp::create($nself).BUILDALL(Empty, %attrinit)
+          !! $bless($nself,|%attrinit)
     }
     multi method new($, *@) {
         X::Constructor::Positional.new(:type( self )).throw();

--- a/src/core.c/Num.pm6
+++ b/src/core.c/Num.pm6
@@ -22,7 +22,7 @@ my class Num does Real { # declared in BOOTSTRAP
     multi method Bool(Num:D:) { nqp::hllbool(nqp::isne_n(self,0e0)) }
     method Capture() { X::Cannot::Capture.new( :what(self) ).throw }
     method Num() { self }
-    method Bridge(Num:D:) { self }
+    method Bridge(Num:) { self.defined ?? self !! self.Real::Bridge }
     method Range(Num:U:) { Range.new(-Inf,Inf) }
 
     method Int(Num:D:) {

--- a/src/core.c/Numeric.pm6
+++ b/src/core.c/Numeric.pm6
@@ -5,7 +5,8 @@ my role Numeric {
     multi method Numeric(Numeric:D:) { self }
     multi method Numeric(Numeric:U:) {
         self.Mu::Numeric; # issue a warning
-        self.new
+        # We need to be specific about coercions to make `Numeric() == 0` working as specced.
+        (self.HOW.archetypes.coercive ?? self.^nominalize !! self).new
     }
 
     multi method ACCEPTS(Numeric:D: Any:D \a) {

--- a/src/core.c/Parameter.pm6
+++ b/src/core.c/Parameter.pm6
@@ -35,6 +35,7 @@ my class Parameter { # declared in BOOTSTRAP
     my constant $SIG_ELEM_DEFAULT_IS_LITERAL = 1 +< 20;
     my constant $SIG_ELEM_SLURPY_ONEARG      = 1 +< 24;
     my constant $SIG_ELEM_CODE_SIGIL         = 1 +< 25;
+    my constant $SIG_ELEM_IS_COERCIVE        = 1 +< 26;
 
     my constant $SIG_ELEM_IS_NOT_POSITIONAL = $SIG_ELEM_SLURPY_POS
                                            +| $SIG_ELEM_SLURPY_NAMED
@@ -375,6 +376,13 @@ my class Parameter { # declared in BOOTSTRAP
     }
     method multi-invocant(Parameter:D: --> Bool:D) {
         nqp::hllbool(nqp::bitand_i($!flags,$SIG_ELEM_MULTI_INVOCANT))
+    }
+    method coercive(Parameter:D: --> Bool:D) {
+        if nqp::getenvhash<RAKUDO_DEBUG> {
+            nqp::say("??? Parameter::coercive on " ~ self.name ~ " of " ~ $!nominal_type.^name);
+            nqp::say("??? " ~ $SIG_ELEM_IS_COERCIVE.fmt('%08x') ~ " +& " ~ $!flags.fmt('%08x') ~ " -> " ~ nqp::hllbool(nqp::bitand_i($!flags,$SIG_ELEM_IS_COERCIVE)));
+        }
+        nqp::hllbool(nqp::bitand_i($!flags,$SIG_ELEM_IS_COERCIVE))
     }
 
     method default(Parameter:D: --> Code:_) {

--- a/src/core.c/Parameter.pm6
+++ b/src/core.c/Parameter.pm6
@@ -4,10 +4,7 @@ my class Parameter { # declared in BOOTSTRAP
     #     has @!named_names
     #     has @!type_captures
     #     has int $!flags
-    #     has Mu $!nominal_type
     #     has @!post_constraints
-    #     has Mu $!coerce_type
-    #     has str $!coerce_method
     #     has Signature $!sub_signature
     #     has Code $!default_value
     #     has Mu $!container_descriptor;
@@ -179,25 +176,26 @@ my class Parameter { # declared in BOOTSTRAP
                 if nqp::istype($type,Str) {
                     if $type.ends-with(Q/)/) {
                         my $start = $type.index(Q/(/);
-                        $!nominal_type :=
+                        my $target-type :=
                           str-to-type($type.substr($start + 1, *-1), my $);
-                        $!coerce_type :=
+                        my $constraint-type :=
                           str-to-type($type.substr(0, $start), $flags);
+                        $!type := Metamodel::CoercionHOW.new_type($target-type, $constraint-type);
                     }
                     else {
-                        $!nominal_type := str-to-type($type, $flags)
+                        $!type := str-to-type($type, $flags)
                     }
                 }
                 else {
-                    $!nominal_type := $type.WHAT;
+                    $!type := $type.WHAT;
                 }
             }
             else {
-                $!nominal_type := $type;
+                $!type := $type;
             }
         }
         else {
-            $!nominal_type := Any;
+            $!type := Any;
         }
 
         if %args.EXISTS-KEY('default') {
@@ -233,6 +231,7 @@ my class Parameter { # declared in BOOTSTRAP
         $flags +|= $SIG_ELEM_IS_COPY        if $is-copy;
         $flags +|= $SIG_ELEM_IS_RAW         if $is-raw;
         $flags +|= $SIG_ELEM_IS_RW          if $is-rw;
+        $flags +|= $SIG_ELEM_IS_COERCIVE    if $!type.HOW.archetypes.coercive;
 
         $!variable_name = $name if $name;
         $!flags = $flags;
@@ -321,9 +320,9 @@ my class Parameter { # declared in BOOTSTRAP
         all(nqp::isnull(@!post_constraints) ?? () !! nqp::hllize(@!post_constraints))
     }
 
-    method type(Parameter:D: --> Mu) { $!nominal_type }
+    method type(Parameter:D: --> Mu) { $!type }
 
-    method coerce_type(Parameter:D: --> Mu) { $!coerce_type }
+    method nominal_type(Parameter:D --> Mu) { $!type.HOW.archetypes.nominalizable ?? $!type.^nominalize !! $!type }
 
     method named_names(Parameter:D: --> List:D) {
         nqp::if(
@@ -377,13 +376,6 @@ my class Parameter { # declared in BOOTSTRAP
     method multi-invocant(Parameter:D: --> Bool:D) {
         nqp::hllbool(nqp::bitand_i($!flags,$SIG_ELEM_MULTI_INVOCANT))
     }
-    method coercive(Parameter:D: --> Bool:D) {
-        if nqp::getenvhash<RAKUDO_DEBUG> {
-            nqp::say("??? Parameter::coercive on " ~ self.name ~ " of " ~ $!nominal_type.^name);
-            nqp::say("??? " ~ $SIG_ELEM_IS_COERCIVE.fmt('%08x') ~ " +& " ~ $!flags.fmt('%08x') ~ " -> " ~ nqp::hllbool(nqp::bitand_i($!flags,$SIG_ELEM_IS_COERCIVE)));
-        }
-        nqp::hllbool(nqp::bitand_i($!flags,$SIG_ELEM_IS_COERCIVE))
-    }
 
     method default(Parameter:D: --> Code:_) {
         nqp::isnull($!default_value)
@@ -409,8 +401,6 @@ my class Parameter { # declared in BOOTSTRAP
         )
     }
 
-    method !flags() { $!flags }
-
     multi method ACCEPTS(Parameter:D: Parameter:D \other --> Bool:D) {
 
         # we're us
@@ -418,7 +408,7 @@ my class Parameter { # declared in BOOTSTRAP
         return True if nqp::eqaddr(self,o);
 
         # nominal type is acceptable
-        if $!nominal_type.ACCEPTS(nqp::getattr(o,Parameter,'$!nominal_type')) {
+        if $!type.ACCEPTS(nqp::getattr(o,Parameter,'$!type')) {
             my \oflags := nqp::getattr(o,Parameter,'$!flags');
 
             # flags are not same, so we need to look more in depth
@@ -551,9 +541,7 @@ my class Parameter { # declared in BOOTSTRAP
         $raku ~= "::$_ " for @.type_captures;
 
         my $modifier = $.modifier;
-        my $type     = $!nominal_type.^name;
-        $type = $!coerce_type.^name ~ "($type)"
-          unless nqp::isnull($!coerce_type);
+        my $type     = $!type.^name;
         if $!flags +& $SIG_ELEM_ARRAY_SIGIL or
             $!flags +& $SIG_ELEM_HASH_SIGIL or
             $!flags +& $SIG_ELEM_CODE_SIGIL {
@@ -561,7 +549,7 @@ my class Parameter { # declared in BOOTSTRAP
             $raku ~= $/ ~ $modifier if $/;
         }
         elsif $modifier or
-                !nqp::eqaddr($!nominal_type, nqp::decont($elide-type)) {
+                !nqp::eqaddr($!type, nqp::decont($elide-type)) {
             $raku ~= $type ~ $modifier;
         }
 
@@ -653,16 +641,10 @@ multi sub infix:<eqv>(Parameter:D \a, Parameter:D \b) {
     return False unless a.WHAT =:= b.WHAT;
 
     # different nominal or coerce type
-    my $acoerce := nqp::getattr(a,Parameter,'$!coerce_type');
-    my $bcoerce := nqp::getattr(b,Parameter,'$!coerce_type');
     return False
-      unless nqp::iseq_s(
-          nqp::getattr(a,Parameter,'$!nominal_type').^name,
-          nqp::getattr(b,Parameter,'$!nominal_type').^name
-        )
-      && nqp::iseq_s(
-          nqp::isnull($acoerce) ?? "" !! $acoerce.^name,
-          nqp::isnull($bcoerce) ?? "" !! $bcoerce.^name
+        unless nqp::eqaddr(
+            nqp::getattr(a,Parameter,'$!type'),
+            nqp::getattr(b,Parameter,'$!type')
         );
 
     # different flags

--- a/src/core.c/Parameter.pm6
+++ b/src/core.c/Parameter.pm6
@@ -646,10 +646,14 @@ multi sub infix:<eqv>(Parameter:D \a, Parameter:D \b) {
     # different nominal or coerce type
     my \atype = nqp::getattr(a,Parameter,'$!type');
     my \btype = nqp::getattr(b,Parameter,'$!type');
+    # (atype is btype) && (btype is atype) ensures type equivalence. Works for different curryings of a parametric role
+    # which are parameterized with the same argument. nqp::eqaddr is not applicable here because if coming from
+    # different compunits the curryings would be different typeobject instances.
     return False
         unless
             (atype.HOW.archetypes.generic && btype.HOW.archetypes.generic)
-            || nqp::eqaddr(atype, btype);
+            || (nqp::istype(atype, btype)
+                && nqp::istype(btype, atype));
 
     # different flags
     return False

--- a/src/core.c/Rational.pm6
+++ b/src/core.c/Rational.pm6
@@ -105,8 +105,6 @@ my role Rational[::NuT = Int, ::DeT = ::("NuT")] does Real {
 
     multi method Bool(::?CLASS:D:) { nqp::hllbool(nqp::istrue($!numerator)) }
 
-    method Bridge() { self.Num }
-
     method Range(::?CLASS:U:) { Range.new(-Inf, Inf) }
 
     method isNaN (--> Bool:D) {

--- a/src/core.c/Real.pm6
+++ b/src/core.c/Real.pm6
@@ -148,7 +148,7 @@ multi sub infix:<**>(Real \a, Real \b)  { a.Bridge ** b.Bridge }
 
 multi sub infix:«<=>»(Real \a, Real \b) { a.Bridge <=> b.Bridge }
 
-multi sub infix:<==>(Real \a, Real \b)  { a.Bridge == b.Bridge }
+multi sub infix:<==>(Real:D \a, Real:D \b)  { a.Bridge == b.Bridge }
 
 multi sub infix:«<»(Real \a, Real \b)   { a.Bridge < b.Bridge }
 

--- a/src/core.c/Real.pm6
+++ b/src/core.c/Real.pm6
@@ -1,4 +1,5 @@
 my class Complex { ... }
+my class X::Numeric::Uninitialized { ... }
 
 my role Real does Numeric {
     method Rat(Real:D: Real $epsilon = 1.0e-6) { self.Bridge.Rat($epsilon) }
@@ -125,7 +126,13 @@ my role Real does Numeric {
         self.Mu::Real; # issue a warning;
         self.new
     }
-    method Bridge(Real:D:) { self.Num }
+    method Bridge(Real: --> Num:D) {
+        self.defined
+            ?? self.Num
+            !! (self.HOW.archetypes.coercive
+                ?? self.Mu::Numeric.Num
+                !! X::Numeric::Uninitialized.new(:type(self)).throw)
+    }
     method Int(Real:D:) { self.Bridge.Int }
     method Num(Real:D:) { self.Bridge.Num }
     multi method Str(Real:D:) { self.Bridge.Str }
@@ -148,7 +155,7 @@ multi sub infix:<**>(Real \a, Real \b)  { a.Bridge ** b.Bridge }
 
 multi sub infix:«<=>»(Real \a, Real \b) { a.Bridge <=> b.Bridge }
 
-multi sub infix:<==>(Real:D \a, Real:D \b)  { a.Bridge == b.Bridge }
+multi sub infix:<==>(Real \a, Real \b)  { a.Bridge == b.Bridge }
 
 multi sub infix:«<»(Real \a, Real \b)   { a.Bridge < b.Bridge }
 

--- a/src/core.c/Routine.pm6
+++ b/src/core.c/Routine.pm6
@@ -27,7 +27,8 @@ my class Routine { # declared in BOOTSTRAP
             (self,)
     }
 
-    method cando(Capture:D $c) {
+    proto method cando(|) {*}
+    multi method cando(Capture:D $c) {
         my $disp;
         if self.is_dispatcher {
             $disp := self;
@@ -42,6 +43,7 @@ my class Routine { # declared in BOOTSTRAP
         }
         checker(|$c);
     }
+    multi method cando(|c) { self.cando(c) }
 
     method multi() {
         self.dispatcher.defined

--- a/src/core.c/Str.pm6
+++ b/src/core.c/Str.pm6
@@ -62,6 +62,11 @@ my class Str does Stringy { # declared in BOOTSTRAP
     multi method Stringy(Str:D:) { self }
     multi method DUMP(Str:D: --> Str:D) { self.raku }
 
+    proto method COERCE(|) {*}
+    multi method COERCE(Mu \s) {
+        self.new(:value(nqp::p6box_s(s)))
+    }
+
     method Int(Str:D: --> Int:D) {
         nqp::istype((my $n := self.Numeric),Int) || nqp::istype($n,Failure)
           ?? $n

--- a/src/core.c/Version.pm6
+++ b/src/core.c/Version.pm6
@@ -155,7 +155,7 @@ augment class Version {
         )
     }
 
-    multi method Str(Version:D:)  { $!string }
+    multi method Str(Version:D:)  { nqp::hllize($!string) }
     multi method gist(Version:D:) { nqp::concat("v",$!string) }
     multi method raku(Version:D:) {
         if nqp::chars($!string) {

--- a/src/core.c/Version.pm6
+++ b/src/core.c/Version.pm6
@@ -155,7 +155,7 @@ augment class Version {
         )
     }
 
-    multi method Str(Version:D:)  { nqp::hllize($!string) }
+    multi method Str(Version:D:)  { nqp::p6box_s($!string) }
     multi method gist(Version:D:) { nqp::concat("v",$!string) }
     multi method raku(Version:D:) {
         if nqp::chars($!string) {

--- a/src/core.c/core_prologue.pm6
+++ b/src/core.c/core_prologue.pm6
@@ -38,6 +38,7 @@ my role PositionalBindFailover { ... }
 # Make Iterable available for the code-gen.
 BEGIN nqp::bindhllsym('Raku', 'Iterable', Iterable);
 nqp::bindhllsym('Raku', 'Iterable', Iterable);
+nqp::bindhllsym('Raku', 'Failure', Failure);
 
 BEGIN {
     # Ensure routines with traits using mixins applied to them typecheck as Callable.

--- a/src/vm/jvm/runtime/org/raku/rakudo/Binder.java
+++ b/src/vm/jvm/runtime/org/raku/rakudo/Binder.java
@@ -379,7 +379,7 @@ public final class Binder {
         boolean didHLLTransform = false;
         SixModelObject paramType = param.get_attribute_boxed(tc, gcx.Parameter, "$!type", HINT_type);
         SixModelObject ContextRef = null;
-        SixModelObject HOW = null;
+        SixModelObject HOW = paramType.st.HOW;
         if (flag == CallSiteDescriptor.ARG_OBJ && !(is_rw && desiredNative != 0)) {
             /* We need to work on the decontainerized value. */
             decontValue = Ops.decont(arg_o, tc);
@@ -390,14 +390,12 @@ public final class Binder {
             if (decontValue != beforeHLLize)
                 didHLLTransform = true;
 
-
             /* Skip nominal type check if not needed. */
             if (!noNomTypeCheck) {
                 /* Is the nominal type generic and in need of instantiation? (This
                  * can happen in (::T, T) where we didn't learn about the type until
                  * during the signature bind.) */
                 if ((paramFlags & SIG_ELEM_TYPE_GENERIC) != 0) {
-                    HOW = paramType.st.HOW;
                     SixModelObject ig = Ops.findmethod(HOW,
                         "instantiate_generic", tc);
                     ContextRef = tc.gc.ContextRef;
@@ -514,9 +512,8 @@ public final class Binder {
                 return BIND_RESULT_FAIL;
             }
 
-            HOW = paramType.st.HOW;
             SixModelObject coerceMeth = Ops.findmethod(HOW, "coerce", tc);
-            Ops.invokeDirect(tc, coerceMeth, genIns, new Object[] { HOW, paramType, origArg });
+            Ops.invokeDirect(tc, coerceMeth, genIns, new Object[] { HOW, paramType, arg_o });
             arg_o = Ops.result_o(tc.curFrame);
             decontValue = Ops.decont(arg_o, tc);
         }

--- a/src/vm/jvm/runtime/org/raku/rakudo/Binder.java
+++ b/src/vm/jvm/runtime/org/raku/rakudo/Binder.java
@@ -43,7 +43,7 @@ public final class Binder {
     private static final int SIG_ELEM_UNDEFINED_ONLY      = 65536;
     private static final int SIG_ELEM_DEFINED_ONLY        = 131072;
     private static final int SIG_ELEM_DEFINEDNES_CHECK    = (SIG_ELEM_UNDEFINED_ONLY | SIG_ELEM_DEFINED_ONLY);
-    private static final int SIG_ELEM_NOMINAL_GENERIC     = 524288;
+    private static final int SIG_ELEM_TYPE_GENERIC        = 524288;
     private static final int SIG_ELEM_DEFAULT_IS_LITERAL  = 1048576;
     private static final int SIG_ELEM_NATIVE_INT_VALUE    = 2097152;
     private static final int SIG_ELEM_NATIVE_NUM_VALUE    = 4194304;
@@ -51,20 +51,20 @@ public final class Binder {
     private static final int SIG_ELEM_NATIVE_VALUE        = (SIG_ELEM_NATIVE_INT_VALUE | SIG_ELEM_NATIVE_NUM_VALUE | SIG_ELEM_NATIVE_STR_VALUE);
     private static final int SIG_ELEM_SLURPY_ONEARG       = 16777216;
     private static final int SIG_ELEM_SLURPY              = (SIG_ELEM_SLURPY_POS | SIG_ELEM_SLURPY_NAMED | SIG_ELEM_SLURPY_LOL | SIG_ELEM_SLURPY_ONEARG);
+    private static final int SIG_ELEM_CODE_SIGIL          = 33554432;
+    private static final int SIG_ELEM_IS_COERCIVE         = 67108864;
 
     /* Hints for Parameter attributes. */
     private static final int HINT_variable_name = 0;
     private static final int HINT_named_names = 1;
     private static final int HINT_type_captures = 2;
     private static final int HINT_flags = 3;
-    private static final int HINT_nominal_type = 4;
+    private static final int HINT_type = 4;
     private static final int HINT_post_constraints = 5;
-    private static final int HINT_coerce_type = 6;
-    private static final int HINT_coerce_method = 7;
-    private static final int HINT_sub_signature = 8;
-    private static final int HINT_default_value = 9;
-    private static final int HINT_container_descriptor = 10;
-    private static final int HINT_attr_package = 11;
+    private static final int HINT_sub_signature = 6;
+    private static final int HINT_default_value = 7;
+    private static final int HINT_container_descriptor = 8;
+    private static final int HINT_attr_package = 9;
 
     /* Other hints. */
     private static final int HINT_ENUMMAP_storage = 0;
@@ -377,7 +377,7 @@ public final class Binder {
          * further checking. */
         SixModelObject decontValue = null;
         boolean didHLLTransform = false;
-        SixModelObject nomType = null;
+        SixModelObject paramType = param.get_attribute_boxed(tc, gcx.Parameter, "$!type", HINT_type);
         SixModelObject ContextRef = null;
         SixModelObject HOW = null;
         if (flag == CallSiteDescriptor.ARG_OBJ && !(is_rw && desiredNative != 0)) {
@@ -390,28 +390,27 @@ public final class Binder {
             if (decontValue != beforeHLLize)
                 didHLLTransform = true;
 
+
             /* Skip nominal type check if not needed. */
             if (!noNomTypeCheck) {
                 /* Is the nominal type generic and in need of instantiation? (This
                  * can happen in (::T, T) where we didn't learn about the type until
                  * during the signature bind.) */
-                nomType = param.get_attribute_boxed(tc, gcx.Parameter,
-                    "$!nominal_type", HINT_nominal_type);
-                if ((paramFlags & SIG_ELEM_NOMINAL_GENERIC) != 0) {
-                    HOW = nomType.st.HOW;
+                if ((paramFlags & SIG_ELEM_TYPE_GENERIC) != 0) {
+                    HOW = paramType.st.HOW;
                     SixModelObject ig = Ops.findmethod(HOW,
                         "instantiate_generic", tc);
                     ContextRef = tc.gc.ContextRef;
                     SixModelObject cc = ContextRef.st.REPR.allocate(tc, ContextRef.st);
                     ((ContextRefInstance)cc).context = cf;
                     Ops.invokeDirect(tc, ig, genIns,
-                        new Object[] { HOW, nomType, cc });
-                    nomType = Ops.result_o(tc.curFrame);
+                        new Object[] { HOW, paramType, cc });
+                    paramType = Ops.result_o(tc.curFrame);
                 }
 
                 /* If the expected type is Positional, see if we need to do the
                  * positional bind failover. */
-                if (nomType == gcx.Positional) {
+                if (paramType == gcx.Positional) {
                     if (Ops.istype_nd(arg_o, gcx.PositionalBindFailover, tc) != 0) {
                         SixModelObject ig = Ops.findmethod(arg_o, "cache", tc);
                         Ops.invokeDirect(tc, ig, Ops.invocantCallSite, new Object[] { arg_o });
@@ -429,14 +428,14 @@ public final class Binder {
                  * anything goes.
                  * When binding a slurpy named hash while compiling the setting don't check for Associative.
                  */
-                if (nomType != gcx.Mu && !(isSlurpyNamed && nomType == gcx.Associative) && Ops.istype_nd(decontValue, nomType, tc) == 0) {
+                if (paramType != gcx.Mu && !(isSlurpyNamed && paramType == gcx.Associative) && Ops.istype_nd(decontValue, paramType, tc) == 0) {
                     /* Type check failed; produce error if needed. */
                     if (error != null) {
                         SixModelObject thrower = RakOps.getThrower(tc, "X::TypeCheck::Binding::Parameter");
                         if (thrower != null) {
                             error[0] = thrower;
                             error[1] = bindParamThrower;
-                            error[2] = new Object[] { decontValue, nomType.st.WHAT,
+                            error[2] = new Object[] { decontValue, paramType.st.WHAT,
                                 varName, param, (long)0 };
                         }
                         else {
@@ -459,7 +458,7 @@ public final class Binder {
                     if (shouldBeConcrete || ((paramFlags & SIG_ELEM_UNDEFINED_ONLY) != 0 && Ops.isconcrete(arg_o, tc) == 1)) {
                         if (error != null) {
                             String typeName = Ops.typeName(param.get_attribute_boxed(tc,
-                                gcx.Parameter, "$!nominal_type", HINT_nominal_type), tc);
+                                gcx.Parameter, "$!type", HINT_type), tc);
                             String argName = Ops.typeName(arg_o, tc);
                             String methodName = cf.codeRef.name;
                             SixModelObject thrower = RakOps.getThrower(tc, "X::Parameter::InvalidConcreteness");
@@ -503,9 +502,9 @@ public final class Binder {
             bindTypeCaptures(tc, typeCaps, cf, decontValue.st.WHAT);
 
         /* Do a coercion, if one is needed. */
-        SixModelObject coerceType = param.get_attribute_boxed(tc, gcx.Parameter,
-            "$!coerce_type", HINT_coerce_type);
-        if (coerceType != null) {
+        SixModelObject coerciveMeth = Ops.findmethod(param.st.WHAT, "coercive", tc);
+        Ops.invokeDirect(tc, coerciveMeth, Ops.invocantCallSite, new Object[] { param });
+        if (Ops.istrue(Ops.result_o(tc.curFrame), tc) == 1) {
             /* Coercing natives not possible - nothing to call a method on. */
             if (flag != CallSiteDescriptor.ARG_OBJ) {
                 if (error != null)
@@ -515,45 +514,11 @@ public final class Binder {
                 return BIND_RESULT_FAIL;
             }
 
-            /* Is the coercion target generic and in need of instantiation?
-             * (This can happen in (::T, T) where we didn't learn about the
-             * type until during the signature bind.) */
-            param.get_attribute_native(tc, gcx.Parameter, "$!coerce_method", HINT_coerce_method);
-            String methName = tc.native_s;
-            HOW = coerceType.st.HOW;
-            SixModelObject archetypesMeth = Ops.findmethod(HOW, "archetypes", tc);
-            Ops.invokeDirect(tc, archetypesMeth, Ops.invocantCallSite, new Object[] { HOW });
-            SixModelObject Archetypes = Ops.result_o(tc.curFrame);
-            SixModelObject genericMeth = Ops.findmethod(Archetypes, "generic", tc);
-            Ops.invokeDirect(tc, genericMeth, Ops.invocantCallSite, new Object[] { Archetypes });
-            if (Ops.istrue(Ops.result_o(tc.curFrame), tc) == 1) {
-                ContextRef = tc.gc.ContextRef;
-                SixModelObject ctcc = ContextRef.st.REPR.allocate(tc, ContextRef.st);
-                ((ContextRefInstance)ctcc).context = cf;
-                SixModelObject ctig = Ops.findmethod(HOW, "instantiate_generic", tc);
-                Ops.invokeDirect(tc, ctig, genIns, new Object[] { HOW, coerceType, ctcc });
-                coerceType = Ops.result_o(tc.curFrame);
-                methName = Ops.typeName(coerceType, tc);
-            }
-
-            /* Only coerce if we don't already have the correct type. */
-            if (Ops.istype(decontValue, coerceType, tc) == 0) {
-                SixModelObject coerceMeth = Ops.findmethodNonFatal(decontValue, methName, tc);
-                if (coerceMeth != null) {
-                    Ops.invokeDirect(tc, coerceMeth,
-                        Ops.invocantCallSite,
-                        new Object[] { decontValue });
-                    arg_o = Ops.result_o(tc.curFrame);
-                    decontValue = Ops.decont(arg_o, tc);
-                }
-                else {
-                    if (error != null)
-                        error[0] = String.format(
-                            "Unable to coerce value for '%s' to %s; no coercion method defined",
-                            varName, methName);
-                    return BIND_RESULT_FAIL;
-                }
-            }
+            HOW = paramType.st.HOW;
+            SixModelObject coerceMeth = Ops.findmethod(HOW, "coerce", tc);
+            Ops.invokeDirect(tc, coerceMeth, genIns, new Object[] { HOW, paramType, origArg });
+            arg_o = Ops.result_o(tc.curFrame);
+            decontValue = Ops.decont(arg_o, tc);
         }
 
         /* If it's not got attributive binding, we'll go about binding it into the
@@ -634,9 +599,9 @@ public final class Binder {
                      * in the container descriptor takes care of the rest). */
                     else {
                         boolean wrap = (paramFlags & SIG_ELEM_IS_COPY) != 0;
-                        if (!wrap && nomType != null && gcx.Iterable != null) {
-                            wrap = Ops.istype(gcx.Iterable, nomType, tc) != 0
-                                || Ops.istype(nomType, gcx.Iterable, tc) != 0;
+                        if (!wrap && paramType != null && gcx.Iterable != null) {
+                            wrap = Ops.istype(gcx.Iterable, paramType, tc) != 0
+                                || Ops.istype(paramType, gcx.Iterable, tc) != 0;
                         }
                         if (wrap || varName.equals("$_")) {
                             STable stScalar = gcx.Scalar.st;
@@ -843,7 +808,7 @@ public final class Binder {
                     case SIG_ELEM_NATIVE_STR_VALUE:
                         return createBox(tc, gcx, null, CallSiteDescriptor.ARG_STR);
                     default:
-                        return param.get_attribute_boxed(tc, gcx.Parameter, "$!nominal_type", HINT_nominal_type);
+                        return param.get_attribute_boxed(tc, gcx.Parameter, "$!type", HINT_type);
                 }
             }
         }

--- a/src/vm/moar/spesh-plugins.nqp
+++ b/src/vm/moar/spesh-plugins.nqp
@@ -335,6 +335,10 @@ sub assign-scalar-nil-no-whence($cont, $value) {
 }
 sub assign-scalar-no-whence($cont, $value) {
     my $desc := nqp::getattr($cont, Scalar, '$!descriptor');
+    my $of := $desc.of;
+    if $of.HOW.archetypes.coercive {
+        $value := $of.HOW.coerce($of, $value);
+    }
     my $type := nqp::getattr($desc, ContainerDescriptor, '$!of');
     if nqp::istype($value, $type) {
         nqp::bindattr($cont, Scalar, '$!value', $value);
@@ -358,6 +362,9 @@ sub assign-scalar-bindpos($cont, $value) {
     my $next := nqp::getattr($desc, ContainerDescriptor::BindArrayPos, '$!next-descriptor');
     my $type := nqp::getattr($next, ContainerDescriptor, '$!of');
     if nqp::istype($value, $type) {
+        if $type.HOW.archetypes.coercive {
+            $value := $type.HOW.coerce($type, $value);
+        }
         nqp::bindattr($cont, Scalar, '$!value', $value);
         nqp::bindpos(
             nqp::getattr($desc, ContainerDescriptor::BindArrayPos, '$!target'),

--- a/t/02-rakudo/99-misc.t
+++ b/t/02-rakudo/99-misc.t
@@ -4,15 +4,15 @@ use Test::Helpers;
 
 plan 11;
 
-subtest '.lang-ver-before method on Perl6::World' => {
+subtest '.lang-rev-before method on Perl6::World' => {
     plan 5;
-    is-run ｢use v6.c; BEGIN print ?$*W.lang-ver-before: 'd'｣, 'c is before d', :out<True>;
-    is-run ｢use v6.c; BEGIN print ?$*W.lang-ver-before: 'c'｣, 'c is not before d', :out<False>;
-    is-run ｢use v6.e.PREVIEW; BEGIN print ?$*W.lang-ver-before: 'e'｣, 'e.PREVIEW is not before e', :out<False>;
-    is-run ｢use v6.e.PREVIEW; BEGIN print ?$*W.lang-ver-before: 'd'｣, 'e is not before d', :out<False>;
-    throws-like ｢BEGIN $*W.lang-ver-before: <6.d>｣, Exception,
+    is-run ｢use v6.c; BEGIN print ?$*W.lang-rev-before: 'd'｣, 'c is before d', :out<True>;
+    is-run ｢use v6.c; BEGIN print ?$*W.lang-rev-before: 'c'｣, 'c is not before d', :out<False>;
+    is-run ｢use v6.e.PREVIEW; BEGIN print ?$*W.lang-rev-before: 'e'｣, 'e.PREVIEW is not before e', :out<False>;
+    is-run ｢use v6.e.PREVIEW; BEGIN print ?$*W.lang-rev-before: 'd'｣, 'e is not before d', :out<False>;
+    throws-like ｢BEGIN $*W.lang-rev-before: <6.d>｣, Exception,
         :self{.exception.message.contains: 'must be 1 char long'},
-    'using wrong version format as argument throws';
+        'using wrong revision format as argument throws';
 }
 
 subtest 'IO::Handle.raku.EVAL roundtrips' => {

--- a/t/05-messages/02-errors.t
+++ b/t/05-messages/02-errors.t
@@ -215,46 +215,46 @@ subtest 'cannot use Int type object as an operand' => {
     plan 14;
 
     throws-like ｢(1/1)+Int｣,
-        X::Parameter::InvalidConcreteness,
+        X::Numeric::Uninitialized,
         'A Rational instance cannot be added by an Int type object';
     throws-like ｢Int+(1/1)｣,
-        X::Parameter::InvalidConcreteness,
+        X::Numeric::Uninitialized,
         'An Int type object cannot be added by a Rational instance';
     throws-like ｢(1/1)-Int｣,
-        X::Parameter::InvalidConcreteness,
+        X::Numeric::Uninitialized,
         'A Rational instance cannot be subtracted by an Int type object';
     throws-like ｢Int-(1/1)｣,
-        X::Parameter::InvalidConcreteness,
+        X::Numeric::Uninitialized,
         'An Int type object cannot be subtracted by a Rational instance';
     throws-like ｢(1/1)*Int｣,
-        X::Parameter::InvalidConcreteness,
+        X::Numeric::Uninitialized,
         'A Rational instance cannot be multiplied by an Int type object';
     throws-like ｢Int*(1/1)｣,
-        X::Parameter::InvalidConcreteness,
+        X::Numeric::Uninitialized,
         'An Int type object cannot be multiplied by a Rational instance';
     throws-like ｢(1/1)/Int｣,
-        X::Parameter::InvalidConcreteness,
+        X::Numeric::Uninitialized,
         'A Rational instance cannot be divided by an Int type object';
     throws-like ｢Int/(1/1)｣,
-        X::Parameter::InvalidConcreteness,
+        X::Numeric::Uninitialized,
         'An Int type object cannot be divided by a Rational instance';
     throws-like ｢Int/Int｣,
-        X::Parameter::InvalidConcreteness,
+        X::Numeric::Uninitialized,
         'An Int type object cannot be divided by an Int type object';
     throws-like ｢Int/1｣,
-        X::Parameter::InvalidConcreteness,
+        X::Numeric::Uninitialized,
         'An Int type object cannot be divided by an Int instance';
     throws-like ｢1/Int｣,
-        X::Parameter::InvalidConcreteness,
+        X::Numeric::Uninitialized,
         'An Int instance cannot be divided by an Int type object';
     throws-like ｢(1/1)%Int｣,
-        X::Parameter::InvalidConcreteness,
+        X::Numeric::Uninitialized,
         'A Rational instance modulo an Int type object is incalculable';
     throws-like ｢Int%(1/1)｣,
-        X::Parameter::InvalidConcreteness,
+        X::Numeric::Uninitialized,
         'An Int type object modulo a Rational instance is incalculable';
     throws-like ｢(1/1)**Int｣,
-        X::Parameter::InvalidConcreteness,
+        X::Numeric::Uninitialized,
         'A Rational instance cannot be powered by an Int type object';
 }
 


### PR DESCRIPTION
This is a research work inspired by rakudo/rakudo#1285. The following
changes are included:

- Coerions are made first-class type objects. It's now possible to pass
  a coercion around normally. Non-instantiable though akin to definites
  and subsets.
- A parameter is now marked as `coercive` if its type is a coerce.
- Coercions redelegate method calls to their target type.
- Coercions type checks almost as they should. This is a temporary
  situation. Yet, `Str ~~ Int(Str)` is `True`, and 'Rat ~~ Int(Str)` is
  `False`.
- Coercions are nominalizable. Nominalize into the target type.

Aside of these, coercion protocol is introduced. If `coerce` method of
`Metamodel::CoercionHOW` is used for `Foo(Bar)` then the following
methods are tried in the order of mentioning:

- the current standard of `Bar.Foo`
- `Bar.COERCE-INTO(Foo)`
- `Foo.COERCE-FROM(Bar)`

Considering the discussion in Raku/problem-solving#137, the last one is
the fallback of despair because, as was mentioned in the ticket, `Foo`
might not have full information about `Bar` state and thus may not
result in proper coercion. But the approach is safe to use for coercing
from simple type objects. And in any case I think it is better to have
something than have nothing and be forced to use augmentation.

In either case, the use of `COERCE-*` methods allows to handle types
with compound names without the risk of name clashes if short names of
two or more type objects match.