### PR TITLE
Implement `sec`, `asec` and `sech` in terms of other NQP trigonometric functions.

### DIFF
--- a/src/core.c/Num.pm6
+++ b/src/core.c/Num.pm6
@@ -190,11 +190,11 @@ my class Num does Real { # declared in BOOTSTRAP
     }
     proto method sec(|) {*}
     multi method sec(Num:D: ) {
-        nqp::p6box_n(nqp::sec_n(nqp::unbox_n(self)));
+        nqp::p6box_n(nqp::div_n(1e0, nqp::cos_n(nqp::unbox_n(self))));
     }
     proto method asec(|) {*}
     multi method asec(Num:D: ) {
-        nqp::p6box_n(nqp::asec_n(nqp::unbox_n(self)));
+        nqp::p6box_n(nqp::acos_n(nqp::div_n(1e0, nqp::unbox_n(self))));
     }
     method cosec(Num:D:) {
         nqp::p6box_n(nqp::div_n(1e0, nqp::sin_n(nqp::unbox_n(self))));
@@ -242,7 +242,7 @@ my class Num does Real { # declared in BOOTSTRAP
     }
     proto method sech(|) {*}
     multi method sech(Num:D: ) {
-        nqp::p6box_n(nqp::sech_n(nqp::unbox_n(self)));
+        nqp::p6box_n(nqp::div_n(1e0, nqp::cosh_n(nqp::unbox_n(self))));
     }
     proto method asech(|) {*}
     multi method asech(Num:D: ) {
@@ -562,10 +562,10 @@ multi sub atan(num $x --> num) {
     nqp::atan_n($x);
 }
 multi sub sec(num $x --> num) {
-    nqp::sec_n($x);
+    nqp::div_n(1e0, nqp::cos_n($x));
 }
 multi sub asec(num $x --> num) {
-    nqp::asec_n($x);
+    nqp::acos_n(nqp::div_n(1e0, $x));
 }
 
 multi sub cotan(num $x --> num) {
@@ -612,7 +612,7 @@ multi sub atanh(num $x --> num) {
     $x == 1e0 ?? Inf !! log((1e0 + $x) / (1e0 - $x)) / 2e0;
 }
 multi sub sech(num $x --> num) {
-    nqp::sech_n($x);
+    1e0 / cosh($x)
 }
 multi sub asech(num $x --> num) {
     acosh(1e0 / $x);


### PR DESCRIPTION
There is some inconsistency in MoarVM - as well as the usual trigonometric
functions `sin`, `cos`, `tan` and their inverses, *some* of the others are
implemented directly as NQP ops, but not all. So we have nqp::sec and
nqp::asec for secants, but no OPs for cosecants or cotangents (or their
inverses), with the result that these are implemented by Num.pm6 as
arithmetic relations using the OPs that exist.

Similarly, `sech` exists as a wrapper, but not `cosech` or `cotanh` (or any
of the inverses).

Looking at MoarVM's interp.c I see that the 3 OPs in question *don't* call
C library functions for the primitives - each is C code implementing the
operation in terms of arithmetic on other library functions - library
functions that we expose as NQP ops.

Hence it's much simpler if we move this arithmetic from MoarVM to the CORE:
1) We can remove the OPs from MoarVM
2) The code can now be JITted (everything that wrapper uses is in the JIT,
   whereas the 3 synthesised functions are not)
3) The 3 OPs don't seem to be implemented in the JVM or JS backends, so we
   also improve their test pass percentage :-)