### PR TITLE
Fix freezes caused by concurrently produced iterators

### DIFF
--- a/src/core.c/Exception.pm6
+++ b/src/core.c/Exception.pm6
@@ -3184,11 +3184,12 @@ my class X::MultipleTypeSmiley does X::Comp {
 }
 
 my class X::Seq::Consumed is Exception {
-    has Str:D $.kind = "Seq";
+    has $.kind = Seq;
     method message() {
-        ("The iterator of this $!kind is already in use/consumed by another $!kind" ~
-        " (you might solve this by adding .cache on usages of the $!kind, or " ~
-        "by assigning the $!kind into an array)").naive-word-wrapper
+        my $kind_name = $!kind.^name;
+        ("The iterator of this $kind_name is already in use/consumed by another $kind_name" ~
+        " (you might solve this by adding .cache on usages of the $kind_name, or " ~
+        "by assigning the $kind_name into an array)").naive-word-wrapper
     }
 }
 

--- a/src/core.c/Exception.pm6
+++ b/src/core.c/Exception.pm6
@@ -3184,10 +3184,11 @@ my class X::MultipleTypeSmiley does X::Comp {
 }
 
 my class X::Seq::Consumed is Exception {
+    has Str:D $.kind = "Seq";
     method message() {
-        "The iterator of this Seq is already in use/consumed by another Seq\n" ~
-        "(you might solve this by adding .cache on usages of the Seq, or\n" ~
-        "by assigning the Seq into an array)"
+        ("The iterator of this $!kind is already in use/consumed by another $!kind" ~
+        " (you might solve this by adding .cache on usages of the $!kind, or " ~
+        "by assigning the $!kind into an array)").naive-word-wrapper
     }
 }
 

--- a/src/core.c/HyperSeq.pm6
+++ b/src/core.c/HyperSeq.pm6
@@ -1,45 +1,58 @@
 # A HyperSeq performs batches of work in parallel, but retains order of output
 # values relative to input values.
 #?if !js
-my class HyperSeq does Iterable does Sequence {
+
+my role Sequence::Hyper does Iterable does Sequence {
     has HyperConfiguration $.configuration;
     has Rakudo::Internals::HyperWorkStage $!work-stage-head;
+    has $!joiner;
 
     submethod BUILD(:$!configuration!, :$!work-stage-head!) {}
 
-    method iterator(HyperSeq:D: --> Iterator) {
-        my $joiner := Rakudo::Internals::HyperToIterator.new:
+    method iterator(::?CLASS:D: --> Iterator) {
+        X::Seq::Consumed.new(:kind(::?CLASS.^name)).throw
+            if nqp::isconcrete($!joiner);
+        $!joiner := Rakudo::Internals::HyperToIterator.new:
             source => $!work-stage-head;
-        Rakudo::Internals::HyperPipeline.start($joiner, $!configuration);
-        $joiner
+        Rakudo::Internals::HyperPipeline.start($!joiner, $!configuration);
+        $!joiner
     }
 
-    method grep(HyperSeq:D: $matcher, *%options) {
+    method grep(::?CLASS:D: $matcher, *%options) {
         Rakudo::Internals::HyperRaceSharedImpl.grep:
             self, $!work-stage-head, $matcher, %options
     }
 
-    method map(HyperSeq:D: $matcher, *%options) {
+    method map(::?CLASS:D: $matcher, *%options) {
         Rakudo::Internals::HyperRaceSharedImpl.map:
             self, $!work-stage-head, $matcher, %options
     }
 
-    method invert(HyperSeq:D:) {
+    method invert(::?CLASS:D:) {
         Rakudo::Internals::HyperRaceSharedImpl.invert(self, $!work-stage-head)
     }
 
-    method hyper(HyperSeq:D:) { self }
-
-    method race(HyperSeq:D:) {
-        RaceSeq.new(:$!configuration, :$!work-stage-head)
-    }
+    method hyper(::?CLASS:D:) {...}
+    method race(::?CLASS:D:) {...}
 
     method is-lazy(--> False) { }
 
-    multi method serial(HyperSeq:D:) { self.Seq }
+    multi method serial(::?CLASS:D:) { self.Seq }
 
     method sink(--> Nil) {
         Rakudo::Internals::HyperRaceSharedImpl.sink(self, $!work-stage-head)
+    }
+
+}
+
+my class HyperSeq does Sequence::Hyper {
+    method hyper(HyperSeq:D:) { self }
+
+    method race(HyperSeq:D:) {
+        RaceSeq.new(
+            :$!configuration,
+            work-stage-head =>
+                Rakudo::Internals::HyperIteratorBatcher.new(:$.iterator))
     }
 }
 #?endif

--- a/src/core.c/HyperSeq.pm6
+++ b/src/core.c/HyperSeq.pm6
@@ -1,51 +1,7 @@
 # A HyperSeq performs batches of work in parallel, but retains order of output
 # values relative to input values.
 #?if !js
-
-my role Sequence::Hyper does Iterable does Sequence {
-    has HyperConfiguration $.configuration;
-    has Rakudo::Internals::HyperWorkStage $!work-stage-head;
-    has $!joiner;
-
-    submethod BUILD(:$!configuration!, :$!work-stage-head!) {}
-
-    method iterator(::?CLASS:D: --> Iterator) {
-        X::Seq::Consumed.new(:kind(::?CLASS.^name)).throw
-            if nqp::isconcrete($!joiner);
-        $!joiner := Rakudo::Internals::HyperToIterator.new:
-            source => $!work-stage-head;
-        Rakudo::Internals::HyperPipeline.start($!joiner, $!configuration);
-        $!joiner
-    }
-
-    method grep(::?CLASS:D: $matcher, *%options) {
-        Rakudo::Internals::HyperRaceSharedImpl.grep:
-            self, $!work-stage-head, $matcher, %options
-    }
-
-    method map(::?CLASS:D: $matcher, *%options) {
-        Rakudo::Internals::HyperRaceSharedImpl.map:
-            self, $!work-stage-head, $matcher, %options
-    }
-
-    method invert(::?CLASS:D:) {
-        Rakudo::Internals::HyperRaceSharedImpl.invert(self, $!work-stage-head)
-    }
-
-    method hyper(::?CLASS:D:) {...}
-    method race(::?CLASS:D:) {...}
-
-    method is-lazy(--> False) { }
-
-    multi method serial(::?CLASS:D:) { self.Seq }
-
-    method sink(--> Nil) {
-        Rakudo::Internals::HyperRaceSharedImpl.sink(self, $!work-stage-head)
-    }
-
-}
-
-my class HyperSeq does Sequence::Hyper {
+my class HyperSeq does ParallelSequence {
     method hyper(HyperSeq:D:) { self }
 
     method race(HyperSeq:D:) {

--- a/src/core.c/ParallelSequence.rakumod
+++ b/src/core.c/ParallelSequence.rakumod
@@ -2,7 +2,7 @@
 my role ParallelSequence does Iterable does Sequence {
     has HyperConfiguration $.configuration;
     has Rakudo::Internals::HyperWorkStage $!work-stage-head;
-    has $!has-iterator;
+    has atomicint $!has-iterator;
 
     submethod BUILD(:$!configuration!, :$!work-stage-head!) {
         $!has-iterator = 0;
@@ -10,7 +10,7 @@ my role ParallelSequence does Iterable does Sequence {
 
     method iterator(::?CLASS:D: --> Iterator) {
         X::Seq::Consumed.new(:kind(::?CLASS)).throw
-            if nqp::cas($!has-iterator, 0, 1);
+            if nqp::cas_i($!has-iterator, 0, 1);
         my $joiner := Rakudo::Internals::HyperToIterator.new:
                         source => $!work-stage-head;
         Rakudo::Internals::HyperPipeline.start($joiner, $!configuration);

--- a/src/core.c/ParallelSequence.rakumod
+++ b/src/core.c/ParallelSequence.rakumod
@@ -1,0 +1,44 @@
+# ParallelSequence role implements common functionality of HyperSeq and RaceSeq classes.
+my role ParallelSequence does Iterable does Sequence {
+    has HyperConfiguration $.configuration;
+    has Rakudo::Internals::HyperWorkStage $!work-stage-head;
+    has $!has-iterator;
+
+    submethod BUILD(:$!configuration!, :$!work-stage-head!) {
+        $!has-iterator = 0;
+    }
+
+    method iterator(::?CLASS:D: --> Iterator) {
+        X::Seq::Consumed.new(:kind(::?CLASS)).throw
+            if nqp::cas($!has-iterator, 0, 1);
+        my $joiner := Rakudo::Internals::HyperToIterator.new:
+                        source => $!work-stage-head;
+        Rakudo::Internals::HyperPipeline.start($joiner, $!configuration);
+        $joiner
+    }
+
+    method grep(::?CLASS:D: $matcher, *%options) {
+        Rakudo::Internals::HyperRaceSharedImpl.grep:
+            self, $!work-stage-head, $matcher, %options
+    }
+
+    method map(::?CLASS:D: $matcher, *%options) {
+        Rakudo::Internals::HyperRaceSharedImpl.map:
+            self, $!work-stage-head, $matcher, %options
+    }
+
+    method invert(::?CLASS:D:) {
+        Rakudo::Internals::HyperRaceSharedImpl.invert(self, $!work-stage-head)
+    }
+
+    method hyper(::?CLASS:D:) {...}
+    method race(::?CLASS:D:) {...}
+
+    method is-lazy(--> False) { }
+
+    multi method serial(::?CLASS:D:) { self.Seq }
+
+    method sink(--> Nil) {
+        Rakudo::Internals::HyperRaceSharedImpl.sink(self, $!work-stage-head)
+    }
+}

--- a/src/core.c/RaceSeq.pm6
+++ b/src/core.c/RaceSeq.pm6
@@ -3,7 +3,7 @@
 # the input).
 
 #?if !js
-my class RaceSeq does Sequence::Hyper {
+my class RaceSeq does ParallelSequence {
     method hyper(RaceSeq:D:) {
         HyperSeq.new(
             :$!configuration,

--- a/src/core.c/RaceSeq.pm6
+++ b/src/core.c/RaceSeq.pm6
@@ -3,47 +3,15 @@
 # the input).
 
 #?if !js
-my class RaceSeq does Iterable does Sequence {
-    has HyperConfiguration $.configuration;
-    has Rakudo::Internals::HyperWorkStage $!work-stage-head;
-
-    submethod BUILD(:$!configuration!, :$!work-stage-head!) {}
-
-    method iterator(RaceSeq:D: --> Iterator) {
-        my $joiner := Rakudo::Internals::RaceToIterator.new:
-            source => $!work-stage-head;
-        Rakudo::Internals::HyperPipeline.start($joiner, $!configuration);
-        $joiner
-    }
-
-    method grep(RaceSeq:D: $matcher, *%options) {
-        Rakudo::Internals::HyperRaceSharedImpl.grep:
-            self, $!work-stage-head, $matcher, %options
-    }
-
-    method map(RaceSeq:D: $matcher, *%options) {
-        Rakudo::Internals::HyperRaceSharedImpl.map:
-            self, $!work-stage-head, $matcher, %options
-    }
-
-    method invert(RaceSeq:D:) {
-        Rakudo::Internals::HyperRaceSharedImpl.invert:
-            self, $!work-stage-head
-    }
-
+my class RaceSeq does Sequence::Hyper {
     method hyper(RaceSeq:D:) {
-        HyperSeq.new(:$!configuration, :$!work-stage-head)
+        HyperSeq.new(
+            :$!configuration,
+            work-stage-head =>
+                Rakudo::Internals::HyperIteratorBatcher.new(:$.iterator))
     }
 
     method race(RaceSeq:D:) { self }
-
-    method is-lazy(--> False) { }
-
-    multi method serial(RaceSeq:D:) { self.Seq }
-
-    method sink(--> Nil) {
-        Rakudo::Internals::HyperRaceSharedImpl.sink(self, $!work-stage-head)
-    }
 }
 #?endif
 #?if js

--- a/t/02-rakudo/03-corekeys-6c.t
+++ b/t/02-rakudo/03-corekeys-6c.t
@@ -609,6 +609,7 @@ my @expected = (
   Q{PROTO_TCP},
   Q{PROTO_UDP},
   Q{Pair},
+  Q{ParallelSequence},
   Q{Parameter},
   Q{Perl},
   Q{PhasersList},

--- a/t/02-rakudo/03-corekeys-6d.t
+++ b/t/02-rakudo/03-corekeys-6d.t
@@ -609,6 +609,7 @@ my @expected = (
     Q{PROTO_TCP},
     Q{PROTO_UDP},
     Q{Pair},
+    Q{ParallelSequence},
     Q{Parameter},
     Q{Perl},
     Q{PhasersList},

--- a/t/02-rakudo/03-corekeys-6e.t
+++ b/t/02-rakudo/03-corekeys-6e.t
@@ -611,6 +611,7 @@ my @expected = (
     Q{PROTO_TCP},
     Q{PROTO_UDP},
     Q{Pair},
+    Q{ParallelSequence},
     Q{Parameter},
     Q{Perl},
     Q{PhasersList},

--- a/t/02-rakudo/03-corekeys.t
+++ b/t/02-rakudo/03-corekeys.t
@@ -612,6 +612,7 @@ my @allowed =
       Q{PROTO_TCP},
       Q{PROTO_UDP},
       Q{Pair},
+      Q{ParallelSequence},
       Q{Parameter},
       Q{Perl},
       Q{PhasersList},

--- a/t/02-rakudo/04-settingkeys-6c.t
+++ b/t/02-rakudo/04-settingkeys-6c.t
@@ -609,6 +609,7 @@ my %allowed = (
     Q{PROTO_TCP},
     Q{PROTO_UDP},
     Q{Pair},
+    Q{ParallelSequence},
     Q{Parameter},
     Q{Perl},
     Q{PhasersList},

--- a/t/02-rakudo/04-settingkeys-6e.t
+++ b/t/02-rakudo/04-settingkeys-6e.t
@@ -609,6 +609,7 @@ my %allowed = (
     Q{PROTO_TCP},
     Q{PROTO_UDP},
     Q{Pair},
+    Q{ParallelSequence},
     Q{Parameter},
     Q{Perl},
     Q{PhasersList},

--- a/tools/templates/6.c/core_sources
+++ b/tools/templates/6.c/core_sources
@@ -57,6 +57,7 @@ src/core.c/Encoding/Registry.pm6
 src/core.c/Str.pm6
 src/core.c/Capture.pm6
 src/core.c/IterationBuffer.pm6
+src/core.c/atomicops.pm6
 src/core.c/Sequence.pm6
 src/core.c/Seq.pm6
 src/core.c/Rakudo/Internals/HyperWorkBatch.pm6
@@ -165,7 +166,6 @@ src/core.c/Hyper.pm6
 src/core.c/metaops.pm6
 src/core.c/precedence.pm6
 src/core.c/Deprecations.pm6
-src/core.c/atomicops.pm6
 src/core.c/Thread.pm6
 src/core.c/Lock.pm6
 src/core.c/Lock/Async.pm6

--- a/tools/templates/6.c/core_sources
+++ b/tools/templates/6.c/core_sources
@@ -66,6 +66,8 @@ src/core.c/Rakudo/Internals/HyperIteratorBatcher.pm6
 src/core.c/Rakudo/Internals/HyperToIterator.pm6
 src/core.c/Rakudo/Internals/RaceToIterator.pm6
 src/core.c/Rakudo/Internals/HyperRaceSharedImpl.pm6
+@if(backend!=js
+src/core.c/ParallelSequence.rakumod)@
 src/core.c/HyperSeq.pm6
 src/core.c/RaceSeq.pm6
 src/core.c/Nil.pm6


### PR DESCRIPTION
Freezes were happening with code similar to:

    (.list, .list) given (^10).hyper;

The cause was tracked down to two iterators created for the same
`$!work-stage-head` object. In an identical situation `Seq` would throw
`X::Seq::Consumed` which seems logical. Similar approach was taken for
`HyperSeq` and `RaceSeq`.

Aside of this, I noticed that `HyperSeq` and `RaceSeq` share basicall
all their code except for `hyper` and `race` methods. I found it
reasonable to move all commonalities into a role.

Fixes #4413