### PR TITLE
[JVM] Unbreak build after merge of new-disp

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -9074,6 +9074,10 @@ class Perl6::Actions is HLL::Actions does STDActions {
         # handling.
         if $need_full_binder {
             $block.custom_args(1);
+#?if !moar
+            $block[0].push(QAST::Op.new( :op('p6bindsig') ));
+#?endif
+#?if moar
             $block[0].push(QAST::Op.new(
                 :op('if'),
                 QAST::Op.new(
@@ -9087,6 +9091,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
                 ),
                 QAST::Op.new( :op('p6bindsig') )
             ));
+#?endif
         }
 
 #?if moar

--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -4265,7 +4265,7 @@ class Perl6::World is HLL::World {
         # discovered close to release, so only the Moar backend - that really
         # needs this - is being updated for now.
         my class FixupList {
-            has $!Code;
+            has $!Code;        ## only used on MoarVM
             has $!list;
             has $!resolved;
             has $!resolver;
@@ -4289,8 +4289,13 @@ class Perl6::World is HLL::World {
                         }
                     }
                     unless $added_update {
+#?if !moar
+                        nqp::p6captureouters2([$code], $!resolved);
+#?endif
+#?if moar
                         my $do := nqp::getattr($code, $!Code, '$!do');
                         nqp::p6captureouters2([$do], $!resolved);
+#?endif
                     }
                 }
             }
@@ -4298,6 +4303,10 @@ class Perl6::World is HLL::World {
                 nqp::scwbdisable();
                 $!resolved := $resolved;
                 nqp::scwbenable();
+#?if !moar
+                nqp::p6captureouters2($!list, $resolved);
+#?endif
+#?if moar
                 my $do-list := nqp::list();
                 my int $i := 0;
                 my int $n := nqp::elems($!list);
@@ -4306,11 +4315,17 @@ class Perl6::World is HLL::World {
                     $i++;
                 }
                 nqp::p6captureouters2($do-list, $resolved);
+#?endif
             }
             method update($code) {
                 if !nqp::isnull($!resolved) && !nqp::istype($!resolved, NQPMu) {
+#?if !moar
+                    nqp::p6captureouters2([$code],
+#?endif
+#?if moar
                     my $do := nqp::getattr($code, $!Code, '$!do');
                     nqp::p6captureouters2([$do],
+#?endif
                         nqp::getcomp('Raku').backend.name eq 'moar'
                             ?? nqp::getstaticcode($!resolved)
                             !! $!resolved);
@@ -4321,8 +4336,10 @@ class Perl6::World is HLL::World {
         # Create a list and put it in the SC.
         my $fixup_list := nqp::create(FixupList);
         self.add_object_if_no_sc($fixup_list);
+#?if moar
         nqp::bindattr($fixup_list, FixupList, '$!Code',
             self.find_single_symbol('Code', :setting-only));
+#?endif
         nqp::bindattr($fixup_list, FixupList, '$!list', nqp::list());
         nqp::bindattr($fixup_list, FixupList, '$!resolver', self.handle());
 

--- a/src/vm/jvm/Perl6/Ops.nqp
+++ b/src/vm/jvm/Perl6/Ops.nqp
@@ -69,7 +69,7 @@ proto sub trial_bind(*@args) {
 my $trial_bind := -> $qastcomp, $op {
     $qastcomp.as_jast(QAST::Op.new(
         :op('call'),
-        QAST::WVal.new( :value(nqp::getcodeobj(&trial_bind)) ),
+        QAST::WVal.new( :value(&trial_bind) ),
         |@($op)
     ));
 };
@@ -78,7 +78,7 @@ proto sub get_binder()   { $Binder }
 $ops.add_hll_op('nqp', 'p6setbinder', -> $qastcomp, $op {
     $qastcomp.as_jast(QAST::Op.new(
         :op('call'),
-        QAST::WVal.new( :value(nqp::getcodeobj(&set_binder)) ),
+        QAST::WVal.new( :value(&set_binder) ),
         |@($op)
     ));
 });


### PR DESCRIPTION
There where three errors during the build of the JVM backend that
have been fixed / worked around as follows:

* The change to src/vm/jvm/Perl6/Ops.nqp prevents an explosion with
  "getcodeobj can only be used with a CodeRef".

* After fixing that the build died with "Error while compiling op
  dispatch, no registered operation handler". This seems to be caused
  by https://github.com/rakudo/rakudo/commit/de24aac1b8 and just
  re-introducing the old behaviour for the other backends brought up
  the third error:

* "Could not instantiate role '<anon|1>': CodeRef representation does
  not support attributes". It looks like this happened since
  commit https://github.com/rakudo/rakudo/commit/25d2f634dd. Again,
  just re-introduing the old behaviour for the other backends avoided
  the error.

The first two errors and possible workarounds were spotted by
 MasterDuke++.