### PR TITLE
Add sanity check in infix handling, fixes R#3949

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -7084,6 +7084,8 @@ class Perl6::Actions is HLL::Actions does STDActions {
                 && ($push-target := $target.ann: 'fake_infix_adverb_target');
 
                 my $cpast := $<colonpair>.ast;
+                $/.typed_panic: 'X::Syntax::Adverb', what => ~$/
+                  unless try $cpast[1];
                 $cpast[2].named(compile_time_value_str($cpast[1], 'LHS of pair', $/));
                 $push-target.push(WANTED($cpast[2],'EXPR/POSTFIX'));
 


### PR DESCRIPTION
Before this, an "infix:(&)" (note the missing < > there) would cause a:

    $ raku -e 'infix:(&)'
    This type (QAST::WVal) does not support positional operations

crash without any indication on *where* in the code the actual error was.
After this, it will cause a correct compilation error:

    $ raku -e 'infix:(&)'
    ===SORRY!=== Error while compiling -e
    You can't adverb :(&)
    at -e:1
    ------> infix:(&)⏏<EOL>