### PR TITLE
Add Iterable cmp Iterable candidates

### DIFF
--- a/src/core.c/Order.pm6
+++ b/src/core.c/Order.pm6
@@ -16,6 +16,15 @@ multi sub infix:<cmp>(\a, \b) {
       ?? Same
       !! a.Stringy cmp b.Stringy
 }
+multi sub infix:<cmp>(Iterable:D \a, Iterable:D \b) {
+    a.iterator cmp b.iterator
+}
+multi sub infix:<cmp>(Iterable:D \a, \b) is default {
+    a.iterator cmp b.iterator
+}
+multi sub infix:<cmp>(\a, Iterable:D \b) is default {
+    a.iterator cmp b.iterator
+}
 multi sub infix:<cmp>(Real:D \a, \b) {
      a === -Inf
        ?? Less


### PR DESCRIPTION
If either side of an `infix:<cmp>` is an `Iterable`, then use the iterator
on both sides to determine the result, rather than stringifying the
Iterable(s).  This is, I think, more correct, and much more memory
friendly as there is not `Str` representation created of the argument.

This change is spectest error free.  It however changes the outcome
of:

    dd "a b" cmp ("a","b")

from: `Order::Same` (which I consider to be incorrect), to `Order::More`.

The `is default` is needed to prevent ambiguous dispatch errors with
the `Any` / `Real` and `Real` / `Any` candidates.