### PR TITLE
Fix installation to to-be-created CURIS on Windows

### DIFF
--- a/src/core.c/CompUnit/Repository/Installation.pm6
+++ b/src/core.c/CompUnit/Repository/Installation.pm6
@@ -26,7 +26,7 @@ class CompUnit::Repository::Installation does CompUnit::Repository::Locally does
 
     method !prefix-writeable {
             if Rakudo::Internals.IS-WIN {
-                $!prefix-writeable-cache //= do {
+                $!prefix-writeable-cache ||= do {
                     my $writable = False;
                     try {
                         my $check-file = $.prefix.add('test-file');


### PR DESCRIPTION
The negative test for writeability when the repo was still not existing was
cached and spoilt all further checks. Now we only cache a successful
writeability check.