### PR TITLE
Provide single arg semantics for @array = QuantHash

### DIFF
--- a/src/core.c/Array.pm6
+++ b/src/core.c/Array.pm6
@@ -297,6 +297,17 @@ my class Array { # declared in BOOTSTRAP
         );
         nqp::p6bindattrinvres(self,List,'$!reified',buffer)
     }
+    multi method STORE(Array:D: QuantHash:D \qh --> Array:D) {
+        qh.iterator.push-all(
+          ArrayReificationTarget.new(
+            (my \buffer = nqp::create(IterationBuffer)),
+            nqp::decont($!descriptor)
+          )
+        );
+        nqp::bindattr(self,List,'$!todo',Mu);  # exhausted
+        nqp::bindattr(self,List,'$!reified',buffer);
+        self
+    }
     multi method STORE(Array:D: Mu \item --> Array:D) {
         nqp::push(
           (my \buffer = nqp::create(IterationBuffer)),

--- a/src/core.c/Array.pm6
+++ b/src/core.c/Array.pm6
@@ -298,15 +298,14 @@ my class Array { # declared in BOOTSTRAP
         nqp::p6bindattrinvres(self,List,'$!reified',buffer)
     }
     multi method STORE(Array:D: QuantHash:D \qh --> Array:D) {
-        qh.iterator.push-all(
-          ArrayReificationTarget.new(
-            (my \buffer = nqp::create(IterationBuffer)),
-            nqp::decont($!descriptor)
-          )
-        );
+        my \buffer = nqp::create(IterationBuffer);
+        nqp::iscont(qh)
+          ?? nqp::push(buffer,nqp::p6scalarwithvalue($!descriptor,qh))
+          !! qh.iterator.push-all(
+               ArrayReificationTarget.new(buffer,nqp::decont($!descriptor))
+             );
         nqp::bindattr(self,List,'$!todo',Mu);  # exhausted
-        nqp::bindattr(self,List,'$!reified',buffer);
-        self
+        nqp::p6bindattrinvres(self,List,'$!reified',buffer)
     }
     multi method STORE(Array:D: Mu \item --> Array:D) {
         nqp::push(


### PR DESCRIPTION
Inspired by

  https://donaldh.wtf/2021/01/if-sets-would-dwim/

and the subsequent discussion at

  https://www.reddit.com/r/rakulang/comments/l5qub2/if_sets_would_dwim/

this provides an Array.STORE candidate that will handle a single QuantHash
argument with single argument semantics, just like `for` does.