### PR TITLE
Prevent heredocs from using block variables when continuing after the block

### DIFF
--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -1069,11 +1069,11 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
             '{'
             <!!{ $*VARIABLE := '' if $*VARIABLE; 1 }>
             <statementlist(1)>
+            { $*CURPAD := $*W.pop_lexpad() }
             [<.cheat_heredoc> || '}']
             <?ENDSTMT>
         || <.missing_block($borg, $has_mystery)>
         ]
-        { $*CURPAD := $*W.pop_lexpad() }
     }
 
     token unitstart { <?> }


### PR DESCRIPTION
This change addresses proper handling of heredocs
raised in issue #4539 where the docs implied a heredoc
could be defined with its terminator following a block.

Jonathan said that was not intended and explained
how to fix it. That was the only change to the
code and it had the desired effect: a heredoc
cannot be defined with its terminator following a block, 
but it can be defined with its terminator following a function 
call line.

New tests have been added for this change in roast file 
'S02-literals/heredocs.t'.

Note the docs should be updated to discuss the ramifications
of this fix.