### PR TITLE
Fix handling of constrained Mu parameters in signature smartmatching

### DIFF
--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -1965,7 +1965,7 @@ BEGIN {
     Parameter.HOW.add_attribute(Parameter, scalar_attr('$!container_descriptor', Mu, Parameter, :!auto_viv_container));
     Parameter.HOW.add_attribute(Parameter, Attribute.new(:name<$!attr_package>, :type(Mu), :package(Parameter)));
     Parameter.HOW.add_attribute(Parameter, Attribute.new(:name<$!why>, :type(Mu), :package(Parameter)));
-    Parameter.HOW.add_attribute(Parameter, Attribute.new(:name<$!signature_constraint>, :type(Signature), :package(Parameter)));
+    Parameter.HOW.add_attribute(Parameter, scalar_attr('$!signature_constraint', Signature, Parameter, :!auto_viv_container));
     Parameter.HOW.add_method(Parameter, 'is_generic', nqp::getstaticcode(sub ($self) {
             # If nonimnal type or attr_package is generic, so are we.
             my $type := nqp::getattr($self, Parameter, '$!type');

--- a/src/core.c/Parameter.pm6
+++ b/src/core.c/Parameter.pm6
@@ -498,29 +498,22 @@ my class Parameter { # declared in BOOTSTRAP
         }
 
         # we have sub sig and not the same
-        my \osub_signature := nqp::getattr(o,Parameter,'$!sub_signature');
-        if $!sub_signature {
+        if nqp::isconcrete($!sub_signature) {
+            my \osub_signature := nqp::getattr(o,Parameter,'$!sub_signature');
             return False
-              unless osub_signature
-              && $!sub_signature.ACCEPTS(osub_signature);
+              unless nqp::isconcrete(osub_signature)
+                && $!sub_signature.ACCEPTS(osub_signature);
         }
 
-        # no sub sig, but other has one
-        elsif osub_signature {
-            return False;
-        }
-
-        my \osignature_constraint := nqp::getattr(o, Parameter, '$!signature_constraint');
-        if nqp::defined($!signature_constraint) {
-            return False unless nqp::defined(osignature_constraint)
-                                && $!signature_constraint.ACCEPTS(osignature_constraint);
-        }
-        else {
-            return False if nqp::defined(osignature_constraint);
+        if nqp::isconcrete($!signature_constraint) {
+            my \osignature_constraint := nqp::getattr(o, Parameter, '$!signature_constraint');
+            return False
+              unless nqp::isconcrete(osignature_constraint)
+                && $!signature_constraint.ACCEPTS(osignature_constraint);
         }
 
         # we have a post constraint
-        if nqp::islist(@!post_constraints) {
+        if nqp::isconcrete(@!post_constraints) {
 
             # callable means runtime check, so no match
             return False
@@ -537,11 +530,6 @@ my class Parameter { # declared in BOOTSTRAP
             return False
               unless nqp::atpos(@!post_constraints,0).ACCEPTS(
                 nqp::atpos(opc,0));
-        }
-
-        # we don't, other *does* have a post constraint
-        elsif nqp::islist(nqp::getattr(o,Parameter,'@!post_constraints')) {
-            return False;
         }
 
         # it's a match!

--- a/src/core.c/Parameter.pm6
+++ b/src/core.c/Parameter.pm6
@@ -630,6 +630,14 @@ my class Parameter { # declared in BOOTSTRAP
         nqp::isnull($!signature_constraint) ?? Signature !! $!signature_constraint
     }
 
+    method untyped(Parameter:D: --> Bool:D) {
+        nqp::hllbool(
+          nqp::eqaddr($!type, Mu) &&
+          nqp::isnull(@!post_constraints) &&
+          nqp::isnull($!sub_signature) &&
+          nqp::isnull($!signature_constraint))
+    }
+
     method set_why(Parameter:D: $why --> Nil) {
         $!why := $why;
     }

--- a/src/core.c/Signature.pm6
+++ b/src/core.c/Signature.pm6
@@ -90,7 +90,7 @@ my class Signature { # declared in BOOTSTRAP
                     return False unless $l-param ~~ @r-pos-queue.shift;
                 }
                 else {
-                    return False unless $r-pos-sink or $l-param.optional;
+                    return False unless $r-pos-sink;
                 }
             }
             elsif $l-param.named {
@@ -113,7 +113,7 @@ my class Signature { # declared in BOOTSTRAP
                     return False unless $found or $l-param.optional && $l-param.untyped;
                 }
                 else {
-                    return False unless $r-named-sink or $l-param.optional && $l-param.untyped;
+                    return False unless $r-named-sink;
                 }
             }
             else {

--- a/src/core.c/Signature.pm6
+++ b/src/core.c/Signature.pm6
@@ -110,20 +110,20 @@ my class Signature { # declared in BOOTSTRAP
                             $found := True;
                         }
                     }
-                    return False unless $found or $l-param.optional and $l-param.type =:= Mu;
+                    return False unless $found or $l-param.optional && $l-param.untyped;
                 }
                 else {
-                    return False unless $r-named-sink or $l-param.optional and $l-param.type =:= Mu;
+                    return False unless $r-named-sink or $l-param.optional && $l-param.untyped;
                 }
             }
             else {
-                return False unless $r-pos-sink and $r-named-sink;
+                return False unless $r-pos-sink && $r-named-sink;
             }
         }
 
         return False unless .optional for @r-pos-queue;
 
-        return False unless .optional and .type =:= Mu for %r-named-queue.values;
+        return False unless .optional && .untyped for %r-named-queue.values;
 
         self.returns =:= $topic.returns
     }


### PR DESCRIPTION
`Signature.ACCEPTS` detects the absence of a type for a parameter by comparing its type object to `Mu`. The problem is this doesn't consider any type constraints (where clauses, subsignatures, `Callable` signatures) the parameter may have, leading to false positives when the type object is lacking. `Parameter.ACCEPTS` also mishandles type constraints: it has paranoid guards against constraints in the LHS lacking in the RHS that prevents subtyping of parameters in this way, leading to false negatives.

While fixing `Parameter.ACCEPTS` is primarily a matter of removing said conditions, the absence of any type-related information in a `Parameter:D` whatsoever isn't very efficient to introspect from outside `Parameter`, thus the introduction of the `untyped` getter. Now fixing `Signature.ACCEPTS` is just a matter of replacing comparisons to `Mu` with calls to `Parameter.untyped`.

Fixes https://github.com/rakudo/rakudo/issues/4558.