### PR TITLE
Ensure all methods use the updated comp-unit-id

### DIFF
--- a/src/core.c/CompUnit/Repository/FileSystem.pm6
+++ b/src/core.c/CompUnit/Repository/FileSystem.pm6
@@ -24,7 +24,7 @@ class CompUnit::Repository::FileSystem
     }
 
     method !comp-unit-id($name) {
-        CompUnit::PrecompilationId.new-from-string($name);
+        CompUnit::PrecompilationId.new-from-string(self.id ~ $name);
     }
 
     method !precomp-stores() {
@@ -75,7 +75,7 @@ class CompUnit::Repository::FileSystem
 
         with self!matching-dist($spec) {
             my $name = $spec.short-name;
-            my $id   = self!comp-unit-id(self.id ~ $name);
+            my $id   = self!comp-unit-id($name);
             my $*DISTRIBUTION  = $_;
             my $*RESOURCES     = Distribution::Resources.new(:repo(self), :dist-id(''));
             my $source-handle  = $_.content($_.meta<provides>{$name});


### PR DESCRIPTION
In a recent change the distribution id was added to the module name when generating a comp-unit-id for `need` to allow multiple versions of the same name to be loaded. However,`need` and `resolve` need to generate identical comp-unit-ids for a given module name since `resolve` will be called by CUR::PrecompilationRepository when `need`ing a module.