### PR TITLE
Add IO::Path.user/group methods

### DIFF
--- a/src/core.c/IO/Path.pm6
+++ b/src/core.c/IO/Path.pm6
@@ -667,6 +667,18 @@ my class IO::Path is Cool does IO {
         spurt-blob($path, $mode, $blob)
     }
 
+    method user(IO::Path:D:) {
+        Rakudo::Internals.FILETEST-E(my str $path = self.absolute)
+          ?? nqp::stat($path,nqp::const::STAT_UID)
+          !! self!does-not-exist("user")
+    }
+
+    method group(IO::Path:D:) {
+        Rakudo::Internals.FILETEST-E(my str $path = self.absolute)
+          ?? nqp::stat($path,nqp::const::STAT_GID)
+          !! self!does-not-exist("group")
+    }
+
     proto method spurt(|) {*}
     multi method spurt(IO::Path:D: --> Bool:D) {
         self.open(:w).close


### PR DESCRIPTION
- .user returns the uid of the path, or a failure if it doesn't exist
- .group returns the gid of the path, or a failure if it doesn't exist

This basically exposes the nqp::const::STAT_UID and nqp::const::STAT_GID
slots of nqp::stat.

I did consider making these allomorphs with the user / group name in string
format as well, but that turned out to be pretty difficult to do without
NativeCall or calling some external program to get the group name.

I also have no idea what these nqp::stat slots mean on Windows.

Lack of this functionality mentioned in some private email conversations
with a sysadmin wanting to use Raku more.