### PR TITLE
Make sure we don't go past stack top

### DIFF
--- a/lib/Test.rakumod
+++ b/lib/Test.rakumod
@@ -773,9 +773,10 @@ sub proclaim(Bool(Mu) $cond, $desc is copy, $unescaped-prefix = '') {
         my $tester = $caller;
 
         repeat {
-            my \code := ($caller = callframe($level++)).code;
+            ($caller = callframe($level++)) or last;
+            my \code := $caller.code;
             $tester = callframe($level)  # the next one should be reported
-              if nqp::can(code,'is-test-assertion');  # must use nqp
+                if nqp::can(code,'is-test-assertion');  # must use nqp
         } until !$caller.file || $caller.file.ends-with('.nqp');
 
         # the final place we want to report from


### PR DESCRIPTION
Stop iterating frames if a `Failure` detected.

Fixes #4176 