### PR TITLE
Make concurrent use of %!conc_table safe

### DIFF
--- a/src/Perl6/Metamodel/Concretization.nqp
+++ b/src/Perl6/Metamodel/Concretization.nqp
@@ -36,11 +36,13 @@ role Perl6::Metamodel::Concretization {
     }
 
     method !rebuild_table() {
+        my %new_conc_table := nqp::clone(%!conc_table);
         for @!concretizations {
-            nqp::scwbdisable();
-            %!conc_table{~nqp::objectid(nqp::decont($_[0]))} := nqp::decont($_[1]);
-            nqp::scwbenable();
+            %new_conc_table{~nqp::objectid(nqp::decont($_[0]))} := nqp::decont($_[1]);
         }
+        nqp::scwbdisable();
+        %!conc_table := %new_conc_table;
+        nqp::scwbenable();
     }
 
     # Returns a list where the first element is the number of roles found and the rest are actual type objects.


### PR DESCRIPTION
Because it's used by MRO method dispatch, doing things such as parsing a
grammar in a start block can cause concurrent access and modification.
Locking didn't seem to work, but clone->modify-clone->replace-with-clone
does. Fixes the various hash-related MVM_oops in S17-promise/start.t.
dogbert17++, nine++, vrurg++