### PR TITLE
Generate a `rakuw.exe` on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,8 @@ perl6.rc
 /inst-perl6-debug.exe
 /inst-perl6-m.exe
 /inst-perl6-debug-m.exe
+/inst-perl6w.exe
+/inst-perl6w-m.exe
 /inst-rakudo
 /inst-rakudo-debug
 /inst-rakudo-m
@@ -114,6 +116,8 @@ perl6.rc
 /inst-rakudo-debug.exe
 /inst-rakudo-m.exe
 /inst-rakudo-debug-m.exe
+/inst-rakudow.exe
+/inst-rakudow-m.exe
 t/localtest.data
 t/spec
 t/packages/tap-harness6

--- a/docs/running.pod
+++ b/docs/running.pod
@@ -154,6 +154,25 @@ Allows to override the NQP installation path. Defaults to C<[rakudo_executable_d
 
 =back
 
+=head1 WINDOWS PECULIARITIES
+
+=head 2 Non-console applications
+
+On Windows programs are compiled to either be I<console> applications or I<non-console>
+applications. I<Console> applications always open a console window. There is no straightforward way
+to suppress this window.
+
+Rakudo provides a separate set of executables suffixed with a C<'w'> (C<rakuw.exe>, C<rakudow.exe>,
+...) that are compiled as I<non-console> applications. These do not spawn this console window.
+
+B<WARNING> These I<non-console> applications do not have their C<STDIN>, C<STDOUT> and C<STDERR>
+attached. Trying to write to these handles will cause the application to abort.
+
+One can place the following snippet at the top of a program to have all its output be silently
+ignored instead.
+
+C<$*OUT=$*ERR=class {method print(*@args){}};>
+
 =head1 AUTHORS
 
 Written by the Rakudo contributors, see the CREDITS file.

--- a/docs/running.pod
+++ b/docs/running.pod
@@ -144,7 +144,7 @@ C<IO::Spec::Cygwin> inherits this from C<IO::Spec::Unix>.
 C<IO::Spec::Win32.path> will read the first defined of either C<%PATH%> or C<%Path%> as a
 semicolon-delimited list.
 
-=item C<RAKU_HOME>
+=item C<RAKUDO_HOME>
 
 Allows to override the Raku installation path. Defaults to C<[rakudo_executable_dir]/../share/perl6>.
 

--- a/tools/build/binary-release/Windows/README.md
+++ b/tools/build/binary-release/Windows/README.md
@@ -67,6 +67,27 @@ To make use of the Build Tools in Rakudo using PowerShell:
 - Execute `C:\path\to\this\folder\scripts\set-env.ps1`
 
 
+Non-console applications
+------------------------
+
+On Windows programs are compiled to either be _console_ applications or
+_non-console_ applications. _Console_ applications always open a console
+window. There is no straightforward way to suppress this window.
+
+Rakudo provides a separate set of executables suffixed with a 'w' (`rakuw.exe`,
+`rakudow.exe`, ...) that are compiled as _non-console_ applications. These do
+not spawn this console window.
+
+**WARNING** These _non-console_ applications do not have their `STDIN`,
+`STDOUT` and `STDERR` attached. Trying to write to these handles will cause the
+application to abort.
+
+One can place the following snippet at the top of a program to have all its
+output be silently ignored instead.
+
+    $*OUT=$*ERR=class {method print(*@args){}};
+
+
 Changes
 =======
 

--- a/tools/lib/NQP/Config/Rakudo.pm
+++ b/tools/lib/NQP/Config/Rakudo.pm
@@ -390,6 +390,7 @@ sub configure_moar_backend {
           );
     }
     $nqp_config->{mingw_unicode} = '';
+    $nqp_config->{subsystem_windows_flag} = '';
 
     my @c_runner_libs;
     if ( $self->is_win ) {
@@ -409,6 +410,14 @@ sub configure_moar_backend {
         if ( $nqp_config->{'moar::os'} eq 'mingw32' ) {
             $nqp_config->{mingw_unicode} = '-municode';
         }
+
+        if ( $nqp_config->{'moar::ld'} eq 'link' ) {
+            $nqp_config->{subsystem_windows_flag} = '/subsystem:windows /entry:wmainCRTStartup';
+        }
+        else {
+            $nqp_config->{subsystem_windows_flag} = '--subsystem=windows --entry=wmainCRTStartup';
+        }
+
         push @c_runner_libs, sprintf( $nqp_config->{'moar::ldusr'}, 'Shlwapi' );
     }
     else {

--- a/tools/templates/moar/Makefile-gen-c-runner.in
+++ b/tools/templates/moar/Makefile-gen-c-runner.in
@@ -3,4 +3,4 @@
 	$(NOECHO)$(RM_F) $@
 # Using only the pkgconfig moar includes does not work, because moar.h assumes all the specific includes below.
 	$(NOECHO@nop())@@bpm(CC)@ @moar::ccswitch@ @exec_path_define@ @static_nqp_home_define@ @static_rakudo_home_define@ @debug_flag@ @bpm(CFLAGS)@ @bpm(MOAR_INC_PATHS)@ @moar::ccout@@obj_file@@moar::obj@ @nfp(src/vm/moar/runner/main.c)@
-	$(NOECHO@nop())@@bpm(LD)@ @moar::ldout@$@ @bpm(LDFLAGS)@ @bpm(MINGW_UNICODE)@ @obj_file@@moar::obj@ @moar::lddir@"@moar::libdir@" @c_runner_libs@ @moar_lib@
+	$(NOECHO@nop())@@bpm(LD)@ @moar::ldout@$@ @bpm(LDFLAGS)@ @subsystem_flag@ @bpm(MINGW_UNICODE)@ @obj_file@@moar::obj@ @moar::lddir@"@moar::libdir@" @c_runner_libs@ @moar_lib@

--- a/tools/templates/moar/Makefile.in
+++ b/tools/templates/moar/Makefile.in
@@ -33,6 +33,7 @@ R_SETTING_MOAR = RESTRICTED.setting.moarvm
 
 @bpv(RAKU)@ = raku@moar::exe@
 @bpv(RAKU_DEBUG)@ = raku-debug@moar::exe@
+@if(platform==windows @bpv(RAKUW)@ = rakuw@moar::exe@)@
 @for_langalias(
 @bpv(@uclangalias@)@ = @langalias@@moar::exe@
 @bpv(@uclangalias@_DEBUG)@ = @langalias@-debug@moar::exe@
@@ -41,7 +42,11 @@ R_SETTING_MOAR = RESTRICTED.setting.moarvm
 @bpv(INST_@uclangalias@)@ = inst-@langalias@@moar::exe@
 @bpv(INST_@uclangalias@_DEBUG)@ = inst-@langalias@-debug@moar::exe@
 @bpv(INST_@uclangalias@_M)@ = inst-@langalias@-m@moar::exe@
-@bpv(INST_@uclangalias@_DEBUG_M)@ = inst-@langalias@-debug-m@moar::exe@)@
+@bpv(INST_@uclangalias@_DEBUG_M)@ = inst-@langalias@-debug-m@moar::exe@
+@if(platform==windows @bpv(@uclangalias@W)@ = @langalias@w@moar::exe@
+@bpv(@uclangalias@W_M)@ = @langalias@w-m@moar::exe@
+@bpv(INST_@uclangalias@W)@ = inst-@langalias@w@moar::exe@
+@bpv(INST_@uclangalias@W_M)@ = inst-@langalias@w-m@moar::exe@)@)@
 
 @bpv(RAKUDO_OPS_DIR)@  = dynext
 @bpv(RAKUDO_OPS_DLL)@  = @bpm(RAKUDO_OPS_DIR)@@nfp(/@perl6_ops_dll@)@
@@ -56,7 +61,9 @@ R_SETTING_MOAR = RESTRICTED.setting.moarvm
 @tab@@bpm(INST_@uclangalias@_DEBUG)@ \
 @tab@@bpm(INST_@uclangalias@_M)@ \
 @tab@@bpm(INST_@uclangalias@_DEBUG_M)@ \
-)@@for_langalias(@for_toolchain(@tab@@bpm(@uclangalias@_@uctoolchain@_RUNNER)@ \
+@if(platform==windows @tab@@bpm(INST_@uclangalias@W)@ \
+@tab@@bpm(INST_@uclangalias@W_M)@ \
+)@)@@for_langalias(@for_toolchain(@tab@@bpm(@uclangalias@_@uctoolchain@_RUNNER)@ \
 )@)@
 
 @bpv(CLEANUPS)@ = \
@@ -66,10 +73,14 @@ R_SETTING_MOAR = RESTRICTED.setting.moarvm
   inst-rakudo-debug-m@moar::obj@ \
   inst-rakudo@moar::obj@ \
   inst-rakudo-debug@moar::obj@ \
+  inst-rakudow-m@moar::obj@ \
+  inst-rakudow@moar::obj@ \
 @for_langalias( @bpm(INST_@uclangalias@)@ \
   @bpm(INST_@uclangalias@_DEBUG)@ \
   @bpm(INST_@uclangalias@_M)@ \
   @bpm(INST_@uclangalias@_DEBUG_M)@ \
+  @bpm(INST_@uclangalias@W)@ \
+  @bpm(INST_@uclangalias@W_M)@ \
 )@  @bpm(RAKUDO_OPS_DLL)@ \
   @bpm(RAKUDO_OPS_OBJ)@ \
 @for_langalias(@for_toolchain(  @bpm(@uclangalias@_@uctoolchain@_RUNNER)@ \
@@ -151,6 +162,12 @@ $(R_SETTING_MOAR): @bsm(RAKUDO)@@for_specs( @bsm(SETTING_@ucspec@)@)@ $(R_SETTIN
         '@bpm(INST_RAKUDO_M)@'       => '@bpm(RAKUDO_M)@',
         '@bpm(INST_RAKUDO_DEBUG_M)@' => '@bpm(RAKUDO_DEBUG_M)@',
     );
+    if ($cfg->cfg('platform') eq 'windows') {
+		$execs{'@bpm(INST_PERL6W)@'} = '@bpm(PERL6W)@';
+		$execs{'@bpm(INST_PERL6W_M)@'} = '@bpm(PERL6W_M)@';
+		$execs{'@bpm(INST_RAKUDOW)@'} = '@bpm(RAKUDOW)@';
+		$execs{'@bpm(INST_RAKUDOW_M)@'} = '@bpm(RAKUDOW_M)@';
+	}
     for my $build (keys %execs) {
         my $installed = $macros->expand($execs{$build});
 		$build = $macros->expand($build);
@@ -163,6 +180,7 @@ $(R_SETTING_MOAR): @bsm(RAKUDO)@@for_specs( @bsm(SETTING_@ucspec@)@)@ $(R_SETTIN
             '-DSTATIC_EXEC_PATH=' . $qchar . $cfg->c_escape_string($cfg->nfp($config{'prefix'} . '/bin/' . $installed )) . $qchar
             if $config{relocatable} eq 'nonreloc';
         $vars{debug_flag} = '-DMOAR_RAKUDO_RUNNER_DEBUG' if $build =~ /DEBUG/;
+        $vars{subsystem_flag} = $config{'subsystem_windows_flag'} if $build =~ 'RAKUDOW';
         $vars{obj_file} = $obj;
         my $scope = $cfg->push_config(%vars);
         $out .= $macros->expand('@insert(Makefile-gen-c-runner)@');
@@ -217,14 +235,13 @@ $(R_SETTING_MOAR): @bsm(RAKUDO)@@for_specs( @bsm(SETTING_@ucspec@)@)@ $(R_SETTIN
 	$(NOECHO)@bpm(RUN_CLEAN_TARGET_FILES)@ @nfpq($(DESTDIR)$(RAKUDO_HOME)/runtime)@ @for_specs($(SETTING_@ucspec@_MOAR) )@$(R_SETTING_MOAR)
 	$(NOECHO)@bpm(RUN_CLEAN_TARGET_FILES)@ @nfpq($(DESTDIR)$(PREFIX)/bin)@ @bsm(RAKUDO)@ @bsm(RAKUDO_DEBUG)@ @bsm(PERL6)@ @bsm(PERL6_DEBUG)@
 
-@backend_prefix@-install-main:: @@bpm(RAKUDO_OPS_DLL)@@ $(R_SETTING_MOAR) @@bpm(INST_RAKUDO_M)@@ @@bpm(INST_RAKUDO_DEBUG_M)@@
+@backend_prefix@-install-main:: @@bpm(RAKUDO_OPS_DLL)@@ $(R_SETTING_MOAR) @for_langalias(@@bpm(INST_@uclangalias@_M)@@ @@bpm(INST_@uclangalias@_DEBUG_M)@@ @if(platform==windows @@bpm(INST_@uclangalias@W_M)@@ )@)@
 	$(NOECHO)$(CP) @bpm(RAKUDO_OPS_DLL)@ @nfpq($(DESTDIR)$(RAKUDO_HOME)/runtime/dynext)@
 	$(NOECHO)$(CP) $(R_SETTING_MOAR) @nfpq($(DESTDIR)$(RAKUDO_HOME)/runtime)@
 @for_langalias(
 	$(NOECHO)$(CP) @bpm(INST_@uclangalias@_M)@ @nfpq($(DESTDIR)$(PREFIX)/bin/@bpm(@uclangalias@_M)@)@
 	$(NOECHO)$(CP) @bpm(INST_@uclangalias@_DEBUG_M)@ @nfpq($(DESTDIR)$(PREFIX)/bin/@bpm(@uclangalias@_DEBUG_M)@)@
-	$(NOECHO)$(CP) @bpm(INST_@uclangalias@_M)@ @nfpq($(DESTDIR)$(PREFIX)/bin/@bpm(@uclangalias@_M)@)@
-	$(NOECHO)$(CP) @bpm(INST_@uclangalias@_DEBUG_M)@ @nfpq($(DESTDIR)$(PREFIX)/bin/@bpm(@uclangalias@_DEBUG_M)@)@
+	@if(platform==windows $(NOECHO)$(CP) @bpm(INST_@uclangalias@W_M)@ @nfpq($(DESTDIR)$(PREFIX)/bin/@bpm(@uclangalias@W_M)@)@)@
 )@@if(platform!=windows @for_langalias(@for_toolchain(@insert(Makefile-install)@)@)@
 )@@if(platform==windows @m_install@)@
 
@@ -233,10 +250,14 @@ $(R_SETTING_MOAR): @bsm(RAKUDO)@@for_specs( @bsm(SETTING_@ucspec@)@)@ $(R_SETTIN
 
 @backend_prefix@-runner-default-install: @backend_prefix@-install
 	@echo(+++ Installing @uc(@backend@)@ launchers)@
-	$(NOECHO)$(CP) @bpm(INST_RAKUDO)@ @nfpq($(DESTDIR)$(PREFIX)/bin/@bpm(RAKUDO)@)@
-	$(NOECHO)$(CP) @bpm(INST_RAKUDO_DEBUG)@ @nfpq($(DESTDIR)$(PREFIX)/bin/@bpm(RAKUDO_DEBUG)@)@
-	$(NOECHO)$(CP) @bpm(INST_RAKUDO)@ @nfpq($(DESTDIR)$(PREFIX)/bin/@bpm(PERL6)@)@
-	$(NOECHO)$(CP) @bpm(INST_RAKUDO_DEBUG)@ @nfpq($(DESTDIR)$(PREFIX)/bin/@bpm(PERL6_DEBUG)@)@
+	$(NOECHO)$(CP) @bpm(INST_RAKUDO_M)@ @nfpq($(DESTDIR)$(PREFIX)/bin/@bpm(RAKUDO)@)@
+	$(NOECHO)$(CP) @bpm(INST_RAKUDO_DEBUG_M)@ @nfpq($(DESTDIR)$(PREFIX)/bin/@bpm(RAKUDO_DEBUG)@)@
+	$(NOECHO)$(CP) @bpm(INST_RAKUDO_M)@ @nfpq($(DESTDIR)$(PREFIX)/bin/@bpm(PERL6)@)@
+	$(NOECHO)$(CP) @bpm(INST_RAKUDO_DEBUG_M)@ @nfpq($(DESTDIR)$(PREFIX)/bin/@bpm(PERL6_DEBUG)@)@
+@if(platform==windows
+	$(NOECHO)$(CP) @bpm(INST_RAKUDOW_M)@ @nfpq($(DESTDIR)$(PREFIX)/bin/@bpm(RAKUDOW)@)@
+	$(NOECHO)$(CP) @bpm(INST_PERL6W_M)@ @nfpq($(DESTDIR)$(PREFIX)/bin/@bpm(PERL6W)@)@
+)@
 @if(with_raku_alias==on @tab@@echo(+++ Creating Raku executable alias)@
 @if(platform!=windows
 	$(NOECHO)$(LN_S) @nfpq(./@bpm(RAKUDO)@)@ @nfpq($(DESTDIR)$(PREFIX)/bin/@bpm(RAKU)@)@
@@ -244,6 +265,7 @@ $(R_SETTING_MOAR): @bsm(RAKUDO)@@for_specs( @bsm(SETTING_@ucspec@)@)@ $(R_SETTIN
 )@@if(platform==windows
 	$(NOECHO)$(CP) @nfpq($(DESTDIR)$(PREFIX)/bin/@bpm(RAKUDO)@)@ @nfpq($(DESTDIR)$(PREFIX)/bin/@bpm(RAKU)@)@
 	$(NOECHO)$(CP) @nfpq($(DESTDIR)$(PREFIX)/bin/@bpm(RAKUDO_DEBUG)@)@ @nfpq($(DESTDIR)$(PREFIX)/bin/@bpm(RAKU_DEBUG)@)@
+	$(NOECHO)$(CP) @nfpq($(DESTDIR)$(PREFIX)/bin/@bpm(RAKUDOW)@)@ @nfpq($(DESTDIR)$(PREFIX)/bin/@bpm(RAKUW)@)@
 )@
 )@
 manifest:


### PR DESCRIPTION
On Windows executables are either marked as "console" applications or
"windows" applications. The first always spawn a console window to which
STDIN, STDOUT and STDERR are connected, the second spawns no such window
and STDIN, STDOUT and STDERR are not connected to anything. This can't be
decided at runtime, but is a flag set on the executable file itself. So the
best we can do to support both usage scenarios is provide separate binaries
for each scenario.
Python does the same. The `python.exe` executable is compiled as "console"
while `pythonw.exe` is a "windows" executable. There is no point in making
up a new naming scheme, so we just do what the others do and name it
`rakudow.exe` / `rakuw.exe`.