### PR TITLE
Introduce %*SUB-MAIN-OPTS<coerce-allomorphs-to>

### DIFF
--- a/src/core.c/Main.pm6
+++ b/src/core.c/Main.pm6
@@ -54,45 +54,16 @@ my sub RUN-MAIN(&main, $mainline, :$in-as-argsfiles) {
         my &coercer = &val;
         if %sub-main-opts<coerce-allomorphs-to>:exists {
             my $type := %sub-main-opts<coerce-allomorphs-to><>;
-            if $type =:= Numeric {
+            if   $type =:= Numeric
+              || $type =:= Int
+              || $type =:= Rat
+              || $type =:= Num
+              || $type =:= Complex
+              || $type =:= Str {
+                my $method := $type.^name;
                 &coercer = -> \value {
                     (my \result := val(value)) ~~ Allomorph
-                      ?? result.Numeric
-                      !! result
-                }
-            }
-            elsif $type =:= Int {
-                &coercer = -> \value {
-                    (my \result := val(value)) ~~ Allomorph
-                      ?? result.Int
-                      !! result
-                }
-            }
-            elsif $type =:= Rat {
-                &coercer = -> \value {
-                    (my \result := val(value)) ~~ Allomorph
-                      ?? result.Rat
-                      !! result
-                }
-            }
-            elsif $type =:= Num {
-                &coercer = -> \value {
-                    (my \result := val(value)) ~~ Allomorph
-                      ?? result.Num
-                      !! result
-                }
-            }
-            elsif $type =:= Complex {
-                &coercer = -> \value {
-                    (my \result := val(value)) ~~ Allomorph
-                      ?? result.Complex
-                      !! result
-                }
-            }
-            elsif $type =:= Str {
-                &coercer = -> \value {
-                    (my \result := val(value)) ~~ Allomorph
-                      ?? result.Str
+                      ?? result."$method"()
                       !! result
                 }
             }

--- a/src/core.c/Main.pm6
+++ b/src/core.c/Main.pm6
@@ -51,10 +51,60 @@ my sub RUN-MAIN(&main, $mainline, :$in-as-argsfiles) {
         my $positional := nqp::create(IterationBuffer);
         my %named;
 
+        my &coercer = &val;
+        if %sub-main-opts<coerce-allomorphs-to>:exists {
+            my $type := %sub-main-opts<coerce-allomorphs-to><>;
+            if $type =:= Numeric {
+                &coercer = -> \value {
+                    (my \result := val(value)) ~~ Allomorph
+                      ?? result.Numeric
+                      !! result
+                }
+            }
+            elsif $type =:= Int {
+                &coercer = -> \value {
+                    (my \result := val(value)) ~~ Allomorph
+                      ?? result.Int
+                      !! result
+                }
+            }
+            elsif $type =:= Rat {
+                &coercer = -> \value {
+                    (my \result := val(value)) ~~ Allomorph
+                      ?? result.Rat
+                      !! result
+                }
+            }
+            elsif $type =:= Num {
+                &coercer = -> \value {
+                    (my \result := val(value)) ~~ Allomorph
+                      ?? result.Num
+                      !! result
+                }
+            }
+            elsif $type =:= Complex {
+                &coercer = -> \value {
+                    (my \result := val(value)) ~~ Allomorph
+                      ?? result.Complex
+                      !! result
+                }
+            }
+            elsif $type =:= Str {
+                &coercer = -> \value {
+                    (my \result := val(value)) ~~ Allomorph
+                      ?? result.Str
+                      !! result
+                }
+            }
+            else {
+                die "Unsupported allomorph coercion: { $type.raku }";
+            }
+        }
+
         sub thevalue(\a) {
             ((my \type := ::(a)) andthen Metamodel::EnumHOW.ACCEPTS(type.HOW))
               ?? type
-              !! val(a)
+              !! coercer(a)
         }
 
         while @args {


### PR DESCRIPTION
This new SUB-MAIN-OPTS setting allows one to specify how allomorphs
should be coerced **prior** to being dispatched.  So suppose you have
a sub MAIN:

    sub MAIN(Int:D $value) {
        say "value is a $value.^name()"
    }

calling such a script with "42" will show that the value is actually
an IntStr, **not** an Int.  Activating this new option with:

    my %*SUB-MAIN-OPTS = coerce-allomorphs-to => Int;

will ensure that all numeric values entered on the command will be
coerced to Ints.

The following type coercions are supported: Numeric, Int, Rat, Num,
Complex and Str.

Inspired by https://github.com/rakudo/rakudo/issues/4004