### PR TITLE
Fix stub packages in multi part declarations only knowing part of the…

### DIFF
--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -1649,13 +1649,13 @@ class Perl6::World is HLL::World {
 
         # If we have a multi-part name, see if we know the opening
         # chunk already. If so, use it for that part of the name.
-        my $longname := '';
+        my $longname := $package =:= $*GLOBALish ?? '' !! $package.HOW.name($package);
         if +@parts {
             try {
                 $cur_pkg := self.find_single_symbol(@parts[0], :upgrade_to_global($create_scope ne 'my'));
                 $cur_lex := 0;
                 $create_scope := 'our';
-                $longname := @parts.shift();
+                $longname := $longname ?? $longname ~ '::' ~ @parts.shift() !! @parts.shift();
             }
         }
 


### PR DESCRIPTION
…ir name

In package Foo { package Bar::Baz { } } the created stub package for Bar had
only "Bar" as longname instead of the expected "Foo::Bar" like you'd get if the
Bar package was created explicitly. Fix by using the target package's name as
starting point when assembling the longname.