### PR TITLE
Use `exec` instead of `system` and then exiting with the return code.

### DIFF
--- a/Configure.pl
+++ b/Configure.pl
@@ -16,7 +16,7 @@ BEGIN {
     my $set_config = !qx{git config rakudo.initialized};
     if ( !-e '3rdparty/nqp-configure/LICENSE' ) {
         my $code = system($^X, 'tools/build/update-submodules.pl', Cwd::cwd(), @ARGV);
-        exit 1 if $code >> 8 != 0;
+        exit 1 if $code;
         $set_config = 1;
     }
     if ($set_config) {

--- a/tools/templates/js/rakudo-js-build.in
+++ b/tools/templates/js/rakudo-js-build.in
@@ -1,5 +1,3 @@
 $ENV{RAKUDO_HOME} = '@sq_escape(@base_dir@/gen/build_rakudo_home)@';
 
-my $exit = system {'node'} ('node', '--max-old-space-size=8192', 'rakudo.js', '--nqp-runtime', '@sq_escape(@nqp_runtime@)@', '--perl6-runtime', '@sq_escape(@perl6_runtime@)@', '--libpath', '@sq_escape(@libpath@)@', '--source-map', @ARGV);
-
-exit($exit >> 8);
+exec {'node'} ('node', '--max-old-space-size=8192', 'rakudo.js', '--nqp-runtime', '@sq_escape(@nqp_runtime@)@', '--perl6-runtime', '@sq_escape(@perl6_runtime@)@', '--libpath', '@sq_escape(@libpath@)@', '--source-map', @ARGV);

--- a/tools/templates/jvm/rakudo-j-build.in
+++ b/tools/templates/jvm/rakudo-j-build.in
@@ -1,5 +1,3 @@
 $ENV{RAKUDO_HOME} = '@sq_escape(@base_dir@/gen/build_rakudo_home)@';
 
-my $exit = system {'@java@'} ('@java@', '-Xss1m', '-Xms500m', '-Xmx3000m', '-cp', '@sq_escape(@classpath@)@', 'perl6', @ARGV);
-
-exit($exit >> 8);
+exec {'@java@'} ('@java@', '-Xss1m', '-Xms500m', '-Xmx3000m', '-cp', '@sq_escape(@classpath@)@', 'perl6', @ARGV);

--- a/tools/templates/moar/rakudo-m-early-build.in
+++ b/tools/templates/moar/rakudo-m-early-build.in
@@ -1,5 +1,3 @@
 $ENV{RAKUDO_HOME} = '@sq_escape(@base_dir@/gen/build_rakudo_home)@';
 
-my $exit = system {'@sq_escape(@moar@)@'} ('@sq_escape(@moar@)@', '--libpath=@sq_escape(@base_dir@/blib)@', '--libpath=@sq_escape(@nqp_libdir@)@', '@sq_escape(@rakudo@)@', @ARGV);
-
-exit($exit >> 8);
+exec {'@sq_escape(@moar@)@'} ('@sq_escape(@moar@)@', '--libpath=@sq_escape(@base_dir@/blib)@', '--libpath=@sq_escape(@nqp_libdir@)@', '@sq_escape(@rakudo@)@', @ARGV);


### PR DESCRIPTION
The approach using `system` misses the case where the invoked program exits
with a signal - for example if the OOM killer takes out the setting build.

Before this change the wrapper script would calmly take the value 137
returned from `system`, shift it right by 8 and exit with status 0, which
make took as success and carried on. At which point the next command invoked
would mysteriously fail due to a missing input file.

Now we see:
    The following step can take a long time, please be patient.
    Stage start      :   0.001
    Stage parse      : 745.469
    Stage syntaxcheck:   0.000
    Stage ast        :   0.000
    Stage optimize   : 102.057
    Stage mast       : Killed
    make: *** [Makefile:1170: blib/CORE.c.setting.moarvm] Error 137

a useful error message and the build aborts.

Where we still need `system` in Configure.pl, simply check whether it
returned non-zero. This way we also catch the error case of death by fatal
signal.

I checked perlport - `exec` and `system` have identical portability
caveats, so this change *should* not cause problems (at least, not cause
problems that we didn't already expose ourselves to).