### PR TITLE
Raku is a legally registered trademark now in the USA, UK and Europe.

### DIFF
--- a/src/Perl6/Compiler.nqp
+++ b/src/Perl6/Compiler.nqp
@@ -41,11 +41,11 @@ class Perl6::Compiler is HLL::Compiler {
         }
 
         if $no-unicode {
-            $raku   := "Raku(tm)";
+            $raku   := "Raku(R)";
             $rakudo := "Rakudo(tm)";
         }
         else {
-            $raku   := "Raku™";
+            $raku   := "Raku®";
             $rakudo := "Rakudo™";
         }
 


### PR DESCRIPTION
More details can be found here:

https://news.perlfoundation.org/post/raku-foundation-and-tm-update