### PR TITLE
RFC for a .pick(**) candidate

### DIFF
--- a/src/core.c/List.pm6
+++ b/src/core.c/List.pm6
@@ -992,6 +992,9 @@ my class List does Iterable does Positional { # declared in BOOTSTRAP
         }
         method is-deterministic(--> False) { }
     }
+    multi method pick(List:D: HyperWhatever) {
+        self.pick(*).Slip xx *
+    }
     multi method pick(List:D: $number is copy) {
         return self.fail-iterator-cannot-be-lazy('.pick from') if self.is-lazy;
         my Int $elems = self.elems;


### PR DESCRIPTION
Like .pick(*), this would exhaust all possible values.  But instead
of stopping providing values, continues with a fresh set again.

The advantage over just using .roll(*) is that you're guaranteed a
more even distribution of values on shorter runs exceeding the
original pool size.

For now this is only implemented for `List`, to test the waters.