### PR TITLE
[JVM] Remove special case for native arrays on JVM

### DIFF
--- a/src/core.c/Rakudo/Internals/PostcircumfixAdverbs.pm6
+++ b/src/core.c/Rakudo/Internals/PostcircumfixAdverbs.pm6
@@ -130,10 +130,10 @@ augment class Rakudo::Internals {
     # initialized here.
     my constant @pc-adverb-mapper = do {
         my int $i = -1;
-#?if moar
+#?if !js
         my uint16 @map;
 #?endif
-#?if !moar
+#?if js
         my @map;
 #?endif
         
@@ -296,10 +296,10 @@ augment class Rakudo::Internals {
         );
 
         # Perform the actual lookup and handling
-#?if moar
+#?if !js
         my int $index = nqp::atpos_i(@pc-adverb-mapper,$bitmap);
 #?endif
-#?if !moar
+#?if js
         my $index = @pc-adverb-mapper[$bitmap];
 #?endif
         nqp::if(
@@ -404,10 +404,10 @@ augment class Rakudo::Internals {
         );
 
         # Perform the actual lookup and handling
-#?if moar
+#?if !js
         my int $index = nqp::atpos_i(@pc-adverb-mapper,$bitmap);
 #?endif
-#?if !moar
+#?if js
         my $index = @pc-adverb-mapper[$bitmap];
 #?endif
         nqp::if(

--- a/src/core.c/ThreadPoolScheduler.pm6
+++ b/src/core.c/ThreadPoolScheduler.pm6
@@ -565,12 +565,7 @@ my class ThreadPoolScheduler does Scheduler {
 
                 scheduler-debug "Supervisor started";
                 my int $last-rusage-time = nqp::time;
-#?if jvm
-                my @rusage := array[int].new;
-#?endif
-#?if !jvm
                 my int @rusage;
-#?endif
                 nqp::getrusage(@rusage);
                 my int $last-usage =
                   nqp::mul_i(
@@ -583,12 +578,7 @@ my class ThreadPoolScheduler does Scheduler {
                       )
                     + nqp::atpos_i(@rusage, nqp::const::RUSAGE_STIME_MSEC);
 
-#?if jvm
-                my @last-utils := array[num].new(0e0 xx NUM_SAMPLES);
-#?endif
-#?if !jvm
                 my num @last-utils = 0e0 xx NUM_SAMPLES;
-#?endif
                 my int $cpu-cores = max(nqp::cpucores() - 1,1);
 
                 # These definitions used to live inside the supervisor loop.

--- a/src/core.c/native_array.pm6
+++ b/src/core.c/native_array.pm6
@@ -3732,7 +3732,7 @@ multi sub postcircumfix:<[ ]>(array:D \SELF, Range:D \range ) is raw {
 }
 
 #- start of postcircumfix candidates of strarray -------------------------------
-#- Generated on 2021-04-03T16:18:57+02:00 by tools/build/makeNATIVE_CANDIDATES.raku
+#- Generated on 2021-06-11T22:50:48+02:00 by tools/build/makeNATIVE_CANDIDATES.raku
 #- PLEASE DON'T CHANGE ANYTHING BELOW THIS LINE
 
 multi sub postcircumfix:<[ ]>(
@@ -3858,12 +3858,7 @@ multi sub postcircumfix:<[ ]>(
 ) is raw {
     my $self    := nqp::decont(SELF);
     my $indices := $pos.iterator;
-#?if jvm
-    my @result := array[str].new;
-#?endif
-#?if !jvm
     my str @result;
-#?endif
 
     nqp::until(
       nqp::eqaddr((my $pulled := $indices.pull-one),IterationEnd),
@@ -3894,12 +3889,7 @@ multi sub postcircumfix:<[ ]>(
     my $self    := nqp::decont(SELF);
     my $indices := $pos.iterator;
     my int $i    = -1;
-#?if jvm
-    my @result := array[str].new;
-#?endif
-#?if !jvm
     my str @result;
-#?endif
 
     nqp::until(
       nqp::eqaddr((my $pulled := $indices.pull-one),IterationEnd),
@@ -3937,12 +3927,7 @@ multi sub postcircumfix:<[ ]>(
     my $self    := nqp::decont(SELF);
     my $indices := $pos.iterator;
     my $values  := Rakudo::Iterator.TailWith(values.iterator,'');
-#?if jvm
-    my @result := array[str].new;
-#?endif
-#?if !jvm
     my str @result;
-#?endif
 
     nqp::until(
       nqp::eqaddr((my $pulled := $indices.pull-one),IterationEnd),
@@ -3984,7 +3969,7 @@ multi sub postcircumfix:<[ ]>(
 #- end of postcircumfix candidates of strarray ---------------------------------
 
 #- start of postcircumfix candidates of numarray -------------------------------
-#- Generated on 2021-04-03T16:18:57+02:00 by tools/build/makeNATIVE_CANDIDATES.raku
+#- Generated on 2021-06-11T22:50:48+02:00 by tools/build/makeNATIVE_CANDIDATES.raku
 #- PLEASE DON'T CHANGE ANYTHING BELOW THIS LINE
 
 multi sub postcircumfix:<[ ]>(
@@ -4110,12 +4095,7 @@ multi sub postcircumfix:<[ ]>(
 ) is raw {
     my $self    := nqp::decont(SELF);
     my $indices := $pos.iterator;
-#?if jvm
-    my @result := array[num].new;
-#?endif
-#?if !jvm
     my num @result;
-#?endif
 
     nqp::until(
       nqp::eqaddr((my $pulled := $indices.pull-one),IterationEnd),
@@ -4146,12 +4126,7 @@ multi sub postcircumfix:<[ ]>(
     my $self    := nqp::decont(SELF);
     my $indices := $pos.iterator;
     my int $i    = -1;
-#?if jvm
-    my @result := array[num].new;
-#?endif
-#?if !jvm
     my num @result;
-#?endif
 
     nqp::until(
       nqp::eqaddr((my $pulled := $indices.pull-one),IterationEnd),
@@ -4189,12 +4164,7 @@ multi sub postcircumfix:<[ ]>(
     my $self    := nqp::decont(SELF);
     my $indices := $pos.iterator;
     my $values  := Rakudo::Iterator.TailWith(values.iterator,0e0);
-#?if jvm
-    my @result := array[num].new;
-#?endif
-#?if !jvm
     my num @result;
-#?endif
 
     nqp::until(
       nqp::eqaddr((my $pulled := $indices.pull-one),IterationEnd),
@@ -4236,7 +4206,7 @@ multi sub postcircumfix:<[ ]>(
 #- end of postcircumfix candidates of numarray ---------------------------------
 
 #- start of postcircumfix candidates of intarray -------------------------------
-#- Generated on 2021-04-03T16:18:57+02:00 by tools/build/makeNATIVE_CANDIDATES.raku
+#- Generated on 2021-06-11T22:50:48+02:00 by tools/build/makeNATIVE_CANDIDATES.raku
 #- PLEASE DON'T CHANGE ANYTHING BELOW THIS LINE
 
 multi sub postcircumfix:<[ ]>(
@@ -4362,12 +4332,7 @@ multi sub postcircumfix:<[ ]>(
 ) is raw {
     my $self    := nqp::decont(SELF);
     my $indices := $pos.iterator;
-#?if jvm
-    my @result := array[int].new;
-#?endif
-#?if !jvm
     my int @result;
-#?endif
 
     nqp::until(
       nqp::eqaddr((my $pulled := $indices.pull-one),IterationEnd),
@@ -4398,12 +4363,7 @@ multi sub postcircumfix:<[ ]>(
     my $self    := nqp::decont(SELF);
     my $indices := $pos.iterator;
     my int $i    = -1;
-#?if jvm
-    my @result := array[int].new;
-#?endif
-#?if !jvm
     my int @result;
-#?endif
 
     nqp::until(
       nqp::eqaddr((my $pulled := $indices.pull-one),IterationEnd),
@@ -4441,12 +4401,7 @@ multi sub postcircumfix:<[ ]>(
     my $self    := nqp::decont(SELF);
     my $indices := $pos.iterator;
     my $values  := Rakudo::Iterator.TailWith(values.iterator,0);
-#?if jvm
-    my @result := array[int].new;
-#?endif
-#?if !jvm
     my int @result;
-#?endif
 
     nqp::until(
       nqp::eqaddr((my $pulled := $indices.pull-one),IterationEnd),
@@ -4488,7 +4443,7 @@ multi sub postcircumfix:<[ ]>(
 #- end of postcircumfix candidates of intarray ---------------------------------
 
 #- start of shaped1 postcircumfix candidates of strarray -----------------------
-#- Generated on 2021-04-03T16:18:54+02:00 by tools/build/makeNATIVE_SHAPED1_CANDIDATES.raku
+#- Generated on 2021-06-11T22:51:08+02:00 by tools/build/makeNATIVE_SHAPED1_CANDIDATES.raku
 #- PLEASE DON'T CHANGE ANYTHING BELOW THIS LINE
 
 multi sub postcircumfix:<[ ]>(
@@ -4579,12 +4534,7 @@ multi sub postcircumfix:<[ ]>(
 ) is default is raw {
     my $self     := nqp::decont(SELF);
     my $iterator := $pos.iterator;
-#?if jvm
-    my @result := array[str].new;
-#?endif
-#?if !jvm
     my str @result;
-#?endif
 
     nqp::until(
       nqp::eqaddr((my $pulled := $iterator.pull-one),IterationEnd),
@@ -4610,12 +4560,7 @@ multi sub postcircumfix:<[ ]>(
     my $self    := nqp::decont(SELF);
     my $indices := $pos.iterator;
     my int $i    = -1;
-#?if jvm
-    my @result := array[str].new;
-#?endif
-#?if !jvm
     my str @result;
-#?endif
 
     nqp::until(
       nqp::eqaddr((my $pulled := $indices.pull-one),IterationEnd),
@@ -4640,7 +4585,7 @@ multi sub postcircumfix:<[ ]>(
 #- end of shaped1 postcircumfix candidates of strarray -------------------------
 
 #- start of shaped1 postcircumfix candidates of intarray -----------------------
-#- Generated on 2021-04-03T16:18:54+02:00 by tools/build/makeNATIVE_SHAPED1_CANDIDATES.raku
+#- Generated on 2021-06-11T22:51:08+02:00 by tools/build/makeNATIVE_SHAPED1_CANDIDATES.raku
 #- PLEASE DON'T CHANGE ANYTHING BELOW THIS LINE
 
 multi sub postcircumfix:<[ ]>(
@@ -4731,12 +4676,7 @@ multi sub postcircumfix:<[ ]>(
 ) is default is raw {
     my $self     := nqp::decont(SELF);
     my $iterator := $pos.iterator;
-#?if jvm
-    my @result := array[int].new;
-#?endif
-#?if !jvm
     my int @result;
-#?endif
 
     nqp::until(
       nqp::eqaddr((my $pulled := $iterator.pull-one),IterationEnd),
@@ -4762,12 +4702,7 @@ multi sub postcircumfix:<[ ]>(
     my $self    := nqp::decont(SELF);
     my $indices := $pos.iterator;
     my int $i    = -1;
-#?if jvm
-    my @result := array[int].new;
-#?endif
-#?if !jvm
     my int @result;
-#?endif
 
     nqp::until(
       nqp::eqaddr((my $pulled := $indices.pull-one),IterationEnd),
@@ -4792,7 +4727,7 @@ multi sub postcircumfix:<[ ]>(
 #- end of shaped1 postcircumfix candidates of intarray -------------------------
 
 #- start of shaped1 postcircumfix candidates of numarray -----------------------
-#- Generated on 2021-04-03T16:18:54+02:00 by tools/build/makeNATIVE_SHAPED1_CANDIDATES.raku
+#- Generated on 2021-06-11T22:51:08+02:00 by tools/build/makeNATIVE_SHAPED1_CANDIDATES.raku
 #- PLEASE DON'T CHANGE ANYTHING BELOW THIS LINE
 
 multi sub postcircumfix:<[ ]>(
@@ -4883,12 +4818,7 @@ multi sub postcircumfix:<[ ]>(
 ) is default is raw {
     my $self     := nqp::decont(SELF);
     my $iterator := $pos.iterator;
-#?if jvm
-    my @result := array[num].new;
-#?endif
-#?if !jvm
     my num @result;
-#?endif
 
     nqp::until(
       nqp::eqaddr((my $pulled := $iterator.pull-one),IterationEnd),
@@ -4914,12 +4844,7 @@ multi sub postcircumfix:<[ ]>(
     my $self    := nqp::decont(SELF);
     my $indices := $pos.iterator;
     my int $i    = -1;
-#?if jvm
-    my @result := array[num].new;
-#?endif
-#?if !jvm
     my num @result;
-#?endif
 
     nqp::until(
       nqp::eqaddr((my $pulled := $indices.pull-one),IterationEnd),

--- a/tools/build/makeNATIVE_CANDIDATES.raku
+++ b/tools/build/makeNATIVE_CANDIDATES.raku
@@ -175,12 +175,7 @@ multi sub postcircumfix:<[ ]>(
 ) is raw {
     my $self    := nqp::decont(SELF);
     my $indices := $pos.iterator;
-#?if jvm
-    my @result := array[#type#].new;
-#?endif
-#?if !jvm
     my #type# @result;
-#?endif
 
     nqp::until(
       nqp::eqaddr((my $pulled := $indices.pull-one),IterationEnd),
@@ -211,12 +206,7 @@ multi sub postcircumfix:<[ ]>(
     my $self    := nqp::decont(SELF);
     my $indices := $pos.iterator;
     my int $i    = -1;
-#?if jvm
-    my @result := array[#type#].new;
-#?endif
-#?if !jvm
     my #type# @result;
-#?endif
 
     nqp::until(
       nqp::eqaddr((my $pulled := $indices.pull-one),IterationEnd),
@@ -254,12 +244,7 @@ multi sub postcircumfix:<[ ]>(
     my $self    := nqp::decont(SELF);
     my $indices := $pos.iterator;
     my $values  := Rakudo::Iterator.TailWith(values.iterator,#nil#);
-#?if jvm
-    my @result := array[#type#].new;
-#?endif
-#?if !jvm
     my #type# @result;
-#?endif
 
     nqp::until(
       nqp::eqaddr((my $pulled := $indices.pull-one),IterationEnd),

--- a/tools/build/makeNATIVE_SHAPED1_CANDIDATES.raku
+++ b/tools/build/makeNATIVE_SHAPED1_CANDIDATES.raku
@@ -139,12 +139,7 @@ multi sub postcircumfix:<[ ]>(
 ) is default is raw {
     my $self     := nqp::decont(SELF);
     my $iterator := $pos.iterator;
-#?if jvm
-    my @result := array[#type#].new;
-#?endif
-#?if !jvm
     my #type# @result;
-#?endif
 
     nqp::until(
       nqp::eqaddr((my $pulled := $iterator.pull-one),IterationEnd),
@@ -170,12 +165,7 @@ multi sub postcircumfix:<[ ]>(
     my $self    := nqp::decont(SELF);
     my $indices := $pos.iterator;
     my int $i    = -1;
-#?if jvm
-    my @result := array[#type#].new;
-#?endif
-#?if !jvm
     my #type# @result;
-#?endif
 
     nqp::until(
       nqp::eqaddr((my $pulled := $indices.pull-one),IterationEnd),


### PR DESCRIPTION
It's now possible to use native arrays in the setting.
Fixed with https://github.com/Raku/nqp/pull/720 and
https://github.com/Raku/nqp/pull/722.