### PR TITLE
Fix proclaim stack travesral

### DIFF
--- a/lib/Test.rakumod
+++ b/lib/Test.rakumod
@@ -776,7 +776,7 @@ sub proclaim(Bool(Mu) $cond, $desc is copy, $unescaped-prefix = '') {
             my \code := ($caller = callframe($level++)).code;
             $tester = callframe($level)  # the next one should be reported
               if nqp::can(code,'is-test-assertion');  # must use nqp
-        } until $caller.file.ends-with('.nqp');
+        } until !$caller.file || $caller.file.ends-with('.nqp');
 
         # the final place we want to report from
         _diag $desc


### PR DESCRIPTION
If a test function invoked not from the main thread but somewhere where there is no `.nqp` file found in the stack then `proclaim` dies when encounters the stack bottom by attempting `ends-with` method on `Mu`.