### PR TITLE
Try to rename precomp files multiple times on Windows

### DIFF
--- a/t/08-performance/05-processkeys.t
+++ b/t/08-performance/05-processkeys.t
@@ -6,6 +6,7 @@ my $allowed = (
   Q{$AWAITER},
   Q{$CWD},
   Q{$CORE-SETTING-REV},
+  Q{$DISTRO},
   Q{$ERR},
   Q{$IN},
   Q{$OUT},


### PR DESCRIPTION
File renaming can easily race and fail on Windows. There's no great solution,
so instead just try 10 times catching a failure (and returning out of the
loop and method if it succeeds), and if it hasn't succeeded after that, try
one more time without catching a failure.

Fixes https://github.com/MoarVM/MoarVM/issues/1500

The first commit is arguably a little bit less complicated, but has a bunch of repeated code. The second commit doesn't change the overall logic, but pull that repeated code out. If the overall logic is correct, I don't care which version people prefer.