### PR TITLE
Deprecate parse-names

### DIFF
--- a/src/core.c/Str.pm6
+++ b/src/core.c/Str.pm6
@@ -3230,7 +3230,7 @@ my class Str does Stringy { # declared in BOOTSTRAP
     }
 
     method parse-names(Str:D: --> Str:D) {
-        # XXX TODO: issue deprecation warning in 6.d; remove in 6.e
+        Rakudo::Deprecations.DEPRECATED('uniparse');
         self.uniparse
     }
     method uniparse(Str:D: --> Str:D) {
@@ -3857,7 +3857,7 @@ proto sub samemark($, $, *%) {*}
 multi sub samemark($s, $pat --> Str:D) { $s.samemark($pat) }
 
 sub parse-names(Str:D \names) {
-    # XXX TODO: issue deprecation warning in 6.d; remove in 6.e
+    Rakudo::Deprecations.DEPRECATED('uniparse');
     names.uniparse
 }
 


### PR DESCRIPTION
The `parse-names` method and sub each had a TODO code comment indicating that they should be deprecated in v6d, and [Roast also notes](https://github.com/Raku/roast/blob/master/S32-str/uniparse.t#L8-L11) that this method is deprecated.

This PR replaces those TODO comments with  actual deprecation warnings.

I discuss this change and related missing deprecation warnings in #3901.