### PR TITLE
Implement `last` with value

### DIFF
--- a/src/core.c/Any-iterable-methods.pm6
+++ b/src/core.c/Any-iterable-methods.pm6
@@ -159,7 +159,13 @@ Consider using a block if any of these are necessary for your mapping code."
                       nqp::if(
                         nqp::isnull($result := nqp::getpayload(nqp::exception)),
                         ($result  := IterationEnd),
-                        ($!source  := Rakudo::Iterator.Empty),
+                        nqp::stmts(
+                          nqp::if(
+                            nqp::istype($result, Slip),
+                            ($result := self.start-slip($result))
+                          ),
+                          ($!source  := Rakudo::Iterator.Empty)
+                        )
                       )
                     )
                   ),
@@ -232,7 +238,11 @@ Consider using a block if any of these are necessary for your mapping code."
                           ($done = $!did-iterate = 1),
                           nqp::unless(
                             nqp::isnull($value := nqp::getpayload(nqp::exception)),
-                            target.push($value)
+                            nqp::if(
+                              nqp::istype($value,Slip),
+                              self.slip-all($value,target),
+                              target.push($value)
+                            )
                           )
                         )
                       )
@@ -367,11 +377,18 @@ Consider using a block if any of these are necessary for your mapping code."
                     'LAST', nqp::if(
                       nqp::isnull($result := nqp::getpayload(nqp::exception)),
                       ($result := IterationEnd),
-                      ($!source := Rakudo::Iterator.Empty),
+                      nqp::stmts(
+                        nqp::if(
+                          nqp::istype($result,Slip),
+                          ($result := self.start-slip($result))
+                        ),
+                        ($!source := Rakudo::Iterator.Empty)
+                      )
                     )
-                  ),
+                  )
                 ),
-              :nohandler);
+                :nohandler
+              );
             }
             $result
         }
@@ -406,7 +423,11 @@ Consider using a block if any of these are necessary for your mapping code."
                       'LAST', nqp::stmts(
                         nqp::unless(
                           nqp::isnull($value := nqp::getpayload(nqp::exception)),
-                          target.push($value)
+                          nqp::if(
+                            nqp::istype($value,Slip),
+                            self.slip-all($value,target),
+                            target.push($value)
+                          )
                         ),
                         return
                       )
@@ -520,7 +541,13 @@ Consider using a block if any of these are necessary for your mapping code."
                     'LAST', nqp::if(
                       nqp::isnull($result := nqp::getpayload(nqp::exception)),
                       ($result  := IterationEnd),
-                      ($!source := Rakudo::Iterator.Empty),
+                      nqp::stmts(
+                        nqp::if(
+                          nqp::istype($result,Slip),
+                          ($result := self.start-slip($result))
+                        ),
+                        ($!source := Rakudo::Iterator.Empty)
+                      )
                     )
                   ),
                 ),
@@ -573,14 +600,18 @@ Consider using a block if any of these are necessary for your mapping code."
                       ),
                       'LABELED', $!label,
                       'REDO', ($redo = 1),
+                      'NEXT', nqp::null, # need NEXT for next LABEL support
                       'LAST', nqp::stmts(
                         nqp::unless(
                           nqp::isnull($value := nqp::getpayload(nqp::exception)),
-                          target.push($value)
+                          nqp::if(
+                            nqp::istype($value,Slip),
+                            self.slip-all($result,target),
+                            target.push($value)
+                          )
                         ),
                         return
-                      ),
-                      'NEXT', nqp::null, # need NEXT for next LABEL support
+                      )
                     )
                   ),
                   :nohandler
@@ -720,8 +751,14 @@ Consider using a block if any of these are necessary for your mapping code."
                         ($!did-iterate = 1),
                         nqp::if(
                           nqp::isnull($result := nqp::getpayload(nqp::exception)),
-                          ($result  := IterationEnd),
-                          ($!source := Rakudo::Iterator.Empty)
+                          ($result := IterationEnd),
+                          nqp::stmts(
+                            nqp::if(
+                              nqp::istype($result,Slip),
+                              ($result := self.start-slip($result))
+                            ),
+                            ($!source := Rakudo::Iterator.Empty)
+                          )
                         )
                       )
                     )

--- a/src/core.c/Rakudo/Iterator.pm6
+++ b/src/core.c/Rakudo/Iterator.pm6
@@ -1446,6 +1446,10 @@ class Rakudo::Iterator {
                             ),
                             ($result := IterationEnd),
                             nqp::stmts(
+                              nqp::if(
+                                nqp::istype($result,Slip),
+                                ($result := self.start-slip($result))
+                              ),
                               ($!seen-first = 0),
                               (&!cond := &always-False)
                             )
@@ -2481,7 +2485,13 @@ class Rakudo::Iterator {
                       'LAST', nqp::if(
                         nqp::isnull($result := nqp::getpayload(nqp::exception)),
                         ($result := IterationEnd),
-                        (&!body := &always-IterationEnd)
+                        nqp::stmts(
+                          nqp::if(
+                            nqp::istype($result,Slip),
+                            ($result := self.start-slip($result))
+                          ),
+                          (&!body := &always-IterationEnd)
+                        )
                       )
                     )
                   ),
@@ -3744,7 +3754,13 @@ class Rakudo::Iterator {
                               $result := nqp::getpayload(nqp::exception)
                             ),
                             ($result := IterationEnd),
-                            (&!cond  := &always-False)
+                            nqp::stmts(
+                              nqp::if(
+                                nqp::istype($result,Slip),
+                                ($result := self.start-slip($result))
+                              ),
+                              (&!cond  := &always-False)
+                            )
                           )
                         )
                       ),
@@ -4785,7 +4801,13 @@ class Rakudo::Iterator {
                               $result := nqp::getpayload(nqp::exception)
                             ),
                             ($result := IterationEnd),
-                            (&!cond  := &always-False)
+                            nqp::stmts(
+                              nqp::if(
+                                nqp::istype($result,Slip),
+                                ($result := self.start-slip($result))
+                              ),
+                              (&!cond  := &always-False)
+                            )
                           )
                         )
                       ),

--- a/src/core.c/control.pm6
+++ b/src/core.c/control.pm6
@@ -108,6 +108,7 @@ multi sub goto(Label:D \x --> Nil) { x.goto }
 proto sub last($?, *%) {*}
 multi sub last(--> Nil) { nqp::throwextype(nqp::const::CONTROL_LAST); Nil }
 multi sub last(Label:D \x --> Nil) { x.last }
+multi sub last(\x --> Nil) { THROW(nqp::const::CONTROL_LAST, x) }
 
 proto sub next($?, *%) {*}
 multi sub next(--> Nil) { nqp::throwextype(nqp::const::CONTROL_NEXT); Nil }


### PR DESCRIPTION
This allows for the following constructs:

```raku
say ^10 .map: { $_ == 5 ?? (last)   !! $_ }  # (0 1 2 3 4)
say ^10 .map: { $_ == 5 ?? last(42) !! $_ }  # (0 1 2 3 4 42)
```

and also in `.grep`:
```raku
say ^10 .grep: { $_ == 5 ?? last       !! $_ %% 2 }  # (0 2 4)
say ^10 .grep: { $_ == 5 ?? last(True) !! $_ %% 2 }  # (0 2 4 5)
```

and any other loop constructs that return values, e.g.:

```raku
my $i; say do while ++$i < 10 { $i == 5 ?? (last)   !! $i }  # (1 2 3 4)
```
vs
```raku
my $i; say do while ++$i < 10 { $i == 5 ?? last(42) !! $i }  # (1 2 3 4 42)
```