### PR TITLE
Consistently throw X::Bind errors when rebinding readonly parameters or sigilless terms

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -1243,11 +1243,11 @@ class Perl6::Actions is HLL::Actions does STDActions {
             my $type := $*OFTYPE.ast;
             $cur_lexpad[0].push(QAST::Var.new( :$name, :scope('lexical'),
                 :decl('var'), :returns($type) ));
-            $cur_lexpad.symbol($name, :$type, :scope<lexical>);
+            $cur_lexpad.symbol($name, :$type, :scope<lexical>, :ro(1));
         }
         else {
             $cur_lexpad[0].push(QAST::Var.new(:$name, :scope('lexical'), :decl('var')));
-            $cur_lexpad.symbol($name, :scope('lexical'));
+            $cur_lexpad.symbol($name, :scope('lexical'), :ro(1));
         }
         make $<defterm>.ast;
     }

--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -7591,14 +7591,14 @@ class Perl6::Actions is HLL::Actions does STDActions {
         }
         # Everything else is a (re)binding error.  Check the types to give a more specific msg
         elsif nqp::istype($target, QAST::WVal)
-        && $target.value.raku eq $target.node {    # A type (class, role, etc)
+            && $target.value.raku eq $target.node {    # A type (class, role, etc)
             $*W.throw($/, ['X', 'Bind', 'Rebind'], :target($target.value.raku), :is-type(1))
         }
         elsif nqp::istype($target, QAST::WVal) {   # A constant
             $*W.throw($/, ['X', 'Bind', 'Rebind'], :target(nqp::escape($target.node)))
         }
         elsif nqp::istype($target, QAST::Op)
-        && $target.op eq 'ifnull' {                # Code (subs, regex, etc)
+            && $target.op eq 'ifnull' {                # Code (subs, regex, etc)
             $*W.throw($/, ['X', 'Bind', 'Rebind'], target => nqp::escape($target[0].name));
         }
         else {             # Items that can never be bound (PsudoPackages, literals, etc)

--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -7539,7 +7539,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
                     }
                     $was_lexical := 1;
                 }
-                unless $was_lexical {
+                if $*W.is_lexical_marked_ro($target.name) || !$was_lexical {
                     $*W.throw($/, ['X', 'Bind']);
                 }
             }

--- a/src/core.c/Exception.pm6
+++ b/src/core.c/Exception.pm6
@@ -1500,6 +1500,20 @@ my class X::Bind is Exception {
             !! 'Cannot use bind operator with this left-hand side'
     }
 }
+my class X::Bind::Rebind is X::Bind {
+    has $.is-type;
+    method message() {
+        ("Cannot bind to '$.target' because " ~
+        do given $.target.comb[0] {
+            when <$ @ %>.any { "it was bound in a signature and variables bound
+                                in signatures cannot be rebound unless they were
+                                declared with the 'is rw' or 'is copy' traits"   }
+            when '&'         { "Code items cannot be rebound"                    }
+            when ?$.is-type  { "Types cannot be rebound"                         }
+            default          { "it is a term and terms cannot be rebound"        }
+        }).naive-word-wrapper
+    }
+}
 my class X::Bind::NativeType does X::Comp {
     has $.name;
     method message() {

--- a/src/core.c/ForeignCode.pm6
+++ b/src/core.c/ForeignCode.pm6
@@ -28,7 +28,7 @@ my class Rakudo::Internals::EvalIdSource {
 proto sub EVAL(
   $code is copy where Blob|Cool|Callable,
   Str()       :$lang is copy = 'Raku',
-  PseudoStash :$context,
+  PseudoStash :context($ctx),
   Str()       :$filename = Str,
   Bool()      :$check,
   *%_
@@ -53,7 +53,7 @@ $lang = 'Raku' if $lang eq 'perl6';
     }
     $code = nqp::istype($code,Blob) ?? $code.decode('utf8') !! $code.Str;
 
-    $context := CALLER:: unless nqp::defined($context);
+    my $context := nqp::defined($ctx) ?? $ctx !! CALLER::;
     my $eval_ctx := nqp::getattr(nqp::decont($context), PseudoStash, '$!ctx');
     my $?FILES   := $filename // 'EVAL_' ~ Rakudo::Internals::EvalIdSource.next-id;
     my $*CTXSAVE; # make sure we don't use the EVAL's MAIN context for the

--- a/t/02-rakudo/13-exceptions.t
+++ b/t/02-rakudo/13-exceptions.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 5;
+plan 14;
 
 # GH #2739
 # Prior to the fix the original exception would be lost hidden under 'no handler found' error.
@@ -30,6 +30,164 @@ throws-like q:to/CODE/,
 throws-like q[role R {}; my $foo = 42 but R(1)],
         X::Role::Initialization,
         'passing an initializer when role cannot accept it';
+
+# Rebinding exceptions.  These tests are good candidates to move to Roast once there's enough agreement
+# that the behavior tested below should be specified.  See rakudo#4536 for related discussion
+subtest "Sigiled variables can be rebound", {
+    plan 3;
+    my $scalar := 'old scalar';
+    $scalar    := 'new';
+    is $scalar, 'new', '$-sigiled variable can be rebound';
+
+    my @positional := ['old'];
+    @positional    := ['new'];
+    is @positional, ['new'], '@-sigiled variable can be rebound';
+
+    my %associative := {:old};
+    %associative    := {:new};
+    is %associative, {:new}, '%-sigiled variable can be rebound';
+}
+
+subtest "Scalars in signatures be rebound if they are 'copy' or 'rw'", {
+    plan 2;
+    is-deeply do {
+        sub f($bound-scalar-copy is copy) { $bound-scalar-copy := 'new' }
+        f 'old-value' }, 'new',
+        "Scalars in function signatures can be rebound when they are 'is copy'";
+    is-deeply do {
+        sub f($bound-scalar-rw is rw) { $bound-scalar-rw := 'new' }
+        f my $ = 'old-value' }, 'new',
+        "Scalars in function signatures can be rebound when they are 'is rw' (and get a writable container)";
+}
+
+subtest "Scalars in signatures that aren't 'copy' or 'rw' cannot be rebound", {
+    plan 4;
+    throws-like {
+        ‘sub f($bound-scalar-in-sig) { $bound-scalar-in-sig := 'new' }’.EVAL },
+        X::Bind::Rebind, message => /'$bound-scalar-in-sig'/ & /'signature'/,
+        "Scalars in function signatures cannot be rebound";
+    throws-like {
+        'sub f(Mu $bound-scalar-with-type) { $bound-scalar-with-type := 0 }'.EVAL },
+        X::Bind::Rebind, message => /'$bound-scalar-with-type'/ & /'signature'/,
+        "Scalars in function signatures cannot be rebound even if they have a type constraint";
+    throws-like {
+        ‘my ($bound-scalar,) := ('original',); $bound-scalar := 'new'’.EVAL },
+        X::Bind::Rebind, message => /'$bound-scalar'/ & /'signature'/,
+        "Scalars in bound signatures cannot be rebound";
+    throws-like {
+        ‘my ($a, $b, Int $bound-scalar) := (0, 0, 0); $bound-scalar := 42’.EVAL },
+        X::Bind::Rebind, message => /'$bound-scalar'/ & /'signature'/,
+        "Scalars in more complex bound signatures cannot be rebound";
+}
+
+subtest "Positional and Associative variables in signatures can be rebound if they are 'copy'", {
+    plan 4;
+    is-deeply do {
+        sub f(@positional-copy is copy) { @positional-copy := ['new'] }
+        f ['old-value'] }, ['new'],
+        "Positional variables in function signatures can be rebound when they are 'is copy'";
+    is-deeply do {
+        my ($a, @positional-copy is copy) := (0, ['old']);
+        @positional-copy := ['new'] }, ['new'],
+        "Positional variables in bound signatures can be rebound when they are 'is copy'";
+    is-deeply do {
+        sub f(%associative-copy is copy) { %associative-copy := {:new} }
+        f {:old-value}  }, %(:new),
+        "Associative variables in function signatures can be rebound when they are 'is copy'";
+    is-deeply do {
+        my ($a, %associative-copy is copy) := (0, {:old});
+        %associative-copy := {:new} }, %(:new),
+        "Associative variables bound in signatures can be rebound when they are 'is copy'";
+}
+
+subtest "Positional and Associative variables in signatures that aren't 'copy' cannot be rebound", {
+    plan 4;
+    throws-like {
+        ‘sub f(@bound-positional-in-sig) { @bound-positional-in-sig := ['new'] }’.EVAL },
+        X::Bind::Rebind, message => /'@bound-positional-in-sig'/ & /'signature'/,
+        "Positional variables in function signatures cannot be rebound";
+    throws-like {
+        ‘my ($a, @bound-positional) := (0, []); @bound-positional := ['new']’.EVAL },
+        X::Bind::Rebind, message => /'@bound-positional'/ & /'signature'/,
+        "Positional variables in bound signatures cannot be rebound";
+    throws-like {
+        'sub f(%bound-associative-in-sig) { %bound-associative-in-sig := {:new} }'.EVAL },
+        X::Bind::Rebind, message => /'%bound-associative-in-sig'/ & /'signature'/,
+        "Associative variables in function signatures cannot be rebound";
+    throws-like {
+        ‘my ($a, %bound-associative) := (0, []); %bound-associative := {:new}’.EVAL },
+        X::Bind::Rebind, message => /'%bound-associative'/ & /'signature'/,
+        "Associative variables in bound signatures cannot be rebound";
+}
+
+subtest 'Sigilless "variables" can never be rebound', {
+    plan 4;
+    throws-like {
+        ‘my \sigilless = 'old'; sigilless := 'new'’.EVAL },
+        X::Bind::Rebind, message => /'sigilless'/ & /'signature'/.none,
+        "Sigilless scalar terms cannot be rebound";
+    throws-like {
+        ‘my \sigilless-array = ['old']; sigilless-array := ['new']’.EVAL },
+        X::Bind::Rebind, message => /'sigilless-array'/ & /'signature'/.none,
+        "Sigilless positional terms cannot be rebound";
+    throws-like {
+        ‘my \sigilless-hash = {:old}; sigilless-hash := {:new}’.EVAL },
+        X::Bind::Rebind, message => /'sigilless-hash'/ & /'signature'/.none,
+        "Sigilless associative terms cannot be rebound";
+    throws-like {
+        ‘constant con = 'old'; con := 'new'’.EVAL },
+        X::Bind::Rebind, message => /'con'/ & /'signature'/.none,
+        "Constants cannot be rebound";
+}
+
+subtest "Code items can never be rebound", {
+    plan 2;
+    throws-like {
+        'sub f() { }; &f := &say; }'.EVAL },
+        X::Bind::Rebind, message => /'&f'/ & /'signature'/.none,
+        "A sub cannot be rebound";
+    throws-like {
+        'my regex reg-exp { old }; &reg-exp := /new/; }'.EVAL },
+        X::Bind::Rebind, message => /'&reg-exp'/ & /'signature'/.none,
+        "A regex cannot be rebound";
+}
+
+subtest "Terms can never be rebound", {
+    plan 4;
+    throws-like {
+        'my class C { has $.old }; C := class { has $.new } }'.EVAL },
+        X::Bind::Rebind, message => /'C'/ & /'signature'/.none,
+        "A class cannot be rebound";
+    throws-like {
+        'my role R { has $.old }; R := role { has $.new } }'.EVAL },
+        X::Bind::Rebind, message => /'R'/ & /'signature'/.none,
+        "A role cannot be rebound";
+    throws-like {
+        'my grammar G {  }; G := grammar { } }'.EVAL },
+        X::Bind::Rebind, message => /'G'/ & /'signature'/.none,
+        "A grammar cannot be rebound";
+    throws-like {
+        'int := str;'.EVAL },
+        X::Bind::Rebind, message => /'int'/ & /'signature'/.none,
+        "Native types cannot be rebound";
+}
+
+subtest "Items that were never bound don't throw *re*binding errors", {
+    plan 8;
+    given (try { ‘my int $var := 'new'’.EVAL }) {
+        cmp-ok $!, &[!~~], X::Bind::Rebind,          ‘Binding to a native type doesn't throw X::Bind::Rebind’;
+        throws-like {$!.throw}, X::Bind::NativeType, 'Binding to a native type throws X::Bind::NativeType' }
+    given (try { ‘'literal string' := 'new'’.EVAL}) {
+        cmp-ok $!, &[!~~], X::Bind::Rebind,          ‘Binding to a literal doesn't throw X::Bind::Rebind’;
+        throws-like {$!.throw}, X::Bind,             'Binding to a literal throws X::Bind' }
+    given (try { ‘sub f {}; f() := 'new'’.EVAL }) {
+        cmp-ok $!, &[!~~], X::Bind::Rebind,          ‘Binding to a function call LHS doesn't throw X::Bind::Rebind’;
+        throws-like {$!.throw}, X::Bind,             'Binding to a function call LHS throws X::Bind' }
+    given (try { ‘::OUTER := 'new'’.EVAL }) {
+        cmp-ok $!, &[!~~], X::Bind::Rebind,          ‘Binding to a pseudo-package LHS doesn't throw X::Bind::Rebind’;
+        throws-like {$!.throw}, X::Bind,             'Binding to a pseudo-package LHS throws X::Bind' }
+}
+
 
 done-testing;
 


### PR DESCRIPTION
According to [S06](https://design.raku.org/S06.html#Parameters_and_arguments), "A [readonly] parameter may also not be rebound; trying to do so results in a compile time error."  See also [S02](https://design.raku.org/S02.html) and [S07](https://design.raku.org/S07.html) (both mentioning that parameter binding has `::=` semantics) and [S03](https://design.raku.org/S03.html) (describing the semantics of `::=`).

However, it appears that this behavior is not currently tested in Roast, creating a bit of a [hole in the spec](https://perl6.party/post/Perl6-On-Specs-Versioning-Changes-And-Breakage#thefutureofthespec) where it doesn't fully test the intend behavior.  Perhaps as a result, the non-rebindability of parameters is inconsistently enforced by Rakudo.

Specifically, prior to this PR, the following code generated a compile-time `X::Bind` error

```raku
sub f($a) { $a := 0 }
```

but neither of the following two lines did:

```raku
sub f(Mu $a) { $a := 0   }
sub g(   @a) { @a := [0] }
```

The first commit in this PR fixes that discrepancy by calling the existing `is_lexical_marked_ro` method to determine whether a parameter is readonly.  It also annotates parameters as readonly or not readonly in a few locations (which is necessary because `is_lexical_marked_ro` is used before the `Parameter` objects are constructed).

Finally, this PR's first commit changes the one location where Rakudo code took advantage of the previous bug by rebinding a readonly parameter.

Because signature destructuring operates by binding the parameters in a signature, this commit also fixes the incorrectly-allowed rebinding of variables with values set in that way.  Both for functions and standalone signatures, non-readonly parameters (that is, any that are `copy` or `rw`) can be freely rebound. Thus,

```raku
my ($a is copy, $b) := (0, 1); $a := 42;
```

is correctly allowed, but generates a compilation error without the `is copy`.

This PR's second commit addresses the similarly inconsistent behavior between `my \a = 0; a := 42` (an `X::Bind` error) and `my Mu \a = 0; a := 42` (previously allowed).  Just like rebinding of parameters, rebinding terms declared with `\` is not supposed to be allowed:

> We sometimes call these "sigilless variables", but they differ from normal variables in one significant way. Unlike a variable binding, a term binding is fixed for the rest of the lexical scope. The term may only be rebound be re-entering the scope. This is useful to enforce a programming style known as SSA, Single Static Assignment (really binding), which, among other benefits, gives the optimizer more guarantees about which symbols can be considered "temporarily immutable".

[S06](https://design.raku.org/S06.html).  See also f303efcea4953268cf51b9cd02728309839203df (commit by @jnthn with the commit message "Enforce SSA on sigilless in `my (\x, \y) = 1, 2;`.")

After this PR, neither form is allowed; unlike with parameters, `\` terms do not have `is copy` or `is rw` as escape hatches.

This PR passes all tests and spectests, and applies cleanly/passes all tests on the `new-disp` branch as well. 

---

I have not prepared any corresponding Roast tests.  Assuming that this PR looks good, is there consensus on pinning down the behavior described in S02, S03, S06, and S07?  I'm inclined to think that we should, given that this behavior is fairly fundamental to Raku's underlying semantics and it would be very helpful to have it documented and speced in Roast.  But I know that specifying new behavior in Roast is a long-term commitment, so I wanted to double check. If there's consensus about adding Roast tests, I'd be happy to prepare a PR.

I spent a while figuring out the intended behavior for rebinding, and asked several people for help.  Thanks especially to @raiph  and @moritz for helping me figure out what the intended behavior is.  The following links point to conversations I had or resources I found when researching the topic (in addition to the previously linked Synopses, of course)

* [StackOverflow: What are the rules for re-binding](https://stackoverflow.com/questions/69231506/what-are-the-rules-for-re-binding)
* [StackOverflow: Should sigilless "variables" with type constraints be re-bindable?](https://stackoverflow.com/questions/69049465/should-sigilless-variables-with-type-constraints-be-re-bindable)
* [Stack Overflow Chat](https://chat.stackoverflow.com/rooms/237343/discussion-between-codesections-and-raiph) (discussing the "What are the rules for re-binding" question at more length)
* [#raku IRC channel, 2021-09-22](https://logs.liz.nl/raku/2021-09-22.html) and [2021-09-23](https://logs.liz.nl/raku/2021-09-23.html) (discussing same SO question).
* [StackOverflow: Is there a purpose or benefit in prohibiting sigilless variables from rebinding?](https://stackoverflow.com/questions/50399784/is-there-a-purpose-or-benefit-in-prohibiting-sigilless-variables-from-rebinding/50401989#50401989) (2018-05-17 answer explaining SSA in `\` terms)
* Raku/doc#3950 (discussing whether current behavior `\` is correct, and how to document it)