### PR TITLE
Allow new versioning values

### DIFF
--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -864,7 +864,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
           # we parse out the numeral, since we could have "6d"
           :my $version := nqp::radix(10,$<version><vnum>[0],0,0)[0];
           [
-          ||  <?{ $version == 6 }> { $*W.load-lang-ver: $<version>, $comp }
+          ||  <?{ $version == 6 || $version == 2015 || $version == 2018 || $version == 2021 }> { $*W.load-lang-ver: $<version>, $comp }
           ||  { $/.typed_panic: 'X::Language::Unsupported',
                   version => ~$<version> }
           ]

--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -584,6 +584,27 @@ class Perl6::World is HLL::World {
         $*STRICT := 1 if $*begin_compunit;
 
         my str $version := ~$ver-match;
+        if $version eq 'v6.c' || $version eq 'v2015' {
+            $*CAN_LOWER_TOPIC := 0;
+            $!setting_name := 'CORE.c';
+            $comp.set_language_version: '6.c';
+            return;
+        }
+        elsif $version eq 'v6.d' || $version eq 'v6' || $version eq 'v2018' {
+            $!setting_name := 'CORE.d';
+            $comp.set_language_version: '6.d';
+            return;
+        }
+        elsif $version eq 'v6.e.PREVIEW' || $version eq 'v2021.PREVIEW' {
+            $!setting_name := 'CORE.e';
+            $comp.set_language_version: '6.e';
+            return;
+        }
+        elsif $version eq 'v2021' {
+            $ver-match.typed_panic: 'X::Language::ModRequired',
+              :$version, modifier => 'PREVIEW';
+        }
+
         my @vparts := nqp::split('.', $version);
         my $vWhatever := nqp::isge_i(nqp::index($version, '*'), 0);
         my $vPlus := nqp::isge_i(nqp::index($version, '+'), 0);


### PR DESCRIPTION
This commmit allows for several version specification alternatives
*without* changing anything else.  It would merely allow people to
refer to the new version values *now*.  Allowed alternatives are:

  v2015          -> v6.c
  v2018          -> v6.d
  v2021.PREVIEW  -> v6.e.PREVIEW

This also simmplifies the version checking logic for the most common
cases.  This appears to have a beneficial effect on the duration of
a spectest run.