### PR TITLE
Make Num coercer demand definite invocant

### DIFF
--- a/src/core.c/Rational.pm6
+++ b/src/core.c/Rational.pm6
@@ -65,7 +65,7 @@ my role Rational[::NuT = Int, ::DeT = ::("NuT")] does Real {
 
     method nude() { $!numerator, $!denominator }
 
-    method Num(--> Num:D) {
+    method Num(Rational:D: --> Num:D) {
         nqp::p6box_n(nqp::div_In($!numerator,$!denominator))
     }
 


### PR DESCRIPTION
This changes the error message reported back to user from a cryptic 

```
Cannot look up attributes in a <...> type object
```

to more correct 

```
Invocant of method 'Num' must be an object instance of type 'Rational',
not a type object of type 'Rat'.  Did you forget a '.new'?
```

Fixes #1517 