### PR TITLE
Fix $*EXECUTABLE

### DIFF
--- a/tools/templates/moar/Makefile.in
+++ b/tools/templates/moar/Makefile.in
@@ -255,13 +255,13 @@ $(R_SETTING_MOAR): @bsm(RAKUDO)@@for_specs( @bsm(SETTING_@ucspec@)@)@ $(R_SETTIN
 
 @backend_prefix@-runner-default-install: @backend_prefix@-install
 	@echo(+++ Installing @uc(@backend@)@ launchers)@
-	$(NOECHO)$(CP) @bpm(INST_RAKUDO_M)@ @nfpq($(DESTDIR)$(PREFIX)/bin/@bpm(RAKUDO)@)@
-	$(NOECHO)$(CP) @bpm(INST_RAKUDO_DEBUG_M)@ @nfpq($(DESTDIR)$(PREFIX)/bin/@bpm(RAKUDO_DEBUG)@)@
-	$(NOECHO)$(CP) @bpm(INST_RAKUDO_M)@ @nfpq($(DESTDIR)$(PREFIX)/bin/@bpm(PERL6)@)@
-	$(NOECHO)$(CP) @bpm(INST_RAKUDO_DEBUG_M)@ @nfpq($(DESTDIR)$(PREFIX)/bin/@bpm(PERL6_DEBUG)@)@
+	$(NOECHO)$(CP) @bpm(INST_RAKUDO)@ @nfpq($(DESTDIR)$(PREFIX)/bin/@bpm(RAKUDO)@)@
+	$(NOECHO)$(CP) @bpm(INST_RAKUDO_DEBUG)@ @nfpq($(DESTDIR)$(PREFIX)/bin/@bpm(RAKUDO_DEBUG)@)@
+	$(NOECHO)$(CP) @bpm(INST_PERL6)@ @nfpq($(DESTDIR)$(PREFIX)/bin/@bpm(PERL6)@)@
+	$(NOECHO)$(CP) @bpm(INST_PERL6_DEBUG)@ @nfpq($(DESTDIR)$(PREFIX)/bin/@bpm(PERL6_DEBUG)@)@
 @if(platform==windows
-	$(NOECHO)$(CP) @bpm(INST_RAKUDOW_M)@ @nfpq($(DESTDIR)$(PREFIX)/bin/@bpm(RAKUDOW)@)@
-	$(NOECHO)$(CP) @bpm(INST_PERL6W_M)@ @nfpq($(DESTDIR)$(PREFIX)/bin/@bpm(PERL6W)@)@
+	$(NOECHO)$(CP) @bpm(INST_RAKUDOW)@ @nfpq($(DESTDIR)$(PREFIX)/bin/@bpm(RAKUDOW)@)@
+	$(NOECHO)$(CP) @bpm(INST_PERL6W)@ @nfpq($(DESTDIR)$(PREFIX)/bin/@bpm(PERL6W)@)@
 )@
 @if(with_raku_alias==on @tab@@echo(+++ Creating Raku executable alias)@
 @if(platform!=windows

--- a/tools/templates/moar/Makefile.in
+++ b/tools/templates/moar/Makefile.in
@@ -33,7 +33,12 @@ R_SETTING_MOAR = RESTRICTED.setting.moarvm
 
 @bpv(RAKU)@ = raku@moar::exe@
 @bpv(RAKU_DEBUG)@ = raku-debug@moar::exe@
-@if(platform==windows @bpv(RAKUW)@ = rakuw@moar::exe@)@
+@if(platform==windows @bpv(RAKU)@ = raku@moar::exe@
+@bpv(INST_RAKU)@ = inst-raku@moar::exe@
+@bpv(RAKU_DEBUG)@ = raku-debug@moar::exe@
+@bpv(INST_RAKU_DEBUG)@ = inst-raku-debug@moar::exe@
+@bpv(RAKUW)@ = rakuw@moar::exe@
+@bpv(INST_RAKUW)@ = inst-rakuw@moar::exe@)@
 @for_langalias(
 @bpv(@uclangalias@)@ = @langalias@@moar::exe@
 @bpv(@uclangalias@_DEBUG)@ = @langalias@-debug@moar::exe@
@@ -63,7 +68,10 @@ R_SETTING_MOAR = RESTRICTED.setting.moarvm
 @tab@@bpm(INST_@uclangalias@_DEBUG_M)@ \
 @if(platform==windows @tab@@bpm(INST_@uclangalias@W)@ \
 @tab@@bpm(INST_@uclangalias@W_M)@ \
-)@)@@for_langalias(@for_toolchain(@tab@@bpm(@uclangalias@_@uctoolchain@_RUNNER)@ \
+)@)@@if(platform==windows @tab@@bpm(INST_RAKU)@ \
+@tab@@bpm(INST_RAKU_DEBUG)@ \
+@tab@@bpm(INST_RAKUW)@ \
+)@@for_langalias(@for_toolchain(@tab@@bpm(@uclangalias@_@uctoolchain@_RUNNER)@ \
 )@)@
 
 @bpv(CLEANUPS)@ = \
@@ -89,6 +97,10 @@ R_SETTING_MOAR = RESTRICTED.setting.moarvm
   rakudo.c \
   rakudo@moar::obj@ \
   rakudo@moar::exe@ \
+  inst-raku@moar::obj@ \
+  inst-raku@moar::exe@ \
+  inst-rakuw@moar::obj@ \
+  inst-rakuw@moar::exe@ \
   inst-perl6*@moar::obj@ \
   inst-perl6*@moar::exe@ \
   @bpm(INST_PERL6)@ \
@@ -165,10 +177,13 @@ $(R_SETTING_MOAR): @bsm(RAKUDO)@@for_specs( @bsm(SETTING_@ucspec@)@)@ $(R_SETTIN
         '@bpm(INST_RAKUDO_DEBUG_M)@' => '@bpm(RAKUDO_DEBUG_M)@',
     );
     if ($cfg->cfg('platform') eq 'windows') {
-		$execs{'@bpm(INST_PERL6W)@'} = '@bpm(PERL6W)@';
-		$execs{'@bpm(INST_PERL6W_M)@'} = '@bpm(PERL6W_M)@';
-		$execs{'@bpm(INST_RAKUDOW)@'} = '@bpm(RAKUDOW)@';
-		$execs{'@bpm(INST_RAKUDOW_M)@'} = '@bpm(RAKUDOW_M)@';
+		$execs{'@bpm(INST_PERL6W)@'}     = '@bpm(PERL6W)@';
+		$execs{'@bpm(INST_PERL6W_M)@'}   = '@bpm(PERL6W_M)@';
+		$execs{'@bpm(INST_RAKUDOW)@'}    = '@bpm(RAKUDOW)@';
+		$execs{'@bpm(INST_RAKUDOW_M)@'}  = '@bpm(RAKUDOW_M)@';
+		$execs{'@bpm(INST_RAKU)@'}       = '@bpm(RAKU)@';
+		$execs{'@bpm(INST_RAKU_DEBUG)@'} = '@bpm(RAKU_DEBUG)@';
+		$execs{'@bpm(INST_RAKUW)@'}      = '@bpm(RAKUW)@';
 	}
     for my $build (keys %execs) {
         my $installed = $macros->expand($execs{$build});
@@ -268,9 +283,9 @@ $(R_SETTING_MOAR): @bsm(RAKUDO)@@for_specs( @bsm(SETTING_@ucspec@)@)@ $(R_SETTIN
 	$(NOECHO)$(LN_S) @nfpq(./@bpm(RAKUDO)@)@ @nfpq($(DESTDIR)$(PREFIX)/bin/@bpm(RAKU)@)@
 	$(NOECHO)$(LN_S) @nfpq(./@bpm(RAKUDO_DEBUG)@)@ @nfpq($(DESTDIR)$(PREFIX)/bin/@bpm(RAKU_DEBUG)@)@
 )@@if(platform==windows
-	$(NOECHO)$(CP) @nfpq($(DESTDIR)$(PREFIX)/bin/@bpm(RAKUDO)@)@ @nfpq($(DESTDIR)$(PREFIX)/bin/@bpm(RAKU)@)@
-	$(NOECHO)$(CP) @nfpq($(DESTDIR)$(PREFIX)/bin/@bpm(RAKUDO_DEBUG)@)@ @nfpq($(DESTDIR)$(PREFIX)/bin/@bpm(RAKU_DEBUG)@)@
-	$(NOECHO)$(CP) @nfpq($(DESTDIR)$(PREFIX)/bin/@bpm(RAKUDOW)@)@ @nfpq($(DESTDIR)$(PREFIX)/bin/@bpm(RAKUW)@)@
+	$(NOECHO)$(CP) @bpm(INST_RAKU)@ @nfpq($(DESTDIR)$(PREFIX)/bin/@bpm(RAKU)@)@
+	$(NOECHO)$(CP) @bpm(INST_RAKU_DEBUG)@ @nfpq($(DESTDIR)$(PREFIX)/bin/@bpm(RAKU_DEBUG)@)@
+	$(NOECHO)$(CP) @bpm(INST_RAKUW)@ @nfpq($(DESTDIR)$(PREFIX)/bin/@bpm(RAKUW)@)@
 )@
 )@
 manifest:


### PR DESCRIPTION
Fix $*EXECUTABLE with the non '_m' suffix executables and the 'raku' variants on Windows.

The path to the executable is compiled into the static executables. Thus one simply can't freely copy or rename them. Each different alias needs a new executable.

Draft for now to see what Windows does.

fixes ugexe/zef#403