### PR TITLE
Remove special cases for hash constants for JVM

### DIFF
--- a/src/core.c/CompUnit/RepositoryRegistry.pm6
+++ b/src/core.c/CompUnit/RepositoryRegistry.pm6
@@ -363,10 +363,10 @@ class CompUnit::RepositoryRegistry {
         }
     }
 
-#?if moar
+#?if !js
     my constant $short-id2class = nqp::hash(
 #?endif
-#?if !moar
+#?if js
     my $short-id2class := nqp::hash(
 #?endif
       'file',   CompUnit::Repository::FileSystem,

--- a/src/core.c/Date.pm6
+++ b/src/core.c/Date.pm6
@@ -2,10 +2,10 @@ my class Date does Dateish {
 
     method !formatter(--> Str:D) { self.yyyy-mm-dd }
 
-#?if moar
+#?if !js
     my constant $valid-units = nqp::hash(
 #?endif
-#?if !moar
+#?if js
     my $valid-units := nqp::hash(
 #?endif
       'day',    1,

--- a/src/core.c/DateTime.pm6
+++ b/src/core.c/DateTime.pm6
@@ -118,10 +118,10 @@ my class DateTime does Dateish {
         nqp::join('',$parts)
     }
 
-#?if moar
+#?if !js
     my constant $valid-units = nqp::hash(
 #?endif
-#?if !moar
+#?if js
     my $valid-units := nqp::hash(
 #?endif
       'second',  0,

--- a/src/core.c/Distro.pm6
+++ b/src/core.c/Distro.pm6
@@ -66,10 +66,10 @@ Rakudo::Internals.REGISTER-DYNAMIC: '$*DISTRO', {
         $release := $_ with $lookup<BuildVersion>;
         $auth    := 'Apple Inc.'; # presumably
 
-#?if moar
+#?if !js
         my constant $names = nqp::hash(
 #?endif
-#?if !moar
+#?if js
         my $names := nqp::hash(
 #?endif
           '10.0',  'Cheetah',

--- a/src/core.c/Encoding/Builtin.pm6
+++ b/src/core.c/Encoding/Builtin.pm6
@@ -31,10 +31,10 @@ class Encoding::Builtin does Encoding {
             !! $encoder
     }
 
-#?if moar
+#?if !js
     my constant $enc_type = nqp::hash(
 #?endif
-#?if !moar
+#?if js
     my $enc_type := nqp::hash(
 #?endif
       'utf8',utf8,'utf16',utf16,'utf32',utf32

--- a/src/core.c/Exception.pm6
+++ b/src/core.c/Exception.pm6
@@ -1739,10 +1739,10 @@ my class X::Syntax::ConditionalOperator::SecondPartInvalid does X::Syntax {
 my class X::Syntax::Perl5Var does X::Syntax {
     has $.name;
     has $.identifier-name;
-#?if moar
+#?if !js
     my constant $m = nqp::hash(
 #?endif
-#?if !moar
+#?if js
     my $m := nqp::hash(
 #?endif
       '$"',    '.join() method',

--- a/src/core.c/IO/Spec.pm6
+++ b/src/core.c/IO/Spec.pm6
@@ -2,10 +2,10 @@ my class VM { ... }
 
 my class IO::Spec {
 
-#?if moar
+#?if !js
     my constant $module = nqp::hash( # only list the non-Unix ones in lowercase
 #?endif
-#?if !moar
+#?if js
     my $module := nqp::hash( # only list the non-Unix ones in lowercase
 #?endif
       'mswin32', 'Win32',

--- a/src/core.c/Match.pm6
+++ b/src/core.c/Match.pm6
@@ -13,11 +13,11 @@ my class Match is Capture is Cool does NQPMatchRole {
 #    has $!match;     # flag indicating Match object set up (NQPdidMATCH)
 #    has str $!name;  # name if named capture
 
-#?if moar
+#?if !js
     my constant $EMPTY_LIST = nqp::list();
     my constant $EMPTY_HASH = nqp::hash();
 #?endif
-#?if !moar
+#?if js
     my $EMPTY_LIST := nqp::list();
     my $EMPTY_HASH := nqp::hash();
 #?endif

--- a/src/core.c/Parameter.pm6
+++ b/src/core.c/Parameter.pm6
@@ -47,10 +47,10 @@ my class Parameter { # declared in BOOTSTRAP
                                          +| $SIG_ELEM_IS_COPY
                                          +| $SIG_ELEM_IS_RAW;
 
-#?if moar
+#?if !js
     my constant $sigils2bit = nqp::hash(
 #?endif
-#?if !moar
+#?if js
     my $sigils2bit := nqp::hash(
 #?endif
       Q/@/, $SIG_ELEM_ARRAY_SIGIL,

--- a/src/core.c/Rakudo/Internals.pm6
+++ b/src/core.c/Rakudo/Internals.pm6
@@ -284,10 +284,10 @@ my class Rakudo::Internals {
     }
     # Fast mapping for identicals
     ### If updating encodings here, also update src/core.c/Encoding/Registry.pm6
-#?if moar
+#?if !js
     my constant $encodings = nqp::hash(
 #?endif
-#?if !moar
+#?if js
     my $encodings := nqp::hash(
 #?endif
       # utf8
@@ -1197,10 +1197,10 @@ implementation detail and has no serviceable parts inside"
           !! nqp::p6box_s(nqp::substr($abspath,$offset + 1));
     }
 
-#?if moar
+#?if !js
     my constant $clean-parts-nul = nqp::hash(
 #?endif
-#?if !moar
+#?if js
     my $clean-parts-nul := nqp::hash(
 #?endif
       '..', 1, '.', 1, '', 1


### PR DESCRIPTION
The underlying problem has been fixed for the JVM backend with
https://github.com/Raku/nqp/commit/00408eea93.

Unfortunately, the special cases are probably still needed for the
JS backend. So I switched the logic from 'use hash constants only
for MoarVM' to 'use hash constants everywhere except for JS'.