### PR TITLE
Force "id" command to use POSIX locale

### DIFF
--- a/src/core.c/Process.pm6
+++ b/src/core.c/Process.pm6
@@ -77,7 +77,7 @@ Rakudo::Internals.REGISTER-DYNAMIC: '$*HOME', {
 
 {
     sub fetch($what) {
-        once if !Rakudo::Internals.IS-WIN && try { qx/id/ } -> $id {
+        once if !Rakudo::Internals.IS-WIN && try { qx/LC_MESSAGES=POSIX id/ } -> $id {
             if $id ~~ m/^
               [ uid "=" $<uid>=(\d+) ]
               [ "(" $<user>=(<-[ ) ]>+) ")" ]


### PR DESCRIPTION
This is a temporary workaround to ensure that $*USER and $*GROUP don't
return Nil on non-English locales.

Resolves #3927.