### PR TITLE
[JVM] Unbust tests for X::Adverb

### DIFF
--- a/src/core.c/Rakudo/Internals/PostcircumfixAdverbs.pm6
+++ b/src/core.c/Rakudo/Internals/PostcircumfixAdverbs.pm6
@@ -300,7 +300,7 @@ augment class Rakudo::Internals {
         my int $index = nqp::atpos_i(@pc-adverb-mapper,$bitmap);
 #?endif
 #?if !moar
-        my int $index = @pc-adverb-mapper[$bitmap];
+        my $index = @pc-adverb-mapper[$bitmap];
 #?endif
         nqp::if(
           nqp::elems($nameds),
@@ -408,7 +408,7 @@ augment class Rakudo::Internals {
         my int $index = nqp::atpos_i(@pc-adverb-mapper,$bitmap);
 #?endif
 #?if !moar
-        my int $index = @pc-adverb-mapper[$bitmap];
+        my $index = @pc-adverb-mapper[$bitmap];
 #?endif
         nqp::if(
           nqp::elems($nameds),


### PR DESCRIPTION
They failed with 'Cannot unbox a type object' on the JVM backend.