### PR TITLE
Provide more improvements to language revision support and fix mixins once more.

### DIFF
--- a/src/Perl6/Compiler.nqp
+++ b/src/Perl6/Compiler.nqp
@@ -81,6 +81,9 @@ class Perl6::Compiler is HLL::Compiler {
             $!language_version := %*COMPILING<%?OPTIONS><language_version> || self.config<language-version>
         }
     }
+    method language_revision() {
+        nqp::substr(self.language_version,2,1)
+    }
     method language_modifier() {
         $!language_modifier
     }

--- a/src/Perl6/Metamodel/Configuration.nqp
+++ b/src/Perl6/Metamodel/Configuration.nqp
@@ -38,6 +38,43 @@ class Perl6::Metamodel::Configuration {
         $role_to_role_applier_type := $rtra_type;
     }
     method role_to_role_applier_type() { $role_to_role_applier_type }
+
+    my $X_package := nqp::null();
+    method set_X_package($X) {
+        $X_package := $X;
+    }
+    method throw_or_die($exception, $die_message, *@pos, *%named) {
+        my $ex_type := nqp::null();
+        unless nqp::isnull($X_package) {
+            my @parts := nqp::split('::', $exception);
+            # If the first part of the long name is not X then pretend there is no such exception. Which is, actually
+            # and most likely, is true.
+            if nqp::iseq_s(nqp::shift(@parts), 'X') {
+                my $who := $X_package.WHO;
+                while +@parts {
+                    my $name := nqp::shift(@parts);
+                    if $who.EXISTS-KEY($name) {
+                        if +@parts {
+                            $who := $who.AT-KEY($name).WHO;
+                        }
+                        else {
+                            $ex_type := $who.AT-KEY($name);
+                        }
+                    }
+                    else {
+                        # Signal the loop end
+                        @parts := nqp::list();
+                    }
+                }
+            }
+        }
+        if nqp::isnull($ex_type) {
+            nqp::die($die_message)
+        }
+        else {
+            $ex_type.new(|@pos, |%named).throw
+        }
+    }
 }
 
 # vim: expandtab sw=4

--- a/src/Perl6/Metamodel/LanguageRevision.nqp
+++ b/src/Perl6/Metamodel/LanguageRevision.nqp
@@ -57,9 +57,14 @@ role Perl6::Metamodel::LanguageRevision
     # Because there could be more than one such boundary in the future they can be passed as an array.
     method check-type-compat($obj, $type, @revs) {
         unless nqp::isnull(self.incompat-revisions($obj, $!lang_rev, $type.HOW.language-revision($type), @revs)) {
-            nqp::die("Type object " ~ $obj.HOW.name($obj) ~ " of v6." ~ $!lang_rev
+            Perl6::Metamodel::Configuration.throw_or_die(
+                'X::Language::IncompatRevisions',
+                "Type object " ~ $obj.HOW.name($obj) ~ " of v6." ~ $!lang_rev
                     ~ " is not compatible with " ~ $type.HOW.name($type)
-                    ~ " of v6." ~ $type.HOW.language-revision($type));
+                    ~ " of v6." ~ $type.HOW.language-revision($type),
+                :type-a($obj),
+                :type-b($type)
+            )
         }
     }
 
@@ -75,6 +80,10 @@ role Perl6::Metamodel::LanguageRevision
 
     method language-revision($obj) {
         $!lang_rev
+    }
+
+    method language-version($obj) {
+        '6.' ~ $!lang_rev
     }
 }
 

--- a/src/Perl6/Metamodel/ParametricRoleGroupHOW.nqp
+++ b/src/Perl6/Metamodel/ParametricRoleGroupHOW.nqp
@@ -202,8 +202,19 @@ class Perl6::Metamodel::ParametricRoleGroupHOW
         $c.HOW.auth($c)
     }
 
+    method language-revision($obj) {
+        my $c := self.'!get_default_candidate'($obj);
+        nqp::unless(nqp::isnull($c),
+                    $c.HOW.language-revision($c),
+                    nqp::null())
+    }
+
     method !get_default_candidate($obj) {
-        self.'!get_nonsignatured_candidate'($obj) || @!candidates[0]
+        nqp::ifnull(self.'!get_nonsignatured_candidate'($obj),
+                    nqp::if(
+                        +@!candidates,
+                        @!candidates[0],
+                        nqp::null()))
     }
 
     method !get_nonsignatured_candidate($obj) {

--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -693,9 +693,10 @@ class Perl6::World is HLL::World {
                 $!setting_revision := nqp::substr($!setting_name, 5, 1);
                 # Compile core with default language version unless the core revision is higher. I.e. when 6.d is the
                 # default only core.e will be compiled with 6.e compiler.
-                nqp::getcomp('Raku').set_language_version( nqp::isgt_s($!setting_revision, $default_revision)
-                                                            ?? $!setting_revision
-                                                            !! $default_revision );
+                my $lang_ver := '6.' ~ (nqp::isgt_s($!setting_revision, $default_revision)
+                                            ?? $!setting_revision
+                                            !! $default_revision);
+                nqp::getcomp('Raku').set_language_version($lang_ver);
             }
             $*UNIT.annotate('IN_DECL', 'mainline');
         }

--- a/src/core.c/Exception.pm6
+++ b/src/core.c/Exception.pm6
@@ -2951,6 +2951,16 @@ my class X::PhaserExceptions is Exception {
     }
 }
 
+my class X::Language::IncompatRevisions is Exception {
+    has Mu $.type-a is built(:bind) is required;
+    has Mu $.type-b is built(:bind) is required;
+    method message() {
+        "Type object "
+        ~ $!type-a.^name ~ " of " ~ $!type-a.^language-version
+        ~ " is not compatible with "
+        ~ $!type-b.^name ~ " of " ~ $!type-b.^language-version
+    }
+}
 
 #?if !moar
 nqp::bindcurhllsym('P6EX', nqp::hash(
@@ -3280,5 +3290,8 @@ my class Exceptions::JSON {
         False  # done processing
     }
 }
+
+# Provide means of accessing any X:: exception to the Metamodel.
+Metamodel::Configuration.set_X_package(X);
 
 # vim: expandtab shiftwidth=4

--- a/src/core.c/core_epilogue.pm6
+++ b/src/core.c/core_epilogue.pm6
@@ -1,5 +1,5 @@
-# Re-parent meta-objects so they appear to be under Any.
 BEGIN {
+    # Re-parent meta-objects so they appear to be under Any.
     Perl6::Metamodel::ClassHOW.HOW.reparent(Perl6::Metamodel::ClassHOW, Any);
     Perl6::Metamodel::ConcreteRoleHOW.HOW.reparent(Perl6::Metamodel::ConcreteRoleHOW, Any);
     Perl6::Metamodel::CurriedRoleHOW.HOW.reparent(Perl6::Metamodel::CurriedRoleHOW, Any);
@@ -69,12 +69,12 @@ augment class Uni {
         my $uni      := nqp::create(self);
         my int $elems = nqp::elems(codepoints);
         my int $i = -1;
-        
+
         nqp::while(
           nqp::islt_i(($i = nqp::add_i($i,1)),$elems),
           nqp::push_i($uni,nqp::atpos_i(codepoints,$i))
         );
-        
+
         $uni
     }
 }


### PR DESCRIPTION
This is a complex PR targeting at a couple of tasks with the primary one to be closing of #4021. 

- Sort out a mess with about language versions and revisions
- Add a flexible and universal API to allow the metamodel to throw typed exceptions instead of plain ad-hoc with `nqp::die`. It is supposed to replace `P6EX` hllsym and get rid of excessive hash of code objects defined in `Exception.pm6`
- A new exception `X::Language::IncompatibleRevisions` is now thrown when class and role language versions are incompatible.
- And, apparently, fix #4021 by setting mixin class language version to the highest one among the mixin roles.