### PR TITLE
Don't inherit mixin class language revision

### DIFF
--- a/src/Perl6/Metamodel/Mixins.nqp
+++ b/src/Perl6/Metamodel/Mixins.nqp
@@ -74,8 +74,6 @@ role Perl6::Metamodel::Mixins {
         # Create new type, derive it from ourself and then add
         # all the roles we're mixing it.
         my $new_type := self.new_type(:name($new_name), :repr($obj.REPR), :is_mixin);
-        $new_type.HOW.set_language_revision($new_type, $obj.HOW.language-revision($obj))
-            if $obj.HOW.is_composed($obj);
         $new_type.HOW.set_is_mixin($new_type);
         $new_type.HOW.add_parent($new_type, $obj.WHAT);
         for @roles {


### PR DESCRIPTION
Use the compiler-default. This fixes #3998 and makes the following code
work:

    use v6.e.PREVIEW;
    role R { }; my $v = 0 but R;

Yet, `$v.^language-revision` will now return `e`, contrary to
`0.^language-revision` returning `c`.