### PR TITLE
Re-imagine basic slice assignment, 5.8x as fast

### DIFF
--- a/src/core.c/Rakudo/Iterator.pm6
+++ b/src/core.c/Rakudo/Iterator.pm6
@@ -3269,6 +3269,7 @@ class Rakudo::Iterator {
     # Positional indexing, the number of elements in the Positional.  The
     # iterator will produce positions until the given iterator is exhausted.
     # Also takes care of Callables being produced by the given iterator.
+    # Any non-numeric position will be returned as is.
     class PosWithCallables {
         has $!iterator;
         has $!elems;
@@ -3296,7 +3297,8 @@ class Rakudo::Iterator {
     # iterator will produce positions until either the given iterator is
     # exhausted, or a position is produced that is greater or equal to the
     # number of elements in the Positional.  Also takes care of Callables
-    # being produced by the given iterator.
+    # being produced by the given iterator.  Anything non-numeric position
+    # will be returned as is.
     class PosWithinRange {
         has $!iterator;
         has $!elems;
@@ -3318,7 +3320,7 @@ class Rakudo::Iterator {
                   $pos := $pos($!elems)
                 ),
                 nqp::if(
-                  $pos >= $!elems,
+                  nqp::istype($pos,Numeric) && $pos >= $!elems,
                   IterationEnd,
                   $pos
                 )

--- a/src/core.c/Rakudo/Iterator.pm6
+++ b/src/core.c/Rakudo/Iterator.pm6
@@ -3272,7 +3272,7 @@ class Rakudo::Iterator {
     class PosWithCallables {
         has $!iterator;
         has $!elems;
-        
+
         method !SET-SELF(\iterator, \elems) {
             $!iterator := iterator;
             $!elems    := elems;
@@ -3300,14 +3300,14 @@ class Rakudo::Iterator {
     class PosWithinRange {
         has $!iterator;
         has $!elems;
-        
+
         method !SET-SELF(\iterator, \elems) {
             $!iterator := iterator;
             $!elems    := elems;
             self
         }
         method new(\iter, \elems) { nqp::create(self)!SET-SELF(iter, elems) }
-        
+
         method pull-one() {
             nqp::if(
               nqp::eqaddr((my $pos := $!iterator.pull-one),IterationEnd),

--- a/src/core.c/array_slice.pm6
+++ b/src/core.c/array_slice.pm6
@@ -236,18 +236,17 @@ multi sub postcircumfix:<[ ]>(
         my sub handle-whatever() {
             my int $i    = -1;
             my int $todo = $elems;
-            nqp::if(
-              nqp::isnull($result),
-              nqp::while(
-                nqp::islt_i(($i = nqp::add_i($i,1)),$todo),
-                nqp::push($containers,SELF.AT-POS($i)),
-                nqp::push($values,$val-iter.pull-one)
-              ),
-              nqp::while(
-                nqp::islt_i(($i = nqp::add_i($i,1)),$todo),
-                nqp::push($result,nqp::push($containers,SELF.AT-POS($i))),
-                nqp::push($values,$val-iter.pull-one)
-              )
+            my $buffer  := nqp::create(IterationBuffer);
+
+            # Set up alternate result handling
+            $result := nqp::clone($containers) if nqp::isnull($result);
+            nqp::push($containers,nqp::push($result,my $));
+            nqp::push($values,$buffer.List);
+
+            nqp::while(
+              nqp::islt_i(($i = nqp::add_i($i,1)),$todo),
+              nqp::push($containers,nqp::push($buffer,SELF.AT-POS($i))),
+              nqp::push($values,$val-iter.pull-one)
             );
         }
 


### PR DESCRIPTION
- makes @a[1,2,3] = 4,5,6 about 5.8x as fast
- breaks 2 spectests that assume handling lazy positions also means
  that the result should be lazy.  The tests in t/spec/S32-list/seq
  (23,25) are in fact marked as testing "experimental behaviour",
  so one could argue that they can be changed.

Should it be deemed necessary that a lazy position should also mean a lazy result, then that could be done relatively easy.  But I would argue that the current behaviour (assigning until a position is produced that is outside of the original `Positional`) makes more sense.