### PR TITLE
Add missing `-I lib` to an is-run test

### DIFF
--- a/t/02-rakudo/99-misc.t
+++ b/t/02-rakudo/99-misc.t
@@ -142,7 +142,7 @@ group-of 2 => 'collation experiment' => {
         use experimental :collation;
         $*COLLATION.set: :primary;
         print 'pass'
-    ｣, :out<pass>, 'we can still use the pragma (to support old code)';
+    ｣, :out<pass>, :compiler-args[<-I lib>], 'we can still use the pragma (to support old code)';
 }
 
 subtest 'Distribution::Resource can be stringified', {

--- a/t/05-messages/02-errors.t
+++ b/t/05-messages/02-errors.t
@@ -118,6 +118,7 @@ is-run '(:::[])', :err(/"No such symbol ':<>'"/), :1exitcode,
 
 # https://github.com/rakudo/rakudo/issues/1333
 is-run 'use Test; cmp-ok 1, "!eqv", 2',
+    :compiler-args[<-I lib>],
     :out{.starts-with: 'not ok 1'},
     :err{.contains: '!eqv' & 'pass it as a Callable' }, :1exitcode,
     'cmp-ok with Str metaop comparator suggests a working alternative`';

--- a/t/05-messages/03-errors.t
+++ b/t/05-messages/03-errors.t
@@ -51,10 +51,10 @@ subtest 'subsets get named in typecheck errors' => {
 subtest 'like/unlike failures give useful diagnostics' => {
     plan 2;
     is-run ｢use Test; plan 1; like 42, /43/｣,
-        :1exitcode, :out(*), :err{.contains: 'expected a match with'},
+        :1exitcode, :compiler-args[<-I lib>], :out(*), :err{.contains: 'expected a match with'},
     '`like` says it wanted a match, not just "expected"';
     is-run ｢use Test; plan 1; unlike 42, /42/｣,
-        :1exitcode, :out(*), :err{.contains: 'expected no match with'},
+        :1exitcode, :compiler-args[<-I lib>], :out(*), :err{.contains: 'expected no match with'},
     '`unlike` says it wanted no match, not just "expected"';
 }
 

--- a/t/05-messages/10-warnings.t
+++ b/t/05-messages/10-warnings.t
@@ -82,7 +82,7 @@ is-run ｢my @a; sink @a; my $b := gather { print 'meow' }; sink $b｣,
     :out<meow>, 'no warnings when sinking variables';
 
 is-run ｢use experimental :macros; macro z($) { quasi {} };
-    z $; z <x>; print "pass"｣, :out<pass>,
+    z $; z <x>; print "pass"｣, :compiler-args[<-I lib>], :out<pass>,
     'args to macros do not cause useless use warnings';
 
 # https://github.com/rakudo/rakudo/issues/2554

--- a/t/09-moar/00-misc.t
+++ b/t/09-moar/00-misc.t
@@ -7,7 +7,7 @@ plan 6;
 # https://github.com/rakudo/rakudo/issues/1534
 {
     (temp %*ENV)<MVM_SPESH_BLOCKING  MVM_SPESH_NODELAY> = 1, 1;
-    is-run ｢use Test; use Test; print "pass"｣, :out<pass>,
+    is-run ｢use Test; use Test; print "pass"｣, :out<pass>, :compiler-args[<-I lib>],
         'no SPESH crashes with duplicate `use Test`';
 }
 


### PR DESCRIPTION
Otherwise it passes when run under make (e.g., `make
t/02-rakudo/99-misc.t` or `make m-test`), but not when run directly
(e.g., `./rakudo-m -I lib t/02-rakudo/99-misc.t`).