### PR TITLE
[JVM] Test if method 'coercive' is available

### DIFF
--- a/src/vm/jvm/runtime/org/raku/rakudo/Binder.java
+++ b/src/vm/jvm/runtime/org/raku/rakudo/Binder.java
@@ -505,22 +505,24 @@ public final class Binder {
         SixModelObject archetypesMeth = Ops.findmethod(HOW, "archetypes", tc);
         Ops.invokeDirect(tc, archetypesMeth, Ops.invocantCallSite, new Object[] { HOW });
         SixModelObject Archetypes = Ops.result_o(tc.curFrame);
-        SixModelObject coerciveMeth = Ops.findmethod(Archetypes, "coercive", tc);
-        Ops.invokeDirect(tc, coerciveMeth, Ops.invocantCallSite, new Object[] { Archetypes });
-        if (Ops.istrue(Ops.result_o(tc.curFrame), tc) == 1) {
-            /* Coercing natives not possible - nothing to call a method on. */
-            if (flag != CallSiteDescriptor.ARG_OBJ) {
-                if (error != null)
-                    error[0] = String.format(
-                        "Unable to coerce natively typed parameter '%s'",
-                        varName);
-                return BIND_RESULT_FAIL;
-            }
+        SixModelObject coerciveMeth = Ops.findmethodNonFatal(Archetypes, "coercive", tc);
+        if (coerciveMeth != null) {
+            Ops.invokeDirect(tc, coerciveMeth, Ops.invocantCallSite, new Object[] { Archetypes });
+            if (Ops.istrue(Ops.result_o(tc.curFrame), tc) == 1) {
+                /* Coercing natives not possible - nothing to call a method on. */
+                if (flag != CallSiteDescriptor.ARG_OBJ) {
+                    if (error != null)
+                        error[0] = String.format(
+                            "Unable to coerce natively typed parameter '%s'",
+                            varName);
+                    return BIND_RESULT_FAIL;
+                }
 
-            SixModelObject coerceMeth = Ops.findmethod(HOW, "coerce", tc);
-            Ops.invokeDirect(tc, coerceMeth, genIns, new Object[] { HOW, paramType, arg_o });
-            arg_o = Ops.result_o(tc.curFrame);
-            decontValue = Ops.decont(arg_o, tc);
+                SixModelObject coerceMeth = Ops.findmethod(HOW, "coerce", tc);
+                Ops.invokeDirect(tc, coerceMeth, genIns, new Object[] { HOW, paramType, arg_o });
+                arg_o = Ops.result_o(tc.curFrame);
+                decontValue = Ops.decont(arg_o, tc);
+            }
         }
 
         /* If it's not got attributive binding, we'll go about binding it into the


### PR DESCRIPTION
A test in MISC/bug-coverage-stress.t was failing with

  Method 'coercive' not found for invocant of class 'Archetypes'

A shortened version of the failing code (no module loading
involved) is:

  my role Bar {
      method compose(Mu \type) { callsame }
  }
  multi trait_mod:<is>(Attribute:D $attr, :$mytrait!) {
      $attr.package.HOW does Bar
  }
  my class Foo {
      has $!bar is mytrait
  }

There is a similar check in src/Perl6/Action.nqp, where we run

  nqp::can($ptype_archetypes, 'coercive')

So I guess it makes sense to verify that the method is available.