### PR TITLE
02-simple-args.c should #include <sys/types.h> to get ssize_t

### DIFF
--- a/t/04-nativecall/02-simple-args.c
+++ b/t/04-nativecall/02-simple-args.c
@@ -9,6 +9,7 @@ typedef signed __int64 int64_t;
 #else
 #define DLLEXPORT extern
 #include <inttypes.h>
+#include <sys/types.h>
 #endif
 
 DLLEXPORT int TakeInt(int x)


### PR DESCRIPTION
Without this the code won't even compile on Solaris.

I assume that other *nix platforms "leak" the definition of ssize_t when
other headers are included, hence why it has not been spotted before.