### PR TITLE
Make CLIENT:: work for code invoked from NQP world

### DIFF
--- a/src/core.c/PseudoStash.pm6
+++ b/src/core.c/PseudoStash.pm6
@@ -217,7 +217,7 @@ my class PseudoStash is Map {
                 '$?PACKAGE');
             my Mu $ctx := nqp::ctxcallerskipthunks(
                 nqp::getattr(nqp::decont($cur), PseudoStash, '$!ctx'));
-            while nqp::getlexrel($ctx, '$?PACKAGE') === $pkg {
+            while nqp::eqaddr(nqp::getlexrel($ctx, '$?PACKAGE'), $pkg) {
                 $ctx := nqp::ctxcallerskipthunks($ctx);
                 die "No client package found" unless $ctx;
             }

--- a/src/core.e/PseudoStash.pm6
+++ b/src/core.e/PseudoStash.pm6
@@ -170,7 +170,7 @@ my class PseudoStash is Map {
                 '$?PACKAGE');
             my Mu $ctx := nqp::ctxcallerskipthunks(
                 nqp::getattr(nqp::decont($cur), PseudoStash, '$!ctx'));
-            while nqp::getlexrel($ctx, '$?PACKAGE') === $pkg {
+            while nqp::eqaddr(nqp::getlexrel($ctx, '$?PACKAGE'), $pkg) {
                 $ctx := nqp::ctxcallerskipthunks($ctx);
                 die "No client package found" unless $ctx;
             }

--- a/t/02-rakudo/18-pseudostash.t
+++ b/t/02-rakudo/18-pseudostash.t
@@ -1,0 +1,29 @@
+use v6;
+use lib $?FILE.IO.parent(2).add('packages');
+use Test;
+use Test::Helpers;
+
+plan 3;
+
+{ # Make sure CLIENT:: works for code invoked from NQP world
+    # Wether or not a code object is invoked by Raku or NQP code is pretty much implementation specific. Moreover,
+    # the chosen PseudoStash path `CALLER::CLIENT::CLIENT::` also depends on how COERCE method is invoked by Rakudo.
+    # Therefore any changes related to coercion protocol implementation may require tweking of this test.
+    for <c d e.PREVIEW> -> $rev {
+        is-run "use v6.$rev;\nmy \$foo = q<This is 6.$rev>;\n"
+                ~ q:to/TEST-CODE/,
+                    my class C {
+                        method COERCE(Int $v) {
+                            print CALLER::CLIENT::CLIENT::MY::<$foo>;
+                            C.new;
+                        }
+                    }
+                    C(42);
+                    TEST-CODE
+                "CLIENT:: doesn't fail on NQP packages for 6.$rev",
+                :out("This is 6.$rev"),
+                :err("");
+    }
+}
+
+done-testing;

--- a/t/02-rakudo/18-pseudostash.t
+++ b/t/02-rakudo/18-pseudostash.t
@@ -17,7 +17,7 @@ plan 3;
                             print CALLER::CLIENT::CLIENT::MY::<$foo>;
                             C.new;
                         }
-                    }
+                    };
                     C(42);
                     TEST-CODE
                 "CLIENT:: doesn't fail on NQP packages for 6.$rev",


### PR DESCRIPTION
Replace use of `===` with `nqp::eqaddr` because the former expects `Any`
arguments.