### PR TITLE
Fix concurrency issue in compilations with heredocs

### DIFF
--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -149,8 +149,6 @@ role STD {
         }
     }
 
-    my @herestub_queue;
-
     my class Herestub {
         has $!delim;
         has $!orignode;
@@ -168,6 +166,7 @@ role STD {
 
     method heredoc () {
         my $actions := self.actions;
+        my @herestub_queue := $*W.herestub_queue;
         if @herestub_queue {
             my $here := self.'!cursor_start_cur'();
             $here.'!cursor_pos'(self.pos);
@@ -208,12 +207,11 @@ role STD {
     }
 
     token cheat_heredoc {
-        <?{ +@herestub_queue }> \h* <[ ; } ]> \h* <?before \n | '#'> <.ws> <?MARKER('endstmt')>
+        <?{ nqp::elems($*W.herestub_queue) }> \h* <[ ; } ]> \h* <?before \n | '#'> <.ws> <?MARKER('endstmt')>
     }
 
     method queue_heredoc($delim, $grammar) {
-        nqp::ifnull(@herestub_queue, @herestub_queue := []);
-        nqp::push(@herestub_queue, Herestub.new(:$delim, :$grammar, :orignode(self)));
+        nqp::push($*W.herestub_queue, Herestub.new(:$delim, :$grammar, :orignode(self)));
         return self;
     }
     method fail-terminator ($/, $start, $stop, $line?) {

--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -229,6 +229,8 @@ class Perl6::World is HLL::World {
         # Cache of container info and descriptor for magicals.
         has %!magical_cds;
 
+        has @!herestub_queue;
+
         method BUILD(:$handle, :$description) {
             @!PADS := [];
             @!PADS_AND_THUNKS := [];
@@ -241,6 +243,7 @@ class Perl6::World is HLL::World {
             %!const_cache := {};
             @!cleanup_tasks := [];
             %!magical_cds := {};
+            @!herestub_queue := [];
         }
 
         method blocks() {
@@ -479,6 +482,10 @@ class Perl6::World is HLL::World {
             $!the_hyper_whatever := $hyper_whatever
         }
 
+
+        method herestub_queue() {
+            @!herestub_queue
+        }
     }
 
     method context_class() {
@@ -5668,6 +5675,10 @@ class Perl6::World is HLL::World {
 
     method quote_lang_cache() {
         %!quote_lang_cache
+    }
+
+    method herestub_queue() {
+        self.context.herestub_queue
     }
 }
 


### PR DESCRIPTION
Using a lexical variable for the herestub queue could lead to all sorts of
unwanted sharing between indepenedent compilations and could lead to errors
in parallel compilations. Put it into the World instead to avoid sharing.