### PR TITLE
Fix escaping of # in regexes

### DIFF
--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -5759,7 +5759,8 @@ grammar Perl6::RegexGrammar is QRegex::P6Regex::Grammar does STD does MatchPacka
     method throw_solitary_quantifier() { self.typed_panic('X::Syntax::Regex::SolitaryQuantifier') }
     method throw_solitary_backtrack_control() { self.typed_sorry('X::Syntax::Regex::SolitaryBacktrackControl') }
 
-    token normspace { <?before \s | '#'> <.LANG('MAIN', 'ws')> }
+    token rxws { [ \s | <.LANG('MAIN', 'comment')> ]* }
+    token normspace {  <?before \s | '#'> <.rxws>  }
 
     token rxstopper { <stopper> }
 


### PR DESCRIPTION
In the `MAIN` language, `foo \# ` is correctly parsed as `foo` followed by an unspace and then a comment.  In the regex Slang, however, unspaces are not allowed; so that code should be parsed the same as `foo '#'`.

However, a 2013 commit (9ed945d) to add support for embedded comments in regexes inadvertently allowed unspaces as well, leading to misparsing of `\#` in some cases.  This PR changes the implementation of the 2013 commit to allow embedded comments without incorrectly allowing unspaces.

Closes #1324 and Raku/doc/issues/3947.  See also raku/old-issue-tracker/issues/6654 (a closed issue describing the same problem)

