### PR TITLE
Remove unneeded and harmfull nqp::hllbool in Perl6::Actions::maybe_ad…

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -4361,7 +4361,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
         # Cannot inline things with custom invocation handler or phasers.
         return 0 if nqp::can($code, 'CALL-ME');
         my $phasers := nqp::getattr($code,$*W.find_single_symbol('Block', :setting-only),'$!phasers');
-        return 0 unless nqp::isnull($phasers) || !nqp::hllbool($phasers);
+        return 0 unless nqp::isnull($phasers) || !$phasers;
 
         # Make sure the block has the common structure we expect
         # (decls then statements).


### PR DESCRIPTION
…d_inlining_info

NQP doesn't have special values for booleans, so the nqp::hllbool op returned
NULL (not even a VMNull, but an actual NULL value) when called when the current
language is NQP. Soon the op will throw an exception in this case on MoarVM.

We can only inline things if they do not have phasers, so the sub can only
continue if the block's $!phasers is (VM-)null or if it is at least falsey,
e.g. an empty hash or a type object. The NQP compiler will already do the right
thing for an expression like !$phasers. No need for a non-working nqp::hllbool.

Since nqp::hllbool always returned NULL which in turn is considered falsey, we
may actually have ended up inlining blocks that we ought not to. This change
fixes that and allows for backends to add error reporting.