### PR TITLE
Fix NativeCall/C++ to allow double instantiation

### DIFF
--- a/lib/NativeCall.rakumod
+++ b/lib/NativeCall.rakumod
@@ -383,7 +383,7 @@ our role Native[Routine $r, $libname where Str|Callable|List|IO::Path|Distributi
             $block.push: QAST::Op.new(
                 :op<if>,
                 QAST::Op.new(
-                    :op<isconcrete>,
+                    :op<isconcrete_nd>,
                     QAST::Var.new(:scope<local>, :name($lowered_param_name)),
                 ),
                 QAST::Op.new(
@@ -480,7 +480,7 @@ our role Native[Routine $r, $libname where Str|Callable|List|IO::Path|Distributi
                     QAST::Op.new(
                         :op<if>,
                         QAST::Op.new(
-                            :op<isconcrete>,
+                            :op<isconcrete_nd>,
                             QAST::Var.new(:scope<local>, :name($lowered_name)),
                         ),
                         QAST::Op.new(

--- a/t/04-nativecall/11-cpp.t
+++ b/t/04-nativecall/11-cpp.t
@@ -16,7 +16,7 @@ try {
     }
 }
 
-plan 21;
+plan 22;
 
 #~ shell 'dumpbin /exports 11-cpp.dll';
 #~ shell 'clang --shared -fPIC -o 11-cpp.so t/04-nativecall/11-cpp.cpp';
@@ -49,6 +49,7 @@ sub SizeofDerived1() returns int32 is mangled is native("./11-cpp") { * }
 
 is nativesizeof(Derived1), SizeofDerived1(), 'sizeof(Derived1)';
 ok my $d1 = Derived1.new, 'can instantiate C++ class';
+ok my Derived1 $d1b .= new, 'can instantiate the same C++ class again using « .= »';
 is $d1.foo,   11,   'can read attribute foo';
 is $d1.bar,   42,   'can read attribute bar';
 is $d1.baz,   43,   'can read attribute baz';


### PR DESCRIPTION
The test of the arguments concreteness using the Op
<isconcrete> instead of <isconcrete_nd> was preventing
the instantiation more than once of the same class
using the following code:

my Class $i .= new;
my Class $j .= new;

The second line, without this commit, fails with the wrong
message: « Native call expected argument 1 with CPPStruct
representation, but got a P6opaque (Scalar) »

This commit possibly fixes other issues related to
argument passing to native calls.