### PR TITLE
Add multilevel list output for Pod::To::Text

### DIFF
--- a/lib/Pod/To/Text.rakumod
+++ b/lib/Pod/To/Text.rakumod
@@ -18,7 +18,7 @@ sub pod2text($pod) is export {
         when Pod::Block::Para       { twrap( $pod.contents.map({pod2text($_)}).join("") ) }
         when Pod::Block::Table      { table2text($pod)               }
         when Pod::Block::Declarator { declarator2text($pod)          }
-        when Pod::Item              { item2text($pod).indent(2)      }
+        when Pod::Item              { item2text($pod)                }
         when Pod::Defn              { pod2text($pod.contents[0]) ~ "\n"
                                       ~ pod2text($pod.contents[1..*-1]) }
 
@@ -43,7 +43,7 @@ sub code2text($pod) {
 }
 
 sub item2text($pod) {
-    '* ' ~ pod2text($pod.contents).chomp.chomp
+    ('* ' ~ pod2text($pod.contents).chomp.chomp).indent(2 * $pod.level)
 }
 
 sub named2text($pod) {


### PR DESCRIPTION
Improves the output of Pod::To::Text by adding indentation for pod6 items based on their level.

For example, given the following script:

```
use Pod::To::Text;

=begin pod
=item item
=item2 item2
=item3 item3
=item item
=item2 item2
=end pod

say pod2text($=pod);
```

The current output would be:

```
  * item

  * item2

  * item3

  * item

  * item2
```

After this modification, the output is:

```
  * item

    * item2

      * item3

  * item

    * item2
```