### PR TITLE
[JVM] Provide clean fix for broken build

### DIFF
--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -4264,7 +4264,7 @@ class Perl6::World is HLL::World {
         # discovered close to release, so only the Moar backend - that really
         # needs this - is being updated for now.
         my class FixupList {
-            has $!Code;        ## only used on MoarVM
+            has $!Code;
             has $!list;
             has $!resolved;
             has $!resolver;
@@ -4288,13 +4288,8 @@ class Perl6::World is HLL::World {
                         }
                     }
                     unless $added_update {
-#?if !moar
-                        nqp::p6captureouters2([$code], $!resolved);
-#?endif
-#?if moar
                         my $do := nqp::getattr($code, $!Code, '$!do');
                         nqp::p6captureouters2([$do], $!resolved);
-#?endif
                     }
                 }
             }
@@ -4302,10 +4297,6 @@ class Perl6::World is HLL::World {
                 nqp::scwbdisable();
                 $!resolved := $resolved;
                 nqp::scwbenable();
-#?if !moar
-                nqp::p6captureouters2($!list, $resolved);
-#?endif
-#?if moar
                 my $do-list := nqp::list();
                 my int $i := 0;
                 my int $n := nqp::elems($!list);
@@ -4314,17 +4305,11 @@ class Perl6::World is HLL::World {
                     $i++;
                 }
                 nqp::p6captureouters2($do-list, $resolved);
-#?endif
             }
             method update($code) {
                 if !nqp::isnull($!resolved) && !nqp::istype($!resolved, NQPMu) {
-#?if !moar
-                    nqp::p6captureouters2([$code],
-#?endif
-#?if moar
                     my $do := nqp::getattr($code, $!Code, '$!do');
                     nqp::p6captureouters2([$do],
-#?endif
                         nqp::getcomp('Raku').backend.name eq 'moar'
                             ?? nqp::getstaticcode($!resolved)
                             !! $!resolved);
@@ -4335,10 +4320,8 @@ class Perl6::World is HLL::World {
         # Create a list and put it in the SC.
         my $fixup_list := nqp::create(FixupList);
         self.add_object_if_no_sc($fixup_list);
-#?if moar
         nqp::bindattr($fixup_list, FixupList, '$!Code',
             self.find_single_symbol('Code', :setting-only));
-#?endif
         nqp::bindattr($fixup_list, FixupList, '$!list', nqp::list());
         nqp::bindattr($fixup_list, FixupList, '$!resolver', self.handle());
 

--- a/src/vm/jvm/runtime/org/raku/rakudo/RakOps.java
+++ b/src/vm/jvm/runtime/org/raku/rakudo/RakOps.java
@@ -408,7 +408,6 @@ public final class RakOps {
     }
 
     public static SixModelObject p6captureouters2(SixModelObject capList, SixModelObject target, ThreadContext tc) {
-        GlobalExt gcx = key.getGC(tc);
         if (!(target instanceof CodeRef))
             ExceptionHandling.dieInternal(tc, "p6captureouters target must be a CodeRef");
         CallFrame cf = ((CodeRef)target).outer;
@@ -416,10 +415,8 @@ public final class RakOps {
             return capList;
         long elems = capList.elems(tc);
         for (long i = 0; i < elems; i++) {
-            SixModelObject codeObj = capList.at_pos_boxed(tc, i);
-            CodeRef closure = (CodeRef)codeObj.get_attribute_boxed(tc,
-                gcx.Code, "$!do", HINT_CODE_DO);
-            CallFrame ctxToDiddle = closure.outer;
+            SixModelObject closure = capList.at_pos_boxed(tc, i);
+            CallFrame ctxToDiddle = ((CodeRef)closure).outer;
             ctxToDiddle.outer = cf;
         }
         return capList;


### PR DESCRIPTION
There was no need to add the special cases to src/Perl6/World.nqp.

The adjustment to p6captureouters2 was inspired by 02c13fad8d.
Again thanks to jnthn++ for the pointer.