### PR TITLE
Restore DateTime.new(now).raku format

### DIFF
--- a/src/core.c/DateTime.pm6
+++ b/src/core.c/DateTime.pm6
@@ -588,7 +588,7 @@ my class DateTime does Dateish {
 
     multi method raku(DateTime:D: --> Str:D) {
         self.^name
-          ~ ".new($!year,$!month,$!day,$!hour,$!minute,$!second"
+          ~ ".new($!year,$!month,$!day,$!hour,$!minute," ~ sprintf('%.6f',$!second)
           ~ (',' ~ :$!timezone.raku if $!timezone)
           ~ ')'
     }


### PR DESCRIPTION
After the nqp::time update, the $!seconds value showed up to 9 digits
after the decimal point, when before it only showed 6.

Fixes a breakage in Games::TauStation::DateTime tests.