### PR TITLE
Implement support for moar::hllincludes config variable

### DIFF
--- a/tools/lib/NQP/Config/Rakudo.pm
+++ b/tools/lib/NQP/Config/Rakudo.pm
@@ -894,7 +894,7 @@ sub _m_for_langalias {
 
 sub _m_source_digest_files {
     my $self   = shift;
-    my $indent = " " x ( $self->cfg->{config}{filelist_indent} || 4 );
+    my $indent = " " x ( $self->cfg->{config}{list_indent} || 4 );
     return join( " \\\n$indent", _all_sources($self) );
 }
 

--- a/tools/templates/moar/Makefile.in
+++ b/tools/templates/moar/Makefile.in
@@ -20,16 +20,7 @@ R_SETTING_MOAR = RESTRICTED.setting.moarvm
 
 @bpv(INCPATH)@ = @nfp($(MOAR_PREFIX)/include)@
 @bpv(MOAR_INC_PATHS)@ = \
-	@moar::cincludes@ \
-	@bpm(CCINC)@@nfpq(@bpm(INCPATH)@)@ \
-	@bpm(CCINC)@@nfpq(@bpm(INCPATH)@/moar)@ \
-	@bpm(CCINC)@@nfpq(@bpm(INCPATH)@/libatomic_ops)@ \
-	@bpm(CCINC)@@nfpq(@bpm(INCPATH)@/dyncall)@ \
-	@bpm(CCINC)@@nfpq(@bpm(INCPATH)@/moar)@ \
-	@bpm(CCINC)@@nfpq(@bpm(INCPATH)@/sha1)@ \
-	@bpm(CCINC)@@nfpq(@bpm(INCPATH)@/tinymt)@ \
-	@bpm(CCINC)@@nfpq(@bpm(INCPATH)@/libtommath)@ \
-	@bpm(CCINC)@@nfpq(@bpm(INCPATH)@/libuv)@
+    @insert_list(moar_includes)@
 
 @bpv(RAKU)@ = raku@moar::exe@
 @bpv(RAKU_DEBUG)@ = raku-debug@moar::exe@

--- a/tools/templates/moar/moar_includes
+++ b/tools/templates/moar/moar_includes
@@ -1,0 +1,5 @@
+@moar::cincludes@
+@moar::ccinc@@nfpq(@moar::prefix@/include)@
+@for(moar::hllincludes
+@moar::ccinc@@nfpq(@moar::prefix@/include/@_@)@
+)@


### PR DESCRIPTION
List of include directories is now provided by moar backend and
respected by Rakudo build.