### PR TITLE
Add a candidate of Promise.at that accepts a DateTime

### DIFF
--- a/src/core.c/Promise.pm6
+++ b/src/core.c/Promise.pm6
@@ -303,7 +303,14 @@ my class Promise does Awaitable {
         $scheduler.cue({ $vow.keep(True) }, :in($seconds));
         $p
     }
-    method at(Promise:U: $at, :$scheduler = $*SCHEDULER) {
+
+    proto method at(|) { * }
+
+    multi method at(Promise:U: Instant() $at, :$scheduler = $*SCHEDULER) {
+        self.in( $at - now, :$scheduler )
+    }
+
+    multi method at(Promise:U: Numeric() $at, :$scheduler = $*SCHEDULER) {
         self.in( $at - now, :$scheduler )
     }
 


### PR DESCRIPTION
Passing a DateTime to Promise.at seems natural and it strikes me that a
common use case will be to pass a date time that one might have at hand.

This adds a candidate with a coercion to Instant for `$at` (so will also
accept a custom class that implements .Instant,) and refines the
existing candidate to coerce to Numeric() so as to make the error on
being passed something that can't be converted to Numeric clearer.