### PR TITLE
Provide $*REPO with an associative interface

### DIFF
--- a/src/core.c/CompUnit/Repository.pm6
+++ b/src/core.c/CompUnit/Repository.pm6
@@ -59,7 +59,7 @@ role CompUnit::Repository {
 }
 
 multi sub postcircumfix:<{ }>(CompUnit::Repository:D \repo, Str() $key) {
-    repo.repo-chain.first(quietly *.?name eq $key)
+    repo.repo-chain.first({ quietly (.?name // .id) eq $key })
 }
 
 # vim: expandtab shiftwidth=4

--- a/src/core.c/CompUnit/Repository.pm6
+++ b/src/core.c/CompUnit/Repository.pm6
@@ -58,4 +58,8 @@ role CompUnit::Repository {
     }
 }
 
+multi sub postcircumfix:<{ }>(CompUnit::Repository:D \repo, Str() $key) {
+    repo.repo-chain.first(quietly *.?name eq $key)
+}
+
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
So that you can access your home repo with $*REPO\<home>, and the core
repo with $*REPO\<core>, etc.