### PR TITLE
Build System: Fix RUN_RAKUDO to use the dummy Rakudo home

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,6 @@ t/03-jvm/*.class
 /zef
 .DS_Store
 node_modules/*
+rakudo-m-early-build
+rakudo-js-build
+rakudo-j-build

--- a/tools/templates/Makefile-backend-common.in
+++ b/tools/templates/Makefile-backend-common.in
@@ -195,7 +195,7 @@ check_@backend_abbr@_nqp_version: @@script(check-nqp-version.pl)@@
 
 @comp_rr(@bsm(RAKUDO_BOOTSTRAP_@ucspec@)@: @use_prereqs(@nfp(@bpm(BUILD_DIR)@/BOOTSTRAP/v6@lcspec@.nqp)@)@ @bsm(RAKUDO_M)@)@
 
-@bsm(SETTING_@ucspec@)@: @bsm(RAKUDO)@ @bsm(RAKUDO_BOOTSTRAP_@ucspec@)@ @bpm(CORE_@ucspec@_SOURCES)@
+@bsm(SETTING_@ucspec@)@: @bsm(RAKUDO)@ @bsm(RAKUDO_BOOTSTRAP_@ucspec@)@ @bpm(CORE_@ucspec@_SOURCES)@ @bpm(RUN_RAKUDO_SCRIPT)@
 	@echo(+++ Compiling	$@)@
 	$(NOECHO)$(CONFIGURE) --expand @shquot(@ctx_template(core_sources)@)@ \
 			 --out @nfpq(@bpm(BUILD_DIR)@/core_sources.@lcspec@)@ \

--- a/tools/templates/js/Makefile.in
+++ b/tools/templates/js/Makefile.in
@@ -1,13 +1,15 @@
 
 @bpv(NQP)@ = @js_nqp@
-@bpv(RUNTIME)@ = @nqp::libdir@@nfp(/nqp-js-on-js/node_modules/nqp-runtime)@
-@bpv(NQP_BASE_FLAGS)@ = --nqp-runtime @bpm(RUNTIME)@ --perl6-runtime @perl6_runtime@ --libpath "@bpm(BLIB)@|||@nqp::libdir@@nfp(/nqp-js-on-js/)@"
-@bpv(NQP_FLAGS)@ = @bpm(NQP_BASE_FLAGS)@ --substagestats --stagestats --source-map
+@bpv(NQP_RUNTIME)@ = @nfp(@nqp::libdir@/nqp-js-on-js/node_modules/nqp-runtime)@
+@bpv(PERL6_RUNTIME)@ = @perl6_runtime@
+@bpv(NQP_FLAGS)@ = --nqp-runtime @bpm(RUNTIME)@ --perl6-runtime @perl6_runtime@ --libpath "@bpm(BLIB)@|||@nqp::libdir@@nfp(/nqp-js-on-js/)@" --source-map --substagestats --stagestats
 @bpv(NQP_FLAGS_EXTRA)@ = --execname @bpm(RUNNER)@ --shebang
-@bpv(RUN_RAKUDO)@ = node --max-old-space-size=8192 rakudo.js @bpm(NQP_BASE_FLAGS)@ --source-map --rakudo-home=@nfpq($(BASE_DIR)/gen/build_rakudo_home)@
+@bpv(RUN_RAKUDO_SCRIPT)@ = rakudo-js-build
+@bpv(RUN_RAKUDO)@ = @shquot(@perl@)@ @bpm(RUN_RAKUDO_SCRIPT)@
 
 @bpv(CLEANUPS)@ = \
 	@bsm(RAKUDO)@ \
+	@bpm(RUN_RAKUDO_SCRIPT)@ \
 	@nfp(@base_dir@/*.js.map)@ \
 	@nfp(@bpm(BLIB)@/*.js.map)@ \
 	@bpm(BLIB_RAKUDO)@/load-compiler.js \
@@ -26,6 +28,15 @@
 
 @nfp(@bpm(BLIB)@/load-compiler.js)@: @nfp(src/vm/js/load-compiler.nqp)@ @bsm(RAKUDO_G)@ @bsm(RAKUDO_A)@ @bsm(RAKUDO_C)@ @bsm(RAKUDO_P)@
 	@$(JS_NQP) $(JS_NQP_FLAGS) --target=js --output=$@ $<
+
+@bpm(RUN_RAKUDO_SCRIPT)@: @@nfp(@template(@backend_subdir@/rakudo-js-build.in)@)@@
+	$(NOECHO)$(RM_F) @q(@bpm(RUN_RAKUDO_SCRIPT)@)@
+	$(NOECHO)$(CONFIGURE) --expand @nfpq(@backend_subdir@/@bpm(RUN_RAKUDO_SCRIPT)@)@ --out @bpm(RUN_RAKUDO_SCRIPT)@ \
+		--set-var=base_dir=@q(@base_dir@)@ \
+		--set-var=nqp_runtime=@q(@bpm(NQP_RUNTIME)@)@ \
+		--set-var=perl6_runtime=@q(@bpm(PERL6_RUNTIME)@)@ \
+		--set-var=libpath=@q(@bpm(BLIB)@|||@nfp(@nqp::libdir@/nqp-js-on-js/)@)@ \
+		--set-var=nqp_base_flags=@sh_quot(@bpm(NQP_BASE_FLAGS)@)@
 
 @bpm(RUNNER)@:
 	@echo(+++ Creating JS runner)@

--- a/tools/templates/js/rakudo-js-build.in
+++ b/tools/templates/js/rakudo-js-build.in
@@ -1,0 +1,5 @@
+$ENV{RAKUDO_HOME} = '@sq_escape(@base_dir@/gen/build_rakudo_home)@';
+
+my $exit = system {'node'} ('node', '--max-old-space-size=8192', 'rakudo.js', '--nqp-runtime', '@sq_escape(@nqp_runtime@)@', '--perl6-runtime', '@sq_escape(@perl6_runtime@)@', '--libpath', '@sq_escape(@libpath@)@', '--source-map', @ARGV);
+
+exit($exit >> 8);

--- a/tools/templates/jvm/Makefile.in
+++ b/tools/templates/jvm/Makefile.in
@@ -5,7 +5,8 @@ JAR     = jar
 NQP_PREFIX  = @nqp_prefix@
 @bpv(NQP)@       = @shquot(@j_nqp@)@
 @bpv(NQP_RR)@    = $(JAVA) -Xss1m -Xms500m -Xmx3000m -cp @q(@nfp(./blib)@@cpsep@@nop($(BLD_NQP_JARS))@@cpsep@rakudo-runtime.jar@cpsep@@nop($(SYSROOT))@@abs2rel(@nqp_classpath@)@)@ nqp
-@bpv(RUN_RAKUDO)@ = $(JAVA) -Xss1m -Xms500m -Xmx3000m -cp @q(@nfp(./blib)@@cpsep@@nop($(BLD_NQP_JARS))@@cpsep@rakudo-runtime.jar@cpsep@rakudo.jar@cpsep@@nop($(SYSROOT))@@abs2rel(@nqp_classpath@)@)@ perl6 --rakudo-home=@nfpq($(BASE_DIR)/gen/build_rakudo_home)@
+@bpv(RUN_RAKUDO_SCRIPT)@ = rakudo-j-build
+@bpv(RUN_RAKUDO)@ = @shquot(@perl@)@ @bpm(RUN_RAKUDO_SCRIPT)@
 
 @bpv(DEBUG_RUNNER)@ = rakudo-debug-@backend_abbr@@bpm(RUNNER_SUFFIX)@
 
@@ -24,6 +25,7 @@ RUNTIME_JAR = rakudo-runtime.jar
 
 @bpv(CLEANUPS)@ = \
   $(RUNTIME_JAR) \
+  @bpm(RUN_RAKUDO_SCRIPT)@ \
   rakudo-eval-server \
   perl6-eval-server \
   rakudo-jdb-server \
@@ -46,6 +48,13 @@ $(RUNTIME_JAR): $(RUNTIME_JAVAS)
 	$(NOECHO)$(MKPATH) bin
 	$(NOECHO)$(JAVAC) --release 9 -cp @q($(BLD_NQP_JARS))@ -g -d bin -encoding UTF8 $(RUNTIME_JAVAS)
 	$(NOECHO)$(JAR) cf0 rakudo-runtime.jar -C bin@slash@ .
+
+@bpm(RUN_RAKUDO_SCRIPT)@: @@nfp(@template(@backend_subdir@/rakudo-j-build.in)@)@@
+	$(NOECHO)$(RM_F) @q(@bpm(RUN_RAKUDO_SCRIPT)@)@
+	$(NOECHO)$(CONFIGURE) --expand @nfpq(@backend_subdir@/@bpm(RUN_RAKUDO_SCRIPT)@)@ --out @bpm(RUN_RAKUDO_SCRIPT)@ \
+		--set-var=base_dir=@q($(BASE_DIR))@ \
+		--set-var=java=$(JAVA) \
+		--set-var=classpath=@q(@nfp(./blib)@@cpsep@@nop($(BLD_NQP_JARS))@@cpsep@rakudo-runtime.jar@cpsep@rakudo.jar@cpsep@@nop($(SYSROOT))@@abs2rel(@nqp_classpath@)@)@
 
 $(J_RUNNER): @@script(create-jvm-runner.pl)@@
 	@echo(+++ Setting up	$@)@

--- a/tools/templates/jvm/rakudo-j-build.in
+++ b/tools/templates/jvm/rakudo-j-build.in
@@ -1,0 +1,5 @@
+$ENV{RAKUDO_HOME} = '@sq_escape(@base_dir@/gen/build_rakudo_home)@';
+
+my $exit = system {'@java@'} ('@java@', '-Xss1m', '-Xms500m', '-Xmx3000m', '-cp', '@sq_escape(@classpath@)@', 'perl6', @ARGV);
+
+exit($exit >> 8);

--- a/tools/templates/moar/Makefile.in
+++ b/tools/templates/moar/Makefile.in
@@ -11,7 +11,8 @@ MOAR_PREFIX = @nfp(@moar::prefix@)@
 MOAR        = @nfpq(@moar::bindir@/moar@moar::exe@)@
 @bpv(NQP)@       = @nfpq(@m_nqp@)@
 @bpv(NQP_RR)@    = @bpm(NQP)@
-@bpv(RUN_RAKUDO)@ = $(MOAR) --libpath=@nfpq($(BASE_DIR)/blib)@ --libpath=@q(@bpm(NQP_LIBDIR)@)@ @bsm(RAKUDO)@ --rakudo-home=@nfpq($(BASE_DIR)/gen/build_rakudo_home)@
+@bpv(RUN_RAKUDO_SCRIPT)@ = rakudo-m-early-build
+@bpv(RUN_RAKUDO)@ = @shquot(@perl@)@ @bpm(RUN_RAKUDO_SCRIPT)@
 
 @bpv(RUNNER_SUFFIX)@ = @moar::exe@
 
@@ -60,6 +61,7 @@ R_SETTING_MOAR = RESTRICTED.setting.moarvm
 
 @bpv(CLEANUPS)@ = \
   $(R_SETTING_MOAR) \
+  @bpm(RUN_RAKUDO_SCRIPT)@ \
   inst-rakudo-m@moar::obj@ \
   inst-rakudo-debug-m@moar::obj@ \
   inst-rakudo@moar::obj@ \
@@ -99,7 +101,7 @@ R_SETTING_MOAR = RESTRICTED.setting.moarvm
 	$(NOECHO)@bpm(CC)@ @moar::ccswitch@ @moar::ccshared@ @bpm(CFLAGS)@ @bpm(MOAR_INC_PATHS)@ @moar::ccout@@bpm(RAKUDO_OPS_OBJ)@ @bpm(RAKUDO_OPS_DLL_SRC)@
 	$(NOECHO)@bpm(LD)@ @moar::ldswitch@ @moar::lddir@"@moar::libdir@" @moar::ldshared@ @bpm(LDFLAGS)@ @bpm(LDLIBS)@ @moar::ldout@@bpm(RAKUDO_OPS_DLL)@ @bpm(RAKUDO_OPS_OBJ)@ @moar_lib@
 
-$(R_SETTING_MOAR): @bsm(RAKUDO)@@for_specs( @bsm(SETTING_@ucspec@)@)@ $(R_SETTING_SRC)
+$(R_SETTING_MOAR): @bsm(RAKUDO)@@for_specs( @bsm(SETTING_@ucspec@)@)@ $(R_SETTING_SRC) @bpm(RUN_RAKUDO_SCRIPT)@
 	$(NOECHO)@bpm(RUN_RAKUDO)@ --target=@btarget@ --ll-exception --output=$(R_SETTING_MOAR) $(R_SETTING_SRC)
 
 @backend_prefix@-runner-default: @bpm(INST_RAKUDO)@ @bpm(INST_RAKUDO_DEBUG)@
@@ -114,6 +116,14 @@ $(R_SETTING_MOAR): @bsm(RAKUDO)@@for_specs( @bsm(SETTING_@ucspec@)@)@ $(R_SETTIN
 		--set-var=runner_opts=@chomp(@insert(Makefile-runner_opts)@)@
 	-$(NOECHO)$(CHMOD) 755 $@
 )@)@)@
+
+@bpm(RUN_RAKUDO_SCRIPT)@: @@nfp(@template(@backend_subdir@/rakudo-m-early-build.in)@)@@
+	$(NOECHO)$(RM_F) @q(@bpm(RUN_RAKUDO_SCRIPT)@)@
+	$(NOECHO)$(CONFIGURE) --expand @nfpq(@backend_subdir@/@bpm(RUN_RAKUDO_SCRIPT)@)@ --out @bpm(RUN_RAKUDO_SCRIPT)@ \
+		--set-var=base_dir=@nfpq(@base_dir@)@ \
+		--set-var=moar=$(MOAR) \
+		--set-var=nqp_libdir=@nfpq(@nqp::libdir@)@ \
+		--set-var=rakudo=@bsm(RAKUDO)@
 
 @bpm(RUNNER)@: @@configure_script@@ @bsm(RAKUDO)@@for_specs( @bsm(SETTING_@ucspec@)@)@ @@nfp(@template(@backend_subdir@/rakudo-m-build.c.in)@)@@ @@nfp(@template(@backend_subdir@/rakudo-m-build.c.windows)@)@@
 	@echo(+++ Generating	$@)@
@@ -244,7 +254,7 @@ manifest:
 	@nowcho@find @nfp(t/spec)@ -type f | grep -v '\.git' >>MANIFEST
 	@nowcho@sort -u -o MANIFEST MANIFEST
 
-release: manifest
+release: manifest @bpm(RUN_RAKUDO_SCRIPT)@
 	$(NOECHO)[ -n "$(VERSION)" ] || ( echo "\nTry 'make release VERSION=yyyy.mm'\n\n"; exit 1 )
 	@echo(+++ Releasing $(VERSION))@
 	$(NOECHO)bash -c '[ "$$(cat VERSION)" == "$(VERSION)" ] || ( echo -e "\nVersion on command line and in VERSION file differ\n"; exit 1 )'

--- a/tools/templates/moar/rakudo-m-early-build.in
+++ b/tools/templates/moar/rakudo-m-early-build.in
@@ -1,0 +1,5 @@
+$ENV{RAKUDO_HOME} = '@sq_escape(@base_dir@/gen/build_rakudo_home)@';
+
+my $exit = system {'@sq_escape(@moar@)@'} ('@sq_escape(@moar@)@', '--libpath=@sq_escape(@base_dir@/blib)@', '--libpath=@sq_escape(@nqp_libdir@)@', '@sq_escape(@rakudo@)@', @ARGV);
+
+exit($exit >> 8);


### PR DESCRIPTION
The command to execute Rakudo during the early stages of the build process
needs to have a Rakudo home set to an empty dummy directory to make sure it
does not try to access the installation directory. If it would, it would
create directories out side of the build directory during the compilation
phase and result in failures if a previous installation is already located
in the install dir. The `--rakudo-home` Configure parameter doesn't exist
(any more?). Replace it with a perl one-liner that sets the Rakudo home via
an environment variable.