### PR TITLE
Avoid BOOTStr being passed to Version.new

### DIFF
--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -632,7 +632,7 @@ class Perl6::World is HLL::World {
 
         for @can_ver_reversed -> $can-ver {
             # Skip if tried version doesn't match the wanted one
-            next unless $vWant.ACCEPTS: my $vCan := $Version.new: $can-ver;
+            next unless $vWant.ACCEPTS: my $vCan := $Version.new: nqp::box_s($can-ver, self.find_single_symbol('Str', :setting-only));
 
             my $vCanElems := $vCan.parts.elems;
             my $can_rev := $vCan.parts.AT-POS: 1;


### PR DESCRIPTION
This fixes 'use v6.e.PREVIEW' on the JVM backend. Without the patch
it dies with X::Coerce::Impossible ("Impossible coercion from
'BOOTStr' into 'Str': value is of unacceptable type BOOTStr").