### PR TITLE
Implement space-delimited CLI arguments (S06; S19)

### DIFF
--- a/src/core.c/Main.pm6
+++ b/src/core.c/Main.pm6
@@ -1,6 +1,5 @@
 # TODO:
 # * Command-line parsing
-#   * Allow both = and space before argument of double-dash args
 #   * Comma-separated list values
 #   * Allow exact Raku forms, quoted away from shell
 # * Fix remaining XXXX
@@ -44,7 +43,7 @@ my sub RUN-MAIN(&main, $mainline, :$in-as-argsfiles) {
     }
 
     # Convert raw command line args into positional and named args for MAIN
-    sub default-args-to-capture($, @args is copy --> Capture:D) {
+    sub default-args-to-capture(&main, @args is copy --> Capture:D) {
         my $no-named-after = nqp::isfalse(%sub-main-opts<named-anywhere>);
         my $bundling = nqp::istrue(%sub-main-opts<bundling>);
 
@@ -78,53 +77,78 @@ my sub RUN-MAIN(&main, $mainline, :$in-as-argsfiles) {
               !! coercer(a)
         }
 
+        my %options-with-req-arg = Hash.new;
+        for &main.candidates {
+            for .signature.params -> $param {
+                if !$param.named { next }
+                for $param.named_names -> str $name {
+                    my int $accepts-true = $param.type.ACCEPTS: True;
+                    for $param.constraint_list { $accepts-true++ if .ACCEPTS: True}
+                    if !$accepts-true { %options-with-req-arg.push($name => True) }
+                }
+            }
+        }
         while @args {
             my str $passed-value = @args.shift;
 
-            # rest considered to be non-parsed
-            if nqp::iseq_s($passed-value,'--') {
+            if nqp::iseq_s($passed-value,'--') { # -- marks rest as positional
                 nqp::push($positional, thevalue($_)) for @args;
                 last;
             }
 
-            # no longer accepting nameds
-            elsif $no-named-after && nqp::isgt_i(nqp::elems($positional),0) {
+            if ($no-named-after && nqp::isgt_i(nqp::elems($positional),0)) {
                 nqp::push($positional, thevalue($passed-value));
+                nqp::push($positional, thevalue($_)) for @args;
+                last;
             }
 
-            # named
-            elsif $passed-value
-              ~~ /^ ( '--' | '-' | ':' ) ('/'?) (<-[0..9\.]> .*) $/ {  # 'hlfix
-                my str $arg = $2.Str;
-                my $split  := nqp::split("=",$arg);
-
-                # explicit value
-                if nqp::isgt_i(nqp::elems($split),1) {
-                    my str $name = nqp::shift($split);
-                    die "Can't combine bundling with explicit arguments" if $bundling && nqp::iseq_s($0.Str, '-') && $name.chars > 1;
-                    %named.push: $name => $1.chars
-                      ?? thevalue(nqp::join("=",$split)) but False
-                      !! thevalue(nqp::join("=",$split));
+            my str $optstring;
+            my int $negated   = 0;
+            my int $short-opt = 0;
+            # long option
+            if nqp::eqat($passed-value, '--', 0) {
+                if nqp::eqat($passed-value, '/', 2) {
+                    $optstring = nqp::substr($passed-value, 3);
+                    $negated = 1;
                 }
-
-                # implicit value
-                else {
-                    if $bundling && nqp::iseq_s($0.Str, '-') {
-                        die "Can't combine bundling with explicit negation" if $1.chars && $arg.chars > 1;
-                        my @chars = nqp::split('',$arg);
-                        for @chars -> $char {
-                            %named.push: $char => !($1.chars);
-                        }
-                    }
-                    else {
-                        %named.push: $arg => !($1.chars);
-                    }
-                }
+                else { $optstring = nqp::substr($passed-value, 2) }
             }
-
+            # short option
+            elsif nqp::eqat($passed-value, '-', 0) || nqp::eqat($passed-value, ':', 0) {
+                $short-opt = 1;
+                if nqp::eqat($passed-value, '/', 1) {
+                    $optstring = nqp::substr($passed-value, 2);
+                    $negated = 1;
+                }
+                else { $optstring = nqp::substr($passed-value, 1) }
+            }
             # positional
             else {
                 nqp::push($positional, thevalue($passed-value));
+                next;
+            }
+
+
+            my $split  := nqp::split("=",$optstring);
+            $optstring = nqp::shift($split);
+            my str $arg = nqp::join('=', $split);
+            if $bundling && $short-opt && nqp::isgt_i(nqp::chars($optstring), 1) {
+                die "Can't combine bundling with explicit negation"  if $negated;
+                die "Can't combine bundling with explicit arguments" if nqp::elems($split);
+                my int $cursor = 1;
+                my str $short-opt = nqp::substr($optstring, 0, 1);
+                while $short-opt {
+                    %named.push: $short-opt => True;
+                    $short-opt = nqp::substr($optstring, $cursor++, 1);
+                }
+            }
+            else  {
+                if nqp::existskey(%options-with-req-arg, $optstring) {
+                    if !$arg { $arg = @args.shift // '' }
+                    %named.push: $optstring => ($negated ?? thevalue($arg) but False !! thevalue($arg));
+                }
+                elsif !nqp::elems($split) { %named.push: $optstring => ($negated ?? False !! True) }
+                else { %named.push: $optstring => $negated ?? thevalue $arg but False !! thevalue $arg }
             }
         }
         Capture.new( list => $positional.List, hash => %named )
@@ -238,9 +262,11 @@ my sub RUN-MAIN(&main, $mainline, :$in-as-argsfiles) {
 
                         }
                         elsif $type !=== Bool {
-                            $argument ~= "=<{
-                                $constraints || $type.^name
-                            }>";
+
+                            my int $accepts-true = $param.type.ACCEPTS: True;
+                            for $param.constraint_list { $accepts-true++ if .ACCEPTS: True}
+                            $argument ~= ($accepts-true ?? "[={$constraints || $type.^name}]"
+                                                        !! "=<{$constraints || $type.^name}>");
                             if Metamodel::EnumHOW.ACCEPTS($type.HOW) {
                                 my $options = $type.^enum_values.keys.sort.Str;
                                 $argument ~= $options.chars > 50
@@ -269,7 +295,7 @@ my sub RUN-MAIN(&main, $mainline, :$in-as-argsfiles) {
                     $argument  = "[$argument]"     if $param.optional;
                     if $total-constraints
                     && $literals-as-constraint == $total-constraints {
-                        $argument .= trans(["'"] => [q|'"'"'|])
+                        $argument .= trans(["'"] => [q|'"'"'|]) # "hlfix
                             if $argument.contains("'");
                         $argument  = "'$argument'"
                             if $argument.contains(' ' | '"');

--- a/t/05-messages/02-errors.t
+++ b/t/05-messages/02-errors.t
@@ -187,7 +187,10 @@ subtest 'USAGE with subsets/where and variables with quotes' => {
         'variable name does not get special quote treatment';
 }
 
-subtest ':bundling and negation/explicit arguments' => {
+if $*DISTRO.is-win {
+    skip ｢is-run() routine doesn't quite work right on Windows｣;
+}
+else { subtest ':bundling and negation/explicit arguments'=> {
     plan 6;
 
     my $allows-bundling = q:to/EOF/;
@@ -207,7 +210,8 @@ subtest ':bundling and negation/explicit arguments' => {
         'cannot combine bundling with negation';
     is-run $allows-bundling, :exitcode(0), :args<-/a bar>,
         'can negate single option, even with bundling enabled';
-}
+}}
+
 
 # https://github.com/Raku/old-issue-tracker/issues/5282
 {

--- a/t/05-messages/02-errors.t
+++ b/t/05-messages/02-errors.t
@@ -2,7 +2,7 @@ use lib <t/packages/>;
 use Test;
 use Test::Helpers;
 
-plan 47;
+plan 48;
 
 # https://github.com/Raku/old-issue-tracker/issues/6613
 
@@ -169,22 +169,44 @@ subtest 'USAGE with subsets/where and variables with quotes' => {
     }
 
     group-of 3 => 'named params' => {
-        uhas ｢UInt :$x!｣,          '<UInt>', 'mentions subset name';
-        uhas ｢Int :$x! where 42｣,  '<Int where { ... }>',
+        uhas ｢UInt :$x!｣,          'UInt', 'mentions subset name';
+        uhas ｢Int :$x! where 42｣,  'Int where { ... }',
             'Type + where clauses shown sanely';
-        uhas ｢UInt :$x! where 42｣, '<UInt where { ... }>',
+        uhas ｢UInt :$x! where 42｣, 'UInt where { ... }',
             'subset + where clauses shown sanely';
     }
     group-of 3 => 'anon positional params' => {
         uhas ｢UInt $｣,          '<UInt>', 'mentions subset name';
-        uhas ｢Int $ where 42｣,  '<Int where { ... }>',
+        uhas ｢Int $ where 42｣,  'Int where { ... }',
             'where clauses shown sanely';
-        uhas ｢UInt $ where 42｣, '<UInt where { ... }>',
+        uhas ｢UInt $ where 42｣, 'UInt where { ... }',
             'subset + where clauses shown sanely';
     }
 
     uhas ｢$don't｣, ｢<don't>｣,
         'variable name does not get special quote treatment';
+}
+
+subtest ':bundling and negation/explicit arguments' => {
+    plan 6;
+
+    my $allows-bundling = q:to/EOF/;
+        my %*SUB-MAIN-OPTS = :bundling;
+        sub MAIN($pos, :$a, :$b, :$c) {}
+    EOF
+
+    is-run $allows-bundling, :err{.contains: 'combine bundling'}, :exitcode(1), :args<-abc=foo bar>,
+        'cannot combine bundling with explicit arguments';
+    is-run $allows-bundling, :err{.contains: 'combine bundling'}, :exitcode(1), :args<-abc='' bar>,
+        'cannot combine bundling with explicit arguments, even the empty string';
+    is-run $allows-bundling, :err{.contains: 'combine bundling'}, :exitcode(1), :args<-abc= bar>,
+        'cannot combine bundling with explicit arguments, even a nil argument';
+    is-run $allows-bundling, :exitcode(0), :args<-a=foo bar>,
+        'can pass explicit argument to a single option, even with bundling enabled';
+    is-run $allows-bundling, :err{.contains: 'combine bundling'}, :exitcode(1), :args<-/abc bar>,
+        'cannot combine bundling with negation';
+    is-run $allows-bundling, :exitcode(0), :args<-/a bar>,
+        'can negate single option, even with bundling enabled';
 }
 
 # https://github.com/Raku/old-issue-tracker/issues/5282


### PR DESCRIPTION
This PR is a slightly revised version of #4201 with a cleaner diff; the companion spectests are at  Raku/roast/pull/716.  The previous commit message is below.

---

This commit resolves the exiting TODO item:
> Allow both = and space before argument of double-dash args

and thereby implements missing functionality described in S06 and S19.

Specifically, this commit adds an additional feature to the command-line programs Raku generates: users may now pass arguments to options separated by whitespace.  That is, if a program takes a `--port` option, users can now call it with `--port 4242` in addition to with `--port=4242`.  This behavior is specified in S06 and S19; it also makes the syntax for invoking Raku CLIs more similar to standard Linux utilities.

This feature was previously discussed in 2011, but was not implemented because no resolution could be found to two issues.  First, whitespace delimited arguments can be ambiguous: does `--profile foo` pass `foo` as an argument to `--profile` or as a positional argument to the program?  (One potential solution to this ambiguity is to inspect whether `foo` starts with `-`.  But this can create hard-to-debug issues for unusual `foo`s and is generally not reliable enough for use in scripts.) Second, is there a way to pass multiple arguments to a single option that allows users to use shell globing?  That is, can a call like `--input-files *.jpg` be made to DWIM?

This commit resolves these issues in a way that is inspired by getopt(1) and thus should be familiar to Linux users.  It also avoids making any changes that would be incompatible with existing Raku CLIs. Before discussing the details, here is an example.  Consider a `demo` program with the following source:

    subset name of Any where Str|True;
    subset port of Str;
    multi MAIN(
        $file,
        name :$profile,    #= Write profile information to a file
        port :$debug-port, #= Listen for debugger connections on the specified port
        Bool :v($verbose), #= Display verbose output

    ) {}
    multi MAIN("--process-files", *@images) {}

This program generates the following usage message:

    Usage:
      demo [--profile[=name]] [--debug-port=<port>] [-v] <file>
      demo --process-files [<images> ...]

        --profile[=name]       Write profile information to a file
        --debug-port=<port>    Listen for debugger connections on the specified port
        -v                     Display verbose output

The following are valid ways to call `demo`:

    demo --profile ~/foo
    demo --profile=/tmp/bar ~/foo
    demo --debug-port 4242 ~/foo
    demo --debug-port=4242 ~/foo
    demo -v ~/foo
    demo --process-files *.jpg

These, however, are not valid

    demo --profile /tmp/bar ~/foo
    demo --debug-port ~/foo

The first is invalid because `/tmp/bar` and `~/foo` are both parsed as positional arguments, which means `demo` was called with too many positional arguments.  The second is invalid because `~/foo` is parsed as an argument to `--debug-port`, and thus `demo` lacks the required positional argument.

Here's how it works:

Raku now distinguishes between three types of options:

 * Boolean options (like `-v`), which _never_ take an argument; they
   are ether present or absent.
 * Options with a mandatory argument (like `--debug-port`), which
   always take an argument.  If you give them an argument with `=`,
   they will use that; if not, they'll take the following argument.
 * Options with an optional argument (like `--profile`), which are
   valid both with and without an argument.  You can _only_ give these
   arguments an option with the `=` syntax; if there is a space after
   the option, that means it was called without an argument.

And here's the signature that produces each type of argument:

 * Boolean options: A `Bool` type constraint.
 * Options with a mandatory argument: A type that does not `.ACCEPT` a
   `Bool`
 * Options with an optional argument: A type that `.ACCEPTS` a
   `True` (because passing an option without an argument is equivalent
   to passing `True`)

This fully resolves the ambiguity discussed above in a way that should feel fairly intuitive to most users (despite how long
explaining it takes!) because it basically boils down to "space separated arguments are fine, unless you don't need to specify a
value; then you've got to use =".  This is the same solution employed by getopt(1) and should be familiar from standard utilities like `ls` and `cp`.

However, distinguishing between options with mandatory/required arguments introduces one potential trap into the language: Types from which `Bool`s inherit will produce an argument that takes an optional argument.  This group includes some numeric types, which may trip up some users.  Thus `sub MAIN(Int :$debug-port)` requires `--debug-port` to be called with `=` (or get a default value of 1), which may surprise some users.  After this feature is added, I will update the documentation to clearly note this issue.

The code in this commit takes an additional step to mitigate this footgun: it modifies the usage message to indicate which option arguments are optional by marking them with `[...]` (as was already done for optional positional arguments).

Finally, the desire to allow multiple arguments to be passed to a single option can be accommodated using the subcommand syntax, as shown in the `--process-files` example above.

Because argument parsing is so often used in interactive CLI programs, it is important that it be as fast as possible and I have written this commit perform as well as possible.  As a result I believe that, despite the increased functionality, the revised code runs ~1ms faster (out of ~6ms previously spent parsing arguments).  This decrease, however, is within the margin of error reported by my benchmarking tool and reflects only one machine.

I have prepared a companion commit that adds 10 tests to Roast (and removes 5 tests marked `todo`) that test this functionality.  Additionally, I have ensured that this test does not break bundling of short flags (a feature that is not specified/tested in Roast but that Raku supports) and have added tests to verify that compatibility.