### PR TITLE
Add new methods to class DateTime

### DIFF
--- a/src/core.c/DateTime.pm6
+++ b/src/core.c/DateTime.pm6
@@ -398,6 +398,21 @@ my class DateTime does Dateish {
         Instant.from-posix: self.posix + $!second % 1, $!second >= 60;
     }
 
+    method day-fraction(DateTime:D: --> Real:D) {
+        my $sec = self.hour * 60 * 60;
+        $sec   += self.minute * 60;
+        $sec   += self.second;
+        $sec / (24.0 * 60 * 60)
+    }
+
+    method mjd(DateTime:D: --> Real:D) {
+        self.daycount + self.day-fraction
+    }
+
+    method juliandate(DateTime:D: --> Real:D) {
+        self.mjd + 2_400_000.5
+    }
+
     method posix(DateTime:D: $ignore-timezone? --> Int:D) {
         return self.utc.posix if $!timezone && !$ignore-timezone;
 

--- a/src/core.c/DateTime.pm6
+++ b/src/core.c/DateTime.pm6
@@ -405,12 +405,12 @@ my class DateTime does Dateish {
         $sec / (24.0 * 60 * 60)
     }
 
-    method mjd(DateTime:D: --> Real:D) {
+    method modified-julian-date(DateTime:D: --> Real:D) {
         self.daycount + self.day-fraction
     }
 
-    method juliandate(DateTime:D: --> Real:D) {
-        self.mjd + 2_400_000.5
+    method julian-date(DateTime:D: --> Real:D) {
+        self.modified-julian-date + 2_400_000.5
     }
 
     method posix(DateTime:D: $ignore-timezone? --> Int:D) {


### PR DESCRIPTION
The following methods have been added to class DateTime to fill in some of the missing well-known time values of the instant:

+ *day-fraction* - The instant's hours, minutes, and seconds as a fraction of a 24-hour day
+ *mjd* - The real number, formed as the sum of *daycount* (the integral part of the *Modifed Julian Date*) and *day-fraction*, known as the *Modified Julian Date* (MJD)
+ *juliandate* - The real number, formed as the sum of the *MJD* and *2_400_000.5*, known to astronomers as the *Julian Date* or *Julian Day Number*
