### PR TITLE
Use Raku instead of NQP ops for literals in a when

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -2329,15 +2329,15 @@ class Perl6::Actions is HLL::Actions does STDActions {
             my $op_type;
             my $method;
             if nqp::istype($sm_exp[2], QAST::IVal) {
-                $op_type := 'i';
+                $op_type := '==';
                 $method  := 'Numeric';
             }
             elsif nqp::istype($sm_exp[2], QAST::SVal) {
-                $op_type := 's';
+                $op_type := 'eq';
                 $method  := 'Stringy';
             }
             elsif nqp::istype($sm_exp[2], QAST::NVal) {
-                $op_type := 'n';
+                $op_type := '==';
                 $method  := 'Numeric';
             }
             else {
@@ -2360,12 +2360,12 @@ class Perl6::Actions is HLL::Actions does STDActions {
 
             # Make sure we're not comparing against a type object, since those could
             # coerce to the value, so gen the equivalent of
-            # `isconcrete($_) && iseq_*(<literal>, $_."$method")`
+            # `isconcrete($_) && <literal> ==|eq $_."$method"`
             my $is_eq :=
                 QAST::Op.new( :op('if'),
                   QAST::Op.new( :op('isconcrete' ),
                     QAST::Var.new( :name('$_'), :scope('lexical') ) ),
-                  QAST::Op.new( :op("iseq_$op_type" ),
+                  QAST::Op.new( :op('call'), :name("&infix:<$op_type>"),
                     $sm_exp[2],
                     WANTED($method_call,'when') ) );
 

--- a/src/core.c/Str.pm6
+++ b/src/core.c/Str.pm6
@@ -777,7 +777,7 @@ my class Str does Stringy { # declared in BOOTSTRAP
          )
         )
     }
-    multi method Numeric(Str:D: Bool :$fail-or-nil --> Numeric:D) {
+    multi method Numeric(Str:D: Bool :$fail-or-mu --> Numeric:D) {
 #?if !jvm
         # check for any combining characters
         nqp::isne_i(nqp::chars(self),nqp::codes(self))
@@ -805,7 +805,7 @@ my class Str does Stringy { # declared in BOOTSTRAP
                  self,0,nqp::chars(self)
                ) == nqp::chars(self)
               ?? 0                                # just spaces
-              !! val(self, :val-or-fail, :$fail-or-nil)          # take the slow route
+              !! val(self, :val-or-fail, :$fail-or-mu)          # take the slow route
     }
 
     multi method gist(Str:D:) { self }

--- a/src/core.c/allomorphs.pm6
+++ b/src/core.c/allomorphs.pm6
@@ -193,7 +193,7 @@ multi sub val(\one-thing) is raw {
     one-thing
 }
 
-multi sub val(Str:D $MAYBEVAL, Bool :$val-or-fail, Bool :$fail-or-nil) {
+multi sub val(Str:D $MAYBEVAL, Bool :$val-or-fail, Bool :$fail-or-mu) {
     # TODO:
     # * Additional numeric styles:
     #   + fractions in [] radix notation:  :100[10,'.',53]
@@ -217,8 +217,8 @@ multi sub val(Str:D $MAYBEVAL, Bool :$val-or-fail, Bool :$fail-or-nil) {
     # string, or a failure if we're Str.Numeric
     my &parse_fail := -> \msg {
         $val-or-fail
-          ?? $fail-or-nil
-            ?? return Nil
+          ?? $fail-or-mu
+            ?? return Mu
             !! fail X::Str::Numeric.new(:source($MAYBEVAL),:reason(msg),:$pos)
           !! return $MAYBEVAL
     }


### PR DESCRIPTION
Otherwise Junctions won't autothread and we could get the wrong result.

Fixes #4089