### PR TITLE
De-huffmanize Capture.raku

### DIFF
--- a/src/core.c/Capture.pm6
+++ b/src/core.c/Capture.pm6
@@ -136,7 +136,7 @@ my class Capture { # declared in BOOTSTRAP
         my int $has-hash  = nqp::isconcrete(%!hash) && nqp::elems(%!hash);
         my Mu  $raku     := nqp::list_s();
         if nqp::eqaddr(self.WHAT, Capture) {
-            nqp::push_s($raku, '\(');
+            nqp::push_s($raku, '(');
             if $has-list {
                 my Mu $iter := nqp::iterator(@!list);
                 nqp::push_s($raku, nqp::unbox_s(nqp::shift($iter).raku));
@@ -147,7 +147,8 @@ my class Capture { # declared in BOOTSTRAP
                 nqp::push_s($raku,
                     nqp::unbox_s(self.Capture::hash.sort.map(*.raku).join(', ')));
             }
-            nqp::push_s($raku, ')');
+            nqp::push_s($raku,',') if nqp::elems($raku) == 2;
+            nqp::push_s($raku, ').Capture');
         } else {
             nqp::push_s($raku, nqp::concat(nqp::unbox_s(self.^name), '.new'));
             if $has-list || $has-hash {


### PR DESCRIPTION
The \\(...) syntax is confusing to a lot of newbies, especially coming
from Perl.  In order to de-emphasize that syntax, change the .raku
output to use the .Capture coercion syntax, which I think makes it
much more clear what is meant.

This will require *one* change in spectest, that specifically tests
for the \\(...) format in output:

    t/spec/S12-introspection/walk.t   test 23

Deprecating / removing the \\(...) syntax would be something for
multiple language versions.