### PR TITLE
Remove two five-year-old compatibility wrappers.

### DIFF
--- a/src/vm/moar/ops/perl6_ops.c
+++ b/src/vm/moar/ops/perl6_ops.c
@@ -9,14 +9,6 @@
 #include <sys/time.h>
 #endif
 
-#ifndef MVM_spesh_get_and_use_facts
-#define MVM_spesh_get_and_use_facts MVM_spesh_get_facts
-#endif
-
-#ifndef MVM_gc_root_add_permanent_desc
-#define MVM_gc_root_add_permanent_desc(tc, obj_ref, description) MVM_gc_root_add_permanent(tc, obj_ref)
-#endif
-
 #define GET_REG(tc, idx)    (*tc->interp_reg_base)[*((MVMuint16 *)(cur_op + idx))]
 #define REAL_BODY(tc, obj)  MVM_p6opaque_real_data(tc, OBJECT_BODY(obj))
 


### PR DESCRIPTION
MoarVM has had `MVM_gc_root_add_permanent_desc` since March 2016 and
`MVM_spesh_get_and_use_facts` since July 2014, so we don't need these
wrappers.

The last use of `MVM_spesh_get_and_use_facts` was actually removed in
June 2018 by commit 6d271667c9ac2c78:
    Implement p6decontrv as a desugar, not an ext op

I don't think that the #ifndef approach ever worked - unlike Perl 5,
as best I can tell MoarVM never defined pre-processor macros to wrap its
API functions, meaning that these macro tests were always false, and the
compatibility macro was always used. Hence likely the (believed) call
to `MVM_spesh_get_and_use_facts` didn't call `MVM_spesh_use_facts`
(as intended and implied by the name.)