### PR TITLE
Implement binding of hash-slices

### DIFF
--- a/src/core.c/hash_slice.pm6
+++ b/src/core.c/hash_slice.pm6
@@ -70,8 +70,28 @@ multi sub postcircumfix:<{ }>(\SELF, Iterable \key, Mu \ASSIGN) is raw {
            )
          ) = ASSIGN)
 }
-multi sub postcircumfix:<{ }>(\SELF, Iterable \key, :$BIND!) is raw {
-    X::Bind::Slice.new(type => SELF.WHAT).throw;
+multi sub postcircumfix:<{ }>(\SELF, Iterable \key, :$BIND! is raw) is raw {
+    if nqp::iscont(key) {
+        SELF.BIND-KEY(key, $BIND);
+    }
+    else {
+        my $result := nqp::create(IterationBuffer);
+        my $keys   := key.iterator;
+        my $binds  := $BIND.iterator;
+        nqp::until(
+          nqp::eqaddr((my $bind := $binds.pull-one),IterationEnd)
+            || nqp::eqaddr((my $key := $keys.pull-one),IterationEnd),
+          nqp::push($result, SELF.BIND-KEY($key, $bind))
+        );
+
+        # fill up if ran out of values to bind?
+        nqp::until(
+          nqp::eqaddr(($key := $keys.pull-one),IterationEnd),
+          nqp::push($result,SELF.ASSIGN-KEY($key,Nil))
+        ) if nqp::eqaddr($bind,IterationEnd);
+
+        $result.List
+    }
 }
 multi sub postcircumfix:<{ }>(\SELF,Iterable \key, Bool() :$delete!,*%other) is raw {
     nqp::iscont(key)


### PR DESCRIPTION
AKA %h<a b c> := 1,2,3 .  For some reason, this was not implemented
before, perhaps because of pre-GLR peculiarities making this difficult.
Implementing turned out not to be such a big thing, so here goes.

This breaks 2 spectests that specifically test for throwing an
X::Bind::Slice exception:

  S03-binding/hashes.t, 38
  S32-exceptions/misc2.t, 47

This makes 10 TODO'd spectests pass:

  t/spec/S32-hash/slice.t, 15-22, 25-26