### PR TITLE
Allow CTRL-c to stop entry in REPL

### DIFF
--- a/src/core.c/REPL.pm6
+++ b/src/core.c/REPL.pm6
@@ -308,7 +308,15 @@ do {
 
         method interactive_prompt() { '> ' }
 
+        my int $sigint;    # did we install a CTRL-c catcher?
+        my int $stopped;   # did we press CTRL-c just now?
+
         method repl-loop(:$no-exit, *%adverbs) {
+            signal(SIGINT).tap: {
+                exit if $stopped++;
+                say "Pressed CTRL-c, press CTRL-c again to exit";
+                print self.interactive_prompt;
+            } unless $sigint++;
 
             say $no-exit
               ?? "Type 'exit' to leave"
@@ -328,6 +336,7 @@ do {
                 my $newcode = self.repl-read(~$prompt);
                 last if $no-exit and $newcode and $newcode eq 'exit';
 
+                $stopped = 0;
                 my $initial_out_position = $*OUT.tell;
 
                 # An undef $newcode implies ^D or similar

--- a/src/core.c/REPL.pm6
+++ b/src/core.c/REPL.pm6
@@ -308,15 +308,13 @@ do {
 
         method interactive_prompt() { '> ' }
 
-        my int $sigint;    # did we install a CTRL-c catcher?
-        my int $stopped;   # did we press CTRL-c just now?
-
         method repl-loop(:$no-exit, *%adverbs) {
+            my int $stopped;   # did we press CTRL-c just now?
             signal(SIGINT).tap: {
                 exit if $stopped++;
                 say "Pressed CTRL-c, press CTRL-c again to exit";
                 print self.interactive_prompt;
-            } unless $sigint++;
+            }
 
             say $no-exit
               ?? "Type 'exit' to leave"


### PR DESCRIPTION
And a second CTRL-c to exit the REPL if nothing else was entered.

This in response to #4402.

This does *not* achieve the suggested behaviour of being able to
stop a runaway piece of code, as Raku's signal handler runs on a
different thread and we currently do not have a way to force an
exception on anything else but the current thread.  It *does*
allow one to restart entry without having to remove all characters.