### PR TITLE
Fix for #4394

### DIFF
--- a/t/04-nativecall/02-simple-args.t
+++ b/t/04-nativecall/02-simple-args.t
@@ -48,7 +48,7 @@ is TakeInt64(0xFFFFFFFFFF), 9, 'passed int64 0xFFFFFFFFFF';
 sub TakeUint8(uint8) returns int32 is native('./02-simple-args') { * }
 sub TakeUint16(uint16) returns int32 is native('./02-simple-args') { * }
 sub TakeUint32(uint32) returns int32 is native('./02-simple-args') { * }
-if $*DISTRO.name eq 'macosx' {
+if $*DISTRO.name ~~ 'macosx'|'macos' {
     #
     # For some reason, on OS X with clang, the following test fails with -O3
     # specified.  One can only assume this is some weird compiler issue (tested


### PR DESCRIPTION
The test is already skipped on OSX, the M1 architecture is now being identified as `macos` rather than `macosx`, this update amends the skip to include both.