### PR TITLE
Add support for whitespace-separated CLI options

### DIFF
--- a/src/Perl6/Optimizer.nqp
+++ b/src/Perl6/Optimizer.nqp
@@ -2337,8 +2337,11 @@ class Perl6::Optimizer {
       elsif self.op_eq_core($metaop, '&METAOP_REVERSE') {
         return NQPMu unless nqp::istype($metaop[0], QAST::Var)
           && nqp::elems($op) == 3;
-        return QAST::Op.new(:op<call>, :name($metaop[0].name),
-                $op[2], $op[1]).annotate_self: 'METAOP_opt_result', 1;
+        my $opt_result := QAST::Op.new(:op<call>, :name($metaop[0].name),
+          $op[2], $op[1]).annotate_self: 'METAOP_opt_result', 1;
+        if $op.named { $opt_result.named($op.named) }
+        if $op.flat { $opt_result.flat($op.flat) }
+        return self.visit_op: $opt_result;
       }
       NQPMu
     }

--- a/src/core.c/Iterator.pm6
+++ b/src/core.c/Iterator.pm6
@@ -129,12 +129,4 @@ my role PredictiveIterator does Iterator {
     method bool-only(--> Bool:D) { self.count-only.Bool }
 }
 
-# The CachedIterator role is a refinement of the PredictiveIterator role for
-# those cases where the source of the iterator is a Positional structure that
-# supports the AT-POS interface.  With such a structure, there is no need to
-# build a separate cache for the PositionalBindFailover functionality.
-my role CachedIterator does PredictiveIterator {
-    method cache(--> Positional:D) { ... }
-}
-
 # vim: expandtab shiftwidth=4

--- a/src/core.c/Main.pm6
+++ b/src/core.c/Main.pm6
@@ -113,7 +113,7 @@ my sub RUN-MAIN(&main, $mainline, :$in-as-argsfiles) {
 
                 # explicit value (option) using whitespace
                 elsif $arg ∈ @script-options && !@args[0].starts-with('-'|':') {
-                    %named.push: $arg => @args.shift
+                    %named.push: $arg => thevalue(@args.shift)
                 }
 
                 # implicit value (flag)

--- a/src/core.c/Rakudo/Iterator.pm6
+++ b/src/core.c/Rakudo/Iterator.pm6
@@ -1702,18 +1702,13 @@ class Rakudo::Iterator {
 
     # Returns a sentinel Iterator object that will never generate any value.
     # Does not take a parameter.
-    my class Empty does CachedIterator {
+    my class Empty does PredictiveIterator {
         method new() { nqp::create(self) }
         method pull-one(--> IterationEnd)  { }
         method push-all($ --> IterationEnd) { }
         method sink-all(--> IterationEnd)  { }
         method skip-one(--> 0) { }
         method skip-at-least($ --> 0) { }
-        method cache() {
-            BEGIN nqp::p6bindattrinvres(
-              nqp::create(List),List,'$!reified',nqp::create(IterationBuffer)
-            )
-        }
         method count-only(--> 0) { }
         method bool-only(--> False) { }
     }
@@ -3283,7 +3278,7 @@ class Rakudo::Iterator {
     # Return an iterator for an Array that has been completely reified
     # already.  Returns a assignable container for elements don't exist
     # before the end of the reified array.
-    my class ReifiedArrayIterator does CachedIterator {
+    my class ReifiedArrayIterator does PredictiveIterator {
         has $!reified;
         has $!descriptor;
         has int $!i;
@@ -3359,13 +3354,6 @@ class Rakudo::Iterator {
               )
             )
         }
-        method cache() is raw {
-            nqp::iseq_i($!i,-1)
-              ?? nqp::p6bindattrinvres(
-                   nqp::create(List),List,'$!reified',$!reified
-                 )
-              !! List.from-iterator(self)
-        }
         method count-only(--> Int:D) {
             nqp::elems($!reified) - $!i - nqp::islt_i($!i,nqp::elems($!reified))
         }
@@ -3378,7 +3366,7 @@ class Rakudo::Iterator {
     # Return an iterator for a List that has been completely reified
     # already.  Returns an nqp::null for elements that don't exist
     # before the end of the reified list.
-    my class ReifiedListIterator does CachedIterator {
+    my class ReifiedListIterator does PredictiveIterator {
         has $!reified;
         has int $!i;
 
@@ -3446,13 +3434,6 @@ class Rakudo::Iterator {
                 nqp::islt_i($!i,nqp::elems($!reified))
               )
             )
-        }
-        method cache() is raw {
-            nqp::iseq_i($!i,-1)
-              ?? nqp::p6bindattrinvres(
-                   nqp::create(List),List,'$!reified',$!reified
-                 )
-              !! List.from-iterator(self)
         }
         method count-only(--> Int:D) {
             nqp::elems($!reified) - $!i - nqp::islt_i($!i,nqp::elems($!reified))

--- a/src/core.c/Seq.pm6
+++ b/src/core.c/Seq.pm6
@@ -11,10 +11,6 @@ my class Seq is Cool does Iterable does Sequence {
     multi method new(Seq: Iterator:D $iter) {
         nqp::p6bindattrinvres(nqp::create(self),Seq,'$!iter',nqp::decont($iter))
     }
-    # Special handling for CachedIterators, setting the cache up immediately
-    multi method new(Seq: CachedIterator:D $iter) {
-        nqp::p6bindattrinvres(nqp::create(self),Seq,'$!list',$iter.cache)
-    }
     # This candidate exists purely for being able to EVAL a .raku
     # representation of a Seq of which the iterator has already been taken,
     multi method new(Seq:) { nqp::create(self) }

--- a/t/02-rakudo/03-corekeys-6c.t
+++ b/t/02-rakudo/03-corekeys-6c.t
@@ -501,7 +501,6 @@ my @expected = (
   Q{Broken},
   Q{Buf},
   Q{CX},
-  Q{CachedIterator},
   Q{CallFrame},
   Q{Callable},
   Q{Cancellation},

--- a/t/02-rakudo/03-corekeys-6d.t
+++ b/t/02-rakudo/03-corekeys-6d.t
@@ -501,7 +501,6 @@ my @expected = (
     Q{Broken},
     Q{Buf},
     Q{CX},
-    Q{CachedIterator},
     Q{CallFrame},
     Q{Callable},
     Q{Cancellation},

--- a/t/02-rakudo/03-corekeys-6e.t
+++ b/t/02-rakudo/03-corekeys-6e.t
@@ -503,7 +503,6 @@ my @expected = (
     Q{Broken},
     Q{Buf},
     Q{CX},
-    Q{CachedIterator},
     Q{CallFrame},
     Q{Callable},
     Q{Cancellation},

--- a/t/02-rakudo/03-corekeys.t
+++ b/t/02-rakudo/03-corekeys.t
@@ -504,7 +504,6 @@ my @allowed =
       Q{Broken},
       Q{Buf},
       Q{CX},
-      Q{CachedIterator},
       Q{CallFrame},
       Q{Callable},
       Q{Cancellation},

--- a/t/02-rakudo/04-settingkeys-6c.t
+++ b/t/02-rakudo/04-settingkeys-6c.t
@@ -501,7 +501,6 @@ my %allowed = (
     Q{Buf},
     Q{CORE-SETTING-REV},
     Q{CX},
-    Q{CachedIterator},
     Q{CallFrame},
     Q{Callable},
     Q{Cancellation},

--- a/t/02-rakudo/04-settingkeys-6e.t
+++ b/t/02-rakudo/04-settingkeys-6e.t
@@ -501,7 +501,6 @@ my %allowed = (
     Q{Buf},
     Q{CORE-SETTING-REV},
     Q{CX},
-    Q{CachedIterator},
     Q{CallFrame},
     Q{Callable},
     Q{Cancellation},

--- a/t/05-messages/02-errors.t
+++ b/t/05-messages/02-errors.t
@@ -169,17 +169,17 @@ subtest 'USAGE with subsets/where and variables with quotes' => {
     }
 
     group-of 3 => 'named params' => {
-        uhas ｢UInt :$x!｣,          '<UInt>', 'mentions subset name';
-        uhas ｢Int :$x! where 42｣,  '<Int where { ... }>',
+        uhas ｢UInt :$x!｣,          'UInt', 'mentions subset name';
+        uhas ｢Int :$x! where 42｣,  'Int where { ... }',
             'Type + where clauses shown sanely';
-        uhas ｢UInt :$x! where 42｣, '<UInt where { ... }>',
+        uhas ｢UInt :$x! where 42｣, 'UInt where { ... }',
             'subset + where clauses shown sanely';
     }
     group-of 3 => 'anon positional params' => {
         uhas ｢UInt $｣,          '<UInt>', 'mentions subset name';
-        uhas ｢Int $ where 42｣,  '<Int where { ... }>',
+        uhas ｢Int $ where 42｣,  'Int where { ... }',
             'where clauses shown sanely';
-        uhas ｢UInt $ where 42｣, '<UInt where { ... }>',
+        uhas ｢UInt $ where 42｣, 'UInt where { ... }',
             'subset + where clauses shown sanely';
     }
 


### PR DESCRIPTION
This PR resolves the exiting TODO item:
> Allow both = and space before argument of double-dash args

More specifically, before this commit, a user could pass a `foo` command that took a named `bar` values in nine ways:

    $ foo --bar=value
    $ foo -bar=value
    $ foo :bar=value
    $ foo --bar      # equivalent to --bar=True
    $ foo -bar
    $ foo :bar
    $ foo --/bar     # equivalent to --bar=False
    $ foo -/bar
    $ foo :bar

(The ways that involve using a single `-` do not work when bundling is turned on, since that would be ambiguous.)

This commit adds three more ways:

    $ foo --bar value
    $ foo -bar value
    $ foo :bar value

(Note that this does not limit space separated values to the `--bar` form.  I'd be happy to add an extra check if anyone would like it, but I didn't see a reason to do more checks to add that limit)

Supporting space-separated options raises one common difficulty.  If `foo` accepts both an option and a positional argument, then the following expression is initially ambiguous:

    $ foo --bar baz

Is that a option `:bar("baz")` and no positional argument?  Or is it `:bar(True)` and a positional argument of `"baz"`?  This PR resolves that ambiguity by treating all values after an option as values for that option _unless_ they start with a `-` or `:` or if the `--bar` is type constrained to be a `Bool` (which indicates that it isn't an option at all, but a flag.)  Thus, if `foo` has the signature

    MAIN(:$bar, Bool :$v, $pos)

It will be parsed as follows:

   $ foo --bar baz     # $bar = "baz"
   $ foo --bar -v baz  # $bar = True;  $v = True; $pos = "baz"

If a user wants to pass a positional argument after an option, they can use `--` to end parsing of non-positional arguments (which was supported prior to this PR).

I looked over the current tests and did not see anywhere that looked like it should include a test for this functionality.  But if anyone would like me to include a test, I'd be happy to do so – just point me in the right direction!

If this PR generally looks good, I'll plan to submit another addressing the CSV TODO in the same file.  Between addressing those two TODOs and #4113, Raku is adding in the last few pieces in its CLI story!