### PR TITLE
Make sure Float.NaN/Double.NaN can be passed by using the NaN

### DIFF
--- a/t/04-nativecall/02-simple-args.c
+++ b/t/04-nativecall/02-simple-args.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <string.h>
+#include <math.h>
 
 #ifdef _WIN32
 #define DLLEXPORT __declspec(dllexport)
@@ -40,9 +41,23 @@ DLLEXPORT int TakeADouble(double x)
     return 0;
 }
 
+DLLEXPORT int TakeADoubleNaN(double x)
+{
+    if (isnan(x))
+        return 4;
+    return 0;
+}
+
 DLLEXPORT int TakeAFloat(float x)
 {
     if (4.2 - x < 0.001)
+        return 5;
+    return 0;
+}
+
+DLLEXPORT int TakeAFloatNaN(float x)
+{
+    if (isnan(x))
         return 5;
     return 0;
 }

--- a/t/04-nativecall/02-simple-args.t
+++ b/t/04-nativecall/02-simple-args.t
@@ -5,7 +5,7 @@ use CompileTestLib;
 use NativeCall;
 use Test;
 
-plan 14;
+plan 16;
 
 compile_test_lib('02-simple-args');
 
@@ -19,9 +19,13 @@ is AssortedIntArgs(101, 102, 103), 3, 'passed an int32, int16 and int8';
 
 # Float related
 sub TakeADouble(num64) returns int32 is native('./02-simple-args') { * }
+sub TakeADoubleNaN(num64) returns int32 is native('./02-simple-args') { * }
 sub TakeAFloat(num32)  returns int32 is native('./02-simple-args') { * }
+sub TakeAFloatNaN(num32)  returns int32 is native('./02-simple-args') { * }
 is TakeADouble(-6.9e0), 4, 'passed a double';
+is TakeADoubleNaN(NaN), 4, 'passed a NaN (double)';
 is TakeAFloat(4.2e0),   5, 'passed a float';
+is TakeAFloatNaN(NaN), 5, 'passed a NaN (float)';
 
 # String related
 sub TakeAString(Str) returns int32 is native('./02-simple-args') { * }


### PR DESCRIPTION
Hi,
I found that nativecall test for NaN is missing when creating a xgboost [0] bindings.
In some machine learning libraries like xgboost, NaN is usable for handling missing feature values.

Cheers,

[0] https://github.com/dmlc/xgboost