### PR TITLE
Make gist fit on one line

### DIFF
--- a/src/core.c/Rakudo/Internals.pm6
+++ b/src/core.c/Rakudo/Internals.pm6
@@ -494,8 +494,7 @@ my class Rakudo::Internals {
     our role ImplementationDetail {
         method new(|) { die self.gist }
         method gist(--> Str:D) {
-            "The '{self.^name}' class is a Rakudo-specific
-implementation detail and has no serviceable parts inside"
+            "The '{self.^name}' class is a Rakudo-specific implementation detail and has no serviceable parts inside"
         }
         method Str( --> Str:D) { self.gist }
         method raku(--> Str:D) { self.gist }


### PR DESCRIPTION
A one line Rakudo::Internals::ImplementationDetail.gist seems more appropriate.

Compare this gist without this patch
```
$ raku -e Rakudo::Internals::ImplementationDetail.new
The 'Rakudo::Internals::ImplementationDetail' class is a Rakudo-specific
implementation detail and has no serviceable parts inside
  in block <unit> at -e line 1
```

And with ths patch:
```
$ raku -e Rakudo::Internals::ImplementationDetail.new
The 'Rakudo::Internals::ImplementationDetail' class is a Rakudo-specific implementation detail and has no serviceable parts inside
  in block <unit> at -e line 1
```
