### PR TITLE
Introduce -Msafe-snapper

### DIFF
--- a/lib/safe-snapper.rakumod
+++ b/lib/safe-snapper.rakumod
@@ -1,0 +1,10 @@
+# shorthand for loading Telemetry and starting a snapper
+# with control-c safety, allowing one to stop the script
+# with control-c and still get a report.
+
+use Telemetry <safe-ctrl-c snapper>;
+
+safe-ctrl-c;
+snapper( %*ENV<RAKUDO_SNAPPER> // 0.1 );
+
+# vim: expandtab shiftwidth=4

--- a/lib/snapper.rakumod
+++ b/lib/snapper.rakumod
@@ -1,8 +1,12 @@
 # shorthand for loading Telemetry and starting a snapper
+# WITHOOUT control-c safety: pressing control-c will stop
+# the process WITHOUT presenting a report.  But this will
+# not start a supervisor thread to safely handle the key
+# handling, which is cleaner from a benchmarking point of
+# view.
 
-use Telemetry <safe-ctrl-c snapper>;
+use Telemetry <snapper>;
 
-safe-ctrl-c;
 snapper( %*ENV<RAKUDO_SNAPPER> // 0.1 );
 
 # vim: expandtab shiftwidth=4

--- a/tools/build/install-core-dist.raku
+++ b/tools/build/install-core-dist.raku
@@ -15,6 +15,7 @@ my %provides =
     "CompUnit::Repository::Staging" => "lib/CompUnit/Repository/Staging.rakumod",
     "Telemetry"                     => "lib/Telemetry.rakumod",
     "snapper"                       => "lib/snapper.rakumod",
+    "safe-snapper"                  => "lib/safe-snapper.rakumod",
     "BUILDPLAN"                     => "lib/BUILDPLAN.rakumod",
 ;
 


### PR DESCRIPTION
Snapper functionality that allows you to press Control-c and *still*
get a Telemetry report.  Removes that functionality from -Msnapper.

Problem with Control-c safety is that it will start up the supervisor
thread to handle the pressing of Control-c, which causes extra load
and reduces the number of available threads, thus affecting the Telemetry
data.