### PR TITLE
Make .sort aware of any &[cmp] additions

### DIFF
--- a/src/core.c/List.pm6
+++ b/src/core.c/List.pm6
@@ -1309,79 +1309,56 @@ my class List does Iterable does Positional { # declared in BOOTSTRAP
         )
     }
 
+    # Helper method for reifying what needs to be sorted
+    method !do-todo(--> Nil) {
+        $!todo.reify-until-lazy;
+        $!todo.fully-reified
+          ?? ($!todo := nqp::null)
+          !! self.throw-iterator-cannot-be-lazy('.sort')
+    }
+
     # https://en.wikipedia.org/wiki/Merge_sort#Bottom-up_implementation
     multi method sort(List:D: --> Seq:D) {
-        nqp::stmts(
-          nqp::if(
-            nqp::isconcrete($!todo),
-            nqp::stmts(
-              $!todo.reify-until-lazy,
-              nqp::if(
-                $!todo.fully-reified,
-                ($!todo := nqp::null),
-                self.throw-iterator-cannot-be-lazy('.sort')
-              )
-            )
-          ),
-          Seq.new(
-            nqp::if(
-              nqp::isconcrete($!reified),
-              Rakudo::Iterator.ReifiedList(
-                Rakudo::Sorting.MERGESORT-REIFIED-LIST(
-                  nqp::p6bindattrinvres(
-                    nqp::create(List),List,'$!reified',
-                    nqp::clone(nqp::getattr(self,List,'$!reified'))
-                  )
-                )
-              ),
-              Rakudo::Iterator.Empty
-            )
-          )
+        self!do-todo if nqp::isconcrete($!todo);
+        my $List := nqp::p6bindattrinvres(
+          nqp::create(List),List,'$!reified',
+          nqp::clone(nqp::getattr(self,List,'$!reified'))
+        );
+
+        Seq.new(nqp::isconcrete($!reified)
+          ?? Rakudo::Iterator.ReifiedList(
+               nqp::eqaddr((my &by := CALLERS::('&infix:<cmp>')),&infix:<cmp>)
+                 ?? Rakudo::Sorting.MERGESORT-REIFIED-LIST($List)
+                 !! Rakudo::Sorting.MERGESORT-REIFIED-LIST-WITH($List, &by)
+             )
+          !! Rakudo::Iterator.Empty
         )
     }
     multi method sort(List:D: &by --> Seq:D) {
-        nqp::stmts(
-          nqp::if(
-            nqp::isconcrete($!todo),
-            nqp::stmts(
-              $!todo.reify-until-lazy,
-              nqp::if(
-                $!todo.fully-reified,
-                ($!todo := nqp::null),
-                self.throw-iterator-cannot-be-lazy('.sort')
-              )
-            )
-          ),
-          Seq.new(
-            nqp::if(
-              nqp::isconcrete($!reified),
-              Rakudo::Iterator.ReifiedList(
-                nqp::if(
-                  nqp::eqaddr(&by,&infix:<cmp>),
-                  Rakudo::Sorting.MERGESORT-REIFIED-LIST(
-                    nqp::p6bindattrinvres(nqp::create(List),List,'$!reified',
-                      nqp::clone(nqp::getattr(self,List,'$!reified')))
-                  ),
-                  nqp::if(
-                    &by.count < 2,
-                    Rakudo::Sorting.MERGESORT-REIFIED-LIST-AS(
-                      nqp::p6bindattrinvres(nqp::create(List),List,'$!reified',
-                        nqp::getattr(self,List,'$!reified')),
-                      &by
-                    ),
-                    Rakudo::Sorting.MERGESORT-REIFIED-LIST-WITH(
-                      nqp::p6bindattrinvres(nqp::create(List),List,'$!reified',
-                        nqp::clone(nqp::getattr(self,List,'$!reified'))),
-                      &by
-                    )
-                  )
+        self!do-todo if nqp::isconcrete($!todo);
+
+        Seq.new(nqp::isconcrete($!reified)
+          ?? Rakudo::Iterator.ReifiedList(nqp::eqaddr(&by,&infix:<cmp>)
+            ?? Rakudo::Sorting.MERGESORT-REIFIED-LIST(
+                 nqp::p6bindattrinvres(nqp::create(List),List,'$!reified',
+                   nqp::clone(nqp::getattr(self,List,'$!reified')))
                 )
-              ),
-              Rakudo::Iterator.Empty
-            )
-          )
+            !! &by.count < 2
+              ?? Rakudo::Sorting.MERGESORT-REIFIED-LIST-AS(
+                   nqp::p6bindattrinvres(nqp::create(List),List,'$!reified',
+                     nqp::getattr(self,List,'$!reified')),
+                   &by
+                 )
+              !! Rakudo::Sorting.MERGESORT-REIFIED-LIST-WITH(
+                   nqp::p6bindattrinvres(nqp::create(List),List,'$!reified',
+                     nqp::clone(nqp::getattr(self,List,'$!reified'))),
+                   &by
+                 )
+             )
+          !! Rakudo::Iterator.Empty
         )
     }
+
     multi method tail(List:D:) is raw {
         nqp::isconcrete($!todo)
           ?? self.Any::tail


### PR DESCRIPTION
This makes .sort aware of any local &[cmp] additions from where .sort
is called, if called without an explicit comparator.

This will use CALLERS:: to find out if the outer &[cmp] is different
from the "system" &[cmp], and will use that if that is the case.

The use of CALLERS:: is a bit icky, and I'm not sure that this workaround
will be needed as soon as new-disp lands.

Also took the opportunity to reduce the amount of nqp code in this logic.

Has no discernable performance effect on any sorting, except on sorting
empty lists.