### PR TITLE
Introduce [1,2,3]:Int syntax

### DIFF
--- a/src/core.c/Exception.pm6
+++ b/src/core.c/Exception.pm6
@@ -2521,8 +2521,13 @@ my class X::TypeCheck::Assignment is X::TypeCheck {
     has $.symbol;
     method operation { 'assignment' }
     method message {
-        my $to = $.symbol.defined && $.symbol ne '$'
-            ?? " to $.symbol" !! "";
+        my $to = $.symbol
+          ?? $.symbol ne '$'
+            ?? " to $.symbol"
+            !! ""
+          !! $.symbol.defined
+            ?? " while creating a [ ]"
+            !! "";
         my $is-itself := nqp::eqaddr(self.expected, self.got);
         my $expected = $is-itself
             ?? "expected type $.expectedn cannot be itself"

--- a/src/core.c/Rakudo/Internals.pm6
+++ b/src/core.c/Rakudo/Internals.pm6
@@ -39,8 +39,21 @@ my class Rakudo::Internals {
         ))
     }
 
+    method hash-with-Array-typename(%hash) {
+        nqp::if(
+          nqp::istype(
+            (my \type := ::(nqp::iterkey_s(
+              nqp::shift(nqp::iterator(nqp::getattr(%hash,Map,'$!storage')))
+            ))),
+            Failure
+          ),
+          type.throw,
+          Array[type]
+        )
+    }
+
     method Array-with-one-elem(Mu \type, Mu \value) {
-        my \array := (nqp::eqaddr(type,Mu) ?? Array !! Array[type]).new;
+        my \array := type.new;
         nqp::p6bindattrinvres(array,List,'$!reified',
           nqp::stmts(
             nqp::bindpos(

--- a/src/core.c/array_operators.pm6
+++ b/src/core.c/array_operators.pm6
@@ -3,20 +3,27 @@ proto sub circumfix:<[ ]>(Mu $?, *%) {*}
 multi sub circumfix:<[ ]>() {
     nqp::create(Array)
 }
-
-multi sub circumfix:<[ ]>(Iterable:D \iterable) {
+multi sub circumfix:<[ ]>(Iterable:D \iterable, *%_) {
+    my Mu \type := nqp::elems(nqp::getattr(%_,Map,'$!storage'))
+      ?? Rakudo::Internals.hash-with-Array-typename(%_)
+      !! Array;
     nqp::if(
       nqp::iscont(iterable),
-      Rakudo::Internals.Array-with-one-elem(Mu, iterable),
+      Rakudo::Internals.Array-with-one-elem(type, iterable),
       nqp::if(
         nqp::istype(iterable,List) && nqp::isfalse(iterable.is-lazy),
-        Array.from-list(iterable),
-        Array.from-iterator(iterable.iterator)
+        type.from-list(iterable),
+        type.from-iterator(iterable.iterator)
       )
     )
 }
-multi sub circumfix:<[ ]>(Mu \x) {   # really only for [$foo]
-    Rakudo::Internals.Array-with-one-elem(Mu, x)
+multi sub circumfix:<[ ]>(Mu \value, *%_) {   # really only for [$foo]
+    Rakudo::Internals.Array-with-one-elem(
+      nqp::elems(nqp::getattr(%_,Map,'$!storage'))
+        ?? Rakudo::Internals.hash-with-Array-typename(%_)
+        !! Array,
+      value
+    )
 }
 
 proto sub pop($, *%) {*}


### PR DESCRIPTION
Arrays created with [] do not have typing.  It is one of Raku's traps
that people do: sub foo(Int @a) { }, and then get a typecheck error
when they pass [1,2,3] as an argument.  This commit would allow
specification of [1,2,3]:Int as a valid argument.

This implementation uses the fact that you *can* specify adverbs on
operators.  It basically looks if there is a single adverb, takes
its name and does a type-lookup for that.  And then uses that type
to create the correctly constrained Array.

Because we cannot have multi candidates that take *no* named arguments
and take any named arguments, this implementation affects the performance
of the standard logic of [].  So this should probably not be merged as
such.

One way around that now, would be to only allow for classes in Core to
be used as a type: then we could add specific candidates for these.

Another solution could be to think of completely new syntax for this
feature.