### PR TITLE
Introducing Routine is test-assertion trait

### DIFF
--- a/lib/Test.rakumod
+++ b/lib/Test.rakumod
@@ -64,6 +64,12 @@ our sub todo_output is rw {
     $todo_output
 }
 
+multi sub trait_mod:<is>(Routine:D $r, :$test-assertion!) is export {
+    $r.^mixin( role is-test-assertion {
+        method is-test-assertion(--> True) { }
+    }) if $test-assertion;
+}
+
 proto sub plan ($?, Cool :$skip-all) {*}
 
 my class X::SubtestsSkipped is Exception {}
@@ -766,7 +772,7 @@ sub proclaim(Bool(Mu) $cond, $desc is copy, $unescaped-prefix = '') {
 
         repeat {
             $tester = callframe($level)  # the next one should be reported
-              if ($caller = callframe($level++)).code.?is-unit-tester;
+              if ($caller = callframe($level++)).code.?is-test-assertion;
         } until $caller.file.ends-with('.nqp');
 
         # the final place we want to report from

--- a/src/core.c/traits.pm6
+++ b/src/core.c/traits.pm6
@@ -408,12 +408,6 @@ multi sub trait_mod:<is>(Routine:D $r, :$hidden-from-USAGE!) {
     }) if $hidden-from-USAGE;
 }
 
-multi sub trait_mod:<is>(Routine:D $r, :$unit-tester!) {
-    $r.^mixin( role is-unit-tester {
-        method is-unit-tester(--> True) { }
-    }) if $unit-tester;
-}
-
 multi sub trait_mod:<is>(Routine:D $r, :$pure!) {
     $r.^mixin( role is-pure {
         method is-pure (--> True) { }

--- a/src/core.c/traits.pm6
+++ b/src/core.c/traits.pm6
@@ -156,7 +156,7 @@ multi sub trait_mod:<is>(Routine:D $r, |c ) {
         highexpect => (
             'rw raw hidden-from-backtrace hidden-from-USAGE pure default',
             'DEPRECATED inlinable nodal prec equiv tighter looser assoc',
-            'leading_docs trailing_docs unit-tester',
+            'leading_docs trailing_docs
             ('',"or did you forget to 'use NativeCall'?"
               if $subtype eq 'native').Slip
           ),

--- a/src/core.c/traits.pm6
+++ b/src/core.c/traits.pm6
@@ -156,7 +156,7 @@ multi sub trait_mod:<is>(Routine:D $r, |c ) {
         highexpect => (
             'rw raw hidden-from-backtrace hidden-from-USAGE pure default',
             'DEPRECATED inlinable nodal prec equiv tighter looser assoc',
-            'leading_docs trailing_docs
+            'leading_docs trailing_docs',
             ('',"or did you forget to 'use NativeCall'?"
               if $subtype eq 'native').Slip
           ),

--- a/src/core.c/traits.pm6
+++ b/src/core.c/traits.pm6
@@ -156,7 +156,7 @@ multi sub trait_mod:<is>(Routine:D $r, |c ) {
         highexpect => (
             'rw raw hidden-from-backtrace hidden-from-USAGE pure default',
             'DEPRECATED inlinable nodal prec equiv tighter looser assoc',
-            'leading_docs trailing_docs',
+            'leading_docs trailing_docs unit-tester',
             ('',"or did you forget to 'use NativeCall'?"
               if $subtype eq 'native').Slip
           ),
@@ -406,6 +406,12 @@ multi sub trait_mod:<is>(Routine:D $r, :$hidden-from-USAGE!) {
     $r.^mixin( role is-hidden-from-USAGE {
         method is-hidden-from-USAGE(--> True) { }
     }) if $hidden-from-USAGE;
+}
+
+multi sub trait_mod:<is>(Routine:D $r, :$unit-tester!) {
+    $r.^mixin( role is-unit-tester {
+        method is-unit-tester(--> True) { }
+    }) if $unit-tester;
 }
 
 multi sub trait_mod:<is>(Routine:D $r, :$pure!) {


### PR DESCRIPTION
Marking a subroutine with the "is test-assertion" trait, indicates that
the subroutine produces Test (aka TAP) output.  All of the exported
subroutines in Test implicitely have this trait.

When a test fails and a failure needs to be reported, the file and
line at which a unit-tester is *called* is shown.  However, if you
build your own subroutines for doing several similar tests depending
on arguments given, any failure will be reported *inside* that subroutine
rather than at the location where your own subroutine was called.  Which
is extremely annoying when writing extensive, parameter driven tests.

With this trait, you can mark your own testing subroutines to get failing
tests to report at the place your own testing subroutine is called!

    use Test;
    sub foo-test($value) is test-assertion {
        is $value, 42, "is the value 42?";  # <-- do *not* report this line
    }
    foo-test(666);    # <-- report *this* line

You can even nest such unit-tester subroutines: any failures will always
point to the call to the outer subroutine;

    sub bar-test($value) is test-assertion {
        foo-test($value);  # <-- do *not* report this line
    }
    bar-test(666);    # <-- report this line