### PR TITLE
Build: A wrong NQP version should abort the build

### DIFF
--- a/tools/lib/NQP/Config/Rakudo.pm
+++ b/tools/lib/NQP/Config/Rakudo.pm
@@ -663,7 +663,7 @@ sub gen_nqp {
     return unless defined($gen_nqp) || defined($gen_moar);
 
     {
-        my $user = $options->{'github-user'} // 'perl6';
+        my $user = $options->{'github-user'} // 'Raku';
 
         # Don't expect any specific default commit in nqp/ if the repo is
         # already checked out and we're force-rebuilding.

--- a/tools/lib/NQP/Config/Rakudo.pm
+++ b/tools/lib/NQP/Config/Rakudo.pm
@@ -643,18 +643,15 @@ sub gen_nqp {
 
         unless ( $force_rebuild
             || !$nqp_have
-            || $nqp_ver_ok
-            || $options->{'ignore-errors'} )
+            || $nqp_ver_ok )
         {
-            $self->note( "WARNING",
+            my $say_sub = $options->{'ignore-errors'} ? 'note' : 'sorry';
+            $self->$say_sub(
                 "$bin version $nqp_have is outdated, $nqp_want expected.\n" );
         }
 
         if ( !$force_rebuild and ( $nqp_ok or $options->{'ignore-errors'} ) ) {
             $impls->{$b}{ok} = 1;
-        }
-        elsif ( $self->opt('with-nqp') ) {
-            $self->sorry("$bin version cannot be used");
         }
         else {
             $need{$b} = 1;
@@ -665,7 +662,7 @@ sub gen_nqp {
 
     return unless defined($gen_nqp) || defined($gen_moar);
 
-    if ( defined $gen_nqp || defined $gen_moar ) {
+    {
         my $user = $options->{'github-user'} // 'perl6';
 
         # Don't expect any specific default commit in nqp/ if the repo is


### PR DESCRIPTION
Irrespective of using the `--with-nqp` configure flag a wrong NQP version is always fatal.
@vrurg The original code looked to be on purpose. That's why I'd like your reassurance that there is actually no reason to allow building with a wrong NQP version.