### PR TITLE
Improve output of Attribute with Pod::To::Text

### DIFF
--- a/lib/Pod/To/Text.rakumod
+++ b/lib/Pod/To/Text.rakumod
@@ -93,6 +93,9 @@ sub declarator2text($pod) {
         when Sub {
             'sub ' ~ $_.name ~ signature2text($_.signature.params, $_.returns)
         }
+        when Attribute {
+            'attribute ' ~ $_.gist
+        }
         when .HOW ~~ Metamodel::EnumHOW {
             "enum $_.raku() { signature2text $_.enums.pairs } \n"
         }


### PR DESCRIPTION
Attributes with declarator blocks currently do not output correctly with `--doc`.

Before:
```
class Foo
This is the class

class Attribute.new
This is the attribute
```

After:
```
class Foo
This is the class

attribute Mu $!bar
This is the attribute
```