### PR TITLE
Update broken IRC log links

### DIFF
--- a/lib/Test.rakumod
+++ b/lib/Test.rakumod
@@ -591,7 +591,7 @@ multi sub eval-lives-ok(Str $code, $reason = '') is export {
 # tests as well. So... for the foreseeable future we decided to leave it
 # as is. If a user really wants to ensure Seq comparison, there's always
 # `cmp-ok` with `eqv` op.
-# https://irclog.perlgeek.de/perl6-dev/2017-05-04#i_14532363
+# https://colabti.org/irclogger/irclogger_log/perl6-dev?date=2017-05-04#l100
 ######################################################################
 multi sub is-deeply(Seq:D $got, Seq:D $expected, $reason = '') is export {
     is-deeply $got.cache, $expected.cache, $reason;

--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -4580,7 +4580,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
             # If the sub is in the form of something:<blah>, then we assume
             # the user is trying to define a custom op for an unknown category
             # We also reserve something:sym<blah> form for future use
-            # (see https://irclog.perlgeek.de/perl6/2017-01-25#i_13988093)
+            # (see https://colabti.org/irclogger/irclogger_log/perl6?date=2017-01-25#l1011)
             # If it's neither of those cases, then it's just a sub with an
             # extended name like sub foo:bar<baz> {}; let the user use it.
             self.typed_panic(

--- a/src/Perl6/Optimizer.nqp
+++ b/src/Perl6/Optimizer.nqp
@@ -2296,7 +2296,7 @@ class Perl6::Optimizer {
             elsif $is-reverse {
               # We end up with two calls of the op if var is not definite.
               # This is by design:
-              # https://irclog.perlgeek.de/perl6-dev/2018-01-12#i_15681388
+              # https://colabti.org/irclogger/irclogger_log/perl6-dev?date=2018-01-12#l208
               $op.push:
               QAST::Op.new: :op<call>, :name($metaop[0][0].name),
                 $operand,
@@ -2308,7 +2308,7 @@ class Perl6::Optimizer {
             else {
               # We end up with two calls of the op if var is not definite.
               # This is by design:
-              # https://irclog.perlgeek.de/perl6-dev/2018-01-12#i_15681388
+              # https://colabti.org/irclogger/irclogger_log/perl6-dev?date=2018-01-12#l208
               $op.push:
               QAST::Op.new: :op<call>, :name($metaop[0].name),
                 QAST::Op.new(:op<if>,

--- a/src/core.c/Buf.pm6
+++ b/src/core.c/Buf.pm6
@@ -21,7 +21,7 @@ my role Blob[::T = uint8] does Positional[T] does Stringy is repr('VMArray') is 
     # other then *8 not supported yet
     my int $bpe = try {
 #?if jvm
-        # https://irclog.perlgeek.de/perl6-dev/2017-01-20#i_13961377
+        # https://colabti.org/irclogger/irclogger_log/perl6-dev?date=2017-01-20#l202
         CATCH { default { Nil } }
 #?endif
         (T.^nativesize / 8).Int

--- a/src/core.c/Encoding/Decoder/Builtin.pm6
+++ b/src/core.c/Encoding/Decoder/Builtin.pm6
@@ -82,7 +82,7 @@ augment class Rakudo::Internals {
                     # anyway, we'll not worry about this case for now.
                     #
                     # --- or at least that was the the idea before we fixed
-                    # that bug: https://irclog.perlgeek.de/perl6/2016-12-07#i_13698178
+                    # that bug: https://colabti.org/irclogger/irclogger_log/perl6?date=2016-12-07#l1192
                     # and tried removing the `with` in 58cdfd8, but then the error
                     # `No such method 'consume-all-chars' for invocant of type 'Any`
                     # started popping up on Proc::Async tests, so...

--- a/src/core.c/Exception.pm6
+++ b/src/core.c/Exception.pm6
@@ -2149,7 +2149,7 @@ my class X::Package::Stubbed does X::Comp {
 
     # The unnamed named param is here so this candidate, rather than
     # the one from X::Comp is used. (is it a bug that this is needed?
-    # No idea: https://irclog.perlgeek.de/perl6-dev/2017-09-14#i_15164569 )
+    # No idea: https://colabti.org/irclogger/irclogger_log/perl6-dev?date=2017-09-14#l405
     multi method gist(::?CLASS:D: :$) {
         $.message;
     }

--- a/src/core.c/IO/Spec/Win32.pm6
+++ b/src/core.c/IO/Spec/Win32.pm6
@@ -57,7 +57,7 @@ my class IO::Spec::Win32 is IO::Spec::Unix {
         nqp::while(
           nqp::elems($parts),
           # unsure why old code removed all `"`, but keeping code same
-          # https://irclog.perlgeek.de/perl6-dev/2017-05-15#i_14585448
+          # https://colabti.org/irclogger/irclogger_log/perl6-dev?date=2017-05-15#l240
           nqp::if(
             ($_ := nqp::join('',nqp::split('"',nqp::shift($parts)))),
             nqp::push($buffer,$_)

--- a/t/02-rakudo/08-inline-native-arith.t
+++ b/t/02-rakudo/08-inline-native-arith.t
@@ -8,14 +8,12 @@ my $p = run($*EXECUTABLE, '--target=optimize',
 like $p.out.slurp(:close), /mul_i/,
     '$i * 2 inlines to mul_i when $i is declared as int';
 
-{ # https://irclog.perlgeek.de/perl6-dev/2018-04-21#i_16073519
-  # https://irclog.perlgeek.de/perl6-dev/2018-04-21#i_16074725
-  # https://irclog.perlgeek.de/perl6-dev/2018-04-21#i_16075097
+{ # https://colabti.org/irclogger/irclogger_log/perl6-dev?date=2018-04-21#l216
     ok nqp::p6trialbind(:($?, $?, *%), nqp::list(Int, int), nqp::list(33, 1)),
         'can trialbiand to a sig with slurpy named param';
 }
 
-{ # https://irclog.perlgeek.de/perl6-dev/2018-04-21#i_16075429
+{ # https://colabti.org/irclogger/irclogger_log/perl6-dev?date=2018-04-21#l366
     nok nqp::p6trialbind(:(| where *.so), nqp::list(), nqp::list()),
         'trial bind notices `where` in the capture';
     nok nqp::p6trialbind(:(*% where *.so), nqp::list(), nqp::list()),

--- a/t/02-rakudo/99-misc.t
+++ b/t/02-rakudo/99-misc.t
@@ -68,7 +68,7 @@ eval-lives-ok ｢
 # https://github.com/rakudo/rakudo/issues/1315
 # https://github.com/rakudo/rakudo/issues/1477
 # The non-optimizing custom stuff might not be spec material:
-# https://irclog.perlgeek.de/perl6-dev/2018-02-07#i_15786958
+# https://colabti.org/irclogger/irclogger_log/perl6-dev?date=2018-02-07#l44
 # and with extra comments on https://github.com/rakudo/rakudo/issues/1477#issuecomment-363644261
 subtest 'postfix-to-prefix-inc-dec opt does not rewrite custom ops' => {
     plan 5;

--- a/t/05-messages/01-errors.t
+++ b/t/05-messages/01-errors.t
@@ -48,12 +48,12 @@ subtest 'chr with large codepoints throws useful error' => {
     }
 }
 
-# https://irclog.perlgeek.de/perl6/2017-03-14#i_14263417
+# https://colabti.org/irclogger/irclogger_log/perl6?date=2017-03-14#l1018
 throws-like ｢m: my @a = for 1..3 <-> { $_ }｣, Exception,
     :message(/«'do for'»/),
     '<-> does not prevent an error suggesting to use `do for`';
 
-# https://irclog.perlgeek.de/perl6-dev/2017-04-13#i_14425133
+# https://colabti.org/irclogger/irclogger_log/perl6-dev?date=2017-04-14#l101
 # https://github.com/Raku/old-issue-tracker/issues/2262
 {
     my $param = '$bar';
@@ -180,7 +180,7 @@ subtest 'non-ASCII digits > 7 in leading-zero-octal warning' => {
         'wrong arity in a signature mentions the name of the method';
 }
 
-{ # https://irclog.perlgeek.de/perl6-dev/2017-05-31#i_14666102
+{ # https://colabti.org/irclogger/irclogger_log/perl6-dev?date=2017-05-31#l169
     throws-like '42.length      ', Exception, '.length on non-List Cool',
         :message{ .contains: <chars codes>.all & none <elems graphs> };
 


### PR DESCRIPTION
irclog.perlgeek.de is no longer online, so I've updated all links to point to colabti.org/irclogger.

Because the perlgeek logs identified individual messages with an auto-incrementing key rather than a line number or timestamp, I had to guess at the exact line.

I did not update files in `doc/archive`, on the theory that archived files should keep their original content.

Closes #4165 