### PR TITLE
Fix List.reduce method failing with &[&&]

### DIFF
--- a/src/core.c/Bool.pm6
+++ b/src/core.c/Bool.pm6
@@ -106,12 +106,14 @@ multi sub infix:<&&>(Mu $x = Bool::True)  { $x }
 multi sub infix:<&&>(Mu \a, &b)           { a && b() }
 multi sub infix:<&&>(Mu \a, Mu \b)        { a && b }
 multi sub infix:<&&>(+@a) {
+    my Mu $a = shift @a;
     while @a {
-        my Mu $a := shift @a;
-        $a := $a() if $a ~~ Callable;
-        return False unless $a;
+        my Mu $b := shift @a;
+        $b := $b() if $b ~~ Callable;
+        return $a unless $a;
+        $a := $b;
     }
-    True
+    $a
 }
 
 proto sub infix:<||>(|)                   {*}
@@ -119,12 +121,14 @@ multi sub infix:<||>(Mu $x = Bool::False) { $x }
 multi sub infix:<||>(Mu \a, &b)           { a || b() }
 multi sub infix:<||>(Mu \a, Mu \b)        { a || b }
 multi sub infix:<||>(+@a) {
+    my Mu $a = shift @a;
     while @a {
-        my Mu $a := shift @a;
-        $a := $a() if $a ~~ Callable;
-        return True if $a;
+        my Mu $b := shift @a;
+        $b := $b() if $a ~~ Callable;
+        return $a if $a;
+        $a := $b;
     }
-    False
+    $a
 }
 
 proto sub infix:<^^>(|)                   {*}

--- a/src/core.c/Bool.pm6
+++ b/src/core.c/Bool.pm6
@@ -101,10 +101,20 @@ multi sub infix:<?^>(Mu \a, Mu \b)        { nqp::hllbool(nqp::ifnull(nqp::xor(a.
 
 # These operators are normally handled as macros in the compiler;
 # we define them here for use as arguments to functions.
-proto sub infix:<&&>(Mu $?, Mu $?, *%)    {*}
+proto sub infix:<&&>(|)    {*}
 multi sub infix:<&&>(Mu $x = Bool::True)  { $x }
 multi sub infix:<&&>(Mu \a, &b)           { a && b() }
 multi sub infix:<&&>(Mu \a, Mu \b)        { a && b }
+multi sub infix:<&&>(+@a) {
+    my Mu $a = shift @a;
+    while @a {
+        my Mu $b := shift @a;
+        $b := $b() if $b ~~ Callable;
+        return False unless $a;
+        $a := $b;
+    }
+    ?$a
+}
 
 proto sub infix:<||>(Mu $?, Mu $?, *%)    {*}
 multi sub infix:<||>(Mu $x = Bool::False) { $x }

--- a/src/core.c/Bool.pm6
+++ b/src/core.c/Bool.pm6
@@ -147,10 +147,20 @@ multi sub infix:<^^>(+@a) {
     $a;
 }
 
-proto sub infix:<//>(Mu $?, Mu $?, *%)    {*}
+proto sub infix:<//>(|)                   {*}
 multi sub infix:<//>(Mu $x = Any)         { $x }
 multi sub infix:<//>(Mu \a, &b)           { a // b }
 multi sub infix:<//>(Mu \a, Mu \b)        { a // b }
+multi sub infix:<//>(+@a) {
+    my Mu $a = shift @a;
+    while @a {
+        my Mu $b := shift @a;
+        $b := $b() if $a ~~ Callable;
+        return $a with $a;
+        $a := $b;
+    }
+    $a
+}
 
 proto sub infix:<and>(Mu $?, Mu $?, *%)   {*}
 multi sub infix:<and>(Mu $x = Bool::True) { $x }

--- a/src/core.c/Bool.pm6
+++ b/src/core.c/Bool.pm6
@@ -116,10 +116,18 @@ multi sub infix:<&&>(+@a) {
     ?$a
 }
 
-proto sub infix:<||>(Mu $?, Mu $?, *%)    {*}
+proto sub infix:<||>(|)                   {*}
 multi sub infix:<||>(Mu $x = Bool::False) { $x }
 multi sub infix:<||>(Mu \a, &b)           { a || b() }
 multi sub infix:<||>(Mu \a, Mu \b)        { a || b }
+multi sub infix:<||>(+@a) {
+    while @a {
+        my Mu $a := shift @a;
+        $a := $a() if $a ~~ Callable;
+        return True if $a;
+    }
+    False
+}
 
 proto sub infix:<^^>(|)                   {*}
 multi sub infix:<^^>(Mu $x = Bool::False) { $x }

--- a/src/core.c/Bool.pm6
+++ b/src/core.c/Bool.pm6
@@ -106,14 +106,12 @@ multi sub infix:<&&>(Mu $x = Bool::True)  { $x }
 multi sub infix:<&&>(Mu \a, &b)           { a && b() }
 multi sub infix:<&&>(Mu \a, Mu \b)        { a && b }
 multi sub infix:<&&>(+@a) {
-    my Mu $a = shift @a;
     while @a {
-        my Mu $b := shift @a;
-        $b := $b() if $b ~~ Callable;
+        my Mu $a := shift @a;
+        $a := $a() if $a ~~ Callable;
         return False unless $a;
-        $a := $b;
     }
-    ?$a
+    True
 }
 
 proto sub infix:<||>(|)                   {*}


### PR DESCRIPTION
Tests:

```
ok (True, True, True, True).permutations».reduce(&infix:<&&>).reduce(&infix:<&&>), '.reduce with infix:<&&> returns True';
nok (True, True, True, False).permutations».reduce(&infix:<&&>).reduce(&infix:<&&>), '.reduce with infix:<&&> returns False';
my &falseish = { False };
my &trueish = { True };
nok (True, True, True, &falseish).permutations».reduce(&infix:<&&>).reduce(&infix:<&&>), '.reduce with infix:<&&> and callable returns False';
ok (True, True, True, &trueish).permutations».reduce(&infix:<&&>).reduce(&infix:<&&>), '.reduce with infix:<&&> and callable returns True';
```