### PR TITLE
Don't make signature part of a callable named parameter

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -5693,19 +5693,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
         }
 
         if $<name><sigterm> || $<sigterm> -> $sig {
-            unless %*PARAM_INFO<post_constraints> {
-                %*PARAM_INFO<post_constraints> := [];
-            }
-            my $get_signature_past := QAST::Op.new(
-                :op('callmethod'),
-                :name('signature'),
-                WANTED(QAST::Var.new( :name('$_'), :scope('lexical') ),'param_var')
-            );
-            my $fakesig := $sig<fakesignature>;
-            my $closure_signature := $fakesig.ast;
-
-            my $where := make_where_block($fakesig, $closure_signature, $get_signature_past);
-            %*PARAM_INFO<post_constraints>.push($where);
+            %*PARAM_INFO<signature_constraint> := $sig<fakesignature>.ast.value;
         }
 
         if $<arrayshape> {
@@ -5759,7 +5747,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
     method named_param($/) {
         %*PARAM_INFO<named_names> := %*PARAM_INFO<named_names> || nqp::list_s();
         if $<name>               { nqp::push_s(%*PARAM_INFO<named_names>, ~$<name>); }
-        elsif $<param_var><name> { 
+        elsif $<param_var><name> {
             my $name := $<param_var><name>;
             nqp::push_s(%*PARAM_INFO<named_names>, ~($name<subshortname> // $name));
         }
@@ -9430,29 +9418,35 @@ class Perl6::Actions is HLL::Actions does STDActions {
                 }
             }
 
-            # Handle coercion.
-            # For a generic we can't know beforehand if it's going to be a coercive or any other nominalizable. Thus
-            # we have to fetch the instantiated parameter object and do run-time processing.
-            if $ptype_archetypes.generic {
-                # For a generic-typed parameter get its instantiated clone and see if its type is a coercion.
-                $decont_name_invalid := 1;
-                my $inst_param := QAST::Node.unique('__lowered_param_obj_');
-                my $low_param_type := QAST::Node.unique('__lowered_param_type');
+            my $inst_param;
+            # Make sure we have (possibly instantiated) parameter object ready when we need it
+            if $is_generic || %info<signature_constraint> {
+                my $inst_param_name := QAST::Node.unique('__lowered_param_obj_');
                 $var.push( # Fetch instantiated Parameter object
                     QAST::Op.new(
                         :op('bind'),
-                        QAST::Var.new( :name($inst_param), :scope('local'), :decl('var') ),
+                        QAST::Var.new( :name($inst_param_name), :scope('local'), :decl('var') ),
                         QAST::Op.new(
                             :op('atpos'),
                             signature_params($var),
                             QAST::IVal.new(:value($i)))));
+                $inst_param := QAST::Var.new(:name($inst_param_name), :scope<local>);
+            }
+
+            # Handle coercion.
+            # For a generic we can't know beforehand if it's going to be a coercive or any other nominalizable. Thus
+            # we have to fetch the instantiated parameter object and do run-time processing.
+            if $is_generic {
+                # For a generic-typed parameter get its instantiated clone and see if its type is a coercion.
+                $decont_name_invalid := 1;
+                my $low_param_type := QAST::Node.unique('__lowered_param_type');
                 $var.push( # Get actual parameter type
                                 QAST::Op.new(
                                     :op('bind'),
                                     QAST::Var.new(:name($low_param_type), :scope('local'), :decl('var')),
                                     QAST::Op.new(
                                         :op('getattr'),
-                                        QAST::Var.new(:name($inst_param), :scope('local')),
+                                        $inst_param,
                                         QAST::WVal.new(:value($Param)),
                                         QAST::SVal.new(:value('$!type')))));
                 $var.push(
@@ -9469,7 +9463,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
                                 :op('bitand_i'),
                                 QAST::Op.new(
                                     :op('getattr'),
-                                    QAST::Var.new(:name($inst_param), :scope('local')),
+                                    $inst_param,
                                     QAST::WVal.new(:value($Param)),
                                     QAST::SVal.new(:value('$!flags'))
                                 ),
@@ -9714,6 +9708,72 @@ class Perl6::Actions is HLL::Actions does STDActions {
                         }
                     }
                 }
+            }
+
+            if %info<signature_constraint> {
+                my $var-qast := QAST::Var.new( :name($name), :scope('local') );
+                my $var-decont := get_decont_name()
+                                    ?? QAST::Var.new( :name(get_decont_name()), :scope('local') )
+                                    !! QAST::Op.new( :op('decont'), $var-qast );
+                my $sigc_name := QAST::Node.unique('__lowered_sig_constraint_');
+                my $sigc-var := QAST::Var.new( :name($sigc_name), :scope<local>);
+                my $sigc-qast;
+                # Produce different code for generic/non-generic signatures because in the latter case instantiation
+                # code would be a waste of memory and performance.
+                if %info<signature_constraint>.is_generic {
+                    $sigc-qast := QAST::Op.new(
+                                    :op<if>,
+                                    QAST::Op.new(
+                                        :op<callmethod>,
+                                        :name<is_generic>,
+                                        QAST::Op.new(
+                                            :op<bind>,
+                                            QAST::Var.new( :name($sigc_name), :scope<local>, :decl<var>),
+                                            QAST::Op.new(
+                                                :op<getattr>,
+                                                $inst_param,
+                                                QAST::Op.new(:op<what>, $inst_param),
+                                                QAST::SVal.new(:value('$!signature-constraint'))))),
+                                    QAST::Op.new(
+                                        :op<callmethod>,
+                                        :name<instantiate_generic>,
+                                        $sigc-var,
+                                        QAST::Op.new(
+                                            :op<ctxlexpad>,
+                                            QAST::Op.new(:op<ctx>))),
+                                    $sigc-var );
+                }
+                else {
+                    $sigc-qast := QAST::Op.new(
+                                    :op<getattr>,
+                                    $inst_param,
+                                    QAST::Op.new(:op<what>, $inst_param),
+                                    QAST::SVal.new(:value('$!signature-constraint')));
+                }
+                $var.push(QAST::ParamTypeCheck.new(
+                    QAST::Op.new(
+                        # If argument is a type object and is the same as parameter default then skip signature
+                        # matching. So far, this is the best way I know to determine if corresponding argument was
+                        # passed or not without inspecting the capture which is too slow.
+                        :op<unless>,
+                        QAST::Op.new(
+                            :op<if>,
+                            QAST::Op.new(
+                                :op<not_i>,
+                                QAST::Op.new( :op<isconcrete>, $var-decont )),
+                            QAST::Op.new(:op<eqaddr>, $var-decont, QAST::WVal.new(:value(%info<type>)))),
+                        # If argument is concrete or is not parameter's default type then try signature matching
+                        QAST::Op.new(
+                            :op<if>,
+                            QAST::Op.new(:op<can>, $var-qast, QAST::SVal.new(:value<signature>)),
+                            QAST::Op.new(
+                                :op<callmethod>,
+                                :name<ACCEPTS>,
+                                $sigc-qast,
+                                QAST::Op.new(
+                                    :op<callmethod>,
+                                    :name<signature>,
+                                    $var-qast ))))));
             }
 
             # Apply post-constraints (must come after variable bind, as constraints can

--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -5582,7 +5582,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
             # Set name, if there is one.
             if $<name> {
                 %*PARAM_INFO<variable_name> := ~$<declname>;
-                %*PARAM_INFO<desigilname> := ~$<name>;
+                %*PARAM_INFO<desigilname> := ~($<name><subshortname> // $<name>);
             }
             %*PARAM_INFO<sigil> := my $sigil := ~$<sigil>;
 
@@ -5759,7 +5759,10 @@ class Perl6::Actions is HLL::Actions does STDActions {
     method named_param($/) {
         %*PARAM_INFO<named_names> := %*PARAM_INFO<named_names> || nqp::list_s();
         if $<name>               { nqp::push_s(%*PARAM_INFO<named_names>, ~$<name>); }
-        elsif $<param_var><name> { nqp::push_s(%*PARAM_INFO<named_names>, ~$<param_var><name>); }
+        elsif $<param_var><name> { 
+            my $name := $<param_var><name>;
+            nqp::push_s(%*PARAM_INFO<named_names>, ~($name<subshortname> // $name));
+        }
         else                     { nqp::push_s(%*PARAM_INFO<named_names>, ''); }
     }
 

--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -9732,8 +9732,8 @@ class Perl6::Actions is HLL::Actions does STDActions {
                                             QAST::Op.new(
                                                 :op<getattr>,
                                                 $inst_param,
-                                                QAST::Op.new(:op<what>, $inst_param),
-                                                QAST::SVal.new(:value('$!signature-constraint'))))),
+                                                QAST::WVal.new(:value($Param)),
+                                                QAST::SVal.new(:value('$!signature_constraint'))))),
                                     QAST::Op.new(
                                         :op<callmethod>,
                                         :name<instantiate_generic>,
@@ -9747,8 +9747,8 @@ class Perl6::Actions is HLL::Actions does STDActions {
                     $sigc-qast := QAST::Op.new(
                                     :op<getattr>,
                                     $inst_param,
-                                    QAST::Op.new(:op<what>, $inst_param),
-                                    QAST::SVal.new(:value('$!signature-constraint')));
+                                    QAST::WVal.new(:value($Param)),
+                                    QAST::SVal.new(:value('$!signature_constraint')));
                 }
                 $var.push(QAST::ParamTypeCheck.new(
                     QAST::Op.new(

--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -2287,9 +2287,7 @@ class Perl6::World is HLL::World {
             nqp::bindattr($parameter, $par_type, '$!sub_signature', %param_info<sub_signature>);
         }
         if nqp::existskey(%param_info, 'signature_constraint') {
-            my $psc-role := $*W.find_symbol(['Parameter', 'SignatureConstraint'], :setting-only);
-            $parameter.HOW.mixin($parameter, $psc-role);
-            nqp::bindattr($parameter, $parameter.WHAT, '$!signature-constraint', %param_info<signature_constraint>);
+            nqp::bindattr($parameter, $par_type, '$!signature_constraint', %param_info<signature_constraint>);
         }
 
         if nqp::existskey(%param_info, 'dummy') {

--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -2286,6 +2286,11 @@ class Perl6::World is HLL::World {
         if nqp::existskey(%param_info, 'sub_signature') {
             nqp::bindattr($parameter, $par_type, '$!sub_signature', %param_info<sub_signature>);
         }
+        if nqp::existskey(%param_info, 'signature_constraint') {
+            my $psc-role := $*W.find_symbol(['Parameter', 'SignatureConstraint'], :setting-only);
+            $parameter.HOW.mixin($parameter, $psc-role);
+            nqp::bindattr($parameter, $parameter.WHAT, '$!signature-constraint', %param_info<signature_constraint>);
+        }
 
         if nqp::existskey(%param_info, 'dummy') {
             my $dummy := %param_info<dummy>;

--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -2502,7 +2502,9 @@ BEGIN {
                     # to check constraint on every dispatch. Same if it's got a
                     # `where` clause.
                     unless nqp::isnull(nqp::getattr($param, Parameter, '$!sub_signature')) &&
-                           nqp::isnull(nqp::getattr($param, Parameter, '@!post_constraints')) {
+                           nqp::isnull(nqp::getattr($param, Parameter, '@!post_constraints')) &&
+                           nqp::not_i(nqp::can($param, 'signature-constraint'))
+                    {
                         %info<bind_check> := 1;
                         %info<constrainty> := 1;
                     }
@@ -2572,7 +2574,8 @@ BEGIN {
                         }
                         %info<types>[$significant_param] := $ptype;
                     }
-                    unless nqp::isnull(nqp::getattr($param, Parameter, '@!post_constraints')) {
+                    unless nqp::isnull(nqp::getattr($param, Parameter, '@!post_constraints'))
+                            && nqp::not_i(nqp::can($param, 'signature-constraint')) {
                         %info<constraints>[$significant_param] := 1;
                     }
                     if $flags +& $SIG_ELEM_MULTI_INVOCANT {

--- a/src/core.c/Exception.pm6
+++ b/src/core.c/Exception.pm6
@@ -2493,9 +2493,17 @@ my class X::TypeCheck::Binding is X::TypeCheck {
 my class X::TypeCheck::Binding::Parameter is X::TypeCheck::Binding {
     has Parameter $.parameter;
     has Bool $.constraint;
+    has Str $.what;
     method expectedn() {
         $.constraint && nqp::istype(self.expected, Code)
             ?? 'anonymous constraint to be met'
+            !! (nqp::istype($.expected, Signature)
+                ?? $.expected.raku
+                !! callsame())
+    }
+    method gotn() {
+        nqp::istype($.expected, Signature) && nqp::eqaddr($.got, Nil)
+            ?? "none"
             !! callsame()
     }
     method message() {
@@ -2505,7 +2513,7 @@ my class X::TypeCheck::Binding::Parameter is X::TypeCheck::Binding {
         my $expected = nqp::eqaddr(self.expected, self.got)
             ?? "expected type $.expectedn cannot be itself"
             !! "expected $.expectedn but got $.gotn";
-        my $what-check = $.constraint ?? 'Constraint type' !! 'Type';
+        my $what-check = $.what // ($.constraint ?? 'Constraint type' !! 'Type');
         self.priors() ~ "$what-check check failed in $.operation$to; $expected";
     }
 }

--- a/src/core.c/Parameter.pm6
+++ b/src/core.c/Parameter.pm6
@@ -577,6 +577,9 @@ my class Parameter { # declared in BOOTSTRAP
         } else {
             $name ~= $sigil ~ $twigil ~ $usage-name;
         }
+        if nqp::isconcrete($!signature_constraint) {
+            $name ~= $!signature_constraint.raku;
+        }
         if nqp::isconcrete(@!named_names) {
             my $var-is-named = False;
             my @outer-names  = gather for @.named_names {

--- a/src/core.c/Parameter.pm6
+++ b/src/core.c/Parameter.pm6
@@ -510,6 +510,15 @@ my class Parameter { # declared in BOOTSTRAP
             return False;
         }
 
+        my \osignature_constraint := nqp::getattr(o, Parameter, '$!signature_constraint');
+        if nqp::defined($!signature_constraint) {
+            return False unless nqp::defined(osignature_constraint)
+                                && $!signature_constraint.ACCEPTS(osignature_constraint);
+        }
+        else {
+            return False if nqp::defined(osignature_constraint);
+        }
+
         # we have a post constraint
         if nqp::islist(@!post_constraints) {
 
@@ -626,19 +635,16 @@ my class Parameter { # declared in BOOTSTRAP
         nqp::isnull($!sub_signature) ?? Signature !! $!sub_signature
     }
 
+    method signature_constraint(Parameter:D: --> Signature:_) {
+        nqp::isnull($!signature_constraint) ?? Signature !! $!signature_constraint
+    }
+
     method set_why(Parameter:D: $why --> Nil) {
         $!why := $why;
     }
 
     method set_default(Parameter:D: Code:D $default --> Nil) {
         $!default_value := $default;
-    }
-}
-
-my role Parameter::SignatureConstraint {
-    has $.signature-constraint;
-    method INSTANTIATE-SIGNATURE-CONSTRAINT(Mu \type_environment) is implementation-detail {
-        $!signature-constraint := $!signature-constraint.instantiate_generic(type_environment);
     }
 }
 

--- a/src/core.c/Parameter.pm6
+++ b/src/core.c/Parameter.pm6
@@ -635,6 +635,13 @@ my class Parameter { # declared in BOOTSTRAP
     }
 }
 
+my role Parameter::SignatureConstraint {
+    has $.signature-constraint;
+    method INSTANTIATE-SIGNATURE-CONSTRAINT(Mu \type_environment) is implementation-detail {
+        $!signature-constraint := $!signature-constraint.instantiate_generic(type_environment);
+    }
+}
+
 multi sub infix:<eqv>(Parameter:D $a, Parameter:D $b) {
 
     # we're us


### PR DESCRIPTION
When a named parameter is declared as `:&foo:(Int)` the name used for
parameter binding was `foo:(Int)` resulting in falling back to
parameter's default - `Callable`. A visible effect of this error was
parameter checking to attempt calling `signature` method on `Callable`
role.

Resolves #4537 