### PR TITLE
Fix 'too many open files' during module uninstall

### DIFF
--- a/src/core.c/CompUnit/Repository/Installation.pm6
+++ b/src/core.c/CompUnit/Repository/Installation.pm6
@@ -81,7 +81,7 @@ sub MAIN(:$name, :$auth, :$ver, *@, *%) {
 
         for $short-dir.dir -> $dir {
             $dir.add($id).unlink;
-            $dir.rmdir unless $dir.dir;
+            $dir.rmdir unless $dir.dir.elems;
         }
     }
 


### PR DESCRIPTION
Recently uninstalling modules might give a 'too many open files' error. By making a call to `.dir` eager this error goes away, although I'm not clear why or what changed in e.g. libuv that would require this now.