### PR TITLE
Revise deprecation warnings to show only on v6.d

### DIFF
--- a/src/core.c/Str.pm6
+++ b/src/core.c/Str.pm6
@@ -3230,8 +3230,10 @@ my class Str does Stringy { # declared in BOOTSTRAP
     }
 
     method parse-names(Str:D: --> Str:D) {
-        Rakudo::Deprecations.DEPRECATED('uniparse');
-        self.uniparse
+        if nqp::getcomp('Raku').language_version eq '6.d' {
+            Rakudo::Deprecations.DEPRECATED('uniparse', '6.d', '6.e');
+        }
+        self.uniparse;
     }
     method uniparse(Str:D: --> Str:D) {
         my     \names := nqp::split(',', self);
@@ -3857,7 +3859,7 @@ proto sub samemark($, $, *%) {*}
 multi sub samemark($s, $pat --> Str:D) { $s.samemark($pat) }
 
 sub parse-names(Str:D \names) {
-    Rakudo::Deprecations.DEPRECATED('uniparse');
+    # Deprecated in 6.d; remove in 6.e
     names.uniparse
 }
 

--- a/src/core.d/Str.pm6
+++ b/src/core.d/Str.pm6
@@ -1,0 +1,5 @@
+sub parse-names(Str:D \names) {
+    Rakudo::Deprecations.DEPRECATED('uniparse', '6.d', '6.e');
+    names.uniparse
+}
+

--- a/tools/templates/6.d/core_sources
+++ b/tools/templates/6.d/core_sources
@@ -1,3 +1,4 @@
 src/core.d/core_prologue.pm6
 src/core.d/await.pm6
 src/core.d/operators.pm6
+src/core.d/Str.pm6


### PR DESCRIPTION
My previous PR (#3900) inadvertently displayed the deprecation warning on v6.c and later; this fixes the code to only display the warning on v6.d.  Thanks to @timo for pointing this out to me on IRC.

I would have liked to put both the sub `parse-names` and the method `parse-names` in the new `core.d/Str.pm6` file for clearer
organization.  However, I could not see a way to correctly modify a `Str` method from inside that file.  If someone can point me in the direction of how to do that in a clean way, I'd be happy to revise this change.