### PR TITLE
Add info to CannotPrecomp exception

### DIFF
--- a/src/core.c/Exception.pm6
+++ b/src/core.c/Exception.pm6
@@ -343,7 +343,7 @@ my class X::Pragma::NoArgs is Exception {
 }
 my class X::Pragma::CannotPrecomp is Exception {
     has $.what = 'This compilation unit';
-    method message { "$.what cannot be pre-compiled and thus cannot be used in a Module" }
+    method message { "$.what cannot be pre-compiled and thus cannot be used in a module" }
 }
 my class X::Pragma::CannotWhat is Exception {
     has $.what;

--- a/src/core.c/Exception.pm6
+++ b/src/core.c/Exception.pm6
@@ -343,7 +343,7 @@ my class X::Pragma::NoArgs is Exception {
 }
 my class X::Pragma::CannotPrecomp is Exception {
     has $.what = 'This compilation unit';
-    method message { "$.what may not be pre-compiled" }
+    method message { "$.what cannot be pre-compiled and thus cannot be used in a Module" }
 }
 my class X::Pragma::CannotWhat is Exception {
     has $.what;


### PR DESCRIPTION
The `CannotPrecomp` error message was LTA because it did not provide actionable information to new users (who may not be aware of the distinction between pre-compiled and interpreted files).  This revision clarifies that users should remove the item that cannot be pre-compiled from a Module.

See [this StackOverflow answer](https://stackoverflow.com/a/69018308/10173009) discussing the LTA error message.