### PR TITLE
Construct CUR::Distribution correctly in CU!WHICH

### DIFF
--- a/src/core.c/CompUnit.pm6
+++ b/src/core.c/CompUnit.pm6
@@ -32,7 +32,7 @@ class CompUnit {
         nqp::push_s($parts,$!auth)             if $!auth;
         nqp::push_s($parts,$!distribution
           ?? CompUnit::Repository::Distribution.new(
-               :dist($!distribution),
+               $!distribution,
                :repo($!repo-id)
              ).Str
           !! $!repo-id


### PR DESCRIPTION
Without this fix `$compilation-unit.perl` fails with
«Too few positionals passed; expected 2 arguments but got 1»

This can be verified by running `./rakudo-m -Ilib -e 'dd $*REPO.need(CompUnit::DependencySpecification.new(short-name => "Test"))'` before and after this patch