### PR TITLE
Add .Buf / .Blob coercers to Blob / Buf

### DIFF
--- a/src/core.c/Buf.pm6
+++ b/src/core.c/Buf.pm6
@@ -704,7 +704,6 @@ my class utf32 does Blob[uint32] is repr('VMArray') {
 }
 
 my role Buf[::T = uint8] does Blob[T] is repr('VMArray') is array_type(T) {
-    my \native-type = T;
 
     multi method WHICH(Buf:D:) { self.Mu::WHICH }
 

--- a/src/core.c/Buf.pm6
+++ b/src/core.c/Buf.pm6
@@ -40,7 +40,7 @@ my role Blob[::T = uint8] does Positional[T] does Stringy is repr('VMArray') is 
     }
 
     multi method new(Blob:) { nqp::create(self) }
-    multi method new(Blob: Blob:D $blob) {
+    multi method new(Blob: Blob:D $blob) is default {
         nqp::splice(nqp::create(self),$blob,0,0)
     }
     multi method new(Blob: int @values) {
@@ -51,6 +51,13 @@ my role Blob[::T = uint8] does Positional[T] does Stringy is repr('VMArray') is 
     }
     multi method new(Blob: *@values) {
         nqp::create(self).STORE(@values, :INITIALIZE)
+    }
+
+    # Because it is (apparently) impossible to stub the Buf role in the
+    # setting, the lookup for Buf needs to be done at runtime, hence the
+    # ::<Buf> rather than just Buf.
+    method Buf(Blob:D:) {
+        (nqp::eqaddr(T,uint8) ?? ::<Buf> !! ::<Buf>.^parameterize(T)).new: self
     }
 
     proto method STORE(Blob:D: |) {*}
@@ -697,8 +704,13 @@ my class utf32 does Blob[uint32] is repr('VMArray') {
 }
 
 my role Buf[::T = uint8] does Blob[T] is repr('VMArray') is array_type(T) {
+    my \native-type = T;
 
     multi method WHICH(Buf:D:) { self.Mu::WHICH }
+
+    method Blob(Blob:D:) {
+        (nqp::eqaddr(T,uint8) ?? Blob !! Blob.^parameterize(T)).new: self
+    }
 
     multi method AT-POS(Buf:D: int \pos) is raw {
         nqp::islt_i(pos,0)


### PR DESCRIPTION
This is a bit of a special case, as Buf / Blob are both *roles*, yet
they are generally used as classes with their default parameterization.

Therefore, the .Buf and .Blob coercers return the type **with the same
parameterization** as the source.  This feels like the most logical
thing to do.

An alternative would be to add .immutable / .mutable methods to Buf / Blob.
This could then maybe also be used for turning a Hash into a Map and an
array into a List (or even, remove all containers from a List).

Note that because it is apparently impossible to actually stub a role in
the setting, the lookup for Buf is done at runtime.