### PR TITLE
Introducing CachedIterator role

### DIFF
--- a/src/core.c/Iterator.pm6
+++ b/src/core.c/Iterator.pm6
@@ -131,4 +131,12 @@ my role PredictiveIterator does Iterator {
     method bool-only(--> Bool:D) { self.count-only.Bool }
 }
 
+# The CachedIterator role is a refinement of the PredictiveIterator role for
+# those cases where the source of the iterator is a Positional structure that
+# supports the AT-POS interface.  With such a structure, there is no need to
+# build a separate cache for the PositionalBindFailover functionality.
+my role CachedIterator does PredictiveIterator {
+    method cache(--> Positional:D) { ... }
+}
+
 # vim: expandtab shiftwidth=4

--- a/src/core.c/Rakudo/Iterator.pm6
+++ b/src/core.c/Rakudo/Iterator.pm6
@@ -1728,13 +1728,18 @@ class Rakudo::Iterator {
 
     # Returns a sentinel Iterator object that will never generate any value.
     # Does not take a parameter.
-    my class Empty does PredictiveIterator {
+    my class Empty does CachedIterator {
         method new() { nqp::create(self) }
         method pull-one(--> IterationEnd)  { }
         method push-all($ --> IterationEnd) { }
         method sink-all(--> IterationEnd)  { }
         method skip-one(--> 0) { }
         method skip-at-least($ --> 0) { }
+        method cache() {
+            BEGIN nqp::p6bindattrinvres(
+              nqp::create(List),List,'$!reified',nqp::create(IterationBuffer)
+            )
+        }
         method count-only(--> 0) { }
         method bool-only(--> False) { }
     }
@@ -3340,7 +3345,7 @@ class Rakudo::Iterator {
     # Return an iterator for an Array that has been completely reified
     # already.  Returns a assignable container for elements don't exist
     # before the end of the reified array.
-    my class ReifiedArrayIterator does PredictiveIterator {
+    my class ReifiedArrayIterator does CachedIterator {
         has $!reified;
         has $!descriptor;
         has int $!i;
@@ -3422,6 +3427,13 @@ class Rakudo::Iterator {
               )
             )
         }
+        method cache() is raw {
+            nqp::iseq_i($!i,-1)
+              ?? nqp::p6bindattrinvres(
+                   nqp::create(List),List,'$!reified',$!reified
+                 )
+              !! List.from-iterator(self)
+        }
         method count-only(--> Int:D) {
             nqp::elems($!reified) - $!i - nqp::islt_i($!i,nqp::elems($!reified))
         }
@@ -3434,7 +3446,7 @@ class Rakudo::Iterator {
     # Return an iterator for a List that has been completely reified
     # already.  Returns an nqp::null for elements that don't exist
     # before the end of the reified list.
-    my class ReifiedListIterator does PredictiveIterator {
+    my class ReifiedListIterator does CachedIterator {
         has $!reified;
         has int $!i;
 
@@ -3507,6 +3519,13 @@ class Rakudo::Iterator {
                 nqp::islt_i($!i,nqp::elems($!reified))
               )
             )
+        }
+        method cache() is raw {
+            nqp::iseq_i($!i,-1)
+              ?? nqp::p6bindattrinvres(
+                   nqp::create(List),List,'$!reified',$!reified
+                 )
+              !! List.from-iterator(self)
         }
         method count-only(--> Int:D) {
             nqp::elems($!reified) - $!i - nqp::islt_i($!i,nqp::elems($!reified))

--- a/src/core.c/Seq.pm6
+++ b/src/core.c/Seq.pm6
@@ -11,6 +11,10 @@ my class Seq is Cool does Iterable does Sequence {
     multi method new(Seq: Iterator:D $iter) {
         nqp::p6bindattrinvres(nqp::create(self),Seq,'$!iter',nqp::decont($iter))
     }
+    # Special handling for CachedIterators, setting the cache up immediately
+    multi method new(Seq: CachedIterator:D $iter) {
+        nqp::p6bindattrinvres(nqp::create(self),Seq,'$!list',$iter.cache)
+    }
     # This candidate exists purely for being able to EVAL a .raku
     # representation of a Seq of which the iterator has already been taken,
     multi method new(Seq:) { nqp::create(self) }

--- a/t/02-rakudo/03-corekeys-6c.t
+++ b/t/02-rakudo/03-corekeys-6c.t
@@ -504,6 +504,7 @@ my @expected = (
   Q{Broken},
   Q{Buf},
   Q{CX},
+  Q{CachedIterator},
   Q{CallFrame},
   Q{Callable},
   Q{Cancellation},

--- a/t/02-rakudo/03-corekeys-6d.t
+++ b/t/02-rakudo/03-corekeys-6d.t
@@ -504,6 +504,7 @@ my @expected = (
     Q{Broken},
     Q{Buf},
     Q{CX},
+    Q{CachedIterator},
     Q{CallFrame},
     Q{Callable},
     Q{Cancellation},

--- a/t/02-rakudo/03-corekeys-6e.t
+++ b/t/02-rakudo/03-corekeys-6e.t
@@ -506,6 +506,7 @@ my @expected = (
     Q{Broken},
     Q{Buf},
     Q{CX},
+    Q{CachedIterator},
     Q{CallFrame},
     Q{Callable},
     Q{Cancellation},

--- a/t/02-rakudo/03-corekeys.t
+++ b/t/02-rakudo/03-corekeys.t
@@ -507,6 +507,7 @@ my @allowed =
       Q{Broken},
       Q{Buf},
       Q{CX},
+      Q{CachedIterator},
       Q{CallFrame},
       Q{Callable},
       Q{Cancellation},

--- a/t/02-rakudo/04-settingkeys-6c.t
+++ b/t/02-rakudo/04-settingkeys-6c.t
@@ -504,6 +504,7 @@ my %allowed = (
     Q{Buf},
     Q{CORE-SETTING-REV},
     Q{CX},
+    Q{CachedIterator},
     Q{CallFrame},
     Q{Callable},
     Q{Cancellation},

--- a/t/02-rakudo/04-settingkeys-6e.t
+++ b/t/02-rakudo/04-settingkeys-6e.t
@@ -504,6 +504,7 @@ my %allowed = (
     Q{Buf},
     Q{CORE-SETTING-REV},
     Q{CX},
+    Q{CachedIterator},
     Q{CallFrame},
     Q{Callable},
     Q{Cancellation},


### PR DESCRIPTION
This is a refinement of the PredictiveIterator role, in that it allows
an Iterator class to provide the cache of the Seq, so that Lists and
Arrays that have already been fully reified, do not need to generate
a cache.  Seems like an easy applicable idea, but unfortunately, this
hit some snags.

First of all, apparently it is legal to advance the iterator on a Seq
*before* .cache is called:

    my @a = ^10; dd @a.Seq.skip(5).cache;  # (5, 6, 7, 8, 9)

This makes it impossible to just have the .cache method of a
CachedIterator return the source wrapped in a List.  One would think that
just wrapping a .splice of the source into a List would also work, but
alas, this causes as yet unexplained spectest errors.  So, for now, in
that case we'll just re-instate the original behaviour in that case, which
is List.from-iterator from the iterator.

How much does this save?  An artificial case such as:

    my @a = ^1000; @a.Seq[*-1] for ^10000;

is 14x as fast.  Note that this situation actually occurs for:

    my @a = ^1000; @a.sort[*-1] for ^100;

but then the savings are only about 3%, because they are drowned out
by the effort of sorting.

This currently breaks 4 spectests:

    t/spec/S32-list/seq.t: 28, 38, 42, 44

These all basically test whether an empty Seq will die because it is
exhausted.  Not sure about the validity of these tests.