### PR TITLE
Gen faster code for some kinds of `when` cases

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -2309,11 +2309,70 @@ class Perl6::Actions is HLL::Actions does STDActions {
         my $pblock := $xblock.shift;
         check_smartmatch($<xblock>,$sm_exp);
 
-        # Handle the smart-match.
-        my $match_past := QAST::Op.new( :op('callmethod'), :name('ACCEPTS'),
-            $sm_exp,
-            WANTED(QAST::Var.new( :name('$_'), :scope('lexical') ),'when')
-        );
+        # Handle the smartmatch, but try to gen some more optimized code first.
+        my $match_past;
+
+        # Fast path for types, e.g., `when Int { ... }`
+        if nqp::istype($sm_exp, QAST::WVal) && !nqp::isconcrete($sm_exp.value) {
+            $match_past :=
+                QAST::Op.new( :op('istype'),
+                  WANTED(QAST::Var.new( :name('$_'), :scope('lexical') ),'when'),
+                  $sm_exp );
+        }
+        # Fast path for things like literals, e.g., `when 5 { ... }`
+        elsif nqp::istype($sm_exp, QAST::Want) {
+            my $op_type;
+            my $method;
+            if nqp::istype($sm_exp[2], QAST::IVal) {
+                $op_type := 'i';
+                $method  := 'Numeric';
+            }
+            elsif nqp::istype($sm_exp[2], QAST::SVal) {
+                $op_type := 's';
+                $method  := 'Stringy';
+            }
+            elsif nqp::istype($sm_exp[2], QAST::NVal) {
+                $op_type := 'n';
+                $method  := 'Numeric';
+            }
+            else {
+                die("Unknown QAST::Want type " ~ $sm_exp[2].HOW.name($sm_exp[2]));
+            }
+
+            # Make sure we're not comparing against a type object, since those could
+            # coerce to the value
+            my $is_eq :=
+                QAST::Op.new( :op('if'),
+                  QAST::Op.new( :op('isconcrete' ),
+                    QAST::Var.new( :name('$_'), :scope('lexical') ) ),
+                  QAST::Op.new( :op("iseq_$op_type" ),
+                    $sm_exp[2],
+                    WANTED(QAST::Op.new( :op('callmethod'), :name($method),
+                             QAST::Var.new( :name('$_'), :scope('lexical') ) ),'when') ) );
+
+            # Needed so we can `handle` the code below
+            fatalize($is_eq);
+
+            # This is the equivalent of sticking a `try` before the genned `iseq_*`, which is
+            # needed because otherwise it'll die with an error when the `$_` is a different type.
+            $match_past :=
+                QAST::Op.new( :op('handle'),
+
+                  # Success path evaluates to the block.
+                  $is_eq,
+
+                  # On failure, just evaluate to False
+                  'CATCH',
+
+                  QAST::WVal.new( :value( $*W.find_single_symbol('False') ) ) );
+        }
+        # The fallback path that does a full smartmatch
+        else {
+            $match_past :=
+              QAST::Op.new( :op('callmethod'), :name('ACCEPTS'),
+                $sm_exp,
+                WANTED(QAST::Var.new( :name('$_'), :scope('lexical') ),'when') );
+        }
 
         # Use the smartmatch result as the condition for running the block,
         # and ensure continue/succeed handlers are in place and that a

--- a/src/core.c/Str.pm6
+++ b/src/core.c/Str.pm6
@@ -772,7 +772,7 @@ my class Str does Stringy { # declared in BOOTSTRAP
          )
         )
     }
-    multi method Numeric(Str:D: --> Numeric:D) {
+    multi method Numeric(Str:D: Bool :$fail-or-nil --> Numeric:D) {
 #?if !jvm
         # check for any combining characters
         nqp::isne_i(nqp::chars(self),nqp::codes(self))
@@ -800,7 +800,7 @@ my class Str does Stringy { # declared in BOOTSTRAP
                  self,0,nqp::chars(self)
                ) == nqp::chars(self)
               ?? 0                                # just spaces
-              !! val(self, :val-or-fail)          # take the slow route
+              !! val(self, :val-or-fail, :$fail-or-nil)          # take the slow route
     }
 
     multi method gist(Str:D:) { self }

--- a/src/core.c/allomorphs.pm6
+++ b/src/core.c/allomorphs.pm6
@@ -193,7 +193,7 @@ multi sub val(\one-thing) is raw {
     one-thing
 }
 
-multi sub val(Str:D $MAYBEVAL, :$val-or-fail) {
+multi sub val(Str:D $MAYBEVAL, Bool :$val-or-fail, Bool :$fail-or-nil) {
     # TODO:
     # * Additional numeric styles:
     #   + fractions in [] radix notation:  :100[10,'.',53]
@@ -217,7 +217,9 @@ multi sub val(Str:D $MAYBEVAL, :$val-or-fail) {
     # string, or a failure if we're Str.Numeric
     my &parse_fail := -> \msg {
         $val-or-fail
-          ?? fail X::Str::Numeric.new(:source($MAYBEVAL),:reason(msg),:$pos)
+          ?? $fail-or-nil
+            ?? return Nil
+            !! fail X::Str::Numeric.new(:source($MAYBEVAL),:reason(msg),:$pos)
           !! return $MAYBEVAL
     }
 


### PR DESCRIPTION
If it's a type or literal, we don't need to do a full smartmatch.
Unfortunately this isn't dramatically faster, since the primary cost is
in generating a Backtrace for the Failure created when a case doesn't
match.

An example test case:
```raku
my $a;
my @a = 1, 5, Int, "hi", "bye", 50, Complex;
my $s = now;
for ^100_000 -> $i {
    $a = do given @a[$i % 7] {
        when Int  { "Int" }
        when 5    { "five" }
        when "hi" { "hello" }
        default   { "default" }
    }
};
say now - $s;
say $a
```
takes ~1.4s with this change, ~1.8s before.

Rakudo builds ok and passes `make m-test m-spectest`.