### PR TITLE
Enable rendering of nested blocks in Pod::To::Text

### DIFF
--- a/lib/Pod/To/Text.rakumod
+++ b/lib/Pod/To/Text.rakumod
@@ -49,7 +49,7 @@ sub item2text($pod) {
 sub named2text($pod) {
     given $pod.name {
         when 'pod'  { pod2text($pod.contents)     }
-        when 'para' { para2text($pod.contents[0]) }
+        when 'para' { pod2text($pod.contents) }
         when 'config' { }
         when 'nested' { pod2text($pod.contents).indent(4) }
         default     { $pod.name ~ "\n" ~ pod2text($pod.contents) }

--- a/lib/Pod/To/Text.rakumod
+++ b/lib/Pod/To/Text.rakumod
@@ -51,7 +51,7 @@ sub named2text($pod) {
         when 'pod'  { pod2text($pod.contents)     }
         when 'para' { para2text($pod.contents[0]) }
         when 'config' { }
-        when 'nested' { }
+        when 'nested' { pod2text($pod.contents).indent(4) }
         default     { $pod.name ~ "\n" ~ pod2text($pod.contents) }
     }
 }


### PR DESCRIPTION
This corrects a number of omissions when rendering S26 (and possibly elsewhere). Rakudo tests and spectests all pass cleanly. A diff of the output from S26 before and after this PR revealed no undesirable side effects.