### PR TITLE
Make enums return Failure on bad conversion

### DIFF
--- a/src/Perl6/Metamodel/CoercionHOW.nqp
+++ b/src/Perl6/Metamodel/CoercionHOW.nqp
@@ -189,7 +189,6 @@ class Perl6::Metamodel::CoercionHOW
             || !(nqp::istype($coerced_decont, $!target_type)
                 || nqp::istype($coerced_decont, nqp::gethllsym('Raku', 'Failure')))
         {
-            my %ex := nqp::gethllsym('Raku', 'P6EX');
             my $target_type_name := $!target_type.HOW.name($!target_type);
             my $value_type_name := $value_type.HOW.name($value_type);
             unless $hint {

--- a/src/Perl6/Metamodel/Configuration.nqp
+++ b/src/Perl6/Metamodel/Configuration.nqp
@@ -43,7 +43,7 @@ class Perl6::Metamodel::Configuration {
     method set_X_package($X) {
         $X_package := $X;
     }
-    method throw_or_die($exception, $die_message, *@pos, *%named) {
+    method find_exception($exception) {
         my $ex_type := nqp::null();
         unless nqp::isnull($X_package) {
             my @parts := nqp::split('::', $exception);
@@ -68,6 +68,10 @@ class Perl6::Metamodel::Configuration {
                 }
             }
         }
+        $ex_type
+    }
+    method throw_or_die($exception, $die_message, *@pos, *%named) {
+        my $ex_type := self.find_exception($exception);
         if nqp::isnull($ex_type) {
             nqp::die($die_message)
         }

--- a/src/Perl6/Metamodel/EnumHOW.nqp
+++ b/src/Perl6/Metamodel/EnumHOW.nqp
@@ -92,7 +92,7 @@ class Perl6::Metamodel::EnumHOW
         }
         nqp::existskey(%!value_to_enum, $value)
             ?? %!value_to_enum{$value}
-            !! $obj.WHAT;
+            !! nqp::null()
     }
 
     method enum_value_list($obj) {

--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -1384,7 +1384,7 @@ BEGIN {
     #     has int $!associative_delegate;
     #     has Mu $!why;
     #     has Mu $!container_initializer;
-    #     has Attribute $!orig; # original attribute object used for instantiation
+    #     has Attribute $!original; # original attribute object used for instantiation
     Attribute.HOW.add_parent(Attribute, Any);
     Attribute.HOW.add_attribute(Attribute, BOOTSTRAPATTR.new(:name<$!name>, :type(str), :package(Attribute)));
     # The existence of both $!rw and $!ro might be confusing, but they're needed for late trait application with

--- a/src/core.c/Attribute.pm6
+++ b/src/core.c/Attribute.pm6
@@ -22,6 +22,8 @@ my class Attribute { # declared in BOOTSTRAP
 
     method compose(Mu $package, :$compiler_services) {
         return if $!composed;
+        my $dcpkg := nqp::decont($package);
+        nqp::bindattr(self, Attribute, '$!package', $dcpkg);
         # Generate accessor method, if we're meant to have one.
         if self.has_accessor {
             my str $name   = nqp::unbox_s(self.name);
@@ -31,7 +33,6 @@ my class Attribute { # declared in BOOTSTRAP
                     || (nqp::can($package.HOW, 'has_multi_candidate')
                         && $package.^has_multi_candidate($meth_name))
             {
-                my $dcpkg := nqp::decont($package);
                 my $meth;
                 my int $attr_type = nqp::objprimspec($!type);
 

--- a/src/core.c/Exception.pm6
+++ b/src/core.c/Exception.pm6
@@ -2773,10 +2773,10 @@ my class X::Numeric::Confused is Exception {
 }
 
 my class X::Enum::NoValue is Exception {
-    has Mu $.enum is required;
+    has Mu $.type is required;
     has $.value is required;
     method message {
-        "No value '" ~ $!value ~ "' found in enum " ~ $!enum.^name
+        "No value '" ~ $!value ~ "' found in enum " ~ $!type.^name
     }
 }
 

--- a/src/core.c/Exception.pm6
+++ b/src/core.c/Exception.pm6
@@ -2772,6 +2772,14 @@ my class X::Numeric::Confused is Exception {
     }
 }
 
+my class X::Enum::NoValue is Exception {
+    has Mu $.enum is required;
+    has $.value is required;
+    method message {
+        "No value '" ~ $!value ~ "' found in enum " ~ $!enum.^name
+    }
+}
+
 my class X::PseudoPackage::InDeclaration does X::Comp {
     has $.pseudo-package;
     has $.action;


### PR DESCRIPTION
The current behavior of an enum is to return the enum's type object if conversion fails:

```
enum Foo <a b c>;
say Foo(10); # (Foo)
```

With this PR the above operation will result in a `Failure` wrapping around `X::Enum::NoValue`.

Resolves #4116.

Alongside with the main target the following changes were needed and have been implemented:

- When an `Attribute` instance is composed its `$!package` is set to the ultimate package the attribute gets installed into. This fixes `get_value` method previously failing because of `$!package` holding the original parametric role. Now to get the role one must use `$!original.package`.
- `S12-enums/pseudo-functional.t` specs that `EnumType($mixin)` must not throw if `$mixin` is made of `EnumType`. The problem is that the test was originally passing only due to the coercion returning the enum type itself. To get the spec working again the coercion behavior has been slightly changed. `Enumeration` now first checks if the source value is a mixin and that a valid `EnumType` could be pulled out of it. If it can then the `EnumType` value is used as the result of the operation. This has the following side effect:
  ```
  enum Foo <a b c>;
  my $mix = 1 but Foo(c);
  say "Foo(1): ", Foo(1).raku;       # Foo(1): Foo::b
  say "Foo(mix): ", Foo($mix).raku;  # Foo(mix): Foo::c
  ```

  I consider this the right behavior because the mixin does represent the enum value.