### PR TITLE
Give DateTime its own infix:<eqv>

### DIFF
--- a/src/core.c/DateTime.pm6
+++ b/src/core.c/DateTime.pm6
@@ -630,5 +630,11 @@ multi sub infix:<+>(DateTime:D \a, Duration:D \b --> DateTime:D) {
 multi sub infix:<+>(Duration:D \a, DateTime:D \b --> DateTime:D) {
     b.new(b.Instant + a).in-timezone(b.timezone)
 }
+multi sub infix:<eqv>(DateTime:D \a, DateTime:D \b --> Bool:D) {
+    nqp::hllbool(
+          nqp::eqaddr(nqp::decont(a),nqp::decont(b))
+      || (nqp::eqaddr(a.WHAT,b.WHAT) && a == b)
+    )
+}
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
Otherwise it falls back to Mu's, which just relies on the .raku output.

Rakudo builds ok and passes `make m-test m-spectest`.

This is about 0.15s slower for `my $d1 := DateTime.new(1524424977.922727.rand.Rat); my $d2 := DateTime.new(1524424977.922727.rand.Rat); my $a; $a := $d1 eqv $d2 for ^100_000; say now - INIT now`, but I think is a better fix for the recent regression with Games::TauStation::DateTime than https://github.com/rakudo/rakudo/pull/4311 (which I didn't time, but probably has some sort of slowdown also, since it adds a sprintf call)