### PR TITLE
Minimal fix for MAIN usage regression from #4278

### DIFF
--- a/src/core.c/Main.pm6
+++ b/src/core.c/Main.pm6
@@ -83,7 +83,7 @@ my sub RUN-MAIN(&main, $mainline, :$in-as-argsfiles) {
                 if !$param.named { next }
                 for $param.named_names -> str $name {
                     my int $accepts-true = $param.type.ACCEPTS: True;
-                    for $param.constraint_list { $accepts-true++ if .ACCEPTS: True}
+                    for $param.constraint_list { $accepts-true++ if try .ACCEPTS: True}
                     if !$accepts-true { %options-with-req-arg.push($name => True) }
                 }
             }
@@ -264,7 +264,7 @@ my sub RUN-MAIN(&main, $mainline, :$in-as-argsfiles) {
                         elsif $type !=== Bool {
 
                             my int $accepts-true = $param.type.ACCEPTS: True;
-                            for $param.constraint_list { $accepts-true++ if .ACCEPTS: True}
+                            for $param.constraint_list { $accepts-true++ if try .ACCEPTS: True}
                             $argument ~= ($accepts-true ?? "[={$constraints || $type.^name}]"
                                                         !! "=<{$constraints || $type.^name}>");
                             if Metamodel::EnumHOW.ACCEPTS($type.HOW) {


### PR DESCRIPTION
This commit fixes the regression noted in #4278 (where certain complex default arguments would throw errors when used in a pre-compiled module, despite working fine is .raku files).  The implemented fix correctly treats these arguments as non-required, since they have defaults.

However, the presence of the error likely indicates a more subtle bug in Bootstrap: it seems that a pre-compiled value is not being assigned when it should be.  I do not know my way around the Bootstrap code well enough to hunt that down so, in the interest of not breaking anything, the current fix resolves the issue.  But if anyone would like to take a look in Bootstrap, that could provide a better solution.

I manually tested this bugfix against the code in issue #4278 and the other affected code [mentioned in #raku](https://colabti.org/irclogger/irclogger_log/raku?date=2021-04-10#l412). I didn't add a test to the t/ directory because I wasn't sure how to test a bug that only comes up in pre-compiled modules and wasn't sure where such a test should live.