### PR TITLE
Add Cool.Version coercer

### DIFF
--- a/src/core.c/Cool.pm6
+++ b/src/core.c/Cool.pm6
@@ -448,6 +448,8 @@ my class Cool { # declared in BOOTSTRAP
           ?? $numeric
           !! $numeric.Complex
     }
+
+    method Version() { self.Str.Version }
 }
 Metamodel::ClassHOW.exclude_parent(Cool);
 


### PR DESCRIPTION
There is already a Str.Coercer.  It struck me that coercing a number
or a list of numbers to a Version object, would first need coercing
to Str.  Whereas we already do other Cool coercers.  Hence this.

   say 42.Version;                 # v42
   say (1,2,3).Version;            # v1.2.3
   say "42".match(/\d+/).Version;  # v42