### PR TITLE
Fix building on Windows with MinGW

### DIFF
--- a/src/vm/moar/runner/main.c
+++ b/src/vm/moar/runner/main.c
@@ -9,6 +9,7 @@
 #  include <sys/stat.h>
 #  include <process.h>
 #  include <shlwapi.h>
+#  include <io.h>
 #  if defined(_MSC_VER)
 #    define strtoll _strtoi64
 #  endif

--- a/src/vm/moar/runner/main.c
+++ b/src/vm/moar/runner/main.c
@@ -202,7 +202,7 @@ int set_std_handle_to_nul(FILE *file, int fd, BOOL read, int std_handle_type) {
 #endif
 
 #if defined(_WIN32) && defined(SUBSYSTEM_WINDOWS)
-int WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR lpCmdLine, INT nCmdShow) {
+int wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdLine, INT nCmdShow) {
     int argc;
     LPWSTR *wargv = CommandLineToArgvW(GetCommandLineW(), &argc);
     char **argv = MVM_UnicodeToUTF8_argv(argc, wargv);

--- a/tools/lib/NQP/Config/Rakudo.pm
+++ b/tools/lib/NQP/Config/Rakudo.pm
@@ -416,7 +416,7 @@ sub configure_moar_backend {
             $nqp_config->{subsystem_win_ld_flags} = '/subsystem:windows';
         }
         else {
-            $nqp_config->{subsystem_win_ld_flags} = '--subsystem=windows';
+            $nqp_config->{subsystem_win_ld_flags} = '-mwindows';
         }
 
         push @c_runner_libs, sprintf( $nqp_config->{'moar::ldusr'}, 'Shlwapi' );


### PR DESCRIPTION
The flag `--subsystem=windows` is possibly supported by the gnu linker, but it's not supported by GCC. So we use `-mwindows` which is supported by GCC. It is possible that flag also automatically makes GCC link some additional libraries, but that won't hurt.

Also switch to using `wWinMain`, as the gcc toolchain seems to not accept a `WinMain` (possibly because of the `-municode` flag). The MSVC toolchain doesn't seem to mind.

This PR also contains another commit that fixes a compiler warning in `src/vm/moar/runner/main.c`.

Fixes #4009