### PR TITLE
Fix memory leak in runner

### DIFF
--- a/src/vm/moar/runner/main.c
+++ b/src/vm/moar/runner/main.c
@@ -494,6 +494,9 @@ int main(int argc, char *argv[]) {
     free(exec_dir_path_temp);
 #ifndef STATIC_RAKUDO_HOME
     free(rakudo_home);
+#else
+    if (getenv("PERL6_HOME") || getenv("RAKUDO_HOME"))
+        free(rakudo_home);
 #endif
 #ifndef STATIC_NQP_HOME
     free(nqp_home);


### PR DESCRIPTION
If the `(PERL6|RAKUDO)_HOME` env var is set, `rakudo_home` is
malloced, but wasn't being freed.

For `RAKUDO_HOME=/home/dan/Source/perl6/install/share/perl6 valgrind --leak-check=full ./install/bin/raku --full-cleanup -e ''`
Before:
```
==677926== 43 bytes in 1 blocks are definitely lost in loss record 1 of 6
==677926==    at 0x483E77F: malloc (vg_replace_malloc.c:307)
==677926==    by 0x109B7D: retrieve_home (main.c:130)
==677926==    by 0x109901: main (main.c:406)
<...>
==677926== LEAK SUMMARY:
==677926==    definitely lost: 43 bytes in 1 blocks
```
After:
```
==681207== LEAK SUMMARY:
==681207==    definitely lost: 0 bytes in 0 blocks
```