### PR TITLE
Use "#!/usr/bin/env rakudo" instead of perl6 in module scripts

### DIFF
--- a/src/core.c/CompUnit/Repository/Installation.pm6
+++ b/src/core.c/CompUnit/Repository/Installation.pm6
@@ -38,19 +38,19 @@ class CompUnit::Repository::Installation does CompUnit::Repository::Locally does
     my $windows_wrapper = '@rem = \'--*-Perl-*--
 @echo off
 if "%OS%" == "Windows_NT" goto WinNT
-#perl# "%~dpn0" %1 %2 %3 %4 %5 %6 %7 %8 %9
-goto endofperl
+#raku# "%~dpn0" %1 %2 %3 %4 %5 %6 %7 %8 %9
+goto endofraku
 :WinNT
-#perl# "%~dpn0" %*
-if NOT "%COMSPEC%" == "%SystemRoot%\system32\cmd.exe" goto endofperl
-if %errorlevel% == 9009 echo You do not have Perl in your PATH.
+#raku# "%~dpn0" %*
+if NOT "%COMSPEC%" == "%SystemRoot%\system32\cmd.exe" goto endofraku
+if %errorlevel% == 9009 echo You do not have Rakudo in your PATH.
 if errorlevel 1 goto script_failed_so_exit_with_non_zero_val 2>nul
-goto endofperl
+goto endofraku
 @rem \';
 __END__
-:endofperl
+:endofraku
 ';
-    my $perl_wrapper = '#!/usr/bin/env #perl#
+    my $raku_wrapper = '#!/usr/bin/env #raku#
 sub MAIN(:$name, :$auth, :$ver, *@, *%) {
     CompUnit::RepositoryRegistry.run-script("#name#", :$name, :$auth, :$ver);
 }';
@@ -212,10 +212,10 @@ sub MAIN(:$name, :$auth, :$ver, *@, *%) {
             my $withoutext  = $name-path.subst(/\.[exe|bat]$/, '');
             for '', '-j', '-m', '-js' -> $be {
                 $.prefix.add("$withoutext$be").IO.spurt:
-                    $perl_wrapper.subst('#name#', $name, :g).subst('#perl#', "perl6$be");
+                    $raku_wrapper.subst('#name#', $name, :g).subst('#raku#', "rakudo$be");
                 if $is-win {
                     $.prefix.add("$withoutext$be.bat").IO.spurt:
-                        $windows_wrapper.subst('#perl#', "perl6$be", :g);
+                        $windows_wrapper.subst('#raku#', "rakudo$be", :g);
                 }
                 else {
                     $.prefix.add("$withoutext$be").IO.chmod(0o755);


### PR DESCRIPTION
As far as I can see there's no need to put "#!/usr/bin/env perl6" any longer into scripts like cro and zef when these modules are built and installed with recent Rakudo versions. This pull request replaces perl6 with rakudo, perl6-m with rakudo-m etc. in src/core.c/CompUnit/Repository/Installation.pm6.

BTW, if scripts use #!/usr/bin/env the package tool rpmbuild adds automatic dependencies on the package coreutils, which provides /usr/bin/env, instead of rakudo. But that's another issue that I handle in the RPM spec file.

