### PR TITLE
Move Int candidates from Numeric.pm6 to Int.pm6

### DIFF
--- a/src/core.c/Int.pm6
+++ b/src/core.c/Int.pm6
@@ -395,6 +395,25 @@ multi sub infix:<%>(int $a, int $b --> int) {
     nqp::mod_i(nqp::add_i(nqp::mod_i($a,$b),$b),$b) # quick fix https://github.com/Raku/old-issue-tracker/issues/4999
 }
 
+multi sub infix:<%%>(Int:D \a, Int:D \b) {
+    nqp::if(
+      nqp::isbig_I(nqp::decont(a)) || nqp::isbig_I(nqp::decont(b)),
+      nqp::if(
+        b,
+        !nqp::mod_I(nqp::decont(a),nqp::decont(b),Int),
+        Failure.new(
+          X::Numeric::DivideByZero.new(using => 'infix:<%%>', numerator => a)
+        )
+      ),
+      nqp::if(
+        nqp::isne_i(b,0),
+        nqp::hllbool(nqp::not_i(nqp::mod_i(nqp::decont(a),nqp::decont(b)))),
+        Failure.new(
+          X::Numeric::DivideByZero.new(using => 'infix:<%%>', numerator => a)
+        )
+      )
+    )
+}
 multi sub infix:<%%>(int $a, int $b --> Bool:D) {
     nqp::hllbool(nqp::iseq_i(nqp::mod_i($a, $b), 0))
 }
@@ -415,6 +434,7 @@ multi sub infix:<**>(int $a, int $b --> int) {
     nqp::pow_i($a, $b);
 }
 
+multi sub infix:<lcm>(Int:D $x = 1) { $x }
 multi sub infix:<lcm>(Int:D \a, Int:D \b --> Int:D) {
     nqp::lcm_I(nqp::decont(a), nqp::decont(b), Int);
 }
@@ -422,6 +442,7 @@ multi sub infix:<lcm>(int $a, int $b --> int) {
     nqp::lcm_i($a, $b)
 }
 
+multi sub infix:<gcd>(Int:D $x) { $x }
 multi sub infix:<gcd>(Int:D \a, Int:D \b --> Int:D) {
     nqp::gcd_I(nqp::decont(a), nqp::decont(b), Int);
 }

--- a/src/core.c/Numeric.pm6
+++ b/src/core.c/Numeric.pm6
@@ -239,25 +239,6 @@ multi sub infix:<%>(\a, \b)    { a.Real % b.Real }
 proto sub infix:<%%>($?, $?, *%) is pure  {*}
 multi sub infix:<%%>() { Failure.new("No zero-arg meaning for infix:<%%>") }
 multi sub infix:<%%>($)         { Bool::True }
-multi sub infix:<%%>(Int:D \a, Int:D \b) {
-    nqp::if(
-      nqp::isbig_I(nqp::decont(a)) || nqp::isbig_I(nqp::decont(b)),
-      nqp::if(
-        b,
-        !nqp::mod_I(nqp::decont(a),nqp::decont(b),Int),
-        Failure.new(
-          X::Numeric::DivideByZero.new(using => 'infix:<%%>', numerator => a)
-        )
-      ),
-      nqp::if(
-        nqp::isne_i(b,0),
-        nqp::hllbool(nqp::not_i(nqp::mod_i(nqp::decont(a),nqp::decont(b)))),
-        Failure.new(
-          X::Numeric::DivideByZero.new(using => 'infix:<%%>', numerator => a)
-        )
-      )
-    )
-}
 multi sub infix:<%%>(\a, \b) {
     nqp::if(
       b,
@@ -269,12 +250,10 @@ multi sub infix:<%%>(\a, \b) {
 }
 
 proto sub infix:<lcm>($?, $?, *%) is pure  {*}
-multi sub infix:<lcm>(Int:D $x = 1) { $x }
 multi sub infix:<lcm>(\a, \b)   { a.Int lcm b.Int }
 
 proto sub infix:<gcd>($?, $?, *%) is pure {*}
 multi sub infix:<gcd>() { Failure.new('No zero-arg meaning for infix:<gcd>') }
-multi sub infix:<gcd>(Int:D $x)    { $x }
 multi sub infix:<gcd>(\a, \b)  { a.Int gcd b.Int }
 
 proto sub infix:<**>($?, $?, *%) is pure  {*}


### PR DESCRIPTION
Rakudo builds ok and passes `make m-test m-spectest`.