### PR TITLE
Introducing Seq.slice(indices)

### DIFF
--- a/src/core.c/Any-iterable-methods.pm6
+++ b/src/core.c/Any-iterable-methods.pm6
@@ -1519,6 +1519,9 @@ Consider using a block if any of these are necessary for your mapping code."
         (find-reducer-for-op(&with))(&with,1)(self)
     }
 
+    proto method slice(|) is nodal { * }
+    multi method slice(Any:D: *@indices) { self.Seq.slice(@indices) }
+
     proto method unique(|) is nodal {*}
 
     my class Unique does Iterator {

--- a/src/core.c/Any-iterable-methods.pm6
+++ b/src/core.c/Any-iterable-methods.pm6
@@ -1520,7 +1520,7 @@ Consider using a block if any of these are necessary for your mapping code."
     }
 
     proto method slice(|) is nodal { * }
-    multi method slice(Any:D: *@indices) { self.Seq.slice(@indices) }
+    multi method slice(Any:D: *@indices --> Seq:D) { self.Seq.slice(@indices) }
 
     proto method unique(|) is nodal {*}
 

--- a/src/core.c/Seq.pm6
+++ b/src/core.c/Seq.pm6
@@ -131,6 +131,20 @@ my class Seq is Cool does Iterable does Sequence {
         )
     }
 
+    multi method slice(Seq:D: Iterable:D \iterable --> Seq:D) {
+        Seq.new(
+          Rakudo::Iterator.MonotonicIndexes(
+            self.iterator,
+            iterable.iterator,
+            0,
+            -> $index, $next {
+                die "Provided index $index, which is lower than $next";
+            }
+          )
+        )
+    }
+    multi method slice(Seq:D: *@indices --> Seq:D) { self.slice(@indices) }
+
     method sink(--> Nil) {
         nqp::if(
           nqp::isconcrete($!iter),


### PR DESCRIPTION
It appears that a "slice" method on Seq has been discussed extensively
in the longer ago past.  So I thought I'd have a go at it today.

The .slice method takes any number of indices that are monotonocally
increasing (that is, any later index value *must* be greater than any
previous index value), and produces the associated values from the
iterator of the given sequence.  To give an artificial example:

    my @a = ^10; dd @a.Seq.slice(0, 2 ... *);  # (0, 2, 4, 6, 8).Seq

is about 2x as fast as:

    my @a = ^10; dd @a.Seq[0, 2 ... *];       # (0, 2, 4, 6, 8)

This is because the .slice method does *not* have to do any caching.

Note that if an index is produced that does not follow the rule, an
exception will be thrown.

Turns out the underlying iterator had already been implemented for some
aspects of Match processing, so this was actually only creating a frontend
for that functionality.