### PR TITLE
Replace use of P6EX hllsym with Metamodel::Configuration.throw_or_die

### DIFF
--- a/src/Perl6/Metamodel/Configuration.nqp
+++ b/src/Perl6/Metamodel/Configuration.nqp
@@ -39,43 +39,20 @@ class Perl6::Metamodel::Configuration {
     }
     method role_to_role_applier_type() { $role_to_role_applier_type }
 
-    my $X_package := nqp::null();
-    method set_X_package($X) {
-        $X_package := $X;
-    }
-    method find_exception($exception) {
-        my $ex_type := nqp::null();
-        unless nqp::isnull($X_package) {
-            my @parts := nqp::split('::', $exception);
-            # If the first part of the long name is not X then pretend there is no such exception. Which is, actually
-            # and most likely, is true.
-            if nqp::iseq_s(nqp::shift(@parts), 'X') {
-                my $who := $X_package.WHO;
-                while +@parts {
-                    my $name := nqp::shift(@parts);
-                    if $who.EXISTS-KEY($name) {
-                        if +@parts {
-                            $who := $who.AT-KEY($name).WHO;
-                        }
-                        else {
-                            $ex_type := $who.AT-KEY($name);
-                        }
-                    }
-                    else {
-                        # Signal the loop end
-                        @parts := nqp::list();
-                    }
-                }
-            }
-        }
-        $ex_type
+    my &sym_lookup := nqp::null();
+    method set_sym_lookup_routine(&slr) {
+        &sym_lookup := &slr;
     }
     method throw_or_die($exception, $die_message, *@pos, *%named) {
-        my $ex_type := self.find_exception($exception);
-        if nqp::isnull($ex_type) {
+        if nqp::isnull(&sym_lookup) {
             nqp::die($die_message)
         }
         else {
+            # When &sym_lookup is registered we do have all core exception classes declared. Therefore we can use
+            # use &sym_lookup safely. If it fails to find a symbol then fully legit X::NoSuchSymbol will be thrown.
+            my $ex_type := &sym_lookup(nqp::hllizefor($exception, 'Raku'));
+            # HLLize all named arguments for exception constructor. Note that if an exception attribute is Bool the the
+            # caller of this method is responsible for using nqp::hllboolfor to produce a valid Bool instance.
             my %hll_named;
             for %named {
                 %hll_named{nqp::iterkey_s($_)} := nqp::hllizefor(nqp::iterval($_), 'Raku');

--- a/src/Perl6/Metamodel/Configuration.nqp
+++ b/src/Perl6/Metamodel/Configuration.nqp
@@ -76,7 +76,11 @@ class Perl6::Metamodel::Configuration {
             nqp::die($die_message)
         }
         else {
-            $ex_type.new(|@pos, |%named).throw
+            my %hll_named;
+            for %named {
+                %hll_named{nqp::iterkey_s($_)} := nqp::hllizefor(nqp::iterval($_), 'Raku');
+            }
+            $ex_type.new(|@pos, |%hll_named).throw
         }
     }
 }

--- a/src/Perl6/Metamodel/Configuration.nqp
+++ b/src/Perl6/Metamodel/Configuration.nqp
@@ -83,6 +83,10 @@ class Perl6::Metamodel::Configuration {
             $ex_type.new(|@pos, |%hll_named).throw
         }
     }
+
+    # Register HLL symbol for code which doesn't have direct access to this class. For example, moar/Perl6/Ops.nqp
+    # relies on this symbol.
+    nqp::bindhllsym('Raku', 'METAMODEL_CONFIGURATION', Perl6::Metamodel::Configuration);
 }
 
 # vim: expandtab sw=4

--- a/src/Perl6/Metamodel/MethodContainer.nqp
+++ b/src/Perl6/Metamodel/MethodContainer.nqp
@@ -20,14 +20,20 @@ role Perl6::Metamodel::MethodContainer {
         $name := nqp::decont_s($name);
         if nqp::existskey(%!methods, $name) || nqp::existskey(%!submethods, $name) {
             # XXX try within nqp::die() causes a hang. Pre-cache the result and use it later.
-            my $method_type := try { nqp::lc($code_obj.HOW.name($code_obj)) } // 'method';
-            nqp::die("Package '"
-              ~ self.name($obj)
-              ~ "' already has a "
-              ~ $method_type
-              ~ " '"
-              ~ $name
-              ~ "' (did you mean to declare a multi method?)");
+            my $method-type := try { nqp::lc($code_obj.HOW.name($code_obj)) } // 'method';
+            Perl6::Metamodel::Configuration.throw_or_die(
+                'X::Method::Duplicate',
+                "Package '"
+                    ~ self.name($obj)
+                    ~ "' already has a "
+                    ~ $method-type
+                    ~ " '"
+                    ~ $name
+                    ~ "' (did you mean to declare a multi method?)",
+                :$method-type,
+                :method($name),
+                :typename(self.name($obj))
+            );
         }
 
         # Add to correct table depending on if it's a Submethod.

--- a/src/Perl6/Metamodel/Mixins.nqp
+++ b/src/Perl6/Metamodel/Mixins.nqp
@@ -39,14 +39,12 @@ role Perl6::Metamodel::Mixins {
         if $need-mixin-attribute {
             my $found := $mixin_type.HOW.mixin_attribute($mixin_type);
             unless $found {
-                my %ex := nqp::gethllsym('Raku', 'P6EX');
-                if !nqp::isnull(%ex) && nqp::existskey(%ex, 'X::Role::Initialization') {
-                    nqp::atkey(%ex, 'X::Role::Initialization')(@roles[0]);
-                }
-                else {
-                    my $name := @roles[0].HOW.name(@roles[0]);
-                    nqp::die("Can only supply an initialization value for a role if it has a single public attribute, but this is not the case for '$name'");
-                }
+                my $name := @roles[0].HOW.name(@roles[0]);
+                Perl6::Metamodel::Configuration.throw_or_die(
+                    'X::Role::Initialization',
+                    "Can only supply an initialization value for a role if it has a single public attribute, but this is not the case for '$name'",
+                    :role(@roles[0])
+                );
             }
         }
 

--- a/src/Perl6/Metamodel/MultipleInheritance.nqp
+++ b/src/Perl6/Metamodel/MultipleInheritance.nqp
@@ -34,12 +34,13 @@ role Perl6::Metamodel::MultipleInheritance {
         }
         my $parent_how := $parent.HOW;
         if nqp::can($parent_how, 'repr_composed') && !$parent_how.repr_composed($parent) {
-            my %ex := nqp::gethllsym('Raku', 'P6EX');
-            if !nqp::isnull(%ex) && nqp::existskey(%ex, 'X::Inheritance::NotComposed') {
-                %ex{'X::Inheritance::NotComposed'}(self.name($obj), $parent_how.name($parent))
-            }
-            nqp::die("Class " ~ self.name($obj) ~ " cannot inherit from "
-                ~ $parent_how.name($parent) ~ " because the parent is not composed yet");
+            Perl6::Metamodel::Configuration.throw_or_die(
+                'X::Inheritance::NotComposed',
+                "Class " ~ self.name($obj) ~ " cannot inherit from "
+                    ~ $parent_how.name($parent) ~ " because the parent is not composed yet",
+                :child-name(nqp::hllizefor(self.name($obj), 'Raku')),
+                :parent-name(nqp::hllizefor($parent_how.name($parent), 'Raku'))
+            );
         }
         for @!parents {
             if nqp::decont($_) =:= nqp::decont($parent) {

--- a/src/Perl6/Metamodel/SubsetHOW.nqp
+++ b/src/Perl6/Metamodel/SubsetHOW.nqp
@@ -63,13 +63,11 @@ class Perl6::Metamodel::SubsetHOW
         }
         $!refinee := nqp::decont($refinee);
         if nqp::objprimspec($!refinee) {
-            my %ex := nqp::gethllsym('Raku', 'P6EX');
-            if nqp::existskey(%ex, 'X::NYI') {
-                %ex{'X::NYI'}('Subsets of native types');
-            }
-            else {
-                nqp::die("Subsets of native types NYI");
-            }
+            Perl6::Metamodel::Configuration.throw_or_die(
+                'X::NYI',
+                "Subsets of native types NYI",
+                :feature(nqp::hllizefor('Subsets of native types', 'Raku'))
+            );
         }
     }
 

--- a/src/core.c/Exception.pm6
+++ b/src/core.c/Exception.pm6
@@ -301,6 +301,22 @@ my class X::Method::NotFound is Exception {
     }
 }
 
+my class X::Method::Duplicate is Exception {
+    has $.method-type;
+    has $.method;
+    has $.typename;
+
+    method message() {
+        "Package '"
+        ~ $.typename
+        ~ "' already has a "
+        ~ $.method-type
+        ~ " '"
+        ~ $.method
+        ~ "' (did you mean to declare a multi method?)"
+    }
+}
+
 my class X::Method::InvalidQualifier is Exception {
     has $.method;
     has $.invocant;

--- a/src/core.c/Exception.pm6
+++ b/src/core.c/Exception.pm6
@@ -3314,7 +3314,9 @@ my class Exceptions::JSON {
     }
 }
 
-# Provide means of accessing any X:: exception to the Metamodel.
-Metamodel::Configuration.set_X_package(X);
+# Provide Metamodel::Configuration with symbol lookup routine. We do it here because throw_or_die method learn about
+# availability of all exception classes based on this registration. OTOH, it is better to provide them as soon as
+# possible as this might improve diagnostics of CORE.setting compilation failures.
+Metamodel::Configuration.set_sym_lookup_routine( -> $sym is raw { ::($sym) } );
 
 # vim: expandtab shiftwidth=4

--- a/src/core.c/Exception.pm6
+++ b/src/core.c/Exception.pm6
@@ -2993,7 +2993,6 @@ my class X::Nominalizable::NoKind does X::Nominalizable {
     }
 }
 
-nqp::bindcurhllsym('METAMODEL_CONFIGURATION', Perl6::Metamodel::Configuration);
 #?if !moar
 nqp::bindcurhllsym('P6EX', nqp::hash(
   'X::TypeCheck::Binding',

--- a/src/vm/moar/Perl6/Ops.nqp
+++ b/src/vm/moar/Perl6/Ops.nqp
@@ -136,15 +136,14 @@ $ops.add_hll_op('Raku', 'p6bindassert', -> $qastcomp, $op {
 
     # Error generation.
     proto bind_error($got, $wanted) {
-        my %ex := nqp::gethllsym('Raku', 'P6EX');
-        if nqp::isnull(%ex) || !nqp::existskey(%ex, 'X::TypeCheck::Binding') {
-            nqp::die("Type check failed in binding; expected '" ~
+        nqp::gethllsym('Raku', 'METAMODEL_CONFIGURATION').throw_or_die(
+            'X::TypeCheck::Binding',
+            "Type check failed in binding; expected '" ~
                 $wanted.HOW.name($wanted) ~ "' but got '" ~
-                $got.HOW.name($got) ~ "'");
-        }
-        else {
-            nqp::atkey(%ex, 'X::TypeCheck::Binding')($got, $wanted)
-        }
+                $got.HOW.name($got) ~ "'",
+            :$got,
+            :expected($wanted)
+        );
     }
     my $err_rep := $qastcomp.as_mast(QAST::WVal.new( :value(nqp::getcodeobj(&bind_error)) ));
     MAST::Call.new(

--- a/src/vm/moar/spesh-plugins.nqp
+++ b/src/vm/moar/spesh-plugins.nqp
@@ -171,15 +171,14 @@ sub identity($obj) { $obj }
     }
 
     sub return_error($got, $wanted) {
-        my %ex := nqp::gethllsym('Raku', 'P6EX');
-        if nqp::isnull(%ex) || !nqp::existskey(%ex, 'X::TypeCheck::Return') {
-            nqp::die("Type check failed for return value; expected '" ~
+        Perl6::Metamodel::Configuration.throw_or_die(
+            'X::TypeCheck::Return',
+            "Type check failed for return value; expected '" ~
                 $wanted.HOW.name($wanted) ~ "' but got '" ~
-                $got.HOW.name($got) ~ "'");
-        }
-        else {
-            nqp::atkey(%ex, 'X::TypeCheck::Return')($got, $wanted)
-        }
+                $got.HOW.name($got) ~ "'",
+            :$got,
+            :expected($wanted)
+        );
     }
 
     sub make-unchecked-coercion($rv, $coerce_to) {
@@ -314,13 +313,13 @@ sub identity($obj) { $obj }
 # We case-analyze assignments and provide these optimized paths for a range of
 # common situations.
 sub assign-type-error($desc, $value) {
-    my %x := nqp::gethllsym('Raku', 'P6EX');
-    if nqp::ishash(%x) {
-        %x<X::TypeCheck::Assignment>($desc.name, $value, $desc.of);
-    }
-    else {
-        nqp::die("Type check failed in assignment");
-    }
+    Perl6::Metamodel::Configuration.throw_or_die(
+        'X::TypeCheck::Assignment',
+        "Type check failed in assignment",
+        :symbol($desc.name),
+        :got($value),
+        :expected($desc.of)
+    );
 }
 sub assign-fallback($cont, $value) {
     nqp::assign($cont, $value)

--- a/t/02-rakudo/13-exceptions.t
+++ b/t/02-rakudo/13-exceptions.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 3;
+plan 5;
 
 # GH #2739
 # Prior to the fix the original exception would be lost hidden under 'no handler found' error.
@@ -17,6 +17,19 @@ throws-like q[multi sub f(int $foo is rw) { }; f(42)],
 throws-like q[multi sub f(Int $foo is rw) { }; f(42)],
         X::Comp,
         'calling multi sub that expects a rw non-native argument with a literal is caught at compile time';
+
+throws-like q:to/CODE/,
+                my \parent := Metamodel::ClassHOW.new_type(:name('Parent'));
+                my \child := Metamodel::ClassHOW.new_type(:name('Child'));
+                child.^add_parent(parent);
+                child.^compose;
+                CODE
+        X::Inheritance::NotComposed,
+        'inheriting from uncomposed parent';
+
+throws-like q[role R {}; my $foo = 42 but R(1)],
+        X::Role::Initialization,
+        'passing an initializer when role cannot accept it';
 
 done-testing;
 


### PR DESCRIPTION
The advantages of this move are:

- less boilerplate code as one doesn't need to add an entry to `P6EX`
  hash if wants to throw an exception from Metamodel code
- much better readability
- should also reduce the number of closure allocations as the code
  objects stored in `P6EX` are now gone

What is not solved yet:

- Java/JS backends. I just don't know how to deal with them
- perl6_ops.c which is currently the only case where `P6EX` is used