### PR TITLE
Make Array.DELETE-POS return Nil on non-existent elements

### DIFF
--- a/src/core.c/Array.pm6
+++ b/src/core.c/Array.pm6
@@ -678,10 +678,10 @@ my class Array { # declared in BOOTSTRAP
                   ),
                   $value                                   # value, if any
                 ),
-                self.default                               # outlander
+                Nil                                        # outlander
               ),
             ),
-            self.default                                 # no elements
+            Nil                                          # no elements
           )
         )
     }


### PR DESCRIPTION
Currently, it returns the default value. Which basically does not
allow you to differentiate between:

    my @a; dd @a.DELETE-POS(0);             # Any

which does not remove an element, and:

    my @a = Any; dd @a.DELETE-POS(0);       # Any

which did remove an element. Making it return Nil, would allow you
to see the difference (well in all but the most contrived cases).

Also, DELETE-POS on shaped arrays already returns Nil:

    my @a[10]; dd @a[9]:delete;             # Nil

so this would also make this more consistent.

This is a breaking change, it breaks these spectests:

    t/spec/S32-array/delete-adverb-native.t                         (Wstat: 1024 Tests: 138 Failed: 4)
      Failed tests:  21, 28, 42, 63
    t/spec/S32-array/delete-adverb.t                                (Wstat: 1024 Tests: 219 Failed: 4)
      Failed tests:  21, 28, 42, 141
    t/spec/S32-basics/xxPOS.rakudo.moar                             (Wstat: 512 Tests: 64 Failed: 2)
      Failed tests:  20, 41

These all test for the default value being returned.