### PR TITLE
Do not include falsy attribute in exception's message

### DIFF
--- a/src/core.c/Exception.pm6
+++ b/src/core.c/Exception.pm6
@@ -2749,7 +2749,9 @@ my class X::Numeric::CannotConvert is Exception {
     has $.source;
 
     method message() {
-        "Cannot convert {$!source // $!source.raku} to {$!target // $!target.raku}: $!reason";
+        $!reason
+          ?? "Cannot convert {$!source // $!source.raku} to {$!target // $!target.raku}: $!reason"
+          !! "Cannot convert {$!source // $!source.raku} to {$!target // $!target.raku}";
     }
 
 }


### PR DESCRIPTION
Without this patch, one can see, for example:
```
$ raku -e 'NaN.Int(); CATCH {default { .say }}'
Use of uninitialized value element of type Any in string context.
Methods .^name, .raku, .gist, or .say can be used to stringify it to something meaningful.
  in block  at -e line 1
Cannot convert NaN to Int: 
  in block <unit> at -e line 1
```
And with this patch, one would see:
```
$ raku -e 'NaN.Int(); CATCH {default { .say }}'
Cannot convert NaN to Int
  in block <unit> at -e line 1
```