### PR TITLE
Add 'modf' to the Raku core's numerical routines

### DIFF
--- a/src/core.c/Cool.pm6
+++ b/src/core.c/Cool.pm6
@@ -40,6 +40,10 @@ my class Cool { # declared in BOOTSTRAP
     multi method log(Cool:D: )      { self.Numeric.log          }
     multi method log(Cool:D: $base) { self.Numeric.log($base.Numeric) }
 
+    proto method modf(|) {*}
+    multi method modf(Cool:D --> List)          { self.Numeric.modf                  }
+    multi method modf(Cool:D $places --> List)  { self.Numeric.modf($places.Numeric) }
+
     proto method exp(|) {*}
     multi method exp(Cool:D: )      { self.Numeric.exp          }
     multi method exp(Cool:D: $base) { self.Numeric.exp($base.Numeric) }

--- a/src/core.c/Num.pm6
+++ b/src/core.c/Num.pm6
@@ -168,6 +168,29 @@ my class Num does Real { # declared in BOOTSTRAP
     multi method sin(Num:D: ) {
         nqp::p6box_n(nqp::sin_n(nqp::unbox_n(self)));
     }
+
+    proto method modf(|) {*} 
+    multi method modf(Num:D: Num $places? --> List) { # method source of the return values, patterned after sub log
+        my $x = self; 
+        my \sign = $x.sign;
+        $x .= abs;  # now signless
+
+        # operate on absolute parts
+        my $int  = $x.Int;  
+        my $frac = $x - $int;
+        # restore original sign
+        $int  *= sign; 
+        $frac *= sign; 
+        $int  = 0 if $int  == 0;
+        $frac = 0 if $frac == 0;
+
+        if $places.defined and $places > 0 {
+            $frac = sprintf '%.*f', $places, $frac;
+        }
+
+        $int, $frac
+    }
+
     proto method asin(|) {*}
     multi method asin(Num:D: ) {
         nqp::p6box_n(nqp::asin_n(nqp::unbox_n(self)));
@@ -541,6 +564,26 @@ multi sub acosec(Num:D \x) {
 
 multi sub log(num $x --> num) {
     nqp::log_n($x);
+}
+
+multi sub modf(num $x is copy, num $places? --> List) { # sub source of the return values, patterned after sub log
+        my \sign = $x.sign;
+        $x .= abs;  # now signless
+
+        # operate on absolute parts
+        my $int  = $x.Int;  
+        my $frac = $x - $int;
+        # restore original sign
+        $int  *= sign; 
+        $frac *= sign; 
+        $int  = 0 if $int  == 0;
+        $frac = 0 if $frac == 0;
+
+        if $places.defined and $places > 0 {
+            $frac = sprintf '%.*f', $places, $frac;
+        }
+
+        $int, $frac
 }
 
 multi sub sin(num $x --> num) {

--- a/src/core.c/Numeric.pm6
+++ b/src/core.c/Numeric.pm6
@@ -72,6 +72,12 @@ proto sub sign($, *%) is pure {*}
 multi sub sign(Numeric \x) { x.sign }
 multi sub sign(Cool \x)    { x.Numeric.sign }
 
+proto sub modf($, $?, *%) is pure {*}
+multi sub modf(Numeric $x --> List)                  { $x.modf                  }
+multi sub modf(Numeric $x, Numeric $places --> List) { $x.modf($places)         }
+multi sub modf(Cool $x --> List)                     { $x.Numeric.modf          }
+multi sub modf(Cool $x, Cool $places --> List)       { $x.Numeric.modf($places) }
+
 proto sub log($, $?, *%) is pure {*}
 multi sub log(Numeric $x) { $x.log }
 multi sub log(Numeric $x, Numeric $base) { $x.log($base) }

--- a/src/core.c/Real.pm6
+++ b/src/core.c/Real.pm6
@@ -53,6 +53,11 @@ my role Real does Numeric {
         Complex.new(self.cos, self.sin);
     }
     method Complex() { Complex.new(self.Num, 0e0) }
+
+    proto method modf(|) {*}
+    multi method modf(Real:D: --> List)    { self.Bridge.modf                 }
+    multi method modf(Real:D: Int $places) { self.Bridge.modf($places.Bridge) }
+
     proto method log(|) {*}
     multi method log(Real:D: )           { self.Bridge.log               }
     multi method log(Real:D: Real $base) { self.Bridge.log($base.Bridge) }

--- a/t/02-rakudo/03-corekeys-6c.t
+++ b/t/02-rakudo/03-corekeys-6c.t
@@ -332,6 +332,7 @@ my @expected = (
   Q{&minmax},
   Q{&mix},
   Q{&mkdir},
+  Q{&modf},
   Q{&move},
   Q{&msb},
   Q{&next},

--- a/t/02-rakudo/03-corekeys-6d.t
+++ b/t/02-rakudo/03-corekeys-6d.t
@@ -332,6 +332,7 @@ my @expected = (
     Q{&minmax},
     Q{&mix},
     Q{&mkdir},
+    Q{&modf},
     Q{&move},
     Q{&msb},
     Q{&next},

--- a/t/02-rakudo/03-corekeys-6e.t
+++ b/t/02-rakudo/03-corekeys-6e.t
@@ -334,6 +334,7 @@ my @expected = (
     Q{&minmax},
     Q{&mix},
     Q{&mkdir},
+    Q{&modf},
     Q{&move},
     Q{&msb},
     Q{&next},

--- a/t/02-rakudo/03-corekeys.t
+++ b/t/02-rakudo/03-corekeys.t
@@ -335,6 +335,7 @@ my @allowed =
       Q{&minmax},
       Q{&mix},
       Q{&mkdir},
+      Q{&modf},
       Q{&move},
       Q{&msb},
       Q{&next},

--- a/t/02-rakudo/04-settingkeys-6c.t
+++ b/t/02-rakudo/04-settingkeys-6c.t
@@ -331,6 +331,7 @@ my %allowed = (
     Q{&minmax},
     Q{&mix},
     Q{&mkdir},
+    Q{&modf},
     Q{&move},
     Q{&msb},
     Q{&next},

--- a/t/02-rakudo/04-settingkeys-6e.t
+++ b/t/02-rakudo/04-settingkeys-6e.t
@@ -331,6 +331,7 @@ my %allowed = (
     Q{&minmax},
     Q{&mix},
     Q{&mkdir},
+    Q{&modf},
     Q{&move},
     Q{&msb},
     Q{&next},

--- a/t/02-rakudo/07-implementation-detail-6.c.t
+++ b/t/02-rakudo/07-implementation-detail-6.c.t
@@ -24,7 +24,7 @@ my @lower = ("",<<
   flat flip floor full-barrier get getc gist goto grep hash index
   indices indir is-prime item join keys kv last lastcall lc leave
   lines link list log log10 log2 lsb make map max min minmax mix
-  mkdir move msb next nextcallee nextsame nextwith nodemap none
+  mkdir modf move msb next nextcallee nextsame nextwith nodemap none
   not note one open ord ords pair pairs parse-base parse-names
   permutations pick pop prepend print printf proceed produce
   prompt push put rand redo reduce rename repeated repl return

--- a/t/02-rakudo/07-implementation-detail-6.d.t
+++ b/t/02-rakudo/07-implementation-detail-6.d.t
@@ -24,7 +24,7 @@ my @lower = ("",<<
   flat flip floor full-barrier get getc gist goto grep hash index
   indices indir is-prime item join keys kv last lastcall lc leave
   lines link list log log10 log2 lsb make map max min minmax mix
-  mkdir move msb next nextcallee nextsame nextwith nodemap none
+  mkdir modf move msb next nextcallee nextsame nextwith nodemap none
   not note one open ord ords pair pairs parse-base parse-names
   permutations pick pop prepend print printf proceed produce
   prompt push put rand redo reduce rename repeated repl return

--- a/t/02-rakudo/07-implementation-detail-6.e.t
+++ b/t/02-rakudo/07-implementation-detail-6.e.t
@@ -24,7 +24,7 @@ my @lower = ("",<<
   flat flip floor full-barrier get getc gist goto grep hash index
   indices indir is-prime item join keys kv last lastcall lc leave
   lines link list log log10 log2 lsb make map max min minmax mix
-  mkdir move msb next nextcallee nextsame nextwith nodemap none
+  mkdir modf move msb next nextcallee nextsame nextwith nodemap none
   not note one open ord ords pair pairs parse-base parse-names
   permutations pick pop prepend print printf proceed produce
   prompt push put rand redo reduce rename repeated repl return


### PR DESCRIPTION
This routine is commonly found in many popular
programming languages (including Python) but
was not included in the original Raku release.

The routine as added follows the basic implementation
as found in C and C++ with some slght modifications
to take advantage of existing Raku features.
As implemented in Raku routine 'modf' provides:

+ for any number input it returns a list of the integral and
  fractional parts
+ both parts retain the sign of the input number
+ if either part is zero, that part is coerced to an integer
  zero
+ the returned integral part is truly an integer (as opposed
  to some other languages such as C and C++)
+ an optional second parameter ('places') can be entered to
  force the fractional part to the desired number of
  decimal places (useful for testing)