### PR TITLE
Fix `rakuw.exe` to be a non-console app

### DIFF
--- a/tools/templates/moar/Makefile.in
+++ b/tools/templates/moar/Makefile.in
@@ -188,7 +188,7 @@ $(R_SETTING_MOAR): @bsm(RAKUDO)@@for_specs( @bsm(SETTING_@ucspec@)@)@ $(R_SETTIN
             '-DSTATIC_EXEC_PATH=' . $qchar . $cfg->c_escape_string($cfg->nfp($config{'prefix'} . '/bin/' . $installed )) . $qchar
             if $config{relocatable} eq 'nonreloc';
         $vars{debug_flag} = '-DMOAR_RAKUDO_RUNNER_DEBUG' if $build =~ /DEBUG/;
-        if ($build !~ /RAKUDOW|PERL6W/) {
+        if ($build !~ /RAKUW|RAKUDOW|PERL6W/) {
             $vars{subsystem_win_ld_flags} = '';
             $vars{subsystem_win_cc_flags} = '';
         }


### PR DESCRIPTION
The *w.exe binaries are the "windowed" variants that don't open a console window.
`rakuw.exe` was missing in the respective build system check.