### PR TITLE
Use distribution specific comp unit ids in CURFS

### DIFF
--- a/src/core.c/CompUnit/Repository/FileSystem.pm6
+++ b/src/core.c/CompUnit/Repository/FileSystem.pm6
@@ -75,7 +75,7 @@ class CompUnit::Repository::FileSystem
 
         with self!matching-dist($spec) {
             my $name = $spec.short-name;
-            my $id   = self!comp-unit-id($name);
+            my $id   = self!comp-unit-id($_.id ~ $name);
             my $*DISTRIBUTION  = $_;
             my $*RESOURCES     = Distribution::Resources.new(:repo(self), :dist-id(''));
             my $source-handle  = $_.content($_.meta<provides>{$name});


### PR DESCRIPTION
Previously CU::R::FileSystem would only use the short name when generating a
comp unit id. However when two different versions of the otherwise same
module were loaded the same precomp file would get used. This changes to use
the distribution id (which already accounts for version/api/auth) in
combination with the short name of the requested module.