### PR TITLE
Implement invocation protocol for roles

### DIFF
--- a/src/Perl6/Metamodel/ClassHOW.nqp
+++ b/src/Perl6/Metamodel/ClassHOW.nqp
@@ -30,6 +30,7 @@ class Perl6::Metamodel::ClassHOW
     has @!role_typecheck_list;
     has @!fallbacks;
     has $!composed;
+    has $!is_pun;
     has $!pun_source; # If class is coming from a pun then this is the source role
 
     my $archetypes := Perl6::Metamodel::Archetypes.new(
@@ -312,6 +313,15 @@ class Perl6::Metamodel::ClassHOW
 
     method set_pun_source($obj, $role) {
         $!pun_source := nqp::decont($role);
+        $!is_pun := 1;
+    }
+
+    method is_pun($obj) {
+        $!is_pun
+    }
+
+    method pun_source($obj) {
+        $!pun_source
     }
 }
 

--- a/src/Perl6/Metamodel/CurriedRoleHOW.nqp
+++ b/src/Perl6/Metamodel/CurriedRoleHOW.nqp
@@ -21,6 +21,7 @@ class Perl6::Metamodel::CurriedRoleHOW
     does Perl6::Metamodel::Naming
     does Perl6::Metamodel::RoleContainer
     does Perl6::Metamodel::LanguageRevision
+    does Perl6::Metamodel::InvocationProtocol
 {
     has $!curried_role;
     has $!candidate;                # Will contain matching candidate from curried role group
@@ -72,6 +73,7 @@ class Perl6::Metamodel::CurriedRoleHOW
             :named_args(%named_args), :name($name));
         my $type := nqp::settypehll(nqp::newtype($meta, 'Uninstantiable'), 'Raku');
         $meta.set_name($type, $name);
+        $meta.compose_invocation($type);
 
         nqp::settypecheckmode($type, 2);
     }
@@ -245,7 +247,6 @@ class Perl6::Metamodel::CurriedRoleHOW
     method shortname($curried_role) {
         $curried_role.HOW.name($curried_role);
     }
-
 }
 
 # vim: expandtab sw=4

--- a/src/Perl6/Metamodel/InvocationProtocol.nqp
+++ b/src/Perl6/Metamodel/InvocationProtocol.nqp
@@ -49,46 +49,53 @@ role Perl6::Metamodel::InvocationProtocol {
         # Check if we have a invoke, and if so install
         # the default invocation forwarder. Otherwise, see if we or
         # a parent has an invocation attr.
-        my $pcmeth := self.find_method($obj, 'CALL-ME', :no_fallback(1));
-        if !nqp::isnull($pcmeth) && nqp::defined($pcmeth) {
-            nqp::die('Default invocation handler is not invokable')
-                unless nqp::isinvokable($default_invoke_handler);
+        if $obj.HOW.archetypes.composable {
+            # We special case roles by using only default handler
             nqp::setinvokespec($obj, nqp::null(), nqp::null_s(),
                 $default_invoke_handler);
         }
         else {
-            for self.mro($obj) -> $class {
-                if nqp::can($class.HOW, 'has_invocation_attr') {
-                    if $class.HOW.has_invocation_attr($class) {
-                        nqp::setinvokespec($obj,
-                            $class.HOW.invocation_attr_class($class),
-                            $class.HOW.invocation_attr_name($class),
-                            nqp::null());
-                        last;
-                    }
-                }
-                if nqp::can($class.HOW, 'has_invocation_handler') {
-                    if $class.HOW.has_invocation_handler($class) {
-                        nqp::setinvokespec($obj,
-                            nqp::null(), nqp::null_s(),
-                            $class.HOW.invocation_handler($class));
-                        last;
-                    }
-                }
+            my $pcmeth := self.find_method($obj, 'CALL-ME', :no_fallback(1));
+            if nqp::defined($pcmeth) {
+                nqp::die('Default invocation handler is not invokable')
+                    unless nqp::isinvokable($default_invoke_handler);
+                nqp::setinvokespec($obj, nqp::null(), nqp::null_s(),
+                    $default_invoke_handler);
             }
+            else {
+                for self.mro($obj) -> $class {
+                    if nqp::can($class.HOW, 'has_invocation_attr') {
+                        if $class.HOW.has_invocation_attr($class) {
+                            nqp::setinvokespec($obj,
+                                $class.HOW.invocation_attr_class($class),
+                                $class.HOW.invocation_attr_name($class),
+                                nqp::null());
+                            last;
+                        }
+                    }
+                    if nqp::can($class.HOW, 'has_invocation_handler') {
+                        if $class.HOW.has_invocation_handler($class) {
+                            nqp::setinvokespec($obj,
+                                nqp::null(), nqp::null_s(),
+                                $class.HOW.invocation_handler($class));
+                            last;
+                        }
+                    }
+                }
 #?if moar
-            for self.mro($obj) -> $class {
-                if nqp::can($class.HOW, 'has_multi_invocation_attrs') {
-                    if $class.HOW.has_multi_invocation_attrs($class) {
-                        nqp::setmultispec($obj,
-                            $class.HOW.multi_attr_class($class),
-                            $class.HOW.multi_valid_attr_name($class),
-                            $class.HOW.multi_cache_attr_name($class));
-                        last;
+                for self.mro($obj) -> $class {
+                    if nqp::can($class.HOW, 'has_multi_invocation_attrs') {
+                        if $class.HOW.has_multi_invocation_attrs($class) {
+                            nqp::setmultispec($obj,
+                                $class.HOW.multi_attr_class($class),
+                                $class.HOW.multi_valid_attr_name($class),
+                                $class.HOW.multi_cache_attr_name($class));
+                            last;
+                        }
                     }
                 }
-            }
 #?endif
+            }
         }
     }
 }

--- a/src/Perl6/Metamodel/ParametricRoleGroupHOW.nqp
+++ b/src/Perl6/Metamodel/ParametricRoleGroupHOW.nqp
@@ -17,6 +17,7 @@ class Perl6::Metamodel::ParametricRoleGroupHOW
     does Perl6::Metamodel::TypePretense
     does Perl6::Metamodel::RolePunning
     does Perl6::Metamodel::BoolificationProtocol
+    does Perl6::Metamodel::InvocationProtocol
 {
     has @!candidates;
     has $!selector;
@@ -52,6 +53,8 @@ class Perl6::Metamodel::ParametricRoleGroupHOW
         nqp::setparameterizer($type_obj, sub ($type, @packed) {
             $type.HOW.'!produce_parameterization'($type, @packed);
         });
+
+        $meta.compose_invocation($type_obj);
 
         $type_obj
     }

--- a/src/Perl6/Metamodel/ParametricRoleHOW.nqp
+++ b/src/Perl6/Metamodel/ParametricRoleHOW.nqp
@@ -14,6 +14,7 @@ class Perl6::Metamodel::ParametricRoleHOW
     does Perl6::Metamodel::TypePretense
     does Perl6::Metamodel::RolePunning
     does Perl6::Metamodel::ArrayType
+    does Perl6::Metamodel::InvocationProtocol
 {
     has $!composed;
     has $!body_block;
@@ -88,6 +89,7 @@ class Perl6::Metamodel::ParametricRoleHOW
             }
         }
         @!role_typecheck_list := @rtl;
+        self.compose_invocation($obj);
         $!composed := 1;
         $obj
     }

--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -3626,7 +3626,8 @@ BEGIN {
                     Perl6::Metamodel::Configuration.throw_or_die(
                         'X::Method::NotFound',
                         "No such method 'CALL-ME' for invocant of type '$self_name'",
-                        :invocant($self), :method<CALL-ME>, :typename($self.HOW.name($self))
+                        :invocant($self), :method(nqp::hllizefor('CALL-ME', "Raku")),
+                        :typename(nqp::hllizefor($self_name, "Raku"))
                     );
                 }
             }

--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -3605,7 +3605,7 @@ BEGIN {
             }
             else {
                 my $self_name := $self.HOW.name($self);
-                if !nqp::isconcrete($self) {
+                if !nqp::isconcrete($self) && +@pos {
                     my $val;
                     if +@pos == 1 {
                         $val := @pos[0];

--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -3619,8 +3619,9 @@ BEGIN {
                         "Cannot coerce to $self_name with named arguments",
                         :target-type($self.WHAT), :from-type($val.WHAT), :hint("named arguments passed")
                     ) if +%named;
+                    my $how := $self.HOW;
                     my $coercion_type := Perl6::Metamodel::CoercionHOW.new_type(
-                        ($self.HOW.is_pun($self)
+                        (nqp::istype($how, Perl6::Metamodel::ClassHOW) && $how.is_pun($self)
                             ?? $self.HOW.pun_source($self)
                             !! $self.WHAT),
                         $val.WHAT);

--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -3619,7 +3619,11 @@ BEGIN {
                         "Cannot coerce to $self_name with named arguments",
                         :target-type($self.WHAT), :from-type($val.WHAT), :hint("named arguments passed")
                     ) if +%named;
-                    my $coercion_type := Perl6::Metamodel::CoercionHOW.new_type($self.WHAT, $val.WHAT);
+                    my $coercion_type := Perl6::Metamodel::CoercionHOW.new_type(
+                        ($self.HOW.is_pun($self)
+                            ?? $self.HOW.pun_source($self)
+                            !! $self.WHAT),
+                        $val.WHAT);
                     nqp::hllizefor($coercion_type.HOW.coerce($coercion_type, $val), "Raku");
                 }
                 else {

--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -3604,27 +3604,30 @@ BEGIN {
                 $self.CALL-ME(|@pos, |%named)
             }
             else {
+                my $self_name := $self.HOW.name($self);
                 if !nqp::isconcrete($self) {
-                    my $coercer_name := $self.HOW.name($self);
-                    nqp::die("Cannot coerce to $coercer_name with named arguments")
-                      if +%named;
+                    my $val;
                     if +@pos == 1 {
-                        nqp::hllizefor(@pos[0]."$coercer_name"(), 'Raku')
+                        $val := @pos[0];
                     }
                     else {
-                        my $list := nqp::create(List);
-                        nqp::bindattr($list, List, '$!reified', @pos);
-                        nqp::hllizefor($list."$coercer_name"(), 'Raku')
+                        $val := nqp::create(List);
+                        nqp::bindattr($val, List, '$!reified', @pos);
                     }
+                    Perl6::Metamodel::Configuration.throw_or_die(
+                        'X::Coerce::Impossible',
+                        "Cannot coerce to $self_name with named arguments",
+                        :target-type($self.WHAT), :from-type($val.WHAT), :hint("named arguments passed")
+                    ) if +%named;
+                    my $coercion_type := Perl6::Metamodel::CoercionHOW.new_type($self.WHAT, $val.WHAT);
+                    nqp::hllizefor($coercion_type.HOW.coerce($coercion_type, $val), "Raku");
                 }
                 else {
-                    my %ex := nqp::gethllsym('Raku', 'P6EX');
-                    if nqp::isnull(%ex) || !nqp::existskey(%ex, 'X::Method::NotFound') {
-                        nqp::die("No such method 'CALL-ME' for invocant of type '" ~ $self.HOW.name($self) ~ "'");
-                    }
-                    else {
-                        nqp::atkey(%ex, 'X::Method::NotFound')($self, 'CALL-ME', $self.HOW.name($self))
-                    }
+                    Perl6::Metamodel::Configuration.throw_or_die(
+                        'X::Method::NotFound',
+                        "No such method 'CALL-ME' for invocant of type '$self_name'",
+                        :invocant($self), :method<CALL-ME>, :typename($self.HOW.name($self))
+                    );
                 }
             }
         });
@@ -3992,6 +3995,14 @@ Perl6::Metamodel::PackageHOW.pretend_to_be([Any, Mu]);
 Perl6::Metamodel::PackageHOW.delegate_methods_to(Any);
 Perl6::Metamodel::ModuleHOW.pretend_to_be([Any, Mu]);
 Perl6::Metamodel::ModuleHOW.delegate_methods_to(Any);
+
+# Make roles handle invocations.
+my $role_invoke_handler := nqp::getstaticcode(sub ($self, *@pos, *%named) {
+    $self.HOW.pun($self)(|@pos, |%named)
+});
+Perl6::Metamodel::ParametricRoleGroupHOW.set_default_invoke_handler($role_invoke_handler);
+Perl6::Metamodel::ParametricRoleHOW.set_default_invoke_handler($role_invoke_handler);
+Perl6::Metamodel::CurriedRoleHOW.set_default_invoke_handler($role_invoke_handler);
 
 # Let ClassHOW and EnumHOW know about the invocation handler.
 Perl6::Metamodel::ClassHOW.set_default_invoke_handler(

--- a/src/core.c/Exception.pm6
+++ b/src/core.c/Exception.pm6
@@ -313,10 +313,11 @@ my class X::Method::InvalidQualifier is Exception {
 
 my class X::Role::Parametric::NoSuchCandidate is Exception {
     has Mu $.role;
+    has $.hint;
     method message {
         "No appropriate parametric role variant available for '"
-        ~ $.role.^name
-        ~ "'";
+        ~ $.role.^name ~ "'"
+        ~ ($.hint ?? ":\n" ~ (~$.hint).indent(4) !! "")
     }
 }
 
@@ -3024,10 +3025,6 @@ nqp::bindcurhllsym('P6EX', BEGIN nqp::hash(
   'X::Role::Initialization',
   -> $role is raw {
       X::Role::Initialization.new(:$role).throw
-  },
-  'X::Role::Parametric::NoSuchCandidate',
-  -> Mu $role is raw {
-      X::Role::Parametric::NoSuchCandidate.new(:$role).throw;
   },
   'X::Inheritance::NotComposed',
   -> $child-name is raw, $parent-name is raw {


### PR DESCRIPTION
Basically, it all winds down to puning a role and then invoking the
resulting class. For that matter only the default handler is used
which is different from that used for other type objects.

Fixes #4094