### PR TITLE
Fix segfault caused by repossession of native call site

### DIFF
--- a/lib/NativeCall.rakumod
+++ b/lib/NativeCall.rakumod
@@ -275,6 +275,7 @@ our role Native[Routine $r, $libname where Str|Callable|List|IO::Path|Distributi
 
     method !setup() {
         $setup-lock.protect: {
+            nqp::neverrepossess(self);
             return if nqp::unbox_i($!call);
 
             # Make sure that C++ methods are treated as mangled (unless set otherwise)
@@ -516,6 +517,7 @@ our role Native[Routine $r, $libname where Str|Callable|List|IO::Path|Distributi
     method create-optimized-call() {
         unless $!optimized-body {
             $setup-lock.protect: {
+                nqp::neverrepossess(self);
                 unless nqp::defined(nqp::getobjsc(self)) {
                     if $*W {
                         $*W.add_object(self);
@@ -548,6 +550,7 @@ our role Native[Routine $r, $libname where Str|Callable|List|IO::Path|Distributi
                     $*W.add_object($?CLASS);
                     $*UNIT.push($optimized-body);
                     $*UNIT.push($jit-optimized-body);
+                    $fixups.push(QAST::Op.new(:op<neverrepossess>, QAST::WVal.new(:value(self))));
                     $fixups.push($*W.set_attribute(self, $?CLASS, '$!optimized-body',
                         QAST::BVal.new( :value($optimized-body) )));
                     $fixups.push($*W.set_attribute(self, $?CLASS, '$!jit-optimized-body',


### PR DESCRIPTION
We deserialize a native call site. Then we call the function which triggers the
actual setup, i.e. resolving the library name, loading the library, generating
caller code. We run the function often enough that spesh decides its worth its
time. While spesh is working however, we deserialize the module again and as
part of the repossession process clear the native call site's body. I.e.
body->entry_point becomes NULL. This causes us to compile a jump to 0.

The fix is to avoid repossession of the native call site in the first place.
Since the native call site is an attribute of the routine (via the Native role)
and attributes are flattened into the objects holding them, we have to mark the
entire routine neverrepossess.