### PR TITLE
Revert CurFS fixes for now

### DIFF
--- a/src/core.c/CompUnit/Repository/FileSystem.pm6
+++ b/src/core.c/CompUnit/Repository/FileSystem.pm6
@@ -75,7 +75,7 @@ class CompUnit::Repository::FileSystem
 
         with self!matching-dist($spec) {
             my $name = $spec.short-name;
-            my $id   = self!comp-unit-id(self.id ~ $name);
+            my $id   = self!comp-unit-id($name);
             my $*DISTRIBUTION  = $_;
             my $*RESOURCES     = Distribution::Resources.new(:repo(self), :dist-id(''));
             my $source-handle  = $_.content($_.meta<provides>{$name});


### PR DESCRIPTION
Until we can figure out why this is causing the spectest to take
about 2x as long (from 357 -> 616 wallclock for yours truly)