### PR TITLE
Add new routine 'frac'

### DIFF
--- a/src/core.c/Cool.pm6
+++ b/src/core.c/Cool.pm6
@@ -56,6 +56,7 @@ my class Cool { # declared in BOOTSTRAP
     method floor()          { self.Numeric.floor        }
     method ceiling()        { self.Numeric.ceiling      }
     method truncate()       { self.Numeric.truncate     }
+    method frac()           { self.Numeric.frac         }
 
     ## string methods
 

--- a/src/core.c/Real.pm6
+++ b/src/core.c/Real.pm6
@@ -60,7 +60,7 @@ my role Real does Numeric {
     multi method exp(Real:D: )           { self.Bridge.exp               }
     
     method frac(Real:D:) {
-        self.abs - self.Int.abs
+        abs(self - self.Int)
     }
     method truncate(Real:D:) {
         self < 0  ?? self.ceiling !! self.floor

--- a/src/core.c/Real.pm6
+++ b/src/core.c/Real.pm6
@@ -58,6 +58,10 @@ my role Real does Numeric {
     multi method log(Real:D: Real $base) { self.Bridge.log($base.Bridge) }
     proto method exp(|) {*}
     multi method exp(Real:D: )           { self.Bridge.exp               }
+    
+    method frac(Real:D:) {
+        self.abs - self.Int.abs
+    }
     method truncate(Real:D:) {
         self < 0  ?? self.ceiling !! self.floor
     }
@@ -176,10 +180,13 @@ multi sub abs(Real \a) {
     a < 0 ?? -a !! a;
 }
 
+proto sub frac($, *%) {*}
+multi sub frac(Real:D $x) { $x.frac }
+multi sub frac(Cool:D $x) { $x.Numeric.frac }
+
 proto sub truncate($, *%) {*}
 multi sub truncate(Real:D $x) { $x.truncate }
 multi sub truncate(Cool:D $x) { $x.Numeric.truncate }
-
 
 proto sub atan2($, $?, *%)    {*}
 multi sub atan2(Real \a, Real \b = 1e0) { a.Bridge.atan2(b.Bridge) }

--- a/t/02-rakudo/03-corekeys-6c.t
+++ b/t/02-rakudo/03-corekeys-6c.t
@@ -157,6 +157,7 @@ my @expected = (
   Q{&flat},
   Q{&flip},
   Q{&floor},
+  Q{&frac},
   Q{&from-json},
   Q{&full-barrier},
   Q{&get},

--- a/t/02-rakudo/03-corekeys-6d.t
+++ b/t/02-rakudo/03-corekeys-6d.t
@@ -157,6 +157,7 @@ my @expected = (
     Q{&flat},
     Q{&flip},
     Q{&floor},
+    Q{&frac},
     Q{&from-json},
     Q{&full-barrier},
     Q{&get},

--- a/t/02-rakudo/03-corekeys-6e.t
+++ b/t/02-rakudo/03-corekeys-6e.t
@@ -159,6 +159,7 @@ my @expected = (
     Q{&flat},
     Q{&flip},
     Q{&floor},
+    Q{&frac},
     Q{&from-json},
     Q{&full-barrier},
     Q{&get},

--- a/t/02-rakudo/03-corekeys.t
+++ b/t/02-rakudo/03-corekeys.t
@@ -160,6 +160,7 @@ my @allowed =
       Q{&flat},
       Q{&flip},
       Q{&floor},
+      Q{&frac},
       Q{&from-json},
       Q{&full-barrier},
       Q{&get},

--- a/t/02-rakudo/04-settingkeys-6c.t
+++ b/t/02-rakudo/04-settingkeys-6c.t
@@ -156,6 +156,7 @@ my %allowed = (
     Q{&flat},
     Q{&flip},
     Q{&floor},
+    Q{&frac},
     Q{&from-json},
     Q{&full-barrier},
     Q{&get},

--- a/t/02-rakudo/04-settingkeys-6e.t
+++ b/t/02-rakudo/04-settingkeys-6e.t
@@ -156,6 +156,7 @@ my %allowed = (
     Q{&flat},
     Q{&flip},
     Q{&floor},
+    Q{&frac},
     Q{&from-json},
     Q{&full-barrier},
     Q{&get},

--- a/t/02-rakudo/07-implementation-detail-6.c.t
+++ b/t/02-rakudo/07-implementation-detail-6.c.t
@@ -21,7 +21,7 @@ my @lower = ("",<<
   chars chdir chmod chomp chop chr chrs cis classify close comb
   combinations copy cos cosec cosech cosh cotan cotanh deepmap defined
   die dir done duckmap elems emit end exit exp expmod fail fc first
-  flat flip floor full-barrier get getc gist goto grep hash index
+  flat flip floor frac full-barrier get getc gist goto grep hash index
   indices indir is-prime item join keys kv last lastcall lc leave
   lines link list log log10 log2 lsb make map max min minmax mix
   mkdir move msb next nextcallee nextsame nextwith nodemap none

--- a/t/02-rakudo/07-implementation-detail-6.d.t
+++ b/t/02-rakudo/07-implementation-detail-6.d.t
@@ -21,7 +21,7 @@ my @lower = ("",<<
   chars chdir chmod chomp chop chr chrs cis classify close comb
   combinations copy cos cosec cosech cosh cotan cotanh deepmap defined
   die dir done duckmap elems emit end exit exp expmod fail fc first
-  flat flip floor full-barrier get getc gist goto grep hash index
+  flat flip floor frac full-barrier get getc gist goto grep hash index
   indices indir is-prime item join keys kv last lastcall lc leave
   lines link list log log10 log2 lsb make map max min minmax mix
   mkdir move msb next nextcallee nextsame nextwith nodemap none

--- a/t/02-rakudo/07-implementation-detail-6.e.t
+++ b/t/02-rakudo/07-implementation-detail-6.e.t
@@ -21,7 +21,7 @@ my @lower = ("",<<
   chars chdir chmod chomp chop chr chrs cis classify close comb
   combinations copy cos cosec cosech cosh cotan cotanh deepmap defined
   die dir done duckmap elems emit end exit exp expmod fail fc first
-  flat flip floor full-barrier get getc gist goto grep hash index
+  flat flip floor frac full-barrier get getc gist goto grep hash index
   indices indir is-prime item join keys kv last lastcall lc leave
   lines link list log log10 log2 lsb make map max min minmax mix
   mkdir move msb next nextcallee nextsame nextwith nodemap none

--- a/t/02-rakudo/12-proto-arity-count.t
+++ b/t/02-rakudo/12-proto-arity-count.t
@@ -134,6 +134,7 @@ sub all-the-protos {
     &flat,
     &flip,
     &floor,
+    &frac,
     &full-barrier,
     &get,
     &getc,


### PR DESCRIPTION
This PR adds a **frac** routine to Rakudo. The routine takes a real or integer argument and returns the fractional part as a positive number (0 <= n < 1). It will throw on Inf or NaN arguments.

This PR is accompanied by a PR to roast adding a new test file for **frac**.

Although not commonly found in modern programming languages, such a routine is used frequently in astronomical calculations and is described in the book *Celestial Calculations: A Gentle Guide  to Computational Astronomy* (J. L. Lawrence, The MIT Press, 2019) on page 7.

Adding this routine I believe would add a positive note to Raku's reputation.