### PR TITLE
Throw an exception if &make is called w/o a valid match in $/

### DIFF
--- a/src/core.c/Match.pm6
+++ b/src/core.c/Match.pm6
@@ -4,7 +4,7 @@ my class X::MakeWithInvalidMatch is Exception {
     method message(::?CLASS:D: --> Str:D) {
         "&make called with an invalid match in lexical variable \$\/ ({
             Rakudo::Internals.SHORT-STRING: $!match, :method<raku>
-        }).{' Is there any in scope?' if $!match =:= Nil}"
+        })."
     }
 }
 


### PR DESCRIPTION
This adds a new `X::MakeWithInvalidMatch` exception, which is thrown by
`&make` when `$/` is not an `NQPMatchRole`. This fixes a LTA error when
`&make` is called, but `$/` hasn't been given a value.

Passes `make test` and `make spectest` (outside of https://github.com/rakudo/rakudo/issues/4027). 