### PR TITLE
Implement explicitly setting arg0 in `Proc`s

### DIFF
--- a/src/core.c/Proc.pm6
+++ b/src/core.c/Proc.pm6
@@ -165,9 +165,9 @@ my class Proc {
           if nqp::istype($!exitcode,Nil);
     }
 
-    method spawn(*@args where .so, :$cwd = $*CWD, :$env, :$win-verbatim-args = False --> Bool:D) {
+    method spawn(*@args where .so, :$cwd = $*CWD, :$env, :$arg0, :$win-verbatim-args = False --> Bool:D) {
         @!command := @args.List;
-        self!spawn-internal(@args, $cwd, $env, :$win-verbatim-args)
+        self!spawn-internal(@args, $cwd, $env, :$arg0, :$win-verbatim-args)
     }
 
     method shell($cmd, :$cwd = $*CWD, :$env --> Bool:D) {
@@ -178,9 +178,9 @@ my class Proc {
         self!spawn-internal(@args, $cwd, $env, :win-verbatim-args)
     }
 
-    method !spawn-internal(@args, $cwd, $env, :$win-verbatim-args --> Bool:D) {
+    method !spawn-internal(@args, $cwd, $env, :$arg0, :$win-verbatim-args --> Bool:D) {
         my %ENV := $env ?? $env.hash !! %*ENV;
-        $!proc := Proc::Async.new(|@args, :$!w, :$win-verbatim-args);
+        $!proc := Proc::Async.new(|@args, :$!w, :$arg0, :$win-verbatim-args);
         .() for @!pre-spawn;
         $!finished = $!proc.start(:$cwd, :%ENV, scheduler => $PROCESS::SCHEDULER);
         my $is-spawned := do {
@@ -240,9 +240,9 @@ my class Proc {
 proto sub run(|) {*}
 multi sub run(*@args where .so, :$in = '-', :$out = '-', :$err = '-',
         Bool :$bin, Bool :$chomp = True, Bool :$merge,
-        Str  :$enc, Str:D :$nl = "\n", :$cwd = $*CWD, :$env, :$win-verbatim-args = False) {
+        Str  :$enc, Str:D :$nl = "\n", :$cwd = $*CWD, :$env, :$arg0, :$win-verbatim-args = False) {
     my $proc := Proc.new(:$in, :$out, :$err, :$bin, :$chomp, :$merge, :$enc, :$nl);
-    $proc.spawn(@args, :$cwd, :$env, :$win-verbatim-args);
+    $proc.spawn(@args, :$cwd, :$env, :$arg0, :$win-verbatim-args);
     $proc
 }
 

--- a/src/core.c/Proc/Async.pm6
+++ b/src/core.c/Proc/Async.pm6
@@ -101,6 +101,7 @@ my class Proc::Async {
     has $.w;
     has $.enc = 'utf8';
     has $.translate-nl = True;
+    has $.arg0;
     has $.win-verbatim-args = False;
     has Bool $.started = False;
     has $!stdout_supply;
@@ -130,6 +131,9 @@ my class Proc::Async {
 
     submethod TWEAK(--> Nil) {
         $!encoder := Encoding::Registry.find($!enc).encoder(:$!translate-nl);
+
+        $!arg0 //= $!path;
+        @!args.unshift: $!arg0;
     }
 
     method !pipe-cbs(\channel) {
@@ -323,22 +327,22 @@ my class Proc::Async {
 #?if jvm
         # The Java process API does not allow disabling Javas
         # sophisticated heuristics of command mangling.
-        # So it's not easily possible to do the quoting ourselves.
-        # So the $!win-quote-args argument is ignored on JVM and we
-        # just let Java do its magic.
-        my @quoted-args := $!path, |@!args;
+        # NQPs spawnprocasync implementation on JVM thus overwrites
+        # arg[0] with the program name and forwards the result to Javas
+        # APIs.
+        # So we do not quote the arguments and just let Java do its magic.
+        my @quoted-args := @!args;
 #?endif
 #?if !jvm
         my @quoted-args;
         if Rakudo::Internals.IS-WIN {
-            @quoted-args.append(
-                self!win-quote-CommandLineToArgvW($!path),
+            @quoted-args.push(
                 $!win-verbatim-args
                     ?? @!args.join(' ')
                     !! self!win-quote-CommandLineToArgvW(@!args));
         }
         else {
-            @quoted-args := $!path, |@!args;
+            @quoted-args := @!args;
         }
 #?endif
 
@@ -348,7 +352,7 @@ my class Proc::Async {
         nqp::bindkey($callbacks, 'done', -> Mu \status {
            $!exit_promise.keep(Proc.new(
                :exitcode(status +> 8), :signal(status +& 0xFF),
-               :command( $!path, |@!args ),
+               :command( @!command ),
            ))
         });
 


### PR DESCRIPTION
On basically all operating systems the process calling API usually expects
arg0 to be the program being called. But not necessarily so. With this
change it is now possible to optionally explicitly set arg0 to a different
value. This is analogous to the node.js API.

Tests in: https://github.com/Raku/roast/pull/714
Docs in: https://github.com/Raku/doc/pull/3784