### PR TITLE
Remove utf32 from encodings lists for MoarVM

### DIFF
--- a/src/core.c/Encoding/Registry.pm6
+++ b/src/core.c/Encoding/Registry.pm6
@@ -15,7 +15,9 @@ my class Encoding::Registry {
           nqp::list('utf16',   'utf-16'),
           nqp::list('utf16le', 'utf-16le', 'utf16-le', 'utf-16-le'),
           nqp::list('utf16be', 'utf-16be', 'utf16-be', 'utf-16-be'),
+#?if !moar
           nqp::list('utf32',   'utf-32'),
+#?endif
           nqp::list('ascii'),
           nqp::list('iso-8859-1','iso_8859-1:1987','iso_8859-1','iso-ir-100',
             'latin1','latin-1','csisolatin1','l1','ibm819','cp819'),

--- a/src/core.c/Rakudo/Internals.pm6
+++ b/src/core.c/Rakudo/Internals.pm6
@@ -311,9 +311,11 @@ my class Rakudo::Internals {
       'utf-16be',        'utf16be',
       'utf16-be',        'utf16be',
       'utf-16-be',       'utf16be',
+#?if !moar
       # utf32
       'utf32',           'utf32',
       'utf-32',          'utf32',
+#?endif
       # ascii
       'ascii',           'ascii',
       # iso-8859-1 according to http://de.wikipedia.org/wiki/ISO-8859-1


### PR DESCRIPTION
Rakudo currently lists utf32 as one of the encoding/decoding operations it supports.  However, this support has never been added to the MoarVM backend and attempting to use it throws a somewhat confusing exception.

Accordingly, this commit removes utf32 from relevant lists in Rakudo::Internals and Encoding::Registry when Rakudo is compiled for MoarVM (the JVM backend supports utf32).  This causes spectest failures because Roast was checking whether an encoding was listed in the Encoding::Registry without testing whether the encoding could actually be used.

I have prepared a companion PR that marks these tests as todo for rakudo.moar and that adds substests to ensure that registered encodings can actually be used.

Related issues: #3293 and  MoarVM/MoarVM#1348