### PR TITLE
Enhance signature-signature typechecking

### DIFF
--- a/src/core.c/Signature.pm6
+++ b/src/core.c/Signature.pm6
@@ -64,6 +64,7 @@ my class Signature { # declared in BOOTSTRAP
         }
 
         for @l-params -> $l-param is raw {
+            state %r-to-l-named{Mu};
             if $l-param.positional {
                 if $l-param.slurpy {
                     return False unless $r-pos-sink;
@@ -85,6 +86,10 @@ my class Signature { # declared in BOOTSTRAP
                         if %r-named-queue{$name}:exists {
                             my $r-param := %r-named-queue{$name}:delete;
                             return False unless $l-param ~~ $r-param;
+                            return False
+                                if %r-to-l-named{$r-param}:exists and not
+                                   %r-to-l-named{$r-param} =:= $l-param;
+                            %r-to-l-named{$r-param} := $l-param;
                             $found := True;
                         }
                     }


### PR DESCRIPTION
`Signature.ACCEPTS(Signature:D: Signature:D)` has been a pet peeve of mine for a while now because it seemed repetitive, but I couldn't make it any more efficient. There should only be a need to iterate over arguments of a signature and a topic signature once in most cases. With a refactor of `ACCEPTS` to iterate more sparingly, the following can become valid more readily:

```raku
:(:a($x), :b($y)) !~~ :(:a(:b(:c($x))))
```

All cases should get improved performance, but this isn't the sort of algorithm I can give a sweeping "x% faster":

- The following scenario becomes ~9x faster because it has predictable positional parameter placement:

```raku
:($a, $b, $c) ~~ :($a, $b, $c)
```

- The following becomes ~6x faster because positional slurpy and named parameters take more work to typecheck:

```raku
:($a, Int:D $b, :$c = :$b, :$d) ~~ :($a, :$c, +, *%)
```

- The following becomes ~9x faster again because typechecks fail earlier in all cases:

```raku
:($a, Int:D $b, :$c = $b, Int:D :$d!) ~~ :($a, :$b, +, *%)
```
