### PR TITLE
Implement the prefix:<||> operator in postcircumfixes

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -1554,12 +1554,11 @@ class Perl6::Actions is HLL::Actions does STDActions {
 
                 # anything like "||foo" ?
                 if nqp::istype($ast,QAST::Op) && $ast.name eq '&prefix:<|>' {
-                    if $*W.lang-ver-before("e") {
-                        # no action for settings < "e"
-                    }
-                    elsif nqp::istype($ast[0],QAST::Op) && $ast[0].name eq '&prefix:<|>' {
-                        $ast := $ast[0][0];  # cut out the || ops
-                        $past.annotate('multislice', 1);
+                    if nqp::istype($ast[0],QAST::Op) && $ast[0].name eq '&prefix:<|>' {
+                        unless $*W.lang-ver-before("e") {
+                            $ast := $ast[0][0];  # cut out the || ops
+                            $past.annotate('multislice', 1);
+                        }
                     }
                 }
 


### PR DESCRIPTION
- for 6.e and later only
- described by https://design.raku.org/S09.html#line_419
- sort of implemented by Wenzel P.P. Peppmeyer in Slippy::Semilist
- does not actually add a prefix operator: it's just a double slip
- manipulates the AST in case of a postcircumfix, to select the ; variant
- the postcircumfix:<{; }> variant does the right thing for prefix:<||>