### PR TITLE
Fix compilation failure with EVAL in precompiled module's mainline

### DIFF
--- a/src/core.c/CompUnit/Loader.pm6
+++ b/src/core.c/CompUnit/Loader.pm6
@@ -34,8 +34,6 @@ class CompUnit::Loader is repr('Uninstantiable') {
     multi method load-precompilation-file(IO::Path $path --> CompUnit::Handle:D) {
         my $handle     := CompUnit::Handle.new;
         my $*CTXSAVE   := $handle;
-        # '%?OPTIONS' is expected by some code; mainly by the World object
-        my %*COMPILING := nqp::hash('%?OPTIONS', nqp::hash());
         nqp::loadbytecode($path.Str);
         $handle
     }
@@ -43,7 +41,6 @@ class CompUnit::Loader is repr('Uninstantiable') {
     multi method load-precompilation-file(IO::Handle $file --> CompUnit::Handle:D) {
         my $handle     := CompUnit::Handle.new;
         my $*CTXSAVE   := $handle;
-        my %*COMPILING := nqp::hash('%?OPTIONS', nqp::hash());
 #?if !jvm
         # Switch file handle to binary mode before passing it off to the VM,
         # so we don't lose things hanging around in the decoder.
@@ -58,7 +55,6 @@ class CompUnit::Loader is repr('Uninstantiable') {
     method load-precompilation(Blob:D $bytes --> CompUnit::Handle:D) {
         my $handle     := CompUnit::Handle.new;
         my $*CTXSAVE   := $handle;
-        my %*COMPILING := nqp::hash('%?OPTIONS', nqp::hash());
         nqp::loadbytecodebuffer($bytes);
         $handle
     }


### PR DESCRIPTION
The error was reported as "Cannot look up attributes in a NQPMu type object"
with a require in a module's mainline. The error message gets reported because
QASTCompilerMAST cannot find the frame for a given CUID. The error only
appeared when the require loaded an already installed and precompiled module
and only if the repository chain got changed since (by way of 'use lib' or -I).
The reason is that in this case we re-check dependencies and have to run an
EVAL to create the DependencySpecification object.

The EVAL got compiled and ordinarily the created frame would be added to
%*COMPILING<moar><mast_frames> but we cleared %*COMPILING before loading a
precompiled module. QASTCompilerMAST would therefore initialize a new
mast_frames hash to add the frames to but this hash would not be known to the
outside compiler.

The code for clearing %*COMPILING originated in the very first implementation
of the export trait in 2011. Back then we had a $*COMPILING flag and the export
trait would only do something if that flag was set. This was a hack required
because traits were also run when loading a module. The flag was later replaced
by %*COMPILING. The hack itself has been removed already in 2012 in a commit
aptly named "Eliminate old hack from the bad old days when we ran traits again
at startup". However the clearing of %*COMPILING remained and has since been
faithfully ported through all our module loading refactors.

Lay the remnants of the original hack to rest, finally.
Fixes GH #3749