### PR TITLE
Fix issue preventing CLI handler MAIN from having a type constraint

### DIFF
--- a/src/core.c/Main.pm6
+++ b/src/core.c/Main.pm6
@@ -288,7 +288,7 @@ my sub RUN-MAIN(&main, $mainline, :$in-as-argsfiles) {
     }
 
     sub find-candidates($capture) {
-        &main.^name eq 'Sub'
+        &main.^name ~~ /^ Sub [ '+{Callable[' .*? ']}' ]? $/
           ?? &main
                # Get a list of candidates that match according to the dispatcher
                .cando($capture)


### PR DESCRIPTION
Rakudo 2020.10 has an issue preventing MAIN subs from having a type constraint:

```
raku -e 'sub MAIN (--> Nil) {}'
MAIN must be a 'sub' to allow it to be called as a CLI handler
  in block <unit> at -e line 1
```

Rakudo 2020.09:
```
raku -e 'sub MAIN (--> Nil) {}; &MAIN.^name.say'
Sub+{Callable[Nil]}
```