### PR TITLE
Add Cool.Order "coercer"

### DIFF
--- a/src/core.c/Cool.pm6
+++ b/src/core.c/Cool.pm6
@@ -40,6 +40,8 @@ my class Cool { # declared in BOOTSTRAP
     multi method log(Cool:D: )      { self.Numeric.log          }
     multi method log(Cool:D: $base) { self.Numeric.log($base.Numeric) }
 
+    method Order(Cool:D:) { ORDER(self.Int) }
+
     proto method exp(|) {*}
     multi method exp(Cool:D: )      { self.Numeric.exp          }
     multi method exp(Cool:D: $base) { self.Numeric.exp($base.Numeric) }


### PR DESCRIPTION
Convert a Cool value to the associated Order enum:
- < 0  -> Less
-   0  -> Same
- \> 0  -> More

The only other way to currently do this, is by basically writing the
ORDER (implementation-detail) subroutine again, or just do a call to
ORDER.  This allows syntactic sugar to not have to do it like that.