### PR TITLE
Make Hash.DELETE-KEY return Nil on non-existent keys

### DIFF
--- a/src/core.c/Hash.pm6
+++ b/src/core.c/Hash.pm6
@@ -167,7 +167,7 @@ my class Hash { # declared in BOOTSTRAP
             nqp::getattr(self,Map,'$!storage'),
             key
           )),
-          $!descriptor.default,
+          Nil,
           nqp::stmts(
             nqp::deletekey(
               nqp::getattr(self,Map,'$!storage'),
@@ -540,7 +540,7 @@ my class Hash { # declared in BOOTSTRAP
                 nqp::getattr(self,Map,'$!storage'),
                 (my str $WHICH = key.WHICH)
               )),
-              TValue,
+              Nil,
               nqp::stmts(
                 nqp::deletekey(nqp::getattr(self,Map,'$!storage'),$WHICH),
                 nqp::getattr(value,Pair,'$!value')


### PR DESCRIPTION
Currently, it returns the default value.  Which basically does not
allow you to differentiate between:

    my %h; dd %h.DELETE-KEY("a");             # Any

which does not remove a key, and:

    my %h = a => Any; dd %h.DELETE-KEY("a");  # Any

which *did* remove a key.  Making it return `Nil`, *would* allow you to
see the difference (well in all but the most contrived cases).

This is a breaking change, it breaks these spectests:

    t/spec/S32-basics/xxKEY.rakudo.moar                             (Wstat: 768 Tests: 129 Failed: 3)
      Failed tests:  18, 37, 56
      Non-zero exit status: 3
    t/spec/S32-hash/delete-adverb.t                                 (Wstat: 768 Tests: 131 Failed: 3)
      Failed tests:  21, 27, 39
      Non-zero exit status: 3
    t/spec/S32-exceptions/misc.rakudo.moar                          (Wstat: 512 Tests: 180 Failed: 2)
      Failed tests:  156-157
      Non-zero exit status: 2
    t/spec/integration/advent2013-day12.t                           (Wstat: 768 Tests: 32 Failed: 3)
      Failed tests:  9, 11-12
      Non-zero exit status: 3