### PR TITLE
Implement "is implementation-detail" for classes

### DIFF
--- a/src/Perl6/Metamodel/ConcreteRoleHOW.nqp
+++ b/src/Perl6/Metamodel/ConcreteRoleHOW.nqp
@@ -160,6 +160,10 @@ class Perl6::Metamodel::ConcreteRoleHOW
             nqp::null()
         }
     }
+
+    method is-implementation-detail($obj) {
+        @!roles[0].is-implementation-detail($obj)
+    }
 }
 
 # vim: expandtab sw=4

--- a/src/Perl6/Metamodel/CurriedRoleHOW.nqp
+++ b/src/Perl6/Metamodel/CurriedRoleHOW.nqp
@@ -247,6 +247,10 @@ class Perl6::Metamodel::CurriedRoleHOW
     method shortname($curried_role) {
         $curried_role.HOW.name($curried_role);
     }
+
+    method is-implementation-detail($obj) {
+        $!curried_role.is-implementation-detail($obj)
+    }
 }
 
 # vim: expandtab sw=4

--- a/src/Perl6/Metamodel/Documenting.nqp
+++ b/src/Perl6/Metamodel/Documenting.nqp
@@ -8,6 +8,8 @@ role Perl6::Metamodel::Documenting {
     method set_why($why) {
         $!why := $why;
     }
+
+    method is-implementation-detail($type) { 0 }
 }
 
 # vim: expandtab sw=4

--- a/src/Perl6/Metamodel/ParametricRoleGroupHOW.nqp
+++ b/src/Perl6/Metamodel/ParametricRoleGroupHOW.nqp
@@ -215,6 +215,11 @@ class Perl6::Metamodel::ParametricRoleGroupHOW
                     nqp::null())
     }
 
+    method is-implementation-detail($obj) {
+        my $c := self.'!get_default_candidate'($obj);
+        $c.HOW.is-implementation-detail($c)
+    }
+
     method !get_default_candidate($obj) {
         nqp::ifnull(self.'!get_nonsignatured_candidate'($obj),
                     nqp::if(

--- a/src/core.c/traits.pm6
+++ b/src/core.c/traits.pm6
@@ -80,6 +80,13 @@ multi sub trait_mod:<is>(Mu:U $type, Mu:U $parent, Hash) {
       :what<Hash>
     ).throw;
 }
+multi sub trait_mod:<is>(Mu:U $type, :$implementation-detail!) {
+    my role is-implementation-detail {
+        method is-implementation-detail(Mu --> 1) { }
+    }
+    $type.HOW.^mixin(is-implementation-detail)
+      if $implementation-detail;
+}
 multi sub trait_mod:<is>(Mu:U $type, *%fail) {
     if %fail.keys[0] !eq $type.^name {
         X::Inheritance::UnknownParent.new(


### PR DESCRIPTION
This implements the "is implementation-detail" trait on classes.
It also implements a "is-implementation-detail" method on classes,
that will either return 0 if the class **is not** an implementation
detail, and 1 if the class *is* an implementation detail.

    class Foo is implementation-detail { }
    class Bar { }

    say Foo.^is-implementation-detail;   # 1
    say Bar.^is-implementation-detail;   # 0