### PR TITLE
Make GLOBAL available to compile time code

### DIFF
--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -724,6 +724,8 @@ class Perl6::World is HLL::World {
             self.pkg_compose($/, $*GLOBALish);
         }
 
+        nqp::bindhllsym('Raku', 'GLOBAL', $*GLOBALish);
+
         # Create or pull in existing EXPORT.
         if $!have_outer && $*UNIT_OUTER.symbol('EXPORT') {
             $*EXPORT :=


### PR DESCRIPTION
This should resolve #4557 but primarily this fixes
CompUnit::RepositoryRegistry::short-id2class which throws on
`::($short-id)` statement because `GLOBAL` is not available at this
point despite it is already known either from compiler options, or from
unit's outers, or via a new one created by the World object.

As far as I'm aware, this also makes `GLOBAL` the same symbol for
compunit's mainline when it is executed at load time, and for run-time
code.