### PR TITLE
Add "Solaris" to $?Perl.KERNELnames

### DIFF
--- a/src/core.c/Raku.pm6
+++ b/src/core.c/Raku.pm6
@@ -11,7 +11,7 @@ class Raku does Systemic {
     method VMnames { <moar jvm js> }
 
     method DISTROnames { <macosx linux freebsd mswin32 openbsd dragonfly netbsd browser> }
-    method KERNELnames { <darwin linux freebsd openbsd netbsd  dragonfly win32 browser>  }
+    method KERNELnames { <darwin linux freebsd openbsd netbsd dragonfly sunos win32 browser>  }
 
     my $version-cache      := nqp::hash;
     my $version-cache-lock := Lock.new;


### PR DESCRIPTION
Technically "Solaris 2", as SunOS 4 was retconned to "Solaris 1", but
that's all froth in the Marketing Layer, as the Engineering Layer still
reports "SunOS 5.x". eg

    $ uname -sr
    SunOS 5.11