### PR TITLE
Remove tai-offset-nanos from CORE::.keys

### DIFF
--- a/src/core.c/Instant.pm6
+++ b/src/core.c/Instant.pm6
@@ -125,10 +125,10 @@ sub term:<time>(--> Int:D) { nqp::time() div 1000000000 }
 # 37 is $initial-offset from Rakudo::Internals + # of years
 # that have had leap seconds so far. Will need to be incremented
 # when new leap seconds occur.
-my int constant \tai-offset-nanos = 37 * 1000000000;
 sub term:<now>(--> Instant:D) {
     # FIXME: During a leap second, the returned value is one
     # second greater than it should be.
+    my int constant \tai-offset-nanos = 37 * 1000000000;
     Instant.from-posix-nanos(nqp::add_i(nqp::time,tai-offset-nanos))
 }
 

--- a/t/02-rakudo/03-corekeys-6c.t
+++ b/t/02-rakudo/03-corekeys-6c.t
@@ -766,7 +766,6 @@ my @expected = (
   Q{π},
   Q{τ},
   Q{𝑒},
-  Q{tai-offset-nanos},
 );
 
 my %nyi-for-backend = (

--- a/t/02-rakudo/03-corekeys-6d.t
+++ b/t/02-rakudo/03-corekeys-6d.t
@@ -766,7 +766,6 @@ my @expected = (
     Q{π},
     Q{τ},
     Q{𝑒},
-    Q{tai-offset-nanos},
 );
 
 my %nyi-for-backend = (

--- a/t/02-rakudo/03-corekeys-6e.t
+++ b/t/02-rakudo/03-corekeys-6e.t
@@ -768,7 +768,6 @@ my @expected = (
     Q{π},
     Q{τ},
     Q{𝑒},
-    Q{tai-offset-nanos},
 );
 
 my %nyi-for-backend = (

--- a/t/02-rakudo/03-corekeys.t
+++ b/t/02-rakudo/03-corekeys.t
@@ -769,7 +769,6 @@ my @allowed =
       Q{π},
       Q{τ},
       Q{𝑒},
-      Q{tai-offset-nanos},
     ),
     d => (
         Q{$!},

--- a/t/02-rakudo/04-settingkeys-6c.t
+++ b/t/02-rakudo/04-settingkeys-6c.t
@@ -766,7 +766,6 @@ my %allowed = (
     Q{π},
     Q{τ},
     Q{𝑒},
-    Q{tai-offset-nanos},
 ).map: { $_ => 1 };
 
 my %nyi-for-backend = (

--- a/t/02-rakudo/04-settingkeys-6e.t
+++ b/t/02-rakudo/04-settingkeys-6e.t
@@ -766,7 +766,6 @@ my %allowed = (
     Q{π},
     Q{τ},
     Q{𝑒},
-    Q{tai-offset-nanos},
 ).map: { $_ => 1 };
 
 my %nyi-for-backend = (


### PR DESCRIPTION
This constant is an implementation detail and should not be visible
outside of the sub that needs it.