### PR TITLE
Test.rakumod: fix a syntax error in is sub

### DIFF
--- a/lib/Test.rakumod
+++ b/lib/Test.rakumod
@@ -199,7 +199,7 @@ multi sub is(Mu $got, Mu:D $expected, $desc = '') is export {
                     _diag "expected: '$expected'\n"
                     ~ "     got: '$got'";
                     True;
-                } or {
+                } or do {
                     _diag "expected: $expected.raku()\n"
                     ~ "     got: $got.raku()";
                 }


### PR DESCRIPTION
This make a 'is' test failing to properly show the expect/got message when the .Str method can't be called on the objects.
It's actually a fix for an old PR https://github.com/rakudo/rakudo/pull/3613