### PR TITLE
Add a predicated wait for Lock::ConditionVariable

### DIFF
--- a/src/core.c/Awaiter.pm6
+++ b/src/core.c/Awaiter.pm6
@@ -92,13 +92,8 @@ my class Awaiter::Blocking does Awaiter {
                 });
             }
 
-            # Block until remaining is 0 (need the loop to cope with suprious
-            # wakeups).
-            loop {
-                $l.protect: {
-                    last if $remaining == 0;
-                    $ready.wait;
-                }
+            $l.protect: {
+                $ready.wait: { $remaining == 0 }
             }
 
             # If we got an exception, throw it.

--- a/src/core.c/Lock.pm6
+++ b/src/core.c/Lock.pm6
@@ -9,7 +9,9 @@ my class Lock {
         method new() {
             X::Lock::ConditionVariable::New.new.throw
         }
-        method wait() { nqp::condwait(self) }
+        proto method wait(|) {*}
+        multi method wait(--> Nil) { nqp::condwait(self) }
+        multi method wait(&predicate --> Nil) { nqp::condwait(self) until predicate; }
         method signal() { nqp::condsignalone(self) }
         method signal_all() { nqp::condsignalall(self) }
     }

--- a/src/core.c/Promise.pm6
+++ b/src/core.c/Promise.pm6
@@ -155,14 +155,10 @@ my class Promise does Awaitable {
     method result(Promise:D:) {
         # One important missing optimization here is that if the promise is
         # not yet started, then the work can be done immediately by the
-        # thing that is blocking on it. (Note the while loop is there to cope
-        # with spurious wake-ups).
-        while $!status == Planned {
-            $!lock.protect({
-                # Re-check planned to avoid data race.
-                $!cond.wait() if $!status == Planned;
-            });
-        }
+        # thing that is blocking on it.
+        $!lock.protect: {
+            $!cond.wait: { $!status != Planned }
+        };
         if $!status == Kept {
             $!result
         }


### PR DESCRIPTION
## The Problem
Currently, the `wait` method of `Lock::ConditionVariable` follows the paradigm of the C functions. I would suggest adding a more rakuish variant that takes a predicate. Much like the `protect` method in`Lock`, this makes it much easier to do the correct thing (and people will do things incorrectly if the easiest way is not also the correct way). So I propose adding this:

```
multi method wait(&predicate) {
    self.wait until predicate;
}
```

To take an example from `Awaiter`, instead of writing:
```
loop {
    $l.protect: {
        last if $remaining == 0;
        $ready.wait;
    }
}
```
One could now write
```
$l.protect: {
    $ready.wait: { $remaining == 0 }
}
```