### PR TITLE
Speedup exponentiation by Ints

### DIFF
--- a/src/core.c/Int.pm6
+++ b/src/core.c/Int.pm6
@@ -368,12 +368,14 @@ my constant UINT64_UPPER = nqp::pow2_I(2, 64, Int);
 
 multi sub infix:<**>(Int:D $a, Int:D $b --> Real:D) {
     # when a**b is too big nqp::pow2_I returns (Int)
-    nqp::isge_I($b, 0)
-      ?? nqp::isconcrete((my $power := nqp::pow2_I($a, $b, Int))) 
+    nqp::isconcrete((my $power := nqp::pow2_I($a, $b, Int)))
+      ?? nqp::isge_I($b, 0)
         ?? $power
-        !! POW_FAIL(1)
-      !! nqp::isconcrete(($power := nqp::pow2_I($a, nqp::neg_I($b, Int), Int))) && (nqp::islt_I($power, UINT64_UPPER) || nqp::iseq_I($a, 0))
-        ?? 1 / $power
+        !! nqp::islt_I($power, UINT64_UPPER) || nqp::iseq_I($a, 0)
+          ?? 1 / $power
+          !! POW_FAIL(0)
+      !! nqp::isge_I($b, 0)
+        ?? POW_FAIL(1)
         !! POW_FAIL(0)
 }
 

--- a/src/core.c/Int.pm6
+++ b/src/core.c/Int.pm6
@@ -371,10 +371,14 @@ multi sub infix:<**>(Int:D $a, Int:D $b --> Real:D) {
     nqp::isge_I($b, 0)
       ?? nqp::isconcrete((my $power := nqp::pow2_I($a, $b, Int))) 
         ?? $power
-        !! Failure.new(X::Numeric::Overflow.new)
+        !! POW_FAIL(1)
       !! nqp::isconcrete(($power := nqp::pow2_I($a, nqp::neg_I($b, Int), Int))) && (nqp::islt_I($power, UINT64_UPPER) || nqp::iseq_I($a, 0))
         ?? 1 / $power
-        !! Failure.new(X::Numeric::Underflow.new)
+        !! POW_FAIL(0)
+}
+
+sub POW_FAIL(Int:D \b --> Failure:D) is implementation-detail {
+    Failure.new(b ?? X::Numeric::Overflow.new !! X::Numeric::Underflow.new)
 }
 
 multi sub infix:<**>(int $a, int $b --> int) {

--- a/src/core.c/Int.pm6
+++ b/src/core.c/Int.pm6
@@ -370,8 +370,8 @@ multi sub infix:<**>(Int:D \a, Int:D \b --> Real:D) {
     nqp::istype($power, Int)
         ?? $power
         !! nqp::isnanorinf($power)
-            ?? Failure.new(b >= 0 ?? X::Numeric::Overflow.new !! X::Numeric::Underflow.new)
-            !! $power == 0 && a != 0
+            ?? Failure.new(nqp::isge_I(b, 0) ?? X::Numeric::Overflow.new !! X::Numeric::Underflow.new)
+            !! nqp::iseq_n($power, 0e0) && nqp::isne_I(a, 0)
                 ?? Failure.new(X::Numeric::Underflow.new)
                     !! $power.Rat(1e-15);
 }

--- a/src/core.c/Int.pm6
+++ b/src/core.c/Int.pm6
@@ -365,15 +365,15 @@ multi sub infix:<%%>(int $a, int $b --> Bool:D) {
 }
 
 multi sub infix:<**>(Int:D \a, Int:D \b --> Real:D) {
-    my $power := nqp::pow_I(nqp::decont(a), nqp::decont(b), Num, Int);
+    my $power := nqp::pow_I(nqp::decont(a), nqp::decont(b >= 0 ?? b !! -b), Num, Int);
     # when a**b is too big nqp::pow_I returns Inf
-    nqp::istype($power, Int)
-        ?? $power
-        !! nqp::isnanorinf($power)
-            ?? Failure.new(nqp::isge_I(b, 0) ?? X::Numeric::Overflow.new !! X::Numeric::Underflow.new)
-            !! nqp::iseq_n($power, 0e0) && nqp::isne_I(a, 0)
+    nqp::istype($power, Num)
+        ?? Failure.new(
+            b >= 0 ?? X::Numeric::Overflow.new !! X::Numeric::Underflow.new
+        ) !! b >= 0 ?? $power
+            !! ($power := 1 / $power) == 0 && a != 0
                 ?? Failure.new(X::Numeric::Underflow.new)
-                    !! $power.Rat(1e-15);
+                    !! $power;
 }
 
 multi sub infix:<**>(int $a, int $b --> int) {

--- a/src/core.c/Int.pm6
+++ b/src/core.c/Int.pm6
@@ -368,15 +368,21 @@ my constant UINT64_UPPER = nqp::pow_I(2, 64, Num, Int);
 
 multi sub infix:<**>(Int:D \a, Int:D \b --> Real:D) {
     my \decont_b := nqp::decont(b);
-    my $power := nqp::pow_I(nqp::decont(a), nqp::isge_I(decont_b, 0) ?? decont_b !! nqp::neg_I(decont_b, Int), Num, Int);
-    # when a**b is too big nqp::pow_I returns Inf
-    nqp::istype($power, Num)
-        ?? Failure.new(nqp::isge_I(decont_b, 0) ?? X::Numeric::Overflow.new !! X::Numeric::Underflow.new)
-        !! nqp::isge_I(decont_b, 0)
+    my $power;
+    if nqp::isge_I(decont_b, 0) {
+        $power := nqp::pow_I(nqp::decont(a), decont_b, Num, Int);
+        # when a**b is too big nqp::pow_I returns Inf
+        nqp::istype($power, Int)
             ?? $power
-            !! nqp::isge_I($power, UINT64_UPPER) && nqp::isne_I(nqp::decont(a), 0)
-                ?? Failure.new(X::Numeric::Underflow.new)
-                !! 1 / $power;
+            !! Failure.new(X::Numeric::Overflow.new)
+    }
+    else {
+        $power := nqp::pow_I(nqp::decont(a), nqp::neg_I(decont_b, Int), Num, Int);
+        # when a**b is too big nqp::pow_I returns Inf
+        nqp::istype($power, Num) || (nqp::isge_I($power, UINT64_UPPER) && nqp::isne_I(nqp::decont(a), 0))
+            ?? Failure.new(X::Numeric::Underflow.new)
+            !! 1 / $power;
+    }
 }
 
 multi sub infix:<**>(int $a, int $b --> int) {

--- a/src/core.c/Int.pm6
+++ b/src/core.c/Int.pm6
@@ -367,10 +367,10 @@ multi sub infix:<%%>(int $a, int $b --> Bool:D) {
 multi sub infix:<**>(Int:D \a, Int:D \b --> Real:D) {
     my $power := nqp::pow_I(nqp::decont(a), nqp::decont(b), Num, Int);
     # when a**b is too big nqp::pow_I returns Inf
-    nqp::istype($power, Num) && nqp::isnanorinf($power)
-        ?? Failure.new(
-            b >= 0 ?? X::Numeric::Overflow.new !! X::Numeric::Underflow.new
-        ) !! b >= 0 ?? $power
+    nqp::istype($power, Int)
+        ?? $power
+        !! nqp::isnanorinf($power)
+            ?? Failure.new(b >= 0 ?? X::Numeric::Overflow.new !! X::Numeric::Underflow.new)
             !! $power == 0 && a != 0
                 ?? Failure.new(X::Numeric::Underflow.new)
                     !! $power.Rat(1e-15);

--- a/src/core.c/Int.pm6
+++ b/src/core.c/Int.pm6
@@ -365,15 +365,15 @@ multi sub infix:<%%>(int $a, int $b --> Bool:D) {
 }
 
 multi sub infix:<**>(Int:D \a, Int:D \b --> Real:D) {
-    my $power := nqp::pow_I(nqp::decont(a), nqp::decont(b >= 0 ?? b !! -b), Num, Int);
+    my $power := nqp::pow_I(nqp::decont(a), nqp::decont(b), Num, Int);
     # when a**b is too big nqp::pow_I returns Inf
-    nqp::istype($power, Num)
+    nqp::istype($power, Num) && nqp::isnanorinf($power)
         ?? Failure.new(
             b >= 0 ?? X::Numeric::Overflow.new !! X::Numeric::Underflow.new
         ) !! b >= 0 ?? $power
-            !! ($power := 1 / $power) == 0 && a != 0
+            !! $power == 0 && a != 0
                 ?? Failure.new(X::Numeric::Underflow.new)
-                    !! $power;
+                    !! $power.Rat(1e-15);
 }
 
 multi sub infix:<**>(int $a, int $b --> int) {

--- a/src/core.c/Int.pm6
+++ b/src/core.c/Int.pm6
@@ -366,20 +366,19 @@ multi sub infix:<%%>(int $a, int $b --> Bool:D) {
 
 my constant UINT64_UPPER = nqp::pow_I(2, 64, Num, Int);
 
-multi sub infix:<**>(Int:D \a, Int:D \b --> Real:D) {
-    my \decont_b := nqp::decont(b);
+multi sub infix:<**>(Int:D $a, Int:D $b --> Real:D) {
     my $power;
-    if nqp::isge_I(decont_b, 0) {
-        $power := nqp::pow_I(nqp::decont(a), decont_b, Num, Int);
+    if nqp::isge_I($b, 0) {
+        $power := nqp::pow_I($a, $b, Num, Int);
         # when a**b is too big nqp::pow_I returns Inf
         nqp::istype($power, Int)
             ?? $power
             !! Failure.new(X::Numeric::Overflow.new)
     }
     else {
-        $power := nqp::pow_I(nqp::decont(a), nqp::neg_I(decont_b, Int), Num, Int);
+        $power := nqp::pow_I($a, nqp::neg_I($b, Int), Num, Int);
         # when a**b is too big nqp::pow_I returns Inf
-        nqp::istype($power, Num) || (nqp::isge_I($power, UINT64_UPPER) && nqp::isne_I(nqp::decont(a), 0))
+        nqp::istype($power, Num) || (nqp::isge_I($power, UINT64_UPPER) && nqp::isne_I($a, 0))
             ?? Failure.new(X::Numeric::Underflow.new)
             !! 1 / $power;
     }

--- a/src/core.c/Int.pm6
+++ b/src/core.c/Int.pm6
@@ -364,24 +364,17 @@ multi sub infix:<%%>(int $a, int $b --> Bool:D) {
     nqp::hllbool(nqp::iseq_i(nqp::mod_i($a, $b), 0))
 }
 
-my constant UINT64_UPPER = nqp::pow_I(2, 64, Num, Int);
+my constant UINT64_UPPER = nqp::pow2_I(2, 64, Int);
 
 multi sub infix:<**>(Int:D $a, Int:D $b --> Real:D) {
-    my $power;
-    if nqp::isge_I($b, 0) {
-        $power := nqp::pow_I($a, $b, Num, Int);
-        # when a**b is too big nqp::pow_I returns Inf
-        nqp::istype($power, Int)
-            ?? $power
-            !! Failure.new(X::Numeric::Overflow.new)
-    }
-    else {
-        $power := nqp::pow_I($a, nqp::neg_I($b, Int), Num, Int);
-        # when a**b is too big nqp::pow_I returns Inf
-        nqp::istype($power, Num) || (nqp::isge_I($power, UINT64_UPPER) && nqp::isne_I($a, 0))
-            ?? Failure.new(X::Numeric::Underflow.new)
-            !! 1 / $power;
-    }
+    # when a**b is too big nqp::pow2_I returns (Int)
+    nqp::isge_I($b, 0)
+      ?? nqp::isconcrete((my $power := nqp::pow2_I($a, $b, Int))) 
+        ?? $power
+        !! Failure.new(X::Numeric::Overflow.new)
+      !! nqp::isconcrete(($power := nqp::pow2_I($a, nqp::neg_I($b, Int), Int))) && (nqp::islt_I($power, UINT64_UPPER) || nqp::iseq_I($a, 0))
+        ?? 1 / $power
+        !! Failure.new(X::Numeric::Underflow.new)
 }
 
 multi sub infix:<**>(int $a, int $b --> int) {

--- a/src/core.c/Rat.pm6
+++ b/src/core.c/Rat.pm6
@@ -26,8 +26,6 @@ my class Rat is Cool does Rational[Int, Int] {
     }
 }
 
-my constant UINT64_UPPER = nqp::pow_I(2, 64, Num, Int);
-
 my class FatRat is Cool does Rational[Int, Int] {
     method FatRat(FatRat:D: Real $? --> FatRat) {
         self

--- a/src/core.c/Rat.pm6
+++ b/src/core.c/Rat.pm6
@@ -242,22 +242,20 @@ multi sub infix:<**>(Rational:D \a, Int:D \b) {
     my $de;
     nqp::if(
       nqp::isge_I(nqp::decont(b), 0),
-        nqp::if( # if we got Inf
-          nqp::istype(($nu := nqp::pow_I(a.numerator, nqp::decont(b), Num, Int)), Num),
-          Failure.new(X::Numeric::Overflow.new),
-          nqp::if( # if we got Inf
-            nqp::istype(($de := nqp::pow_I(a.denominator, nqp::decont(b), Num, Int)), Num),
-            Failure.new(X::Numeric::Overflow.new),
-            CREATE_RATIONAL_FROM_INTS $nu, $de, a, b)),
-        nqp::if( # if we got Inf
-          nqp::istype(($nu := nqp::pow_I(a.numerator,
-            nqp::neg_I(nqp::decont(b), Int), Num, Int)), Num),
-          Failure.new(X::Numeric::Underflow.new),
-          nqp::if( # if we got Inf
-            nqp::istype(($de := nqp::pow_I(a.denominator,
-              nqp::neg_I(nqp::decont(b), Int), Num, Int)), Num),
-            Failure.new(X::Numeric::Underflow.new),
-            CREATE_RATIONAL_FROM_INTS $de, $nu, a, b)))
+        nqp::if(
+          nqp::isconcrete(($nu := nqp::pow2_I(a.numerator, nqp::decont(b), Int))),
+            nqp::if(
+              nqp::isconcrete(($de := nqp::pow2_I(a.denominator, nqp::decont(b), Int))),
+                CREATE_RATIONAL_FROM_INTS($nu, $de, a, b),
+                Failure.new(X::Numeric::Overflow.new)), # if we got (Int)
+              Failure.new(X::Numeric::Overflow.new)), # if we got (Int)
+        nqp::if(
+          nqp::isconcrete(($nu := nqp::pow2_I(a.numerator, nqp::neg_I(nqp::decont(b), Int), Int))),
+            nqp::if(
+              nqp::isconcrete(($de := nqp::pow2_I(a.denominator, nqp::neg_I(nqp::decont(b), Int), Int))),
+                CREATE_RATIONAL_FROM_INTS($de, $nu, a, b),
+                Failure.new(X::Numeric::Underflow.new)), # if we got (Int)
+              Failure.new(X::Numeric::Underflow.new))) # if we got (Int)
 }
 
 multi sub infix:<==>(Rational:D \a, Rational:D \b --> Bool:D) {

--- a/src/core.c/Rational.pm6
+++ b/src/core.c/Rational.pm6
@@ -159,7 +159,7 @@ my role Rational[::NuT = Int, ::DeT = ::("NuT")] does Real {
 
     method !STRINGIFY(\whole, \fract, int $digits) {
         my str $s = nqp::tostr_I(
-          (fract * nqp::pow_I(10,$digits,Num,Int)).round
+          (fract * nqp::pow2_I(10,$digits,Int)).round
         );
         $s = nqp::concat(nqp::x('0',$digits - nqp::chars($s)),$s)
           if nqp::chars($s) < $digits;


### PR DESCRIPTION
Before, `my $a; $a := $_ ** 2 for 1..10_000_000; say now - INIT now;`
took ~7.1s, now it takes ~5.7s. However, `my $a; $a := $_ ** -2 for 1..1_000_000; say now - INIT now;`
took ~2.3s and now takes ~3.7s. The slowdown in the -2 case is because
of the non-default (smaller) epsilon passed to .Rat, but without it
`1_000_000 ** -2` would result in 0 instead of 0.000000000001.