### PR TITLE
Make .keys/values/kv/pairs/antipairs/invert work on Enums

### DIFF
--- a/src/core.c/Any.pm6
+++ b/src/core.c/Any.pm6
@@ -92,39 +92,39 @@ my class Any { # declared in BOOTSTRAP
     multi method end(Any:D:) { self.list.end }
 
     proto method keys(|) is nodal {*}
-    multi method keys(Any:U:) {
-        nqp::istype(self.HOW,Metamodel::EnumHOW) ?? self.enums.keys !! ()
-    }
+    multi method keys(Enumeration:) { self.enums.keys }
+    multi method keys(Bool:)        { self.enums.keys }
+    multi method keys(Any:U:) { () }
     multi method keys(Any:D:) { self.list.keys }
 
     proto method kv(|) is nodal {*}
-    multi method kv(Any:U:) {
-        nqp::istype(self.HOW,Metamodel::EnumHOW) ?? self.enums.kv !! ()
-    }
+    multi method kv(Enumeration:) { self.enums.kv }
+    multi method kv(Bool:)        { self.enums.kv }
+    multi method kv(Any:U:) { () }
     multi method kv(Any:D:) { self.list.kv }
 
     proto method values(|) is nodal {*}
-    multi method values(Any:U:) {
-        nqp::istype(self.HOW,Metamodel::EnumHOW) ?? self.enums.values !! ()
-    }
+    multi method values(Enumeration:) { self.enums.values }
+    multi method values(Bool:)        { self.enums.values }
+    multi method values(Any:U:) { () }
     multi method values(Any:D:) { self.list }
 
     proto method pairs(|) is nodal {*}
-    multi method pairs(Any:U:) {
-        nqp::istype(self.HOW,Metamodel::EnumHOW) ?? self.enums.pairs !! ()
-    }
+    multi method pairs(Enumeration:) { self.enums.pairs }
+    multi method pairs(Bool:)        { self.enums.pairs }
+    multi method pairs(Any:U:) { () }
     multi method pairs(Any:D:) { self.list.pairs }
 
     proto method antipairs(|) is nodal {*}
-    multi method antipairs(Any:U:) {
-        nqp::istype(self.HOW,Metamodel::EnumHOW) ?? self.enums.antipairs !! ()
-    }
+    multi method antipairs(Enumeration:) { self.enums.antipairs }
+    multi method antipairs(Bool:)        { self.enums.antipairs }
+    multi method antipairs(Any:U:) { () }
     multi method antipairs(Any:D:) { self.list.antipairs }
 
     proto method invert(|) is nodal {*}
-    multi method invert(Any:U:) {
-        nqp::istype(self.HOW,Metamodel::EnumHOW) ?? self.enums.invert !! ()
-    }
+    multi method invert(Enumeration:) { self.enums.invert }
+    multi method invert(Bool:)        { self.enums.invert }
+    multi method invert(Any:U:) { () }
     multi method invert(Any:D:) { self.list.invert }
 
     proto method splice(|) is nodal {*}

--- a/src/core.c/Any.pm6
+++ b/src/core.c/Any.pm6
@@ -92,27 +92,39 @@ my class Any { # declared in BOOTSTRAP
     multi method end(Any:D:) { self.list.end }
 
     proto method keys(|) is nodal {*}
-    multi method keys(Any:U:) { () }
+    multi method keys(Any:U:) {
+        nqp::istype(self.HOW,Metamodel::EnumHOW) ?? self.enums.keys !! ()
+    }
     multi method keys(Any:D:) { self.list.keys }
 
     proto method kv(|) is nodal {*}
-    multi method kv(Any:U:) { () }
+    multi method kv(Any:U:) {
+        nqp::istype(self.HOW,Metamodel::EnumHOW) ?? self.enums.kv !! ()
+    }
     multi method kv(Any:D:) { self.list.kv }
 
     proto method values(|) is nodal {*}
-    multi method values(Any:U:) { () }
+    multi method values(Any:U:) {
+        nqp::istype(self.HOW,Metamodel::EnumHOW) ?? self.enums.values !! ()
+    }
     multi method values(Any:D:) { self.list }
 
     proto method pairs(|) is nodal {*}
-    multi method pairs(Any:U:) { () }
+    multi method pairs(Any:U:) {
+        nqp::istype(self.HOW,Metamodel::EnumHOW) ?? self.enums.pairs !! ()
+    }
     multi method pairs(Any:D:) { self.list.pairs }
 
     proto method antipairs(|) is nodal {*}
-    multi method antipairs(Any:U:) { () }
+    multi method antipairs(Any:U:) {
+        nqp::istype(self.HOW,Metamodel::EnumHOW) ?? self.enums.antipairs !! ()
+    }
     multi method antipairs(Any:D:) { self.list.antipairs }
 
     proto method invert(|) is nodal {*}
-    multi method invert(Any:U:) { () }
+    multi method invert(Any:U:) {
+        nqp::istype(self.HOW,Metamodel::EnumHOW) ?? self.enums.invert !! ()
+    }
     multi method invert(Any:D:) { self.list.invert }
 
     proto method splice(|) is nodal {*}

--- a/src/core.c/core_prologue.pm6
+++ b/src/core.c/core_prologue.pm6
@@ -33,6 +33,7 @@ my role Positional { ... }
 my role Associative { ... }
 my role Callable { ... }
 my role Iterable { ... }
+my role Enumeration { ... }
 my role PositionalBindFailover { ... }
 my role Hash::Typed { ... }
 my role Hash::Object { ... }


### PR DESCRIPTION
It appears to be a recurring WAT when people try to find out which
possibilities there are when using a specific enum.  Before this
commit, "say Bool.keys" would show "()", after this commit it will
show "(True False)" (or "(False True)" depending on hash order).

This is achieved by adding a check for enums to the Any:U candidates
of these methods, and then calling the appropriate method on the
.enums method.

cog++ for the nudge