### PR TITLE
Add RAKU_TEST_DIAG_LINE_ON_FAIL

### DIFF
--- a/lib/Test.rakumod
+++ b/lib/Test.rakumod
@@ -8,6 +8,8 @@ my int $raku_test_times =
   ?(%*ENV<RAKU_TEST_TIME> // %*ENV<PERL6_TEST_TIMES>);
 my int $die_on_fail =
   ?(%*ENV<RAKU_TEST_DIE_ON_FAIL> // %*ENV<PERL6_TEST_DIE_ON_FAIL>);
+my int $diag_line_on_fail =
+  %*ENV<RAKU_TEST_DIAG_LINE_ON_FAIL> // 1;
 
 # global state
 my @vars;
@@ -761,9 +763,11 @@ sub proclaim(Bool(Mu) $cond, $desc is copy, $unescaped-prefix = '') {
             $caller = callframe($level++);
         }
 
-        _diag $desc
+        if nqp::iseq_i($diag_line_on_fail,1) {
+          _diag $desc
           ?? "Failed test '$desc'\nat $caller.file() line $caller.line()"
           !! "Failed test at $caller.file() line $caller.line()";
+        }
     }
 
     # must clear this between tests


### PR DESCRIPTION
Defaults to 1. If set to empty/0, disables the diag output in testing
that adds file/line number information on failed tests.

Purpose is to conditionally hide additional diag output on failing tests. For files with individual tests, file::line is helpful. For tests that have loops and all fail in the same place, the diag output is useless. Leaving defaulted on in this PR, but could change the default to off easily.