### PR TITLE
Prefer api sorting over version sorting

### DIFF
--- a/src/core.c/CompUnit/Repository/Installation.pm6
+++ b/src/core.c/CompUnit/Repository/Installation.pm6
@@ -429,7 +429,7 @@ sub MAIN(:$name, :$auth, :$ver, *@, *%) {
         }
 
         # Sort from highest to lowest by version and api
-        my $sorted-metas := $matching-metas.sort(*.value<api>).sort(*.value<ver>).reverse;
+        my $sorted-metas := $matching-metas.sort(*.value<ver>).sort(*.value<api>).reverse;
 
         # There is nothing left to do with the subset of meta data, so initialize a lazy distribution with it
         my $distributions := $sorted-metas.map(*.kv).map: -> ($dist-id, $meta) { self!lazy-distribution($dist-id, :$meta) }

--- a/src/core.c/CompUnit/RepositoryRegistry.pm6
+++ b/src/core.c/CompUnit/RepositoryRegistry.pm6
@@ -314,7 +314,7 @@ class CompUnit::RepositoryRegistry {
             exit 1;
         }
 
-        my $meta = @metas.sort(*.<ver>).reverse.head;
+        my $meta = @metas.sort(*.<ver>).sort(*.<api>).reverse.head;
         my $bin  = $meta<source>;
         require "$bin";
     }


### PR DESCRIPTION
When sorting distributions my intention was for the highest api to be preferred (with the highest version being used if there was a tie in api version). This change aligns raku behavior with those intentions instead of preferring version over api.