### PR TITLE
Build: If NQP is stale and `--gen-nqp` is passed: rebuild

### DIFF
--- a/tools/lib/NQP/Config/Rakudo.pm
+++ b/tools/lib/NQP/Config/Rakudo.pm
@@ -652,7 +652,8 @@ sub gen_nqp {
 
         unless ( $force_rebuild
             || !$nqp_have
-            || $nqp_ver_ok )
+            || $nqp_ok
+            || defined($gen_nqp))
         {
             my $say_sub = $options->{'ignore-errors'} ? 'note' : 'sorry';
             $self->$say_sub(


### PR DESCRIPTION
If `--gen-nqp` is passed don't fail with "nqp version XXX is outdated" errors, rebuild in that case.

Fixes #3964