### PR TITLE
Allow a string to be specified with exit()

### DIFF
--- a/src/core.c/Rakudo/Internals.pm6
+++ b/src/core.c/Rakudo/Internals.pm6
@@ -1809,6 +1809,7 @@ Rakudo::Internals.REGISTER-DYNAMIC: '&*EXIT', {
 
 proto sub exit($?, *%) {*}
 multi sub exit() { &*EXIT(0) }
+multi sub exit(Str:D $message) { note $message; &*EXIT(1) }
 multi sub exit(Int(Any) $status) { &*EXIT($status) }
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
This came up recently in a blog post: having an easy way to exit a
CLI script with a message and an error, but *without* any stack trace.

In Perl, this is achieved with die() if the message has a newline.

In Raku, I propose to use multi-dispatch for that, by simply allowing
a string to be given to exit(), which will then note() the string and
exit with 1.

One could consider adding the possibility to also specify a status
value in that case: but that would need a change in the proto of
exit() and may cause other issues.  This is intended as a convenience
shortcut for CLI scripts: if you need more control, do the note() and
the exit(Int) explicitely.