### PR TITLE
Fix issue #3971: attempt to copy a directory to a file destroys the file!

### DIFF
--- a/src/core.c/IO/Path.pm6
+++ b/src/core.c/IO/Path.pm6
@@ -448,6 +448,13 @@ my class IO::Path is Cool does IO {
     }
 
     method copy(IO::Path:D: IO() $to, :$createonly --> True) {
+        # add fix for issue #3971 where attempt to copy a dir
+        # to a file clobbers the file.
+        self.d and $to.f and fail X::IO::Copy.new:
+            :from($.absolute),
+            :to($to.absolute),
+            :os-error('cannot copy a directory to a file');
+
         $createonly and $to.e and fail X::IO::Copy.new:
             :from($.absolute),
             :to($to.absolute),


### PR DESCRIPTION
This **very serious** issue apparently has been in core for a very long time and **there is no existing test for it**.  It should be incorporated **before the next release**.

**ISSUE:** Attempting to copy a directory to a file fails as expected, **but the file is deleted**. 

**FIX:** In **method copy** add an initial check for the **self** and **$to** IO types and fail immediately if **self** is a directory and **$to** is a file. (See roast PR 690 for an added test for this fix.)

File modified:

    src/core.c/IO/Path.pm6