### PR TITLE
Add :throw named argument to run()

### DIFF
--- a/src/core.c/Proc.pm6
+++ b/src/core.c/Proc.pm6
@@ -237,11 +237,26 @@ my class Proc {
 }
 
 proto sub run(|) {*}
-multi sub run(*@args where .so, :$in = '-', :$out = '-', :$err = '-',
-        Bool :$bin, Bool :$chomp = True, Bool :$merge,
-        Str  :$enc, Str:D :$nl = "\n", :$cwd = $*CWD, :$env, :$arg0, :$win-verbatim-args = False) {
-    my $proc := Proc.new(:$in, :$out, :$err, :$bin, :$chomp, :$merge, :$enc, :$nl);
+multi sub run(*@args where .so,
+       :$in  = '-',
+       :$out = '-',
+       :$err = '-',
+  Bool :$bin,
+  Bool :$chomp = True,
+  Bool :$merge,
+  Str  :$enc,
+  Str  :$nl = "\n",
+       :$cwd = $*CWD,
+       :$env,
+       :$arg0,
+       :$win-verbatim-args = False,
+       :$throw,
+--> Proc:D) {
+    my $proc := Proc.new(
+      :$in, :$out, :$err, :$bin, :$chomp, :$merge, :$enc, :$nl
+    );
     $proc.spawn(@args, :$cwd, :$env, :$arg0, :$win-verbatim-args);
+    $proc.sink if $throw;
     $proc
 }
 


### PR DESCRIPTION
Basically, this will just run the same logic as sinking, causing a
failure to be thrown immediately, instead of silently continuing.
And this not producing any output with :out.

Also some style changes to run() to make it better readable