### PR TITLE
[JVM] Restore pre-new-disp behaviour for phasers

### DIFF
--- a/src/vm/jvm/runtime/org/raku/rakudo/RakOps.java
+++ b/src/vm/jvm/runtime/org/raku/rakudo/RakOps.java
@@ -503,10 +503,8 @@ public final class RakOps {
     }
 
     public static SixModelObject p6setfirstflag(SixModelObject codeObj, ThreadContext tc) {
-        GlobalExt gcx = key.getGC(tc);
         ThreadExt tcx = key.getTC(tc);
-        tcx.firstPhaserCodeBlock = codeObj.get_attribute_boxed(tc,
-            gcx.Code, "$!do", HINT_CODE_DO);
+        tcx.firstPhaserCodeBlock = codeObj;
         return codeObj;
     }
 


### PR DESCRIPTION
This basically undoes the changes from 84da856ae6 for the non-moar
backends. This unbreaks a couple of tests for the JVM backend, that
now die with "CodeRef representation does not support attributes".