### PR TITLE
Improve the performance of signature binding

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -9235,9 +9235,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
                             QAST::Var.new(:name($instantiated_code), :scope('local'), :decl('var')),
                             QAST::Op.new(
                                 :op('getcodeobj'),
-                                QAST::Op.new(
-                                    :op('ctxcode'),
-                                    QAST::Op.new(:op('ctx'))))));
+                                QAST::Op.new(:op('curcode')))));
                 }
                 my $inst_param := QAST::Node.unique('__lowered_param_obj_');
                 $var.push(


### PR DESCRIPTION
Replacing `nqp::ctxcode(nqp::ctx)` pair with `nqp::curcode` reduces the overall performance loss on a test script from 20-30% to 14-20% with 14% being the most likely outcome.

This is should eventually resolve #4056.