### PR TITLE
Change guard to track value be non-Nil

### DIFF
--- a/src/vm/moar/dispatchers.nqp
+++ b/src/vm/moar/dispatchers.nqp
@@ -396,9 +396,7 @@
                     }
                     else {
                         # Non-nominal or type check error.
-                        my $tracked-of := nqp::dispatch('boot-syscall', 'dispatcher-track-attr',
-                                $tracked-desc, ContainerDescriptor, '$!of');
-                        nqp::dispatch('boot-syscall', 'dispatcher-guard-literal', $tracked-of);
+                        nqp::dispatch('boot-syscall', 'dispatcher-guard-not-literal-obj', $tracked-value, Nil);
                         nqp::dispatch('boot-syscall', 'dispatcher-delegate', 'boot-code-constant',
                             nqp::dispatch('boot-syscall', 'dispatcher-insert-arg-literal-obj',
                                 $capture, 0, $assign-scalar-no-whence));


### PR DESCRIPTION
Without this guard under certain conditions it is possible that a
container with non-nominal `.of` (like a subset) would take over the
optimization path of assigning `Nil` to a nominal container.

There're two scenarios where this problem occurs. The first is
`nqp::clone` of attribute's `auto_viv_container` and assign to the clone
bound to a lexical.

The second path is to `nqp::create(Scalar)` and set its descriptor to
attribute's container descriptor.

Don't know if there is way to experience this behavior without
involvement of nqp ops.