### PR TITLE
Fix unimatch for non-base properties

### DIFF
--- a/src/core.c/unicodey.pm6
+++ b/src/core.c/unicodey.pm6
@@ -77,7 +77,7 @@ my class Rakudo::Unicodey is implementation-detail {
         my $prop := nqp::unipropcode($propname);
         nqp::hllbool(
           nqp::matchuniprop($code,$prop,nqp::unipvalcode($prop,$pvalname))
-        )
+        ) || uniprop($code, $propname) eq $pvalname
     }
 
     my constant $gcprop = nqp::unipropcode("General_Category");
@@ -377,6 +377,7 @@ augment class Cool {
     multi method ords(Cool:D:) { self.Str.ords }
 
     proto method unimatch($, $?, *%) is pure {*}
+
     multi method unimatch(Cool:D: Str:D $pvalname --> Bool:D) {
         self.Int.unimatch($pvalname)
     }


### PR DESCRIPTION
Prior to PR #4172, unimatch worked for non-base properties such as
```raku
    unimatch '[', ']', 'Bidi_Mirroring_Glyph'; # True
```
That PR, however, provided a speedup for base properties, but broke the more advanced use.  This adds back support for the more advanced use case as a fallback _after_ testing for a base property (which should avoid performance impacts in most cases).

If this generally looks good, I'll add Roast tests to [S15/unimatch-general](https://github.com/Raku/roast/blob/dffc2a4cec4a1b91a14289a88cead3ceecd5f5b4/S15-unicode-information/unimatch-general.t) which currently tests the base property but not others (such as those that return strings).

Thanks to @alabamenhu for help tracking down this regression.