### PR TITLE
Resurrect 'make test' on the JVM backend

### DIFF
--- a/t/05-messages/11-overflow.t
+++ b/t/05-messages/11-overflow.t
@@ -2,6 +2,8 @@ use lib <t/packages/>;
 use Test;
 use Test::Helpers;
 
+$*VM.name eq 'jvm' and plan :skip-all<These tests do not throw on JVM backend>;
+
 # This file contains tests for behaviour on overflow in various routines
 
 plan 2;

--- a/t/harness5
+++ b/t/harness5
@@ -30,11 +30,11 @@ GetOptions(
     'archive=s'         => \my $archive,
     'precompile'        => \my $precompile,
     'jvm'               => \my $jvm,
-    'js'               => \my $js,
+    'js'                => \my $js,
     'moar'              => \my $moar,
     'randomize'         => \my $randomize,
     'slow'              => \(my $slow = !$win),
-    'no-merge'             => \my $no_merge,
+    'no-merge'          => \my $no_merge,
     'help|h' => sub { pod2usage(1); },
 ) or pod2usage(2);
 
@@ -258,13 +258,13 @@ Options:
     --help / -h - display the help message.
     --tests-from-file=[filename] - get the tests from the filename.
     --fudge - fudge (?)
-    --jobs - number of jobs. Defaults to TEST_JOBS env var if specified, or 1
+    --jobs - number of jobs. Defaults to TEST_JOBS env var if specified, or 6
     --quick - do not run tests marked as long-running
     --stress - run tests marked as stress tests
     --archive=[archive] - write to an archive.
     --randomize randomize the order in which test-files are processed.
     --slow - spread tests marked "slow" equally over the run (default on non-Win)
-    --moar/--jvm/--js - mutually exclusive. Use MoarVM/JVM backend
+    --moar/--jvm/--js - mutually exclusive. Use MoarVM/JVM/JS backend
     --no-merge - pass STDERR from the tests through to the terminal's STDERR
     --precompile - precompile tests before running them
 

--- a/t/harness5
+++ b/t/harness5
@@ -29,6 +29,7 @@ GetOptions(
     'stress:1'          => \my $do_stress,
     'archive=s'         => \my $archive,
     'precompile'        => \my $precompile,
+    'evalserver'        => \my $evalserver,
     'jvm'               => \my $jvm,
     'js'                => \my $js,
     'moar'              => \my $moar,
@@ -135,7 +136,7 @@ if ($archive) {
     if $ENV{SMOLDER_SUBMITTER};
 }
 
-if ($jvm) {
+if ($jvm && $evalserver) {
     unlink("TESTTOKEN");
     $ENV{HARNESS_PERL} = "$^X .${slash}eval-client.pl TESTTOKEN run";
 
@@ -148,7 +149,7 @@ if ($jvm) {
 if (eval "require $tap_harness_class;") {
     my $run_with_perl = $precompile ? [$ENV{HARNESS_PERL}, 't/precompileandrun'] : [$ENV{HARNESS_PERL}];
     my %harness_options = (
-        exec        => $jvm ? [$^X, "./eval-client.pl", "TESTTOKEN", "run"] : $run_with_perl,
+        exec        => $jvm && $evalserver ? [$^X, "./eval-client.pl", "TESTTOKEN", "run"] : $run_with_perl,
         verbosity   => 0+$Test::Harness::verbose,
         jobs        => $jobs,
         ignore_exit => 1,
@@ -264,6 +265,7 @@ Options:
     --archive=[archive] - write to an archive.
     --randomize randomize the order in which test-files are processed.
     --slow - spread tests marked "slow" equally over the run (default on non-Win)
+    --evalserver - use EvalServer. Only has effect for JVM backend
     --moar/--jvm/--js - mutually exclusive. Use MoarVM/JVM/JS backend
     --no-merge - pass STDERR from the tests through to the terminal's STDERR
     --precompile - precompile tests before running them

--- a/tools/templates/Makefile-backend-common.in
+++ b/tools/templates/Makefile-backend-common.in
@@ -126,7 +126,7 @@
 @backend_prefix@-stresstest: @backend_prefix@-stresstest@bpm(HARNESS_TYPE)@
 
 @backend_prefix@-coretest5: @backend_prefix@-all
-	@bpm(HARNESS5)@ @nfpl(t/01-sanity t/02-rakudo t/04-nativecall t/05-messages t/06-telemetry t/07-pod-to-text t/08-performance t/09-moar t/10-qast)@
+	@bpm(HARNESS5)@ $(COMMON_TEST_DIRS) @bsm(SPECIFIC_TEST_DIRS)@
 
 # Run the spectests that we know work.
 @backend_prefix@-spectest5: @backend_prefix@-testable $(SPECTEST_DATA)

--- a/tools/templates/Makefile-common-macros.in
+++ b/tools/templates/Makefile-common-macros.in
@@ -41,6 +41,9 @@ BOOTSTRAP_SOURCES = \
 COMMON_METAMODEL_SOURCES = \
     @insert_filelist(common_metamodel_sources)@
 
+COMMON_TEST_DIRS = \
+    @insert_filelist(common_test_dirs)@
+
 NQP_CONFIG_DIR = @nfp(3rdparty/nqp-configure/lib)@
 
 CONFIGURE_SOURCES = \

--- a/tools/templates/common_test_dirs
+++ b/tools/templates/common_test_dirs
@@ -1,0 +1,8 @@
+t/01-sanity
+t/02-rakudo
+t/04-nativecall
+t/05-messages
+t/06-telemetry
+t/07-pod-to-text
+t/08-performance
+t/10-qast

--- a/tools/templates/js/Makefile.in
+++ b/tools/templates/js/Makefile.in
@@ -22,6 +22,8 @@
 	@echo(!!! Installing the js backend is not yet implemented.)@
 	$(NOECHO)exit 1
 
+@bsv(SPECIFIC_TEST_DIRS)@ = @nfp(t/11-js)@
+
 @include(Makefile-backend-common)@
 
 # files we create

--- a/tools/templates/jvm/Makefile.in
+++ b/tools/templates/jvm/Makefile.in
@@ -41,6 +41,8 @@ RUNTIME_JAR = rakudo-runtime.jar
 
 @bpv(HARNESS_TYPE)@ = 5
 
+@bsv(SPECIFIC_TEST_DIRS)@ = @nfp(t/03-jvm)@
+
 @include(Makefile-backend-common)@
 
 $(RUNTIME_JAR): $(RUNTIME_JAVAS)

--- a/tools/templates/moar/Makefile.in
+++ b/tools/templates/moar/Makefile.in
@@ -105,6 +105,8 @@ R_SETTING_MOAR = RESTRICTED.setting.moarvm
 
 @bpv(RUN_CLEAN_TARGET_FILES)@ = @nfp(@base_dir@/@bpm(RUNNER)@)@ @script(clean-target-files.raku)@ $(VERBOSE)
 
+@bsv(SPECIFIC_TEST_DIRS)@ = @nfp(t/09-moar)@
+
 @include(Makefile-backend-common)@
 
 @bpm(RAKUDO_OPS_DLL)@: @bpm(RAKUDO_OPS_DLL_SRC)@

--- a/tools/templates/moar/Makefile.in
+++ b/tools/templates/moar/Makefile.in
@@ -199,7 +199,7 @@ $(R_SETTING_MOAR): @bsm(RAKUDO)@@for_specs( @bsm(SETTING_@ucspec@)@)@ $(R_SETTIN
 @backend_prefix@-test6   : @backend_prefix@-coretest6
 
 @backend_prefix@-coretest6: @backend_prefix@-all
-	@bpm(HARNESS6)@ @nfpl(t/01-sanity t/02-rakudo t/04-nativecall t/05-messages t/06-telemetry t/07-pod-to-text t/08-performance t/09-moar t/10-qast)@
+	@bpm(HARNESS6)@ $(COMMON_TEST_DIRS) @bsm(SPECIFIC_TEST_DIRS)@
 
 # Run the spectests that we know work.
 @backend_prefix@-spectest6: @backend_prefix@-testable $(SPECTEST_DATA)


### PR DESCRIPTION
There are a lot of failing tests, but at least one *could* run 'make test' again.