### PR TITLE
Make auto-generated mixin role be of language revision 'c'

### DIFF
--- a/src/core.c/operators.pm6
+++ b/src/core.c/operators.pm6
@@ -84,6 +84,8 @@ multi sub infix:<but>(Mu:U \obj, Mu:U \rolish) {
 }
 sub GENERATE-ROLE-FROM-VALUE($val) is implementation-detail {
     my $role := Metamodel::ParametricRoleHOW.new_type();
+    # The auto-generated role doesn't use any of 6.e features. Thus can safely be proclaimed as 6.c.
+    $role.^set_language_revision('c');
     my $meth := method () { $val };
     $meth.set_name($val.^name);
     $role.^add_method($meth.name, $meth);


### PR DESCRIPTION
Fix `$a but $b` under `use v6.e` pragma.