### PR TITLE
Allow for a contentless spurt

### DIFF
--- a/src/core.c/IO/Path.pm6
+++ b/src/core.c/IO/Path.pm6
@@ -673,6 +673,9 @@ my class IO::Path is Cool does IO {
     }
 
     proto method spurt(|) {*}
+    multi method spurt(IO::Path:D: --> Bool:D) {
+        self.open(:w).close
+    }
     multi method spurt(IO::Path:D: Blob:D \data, :$append! --> Bool:D) {
         spurt-blob(self.absolute, $append ?? 'wa' !! 'w', data)
     }

--- a/src/core.c/io_operators.pm6
+++ b/src/core.c/io_operators.pm6
@@ -130,12 +130,15 @@ multi sub slurp(IO() $path, :$bin!) { $path.slurp(:$bin) }
 multi sub slurp(IO() $path, :$enc ) { $path.slurp(:$enc) }
 multi sub slurp(IO() $path        ) { $path.slurp(:enc<utf8>) }
 
-proto sub spurt($, $, |) {*}
+proto sub spurt($, |) {*}
 # Don't do anything special for the IO::Handle, as using spurt() as a sub
 # when you've gone through the trouble of creating an IO::Handle, is not
 # so likely, as you would probably just call the .spurt method on the handle.
 multi sub spurt(IO::Handle:D $fh, $data, *%_) is default {
     $fh.spurt($data, |%_)
+}
+multi sub spurt(IO() $path) {
+    $path.spurt
 }
 multi sub spurt(IO() $path, Blob:D \data, :$append!) {
     $path.spurt(data, :$append)


### PR DESCRIPTION
To give "touch" like capability.  This can already be achieved by
explicitely specifying "", so maybe we should emphasize that in the
documentation instead.