### PR TITLE
Add warnings on improper use of .contains and .index

### DIFF
--- a/src/core.c/Map.pm6
+++ b/src/core.c/Map.pm6
@@ -13,6 +13,18 @@ my class Map does Iterable does Associative { # declared in BOOTSTRAP
         self.new.STORE(@args, :INITIALIZE)
     }
 
+    multi method contains(Map:D: \needle) {
+        my $name := self.^name;
+        warn "Applying '.contains' to a $name will look at its .Str representation.  Did you mean '$name\{needle}:exists'?".naive-word-wrapper;
+        self.Str.contains(needle)
+    }
+
+    multi method index(Map:D: \needle) {
+        my $name := self.^name;
+        warn "Applying '.index' to a $name will look at its .Str representation.  Did you mean '$name\{needle}:exists'?".naive-word-wrapper;
+        self.Str.index(needle)
+    }
+
     multi method Map(Map:) { self }
 
     multi method Hash(Map:U:) { Hash }

--- a/src/core.c/Range.pm6
+++ b/src/core.c/Range.pm6
@@ -21,7 +21,7 @@ my class Range is Cool does Iterable does Positional {
     multi method is-lazy(Range:D:) { self.infinite }
 
     multi method contains(Range:D: \needle) {
-        warn "Applying '.contains' to a Range will look at its .Str representation.  Did you mean 'Range (elem) needle'?".naive-word-wrapper;
+        warn "Applying '.contains' to a Range will look at its .Str representation.  Did you mean 'needle (elem) Range'?".naive-word-wrapper;
         self.Str.contains(needle)
     }
 

--- a/src/core.c/Range.pm6
+++ b/src/core.c/Range.pm6
@@ -20,6 +20,16 @@ my class Range is Cool does Iterable does Positional {
     }
     multi method is-lazy(Range:D:) { self.infinite }
 
+    multi method contains(Range:D: \needle) {
+        warn "Applying '.contains' to a Range will look at its .Str representation.  Did you mean 'Range (elem) needle'?".naive-word-wrapper;
+        self.Str.contains(needle)
+    }
+
+    multi method index(Range:D: \needle) {
+        warn "Applying '.index' to a Range will look at its .Str representation.  Did you mean 'Range.first(needle, :k)'?".naive-word-wrapper;
+        self.Str.index(needle)
+    }
+
     # The order of "method new" declarations matters here, to ensure
     # appropriate candidate tiebreaking when mixed type arguments
     # are present (e.g., Range,Whatever or Real,Range).


### PR DESCRIPTION
As part of the discussion in #4098.  Spectest clean.