### PR TITLE
Fix ecaf334 that partly caused #3966

### DIFF
--- a/lib/NativeCall.rakumod
+++ b/lib/NativeCall.rakumod
@@ -383,7 +383,7 @@ our role Native[Routine $r, $libname where Str|Callable|List|IO::Path|Distributi
             $block.push: QAST::Op.new(
                 :op<if>,
                 QAST::Op.new(
-                    :op<isconcrete_nd>,
+                    :op<isconcrete>,
                     QAST::Var.new(:scope<local>, :name($lowered_param_name)),
                 ),
                 QAST::Op.new(


### PR DESCRIPTION
The test of installation of Compress::Bzip2
failed after ecaf334. There was a change from
isconcrete to isconcrete_nd in excess.