### PR TITLE
Revert "Revert "Test mkdir when parent was created but child fails""

### DIFF
--- a/t/02-rakudo/19-mkdir.t
+++ b/t/02-rakudo/19-mkdir.t
@@ -1,0 +1,9 @@
+use lib <t/packages/>;
+use Test;
+use Test::Helpers;
+
+plan 1;
+
+# mkdir soft-fails when directory name is too long (over 255 bytes).
+my $path = make-temp-dir.add("foobar").add("universe" x 42);
+fails-like { $path.mkdir }, X::IO::Mkdir;


### PR DESCRIPTION
Reverts rakudo/rakudo#4444

Must now pass CI check before merging.