### PR TITLE
Add cmp candidates for Code

### DIFF
--- a/src/core.c/Order.pm6
+++ b/src/core.c/Order.pm6
@@ -54,6 +54,16 @@ multi sub infix:<cmp>(int $a, int $b) {
     ORDER(nqp::cmp_i($a, $b))
 }
 
+multi sub infix:<cmp>(Code:D \a, Code:D \b) {
+     a.name cmp b.name
+}
+multi sub infix:<cmp>(Code:D \a, \b) {
+     a.name cmp b.Stringy
+}
+multi sub infix:<cmp>(\a, Code:D \b) {
+     a.Stringy cmp b.name
+}
+
 multi sub infix:«<=>»(Int:D \a, Int:D \b) {
     ORDER(nqp::cmp_I(nqp::decont(a), nqp::decont(b)))
 }


### PR DESCRIPTION
Fixes #3885 wherein gisting Hashes with non-Str keys could produce warnings.

The root of the problem is that `cmp` resorted to stringification, which generates warnings with `Code` objects (the only non-`Nil` types to do so).  Now `Code` objects will stringify using their `name`, which matches previous behavior but without the warnings.  Warnings elsewhere —where they are more useful— are thus preserved.