### PR TITLE
[WIP] revised USAGE message with --help

### DIFF
--- a/new-help.raku
+++ b/new-help.raku
@@ -1,0 +1,409 @@
+my %*SUB-MAIN-OPTS ;# = :named-anywhere;
+
+#| Manage documentation generation for Raku projects
+proto MAIN(|) {*}
+
+#| Universal options
+multi MAIN (
+    Bool :V(:$version), #= Display the current version and exit
+) {}
+
+#| Download and untar default assets to generate the site
+multi MAIN ("setup", Bool :o(:$override) = False) {}
+
+subset OptionalStr where Str | False;
+#| Start the documentation generation with the specified options
+multi MAIN (
+    "start",     #= What goes here? A: currently unprinted
+            $foo, $bar, $baz?,
+            Str  :$topdir         = "doc",          #= Directory where the pod collection is stored
+            Str  :$conf           = "doc-new.json", #= Configuration file
+            Bool :v(:$verbose) = False,          #= Prints progress information
+            Str :$qux!,
+            Bool :$aaa,
+            Bool :$bbb!,
+            Bool :$ccc,
+            Str :$AAA,
+            OptionalStr :$BBB,
+            Str :$CCC,
+            OptionalStr :$DDD,
+            
+           ) {}
+
+#| Check which pod files have changed and regenerate its HTML files.
+multi MAIN ("update",
+            Str  :$topdir    = "doc",               #= Directory where the pod collection is stored
+            Str  :$conf      = "doc-updates.json",  #= Configuration file for updates
+            Bool :$backup    = False                #= Back up existing files before performing the update
+           ) {}
+
+DOC CHECK {
+    use Test;
+    subtest 'Simple MAIN', {
+        enum limit <foo bar baz>;
+        class Class {}
+        role Role {}
+        role pRole[::T] {}
+        for sub ($one-arg) {},
+            sub (Str $str-arg) {},
+            sub (Int $int-arg) {},
+            sub ($first, $second) {},
+            sub ($first, $optional-second?) {},
+            sub (:$named) {},
+            sub (Bool :$flag) {},
+            sub (Bool :$required-flag!) {},
+            sub (Str :$str-opt) {},
+            sub (Str :$req-str-opt!) {},
+            sub (:$with-where where  *.chars > 5) {},
+            sub ('literal' :$named) {},
+            sub ($foo where Int) {},
+            sub ($AAA, Int) {},
+            sub ($BBB, 'bbb') {},
+            sub (@CCC[Int]) {},
+            sub (Class $DDD) {},
+            sub (Role $EEE) {},
+            sub (pRole[Str] $EEE) {},
+            sub ($ ($FFF, $FF)) {},
+            sub (Bool  :@GGG) {},
+            sub (:@HHH) {},            
+            sub (@JJJ) {},                     # TODO: Is this right?
+            sub (*@LLL) {},                     # TODO: Is this right?
+            sub (*%MMM) {},           
+
+            sub (\aaa) {},
+            sub ($*bbb) {},
+            sub (:$*ccc) {},
+            sub (&ddd) {},
+            sub ($) {},
+            sub (:$foo where 'bar') {},
+            sub (:aaa(:bbb(:$ccc))) {},  # TODO: aliases generally
+            sub (:$v) {}                 # TODO: Short arguments generally
+            #sub (limit :$foo) {} 
+        -> &MAIN {
+            new-generate-usage(&MAIN).&is: default-generate-usage(&MAIN),
+            &MAIN.signature.params.map: *.gist;
+            diag(new-generate-usage(&MAIN));
+            #diag(default-generate-usage(&MAIN));
+        } 
+        
+    }
+    
+}
+## setup
+use nqp;
+my %sub-main-opts = %*SUB-MAIN-OPTS;
+my &GENERATE-USAGE = &default-generate-usage;
+#my &GENERATE-USAGE = &new-generate-usage;
+
+    # &main.candidates.classify: 
+    #     {.signature.params[0].name eq '' ?? 'subcommands' !! 'main'},
+    #     :as{ given .signature.params -> $params ($first, *@rest) {
+    #                    $first.name eq ''  ?? ($first.gist.substr(1, *-1) => @rest) !! |$params}},
+    #     :into(my %commands);
+
+## Patch for core.c/Main.pm6
+
+class Script {
+    class Command {...}
+    class Positional {...}
+    class Option {...}
+    
+    has %.subcmds;
+    has Command $.main-command;
+
+    method add(List $params) {
+        my $cmd = Command.new();
+        for @($params) {
+            when !.named {
+                .optional ?? $cmd.positionals<optional>.push: Positional($_)
+                          !! $cmd.positionals<required>.push: Positional($_) }
+            for .named_names -> str $name {
+                .optional ?? $cmd.options<optional>.push: Option($_)
+                          !! $cmd.options<required>.push: Option($_) }
+        }
+        $!main-command = $cmd;
+    }
+
+    method new { self.bless } # All options start empty
+
+    class Positional {
+        has Str  $.name;
+        has Bool $.literal;
+        has Bool $.accepts-multiple; # TODO: NYI
+        
+        multi method COERCE(Parameter $p) {
+            my $name = $p.usage-name || $p.type.^name;
+            my $literal = False;
+            for $p.constraint_list {
+                nqp::if(!nqp::istype($_, Callable),
+                        (nqp::stmts ($name = .gist),
+                         ($literal = True)))}
+
+            if $p.type !=== Bool && Metamodel::EnumHOW.ACCEPTS($p.type.HOW) {
+                 my $options = $p.type.^enum_values.keys.join('|');
+                 $name = $options.chars > 50 ?? substr($options,0,50) ~'...' !! "$options"
+            }
+
+            self.new(:$name, :$literal)
+        }
+    } 
+    
+    class Option {
+        has Str $.name;
+        has Str $.arg;
+        has Str $.arg-kind;
+        has Bool $.accepts-multiple;
+
+        multi method COERCE(Parameter $p) {
+            my int $accepts-true = $p.type.ACCEPTS: True;
+            for $p.constraint_list { $accepts-true++ if .ACCEPTS: True}
+                        my int $other-accepts-true = $p.type.ACCEPTS: True;
+                        for $p.constraint_list { $other-accepts-true++ if .ACCEPTS: True}
+            my $name = $p.usage-name || $p.type.^name;
+            my $accepts-multiple = False;
+
+            my $arg  = $p.type.^name;
+            if $arg.starts-with('Positional') {
+                $accepts-multiple = True;
+                $arg eq 'Positional' ?? ($arg = 'Any') !! $arg.=substr(11, *-1)}
+             
+            for $p.constraint_list {
+                nqp::if(nqp::istype($_, Callable), ($arg ~= ' where { ... }'), ($arg = .gist))
+            };
+            if $p.type !=== Bool && Metamodel::EnumHOW.ACCEPTS($p.type.HOW) {
+                            my $options = $p.type.^enum_values.keys.join('|');
+                            $arg = $options.chars > 50
+                              ?? substr($options,0,50) ~ '...'
+                              !! "$options"
+                        }
+
+            when $arg.starts-with('Bool') { self.new(:$name:$arg :arg-kind<flag>:$accepts-multiple) }
+            when ?$accepts-true           { self.new(:$name:$arg :arg-kind<optional>:$accepts-multiple)}
+            default                       { self.new(:$name:$arg :arg-kind<required>:$accepts-multiple)}
+        }
+    }
+    class Command {
+        has %.options    is Map;
+        has %.positionals is Map;
+
+        method new { self.bless: :positionals(required => @[], optional => @[])
+                                 :options(    required => @[], optional => @[]) }
+    } 
+    
+}
+
+sub new-generate-usage(&main, |capture) {
+    
+    my $opts = Script.new();
+    for &main.candidates { given .signature.params -> @params ($first, *@) {
+        $first.name || !$first.constraint_list ?? $opts.add(@params) !! (note "SUBCOMMAND??")}
+    }
+
+
+    my sub strip_path_prefix(str $name) {
+        when nqp::iseq_s($name, '-e') { "-e '...'" }
+        my (str $vol, str $dir, str $base) = $*SPEC.splitpath($name);
+        for $*SPEC.path() -> str $path-dir {
+            # Because checking file existance is slow, only do it if we _could_ match
+            if nqp::eqat($dir, $path-dir, 0) {
+                my str $file = $*SPEC.catpath($vol, $path-dir, $base).IO;
+                return $base if $file.x && $file.f;
+            }
+        }
+        $name;
+    }
+    my str $prog-name = strip_path_prefix($*PROGRAM-NAME);
+    #dd $opts;
+    my $main-cmd = $opts.main-command; # TODO fixme
+    #dd :$main-cmd;
+    my $res = ("Usage:\n  "
+     ~ ($prog-name, 
+        |$main-cmd.positionals<required>.map(-> $pos { $pos.literal ?? $pos.name !! "<{$pos.name}>" }),
+        |$main-cmd.positionals<optional>.map(-> $pos { $pos.literal ?? $pos.name !! "[<{$pos.name}>]" }),
+        # TODO: allow multiple
+                    |$main-cmd.options<optional>.map(-> $opt {
+                         "[--{$opt.name}"  ~("[={$opt.arg}]" if $opt.arg-kind eq 'optional')
+                                           ~("=<{$opt.arg}>" if $opt.arg-kind eq 'required')
+                                           ~']' ~(if $opt.accepts-multiple { '...'})}),
+                    |$main-cmd.options<required>.map(-> $opt { "--{$opt.name}"})
+                      # TODO: Can there be required options with optional args?
+       ).join: ' '
+                                                                                                   
+              );
+   # note now - ENTER now;
+    $res;
+    
+}
+
+# Generate $*USAGE string (default usage info for MAIN)
+sub default-generate-usage(&main, |capture) { #* TODO remove &main (added for testing)
+    my $no-named-after = nqp::isfalse(%sub-main-opts<named-anywhere>);
+
+    my @help-msgs;
+    my Pair @arg-help;
+
+    my sub strip_path_prefix($name) {
+        my $SPEC := $*SPEC;
+        my ($vol, $dir, $base) = $SPEC.splitpath($name);
+        $dir = $SPEC.canonpath($dir);
+        for $SPEC.path() -> $elem {
+            my $file = $SPEC.catpath($vol, $elem, $base).IO;
+            if $file.x && $file.f {
+                return $base if $SPEC.canonpath($elem) eq $dir;
+                # Shadowed command found in earlier PATH element
+                return $name;
+            }
+        }
+        # Not in PATH
+        $name;
+    }
+
+    my $prog-name = %*ENV<PERL6_PROGRAM_NAME> || $*PROGRAM-NAME;
+    $prog-name = $prog-name eq '-e'
+      ?? "-e '...'"
+      !! strip_path_prefix($prog-name);
+
+    # return the Cool constant if the post_constraints of a Parameter is
+    # a single Cool constant, else Nil
+    sub cool_constant(Parameter:D $p) {
+        nqp::not_i(
+          nqp::isnull(
+            (my \post_constraints :=
+              nqp::getattr($p,Parameter,'@!post_constraints'))
+          )
+        ) && nqp::elems(post_constraints) == 1
+          && nqp::istype((my \value := nqp::atpos(post_constraints,0)),Cool)
+          ?? value
+          !! Nil
+    }
+
+    # Select candidates for which to create USAGE string
+    sub usage-candidates($capture) {
+        my @candidates = &main.candidates.grep: { !.?is-hidden-from-USAGE }
+        if $capture.list -> @positionals {
+            my $first := @positionals[0];
+            if @candidates.grep: -> $sub {
+                if $sub.signature.params[0] -> $param {
+                    if cool_constant($param) -> $literal {
+                        $literal.ACCEPTS($first)
+                    }
+                }
+            } -> @candos {
+                return @candos;
+            }
+        }
+        @candidates
+    }
+
+    for usage-candidates(capture) -> $sub {
+        my @required-named;
+        my @optional-named;
+        my @positional;
+        my $docs;
+
+        for $sub.signature.params -> $param {
+            my $argument;
+
+            my int $literals-as-constraint = 0;
+            my int $total-constraints = 0;
+            my $constraints = ~unique $param.constraint_list.map: {
+                ++$total-constraints;
+                nqp::if(
+                  nqp::istype($_, Callable),
+                  'where { ... }',
+                  nqp::stmts(
+                    (my \g = .gist),
+                    nqp::if(
+                      nqp::isconcrete($_),
+                      nqp::stmts(
+                        ++$literals-as-constraint,
+                        g), # we constrained by some literal; gist as is
+                      nqp::substr(g, 1, nqp::chars(g)-2))))
+                      # ^ remove ( ) parens around name in the gist
+            }
+            $_ eq 'where { ... }' and $_ = "$param.type.^name() $_"
+                with $constraints;
+
+            if $param.named {
+                if $param.slurpy {
+                    if $param.name { # ignore anon *%
+                        $argument  = "--<$param.usage-name()>=...";
+                        @optional-named.push("[$argument]");
+                    }
+                }
+                else {
+                    my @names = $param.named_names.reverse;
+                    $argument = @names.map({
+                        (.chars == 1 ?? '-' !! '--') ~ $_
+                    }).join('|');
+
+                    my $type := $param.type;
+                    if $type ~~ Positional {
+                        $argument ~= "=<{ $constraints || "Any" }> ..."
+
+                    }
+                    elsif $type !=== Bool {
+
+                        my int $accepts-true = $param.type.ACCEPTS: True;
+                        for $param.constraint_list { $accepts-true++ if .ACCEPTS: True}
+                        $argument ~= ($accepts-true ?? "[={$constraints || $type.^name}]"
+                                                    !! "=<{$constraints || $type.^name}>");
+                        if Metamodel::EnumHOW.ACCEPTS($type.HOW) {
+                            my $options = $type.^enum_values.keys.sort.Str;
+                            $argument ~= $options.chars > 50
+                              ?? ' (' ~ substr($options,0,50) ~ '...'
+                              !! " ($options)"
+                        }
+                    }
+                    if $param.optional {
+                        @optional-named.push("[$argument]");
+                    }
+                    else {
+                        @required-named.push($argument);
+                    }
+                }
+            }
+            else {
+                $argument = $param.name
+                    ?? "<$param.usage-name()>"
+                    !! $constraints
+                        ?? ($literals-as-constraint == $total-constraints)
+                            ?? $constraints
+                            !! "<{$constraints}>"
+                        !! "<$param.type.^name()>";
+
+                $argument  = "[$argument ...]" if $param.slurpy;
+                $argument  = "[$argument]"     if $param.optional;
+                if $total-constraints
+                && $literals-as-constraint == $total-constraints {
+                    $argument .= trans(["'"] => [q|'"'"'|]) # "hlfix
+                        if $argument.contains("'");
+                    $argument  = "'$argument'"
+                        if $argument.contains(' ' | '"');
+                }
+                @positional.push($argument);
+            }
+            @arg-help.push($argument => $param.WHY.contents) if $param.WHY and (@arg-help.grep:{ .key eq $argument}) == Empty;  # Use first defined
+        }
+        if $sub.WHY {
+            $docs = '-- ' ~ $sub.WHY.contents
+        }
+        my $msg = $no-named-after
+          ?? join(' ', $prog-name, @required-named, @optional-named, @positional, ($docs if $docs))
+          !! join(' ', $prog-name, @positional, @required-named, @optional-named, ($docs if $docs));
+        @help-msgs.push($msg);
+    }
+
+    if @arg-help {
+        @help-msgs.push('');
+        my $offset = max(@arg-help.map: { .key.chars }) + 4;
+        @help-msgs.append(@arg-help.map: { '  ' ~ .key ~ ' ' x ($offset - .key.chars) ~ .value });
+    }
+
+    #note now - ENTER now;
+    my $res=@help-msgs
+      ?? "Usage:\n" ~ @help-msgs.map('  ' ~ *).join("\n")
+      !! "No usage information could be determined";
+    #note now - ENTER now;
+    $res;
+}

--- a/t/12-usage/01-one-command.t
+++ b/t/12-usage/01-one-command.t
@@ -1,0 +1,4272 @@
+use lib <t/packages/>;
+use Test;
+use Test::Helpers;
+plan 187;
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester <pos>
+          
+            <pos>    help1
+        §usage-msg
+    'unchanged usage for MAIN($pos)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $opt-pos?, #= help2
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester [<opt-pos>]
+          
+            [<opt-pos>]    help2
+        §usage-msg
+    'unchanged usage for MAIN($opt-pos?)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester [--named[=Any]]
+          
+            --named[=Any]    help3
+        §usage-msg
+    'unchanged usage for MAIN(:$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any]
+          
+            --req-named[=Any]    help4
+        §usage-msg
+    'unchanged usage for MAIN(:$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        ‘literal’ #= help5
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester literal -- help5
+        §usage-msg
+    'unchanged usage for MAIN(‘literal)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        Int #= help6
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester <Int> -- help6
+        §usage-msg
+    'unchanged usage for MAIN(In)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        $opt-pos?, #= help2
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester <pos> [<opt-pos>]
+          
+            <pos>          help1
+            [<opt-pos>]    help2
+        §usage-msg
+    'unchanged usage for MAIN($pos, $opt-pos?)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester [--named[=Any]] <pos>
+          
+            <pos>            help1
+            --named[=Any]    help3
+        §usage-msg
+    'unchanged usage for MAIN($pos, :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] <pos>
+          
+            <pos>                help1
+            --req-named[=Any]    help4
+        §usage-msg
+    'unchanged usage for MAIN($pos, :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        ‘literal’ #= help5
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester <pos> literal
+          
+            <pos>    help1 help5
+        §usage-msg
+    'unchanged usage for MAIN($pos, ‘literal)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        ‘literal’ #= help5
+                        $pos, #= help1
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester <pos> -- help5
+          
+            <pos>    help1
+        §usage-msg
+    'unchanged usage for MAIN(‘literal’ $pos)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        Int #= help6
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester <pos> <Int>
+          
+            <pos>    help1 help6
+        §usage-msg
+    'unchanged usage for MAIN($pos, In)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        Int #= help6
+                        $pos, #= help1
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester <pos> -- help6
+          
+            <pos>    help1
+        §usage-msg
+    'unchanged usage for MAIN(Int $pos)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $opt-pos?, #= help2
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester [--named[=Any]] [<opt-pos>]
+          
+            [<opt-pos>]      help2
+            --named[=Any]    help3
+        §usage-msg
+    'unchanged usage for MAIN($opt-pos?, :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $opt-pos?, #= help2
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [<opt-pos>]
+          
+            [<opt-pos>]          help2
+            --req-named[=Any]    help4
+        §usage-msg
+    'unchanged usage for MAIN($opt-pos?, :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        ‘literal’ #= help5
+                        $opt-pos?, #= help2
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester [<opt-pos>] -- help5
+          
+            [<opt-pos>]    help2
+        §usage-msg
+    'unchanged usage for MAIN(‘literal’ $opt-pos?)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        Int #= help6
+                        $opt-pos?, #= help2
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester [<opt-pos>] -- help6
+          
+            [<opt-pos>]    help2
+        §usage-msg
+    'unchanged usage for MAIN(Int $opt-pos?)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        :$named, #= help3
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [--named[=Any]]
+          
+            --named[=Any]        help3
+            --req-named[=Any]    help4
+        §usage-msg
+    'unchanged usage for MAIN(:$named, :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        :$req-named!, #= help4
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [--named[=Any]]
+          
+            --req-named[=Any]    help4
+            --named[=Any]        help3
+        §usage-msg
+    'unchanged usage for MAIN(:$req-named!, :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        ‘literal’ #= help5
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester [--named=<literal>] -- help5
+          
+            --named=<literal>    help3
+        §usage-msg
+    'unchanged usage for MAIN(‘literal’ :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        Int #= help6
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester [--named[=Int]] -- help6
+          
+            --named[=Int]    help3
+        §usage-msg
+    'unchanged usage for MAIN(Int :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        ‘literal’ #= help5
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named=<literal> -- help5
+          
+            --req-named=<literal>    help4
+        §usage-msg
+    'unchanged usage for MAIN(‘literal’ :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        Int #= help6
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Int] -- help6
+          
+            --req-named[=Int]    help4
+        §usage-msg
+    'unchanged usage for MAIN(Int :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        $opt-pos?, #= help2
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester [--named[=Any]] <pos> [<opt-pos>]
+          
+            <pos>            help1
+            [<opt-pos>]      help2
+            --named[=Any]    help3
+        §usage-msg
+    'unchanged usage for MAIN($pos, $opt-pos?, :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        $opt-pos?, #= help2
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] <pos> [<opt-pos>]
+          
+            <pos>                help1
+            [<opt-pos>]          help2
+            --req-named[=Any]    help4
+        §usage-msg
+    'unchanged usage for MAIN($pos, $opt-pos?, :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        ‘literal’ #= help5
+                        $opt-pos?, #= help2
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester <pos> [<opt-pos>]
+          
+            <pos>          help1 help5
+            [<opt-pos>]    help2
+        §usage-msg
+    'unchanged usage for MAIN($pos, ‘literal’ $opt-pos?)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        ‘literal’ #= help5
+                        $pos, #= help1
+                        $opt-pos?, #= help2
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester <pos> [<opt-pos>] -- help5
+          
+            <pos>          help1
+            [<opt-pos>]    help2
+        §usage-msg
+    'unchanged usage for MAIN(‘literal’ $pos, $opt-pos?)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        Int #= help6
+                        $opt-pos?, #= help2
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester <pos> [<opt-pos>]
+          
+            <pos>          help1 help6
+            [<opt-pos>]    help2
+        §usage-msg
+    'unchanged usage for MAIN($pos, Int $opt-pos?)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        Int #= help6
+                        $pos, #= help1
+                        $opt-pos?, #= help2
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester <pos> [<opt-pos>] -- help6
+          
+            <pos>          help1
+            [<opt-pos>]    help2
+        §usage-msg
+    'unchanged usage for MAIN(Int $pos, $opt-pos?)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        :$named, #= help3
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [--named[=Any]] <pos>
+          
+            <pos>                help1
+            --named[=Any]        help3
+            --req-named[=Any]    help4
+        §usage-msg
+    'unchanged usage for MAIN($pos, :$named, :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        :$req-named!, #= help4
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [--named[=Any]] <pos>
+          
+            <pos>                help1
+            --req-named[=Any]    help4
+            --named[=Any]        help3
+        §usage-msg
+    'unchanged usage for MAIN($pos, :$req-named!, :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        ‘literal’ #= help5
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester [--named=<literal>] <pos>
+          
+            <pos>                help1 help5
+            --named=<literal>    help3
+        §usage-msg
+    'unchanged usage for MAIN($pos, ‘literal’ :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        ‘literal’ #= help5
+                        $pos, #= help1
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester [--named[=Any]] <pos> -- help5
+          
+            <pos>            help1
+            --named[=Any]    help3
+        §usage-msg
+    'unchanged usage for MAIN(‘literal’ $pos, :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        Int #= help6
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester [--named[=Int]] <pos>
+          
+            <pos>            help1 help6
+            --named[=Int]    help3
+        §usage-msg
+    'unchanged usage for MAIN($pos, Int :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        Int #= help6
+                        $pos, #= help1
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester [--named[=Any]] <pos> -- help6
+          
+            <pos>            help1
+            --named[=Any]    help3
+        §usage-msg
+    'unchanged usage for MAIN(Int $pos, :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        ‘literal’ #= help5
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named=<literal> <pos>
+          
+            <pos>                    help1 help5
+            --req-named=<literal>    help4
+        §usage-msg
+    'unchanged usage for MAIN($pos, ‘literal’ :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        ‘literal’ #= help5
+                        $pos, #= help1
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] <pos> -- help5
+          
+            <pos>                help1
+            --req-named[=Any]    help4
+        §usage-msg
+    'unchanged usage for MAIN(‘literal’ $pos, :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        Int #= help6
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Int] <pos>
+          
+            <pos>                help1 help6
+            --req-named[=Int]    help4
+        §usage-msg
+    'unchanged usage for MAIN($pos, Int :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        Int #= help6
+                        $pos, #= help1
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] <pos> -- help6
+          
+            <pos>                help1
+            --req-named[=Any]    help4
+        §usage-msg
+    'unchanged usage for MAIN(Int $pos, :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        ‘literal’ #= help5
+                        $pos, #= help1
+                        Int #= help6
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester <pos> <Int> -- help5
+          
+            <pos>    help1 help6
+        §usage-msg
+    'unchanged usage for MAIN(‘literal’ $pos, In)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        Int #= help6
+                        $pos, #= help1
+                        ‘literal’ #= help5
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester <pos> literal -- help6
+          
+            <pos>    help1 help5
+        §usage-msg
+    'unchanged usage for MAIN(Int $pos, ‘literal)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $opt-pos?, #= help2
+                        :$named, #= help3
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [--named[=Any]] [<opt-pos>]
+          
+            [<opt-pos>]          help2
+            --named[=Any]        help3
+            --req-named[=Any]    help4
+        §usage-msg
+    'unchanged usage for MAIN($opt-pos?, :$named, :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $opt-pos?, #= help2
+                        :$req-named!, #= help4
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [--named[=Any]] [<opt-pos>]
+          
+            [<opt-pos>]          help2
+            --req-named[=Any]    help4
+            --named[=Any]        help3
+        §usage-msg
+    'unchanged usage for MAIN($opt-pos?, :$req-named!, :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $opt-pos?, #= help2
+                        ‘literal’ #= help5
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester [--named=<literal>] [<opt-pos>]
+          
+            [<opt-pos>]          help2 help5
+            --named=<literal>    help3
+        §usage-msg
+    'unchanged usage for MAIN($opt-pos?, ‘literal’ :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        ‘literal’ #= help5
+                        $opt-pos?, #= help2
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester [--named[=Any]] [<opt-pos>] -- help5
+          
+            [<opt-pos>]      help2
+            --named[=Any]    help3
+        §usage-msg
+    'unchanged usage for MAIN(‘literal’ $opt-pos?, :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $opt-pos?, #= help2
+                        Int #= help6
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester [--named[=Int]] [<opt-pos>]
+          
+            [<opt-pos>]      help2 help6
+            --named[=Int]    help3
+        §usage-msg
+    'unchanged usage for MAIN($opt-pos?, Int :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        Int #= help6
+                        $opt-pos?, #= help2
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester [--named[=Any]] [<opt-pos>] -- help6
+          
+            [<opt-pos>]      help2
+            --named[=Any]    help3
+        §usage-msg
+    'unchanged usage for MAIN(Int $opt-pos?, :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $opt-pos?, #= help2
+                        ‘literal’ #= help5
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named=<literal> [<opt-pos>]
+          
+            [<opt-pos>]              help2 help5
+            --req-named=<literal>    help4
+        §usage-msg
+    'unchanged usage for MAIN($opt-pos?, ‘literal’ :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        ‘literal’ #= help5
+                        $opt-pos?, #= help2
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [<opt-pos>] -- help5
+          
+            [<opt-pos>]          help2
+            --req-named[=Any]    help4
+        §usage-msg
+    'unchanged usage for MAIN(‘literal’ $opt-pos?, :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $opt-pos?, #= help2
+                        Int #= help6
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Int] [<opt-pos>]
+          
+            [<opt-pos>]          help2 help6
+            --req-named[=Int]    help4
+        §usage-msg
+    'unchanged usage for MAIN($opt-pos?, Int :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        Int #= help6
+                        $opt-pos?, #= help2
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [<opt-pos>] -- help6
+          
+            [<opt-pos>]          help2
+            --req-named[=Any]    help4
+        §usage-msg
+    'unchanged usage for MAIN(Int $opt-pos?, :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        :$named, #= help3
+                        ‘literal’ #= help5
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named=<literal> [--named[=Any]]
+          
+            --named[=Any]            help3 help5
+            --req-named=<literal>    help4
+        §usage-msg
+    'unchanged usage for MAIN(:$named, ‘literal’ :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        :$req-named!, #= help4
+                        ‘literal’ #= help5
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [--named=<literal>]
+          
+            --req-named[=Any]    help4 help5
+            --named=<literal>    help3
+        §usage-msg
+    'unchanged usage for MAIN(:$req-named!, ‘literal’ :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        ‘literal’ #= help5
+                        :$named, #= help3
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [--named=<literal>] -- help5
+          
+            --named=<literal>    help3
+            --req-named[=Any]    help4
+        §usage-msg
+    'unchanged usage for MAIN(‘literal’ :$named, :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        ‘literal’ #= help5
+                        :$req-named!, #= help4
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named=<literal> [--named[=Any]] -- help5
+          
+            --req-named=<literal>    help4
+            --named[=Any]            help3
+        §usage-msg
+    'unchanged usage for MAIN(‘literal’ :$req-named!, :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        :$named, #= help3
+                        Int #= help6
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Int] [--named[=Any]]
+          
+            --named[=Any]        help3 help6
+            --req-named[=Int]    help4
+        §usage-msg
+    'unchanged usage for MAIN(:$named, Int :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        :$req-named!, #= help4
+                        Int #= help6
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [--named[=Int]]
+          
+            --req-named[=Any]    help4 help6
+            --named[=Int]        help3
+        §usage-msg
+    'unchanged usage for MAIN(:$req-named!, Int :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        Int #= help6
+                        :$named, #= help3
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [--named[=Int]] -- help6
+          
+            --named[=Int]        help3
+            --req-named[=Any]    help4
+        §usage-msg
+    'unchanged usage for MAIN(Int :$named, :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        Int #= help6
+                        :$req-named!, #= help4
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Int] [--named[=Any]] -- help6
+          
+            --req-named[=Int]    help4
+            --named[=Any]        help3
+        §usage-msg
+    'unchanged usage for MAIN(Int :$req-named!, :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        $opt-pos?, #= help2
+                        :$named, #= help3
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [--named[=Any]] <pos> [<opt-pos>]
+          
+            <pos>                help1
+            [<opt-pos>]          help2
+            --named[=Any]        help3
+            --req-named[=Any]    help4
+        §usage-msg
+    'unchanged usage for MAIN($pos, $opt-pos?, :$named, :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        $opt-pos?, #= help2
+                        :$req-named!, #= help4
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [--named[=Any]] <pos> [<opt-pos>]
+          
+            <pos>                help1
+            [<opt-pos>]          help2
+            --req-named[=Any]    help4
+            --named[=Any]        help3
+        §usage-msg
+    'unchanged usage for MAIN($pos, $opt-pos?, :$req-named!, :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        $opt-pos?, #= help2
+                        ‘literal’ #= help5
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester [--named=<literal>] <pos> [<opt-pos>]
+          
+            <pos>                help1
+            [<opt-pos>]          help2 help5
+            --named=<literal>    help3
+        §usage-msg
+    'unchanged usage for MAIN($pos, $opt-pos?, ‘literal’ :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        ‘literal’ #= help5
+                        $opt-pos?, #= help2
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester [--named[=Any]] <pos> [<opt-pos>]
+          
+            <pos>            help1 help5
+            [<opt-pos>]      help2
+            --named[=Any]    help3
+        §usage-msg
+    'unchanged usage for MAIN($pos, ‘literal’ $opt-pos?, :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        ‘literal’ #= help5
+                        $pos, #= help1
+                        $opt-pos?, #= help2
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester [--named[=Any]] <pos> [<opt-pos>] -- help5
+          
+            <pos>            help1
+            [<opt-pos>]      help2
+            --named[=Any]    help3
+        §usage-msg
+    'unchanged usage for MAIN(‘literal’ $pos, $opt-pos?, :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        $opt-pos?, #= help2
+                        Int #= help6
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester [--named[=Int]] <pos> [<opt-pos>]
+          
+            <pos>            help1
+            [<opt-pos>]      help2 help6
+            --named[=Int]    help3
+        §usage-msg
+    'unchanged usage for MAIN($pos, $opt-pos?, Int :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        Int #= help6
+                        $opt-pos?, #= help2
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester [--named[=Any]] <pos> [<opt-pos>]
+          
+            <pos>            help1 help6
+            [<opt-pos>]      help2
+            --named[=Any]    help3
+        §usage-msg
+    'unchanged usage for MAIN($pos, Int $opt-pos?, :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        Int #= help6
+                        $pos, #= help1
+                        $opt-pos?, #= help2
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester [--named[=Any]] <pos> [<opt-pos>] -- help6
+          
+            <pos>            help1
+            [<opt-pos>]      help2
+            --named[=Any]    help3
+        §usage-msg
+    'unchanged usage for MAIN(Int $pos, $opt-pos?, :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        $opt-pos?, #= help2
+                        ‘literal’ #= help5
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named=<literal> <pos> [<opt-pos>]
+          
+            <pos>                    help1
+            [<opt-pos>]              help2 help5
+            --req-named=<literal>    help4
+        §usage-msg
+    'unchanged usage for MAIN($pos, $opt-pos?, ‘literal’ :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        ‘literal’ #= help5
+                        $opt-pos?, #= help2
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] <pos> [<opt-pos>]
+          
+            <pos>                help1 help5
+            [<opt-pos>]          help2
+            --req-named[=Any]    help4
+        §usage-msg
+    'unchanged usage for MAIN($pos, ‘literal’ $opt-pos?, :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        ‘literal’ #= help5
+                        $pos, #= help1
+                        $opt-pos?, #= help2
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] <pos> [<opt-pos>] -- help5
+          
+            <pos>                help1
+            [<opt-pos>]          help2
+            --req-named[=Any]    help4
+        §usage-msg
+    'unchanged usage for MAIN(‘literal’ $pos, $opt-pos?, :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        $opt-pos?, #= help2
+                        Int #= help6
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Int] <pos> [<opt-pos>]
+          
+            <pos>                help1
+            [<opt-pos>]          help2 help6
+            --req-named[=Int]    help4
+        §usage-msg
+    'unchanged usage for MAIN($pos, $opt-pos?, Int :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        Int #= help6
+                        $opt-pos?, #= help2
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] <pos> [<opt-pos>]
+          
+            <pos>                help1 help6
+            [<opt-pos>]          help2
+            --req-named[=Any]    help4
+        §usage-msg
+    'unchanged usage for MAIN($pos, Int $opt-pos?, :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        Int #= help6
+                        $pos, #= help1
+                        $opt-pos?, #= help2
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] <pos> [<opt-pos>] -- help6
+          
+            <pos>                help1
+            [<opt-pos>]          help2
+            --req-named[=Any]    help4
+        §usage-msg
+    'unchanged usage for MAIN(Int $pos, $opt-pos?, :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        ‘literal’ #= help5
+                        $pos, #= help1
+                        Int #= help6
+                        $opt-pos?, #= help2
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester <pos> [<opt-pos>] -- help5
+          
+            <pos>          help1 help6
+            [<opt-pos>]    help2
+        §usage-msg
+    'unchanged usage for MAIN(‘literal’ $pos, Int $opt-pos?)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        Int #= help6
+                        $pos, #= help1
+                        ‘literal’ #= help5
+                        $opt-pos?, #= help2
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester <pos> [<opt-pos>] -- help6
+          
+            <pos>          help1 help5
+            [<opt-pos>]    help2
+        §usage-msg
+    'unchanged usage for MAIN(Int $pos, ‘literal’ $opt-pos?)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        :$named, #= help3
+                        ‘literal’ #= help5
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named=<literal> [--named[=Any]] <pos>
+          
+            <pos>                    help1
+            --named[=Any]            help3 help5
+            --req-named=<literal>    help4
+        §usage-msg
+    'unchanged usage for MAIN($pos, :$named, ‘literal’ :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        :$req-named!, #= help4
+                        ‘literal’ #= help5
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [--named=<literal>] <pos>
+          
+            <pos>                help1
+            --req-named[=Any]    help4 help5
+            --named=<literal>    help3
+        §usage-msg
+    'unchanged usage for MAIN($pos, :$req-named!, ‘literal’ :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        ‘literal’ #= help5
+                        :$named, #= help3
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [--named=<literal>] <pos>
+          
+            <pos>                help1 help5
+            --named=<literal>    help3
+            --req-named[=Any]    help4
+        §usage-msg
+    'unchanged usage for MAIN($pos, ‘literal’ :$named, :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        ‘literal’ #= help5
+                        :$req-named!, #= help4
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named=<literal> [--named[=Any]] <pos>
+          
+            <pos>                    help1 help5
+            --req-named=<literal>    help4
+            --named[=Any]            help3
+        §usage-msg
+    'unchanged usage for MAIN($pos, ‘literal’ :$req-named!, :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        ‘literal’ #= help5
+                        $pos, #= help1
+                        :$named, #= help3
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [--named[=Any]] <pos> -- help5
+          
+            <pos>                help1
+            --named[=Any]        help3
+            --req-named[=Any]    help4
+        §usage-msg
+    'unchanged usage for MAIN(‘literal’ $pos, :$named, :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        ‘literal’ #= help5
+                        $pos, #= help1
+                        :$req-named!, #= help4
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [--named[=Any]] <pos> -- help5
+          
+            <pos>                help1
+            --req-named[=Any]    help4
+            --named[=Any]        help3
+        §usage-msg
+    'unchanged usage for MAIN(‘literal’ $pos, :$req-named!, :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        :$named, #= help3
+                        Int #= help6
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Int] [--named[=Any]] <pos>
+          
+            <pos>                help1
+            --named[=Any]        help3 help6
+            --req-named[=Int]    help4
+        §usage-msg
+    'unchanged usage for MAIN($pos, :$named, Int :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        :$req-named!, #= help4
+                        Int #= help6
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [--named[=Int]] <pos>
+          
+            <pos>                help1
+            --req-named[=Any]    help4 help6
+            --named[=Int]        help3
+        §usage-msg
+    'unchanged usage for MAIN($pos, :$req-named!, Int :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        Int #= help6
+                        :$named, #= help3
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [--named[=Int]] <pos>
+          
+            <pos>                help1 help6
+            --named[=Int]        help3
+            --req-named[=Any]    help4
+        §usage-msg
+    'unchanged usage for MAIN($pos, Int :$named, :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        Int #= help6
+                        :$req-named!, #= help4
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Int] [--named[=Any]] <pos>
+          
+            <pos>                help1 help6
+            --req-named[=Int]    help4
+            --named[=Any]        help3
+        §usage-msg
+    'unchanged usage for MAIN($pos, Int :$req-named!, :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        Int #= help6
+                        $pos, #= help1
+                        :$named, #= help3
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [--named[=Any]] <pos> -- help6
+          
+            <pos>                help1
+            --named[=Any]        help3
+            --req-named[=Any]    help4
+        §usage-msg
+    'unchanged usage for MAIN(Int $pos, :$named, :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        Int #= help6
+                        $pos, #= help1
+                        :$req-named!, #= help4
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [--named[=Any]] <pos> -- help6
+          
+            <pos>                help1
+            --req-named[=Any]    help4
+            --named[=Any]        help3
+        §usage-msg
+    'unchanged usage for MAIN(Int $pos, :$req-named!, :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        ‘literal’ #= help5
+                        $pos, #= help1
+                        Int #= help6
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester [--named[=Int]] <pos> -- help5
+          
+            <pos>            help1 help6
+            --named[=Int]    help3
+        §usage-msg
+    'unchanged usage for MAIN(‘literal’ $pos, Int :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        Int #= help6
+                        $pos, #= help1
+                        ‘literal’ #= help5
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester [--named=<literal>] <pos> -- help6
+          
+            <pos>                help1 help5
+            --named=<literal>    help3
+        §usage-msg
+    'unchanged usage for MAIN(Int $pos, ‘literal’ :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        ‘literal’ #= help5
+                        $pos, #= help1
+                        Int #= help6
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Int] <pos> -- help5
+          
+            <pos>                help1 help6
+            --req-named[=Int]    help4
+        §usage-msg
+    'unchanged usage for MAIN(‘literal’ $pos, Int :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        Int #= help6
+                        $pos, #= help1
+                        ‘literal’ #= help5
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named=<literal> <pos> -- help6
+          
+            <pos>                    help1 help5
+            --req-named=<literal>    help4
+        §usage-msg
+    'unchanged usage for MAIN(Int $pos, ‘literal’ :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $opt-pos?, #= help2
+                        :$named, #= help3
+                        ‘literal’ #= help5
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named=<literal> [--named[=Any]] [<opt-pos>]
+          
+            [<opt-pos>]              help2
+            --named[=Any]            help3 help5
+            --req-named=<literal>    help4
+        §usage-msg
+    'unchanged usage for MAIN($opt-pos?, :$named, ‘literal’ :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $opt-pos?, #= help2
+                        :$req-named!, #= help4
+                        ‘literal’ #= help5
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [--named=<literal>] [<opt-pos>]
+          
+            [<opt-pos>]          help2
+            --req-named[=Any]    help4 help5
+            --named=<literal>    help3
+        §usage-msg
+    'unchanged usage for MAIN($opt-pos?, :$req-named!, ‘literal’ :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $opt-pos?, #= help2
+                        ‘literal’ #= help5
+                        :$named, #= help3
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [--named=<literal>] [<opt-pos>]
+          
+            [<opt-pos>]          help2 help5
+            --named=<literal>    help3
+            --req-named[=Any]    help4
+        §usage-msg
+    'unchanged usage for MAIN($opt-pos?, ‘literal’ :$named, :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $opt-pos?, #= help2
+                        ‘literal’ #= help5
+                        :$req-named!, #= help4
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named=<literal> [--named[=Any]] [<opt-pos>]
+          
+            [<opt-pos>]              help2 help5
+            --req-named=<literal>    help4
+            --named[=Any]            help3
+        §usage-msg
+    'unchanged usage for MAIN($opt-pos?, ‘literal’ :$req-named!, :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        ‘literal’ #= help5
+                        $opt-pos?, #= help2
+                        :$named, #= help3
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [--named[=Any]] [<opt-pos>] -- help5
+          
+            [<opt-pos>]          help2
+            --named[=Any]        help3
+            --req-named[=Any]    help4
+        §usage-msg
+    'unchanged usage for MAIN(‘literal’ $opt-pos?, :$named, :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        ‘literal’ #= help5
+                        $opt-pos?, #= help2
+                        :$req-named!, #= help4
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [--named[=Any]] [<opt-pos>] -- help5
+          
+            [<opt-pos>]          help2
+            --req-named[=Any]    help4
+            --named[=Any]        help3
+        §usage-msg
+    'unchanged usage for MAIN(‘literal’ $opt-pos?, :$req-named!, :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $opt-pos?, #= help2
+                        :$named, #= help3
+                        Int #= help6
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Int] [--named[=Any]] [<opt-pos>]
+          
+            [<opt-pos>]          help2
+            --named[=Any]        help3 help6
+            --req-named[=Int]    help4
+        §usage-msg
+    'unchanged usage for MAIN($opt-pos?, :$named, Int :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $opt-pos?, #= help2
+                        :$req-named!, #= help4
+                        Int #= help6
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [--named[=Int]] [<opt-pos>]
+          
+            [<opt-pos>]          help2
+            --req-named[=Any]    help4 help6
+            --named[=Int]        help3
+        §usage-msg
+    'unchanged usage for MAIN($opt-pos?, :$req-named!, Int :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $opt-pos?, #= help2
+                        Int #= help6
+                        :$named, #= help3
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [--named[=Int]] [<opt-pos>]
+          
+            [<opt-pos>]          help2 help6
+            --named[=Int]        help3
+            --req-named[=Any]    help4
+        §usage-msg
+    'unchanged usage for MAIN($opt-pos?, Int :$named, :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $opt-pos?, #= help2
+                        Int #= help6
+                        :$req-named!, #= help4
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Int] [--named[=Any]] [<opt-pos>]
+          
+            [<opt-pos>]          help2 help6
+            --req-named[=Int]    help4
+            --named[=Any]        help3
+        §usage-msg
+    'unchanged usage for MAIN($opt-pos?, Int :$req-named!, :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        Int #= help6
+                        $opt-pos?, #= help2
+                        :$named, #= help3
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [--named[=Any]] [<opt-pos>] -- help6
+          
+            [<opt-pos>]          help2
+            --named[=Any]        help3
+            --req-named[=Any]    help4
+        §usage-msg
+    'unchanged usage for MAIN(Int $opt-pos?, :$named, :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        Int #= help6
+                        $opt-pos?, #= help2
+                        :$req-named!, #= help4
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [--named[=Any]] [<opt-pos>] -- help6
+          
+            [<opt-pos>]          help2
+            --req-named[=Any]    help4
+            --named[=Any]        help3
+        §usage-msg
+    'unchanged usage for MAIN(Int $opt-pos?, :$req-named!, :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        ‘literal’ #= help5
+                        $opt-pos?, #= help2
+                        Int #= help6
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester [--named[=Int]] [<opt-pos>] -- help5
+          
+            [<opt-pos>]      help2 help6
+            --named[=Int]    help3
+        §usage-msg
+    'unchanged usage for MAIN(‘literal’ $opt-pos?, Int :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        Int #= help6
+                        $opt-pos?, #= help2
+                        ‘literal’ #= help5
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester [--named=<literal>] [<opt-pos>] -- help6
+          
+            [<opt-pos>]          help2 help5
+            --named=<literal>    help3
+        §usage-msg
+    'unchanged usage for MAIN(Int $opt-pos?, ‘literal’ :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        ‘literal’ #= help5
+                        $opt-pos?, #= help2
+                        Int #= help6
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Int] [<opt-pos>] -- help5
+          
+            [<opt-pos>]          help2 help6
+            --req-named[=Int]    help4
+        §usage-msg
+    'unchanged usage for MAIN(‘literal’ $opt-pos?, Int :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        Int #= help6
+                        $opt-pos?, #= help2
+                        ‘literal’ #= help5
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named=<literal> [<opt-pos>] -- help6
+          
+            [<opt-pos>]              help2 help5
+            --req-named=<literal>    help4
+        §usage-msg
+    'unchanged usage for MAIN(Int $opt-pos?, ‘literal’ :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        ‘literal’ #= help5
+                        :$named, #= help3
+                        Int #= help6
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Int] [--named=<literal>] -- help5
+          
+            --named=<literal>    help3 help6
+            --req-named[=Int]    help4
+        §usage-msg
+    'unchanged usage for MAIN(‘literal’ :$named, Int :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        ‘literal’ #= help5
+                        :$req-named!, #= help4
+                        Int #= help6
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named=<literal> [--named[=Int]] -- help5
+          
+            --req-named=<literal>    help4 help6
+            --named[=Int]            help3
+        §usage-msg
+    'unchanged usage for MAIN(‘literal’ :$req-named!, Int :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        Int #= help6
+                        :$named, #= help3
+                        ‘literal’ #= help5
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named=<literal> [--named[=Int]] -- help6
+          
+            --named[=Int]            help3 help5
+            --req-named=<literal>    help4
+        §usage-msg
+    'unchanged usage for MAIN(Int :$named, ‘literal’ :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        Int #= help6
+                        :$req-named!, #= help4
+                        ‘literal’ #= help5
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Int] [--named=<literal>] -- help6
+          
+            --req-named[=Int]    help4 help5
+            --named=<literal>    help3
+        §usage-msg
+    'unchanged usage for MAIN(Int :$req-named!, ‘literal’ :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        $opt-pos?, #= help2
+                        :$named, #= help3
+                        ‘literal’ #= help5
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named=<literal> [--named[=Any]] <pos> [<opt-pos>]
+          
+            <pos>                    help1
+            [<opt-pos>]              help2
+            --named[=Any]            help3 help5
+            --req-named=<literal>    help4
+        §usage-msg
+    'unchanged usage for MAIN($pos, $opt-pos?, :$named, ‘literal’ :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        $opt-pos?, #= help2
+                        :$req-named!, #= help4
+                        ‘literal’ #= help5
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [--named=<literal>] <pos> [<opt-pos>]
+          
+            <pos>                help1
+            [<opt-pos>]          help2
+            --req-named[=Any]    help4 help5
+            --named=<literal>    help3
+        §usage-msg
+    'unchanged usage for MAIN($pos, $opt-pos?, :$req-named!, ‘literal’ :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        $opt-pos?, #= help2
+                        ‘literal’ #= help5
+                        :$named, #= help3
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [--named=<literal>] <pos> [<opt-pos>]
+          
+            <pos>                help1
+            [<opt-pos>]          help2 help5
+            --named=<literal>    help3
+            --req-named[=Any]    help4
+        §usage-msg
+    'unchanged usage for MAIN($pos, $opt-pos?, ‘literal’ :$named, :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        $opt-pos?, #= help2
+                        ‘literal’ #= help5
+                        :$req-named!, #= help4
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named=<literal> [--named[=Any]] <pos> [<opt-pos>]
+          
+            <pos>                    help1
+            [<opt-pos>]              help2 help5
+            --req-named=<literal>    help4
+            --named[=Any]            help3
+        §usage-msg
+    'unchanged usage for MAIN($pos, $opt-pos?, ‘literal’ :$req-named!, :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        ‘literal’ #= help5
+                        $opt-pos?, #= help2
+                        :$named, #= help3
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [--named[=Any]] <pos> [<opt-pos>]
+          
+            <pos>                help1 help5
+            [<opt-pos>]          help2
+            --named[=Any]        help3
+            --req-named[=Any]    help4
+        §usage-msg
+    'unchanged usage for MAIN($pos, ‘literal’ $opt-pos?, :$named, :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        ‘literal’ #= help5
+                        $opt-pos?, #= help2
+                        :$req-named!, #= help4
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [--named[=Any]] <pos> [<opt-pos>]
+          
+            <pos>                help1 help5
+            [<opt-pos>]          help2
+            --req-named[=Any]    help4
+            --named[=Any]        help3
+        §usage-msg
+    'unchanged usage for MAIN($pos, ‘literal’ $opt-pos?, :$req-named!, :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        ‘literal’ #= help5
+                        $pos, #= help1
+                        $opt-pos?, #= help2
+                        :$named, #= help3
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [--named[=Any]] <pos> [<opt-pos>] -- help5
+          
+            <pos>                help1
+            [<opt-pos>]          help2
+            --named[=Any]        help3
+            --req-named[=Any]    help4
+        §usage-msg
+    'unchanged usage for MAIN(‘literal’ $pos, $opt-pos?, :$named, :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        ‘literal’ #= help5
+                        $pos, #= help1
+                        $opt-pos?, #= help2
+                        :$req-named!, #= help4
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [--named[=Any]] <pos> [<opt-pos>] -- help5
+          
+            <pos>                help1
+            [<opt-pos>]          help2
+            --req-named[=Any]    help4
+            --named[=Any]        help3
+        §usage-msg
+    'unchanged usage for MAIN(‘literal’ $pos, $opt-pos?, :$req-named!, :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        $opt-pos?, #= help2
+                        :$named, #= help3
+                        Int #= help6
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Int] [--named[=Any]] <pos> [<opt-pos>]
+          
+            <pos>                help1
+            [<opt-pos>]          help2
+            --named[=Any]        help3 help6
+            --req-named[=Int]    help4
+        §usage-msg
+    'unchanged usage for MAIN($pos, $opt-pos?, :$named, Int :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        $opt-pos?, #= help2
+                        :$req-named!, #= help4
+                        Int #= help6
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [--named[=Int]] <pos> [<opt-pos>]
+          
+            <pos>                help1
+            [<opt-pos>]          help2
+            --req-named[=Any]    help4 help6
+            --named[=Int]        help3
+        §usage-msg
+    'unchanged usage for MAIN($pos, $opt-pos?, :$req-named!, Int :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        $opt-pos?, #= help2
+                        Int #= help6
+                        :$named, #= help3
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [--named[=Int]] <pos> [<opt-pos>]
+          
+            <pos>                help1
+            [<opt-pos>]          help2 help6
+            --named[=Int]        help3
+            --req-named[=Any]    help4
+        §usage-msg
+    'unchanged usage for MAIN($pos, $opt-pos?, Int :$named, :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        $opt-pos?, #= help2
+                        Int #= help6
+                        :$req-named!, #= help4
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Int] [--named[=Any]] <pos> [<opt-pos>]
+          
+            <pos>                help1
+            [<opt-pos>]          help2 help6
+            --req-named[=Int]    help4
+            --named[=Any]        help3
+        §usage-msg
+    'unchanged usage for MAIN($pos, $opt-pos?, Int :$req-named!, :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        Int #= help6
+                        $opt-pos?, #= help2
+                        :$named, #= help3
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [--named[=Any]] <pos> [<opt-pos>]
+          
+            <pos>                help1 help6
+            [<opt-pos>]          help2
+            --named[=Any]        help3
+            --req-named[=Any]    help4
+        §usage-msg
+    'unchanged usage for MAIN($pos, Int $opt-pos?, :$named, :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        Int #= help6
+                        $opt-pos?, #= help2
+                        :$req-named!, #= help4
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [--named[=Any]] <pos> [<opt-pos>]
+          
+            <pos>                help1 help6
+            [<opt-pos>]          help2
+            --req-named[=Any]    help4
+            --named[=Any]        help3
+        §usage-msg
+    'unchanged usage for MAIN($pos, Int $opt-pos?, :$req-named!, :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        Int #= help6
+                        $pos, #= help1
+                        $opt-pos?, #= help2
+                        :$named, #= help3
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [--named[=Any]] <pos> [<opt-pos>] -- help6
+          
+            <pos>                help1
+            [<opt-pos>]          help2
+            --named[=Any]        help3
+            --req-named[=Any]    help4
+        §usage-msg
+    'unchanged usage for MAIN(Int $pos, $opt-pos?, :$named, :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        Int #= help6
+                        $pos, #= help1
+                        $opt-pos?, #= help2
+                        :$req-named!, #= help4
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [--named[=Any]] <pos> [<opt-pos>] -- help6
+          
+            <pos>                help1
+            [<opt-pos>]          help2
+            --req-named[=Any]    help4
+            --named[=Any]        help3
+        §usage-msg
+    'unchanged usage for MAIN(Int $pos, $opt-pos?, :$req-named!, :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        ‘literal’ #= help5
+                        $opt-pos?, #= help2
+                        Int #= help6
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester [--named[=Int]] <pos> [<opt-pos>]
+          
+            <pos>            help1 help5
+            [<opt-pos>]      help2 help6
+            --named[=Int]    help3
+        §usage-msg
+    'unchanged usage for MAIN($pos, ‘literal’ $opt-pos?, Int :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        Int #= help6
+                        $opt-pos?, #= help2
+                        ‘literal’ #= help5
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester [--named=<literal>] <pos> [<opt-pos>]
+          
+            <pos>                help1 help6
+            [<opt-pos>]          help2 help5
+            --named=<literal>    help3
+        §usage-msg
+    'unchanged usage for MAIN($pos, Int $opt-pos?, ‘literal’ :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        ‘literal’ #= help5
+                        $pos, #= help1
+                        $opt-pos?, #= help2
+                        Int #= help6
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester [--named[=Int]] <pos> [<opt-pos>] -- help5
+          
+            <pos>            help1
+            [<opt-pos>]      help2 help6
+            --named[=Int]    help3
+        §usage-msg
+    'unchanged usage for MAIN(‘literal’ $pos, $opt-pos?, Int :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        ‘literal’ #= help5
+                        $pos, #= help1
+                        Int #= help6
+                        $opt-pos?, #= help2
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester [--named[=Any]] <pos> [<opt-pos>] -- help5
+          
+            <pos>            help1 help6
+            [<opt-pos>]      help2
+            --named[=Any]    help3
+        §usage-msg
+    'unchanged usage for MAIN(‘literal’ $pos, Int $opt-pos?, :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        Int #= help6
+                        $pos, #= help1
+                        $opt-pos?, #= help2
+                        ‘literal’ #= help5
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester [--named=<literal>] <pos> [<opt-pos>] -- help6
+          
+            <pos>                help1
+            [<opt-pos>]          help2 help5
+            --named=<literal>    help3
+        §usage-msg
+    'unchanged usage for MAIN(Int $pos, $opt-pos?, ‘literal’ :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        Int #= help6
+                        $pos, #= help1
+                        ‘literal’ #= help5
+                        $opt-pos?, #= help2
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester [--named[=Any]] <pos> [<opt-pos>] -- help6
+          
+            <pos>            help1 help5
+            [<opt-pos>]      help2
+            --named[=Any]    help3
+        §usage-msg
+    'unchanged usage for MAIN(Int $pos, ‘literal’ $opt-pos?, :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        ‘literal’ #= help5
+                        $opt-pos?, #= help2
+                        Int #= help6
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Int] <pos> [<opt-pos>]
+          
+            <pos>                help1 help5
+            [<opt-pos>]          help2 help6
+            --req-named[=Int]    help4
+        §usage-msg
+    'unchanged usage for MAIN($pos, ‘literal’ $opt-pos?, Int :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        Int #= help6
+                        $opt-pos?, #= help2
+                        ‘literal’ #= help5
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named=<literal> <pos> [<opt-pos>]
+          
+            <pos>                    help1 help6
+            [<opt-pos>]              help2 help5
+            --req-named=<literal>    help4
+        §usage-msg
+    'unchanged usage for MAIN($pos, Int $opt-pos?, ‘literal’ :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        ‘literal’ #= help5
+                        $pos, #= help1
+                        $opt-pos?, #= help2
+                        Int #= help6
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Int] <pos> [<opt-pos>] -- help5
+          
+            <pos>                help1
+            [<opt-pos>]          help2 help6
+            --req-named[=Int]    help4
+        §usage-msg
+    'unchanged usage for MAIN(‘literal’ $pos, $opt-pos?, Int :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        ‘literal’ #= help5
+                        $pos, #= help1
+                        Int #= help6
+                        $opt-pos?, #= help2
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] <pos> [<opt-pos>] -- help5
+          
+            <pos>                help1 help6
+            [<opt-pos>]          help2
+            --req-named[=Any]    help4
+        §usage-msg
+    'unchanged usage for MAIN(‘literal’ $pos, Int $opt-pos?, :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        Int #= help6
+                        $pos, #= help1
+                        $opt-pos?, #= help2
+                        ‘literal’ #= help5
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named=<literal> <pos> [<opt-pos>] -- help6
+          
+            <pos>                    help1
+            [<opt-pos>]              help2 help5
+            --req-named=<literal>    help4
+        §usage-msg
+    'unchanged usage for MAIN(Int $pos, $opt-pos?, ‘literal’ :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        Int #= help6
+                        $pos, #= help1
+                        ‘literal’ #= help5
+                        $opt-pos?, #= help2
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] <pos> [<opt-pos>] -- help6
+          
+            <pos>                help1 help5
+            [<opt-pos>]          help2
+            --req-named[=Any]    help4
+        §usage-msg
+    'unchanged usage for MAIN(Int $pos, ‘literal’ $opt-pos?, :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        ‘literal’ #= help5
+                        :$named, #= help3
+                        Int #= help6
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Int] [--named=<literal>] <pos>
+          
+            <pos>                help1 help5
+            --named=<literal>    help3 help6
+            --req-named[=Int]    help4
+        §usage-msg
+    'unchanged usage for MAIN($pos, ‘literal’ :$named, Int :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        ‘literal’ #= help5
+                        :$req-named!, #= help4
+                        Int #= help6
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named=<literal> [--named[=Int]] <pos>
+          
+            <pos>                    help1 help5
+            --req-named=<literal>    help4 help6
+            --named[=Int]            help3
+        §usage-msg
+    'unchanged usage for MAIN($pos, ‘literal’ :$req-named!, Int :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        Int #= help6
+                        :$named, #= help3
+                        ‘literal’ #= help5
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named=<literal> [--named[=Int]] <pos>
+          
+            <pos>                    help1 help6
+            --named[=Int]            help3 help5
+            --req-named=<literal>    help4
+        §usage-msg
+    'unchanged usage for MAIN($pos, Int :$named, ‘literal’ :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        Int #= help6
+                        :$req-named!, #= help4
+                        ‘literal’ #= help5
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Int] [--named=<literal>] <pos>
+          
+            <pos>                help1 help6
+            --req-named[=Int]    help4 help5
+            --named=<literal>    help3
+        §usage-msg
+    'unchanged usage for MAIN($pos, Int :$req-named!, ‘literal’ :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        ‘literal’ #= help5
+                        $pos, #= help1
+                        :$named, #= help3
+                        Int #= help6
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Int] [--named[=Any]] <pos> -- help5
+          
+            <pos>                help1
+            --named[=Any]        help3 help6
+            --req-named[=Int]    help4
+        §usage-msg
+    'unchanged usage for MAIN(‘literal’ $pos, :$named, Int :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        ‘literal’ #= help5
+                        $pos, #= help1
+                        :$req-named!, #= help4
+                        Int #= help6
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [--named[=Int]] <pos> -- help5
+          
+            <pos>                help1
+            --req-named[=Any]    help4 help6
+            --named[=Int]        help3
+        §usage-msg
+    'unchanged usage for MAIN(‘literal’ $pos, :$req-named!, Int :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        ‘literal’ #= help5
+                        $pos, #= help1
+                        Int #= help6
+                        :$named, #= help3
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [--named[=Int]] <pos> -- help5
+          
+            <pos>                help1 help6
+            --named[=Int]        help3
+            --req-named[=Any]    help4
+        §usage-msg
+    'unchanged usage for MAIN(‘literal’ $pos, Int :$named, :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        ‘literal’ #= help5
+                        $pos, #= help1
+                        Int #= help6
+                        :$req-named!, #= help4
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Int] [--named[=Any]] <pos> -- help5
+          
+            <pos>                help1 help6
+            --req-named[=Int]    help4
+            --named[=Any]        help3
+        §usage-msg
+    'unchanged usage for MAIN(‘literal’ $pos, Int :$req-named!, :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        Int #= help6
+                        $pos, #= help1
+                        :$named, #= help3
+                        ‘literal’ #= help5
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named=<literal> [--named[=Any]] <pos> -- help6
+          
+            <pos>                    help1
+            --named[=Any]            help3 help5
+            --req-named=<literal>    help4
+        §usage-msg
+    'unchanged usage for MAIN(Int $pos, :$named, ‘literal’ :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        Int #= help6
+                        $pos, #= help1
+                        :$req-named!, #= help4
+                        ‘literal’ #= help5
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [--named=<literal>] <pos> -- help6
+          
+            <pos>                help1
+            --req-named[=Any]    help4 help5
+            --named=<literal>    help3
+        §usage-msg
+    'unchanged usage for MAIN(Int $pos, :$req-named!, ‘literal’ :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        Int #= help6
+                        $pos, #= help1
+                        ‘literal’ #= help5
+                        :$named, #= help3
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [--named=<literal>] <pos> -- help6
+          
+            <pos>                help1 help5
+            --named=<literal>    help3
+            --req-named[=Any]    help4
+        §usage-msg
+    'unchanged usage for MAIN(Int $pos, ‘literal’ :$named, :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        Int #= help6
+                        $pos, #= help1
+                        ‘literal’ #= help5
+                        :$req-named!, #= help4
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named=<literal> [--named[=Any]] <pos> -- help6
+          
+            <pos>                    help1 help5
+            --req-named=<literal>    help4
+            --named[=Any]            help3
+        §usage-msg
+    'unchanged usage for MAIN(Int $pos, ‘literal’ :$req-named!, :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $opt-pos?, #= help2
+                        ‘literal’ #= help5
+                        :$named, #= help3
+                        Int #= help6
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Int] [--named=<literal>] [<opt-pos>]
+          
+            [<opt-pos>]          help2 help5
+            --named=<literal>    help3 help6
+            --req-named[=Int]    help4
+        §usage-msg
+    'unchanged usage for MAIN($opt-pos?, ‘literal’ :$named, Int :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $opt-pos?, #= help2
+                        ‘literal’ #= help5
+                        :$req-named!, #= help4
+                        Int #= help6
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named=<literal> [--named[=Int]] [<opt-pos>]
+          
+            [<opt-pos>]              help2 help5
+            --req-named=<literal>    help4 help6
+            --named[=Int]            help3
+        §usage-msg
+    'unchanged usage for MAIN($opt-pos?, ‘literal’ :$req-named!, Int :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $opt-pos?, #= help2
+                        Int #= help6
+                        :$named, #= help3
+                        ‘literal’ #= help5
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named=<literal> [--named[=Int]] [<opt-pos>]
+          
+            [<opt-pos>]              help2 help6
+            --named[=Int]            help3 help5
+            --req-named=<literal>    help4
+        §usage-msg
+    'unchanged usage for MAIN($opt-pos?, Int :$named, ‘literal’ :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $opt-pos?, #= help2
+                        Int #= help6
+                        :$req-named!, #= help4
+                        ‘literal’ #= help5
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Int] [--named=<literal>] [<opt-pos>]
+          
+            [<opt-pos>]          help2 help6
+            --req-named[=Int]    help4 help5
+            --named=<literal>    help3
+        §usage-msg
+    'unchanged usage for MAIN($opt-pos?, Int :$req-named!, ‘literal’ :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        ‘literal’ #= help5
+                        $opt-pos?, #= help2
+                        :$named, #= help3
+                        Int #= help6
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Int] [--named[=Any]] [<opt-pos>] -- help5
+          
+            [<opt-pos>]          help2
+            --named[=Any]        help3 help6
+            --req-named[=Int]    help4
+        §usage-msg
+    'unchanged usage for MAIN(‘literal’ $opt-pos?, :$named, Int :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        ‘literal’ #= help5
+                        $opt-pos?, #= help2
+                        :$req-named!, #= help4
+                        Int #= help6
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [--named[=Int]] [<opt-pos>] -- help5
+          
+            [<opt-pos>]          help2
+            --req-named[=Any]    help4 help6
+            --named[=Int]        help3
+        §usage-msg
+    'unchanged usage for MAIN(‘literal’ $opt-pos?, :$req-named!, Int :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        ‘literal’ #= help5
+                        $opt-pos?, #= help2
+                        Int #= help6
+                        :$named, #= help3
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [--named[=Int]] [<opt-pos>] -- help5
+          
+            [<opt-pos>]          help2 help6
+            --named[=Int]        help3
+            --req-named[=Any]    help4
+        §usage-msg
+    'unchanged usage for MAIN(‘literal’ $opt-pos?, Int :$named, :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        ‘literal’ #= help5
+                        $opt-pos?, #= help2
+                        Int #= help6
+                        :$req-named!, #= help4
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Int] [--named[=Any]] [<opt-pos>] -- help5
+          
+            [<opt-pos>]          help2 help6
+            --req-named[=Int]    help4
+            --named[=Any]        help3
+        §usage-msg
+    'unchanged usage for MAIN(‘literal’ $opt-pos?, Int :$req-named!, :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        Int #= help6
+                        $opt-pos?, #= help2
+                        :$named, #= help3
+                        ‘literal’ #= help5
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named=<literal> [--named[=Any]] [<opt-pos>] -- help6
+          
+            [<opt-pos>]              help2
+            --named[=Any]            help3 help5
+            --req-named=<literal>    help4
+        §usage-msg
+    'unchanged usage for MAIN(Int $opt-pos?, :$named, ‘literal’ :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        Int #= help6
+                        $opt-pos?, #= help2
+                        :$req-named!, #= help4
+                        ‘literal’ #= help5
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [--named=<literal>] [<opt-pos>] -- help6
+          
+            [<opt-pos>]          help2
+            --req-named[=Any]    help4 help5
+            --named=<literal>    help3
+        §usage-msg
+    'unchanged usage for MAIN(Int $opt-pos?, :$req-named!, ‘literal’ :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        Int #= help6
+                        $opt-pos?, #= help2
+                        ‘literal’ #= help5
+                        :$named, #= help3
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [--named=<literal>] [<opt-pos>] -- help6
+          
+            [<opt-pos>]          help2 help5
+            --named=<literal>    help3
+            --req-named[=Any]    help4
+        §usage-msg
+    'unchanged usage for MAIN(Int $opt-pos?, ‘literal’ :$named, :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        Int #= help6
+                        $opt-pos?, #= help2
+                        ‘literal’ #= help5
+                        :$req-named!, #= help4
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named=<literal> [--named[=Any]] [<opt-pos>] -- help6
+          
+            [<opt-pos>]              help2 help5
+            --req-named=<literal>    help4
+            --named[=Any]            help3
+        §usage-msg
+    'unchanged usage for MAIN(Int $opt-pos?, ‘literal’ :$req-named!, :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        $opt-pos?, #= help2
+                        ‘literal’ #= help5
+                        :$named, #= help3
+                        Int #= help6
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Int] [--named=<literal>] <pos> [<opt-pos>]
+          
+            <pos>                help1
+            [<opt-pos>]          help2 help5
+            --named=<literal>    help3 help6
+            --req-named[=Int]    help4
+        §usage-msg
+    'unchanged usage for MAIN($pos, $opt-pos?, ‘literal’ :$named, Int :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        $opt-pos?, #= help2
+                        ‘literal’ #= help5
+                        :$req-named!, #= help4
+                        Int #= help6
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named=<literal> [--named[=Int]] <pos> [<opt-pos>]
+          
+            <pos>                    help1
+            [<opt-pos>]              help2 help5
+            --req-named=<literal>    help4 help6
+            --named[=Int]            help3
+        §usage-msg
+    'unchanged usage for MAIN($pos, $opt-pos?, ‘literal’ :$req-named!, Int :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        $opt-pos?, #= help2
+                        Int #= help6
+                        :$named, #= help3
+                        ‘literal’ #= help5
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named=<literal> [--named[=Int]] <pos> [<opt-pos>]
+          
+            <pos>                    help1
+            [<opt-pos>]              help2 help6
+            --named[=Int]            help3 help5
+            --req-named=<literal>    help4
+        §usage-msg
+    'unchanged usage for MAIN($pos, $opt-pos?, Int :$named, ‘literal’ :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        $opt-pos?, #= help2
+                        Int #= help6
+                        :$req-named!, #= help4
+                        ‘literal’ #= help5
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Int] [--named=<literal>] <pos> [<opt-pos>]
+          
+            <pos>                help1
+            [<opt-pos>]          help2 help6
+            --req-named[=Int]    help4 help5
+            --named=<literal>    help3
+        §usage-msg
+    'unchanged usage for MAIN($pos, $opt-pos?, Int :$req-named!, ‘literal’ :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        ‘literal’ #= help5
+                        $opt-pos?, #= help2
+                        :$named, #= help3
+                        Int #= help6
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Int] [--named[=Any]] <pos> [<opt-pos>]
+          
+            <pos>                help1 help5
+            [<opt-pos>]          help2
+            --named[=Any]        help3 help6
+            --req-named[=Int]    help4
+        §usage-msg
+    'unchanged usage for MAIN($pos, ‘literal’ $opt-pos?, :$named, Int :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        ‘literal’ #= help5
+                        $opt-pos?, #= help2
+                        :$req-named!, #= help4
+                        Int #= help6
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [--named[=Int]] <pos> [<opt-pos>]
+          
+            <pos>                help1 help5
+            [<opt-pos>]          help2
+            --req-named[=Any]    help4 help6
+            --named[=Int]        help3
+        §usage-msg
+    'unchanged usage for MAIN($pos, ‘literal’ $opt-pos?, :$req-named!, Int :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        ‘literal’ #= help5
+                        $opt-pos?, #= help2
+                        Int #= help6
+                        :$named, #= help3
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [--named[=Int]] <pos> [<opt-pos>]
+          
+            <pos>                help1 help5
+            [<opt-pos>]          help2 help6
+            --named[=Int]        help3
+            --req-named[=Any]    help4
+        §usage-msg
+    'unchanged usage for MAIN($pos, ‘literal’ $opt-pos?, Int :$named, :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        ‘literal’ #= help5
+                        $opt-pos?, #= help2
+                        Int #= help6
+                        :$req-named!, #= help4
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Int] [--named[=Any]] <pos> [<opt-pos>]
+          
+            <pos>                help1 help5
+            [<opt-pos>]          help2 help6
+            --req-named[=Int]    help4
+            --named[=Any]        help3
+        §usage-msg
+    'unchanged usage for MAIN($pos, ‘literal’ $opt-pos?, Int :$req-named!, :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        Int #= help6
+                        $opt-pos?, #= help2
+                        :$named, #= help3
+                        ‘literal’ #= help5
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named=<literal> [--named[=Any]] <pos> [<opt-pos>]
+          
+            <pos>                    help1 help6
+            [<opt-pos>]              help2
+            --named[=Any]            help3 help5
+            --req-named=<literal>    help4
+        §usage-msg
+    'unchanged usage for MAIN($pos, Int $opt-pos?, :$named, ‘literal’ :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        Int #= help6
+                        $opt-pos?, #= help2
+                        :$req-named!, #= help4
+                        ‘literal’ #= help5
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [--named=<literal>] <pos> [<opt-pos>]
+          
+            <pos>                help1 help6
+            [<opt-pos>]          help2
+            --req-named[=Any]    help4 help5
+            --named=<literal>    help3
+        §usage-msg
+    'unchanged usage for MAIN($pos, Int $opt-pos?, :$req-named!, ‘literal’ :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        Int #= help6
+                        $opt-pos?, #= help2
+                        ‘literal’ #= help5
+                        :$named, #= help3
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [--named=<literal>] <pos> [<opt-pos>]
+          
+            <pos>                help1 help6
+            [<opt-pos>]          help2 help5
+            --named=<literal>    help3
+            --req-named[=Any]    help4
+        §usage-msg
+    'unchanged usage for MAIN($pos, Int $opt-pos?, ‘literal’ :$named, :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        $pos, #= help1
+                        Int #= help6
+                        $opt-pos?, #= help2
+                        ‘literal’ #= help5
+                        :$req-named!, #= help4
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named=<literal> [--named[=Any]] <pos> [<opt-pos>]
+          
+            <pos>                    help1 help6
+            [<opt-pos>]              help2 help5
+            --req-named=<literal>    help4
+            --named[=Any]            help3
+        §usage-msg
+    'unchanged usage for MAIN($pos, Int $opt-pos?, ‘literal’ :$req-named!, :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        ‘literal’ #= help5
+                        $pos, #= help1
+                        $opt-pos?, #= help2
+                        :$named, #= help3
+                        Int #= help6
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Int] [--named[=Any]] <pos> [<opt-pos>] -- help5
+          
+            <pos>                help1
+            [<opt-pos>]          help2
+            --named[=Any]        help3 help6
+            --req-named[=Int]    help4
+        §usage-msg
+    'unchanged usage for MAIN(‘literal’ $pos, $opt-pos?, :$named, Int :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        ‘literal’ #= help5
+                        $pos, #= help1
+                        $opt-pos?, #= help2
+                        :$req-named!, #= help4
+                        Int #= help6
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [--named[=Int]] <pos> [<opt-pos>] -- help5
+          
+            <pos>                help1
+            [<opt-pos>]          help2
+            --req-named[=Any]    help4 help6
+            --named[=Int]        help3
+        §usage-msg
+    'unchanged usage for MAIN(‘literal’ $pos, $opt-pos?, :$req-named!, Int :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        ‘literal’ #= help5
+                        $pos, #= help1
+                        $opt-pos?, #= help2
+                        Int #= help6
+                        :$named, #= help3
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [--named[=Int]] <pos> [<opt-pos>] -- help5
+          
+            <pos>                help1
+            [<opt-pos>]          help2 help6
+            --named[=Int]        help3
+            --req-named[=Any]    help4
+        §usage-msg
+    'unchanged usage for MAIN(‘literal’ $pos, $opt-pos?, Int :$named, :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        ‘literal’ #= help5
+                        $pos, #= help1
+                        $opt-pos?, #= help2
+                        Int #= help6
+                        :$req-named!, #= help4
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Int] [--named[=Any]] <pos> [<opt-pos>] -- help5
+          
+            <pos>                help1
+            [<opt-pos>]          help2 help6
+            --req-named[=Int]    help4
+            --named[=Any]        help3
+        §usage-msg
+    'unchanged usage for MAIN(‘literal’ $pos, $opt-pos?, Int :$req-named!, :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        ‘literal’ #= help5
+                        $pos, #= help1
+                        Int #= help6
+                        $opt-pos?, #= help2
+                        :$named, #= help3
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [--named[=Any]] <pos> [<opt-pos>] -- help5
+          
+            <pos>                help1 help6
+            [<opt-pos>]          help2
+            --named[=Any]        help3
+            --req-named[=Any]    help4
+        §usage-msg
+    'unchanged usage for MAIN(‘literal’ $pos, Int $opt-pos?, :$named, :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        ‘literal’ #= help5
+                        $pos, #= help1
+                        Int #= help6
+                        $opt-pos?, #= help2
+                        :$req-named!, #= help4
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [--named[=Any]] <pos> [<opt-pos>] -- help5
+          
+            <pos>                help1 help6
+            [<opt-pos>]          help2
+            --req-named[=Any]    help4
+            --named[=Any]        help3
+        §usage-msg
+    'unchanged usage for MAIN(‘literal’ $pos, Int $opt-pos?, :$req-named!, :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        Int #= help6
+                        $pos, #= help1
+                        $opt-pos?, #= help2
+                        :$named, #= help3
+                        ‘literal’ #= help5
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named=<literal> [--named[=Any]] <pos> [<opt-pos>] -- help6
+          
+            <pos>                    help1
+            [<opt-pos>]              help2
+            --named[=Any]            help3 help5
+            --req-named=<literal>    help4
+        §usage-msg
+    'unchanged usage for MAIN(Int $pos, $opt-pos?, :$named, ‘literal’ :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        Int #= help6
+                        $pos, #= help1
+                        $opt-pos?, #= help2
+                        :$req-named!, #= help4
+                        ‘literal’ #= help5
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [--named=<literal>] <pos> [<opt-pos>] -- help6
+          
+            <pos>                help1
+            [<opt-pos>]          help2
+            --req-named[=Any]    help4 help5
+            --named=<literal>    help3
+        §usage-msg
+    'unchanged usage for MAIN(Int $pos, $opt-pos?, :$req-named!, ‘literal’ :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        Int #= help6
+                        $pos, #= help1
+                        $opt-pos?, #= help2
+                        ‘literal’ #= help5
+                        :$named, #= help3
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [--named=<literal>] <pos> [<opt-pos>] -- help6
+          
+            <pos>                help1
+            [<opt-pos>]          help2 help5
+            --named=<literal>    help3
+            --req-named[=Any]    help4
+        §usage-msg
+    'unchanged usage for MAIN(Int $pos, $opt-pos?, ‘literal’ :$named, :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        Int #= help6
+                        $pos, #= help1
+                        $opt-pos?, #= help2
+                        ‘literal’ #= help5
+                        :$req-named!, #= help4
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named=<literal> [--named[=Any]] <pos> [<opt-pos>] -- help6
+          
+            <pos>                    help1
+            [<opt-pos>]              help2 help5
+            --req-named=<literal>    help4
+            --named[=Any]            help3
+        §usage-msg
+    'unchanged usage for MAIN(Int $pos, $opt-pos?, ‘literal’ :$req-named!, :$named)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        Int #= help6
+                        $pos, #= help1
+                        ‘literal’ #= help5
+                        $opt-pos?, #= help2
+                        :$named, #= help3
+                        :$req-named!, #= help4
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [--named[=Any]] <pos> [<opt-pos>] -- help6
+          
+            <pos>                help1 help5
+            [<opt-pos>]          help2
+            --named[=Any]        help3
+            --req-named[=Any]    help4
+        §usage-msg
+    'unchanged usage for MAIN(Int $pos, ‘literal’ $opt-pos?, :$named, :$req-named!)'
+);
+
+is-run(
+    q:to/§script/,
+        my @*ARGS         = '--help';
+        my $*PROGRAM-NAME = 'usage-tester';
+        my &main = sub MAIN(
+                        Int #= help6
+                        $pos, #= help1
+                        ‘literal’ #= help5
+                        $opt-pos?, #= help2
+                        :$req-named!, #= help4
+                        :$named, #= help3
+                      ) {};
+        RUN-MAIN(&main, Nil);
+        §script
+    :out(q:to/§usage-msg/),
+        Usage:
+          usage-tester --req-named[=Any] [--named[=Any]] <pos> [<opt-pos>] -- help6
+          
+            <pos>                help1 help5
+            [<opt-pos>]          help2
+            --req-named[=Any]    help4
+            --named[=Any]        help3
+        §usage-msg
+    'unchanged usage for MAIN(Int $pos, ‘literal’ $opt-pos?, :$req-named!, :$named)'
+);
+
+

--- a/tools/build-USAGE-tests.raku
+++ b/tools/build-USAGE-tests.raku
@@ -1,0 +1,52 @@
+#!/usr/bin/env raku
+use v6.d;
+unit sub MAIN(:$foo);
+
+my @*ARGS         = '--help';
+my $*PROGRAM-NAME = 'usage-tester';
+
+sub generate-test-usage($sig) {
+    use MONKEY-SEE-NO-EVAL;
+    my &*EXIT = {;}
+    my $result;
+    my $*OUT = class { method print(*@args) { $result ~= @args.join; }
+                       method flush {} }
+    with try { EVAL('sub MAIN(\qq[$sig]) {}; &MAIN ')} { RUN-MAIN($_, Nil);
+                                                         ($sig, $result) }
+    else { Empty }
+}
+
+my @tests =
+     ('$pos, #= help1', '$opt-pos?, #= help2', ':$named, #= help3',
+         ':$req-named!, #= help4', '‘literal’ #= help5', 'Int #= help6'
+     ).combinations
+      .map(|*.permutations.map: "\n" ~*.join("\n").indent(24)  ~"\n{' ' x 22}")
+      .skip(1)
+      .map(&generate-test-usage)
+      .race
+      .map( -> ($sig, $usage) {
+          my $sig-no-comments = $sig.lines.map(*.split(‘#’)[0].trim).join(" ").trim.chop(1);
+          q:to/§test/
+          is-run(
+              q:to/§script/,
+                  my @*ARGS         = '--help';
+                  my $*PROGRAM-NAME = 'usage-tester';
+                  my &main = sub MAIN(\qq[{$sig}]) {};
+                  RUN-MAIN(&main, Nil);
+                  §script
+              :out(q:to/§usage-msg/),
+                  \qq[{$usage.indent(8).chomp.trim-leading}]
+                  §usage-msg
+              'unchanged usage for MAIN(\qq[{$sig-no-comments}])'
+          );
+          §test
+});
+
+say qq:to/§all-tests/;
+    use lib <t/packages/>;
+    use Test;
+    use Test::Helpers;
+    plan {+@tests};
+
+    {@tests.join("\n")}
+    §all-tests

--- a/tools/templates/common_test_dirs
+++ b/tools/templates/common_test_dirs
@@ -6,3 +6,4 @@ t/06-telemetry
 t/07-pod-to-text
 t/08-performance
 t/10-qast
+t/12-usage


### PR DESCRIPTION
This is a branch for to publicly track my WIP solution to #4223.

I initially thought that improving the `--help` output for subcommands would not require that large of a change to `default-generate-usage` but, as I have dug into it more deeply, I have realized that it will require a more significant refactor/rewrite of that function.  This rewrite will also, hopefully, allow us to reduce the time it takes to generate a usage message, which is currently slower than I'd like. I'm starting this branch so that anyone interested in the issue can follow my progress and/or provide thoughts as I continue.

The `new-help.raku` file represents my first (**very** rough/tentative) WIP steps towards an implementation.  Note that, when this implementation is further along, the contents of this file will be folded into `src/core.c/Main.pm6`; I have it as a separate file right now simply for iterative development without re-compiling the full source (as described [in this post](https://perl6.party/post/Hacking-on-Rakudo-Perl-6-Compiler-Mix-Your-Fix)).

Aside from from the extremely rough first steps, the main item in this repo so far is a tool for generating/updating snapshot tests based on the _current_ usage message and the tests that were generated by the tool.  The goal of these snapshot tests is to ensure that all changes to the usage message are intentional (that is, that no edge-case regressions slip in, which can be an issue with refactors like this).  The snapshot tool is not yet complete, because it does not yet generate test for `multi MAIN` functions; adding that set of tests will be my next step.

I have added the generated snapshot tests to a new `t/12-usage` folder rather than to Raku/Roast because I believe that the _contents_ of the usage message is implementation defined (even though the presence of a usage message is specified by Roast).  If anyone disagrees with this assessment, please let me know.

