### PR TITLE
Remove unused variable

### DIFF
--- a/lib/NativeCall.rakumod
+++ b/lib/NativeCall.rakumod
@@ -543,7 +543,6 @@ our role Native[Routine $r, $libname where Str|Callable|List|IO::Path|Distributi
                 $jit-optimized-body.code_object(self);
                 nqp::bindattr(self, $?CLASS, '$!jit-optimized-body', $stub);
                 my $fixups := QAST::Stmts.new();
-                my $des := QAST::Stmts.new();
                 if $*W {
                     $*W.add_root_code_ref($stub, $optimized-body);
                     $*W.add_root_code_ref($stub, $jit-optimized-body);


### PR DESCRIPTION
It was added with 80d6b425ce and it looks like a leftover from
developing that patch. (Maybe it was meant to be passed as the
value for :deserialize_ast -- which used $fixups in the end.)