### PR TITLE
Test mkdir when parent was created but child fails

### DIFF
--- a/t/02-rakudo/19-mkdir.t
+++ b/t/02-rakudo/19-mkdir.t
@@ -1,0 +1,9 @@
+use lib <t/packages/>;
+use Test;
+use Test::Helpers;
+
+plan 1;
+
+# mkdir soft-fails when directory name is too long (over 255 bytes).
+my $path = make-temp-dir.add("foobar").add("universe" x 42);
+fails-like { $path.mkdir }, X::IO::Mkdir;


### PR DESCRIPTION
Move Raku/roast@a0d3a9aa27aaa9c2d204db34a33579dd2fdc3f22 from Raku/roast#736 due to the lack of portability of the condition that is tested against (on a few file system like Reiser the maximum filename length is larger than 255).  This test is supposed to show the MoarVM bug where `mkdir` reports success after creating some of the parent directory but (silently) failed to create the final directory.