### PR TITLE
Optimize param typecheck

### DIFF
--- a/src/Perl6/Metamodel/CoercionHOW.nqp
+++ b/src/Perl6/Metamodel/CoercionHOW.nqp
@@ -105,13 +105,11 @@ class Perl6::Metamodel::CoercionHOW
         if $coercion_type =:= $checkee {
             return 1;
         }
-        my $rc := $!target_type.HOW.type_check($!target_type, $checkee);
-        $rc
+        $!target_type.HOW.type_check($!target_type, $checkee);
     }
 
     method accepts_type($coercion_type, $checkee) {
-        my $rc := nqp::istype($checkee, $!target_type) || nqp::istype($checkee, $!constraint_type);
-        $rc
+        nqp::istype($checkee, $!target_type) || nqp::istype($checkee, $!constraint_type);
     }
 
     # Coercion protocol method.


### PR DESCRIPTION
Constraints are rather easy to typecheck against. It is sufficient to typecheck against coercion target and constraint types. They can, in turn, be other nominalizables with complex typechecking. But at least one level of invocation can be eliminated. The optimization makes loop in the following example to run 8x to 9x faster:

```raku
        sub foo(Bool() $v) { !$v }
        for ^10_000_000 { my $r = foo(False); }
```