### PR TITLE
Move to CentOS 7 in binary release linux build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -231,7 +231,7 @@ stages:
       pool:
         vmImage: 'ubuntu-18.04'
       container:
-        image: centos:6
+        image: centos:7
         options: "--name raku-build-container -v /usr/bin/docker:/tmp/docker:ro"
       workspace:
         clean: all

--- a/tools/build/binary-release/build-linux.sh
+++ b/tools/build/binary-release/build-linux.sh
@@ -11,7 +11,7 @@ set -o pipefail
 
 echo "========= Starting build"
 
-echo "========= Updating CentOS 6"
+echo "========= Updating CentOS 7"
 sudo yum -y update
 sudo yum clean all
 


### PR DESCRIPTION
CentOS 6 has gone EOL in 2020-11. According to
https://gist.github.com/wagenet/35adca1a032cec2999d47b6c40aa45b1
CentOS 7 is now the Distro with the oldest glibc (2.17). So we move to
that. This means that from now on the binary releases will not work on CentOS 6 anymore.