### PR TITLE
Add flag for creating symlinks without absolute path

### DIFF
--- a/src/core.c/IO/Path.pm6
+++ b/src/core.c/IO/Path.pm6
@@ -496,8 +496,8 @@ my class IO::Path is Cool does IO {
         }}
     }
 
-    method symlink(IO::Path:D: IO() $name, Bool :$literal --> True) {
-        nqp::symlink($literal ?? ~self !! $.absolute, nqp::unbox_s($name.absolute));
+    method symlink(IO::Path:D: IO() $name, Bool :$absolute = True --> True) {
+        nqp::symlink($absolute ?? $.absolute !! ~self , nqp::unbox_s($name.absolute));
         CATCH { default {
             fail X::IO::Symlink.new:
                 :target($!os-path), :name($name.absolute), :os-error(.Str);

--- a/src/core.c/IO/Path.pm6
+++ b/src/core.c/IO/Path.pm6
@@ -496,8 +496,8 @@ my class IO::Path is Cool does IO {
         }}
     }
 
-    method symlink(IO::Path:D: IO() $name --> True) {
-        nqp::symlink($.absolute, nqp::unbox_s($name.absolute));
+    method symlink(IO::Path:D: IO() $name, Bool :$literal --> True) {
+        nqp::symlink($literal ?? ~self !! $.absolute, nqp::unbox_s($name.absolute));
         CATCH { default {
             fail X::IO::Symlink.new:
                 :target($!os-path), :name($name.absolute), :os-error(.Str);

--- a/src/core.c/io_operators.pm6
+++ b/src/core.c/io_operators.pm6
@@ -290,7 +290,9 @@ multi sub move(IO() $from, IO() $to, :$createonly) {
 }
 
 proto sub symlink($, $, *%) {*}
-multi sub symlink(IO() $target, IO() $name) { $target.symlink($name) }
+multi sub symlink(IO() $target, IO() $name, Bool :$literal) {
+    $target.symlink($name, :$literal)
+}
 
 proto sub link($, $, *%) {*}
 multi sub link(IO() $target, IO() $name) { $target.link($name) }

--- a/src/core.c/io_operators.pm6
+++ b/src/core.c/io_operators.pm6
@@ -290,8 +290,8 @@ multi sub move(IO() $from, IO() $to, :$createonly) {
 }
 
 proto sub symlink($, $, *%) {*}
-multi sub symlink(IO() $target, IO() $name, Bool :$literal) {
-    $target.symlink($name, :$literal)
+multi sub symlink(IO() $target, IO() $name, Bool :$absolute = True) {
+    $target.symlink($name, :$absolute)
 }
 
 proto sub link($, $, *%) {*}


### PR DESCRIPTION
As `.absolute` is called on the path when `.symlink` is called, it is not currently possible to create a relative symlink using this method. The added `:literal` flag is intended to allow for the altering of this behavior, creating a symlink pointing to the path as it was given.