### PR TITLE
Fix race condition when setting up continuation in ThreadPoolScheduler

### DIFF
--- a/src/core.c/ThreadPoolScheduler.pm6
+++ b/src/core.c/ThreadPoolScheduler.pm6
@@ -151,7 +151,9 @@ my class ThreadPoolScheduler does Scheduler {
                             }
                             if $resume {
                                 nqp::push($!queue, {
-                                    nqp::continuationinvoke($continuation, nqp::null())
+                                    $l.protect: {
+                                        nqp::continuationinvoke($continuation, nqp::null())
+                                    }
                                 });
                             }
                         });


### PR DESCRIPTION
The block containing the continuationinvoke gets pushed onto the
ThreadPoolScheduler's queue before the continuation is actually taken. It's
possible that a worker thread takes the block out of the queue while
$continuation is still uninitialized.

But how is that possible? All of this happens under a lock and there's a
protected section right before we push the resume block onto the queue.
Shouldn't this protected section run after we have taken the continuation
and released the lock and therefore the push only happen after the continuation
is set up?

Turns out that the protected section runs on the same thread as the setup of
the continuation. Since our locks are re-entrant, we don't actually wait there
at all. Thus we can reach the push before the lock is set up.

Fix by acquiring the same lock when invoking the continuation.