### PR TITLE
Add a Mu ACCEPTS candidate for Mu:D

### DIFF
--- a/src/core.c/Mu.pm6
+++ b/src/core.c/Mu.pm6
@@ -21,11 +21,11 @@ my class Mu { # declared in BOOTSTRAP
     multi method ACCEPTS(Mu:U: Mu \topic) {
         nqp::hllbool(nqp::istype(topic, self))
     }
-    multi method ACCEPTS(Mu:D: Mu \topic) {
-        nqp::hllbool(nqp::eqaddr(nqp::decont(topic), nqp::if(
-          nqp::defined(topic),
-          self,
-          self.WHAT)))
+    multi method ACCEPTS(Mu:D: Mu:U \topic) {
+        nqp::hllbool(nqp::eqaddr(nqp::decont(topic), self.WHAT))
+    }
+    multi method ACCEPTS(Mu:D: Mu:D \topic) {
+        nqp::hllbool(nqp::eqaddr(nqp::decont(topic), self))
     }
     # Typically, junctions shouldn't be typechecked literally. There are
     # exceptions though, such as Junction in particular, so this probably

--- a/src/core.c/Mu.pm6
+++ b/src/core.c/Mu.pm6
@@ -21,6 +21,12 @@ my class Mu { # declared in BOOTSTRAP
     multi method ACCEPTS(Mu:U: Mu \topic) {
         nqp::hllbool(nqp::istype(topic, self))
     }
+    multi method ACCEPTS(Mu:D: Mu \topic) {
+        nqp::hllbool(nqp::eqaddr(nqp::decont(topic), nqp::if(
+          nqp::defined(topic),
+          self,
+          self.WHAT)))
+    }
     # Typically, junctions shouldn't be typechecked literally. There are
     # exceptions though, such as Junction in particular, so this probably
     # shouldn't be handled by the compiler itself. Having a default ACCEPTS


### PR DESCRIPTION
Smartmatching against `Mu` type objects used to throw. I fixed this with
3b4794f, but at the time I didn't think to check if the same would occur
with `Mu` instances or not (it does). This makes it so `Mu` type objects
will smartmatch against instances of themselves, and `Mu` instances will
smartmatch against themselves.

Passes `make test` and `make spectest`, but is better left alone until after this upcoming release.