### PR TITLE
Use less common names for installation shim arguments

### DIFF
--- a/src/core.c/CompUnit/Repository/Installation.pm6
+++ b/src/core.c/CompUnit/Repository/Installation.pm6
@@ -51,8 +51,8 @@ __END__
 :endofperl
 ';
     my $perl_wrapper = '#!/usr/bin/env #perl#
-sub MAIN(:$name, :$auth, :$ver, *@, *%) {
-    CompUnit::RepositoryRegistry.run-script("#name#", :$name, :$auth, :$ver);
+sub MAIN(:$raku-dist-name, :$raku-dist-auth, :$raku-dist-ver, :$raku-dist-api, *@, *%) {
+    CompUnit::RepositoryRegistry.run-script("#name#", :name($raku-dist-name), :auth($raku-dist-auth), :ver($raku-dist-ver), :api($raku-dist-api));
 }';
 
     method !sources-dir   { with $.prefix.add('sources')   { once { .mkdir unless .e }; $_ } }

--- a/src/core.c/CompUnit/RepositoryRegistry.pm6
+++ b/src/core.c/CompUnit/RepositoryRegistry.pm6
@@ -285,10 +285,6 @@ class CompUnit::RepositoryRegistry {
     }
 
     method run-script($script, :$name, :$auth, :$ver, :$api) {
-        shift @*ARGS if $name;
-        shift @*ARGS if $auth;
-        shift @*ARGS if $ver;
-
         my @installations = $*REPO.repo-chain.grep(CompUnit::Repository::Installation);
         my @metas = @installations.map({ .files("bin/$script", :$name, :$auth, :$ver).head }).grep(*.defined);
         unless +@metas {


### PR DESCRIPTION
A mostly unknown feature of the bin script shims CURI installs is
that it allows choosing the distribution to load the script from,
which allows loading an e.g. older version of some script. However
to do so required using the :$name :$auth :$ver :$api arguments
which prevents any installed raku bin script from taking any
arguments of those names; the shim scripts breaks things such as
providing a `bin/foo --ver` that outputs version information. This
changes the argument names to use something far less likely to be
used by arbitrary scripts (which is fine for rarely used options).