### PR TITLE
Provide a method returning a real 'posix' value

### DIFF
--- a/src/core.c/DateTime.pm6
+++ b/src/core.c/DateTime.pm6
@@ -414,7 +414,11 @@ my class DateTime does Dateish {
         self.modified-julian-date + 2_400_000.5
     }
 
-    method posix(DateTime:D: $ignore-timezone? --> Int:D) {
+    proto method posix(|) {*}
+    multi method posix(DateTime:D: $ignore-timezone?, :$real! --> Real:D) {
+        self.posix($ignore-timezone) + $!second - $!second.Int
+    }
+    multi method posix(DateTime:D: $ignore-timezone? --> Int:D) {
         return self.utc.posix if $!timezone && !$ignore-timezone;
 
         # algorithm from Claus Tøndering


### PR DESCRIPTION
+ Add new multi method "DateTime.posix" which returns a real value
    - Add a required named option ":$real" to the new multi to select the new method
+ Satisfies closed issue #4286
+ Replaces draft PR #4350 (which has been closed)