### PR TITLE
Introduce curried role binding

### DIFF
--- a/src/Perl6/Metamodel/CurriedRoleHOW.nqp
+++ b/src/Perl6/Metamodel/CurriedRoleHOW.nqp
@@ -182,6 +182,10 @@ class Perl6::Metamodel::CurriedRoleHOW
         @!pos_args
     }
 
+    method role_named_arguments($obj) {
+        %!named_args
+    }
+
     method roles($obj, :$transitive = 1, :$mro = 0) {
         self.complete_parameterization($obj);
         self.roles-ordered($obj, self.roles_to_compose($obj), :$transitive, :$mro)

--- a/src/Perl6/Metamodel/CurriedRoleHOW.nqp
+++ b/src/Perl6/Metamodel/CurriedRoleHOW.nqp
@@ -82,18 +82,12 @@ class Perl6::Metamodel::CurriedRoleHOW
     # A curried role may be bound to form a role other than its origin, e.g.  a
     # parametric role group and the candidate we're not quite ready to fetch at
     # construction time. If we're still not ready yet whenever we need it, the
-    # binding is ourself for now. If the origin lacks a means of producing a
-    # binding, we assume it's its own by default.
+    # binding is ourself for now.
     method bind($obj) {
         if $!binding =:= NQPMu {
-            if nqp::can($!curried_role.HOW, 'bind') {
-                my $binding := nqp::decont($!curried_role.HOW.bind($!curried_role, $obj));
-                $!binding := $binding unless $binding =:= $obj;
-                $binding
-            }
-            else {
-                $!binding := $!curried_role
-            }
+            my $binding := nqp::decont($!curried_role.HOW.bind($!curried_role, $obj));
+            $!binding := $binding unless $binding =:= $obj;
+            $binding
         }
         else {
             $!binding

--- a/src/Perl6/Metamodel/CurriedRoleHOW.nqp
+++ b/src/Perl6/Metamodel/CurriedRoleHOW.nqp
@@ -87,8 +87,8 @@ class Perl6::Metamodel::CurriedRoleHOW
     method bind($obj) {
         if $!binding =:= NQPMu {
             if nqp::can($!curried_role.HOW, 'bind') {
-                my $binding := $!curried_role.HOW.bind($!curried_role, $obj);
-                $!binding := $binding unless nqp::decont($binding) =:= $obj;
+                my $binding := nqp::decont($!curried_role.HOW.bind($!curried_role, $obj));
+                $!binding := $binding unless $binding =:= $obj;
                 $binding
             }
             else {
@@ -102,7 +102,7 @@ class Perl6::Metamodel::CurriedRoleHOW
 
     method parameterize_roles($obj) {
         my $binding := self.bind($obj);
-        unless nqp::decont($binding) =:= $obj {
+        unless $binding =:= $obj {
             self.set_language_revision($obj, $binding.HOW.language-revision($binding));
 
             my $type_env;

--- a/src/Perl6/Metamodel/CurriedRoleHOW.nqp
+++ b/src/Perl6/Metamodel/CurriedRoleHOW.nqp
@@ -226,16 +226,16 @@ class Perl6::Metamodel::CurriedRoleHOW
         # that we only want those that have the same parametric role
         # as us.
         my @cands;
-        my $crdc := nqp::decont($!curried_role);
+        my $binding := self.bind($obj);
         if nqp::istype($checkee.HOW, self.WHAT) {
-            if nqp::decont($checkee.HOW.curried_role($checkee)) =:= $crdc {
+            if $checkee.HOW.bind($checkee) =:= $binding {
                 @cands.push($checkee);
             }
         }
         if nqp::can($checkee.HOW, 'role_typecheck_list') {
             for $checkee.HOW.role_typecheck_list($checkee) {
                 if nqp::istype($_.HOW, self.WHAT) && !$_.HOW.archetypes.generic {
-                    if nqp::decont($_.HOW.curried_role($_)) =:= $crdc {
+                    if $_.HOW.bind($_) =:= $binding {
                         @cands.push($_);
                     }
                 }

--- a/src/Perl6/Metamodel/CurriedRoleHOW.nqp
+++ b/src/Perl6/Metamodel/CurriedRoleHOW.nqp
@@ -29,7 +29,7 @@ class Perl6::Metamodel::CurriedRoleHOW
     has %!named_args;
     has @!role_typecheck_list;
     has @!parent_typecheck_list;    # Only for parents instantiated from generics
-    has $!is_complete;
+    has int $!is_complete;
     has $!archetypes;
 
     my $archetypes_g := Perl6::Metamodel::Archetypes.new( :composable(1), :inheritalizable(1), :parametric(1), :generic(1) );

--- a/src/Perl6/Metamodel/CurriedRoleHOW.nqp
+++ b/src/Perl6/Metamodel/CurriedRoleHOW.nqp
@@ -114,7 +114,7 @@ class Perl6::Metamodel::CurriedRoleHOW
                 if $role.HOW.archetypes.generic && $type_env {
                     $role := $role.HOW.instantiate_generic($role, $type_env);
                 }
-                unless $role.HOW.archetypes.generic || $role.HOW.archetypes.parametric {
+                unless $role.HOW.archetypes.composable || $role.HOW.archetypes.composalizable {
                     my $target-name := $obj.HOW.name($obj);
                     my $role-name := $role.HOW.name($role);
                     Perl6::Metamodel::Configuration.throw_or_die(

--- a/src/Perl6/Metamodel/CurriedRoleHOW.nqp
+++ b/src/Perl6/Metamodel/CurriedRoleHOW.nqp
@@ -224,8 +224,8 @@ class Perl6::Metamodel::CurriedRoleHOW
             }
         }
         self.complete_parameterization($obj) unless $!is_complete;
-        for @!parent_typecheck_list -> $parent {
-            if nqp::istype($decont, $parent) {
+        for @!parent_typecheck_list {
+            if nqp::istype(nqp::decont($_), $decont) {
                 return 1
             }
         }

--- a/src/Perl6/Metamodel/ParametricRoleGroupHOW.nqp
+++ b/src/Perl6/Metamodel/ParametricRoleGroupHOW.nqp
@@ -90,6 +90,20 @@ class Perl6::Metamodel::ParametricRoleGroupHOW
         $curried
     }
 
+    method bind($obj, $curried) {
+        my $candidate;
+        my %named_args := $curried.HOW.role_named_arguments($curried);
+        my @pos_args := [$obj];
+        nqp::splice(@pos_args, $curried.HOW.role_arguments($curried), +@pos_args, 0);
+        try {
+            $candidate := self.select_candidate($obj, @pos_args, %named_args);
+            CATCH { return $curried }
+        }
+        nqp::can($candidate.HOW, 'bind')
+          ?? $candidate.HOW.bind($candidate, $curried)
+          !! $candidate
+    }
+
     method add_possibility($obj, $possible) {
         @!candidates[+@!candidates] := $possible;
         nqp::push(@!nonsignatured, nqp::decont($possible)) unless $possible.HOW.signatured($possible);

--- a/src/Perl6/Metamodel/ParametricRoleGroupHOW.nqp
+++ b/src/Perl6/Metamodel/ParametricRoleGroupHOW.nqp
@@ -99,9 +99,7 @@ class Perl6::Metamodel::ParametricRoleGroupHOW
             $candidate := self.select_candidate($obj, @pos_args, %named_args);
             CATCH { return $curried }
         }
-        nqp::can($candidate.HOW, 'bind')
-          ?? $candidate.HOW.bind($candidate, $curried)
-          !! $candidate
+        $candidate.HOW.bind($candidate, $curried)
     }
 
     method add_possibility($obj, $possible) {

--- a/src/Perl6/Metamodel/ParametricRoleHOW.nqp
+++ b/src/Perl6/Metamodel/ParametricRoleHOW.nqp
@@ -111,8 +111,8 @@ class Perl6::Metamodel::ParametricRoleHOW
 
     # $checkee must always be decont'ed
     method type_check_parents($obj, $checkee) {
-        for self.parents($obj, :local) -> $parent {
-            if nqp::istype($checkee, $parent) {
+        for self.parents($obj, :local) {
+            if nqp::istype(nqp::decont($_), $checkee) {
                 return 1;
             }
         }

--- a/src/Perl6/Metamodel/ParametricRoleHOW.nqp
+++ b/src/Perl6/Metamodel/ParametricRoleHOW.nqp
@@ -242,6 +242,9 @@ class Perl6::Metamodel::ParametricRoleHOW
             my $p := $_;
             if $p.HOW.archetypes.generic {
                 $p := $p.HOW.instantiate_generic($p, $type_env);
+                if $p.HOW.archetypes.inheritalizable {
+                    $p := $p.HOW.inheritalize($p);
+                }
             }
             $conc.HOW.add_parent($conc, $p, :hides(self.hides_parent($obj, $_)));
         }

--- a/src/Perl6/Metamodel/ParametricRoleHOW.nqp
+++ b/src/Perl6/Metamodel/ParametricRoleHOW.nqp
@@ -214,9 +214,12 @@ class Perl6::Metamodel::ParametricRoleHOW
         # Roles done by this role need fully specializing also.
         for self.roles_to_compose($obj) {
             my $ins := my $r := $_;
-            if $_.HOW.archetypes.generic {
+            if $ins.HOW.archetypes.generic {
                 $ins := $ins.HOW.instantiate_generic($ins, $type_env);
-                unless $ins.HOW.archetypes.parametric {
+                if $ins.HOW.archetypes.composalizable {
+                    $ins := $ins.HOW.composalize($ins);
+                }
+                unless $ins.HOW.archetypes.composable {
                     my $target-name := $obj.HOW.name($obj);
                     my $role-name := $ins.HOW.name($ins);
                     Perl6::Metamodel::Configuration.throw_or_die(

--- a/src/Perl6/Metamodel/ParametricRoleHOW.nqp
+++ b/src/Perl6/Metamodel/ParametricRoleHOW.nqp
@@ -133,7 +133,11 @@ class Perl6::Metamodel::ParametricRoleHOW
             }
         }
         for self.roles_to_compose($obj) {
-            if nqp::istype($decont, $_) {
+            my $dr := nqp::decont($_);
+            if $decont =:= $dr {
+                return 1;
+            }
+            if nqp::istype($dr, $decont) {
                 return 1;
             }
         }

--- a/src/Perl6/Metamodel/ParametricRoleHOW.nqp
+++ b/src/Perl6/Metamodel/ParametricRoleHOW.nqp
@@ -128,20 +128,13 @@ class Perl6::Metamodel::ParametricRoleHOW
         if $decont =:= $obj.WHAT {
             return 1;
         }
-        if $!in_group && $decont =:= $!group {
-            return 1;
-        }
         for self.pretending_to_be() {
             if $decont =:= nqp::decont($_) {
                 return 1;
             }
         }
-        for self.roles_to_compose($obj) {
-            my $dr := nqp::decont($_);
-            if $decont =:= $dr {
-                return 1;
-            }
-            if nqp::istype($dr, $decont) {
+        for @!role_typecheck_list {
+            if $decont =:= $_ {
                 return 1;
             }
         }

--- a/src/Perl6/Metamodel/ParametricRoleHOW.nqp
+++ b/src/Perl6/Metamodel/ParametricRoleHOW.nqp
@@ -52,6 +52,10 @@ class Perl6::Metamodel::ParametricRoleHOW
         $currier.new_type($obj, |@pos_args, |%named_args)
     }
 
+    method bind($obj, $curried) {
+        $obj
+    }
+
     method set_body_block($obj, $block) {
         $!body_block := $block
     }


### PR DESCRIPTION
As [before](https://github.com/rakudo/rakudo/pull/4436), the following should be valid:

```raku
role Foo[Any ::T] { }
role Bar[::T] does Foo[T] { }
```

But we now also consider:

```raku
role Foo[Any ::T] { }
role Bar[::T] is Foo[T] { }
```

And:

```raku 
role OfIndex[Enumeration ::T] does T { }
```

Curries of parametric role groups already have a notion of a binding in their cached `$!candidate`. Formalizing this via new `bind` metamethods on `Metamodel::CurriedRoleHOW` and `Metamodel::ParametricRoleGroupHOW` makes it possible to fix several issues with role typechecking because if a binding is allowed to fail, it follows operations pertaining to them can follow suit.

`Metamodel::CurriedRoleHOW.bind` defers to its role's `bind` metamethod (if any, in which case it accepts the curry it's invoked from in addition to a metaobject) to produce a final parameterization:

```
bastille% raku -e 'say Blob[uint8].^bind =:= Blob.^bind: Blob[uint8]'
True
bastille% raku -e 'say Blob[uint8].^bind.HOW.^name'
Perl6::Metamodel::ParametricRoleHOW
```

There should be opportunities for optimizations depending on this here. While this passes all tests locally, this is a draft because it has changes reminiscent of those for subsets that were too breaking for v6.c. The effect of any revisions to this on performance should be dampened by the optimizations made now, but aren't made at this point to avoid making them in paranoia.