### PR TITLE
make the offered rakudo-moar-$VERSION-$REVISION-win-x86_64.zip file consistent with the included compressed directory name

### DIFF
--- a/tools/build/binary-release/build-windows.ps1
+++ b/tools/build/binary-release/build-windows.ps1
@@ -64,6 +64,7 @@ cp -Force -r "tools\build\binary-release\Windows\*" install
 cp LICENSE install
 
 echo "========= Preparing archive"
-mv install rakudo-$Env:VERSION
-Compress-Archive -Path rakudo-$Env:VERSION -DestinationPath ..\rakudo-win.zip
+rakudoZipDirectory = "rakudo-moar-" + $Env:VERSION + "-" + $Env:REVISION
+mv install $rakudoZipDirectory
+Compress-Archive -Path $rakudoZipDirectory -DestinationPath ..\rakudo-win.zip
 


### PR DESCRIPTION
see #3996 

the finally generated  "rakudo-win.zip" file here is later renamed in [azure-pipelines.yml](https://github.com/rakudo/rakudo/blob/68196c99dfccbeb708851fdc1592d026bece3042/azure-pipelines.yml#L324) to reflect the $VERSION and $REVISION... so it is more consistent to have everything aligned to the same structure / naming