### PR TITLE
Fix deleting colonpair with R-metaop in value by the Optimizer

### DIFF
--- a/src/Perl6/Optimizer.nqp
+++ b/src/Perl6/Optimizer.nqp
@@ -2337,8 +2337,11 @@ class Perl6::Optimizer {
       elsif self.op_eq_core($metaop, '&METAOP_REVERSE') {
         return NQPMu unless nqp::istype($metaop[0], QAST::Var)
           && nqp::elems($op) == 3;
-        return QAST::Op.new(:op<call>, :name($metaop[0].name),
-                $op[2], $op[1]).annotate_self: 'METAOP_opt_result', 1;
+        my $opt_result := QAST::Op.new(:op<call>, :name($metaop[0].name),
+          $op[2], $op[1]).annotate_self: 'METAOP_opt_result', 1;
+        if $op.named { $opt_result.named($op.named) }
+        if $op.flat { $opt_result.flat($op.flat) }
+        return self.visit_op: $opt_result;
       }
       NQPMu
     }


### PR DESCRIPTION
Optimizer was replacing the call op with METAOP_REVERSE metaop
to the METAOP_REVERSE call only. If the original op had named
parameter then it was lost. After such optimization a colon pair
become only the value.

Issue: #1632 
Tests: [#715](https://github.com/Raku/roast/pull/715)