### PR TITLE
Introduce "done foo" as shortcut for "emit foo; done"

### DIFF
--- a/src/core.c/Rakudo/Supply.pm6
+++ b/src/core.c/Rakudo/Supply.pm6
@@ -129,14 +129,6 @@ class Rakudo::Supply {
         }
 
         method run-done(--> Nil) {
-            my \ex := nqp::exception();
-            unless nqp::isnull(ex) {
-                my \value := nqp::getpayload(ex);
-                unless nqp::isnull(value) || nqp::istype(value,Exception) {
-                    my $emit-handler := &!emit;
-                    $emit-handler(value) if $emit-handler.DEFINITE;
-                }
-            }
             self.get-and-zero-active();
             self.teardown();
             my $done-handler := &!done;
@@ -337,15 +329,6 @@ class Rakudo::Supply {
 
         method run-done(--> Nil) {
             if $!active {
-                my \ex := nqp::exception();
-                unless nqp::isnull(ex) {
-                    my \value := nqp::getpayload(ex);
-                    unless nqp::isnull(value) || nqp::istype(value,Exception) {
-                        my $emit-handler := &!emit;
-                        $emit-handler(value) if $emit-handler.DEFINITE;
-                    }
-                }
-
                 self.teardown();
                 my $done-handler := &!done;
                 $done-handler() if $done-handler.DEFINITE;

--- a/src/core.c/Rakudo/Supply.pm6
+++ b/src/core.c/Rakudo/Supply.pm6
@@ -129,6 +129,14 @@ class Rakudo::Supply {
         }
 
         method run-done(--> Nil) {
+            my \ex := nqp::exception();
+            unless nqp::isnull(ex) {
+                my \value := nqp::getpayload(ex);
+                unless nqp::isnull(value) || nqp::istype(value,Exception) {
+                    my $emit-handler := &!emit;
+                    $emit-handler(value) if $emit-handler.DEFINITE;
+                }
+            }
             self.get-and-zero-active();
             self.teardown();
             my $done-handler := &!done;
@@ -329,6 +337,15 @@ class Rakudo::Supply {
 
         method run-done(--> Nil) {
             if $!active {
+                my \ex := nqp::exception();
+                unless nqp::isnull(ex) {
+                    my \value := nqp::getpayload(ex);
+                    unless nqp::isnull(value) || nqp::istype(value,Exception) {
+                        my $emit-handler := &!emit;
+                        $emit-handler(value) if $emit-handler.DEFINITE;
+                    }
+                }
+
                 self.teardown();
                 my $done-handler := &!done;
                 $done-handler() if $done-handler.DEFINITE;

--- a/src/core.c/control.pm6
+++ b/src/core.c/control.pm6
@@ -197,8 +197,16 @@ sub emit(Mu \value --> Nil) {
     nqp::setextype($ex,nqp::const::CONTROL_EMIT);
     nqp::throw($ex);
 }
-sub done(--> Nil) {
+
+proto sub done(|) {*}
+multi sub done(--> Nil) {
     THROW-NIL(nqp::const::CONTROL_DONE);
+}
+multi sub done(Mu \value --> Nil) {
+    my Mu $ex := nqp::newexception();
+    nqp::setpayload($ex,nqp::p6recont_ro(value));
+    nqp::setextype($ex,nqp::const::CONTROL_DONE);
+    nqp::throw($ex);
 }
 
 proto sub die(|) {*};

--- a/src/core.c/control.pm6
+++ b/src/core.c/control.pm6
@@ -197,16 +197,13 @@ sub emit(Mu \value --> Nil) {
     nqp::setextype($ex,nqp::const::CONTROL_EMIT);
     nqp::throw($ex);
 }
-
 proto sub done(|) {*}
 multi sub done(--> Nil) {
     THROW-NIL(nqp::const::CONTROL_DONE);
 }
 multi sub done(Mu \value --> Nil) {
-    my Mu $ex := nqp::newexception();
-    nqp::setpayload($ex,nqp::p6recont_ro(value));
-    nqp::setextype($ex,nqp::const::CONTROL_DONE);
-    nqp::throw($ex);
+    emit value;
+    done;
 }
 
 proto sub die(|) {*};


### PR DESCRIPTION
As discussed in https://github.com/Raku/problem-solving/issues/249

This makes the "done" sub a multi, and adds logic in the "run-done"
handlers in Rakudo::Supply to handle anything specified that is not
an exception.

Should we want to be able to emit an Exception, then we will have to
add some more logic for handing the QUIT phaser's handling of "run-done".