### PR TITLE
[JVM] Make 'make test' work again

### DIFF
--- a/t/02-rakudo/08-inline-native-arith.t
+++ b/t/02-rakudo/08-inline-native-arith.t
@@ -5,6 +5,7 @@ plan 4;
 
 my $p = run($*EXECUTABLE, '--target=optimize',
     '-e', 'my int $i = 1; for ^10 { $i = $i * 2 }', :out);
+todo 'no mul_i in output of --target=optimize', 1 if $*VM.name eq 'jvm';
 like $p.out.slurp(:close), /mul_i/,
     '$i * 2 inlines to mul_i when $i is declared as int';
 

--- a/t/02-rakudo/10-nqp-ops.t
+++ b/t/02-rakudo/10-nqp-ops.t
@@ -7,6 +7,8 @@ use nqp;
 plan 2;
 
 # https://github.com/Raku/old-issue-tracker/issues/6538
+todo 'org.raku.nqp.sixmodel.reprs.P6OpaqueBaseInstance$BadReferenceRuntimeException: Cannot access a native attribute as a reference attribute',
+    1, if $*VM eq 'jvm';
 lives-ok {
     nqp::p6bindattrinvres(($ := 42), Int, q|$!value|, nqp::getattr(42, Int, q|$!value|))
 }, 'p6bindattrinvres with getattr of bigint does not crash';

--- a/t/02-rakudo/12-proto-arity-count.t
+++ b/t/02-rakudo/12-proto-arity-count.t
@@ -1,4 +1,9 @@
 use Test;
+
+BEGIN if $*VM.name eq 'jvm' {
+    plan :skip-all<some subs are not defined on JVM backend>;
+};
+
 plan +my @protos := all-the-protos;
 
 # https://github.com/rakudo/rakudo/issues/1739

--- a/t/02-rakudo/16-begin-time-eval.t
+++ b/t/02-rakudo/16-begin-time-eval.t
@@ -1,5 +1,10 @@
 use lib <t/packages/02-rakudo/lib>;
 use Test;
+
+BEGIN if $*VM.name eq 'jvm' {
+    plan :skip-all<java.lang.ArrayIndexOutOfBoundsException: Index 7 out of bounds for length 7>;
+}
+
 use BeginTimeEvalAndNativeCall;
 pass 'Module loaded successfully';
 done-testing;

--- a/t/02-rakudo/18-pseudostash.t
+++ b/t/02-rakudo/18-pseudostash.t
@@ -10,6 +10,7 @@ plan 3;
     # the chosen PseudoStash path `CALLER::CLIENT::CLIENT::` also depends on how COERCE method is invoked by Rakudo.
     # Therefore any changes related to coercion protocol implementation may require tweking of this test.
     for <c d e.PREVIEW> -> $rev {
+        todo 'JVM does not have simpler COERCE calling from new-disp', 1 if $*VM.name eq 'jvm';
         is-run "use v6.$rev;\nmy \$foo = q<This is 6.$rev>;\n"
                 ~ q:to/TEST-CODE/,
                     my class C {

--- a/t/02-rakudo/99-misc.t
+++ b/t/02-rakudo/99-misc.t
@@ -35,6 +35,7 @@ if $*DISTRO.is-win {
     skip 'code too complex for Win32';
 }
 else {
+    todo 'Attach a profiler (e.g. JVisualVM) and press enter', 1 if $*VM.name eq 'jvm';
     is-run :compiler-args[
         '--profile', '--profile-filename=' ~ make-temp-path.absolute
     ], ｢
@@ -131,11 +132,13 @@ subtest 'postfix-to-prefix-inc-dec opt does not rewrite custom ops' => {
     multi sub foo($y where /{@res.push: $y}./) {}
     foo 'a';
     foo 'b';
+    todo 'JVM backend still does trial bind, giving [<a a b b>]', 1 if $*VM.name eq 'jvm';
     is-deeply @res, [<a b>],
         'regex blocks update their lexical variables right';
 }
 
 group-of 2 => 'collation experiment' => {
+    todo 'Dynamic variable $*COLLATION not found', 2 if $*VM.name eq 'jvm';
     is-run ｢$*COLLATION.set: :primary; print 'pass'｣,
         :out<pass>, '$*COLLATION.set no longer requires experimental pragma';
     is-run ｢

--- a/t/02-rakudo/repl.t
+++ b/t/02-rakudo/repl.t
@@ -222,7 +222,7 @@ is-run-repl ['Nil'], /Nil/, 'REPL outputs Nil as a Nil';
                                               'num32 $i,  num64 $j,',
                     ') = 1, 2, 3, 4, 5, 6, 7, 8, 9e0, 10e0;';
 
-    todo 'https://github.com/rakudo/rakudo/issues/4161';
+    todo 'https://github.com/rakudo/rakudo/issues/4161' unless $*VM.name eq 'jvm';
     is-run-repl "$code\nsay 'test is good';\n",
         :err(''),
         :out(/'(1 2 3 4 5 6 7 8 9 10)' .* 'test is good'/),

--- a/t/02-rakudo/reproducible-builds.t
+++ b/t/02-rakudo/reproducible-builds.t
@@ -38,17 +38,20 @@ $store.prefix.child('.lock').unlink;
 $store.prefix.child('CACHEDIR.TAG').unlink;
 $store.prefix.rmdir;
 
+todo 'checksums not identical', 1 if $*VM.name eq 'jvm';
 is @checksums[1], @checksums[0], 'Both precompilation runs resulted in the same checksum'
     or do {
-        for :before(@units[0]), :after(@units[1]) {
-            my $bytecode = $_.value.bytecode;
-            $_.value.save-to($_.key().IO);
-            spurt("$_.key().bc", $bytecode);
-            shell("moar --dump $_.key().bc > $_.key().dump");
-            shell("hexdump -C $_.key() > $_.key().hex");
+        unless $*VM.name eq 'jvm' {
+            for :before(@units[0]), :after(@units[1]) {
+                my $bytecode = $_.value.bytecode;
+                $_.value.save-to($_.key().IO);
+                spurt("$_.key().bc", $bytecode);
+                shell("moar --dump $_.key().bc > $_.key().dump");
+                shell("hexdump -C $_.key() > $_.key().hex");
+            }
+            my $proc = shell("diff before.dump after.dump");
+            $proc = shell("diff before.hex after.hex");
         }
-        my $proc = shell("diff before.dump after.dump");
-        $proc = shell("diff before.hex after.hex");
     }
 
 done-testing;

--- a/t/03-jvm/01-interop.t
+++ b/t/03-jvm/01-interop.t
@@ -22,7 +22,10 @@ plan 30;
     is $jstr, "bar", "multi constructor works";
 }
 
-{
+if True {
+    skip 'java.lang.IncompatibleClassChangeError: Inconsistent constant pool data in classfile for class java/util/zip/Checksum', 3;
+}
+else {
     use java::util::zip::CRC32:from<JavaRuntime>;
     # check two of the .update candidates for CRC32
     {
@@ -116,7 +119,10 @@ plan 30;
     }
 }
 
-{
+if True {
+    skip 'java.lang.NullPointerException';
+}
+else {
     use java::util::zip::CRC32:from<JavaRuntime>;
     {
         CRC32.HOW.add_method(CRC32, "doubledValue", method ($self:) {
@@ -157,15 +163,20 @@ plan 30;
 {
     my $r = run('javac', 't/03-jvm/Foo.java');
     if $r && "t/03-jvm/Foo.class".IO ~~ :e {
-        my $out = shell("$*EXECUTABLE -e'use lib q[java#t/03-jvm/]; use Foo:from<Java>; say Foo.bar; say Foo.new.quux;'", :out);
-        is $out.out.lines, "baz womble", "(compiling and) loading a .class file via 'use lib' works";
-           $out = shell("$*EXECUTABLE -e'use lib q[java#t/03-jvm/]; use Foo:from<Java>; say Foo.trizzle([1, 2e0, <bar>])'", :out);
-        is $out.out.lines, "12.0bar", "passing arrays with mixed types to Object[] works";
-           $out = shell("$*EXECUTABLE -e'use lib q[java#t/03-jvm/]; use Foo:from<Java>; say Foo.suzzle([1, 2e0, <bar>])'", :out);
-        is $out.out.lines, "12.0bar", "passing arrays with mixed types to List<Object> works";
-           $out = shell("$*EXECUTABLE -e'use lib q[java#t/03-jvm/]; use Foo:from<Java>; say Foo.foozzle(%(a => 1e0, b => 2, c => \"foo\"))'", 
-                    :out);
-        is $out.out.lines, "a => 1.0, b => 2, c => foo, ", "passing Hash[Str] with mixed types to Map works";
+        if True {
+            skip 'java.lang.IllegalArgumentException: object is not an instance of declaring class', 4;
+        }
+        else {
+            my $out = shell("$*EXECUTABLE -e'use lib q[java#t/03-jvm/]; use Foo:from<Java>; say Foo.bar; say Foo.new.quux;'", :out);
+            is $out.out.lines, "baz womble", "(compiling and) loading a .class file via 'use lib' works";
+               $out = shell("$*EXECUTABLE -e'use lib q[java#t/03-jvm/]; use Foo:from<Java>; say Foo.trizzle([1, 2e0, <bar>])'", :out);
+            is $out.out.lines, "12.0bar", "passing arrays with mixed types to Object[] works";
+               $out = shell("$*EXECUTABLE -e'use lib q[java#t/03-jvm/]; use Foo:from<Java>; say Foo.suzzle([1, 2e0, <bar>])'", :out);
+            is $out.out.lines, "12.0bar", "passing arrays with mixed types to List<Object> works";
+               $out = shell("$*EXECUTABLE -e'use lib q[java#t/03-jvm/]; use Foo:from<Java>; say Foo.foozzle(%(a => 1e0, b => 2, c => \"foo\"))'",
+                        :out);
+            is $out.out.lines, "a => 1.0, b => 2, c => foo, ", "passing Hash[Str] with mixed types to Map works";
+        }
     }
     else {
         skip 2;

--- a/t/04-nativecall/00-misc.t
+++ b/t/04-nativecall/00-misc.t
@@ -5,6 +5,10 @@ use Test::Helpers;
 use CompileTestLib;
 compile_test_lib '00-misc';
 
+if $*VM.name eq 'jvm' {
+    plan :skip-all<NullPointerException in sub NCstrlen>;
+}
+
 { # https://github.com/rakudo/rakudo/issues/3235
     role Foo {
         sub NCstrlen(Str --> int32) is native('./00-misc') { !!! };

--- a/t/04-nativecall/01-argless.t
+++ b/t/04-nativecall/01-argless.t
@@ -21,6 +21,11 @@ Nothing() for ^2;
 
 pass 'survived the call';
 
+if $*VM.name eq 'jvm' {
+    skip-rest 'RuntimeException: No such attribute $!call for this object';
+    exit;
+}
+
 is Argless(), 2, 'called argless function returning int32' for ^2;
 is ArglessChar(), 2, 'called argless function returning char' for ^2;
 is ArglessLongLong(), 2, 'called argless function returning long long' for ^2;

--- a/t/04-nativecall/04-pointers.t
+++ b/t/04-nativecall/04-pointers.t
@@ -31,15 +31,20 @@ ok ReturnNullPointer() === Pointer,           'A returned NULL pointer is the Po
 
 my $p = ReturnPointerToIntArray();
 is $p.deref, 10, 'typed pointer deref method';
-is $p[1], 20, 'typed pointer array dereference';
-is (++$p).deref, 20, 'typed pointer increment';
-is ($p.add: -1).deref, 10, '.add(-1)';
-is $p[0], 20, 'typed pointer incremented (1)';
-is $p[1], 30, 'typed pointer incremented (2)';
-is (--$p).deref, 10, 'typed pointer decrement';
-is $p[0], 10, 'typed pointer incremented (1)';
-is $p[1], 20, 'typed pointer incremented (2)';
-is ($p.add: 2).deref, 30, '.add(2)';
+if $*VM.name eq 'jvm' {
+    skip 'UnsupportedOperationException: This pointer is opaque', 9;
+}
+else {
+    is $p[1], 20, 'typed pointer array dereference';
+    is (++$p).deref, 20, 'typed pointer increment';
+    is ($p.add: -1).deref, 10, '.add(-1)';
+    is $p[0], 20, 'typed pointer incremented (1)';
+    is $p[1], 30, 'typed pointer incremented (2)';
+    is (--$p).deref, 10, 'typed pointer decrement';
+    is $p[0], 10, 'typed pointer incremented (1)';
+    is $p[1], 20, 'typed pointer incremented (2)';
+    is ($p.add: 2).deref, 30, '.add(2)';
+}
 
 
 {

--- a/t/04-nativecall/05-arrays.t
+++ b/t/04-nativecall/05-arrays.t
@@ -7,6 +7,10 @@ use Test;
 
 plan 46;
 
+BEGIN if $*VM.name eq 'jvm' {
+    plan :skip-all<NullPointerException in sub ReturnADoubleArray>;
+};
+
 compile_test_lib('05-arrays');
 
 {

--- a/t/04-nativecall/06-struct.t
+++ b/t/04-nativecall/06-struct.t
@@ -150,7 +150,12 @@ is-approx $ss.b.first,  3.7e0, 'field 1 from struct 2 in struct';
 is-approx $ss.b.second, 0.1e0, 'field 2 from struct 2 in struct';
 
 my PointerStruct $x = ReturnAPointerStruct();
-is $x.p.deref, 19, 'CPointer object in struct';
+if $*VM.name eq 'jvm' {
+    skip 'NullPointerException in sub _deref';
+}
+else {
+    is $x.p.deref, 19, 'CPointer object in struct';
+}
 
 my StringStruct $strstr = ReturnAStringStruct();
 is $strstr.first,  'OMG!',     'first string in struct';
@@ -188,6 +193,11 @@ is $sis.a.second, 77, 'nested second is 77';
 
 {
     throws-like 'class EmptyCStructTest is repr<CStruct> { };', Exception, message => { m/'no attributes'/ };
+}
+
+if $*VM.name eq 'jvm' {
+    skip-rest 'One of the next texts crashes the JVM';
+    exit;
 }
 
 my $iais = InlinedArrayInStruct.new();

--- a/t/04-nativecall/07-writebarrier.t
+++ b/t/04-nativecall/07-writebarrier.t
@@ -7,6 +7,10 @@ use Test;
 
 plan 7;
 
+BEGIN if $*VM.name eq 'jvm' {
+    plan :skip-all<NullPointerException in sub _deref>;
+};
+
 compile_test_lib('07-writebarrier');
 
 class IntPtr is repr('CPointer') {

--- a/t/04-nativecall/08-callbacks.t
+++ b/t/04-nativecall/08-callbacks.t
@@ -62,6 +62,7 @@ sub return_struct() returns Struct {
 
 TakeACallback(&simple_callback);
 OptionallyTakeACallback(&simple_callback);
+todo 'does not work yet on JVM', 1 if $*VM.name eq 'jvm';
 lives-ok { OptionallyTakeACallback(Code) }, "optional callback with Code type object";
 lives-ok { OptionallyTakeACallback(Pointer) }, "optional callback with Pointer type object";
 TakeIntCallback(&int_callback);

--- a/t/04-nativecall/11-cpp.t
+++ b/t/04-nativecall/11-cpp.t
@@ -48,6 +48,10 @@ class Derived1 is repr<CPPStruct> {
 sub SizeofDerived1() returns int32 is mangled is native("./11-cpp") { * }
 
 is nativesizeof(Derived1), SizeofDerived1(), 'sizeof(Derived1)';
+if $*VM.name eq 'jvm' {
+    skip-rest 'RuntimeException: No such attribute $!call for this object';
+    exit;
+}
 ok my $d1 = Derived1.new, 'can instantiate C++ class';
 ok my Derived1 $d1b .= new, 'can instantiate the same C++ class again using « .= »';
 is $d1.foo,   11,   'can read attribute foo';

--- a/t/04-nativecall/21-callback-other-thread.t
+++ b/t/04-nativecall/21-callback-other-thread.t
@@ -17,6 +17,11 @@ sub the_callback(int32 $i --> int32) { 2 * $i }
 SetCallback(&the_callback);
 is CallCallback(1), 6, 'Sanity check: Calling callback on thread that set it works';
 
+if $*VM.name eq 'jvm' {
+    skip-rest 'Unhandled exception: VMNull representation does not support attributes';
+    exit;
+}
+
 my $tap-lock = Lock.new;
 my @threads = do for ^8 -> $i {
     Thread.start({

--- a/t/04-nativecall/22-method.t
+++ b/t/04-nativecall/22-method.t
@@ -7,6 +7,10 @@ use Test;
 
 plan 2;
 
+BEGIN if $*VM.name eq 'jvm' {
+    plan :skip-all<NullPointerException in sub ReturnAStruct>;
+};
+
 compile_test_lib('22-method');
 
 class MyStruct is repr('CStruct') {

--- a/t/04-nativecall/23-incomplete-types.t
+++ b/t/04-nativecall/23-incomplete-types.t
@@ -14,10 +14,12 @@ for (<CUnion CStruct CPPStruct>) -> $cls {
         "class Stub-$cls is repr('CStruct') " ~ ｢{ ... }｣,
         "class Oops$cls" ~ ｢ is repr('｣ ~ $cls ~ ｢') { HAS Stub-｣ ~ $cls ~ ｢ $.stubby; }｣;
     ).join("\n");
+    todo 'code does not die', 1 if $*VM.name eq 'jvm';
     throws-like { EVAL $b }, Exception, :message(/inline.*before.*definition/);
 
     # self-inlining should fail the same way
     my $bad = ("class Oops2$cls is repr(", $cls, ') { HAS Oops2'~$cls~' $.more; }').join(｢'｣);
+    todo 'code does not die', 1 if $*VM.name eq 'jvm';
     throws-like { EVAL $bad }, Exception, :message(/inline.*before.*definition/);
 }
 

--- a/t/05-messages/01-errors.t
+++ b/t/05-messages/01-errors.t
@@ -145,6 +145,7 @@ for <fail die throw rethrow resume> -> $meth {
 subtest 'non-ASCII digits > 7 in leading-zero-octal warning' => {
     plan 2;
 
+    todo "dies at compile time with: '୯' is not a valid number", 2 if $*VM.name eq 'jvm';
     with run $*EXECUTABLE, '-e', 'say 0୯', :err, :out {
         is   .out.slurp(:close), "9\n", 'STDOUT is right';
         like .err.slurp(:close), /'୯ is not a valid octal number'/,
@@ -174,6 +175,7 @@ subtest 'non-ASCII digits > 7 in leading-zero-octal warning' => {
 
 # https://github.com/Raku/old-issue-tracker/issues/6275
 {
+    todo 'no sub name mentioned yet (would require port of 7783fcab24)', 1 if $*VM.name eq 'jvm';
     throws-like { sub foo([$head, $tail]) {}; foo([3, 4], [3]) },
         Exception,
         message => /<<'foo'>>/,
@@ -185,6 +187,7 @@ subtest 'non-ASCII digits > 7 in leading-zero-octal warning' => {
 }
 
 { # https://colabti.org/irclogger/irclogger_log/perl6-dev?date=2017-05-31#l169
+    todo "X::Method::NotFound doesn't offer suggestions here", 2 if $*VM.name eq 'jvm';
     throws-like '42.length      ', Exception, '.length on non-List Cool',
         :message{ .contains: <chars codes>.all & none <elems graphs> };
 
@@ -216,6 +219,7 @@ throws-like { Blob.splice }, X::Multi::NoMatch,
 # https://github.com/Raku/old-issue-tracker/issues/5093
 # https://github.com/Raku/old-issue-tracker/issues/3569
 {
+    todo "X::Method::NotFound doesn't offer suggestions here", 1 if $*VM.name eq 'jvm';
     throws-like q| class RT123078_1 { method foo { self.bar }; method !bar { }; method baz { } }; RT123078_1.new.foo |,
         X::Method::NotFound,
         message => all(/<<"No such method 'bar'" \W/, /<<'RT123078_1'>>/, /\W '!bar'>>/, /<<'baz'>>/),
@@ -224,6 +228,8 @@ throws-like { Blob.splice }, X::Multi::NoMatch,
         X::Method::NotFound,
         message => all(/<<"No such private method '!bar'" \W/, /<<'RT123078_2'>>/, /<<'bar'>>/, /<<'baz'>>/),
         'a public method of the same name as the missing private method is suggested';
+
+    todo "X::Method::NotFound doesn't offer suggestions here", 3 if $*VM.name eq 'jvm';
     throws-like q| class RT123078_3 { method !bar { }; method baz { } }; RT123078_3.new.bar |,
         X::Method::NotFound,
         message => all(/<<"No such method 'bar'" \W/, /<<'RT123078_3'>>/, /\s+ Did \s+ you \s+ mean/),
@@ -246,6 +252,7 @@ throws-like { Blob.splice }, X::Multi::NoMatch,
         :message{ !.contains: "Did you mean 'x'" },
         'Ancestor submethods should not be typo-suggested';
 
+    todo "X::Method::NotFound doesn't offer suggestions here", 1 if $*VM.name eq 'jvm';
     throws-like q| class GH1758_2 { submethod x { };}; GH1758_2.new._ |,
         X::Method::NotFound,
         message => /"Did you mean 'x'"/,

--- a/t/05-messages/03-errors.t
+++ b/t/05-messages/03-errors.t
@@ -22,6 +22,7 @@ throws-like ｢'x'.substr: /x/, 'x'｣, Exception,
             'using substr instead of subst';
 
 # https://github.com/Raku/old-issue-tracker/issues/6672
+todo 'no location of error, yet', 1 if $*VM.name eq 'jvm';
 throws-like ｢sprintf "%d", class Foo {}.new｣,
     X::Str::Sprintf::Directives::BadType, :gist(/«line\s+\d+$$/),
 'errors from sprintf include location of error';

--- a/t/05-messages/10-warnings.t
+++ b/t/05-messages/10-warnings.t
@@ -70,6 +70,7 @@ is-run ｢
 ｣, :out<bar>, 'no spurious warnings when invoking colonpaired routine';
 
 # https://github.com/Raku/old-issue-tracker/issues/6221
+todo 'crashes the JVM', 1 if $*VM.name eq 'jvm';
 is-run ｢my $a; $a [R~]= "b"; $a [Z~]= "b"; $a [X~]= "b"｣,
     'metaops + metaassign op do not produce spurious warnings';
 

--- a/t/06-telemetry/01-basic.t
+++ b/t/06-telemetry/01-basic.t
@@ -24,6 +24,7 @@ plan 42;
 my $T = T;
 isa-ok $T, Telemetry, 'did we get a Telemetry object from T';
 for <wallclock cpu max-rss> {
+    todo 'JVM gives zero for max-rss', 2 if $*VM.name eq 'jvm' and $_ eq 'max-rss';
     ok $T{$_}, "did we get a non-zero value for $_ using AT-KEY";
     ok $T."$_"(), "did we get a non-zero value for $_ with a method";
 }


### PR DESCRIPTION
As described in https://github.com/rakudo/rakudo/issues/4191
```make test``` didn't work for a long time on the JVM backend
and gives a lot of errors at the moment.

With the changes from this PR (and one fix in NQP, that will
arrive with the next bump) ```make test``` runs fine again.
That should help to notice regressions in a timely manner.