### PR TITLE
Create checksums for release files

### DIFF
--- a/docs/release-guide-binary.md
+++ b/docs/release-guide-binary.md
@@ -19,14 +19,25 @@ The process of building is not started automatically, but has to be triggered ma
 - Verify all three archives have a size >10MB.
 - Verify all three archives decompress successfully.
 
-Sign the files:
+Sign the files and create checksum files:
 
-   gpg -b -u your@gpgkey.org --armor rakudo-moar-2020.01-01-linux-x86_64.tar.gz
-   gpg -b -u your@gpgkey.org --armor rakudo-moar-2020.01-01-macos-x86_64.tar.gz
-   gpg -b -u your@gpgkey.org --armor rakudo-moar-2020.01-01-win-x86_64.zip
+    gpg -u your@gpgkey.org --detach-sign --armor rakudo-moar-2020.01-01-linux-x86_64.tar.gz
 
-Upload the three archive files and corresponding `.asc` files to the <https://rakudo.org/> server.
+    md5sum    --tag rakudo-moar-2020.01-01-linux-x86_64.tar.gz >> rakudo-moar-2020.01-01-linux-x86_64.tar.gz.tmp
+    sha1sum   --tag rakudo-moar-2020.01-01-linux-x86_64.tar.gz >> rakudo-moar-2020.01-01-linux-x86_64.tar.gz.tmp
+    sha224sum --tag rakudo-moar-2020.01-01-linux-x86_64.tar.gz >> rakudo-moar-2020.01-01-linux-x86_64.tar.gz.tmp
+    sha256sum --tag rakudo-moar-2020.01-01-linux-x86_64.tar.gz >> rakudo-moar-2020.01-01-linux-x86_64.tar.gz.tmp
+    sha384sum --tag rakudo-moar-2020.01-01-linux-x86_64.tar.gz >> rakudo-moar-2020.01-01-linux-x86_64.tar.gz.tmp
+    sha512sum --tag rakudo-moar-2020.01-01-linux-x86_64.tar.gz >> rakudo-moar-2020.01-01-linux-x86_64.tar.gz.tmp
 
+    gpg -u your@gpgkey.org --clearsign --output rakudo-moar-2020.01-01-linux-x86_64.tar.gz.checksums.txt rakudo-moar-2020.01-01-linux-x86_64.tar.gz.tmp
+    rm rakudo-moar-2020.01-01-linux-x86_64.tar.gz.tmp
+
+Do that for all three release archives and the MSI file.
+
+- Upload the three archive files, the MSI and the checksum files to the <https://rakudo.org/> server:
+
+    scp -P2222 rakudo-moar-2020.01-01-* rakudo.org@lavm-perl6infra-1.atikon.io:public_html/downloads/rakudo/
 
 Manual build
 ============

--- a/docs/release_guide.pod
+++ b/docs/release_guide.pod
@@ -325,21 +325,32 @@ L<< settings -> keys page|https://github.com/settings/keys >>
 
 =item 17.
 
-Sign the tarball with your PGP key:
+Create a signature and checksum file:
 
-    gpg -b --armor rakudo-YYYY.MM.tar.gz
+    gpg --detach-sign --armor rakudo-YYYY.MM.tar.gz
+
+    md5sum    --tag rakudo-YYYY.MM.tar.gz >> rakudo-YYYY.MM.tar.gz.tmp
+    sha1sum   --tag rakudo-YYYY.MM.tar.gz >> rakudo-YYYY.MM.tar.gz.tmp
+    sha224sum --tag rakudo-YYYY.MM.tar.gz >> rakudo-YYYY.MM.tar.gz.tmp
+    sha256sum --tag rakudo-YYYY.MM.tar.gz >> rakudo-YYYY.MM.tar.gz.tmp
+    sha384sum --tag rakudo-YYYY.MM.tar.gz >> rakudo-YYYY.MM.tar.gz.tmp
+    sha512sum --tag rakudo-YYYY.MM.tar.gz >> rakudo-YYYY.MM.tar.gz.tmp
+
+    gpg --clearsign --output rakudo-YYYY.MM.tar.gz.checksums.txt rakudo-YYYY.MM.tar.gz.tmp
+    rm rakudo-YYYY.MM.tar.gz.tmp
 
 =item 18.
 
-Upload the tarball and the signature to L<http://rakudo.org/downloads/rakudo>:
+Upload the tarball, the signature and checksum file to
+L<http://rakudo.org/downloads/rakudo>:
 
-  scp rakudo-YYYY.MM.tar.gz rakudo-YYYY.MM.tar.gz.asc \
-       rakudo@rakudo.org:public_html/downloads/rakudo/
-
+  scp -P2222 rakudo-YYYY.MM.tar.gz rakudo-YYYY.MM.tar.gz.asc \
+       rakudo-YYYY.MM.tar.gz.checksums.txt \
+       rakudo.org@lavm-perl6infra-1.atikon.io:public_html/downloads/rakudo/
 
 If you do not have permissions for that, ask one of (jnthn,
 masak, tadzik, moritz, [Coke], lizmat, timotimo,
- AlexDaniel) on #raku or #raku-dev to do it for you.
+AlexDaniel) on #raku or #raku-dev to do it for you.
 
 =item 19.
 

--- a/tools/releasable/Akefile
+++ b/tools/releasable/Akefile
@@ -68,8 +68,8 @@ my $rakudo-archive = “$RAKUDO-PATH/rakudo-{$version-rakudo}.tar.gz”;
 my $nqp-test-dir    = $temp.add: ‘nqp-test’;
 my $rakudo-test-dir = $temp.add: ‘rakudo-test’;
 
-my @tarball-distributors = ‘rakudo@rakudo.org:public_html/downloads/’,
-                           ‘rakudo@www.p6c.org:public_html/downloads/’;
+my @tarball-distributors = [‘2222’, ‘rakudo.org@lavm-perl6infra-1.atikon.io:public_html/downloads/’],
+                           [‘22’, ‘rakudo@www.p6c.org:public_html/downloads/’];
 
 my @canary-distributors  = ‘rakudo@www.p6c.org:public_html/downloads/’;
 
@@ -188,14 +188,15 @@ task ‘rakudo-push’, { # Step ??? (rakudo release guide)
 
 task ‘nqp-upload’, { # Step ❽ (nqp release guide)
     for @tarball-distributors {
-        run ‘scp’, $nqp-archive, “{$nqp-archive}.asc”, “$_/nqp/”
+        run ‘scp’, “-P{$_[0]}”, $nqp-archive, “{$nqp-archive}.asc”, “{$_[1]}/nqp/”
     }
     True
 }
 
 task ‘rakudo-upload’, { # Step ⓲ (rakudo release guide)
     for @tarball-distributors {
-        run ‘scp’, $rakudo-archive, “{$rakudo-archive}.asc”, “$_/rakudo/”
+        run ‘scp’, “-P{$_[0]}”, $rakudo-archive, “{$rakudo-archive}.asc”,
+            “{$rakudo-archive}.checksums.txt”, “{$_[1]}/rakudo/”
     }
     True
 }
@@ -524,8 +525,19 @@ task ‘rakudo-tag’, { # Step ⓰ (rakudo release guide)
 }
 
 task ‘rakudo-sign’, { # Step ⓱ (rakudo release guide)
-    run <gpg2 --detach-sign --armor>,
-        #`{‘--output’, $rakudo-signature,} ‘--’, $rakudo-archive;
+    my $sig-file = $rakudo-archive ~ ‘.checksums.txt’;
+    my $unsigned-sig-file = $sig-file ~ '.unsigned';
+
+    run <gpg2 --detach-sign --armor -->, $rakudo-archive;
+
+    for <md5sum sha1sum sha224sum sha256sum sha384sum sha512sum> -> $tool {
+        my $proc = run $tool, ‘--tag’, $rakudo-archive, :out;
+        my $sig = $proc.out.slurp: :close;
+        $unsigned-sig-file.IO.spurt: $sig, :append;
+    }
+
+    run <gpg2 --clearsign --output>, $sig-file, ‘--’, $unsigned-sig-file;
+    $unsigned-sig-file.IO.unlink;
     True
 }
 


### PR DESCRIPTION
Checksums for release files have been requested at least once. I consider them good form.

<del>This PR adapts the release docs and `Akefile`, so that two additional files for each file is generated:

- <del>a `filename.checksums.txt` containing checksums
- <del>a `filename.checksums.txt.asc` containing checksums and also a signature (e.g. Fedora provides checksums in this format)

*Edit:* I made up my mind. I think there is no justification for providing a separate checksums and signed checksums file. I think there is no thing you can do with the non signed file that one couldn't do with the signed one. So this PR now only generates one additional file, a `somefile.checksums.txt` which contains checksums and an inline signature.

In general I'd like for us to not change the format again once we have decided on one as checksum checking tends to be a thing people like to automate. Thus I'd like to discuss the alternatives.

Providing separate checksum file for each file produces a lot of files, but that's how the Star Bundle releases are currently doing it. The obvious alternative being having a single checksum file for all files of each release.

See https://rakudo.org/downloads/star for the files the Star Bundle currently provides.
See https://getfedora.org/en/security/ to take a peek at Fedoras checksuming.
See https://cloudflare.cdn.openbsd.org/pub/OpenBSD/6.9/ for how OpenBSD does it.

I don't have a good overview of the landscape. Is there a dominant format most projects have settled on?