### PR TITLE
Add .gitattributes file & specify file extensions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+*.p6        diff=raku
+*.pl6       diff=raku
+*.pm6       diff=raku
+*.raku      diff=raku
+*.rakumod   diff=raku
+*.rakutest  diff=raku


### PR DESCRIPTION
This means if you add something like:
```
[diff "raku"]
    xfuncname = "^\\s*(((my|our) )?((multi|proto) )?(sub|method|submethod) [^{]+)"
```
to your $HOME/.gitconfig or $REPO/.git/config then diffs will have
better headers. E.g., 
`@@ -23,7 +23,8 @@ multi method WHICH(Int:D: --> ValueObjAt:D)`
instead of 
`@@ -23,7 +23,8 @@ my class Int does Real { # declared in BOOTSTRAP`
when I did make an edit to the WHICH method.

Both this file and the change to the git config are required, because
git doesn't have a diff driver for Raku built-in.