### PR TITLE
Adapt filenames in binary release scripts

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -319,9 +319,9 @@ stages:
       - script: |
           OUT_DIR=rakudo-builds-$(VERSION)-$(REVISION)
           mkdir $OUT_DIR
-          cp $(Pipeline.Workspace)/rakudo-linux/rakudo-linux.tar.gz $OUT_DIR/rakudo-moar-$(VERSION)-$(REVISION)-linux-x86_64.tar.gz
-          cp $(Pipeline.Workspace)/rakudo-macos/rakudo-macos.tar.gz $OUT_DIR/rakudo-moar-$(VERSION)-$(REVISION)-macos-x86_64.tar.gz
-          cp $(Pipeline.Workspace)/rakudo-win/rakudo-win.zip        $OUT_DIR/rakudo-moar-$(VERSION)-$(REVISION)-win-x86_64.zip
+          cp $(Pipeline.Workspace)/rakudo-linux/rakudo-linux.tar.gz $OUT_DIR/rakudo-moar-$(VERSION)-$(REVISION)-linux-x86_64-gcc.tar.gz
+          cp $(Pipeline.Workspace)/rakudo-macos/rakudo-macos.tar.gz $OUT_DIR/rakudo-moar-$(VERSION)-$(REVISION)-macos-x86_64-clang.tar.gz
+          cp $(Pipeline.Workspace)/rakudo-win/rakudo-win.zip        $OUT_DIR/rakudo-moar-$(VERSION)-$(REVISION)-win-x86_64-msvc.zip
           tar -czf rakudo-moar-builds-$(VERSION)-$(REVISION).tar.gz $OUT_DIR
 
       - publish: rakudo-moar-builds-$(VERSION)-$(REVISION).tar.gz

--- a/tools/build/binary-release/build-debian.sh
+++ b/tools/build/binary-release/build-debian.sh
@@ -34,6 +34,8 @@ popd
 # Prepare the package
 cp -r tools/build/binary-release/Linux/* install
 cp LICENSE install
-mv install rakudo-$VERSION
-tar -zcv --owner=0 --group=0 --numeric-owner -f ../rakudo-linux.tar.gz rakudo-$VERSION
+
+FILE_NAME=rakudo-moar-$VERSION-$REVISION-linux-x86_64-gcc
+mv install $FILE_NAME
+tar -zcv --owner=0 --group=0 --numeric-owner -f ../rakudo-linux.tar.gz $FILE_NAME
 

--- a/tools/build/binary-release/build-linux.sh
+++ b/tools/build/binary-release/build-linux.sh
@@ -51,6 +51,7 @@ cp -r tools/build/binary-release/Linux/* install
 cp LICENSE install
 
 echo "========= Preparing archive"
-mv install rakudo-$VERSION
-tar -zcv --owner=0 --group=0 --numeric-owner -f ../rakudo-linux.tar.gz rakudo-$VERSION
+FILE_NAME=rakudo-moar-$VERSION-$REVISION-linux-x86_64-gcc
+mv install $FILE_NAME
+tar -zcv --owner=0 --group=0 --numeric-owner -f ../rakudo-linux.tar.gz $FILE_NAME
 

--- a/tools/build/binary-release/build-macos.sh
+++ b/tools/build/binary-release/build-macos.sh
@@ -42,6 +42,7 @@ cp -r tools/build/binary-release/MacOS/* install
 cp LICENSE install
 
 echo "========= Preparing archive"
-mv install rakudo-$VERSION
-gtar -zcv --owner=0 --group=0 --numeric-owner -f ../rakudo-macos.tar.gz rakudo-$VERSION
+FILE_NAME=rakudo-moar-$VERSION-$REVISION-macos-x86_64-clang
+mv install $FILE_NAME
+gtar -zcv --owner=0 --group=0 --numeric-owner -f ../rakudo-macos.tar.gz $FILE_NAME
 

--- a/tools/build/binary-release/build-windows.ps1
+++ b/tools/build/binary-release/build-windows.ps1
@@ -64,6 +64,7 @@ cp -Force -r "tools\build\binary-release\Windows\*" install
 cp LICENSE install
 
 echo "========= Preparing archive"
-mv install rakudo-$Env:VERSION
-Compress-Archive -Path rakudo-$Env:VERSION -DestinationPath ..\rakudo-win.zip
+$FILE_NAME = "rakudo-moar-${Env:VERSION}-${Env:REVISION}-win-x86_64-msvc"
+mv install $FILE_NAME
+Compress-Archive -Path $FILE_NAME -DestinationPath ..\rakudo-win.zip
 


### PR DESCRIPTION
In #3996 the decision was made to rename the binary release archives to
also include the toolchain used. This enables us to offer release files
with multiple different toolchains for the same OS.

Fixes #3996.