### PR TITLE
Give stub packages created by package_at_key a proper longname

### DIFF
--- a/src/core.c/Stash.pm6
+++ b/src/core.c/Stash.pm6
@@ -34,7 +34,7 @@ my class Stash { # declared in BOOTSTRAP
         nqp::ifnull(
           nqp::atkey(storage,$key),
           nqp::stmts(
-            (my $pkg := Metamodel::PackageHOW.new_type(:name($key))),
+            (my $pkg := Metamodel::PackageHOW.new_type(:name("{$!longname}::$key"))),
             $pkg.^compose,
             nqp::bindkey(storage,$key,$pkg)
           )


### PR DESCRIPTION
Stub packages created by simply accessing them like &Foo::Bar::note = sub { };
only got the last part of their name ("Bar"). Now they know who they really are
(Foo::Bar).