### PR TITLE
Remove unnecessary branch in .truncate

### DIFF
--- a/src/core.c/Real.pm6
+++ b/src/core.c/Real.pm6
@@ -58,7 +58,7 @@ my role Real does Numeric {
     proto method exp(|) {*}
     multi method exp(Real:D: )           { self.Bridge.exp               }
     method truncate(Real:D:) {
-        self == 0 ?? 0 !! self < 0  ?? self.ceiling !! self.floor
+        self < 0  ?? self.ceiling !! self.floor
     }
     method isNaN { Bool::False }
 


### PR DESCRIPTION
This fixes the difference between `True.truncate` (which returns True)
and `False.truncate` (which returned 0) so they both return self.

Rakudo builds ok and passes `make m-test m-spectest`.