### PR TITLE
Make sure method `submethod_table` exists.

### DIFF
--- a/src/core.c/Mu.pm6
+++ b/src/core.c/Mu.pm6
@@ -1157,7 +1157,7 @@ my class Mu { # declared in BOOTSTRAP
                 if $methods && !$class.HOW.archetypes.composable {
                     @methods.push: $_ with $class.^method_table{$name}
                 }
-                if $submethods {
+                if $submethods && nqp::can($class.HOW, 'submethod_table') {
                     @methods.push: $_ with $class.^submethod_table{$name}
                 }
             }


### PR DESCRIPTION
WALK must not attempt fetching submethods from typeobjects not
supporting them. Primarily this will help when inheriting from
NQP-world classes or consuming NQP-world roles.