### PR TITLE
Add Iterator.deterministic method

### DIFF
--- a/src/core.c/Iterator.pm6
+++ b/src/core.c/Iterator.pm6
@@ -112,6 +112,12 @@ my role Iterator {
     # user absolutely asks for.  This has e.g. effect on the behaviour
     # on .STORE: a lazy iterator would not reify, a non-lazy would.
     method is-lazy(--> False) { }
+
+    # Whether the iterator will produce values in a deterministic (always
+    # the same for a given data source).  This is True for most iterators,
+    # but *not* true for iterators that typically return keys and/or values
+    # from a hash.
+    method deterministic(--> True) { }
 }
 
 # The PredictiveIterator role is a refinement of the Iterator role for those

--- a/src/core.c/Iterator.pm6
+++ b/src/core.c/Iterator.pm6
@@ -113,7 +113,7 @@ my role Iterator {
     # on .STORE: a lazy iterator would not reify, a non-lazy would.
     method is-lazy(--> False) { }
 
-    # Whether the iterator will produce values in a deterministic (always
+    # Whether the iterator will produce values in a deterministic way (always
     # the same for a given data source).  This is True for most iterators,
     # but *not* true for iterators that typically return keys and/or values
     # from a hash.


### PR DESCRIPTION
By default, this will return True, but it should return False for
iterators that produce values in a non-determnistic way, such as
iterators that operate on hashes.

Why do we need this?  While working on the full implementation of
multidim slices on hashes (including all the possible adverb
combinations), it became clear to me that the use of * as a slice
used as a left-value, will have non-deterministic results.  In a
simpler context:

    my %h = a => 42, b => 666, c => 314;
    %h{%h.keys} = 777,888,999;
    dd %h; # Hash %h = {:a(777), :b(999), :c(888)}
    %h{%h.keys} = 777,888,999;
    dd %h; # Hash %h = {:a(999), :b(777), :c(888)}

Having a "deterministic" attribute on the iterator, would allow us
to either emit a warning on such an assignment, or disallow such an
assignment altogether.

Adding this method to the base Iterator role increases the size of
the CORE.c.setting.moarvm file from 25417728 to 25453112 bytes, aka
in increase of 0.14 %.

This commit *only* adds the method to the Iterator role: setting
explicit False values for affected iterator classes is a separate
job that only makes sense to do if this PR is merged.