### PR TITLE
Use correct api value when calculating dist id

### DIFF
--- a/src/core.c/CompUnit/Repository/Installation.pm6
+++ b/src/core.c/CompUnit/Repository/Installation.pm6
@@ -406,8 +406,8 @@ sub MAIN(:$name, :$auth, :$ver, *@, *%) {
                         my ($ver, $auth, $api, $source, $checksum) = $_.slurp.split("\n");
                         $_.basename => {
                             auth     => $auth,
-                            api      => Version.new( $api || 0 ), # Create the Version objects once
-                            ver      => Version.new( $ver || 0 ), # (used to compare, and then sort)
+                            api      => Version.new( $api // 0 ), # Create the Version objects once
+                            ver      => Version.new( $ver // 0 ), # (used to compare, and then sort)
                             source   => $source || Any,
                             checksum => $checksum || Str,
                         }


### PR DESCRIPTION
When calculating a dist id we treat empty strings as value distinct from 0, but they should be (and generally are) treated the same.