### PR TITLE
Add a `repl` sub to enter the repl from within a program

### DIFF
--- a/src/Perl6/Optimizer.nqp
+++ b/src/Perl6/Optimizer.nqp
@@ -1314,7 +1314,8 @@ class Perl6::Optimizer {
         # This is a hack to compensate for Test.pm6 using unspecified
         # behavior. The EVAL form of it should be deprecated and then
         # removed, at which point this can go away.
-        '&throws-like', NQPMu);
+        '&throws-like', NQPMu,
+        '&repl', NQPMu);
 
     # Called when we encounter a QAST::Op in the tree. Produces either
     # the op itself or some replacement opcode to put in the tree.

--- a/src/core.c/REPL.pm6
+++ b/src/core.c/REPL.pm6
@@ -440,13 +440,13 @@ do {
 
             $!history-file.absolute
         }
-
-        method here() {
-            my $repl := self.new(nqp::getcomp("Raku"),%_);
-            nqp::bindattr($repl,REPL,'$!save_ctx',nqp::ctxcaller(nqp::ctx));
-            $repl.repl-loop
-        }
     }
+}
+
+sub repl(*%_) {
+    my $repl := REPL.new(nqp::getcomp("Raku"),%_);
+    nqp::bindattr($repl,REPL,'$!save_ctx',nqp::ctxcaller(nqp::ctx));
+    $repl.repl-loop
 }
 
 # vim: expandtab shiftwidth=4

--- a/src/core.c/REPL.pm6
+++ b/src/core.c/REPL.pm6
@@ -440,6 +440,12 @@ do {
 
             $!history-file.absolute
         }
+
+        method now() {
+            my $repl := self.new(nqp::getcomp("Raku"),%_);
+            nqp::bindattr($repl,REPL,'$!save_ctx',nqp::ctxcaller(nqp::ctx));
+            $repl.repl-loop
+        }
     }
 }
 

--- a/src/core.c/REPL.pm6
+++ b/src/core.c/REPL.pm6
@@ -441,7 +441,7 @@ do {
             $!history-file.absolute
         }
 
-        method now() {
+        method here() {
             my $repl := self.new(nqp::getcomp("Raku"),%_);
             nqp::bindattr($repl,REPL,'$!save_ctx',nqp::ctxcaller(nqp::ctx));
             $repl.repl-loop

--- a/src/core.c/REPL.pm6
+++ b/src/core.c/REPL.pm6
@@ -246,9 +246,11 @@ do {
             $self but FallbackBehavior
         }
 
-        method new(Mu \compiler, Mu \adverbs) {
-            say compiler.version_string(:shorten-versions);
-            say '';
+        method new(Mu \compiler, Mu \adverbs, $skip?) {
+            unless $skip {
+                say compiler.version_string(:shorten-versions);
+                say '';
+            }
 
             my $multi-line-enabled = !%*ENV<RAKUDO_DISABLE_MULTILINE>;
             my $self = self.bless();
@@ -444,7 +446,7 @@ do {
 }
 
 sub repl(*%_) {
-    my $repl := REPL.new(nqp::getcomp("Raku"),%_);
+    my $repl := REPL.new(nqp::getcomp("Raku"), %_, True);
     nqp::bindattr($repl,REPL,'$!save_ctx',nqp::ctxcaller(nqp::ctx));
     $repl.repl-loop
 }

--- a/src/core.c/REPL.pm6
+++ b/src/core.c/REPL.pm6
@@ -308,7 +308,7 @@ do {
 
         method interactive_prompt() { '> ' }
 
-        method repl-loop(*%adverbs) {
+        method repl-loop(:$no-exit, *%adverbs) {
 
             if $*DISTRO.is-win {
                 say "To exit type 'exit' or '^Z'";
@@ -326,6 +326,7 @@ do {
 
             REPL: loop {
                 my $newcode = self.repl-read(~$prompt);
+                last if $no-exit and $newcode eq 'exit';
 
                 my $initial_out_position = $*OUT.tell;
 
@@ -448,7 +449,7 @@ do {
 sub repl(*%_) {
     my $repl := REPL.new(nqp::getcomp("Raku"), %_, True);
     nqp::bindattr($repl,REPL,'$!save_ctx',nqp::ctxcaller(nqp::ctx));
-    $repl.repl-loop
+    $repl.repl-loop(:no-exit);
 }
 
 # vim: expandtab shiftwidth=4

--- a/src/core.c/REPL.pm6
+++ b/src/core.c/REPL.pm6
@@ -310,11 +310,11 @@ do {
 
         method repl-loop(:$no-exit, *%adverbs) {
 
-            if $*DISTRO.is-win {
-                say "To exit type 'exit' or '^Z'";
-            } else {
-                say "To exit type 'exit' or '^D'";
-            }
+            say $no-exit
+              ?? "Type 'exit' to leave"
+              !! $*DISTRO.is-win
+                ?? "To exit type 'exit' or '^Z'"
+                !! "To exit type 'exit' or '^D'";
 
             my $prompt;
             my $code;
@@ -326,7 +326,7 @@ do {
 
             REPL: loop {
                 my $newcode = self.repl-read(~$prompt);
-                last if $no-exit and $newcode eq 'exit';
+                last if $no-exit and $newcode and $newcode eq 'exit';
 
                 my $initial_out_position = $*OUT.tell;
 

--- a/t/02-rakudo/03-corekeys-6c.t
+++ b/t/02-rakudo/03-corekeys-6c.t
@@ -394,6 +394,7 @@ my @expected = (
   Q{&reduce},
   Q{&rename},
   Q{&repeated},
+  Q{&repl},
   Q{&return},
   Q{&return-rw},
   Q{&reverse},

--- a/t/02-rakudo/03-corekeys-6d.t
+++ b/t/02-rakudo/03-corekeys-6d.t
@@ -394,6 +394,7 @@ my @expected = (
     Q{&reduce},
     Q{&rename},
     Q{&repeated},
+    Q{&repl},
     Q{&return},
     Q{&return-rw},
     Q{&reverse},

--- a/t/02-rakudo/03-corekeys-6e.t
+++ b/t/02-rakudo/03-corekeys-6e.t
@@ -396,6 +396,7 @@ my @expected = (
     Q{&reduce},
     Q{&rename},
     Q{&repeated},
+    Q{&repl},
     Q{&return},
     Q{&return-rw},
     Q{&reverse},

--- a/t/02-rakudo/03-corekeys.t
+++ b/t/02-rakudo/03-corekeys.t
@@ -397,6 +397,7 @@ my @allowed =
       Q{&reduce},
       Q{&rename},
       Q{&repeated},
+      Q{&repl},
       Q{&return},
       Q{&return-rw},
       Q{&reverse},

--- a/t/02-rakudo/04-settingkeys-6c.t
+++ b/t/02-rakudo/04-settingkeys-6c.t
@@ -393,6 +393,7 @@ my %allowed = (
     Q{&reduce},
     Q{&rename},
     Q{&repeated},
+    Q{&repl},
     Q{&return},
     Q{&return-rw},
     Q{&reverse},

--- a/t/02-rakudo/04-settingkeys-6e.t
+++ b/t/02-rakudo/04-settingkeys-6e.t
@@ -393,6 +393,7 @@ my %allowed = (
     Q{&reduce},
     Q{&rename},
     Q{&repeated},
+    Q{&repl},
     Q{&return},
     Q{&return-rw},
     Q{&reverse},

--- a/t/02-rakudo/07-implementation-detail-6.c.t
+++ b/t/02-rakudo/07-implementation-detail-6.c.t
@@ -27,7 +27,7 @@ my @lower = ("",<<
   mkdir move msb next nextcallee nextsame nextwith nodemap none
   not note one open ord ords pair pairs parse-base parse-names
   permutations pick pop prepend print printf proceed produce
-  prompt push put rand redo reduce rename repeated return
+  prompt push put rand redo reduce rename repeated repl return
   return-rw reverse rindex rmdir roll roots rotate round roundrobin
   run samecase samemark samewith say sec sech set shell shift sign
   signal sin sinh sleep sleep-timer sleep-until slip slurp so sort

--- a/t/02-rakudo/07-implementation-detail-6.d.t
+++ b/t/02-rakudo/07-implementation-detail-6.d.t
@@ -27,7 +27,7 @@ my @lower = ("",<<
   mkdir move msb next nextcallee nextsame nextwith nodemap none
   not note one open ord ords pair pairs parse-base parse-names
   permutations pick pop prepend print printf proceed produce
-  prompt push put rand redo reduce rename repeated return
+  prompt push put rand redo reduce rename repeated repl return
   return-rw reverse rindex rmdir roll roots rotate round roundrobin
   run samecase samemark samewith say sec sech set shell shift sign
   signal sin sinh sleep sleep-timer sleep-until slip slurp so sort

--- a/t/02-rakudo/07-implementation-detail-6.e.t
+++ b/t/02-rakudo/07-implementation-detail-6.e.t
@@ -27,7 +27,7 @@ my @lower = ("",<<
   mkdir move msb next nextcallee nextsame nextwith nodemap none
   not note one open ord ords pair pairs parse-base parse-names
   permutations pick pop prepend print printf proceed produce
-  prompt push put rand redo reduce rename repeated return
+  prompt push put rand redo reduce rename repeated repl return
   return-rw reverse rindex rmdir roll roots rotate round roundrobin
   run samecase samemark samewith say sec sech set shell shift sign
   signal sin sinh sleep sleep-timer sleep-until slip slurp so sort


### PR DESCRIPTION
This would allow one to enter the REPL from a non-interactive program.
Ideally, this should be aware of its context, but apparently setting
$!save_ctx is not enough.  Maybe @vrurg has some ideas about that.

Sorta inspired by some comments on the #raku channel today.