### PR TITLE
Expose nqp::indexingoptimized as Str.no-strands

### DIFF
--- a/src/core.c/Str.pm6
+++ b/src/core.c/Str.pm6
@@ -53,6 +53,10 @@ my class Str does Stringy { # declared in BOOTSTRAP
         nqp::bindattr_s(self, Str, '$!value', nqp::unbox_s($value))
     }
 
+    method no-strands(Str:D: --> Str:D) {
+        nqp::bindattr_s(self,Str,'$!value',nqp::indexingoptimized($!value))
+    }
+
     multi method Bool(Str:D: --> Bool:D) {
         nqp::hllbool(nqp::chars($!value));
     }


### PR DESCRIPTION
Calling .no-strands on a Str will make sure that the string in
memory consists of a single array of codepoints, rather than possibly
as a collection of strands (which typically happens with a lot of
~= work on a string).

Benchmarking this is tricky, but a .comb on a string that consists
of 1000 strands, is about 7% faster with calling .no-strands on it
once.

YMMV