### PR TITLE
Positional hyperwhatever

### DIFF
--- a/src/core.c/array_slice.pm6
+++ b/src/core.c/array_slice.pm6
@@ -289,11 +289,19 @@ multi sub postcircumfix:<[ ]>(\SELF, Whatever:D, :$BIND!) is raw {
 }
 
 # @a[**]
-multi sub postcircumfix:<[ ]>(\SELF, HyperWhatever:D $, *%adv) is raw {
-    X::NYI.new(feature => 'HyperWhatever in array index').throw;
+# candidates that are only useful with v6.e features can be found in
+# core.e/array_hyperslice.pm6
+
+multi sub postcircumfix:<[ ]>( \SELF, HyperWhatever:D, *%other ) is raw {
+    gather SELF.deepmap(*.take)
 }
+
+multi sub postcircumfix:<[ ]>( \SELF, HyperWhatever:D, :$v!, *%other ) is raw {
+    gather SELF.deepmap(*.take)
+}
+
 multi sub postcircumfix:<[ ]>(\SELF, HyperWhatever:D $, Mu \assignee) is raw {
-    X::NYI.new(feature => 'HyperWhatever in array index').throw;
+    X::NYI.new(feature => 'Assigning to HyperWhatever in array index').throw;
 }
 
 # @a[]

--- a/src/core.e/array_hyperslice.pm6
+++ b/src/core.e/array_hyperslice.pm6
@@ -1,0 +1,77 @@
+# Positinal postcircumfix with HyperWhatever goes here for 6.e
+
+#| decent into LoL and return a shallow key per leaf
+multi sub postcircumfix:<[ ]>( \SELF, HyperWhatever:D, :$k! ) is raw {
+    sub recurse(\k, \v) {
+        if v ~~ Positional {
+            for v.kv -> \k, \v { recurse k, v }
+        } else {
+            take slip k
+        }
+    }
+
+    gather for SELF.kv -> \k, \v {
+        recurse k, v
+    }
+}
+
+#| decent into LoL and return a shallow key and its sub tree or leaf
+multi sub postcircumfix:<[ ]>( \SELF, HyperWhatever:D, :$tree! ) is raw {
+    sub recurse(\k, \v){
+        if v ~~ Positional {
+            for v.kv -> \k, \v {
+                take slip k, v;
+                recurse k, v
+            }
+        }
+    }
+
+    gather recurse 0, SELF
+}
+
+#| decent into LoL and return a shallow key per leaf and the leaf
+multi sub postcircumfix:<[ ]>( \SELF, HyperWhatever:D, :$kv! ) is raw {
+    sub recurse(\k, \v) {
+        if v ~~ Positional {
+            for v.kv -> \k, \v { recurse k, v }
+        } else {
+            take slip k, v
+        }
+    }
+
+    gather for SELF.kv -> \k, \v {
+        recurse k, v
+    }
+}
+
+#| decent into LoL and return a deep key per leaf
+multi sub postcircumfix:<[ ]>( \SELF, HyperWhatever:D, :$deepk! ) is raw {
+    sub recurse(\v, @keys){
+        if v ~~ Positional {
+            for v.kv -> \k, \v {
+                recurse v, [@keys.Slip, slip k]
+            }
+        } else {
+            take @keys
+        }
+    }
+
+    gather recurse(SELF, [])
+}
+
+#| decent into LoL and return a deep key per leaf and the leaf
+multi sub postcircumfix:<[ ]>( \SELF, HyperWhatever:D, :$deepkv! ) is raw {
+    sub recurse(\v, @keys){
+        if v ~~ Positional {
+            for v.kv -> \k, \v {
+                recurse v, [@keys.Slip, slip k]
+            }
+        }else{
+            take slip(@keys, v)
+        }
+    }
+
+    gather recurse(SELF, [])
+}
+
+# vim: expandtab shiftwidth=4

--- a/t/02-rakudo/03-corekeys.t
+++ b/t/02-rakudo/03-corekeys.t
@@ -794,6 +794,7 @@ my @allowed =
         Q{$¢},
         Q{&postcircumfix:<[; ]>},
         Q{&postcircumfix:<{; }>},
+        Q{&postcircumfix:<[ ]>},
         Q{CORE-SETTING-REV},
         Q{Grammar},
         Q{PseudoStash},

--- a/tools/templates/6.e/core_sources
+++ b/tools/templates/6.e/core_sources
@@ -5,3 +5,4 @@ src/core.e/EXPORTHOW.pm6
 src/core.e/array_multislice.pm6
 src/core.e/hash_multislice.pm6
 src/core.e/Rakudo/Internals/Sprintf.pm6
+src/core.e/array_hyperslice.pm6


### PR DESCRIPTION
Second part of https://github.com/Raku/problem-solving/issues/287 . Since there was already a NYI candidate in core.c, the most basic form resides there.

`@array[**] = 1, [2, 3]` is yet to be solved. I'm sure this is redundant with `@array = 1, [2, 3]` but can't decide if it should fail or just do the thing.