### PR TITLE
Fix a problem with multi submethods been treated as method

### DIFF
--- a/src/core.c/CompUnit/Handle.pm6
+++ b/src/core.c/CompUnit/Handle.pm6
@@ -2,6 +2,7 @@ class CompUnit::Handle {
     has Mu $!module_ctx;
     has Mu $!unit;
 
+    proto submethod new(|) {*}
     multi submethod new() {
         nqp::create(self)
     }

--- a/src/core.c/stubs.pm6
+++ b/src/core.c/stubs.pm6
@@ -61,9 +61,10 @@ sub DYNAMIC(\name) is raw {  # is implementation-detail
 # actually appear in the setting).
 {
     my class Dummy {
-        our proto method AUTOGEN(::T $: |) {*}
+        our proto method AUTOGEN-METHOD(::T $: |) {*}
+        our proto submethod AUTOGEN-SUBMETHOD(::T $: |) {*}
     }
-    Dummy.HOW.set_autogen_proto(&Dummy::AUTOGEN);
+    Dummy.HOW.set_autogen_proto(&Dummy::AUTOGEN-METHOD, &Dummy::AUTOGEN-SUBMETHOD);
 }
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
There was a few issues related to `multi submethod`:

- no autogenerated `proto`
- added to the `%!methods` instead of `%!submethods`
- manually declared `proto submethod` was conflicting with `multi` of
  the same `submethod` resulting in "method already defined" exception.

Resolves #3976 