### PR TITLE
Make DateTime.posix return a fractional value in 6.e

### DIFF
--- a/src/core.e/core_prologue.pm6
+++ b/src/core.e/core_prologue.pm6
@@ -7,9 +7,7 @@ my constant CORE-SETTING-REV = 'e';
 
 my constant DateTimeD = DateTime;
 class DateTime is DateTimeD {
-    method posix(DateTime:D: $ignore-timezone? --> Numeric:D) {
-        return self.utc.posix if $.timezone && !$ignore-timezone;
-
+    multi method posix(DateTime:D: --> Real:D) {
         # algorithm from Claus Tøndering
         my int $a = (14 - $.month) div 12;
         my int $y = $.year + 4800 - $a;
@@ -19,6 +17,7 @@ class DateTime is DateTimeD {
         ($jd - 2440588) * 86400
           + $.hour      * 3600
           + $.minute    * 60
+          - $.timezone
           + nqp::getattr(self,DateTimeD,'$!second')
     }
 }

--- a/src/core.e/core_prologue.pm6
+++ b/src/core.e/core_prologue.pm6
@@ -1,7 +1,26 @@
 use nqp;
 
 # This constant must specify current CORE revision
-# Must preceede class declarations to allow correct recording of their respective language version.
+# Must precede class declarations to allow correct recording of their
+# respective language version.
 my constant CORE-SETTING-REV = 'e';
+
+my constant DateTimeD = DateTime;
+class DateTime is DateTimeD {
+    method posix(DateTime:D: $ignore-timezone? --> Numeric:D) {
+        return self.utc.posix if $.timezone && !$ignore-timezone;
+
+        # algorithm from Claus Tøndering
+        my int $a = (14 - $.month) div 12;
+        my int $y = $.year + 4800 - $a;
+        my int $m = $.month + 12 * $a - 3;
+        my int $jd = $.day + (153 * $m + 2) div 5 + 365 * $y
+            + $y div 4 - $y div 100 + $y div 400 - 32045;
+        ($jd - 2440588) * 86400
+          + $.hour      * 3600
+          + $.minute    * 60
+          + nqp::getattr(self,DateTimeD,'$!second')
+    }
+}
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
This is really a proof-of-concept.  It basically saves the DateTime
class that is known at the beginning of parsing the 6.e core setting
as "DateTimeD", and then creates a DateTime class that inherits from
"DateTimeD".  Several notes to make about this:

- this exposes DateTimeD, it probably shouldn't.  But I don't see
  a way to do that at the moment, and still make the new DateTime
  class work in 6.e code.
- because DateTimeD is exposed, several tests in "make test" fail.
  This is easily fixable should we decide to make it ok to expose
  DateTimeD.
- Because the new DateTime is a subclass of the DateTimeD, attributes
  can only be reached with calling the accessors, or to use nqp::getattr.
  I've used the former for all but .second, as that currently always
  returns an Int apparently.  It would be nice if there were some
  HOW stuff to make DateTimeD trust DateTime, so that direct access
  to the attributes were possible.