### PR TITLE
Fix incorrect assignment passing with coercion

### DIFF
--- a/src/core.c/Compiler.pm6
+++ b/src/core.c/Compiler.pm6
@@ -19,7 +19,7 @@ class Compiler does Systemic {
         nqp::bind($!auth,'The Perl Foundation');
 
         # looks like: 2018.01-50-g8afd791c1
-        nqp::bind($!version,Version.new(nqp::atkey($compiler,'version')))
+        nqp::bind($!version,Version.new(nqp::p6box_s(nqp::atkey($compiler,'version'))))
           unless $!version;
     }
 

--- a/src/core.c/Rakudo/Internals.pm6
+++ b/src/core.c/Rakudo/Internals.pm6
@@ -707,7 +707,7 @@ implementation detail and has no serviceable parts inside"
     }
     method SHORT-STRING(Mu \thing, Str:D :$method = 'gist' --> Str:D) {
         my str $str = nqp::unbox_s(self.MAYBE-STRING: thing, :$method);
-        nqp::isgt_i(nqp::chars($str),23) 
+        nqp::isgt_i(nqp::chars($str),23)
           ?? nqp::p6box_s(nqp::concat(nqp::substr($str, 0, 20), '...'))
           !! nqp::p6box_s($str)
     }

--- a/src/vm/moar/spesh-plugins.nqp
+++ b/src/vm/moar/spesh-plugins.nqp
@@ -335,12 +335,11 @@ sub assign-scalar-nil-no-whence($cont, $value) {
 }
 sub assign-scalar-no-whence($cont, $value) {
     my $desc := nqp::getattr($cont, Scalar, '$!descriptor');
-    my $of := $desc.of;
-    if $of.HOW.archetypes.coercive {
-        $value := $of.HOW.coerce($of, $value);
-    }
     my $type := nqp::getattr($desc, ContainerDescriptor, '$!of');
     if nqp::istype($value, $type) {
+        if $type.HOW.archetypes.coercive {
+            $value := $type.HOW.coerce($type, $value);
+        }
         nqp::bindattr($cont, Scalar, '$!value', $value);
     }
     else {


### PR DESCRIPTION
`my Rat(Str) $foo = 1` will now fail because `Int` is not
passing the type check.

Also made `Metamodel::CoercionHOW::coerce()` more strict about the value
it's trying to coerce. Now it will throw if it doesn't match against
`$!constraint_type`. Normally this shouldn't happen to a user unless it
invokes the method directly, but should be of great help in catching
core errors.