### PR TITLE
Better cope with megamorphic callsites after new-disp

### DIFF
--- a/src/Perl6/Metamodel/MROBasedMethodDispatch.nqp
+++ b/src/Perl6/Metamodel/MROBasedMethodDispatch.nqp
@@ -1,6 +1,6 @@
 role Perl6::Metamodel::MROBasedMethodDispatch {
     # If needed, a cached flattened method table accounting for all methods in
-    # this class and its parents. This is only needed in the sitaution that a
+    # this class and its parents. This is only needed in the situation that a
     # megamorphic callsite involves the class, so calculated and cached on
     # demand.
     has $!cached_all_method_table;

--- a/src/Perl6/Metamodel/MROBasedMethodDispatch.nqp
+++ b/src/Perl6/Metamodel/MROBasedMethodDispatch.nqp
@@ -1,11 +1,17 @@
 role Perl6::Metamodel::MROBasedMethodDispatch {
-    # While we normally end up locating methods through the method cache,
-    # this is here as a fallback.
-    method find_method($obj, $name, :$no_fallback, *%adverbs) {
+    # If needed, a cached flattened method table accounting for all methods in
+    # this class and its parents. This is only needed in the sitaution that a
+    # megamorphic callsite involves the class, so calculated and cached on
+    # demand.
+    has $!cached_all_method_table;
 
-# uncomment line below for verbose information about uncached method lookups
-#nqp::say( "looking for " ~ $name ~ " in " ~ $obj.HOW.name($obj) );
-#
+    # Resolve a method. On MoarVM, with the generalized dispatch mechanism,
+    # this is called to bootstrap callsites. On backends without that, it
+    # is only called on a published cache miss.
+    method find_method($obj, $name, :$no_fallback, *%adverbs) {
+        # uncomment line below for verbose information about uncached method lookups
+        #nqp::say( "looking for " ~ $name ~ " in " ~ $obj.HOW.name($obj) );
+
         my $obj_how := nqp::how_nd($obj);
         if nqp::can($obj_how, 'submethod_table') {
             my %submethods := nqp::hllize($obj_how.submethod_table($obj));
@@ -86,6 +92,37 @@ role Perl6::Metamodel::MROBasedMethodDispatch {
         unless nqp::can(self, 'has_fallbacks') && self.has_fallbacks($obj) {
             nqp::setmethcacheauth($obj, $authable);
         }
+#?endif
+    }
+
+    method all_method_table($obj) {
+        my $table := $!cached_all_method_table;
+        unless nqp::isconcrete($table) {
+            $table := nqp::hash();
+            my @mro := self.mro($obj);
+            my int $i := nqp::elems(@mro);
+            while $i-- {
+                my $class := nqp::atpos(@mro, $i);
+                for nqp::hllize($class.HOW.method_table($class)) {
+                    $table{$_.key} := nqp::decont($_.value);
+                }
+            }
+            for nqp::hllize($obj.HOW.submethod_table($obj)) {
+                $table{$_.key} := nqp::decont($_.value);
+            }
+            nqp::scwbdisable();
+            $!cached_all_method_table := $table;
+            nqp::scwbenable();
+        }
+        $table
+    }
+
+    method invalidate_method_caches($obj) {
+        nqp::scwbdisable();
+        $!cached_all_method_table := nqp::null();
+        nqp::scwbenable();
+#?if !moar
+        nqp::setmethcacheauth($obj, 0);
 #?endif
     }
 }

--- a/src/Perl6/Metamodel/MethodContainer.nqp
+++ b/src/Perl6/Metamodel/MethodContainer.nqp
@@ -46,9 +46,7 @@ role Perl6::Metamodel::MethodContainer {
         }
 
         # Adding a method means any cache is no longer authoritative.
-#?if !moar
-        nqp::setmethcacheauth($obj, 0);
-#?endif
+        try self.invalidate_method_caches($obj);
         %!cache := {};
         @!method_order[+@!method_order] := $code_obj;
         @!method_names[+@!method_names] := $name;

--- a/src/Perl6/Metamodel/ParametricRoleGroupHOW.nqp
+++ b/src/Perl6/Metamodel/ParametricRoleGroupHOW.nqp
@@ -46,6 +46,7 @@ class Perl6::Metamodel::ParametricRoleGroupHOW
         $meta.set_pun_repr($meta, $repr) if $repr;
         $meta.set_boolification_mode($type_obj, 5);
         $meta.publish_boolification_spec($type_obj);
+        $meta.publish_type_cache($type_obj);
         self.add_stash($type_obj);
 
         # We use 6model parametrics to make this a parametric type on the
@@ -233,6 +234,14 @@ class Perl6::Metamodel::ParametricRoleGroupHOW
     method !get_nonsignatured_candidate($obj) {
         return nqp::null unless +@!nonsignatured;
         @!nonsignatured[0]
+    }
+
+    method publish_type_cache($obj) {
+        # We can at least include ourself and the types a role pretends to be.
+        my @tc := nqp::clone(self.pretending_to_be());
+        nqp::push(@tc, $obj.WHAT);
+        nqp::settypecache($obj, @tc);
+        nqp::settypecheckmode($obj, 1);
     }
 }
 

--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -2299,8 +2299,8 @@ BEGIN {
     #     has @!dispatch_order;
     #     has Mu $!dispatch_cache;
     Routine.HOW.add_parent(Routine, Block);
-    Routine.HOW.add_attribute(Routine, Attribute.new(:name<@!dispatchees>, :type(List), :package(Routine)));
-    Routine.HOW.add_attribute(Routine, Attribute.new(:name<$!dispatcher>, :type(Mu), :package(Routine)));
+    Routine.HOW.add_attribute(Routine, Attribute.new(:name<@!dispatchees>, :type(List), :package(Routine), :auto_viv_primitive(nqp::null())));
+    Routine.HOW.add_attribute(Routine, Attribute.new(:name<$!dispatcher>, :type(Mu), :package(Routine), :auto_viv_primitive(nqp::null())));
     Routine.HOW.add_attribute(Routine, Attribute.new(:name<$!flags>, :type(int), :package(Routine)));
     Routine.HOW.add_attribute(Routine, Attribute.new(:name<$!inline_info>, :type(Mu), :package(Routine)));
     Routine.HOW.add_attribute(Routine, Attribute.new(:name<$!package>, :type(Mu), :package(Routine)));

--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -4093,7 +4093,7 @@ nqp::sethllconfig('Raku', nqp::hash(
 #?if moar
     'call_dispatcher', 'raku-call',
     'method_call_dispatcher', 'raku-meth-call',
-    'find_method_dispatcher', 'nqp-find-meth',  # NQP one is probably good enough
+    'find_method_dispatcher', 'raku-find-meth',
     'resume_error_dispatcher', 'raku-resume-error',
     'hllize_dispatcher', 'raku-hllize',
     'istype_dispatcher', 'nqp-istype',  # Can write a Raku one later for more opts

--- a/src/core.c/Mu.pm6
+++ b/src/core.c/Mu.pm6
@@ -113,7 +113,7 @@ my class Mu { # declared in BOOTSTRAP
 
     proto method new(|) {*}
     multi method new(*%attrinit) {
-        nqp::eqaddr((my $bless := nqp::findmethod(self,'bless')),
+        nqp::eqaddr((my $bless := nqp::tryfindmethod(self,'bless')),
                     nqp::findmethod(Mu,'bless'))
                 ?? nqp::create(self).BUILDALL(Empty, %attrinit)
                 !! $bless(self,|%attrinit)

--- a/src/core.c/ObjAt.pm6
+++ b/src/core.c/ObjAt.pm6
@@ -29,6 +29,10 @@ my class ObjAt { # declared in BOOTSTRAP
     }
 }
 
+my class ValueObjAt { # declared in BOOTSTRAP
+    # class ValueObjAt is ObjAt
+}
+
 multi sub infix:<eqv>(ObjAt:D $a, ObjAt:D $b --> Bool:D) {
     nqp::hllbool(
       nqp::eqaddr(nqp::decont($a),nqp::decont($b))

--- a/src/vm/moar/dispatchers.nqp
+++ b/src/vm/moar/dispatchers.nqp
@@ -28,74 +28,87 @@
     }
 
     nqp::dispatch('boot-syscall', 'dispatcher-register', 'raku-rv-decont', -> $capture {
-        # We always need to guard on type and concreteness.
-        my $rv := nqp::captureposarg($capture, 0);
-        my $rv_arg := nqp::dispatch('boot-syscall', 'dispatcher-track-arg',
-                $capture, 0);
-        nqp::dispatch('boot-syscall', 'dispatcher-guard-type', $rv_arg);
-        nqp::dispatch('boot-syscall', 'dispatcher-guard-concreteness', $rv_arg);
+        # If it's heading megamorphic, then we'll install the fallback, without
+        # any conditions, which is faster than over-filling the cache and running
+        # this dispatch logic every time.
+        my int $cache-size := nqp::dispatch('boot-syscall', 'dispatcher-inline-cache-size');
+        if $cache-size >= 16 {
+            nqp::dispatch('boot-syscall', 'dispatcher-delegate', 'boot-code-constant',
+                nqp::dispatch('boot-syscall', 'dispatcher-insert-arg-literal-obj',
+                    nqp::dispatch('boot-syscall', 'dispatcher-insert-arg-literal-obj',
+                        $capture, 0, nqp::gethllsym('Raku', 'Iterable')),
+                    0, $container-fallback));
+        }
+        else {
+            # We always need to guard on type and concreteness.
+            my $rv := nqp::captureposarg($capture, 0);
+            my $rv_arg := nqp::dispatch('boot-syscall', 'dispatcher-track-arg',
+                    $capture, 0);
+            nqp::dispatch('boot-syscall', 'dispatcher-guard-type', $rv_arg);
+            nqp::dispatch('boot-syscall', 'dispatcher-guard-concreteness', $rv_arg);
 
-        # Is it a container?
-        if nqp::isconcrete_nd($rv) && nqp::iscont($rv) {
-            # It's a container. We have special cases for Scalar.
-            if nqp::istype_nd($rv, Scalar) {
-                # Check if the descriptor is undefined, in which case it's read-only.
-                my $desc := nqp::getattr($rv, Scalar, '$!descriptor');
-                my $desc_arg := nqp::dispatch('boot-syscall', 'dispatcher-track-attr',
-                        $rv_arg, Scalar, '$!descriptor');
-                nqp::dispatch('boot-syscall', 'dispatcher-guard-concreteness', $desc_arg);
-                if nqp::isconcrete($desc) {
-                    # Writeable, so we may need to recontainerize the value if
-                    # the type is iterable, otherwise we can decont it.
-                    my $value := nqp::getattr($rv, Scalar, '$!value');
-                    my $value_arg := nqp::dispatch('boot-syscall', 'dispatcher-track-attr',
-                        $rv_arg, Scalar, '$!value');
-                    nqp::dispatch('boot-syscall', 'dispatcher-guard-type', $value_arg);
-                    if nqp::istype_nd($value, nqp::gethllsym('Raku', 'Iterable')) {
-                        # Need to recont in order to preserve item nature.
-                        # Shuffle in the recont code to invoke. We already
-                        # read the deconted value, so we insert that as the
-                        # arg so it needn't be dereferenced again.
-                        nqp::dispatch('boot-syscall', 'dispatcher-delegate', 'boot-code-constant',
-                            nqp::dispatch('boot-syscall', 'dispatcher-insert-arg-literal-obj',
+            # Is it a container?
+            if nqp::isconcrete_nd($rv) && nqp::iscont($rv) {
+                # It's a container. We have special cases for Scalar.
+                if nqp::istype_nd($rv, Scalar) {
+                    # Check if the descriptor is undefined, in which case it's read-only.
+                    my $desc := nqp::getattr($rv, Scalar, '$!descriptor');
+                    my $desc_arg := nqp::dispatch('boot-syscall', 'dispatcher-track-attr',
+                            $rv_arg, Scalar, '$!descriptor');
+                    nqp::dispatch('boot-syscall', 'dispatcher-guard-concreteness', $desc_arg);
+                    if nqp::isconcrete($desc) {
+                        # Writeable, so we may need to recontainerize the value if
+                        # the type is iterable, otherwise we can decont it.
+                        my $value := nqp::getattr($rv, Scalar, '$!value');
+                        my $value_arg := nqp::dispatch('boot-syscall', 'dispatcher-track-attr',
+                            $rv_arg, Scalar, '$!value');
+                        nqp::dispatch('boot-syscall', 'dispatcher-guard-type', $value_arg);
+                        if nqp::istype_nd($value, nqp::gethllsym('Raku', 'Iterable')) {
+                            # Need to recont in order to preserve item nature.
+                            # Shuffle in the recont code to invoke. We already
+                            # read the deconted value, so we insert that as the
+                            # arg so it needn't be dereferenced again.
+                            nqp::dispatch('boot-syscall', 'dispatcher-delegate', 'boot-code-constant',
+                                nqp::dispatch('boot-syscall', 'dispatcher-insert-arg-literal-obj',
+                                    nqp::dispatch('boot-syscall', 'dispatcher-insert-arg',
+                                        nqp::dispatch('boot-syscall', 'dispatcher-drop-arg',
+                                            $capture, 0),
+                                        0, $value_arg),
+                                    0, $recont));
+                        }
+                        else {
+                            # Decont, so just evaluate to the read attr (boot-value
+                            # ignores all put the first argument).
+                            nqp::dispatch('boot-syscall', 'dispatcher-delegate', 'boot-value',
                                 nqp::dispatch('boot-syscall', 'dispatcher-insert-arg',
-                                    nqp::dispatch('boot-syscall', 'dispatcher-drop-arg',
-                                        $capture, 0),
-                                    0, $value_arg),
-                                0, $recont));
+                                    $capture, 0, $value_arg));
+                        }
                     }
                     else {
-                        # Decont, so just evaluate to the read attr (boot-value
-                        # ignores all put the first argument).
-                        nqp::dispatch('boot-syscall', 'dispatcher-delegate', 'boot-value',
-                            nqp::dispatch('boot-syscall', 'dispatcher-insert-arg',
-                                $capture, 0, $value_arg));
+                        # Read-only, so identity will do.
+                        nqp::dispatch('boot-syscall', 'dispatcher-delegate', 'boot-value', $capture);
                     }
                 }
                 else {
-                    # Read-only, so identity will do.
-                    nqp::dispatch('boot-syscall', 'dispatcher-delegate', 'boot-value', $capture);
+                    # Delegate to non-Scalar container fallback.
+                    nqp::dispatch('boot-syscall', 'dispatcher-delegate', 'boot-code-constant',
+                        nqp::dispatch('boot-syscall', 'dispatcher-insert-arg-literal-obj',
+                            nqp::dispatch('boot-syscall', 'dispatcher-insert-arg-literal-obj',
+                                $capture, 0, nqp::gethllsym('Raku', 'Iterable')),
+                            0, $container-fallback));
                 }
             }
             else {
-                # Delegate to non-Scalar container fallback.
-                nqp::dispatch('boot-syscall', 'dispatcher-delegate', 'boot-code-constant',
-                    nqp::dispatch('boot-syscall', 'dispatcher-insert-arg-literal-obj',
+                # Not containerizied, so identity shall do,
+                # Unless it is null, then we map it to Mu.
+                if nqp::isnull($rv) {
+                    nqp::dispatch('boot-syscall', 'dispatcher-delegate', 'boot-constant',
                         nqp::dispatch('boot-syscall', 'dispatcher-insert-arg-literal-obj',
-                            $capture, 0, nqp::gethllsym('Raku', 'Iterable')),
-                        0, $container-fallback));
-            }
-        }
-        else {
-            # Not containerizied, so identity shall do,
-            # Unless it is null, then we map it to Mu.
-            if nqp::isnull($rv) {
-                nqp::dispatch('boot-syscall', 'dispatcher-delegate', 'boot-constant',
-                    nqp::dispatch('boot-syscall', 'dispatcher-insert-arg-literal-obj',
-                        $capture, 0, Mu));
-            }
-            else {
-                nqp::dispatch('boot-syscall', 'dispatcher-delegate', 'boot-value', $capture);
+                            $capture, 0, Mu));
+                }
+                else {
+                    nqp::dispatch('boot-syscall', 'dispatcher-delegate', 'boot-value', $capture);
+                }
             }
         }
     });

--- a/src/vm/moar/dispatchers.nqp
+++ b/src/vm/moar/dispatchers.nqp
@@ -1,3 +1,8 @@
+# Some maximum cache sizes we allow at a callsite before we switch to a
+# megamorphic strategy.
+my int $MEGA-TYPE-CALLSITE-SIZE := 16;
+my int $MEGA-METH-CALLSITE-SIZE := 16;
+
 # Return value decontainerization dispatcher. Often we have nothing at all
 # to do, in which case we can make it identity. Other times, we need a
 # decont. In a few, we need to re-wrap it.
@@ -32,7 +37,7 @@
         # any conditions, which is faster than over-filling the cache and running
         # this dispatch logic every time.
         my int $cache-size := nqp::dispatch('boot-syscall', 'dispatcher-inline-cache-size');
-        if $cache-size >= 16 {
+        if $cache-size >= $MEGA-TYPE-CALLSITE-SIZE {
             nqp::dispatch('boot-syscall', 'dispatcher-delegate', 'boot-code-constant',
                 nqp::dispatch('boot-syscall', 'dispatcher-insert-arg-literal-obj',
                     nqp::dispatch('boot-syscall', 'dispatcher-insert-arg-literal-obj',
@@ -665,7 +670,7 @@ nqp::dispatch('boot-syscall', 'dispatcher-register', 'raku-meth-call', -> $captu
     my str $name := nqp::captureposarg_s($capture, 1);
     my $how := nqp::how_nd($obj);
     my int $cache-size := nqp::dispatch('boot-syscall', 'dispatcher-inline-cache-size');
-    if $cache-size >= 16 && nqp::istype($how, Perl6::Metamodel::ClassHOW) {
+    if $cache-size >= $MEGA-METH-CALLSITE-SIZE && nqp::istype($how, Perl6::Metamodel::ClassHOW) {
         nqp::dispatch('boot-syscall', 'dispatcher-delegate', 'raku-meth-call-mega',
             $capture);
     }
@@ -3084,7 +3089,8 @@ nqp::dispatch('boot-syscall', 'dispatcher-register', 'raku-find-meth', -> $captu
     my $how := nqp::how_nd($obj);
     my int $cache-size := nqp::dispatch('boot-syscall', 'dispatcher-inline-cache-size');
     my int $exceptional := nqp::captureposarg_i($capture, 2);
-    if $cache-size >= 8 && !$exceptional && nqp::istype($how, Perl6::Metamodel::ClassHOW) {
+    if $cache-size >= $MEGA-METH-CALLSITE-SIZE && !$exceptional &&
+            nqp::istype($how, Perl6::Metamodel::ClassHOW) {
         nqp::dispatch('boot-syscall', 'dispatcher-delegate', 'raku-find-meth-mega',
             $capture);
     }

--- a/src/vm/moar/dispatchers.nqp
+++ b/src/vm/moar/dispatchers.nqp
@@ -78,7 +78,7 @@
                         }
                         else {
                             # Decont, so just evaluate to the read attr (boot-value
-                            # ignores all put the first argument).
+                            # ignores all but the first argument).
                             nqp::dispatch('boot-syscall', 'dispatcher-delegate', 'boot-value',
                                 nqp::dispatch('boot-syscall', 'dispatcher-insert-arg',
                                     $capture, 0, $value_arg));

--- a/src/vm/moar/dispatchers.nqp
+++ b/src/vm/moar/dispatchers.nqp
@@ -1855,51 +1855,6 @@ sub raku-multi-plan(@candidates, $capture, int $stop-at-trivial, $orig-capture =
                 unless $type_mismatch || $rwness_mismatch {
                     nqp::push(@possibles, $cur_candidate);
                 }
-#                            if $rwness && !nqp::isrwcont(nqp::captureposarg($capture, $i)) {
-#                                # If we need a container but don't have one it clearly can't work.
-#                                $rwness_mismatch := 1;
-#                            }
-#                            elsif $type_flags +& $TYPE_NATIVE_MASK {
-#                                # Looking for a natively typed value. Did we get one?
-#                                if $got_prim == $BIND_VAL_OBJ {
-#                                    # Object, but could be a native container. If not, mismatch.
-#                                    my $contish := nqp::captureposarg($capture, $i);
-#                                    unless (($type_flags +& $TYPE_NATIVE_INT) && nqp::iscont_i($contish)) ||
-#                                           (($type_flags +& $TYPE_NATIVE_NUM) && nqp::iscont_n($contish)) ||
-#                                           (($type_flags +& $TYPE_NATIVE_STR) && nqp::iscont_s($contish)) {
-#                                        $type_mismatch := 1;
-#                                    }
-#                                }
-#                            }
-#                            else {
-#                                my $param;
-#                                if $got_prim == $BIND_VAL_OBJ {
-#                                    $param := nqp::captureposarg($capture, $i);
-#                                    if    nqp::iscont_i($param) { $param := Int; $primish := 1; }
-#                                    elsif nqp::iscont_n($param) { $param := Num; $primish := 1; }
-#                                    elsif nqp::iscont_s($param) { $param := Str; $primish := 1; }
-#                                    else { $param := nqp::hllizefor($param, 'Raku') }
-#                                }
-#                                if nqp::eqaddr($type_obj, Mu) || nqp::istype($param, $type_obj) {
-#                                    if $i == 0 && nqp::existskey($cur_candidate, 'exact_invocant') {
-#                                        unless $param.WHAT =:= $type_obj {
-#                                            $type_mismatch := 1;
-#                                        }
-#                                    }
-#                                }
-#                                else {
-#                                    if $type_obj =:= $Positional {
-#                                        my $PositionalBindFailover := nqp::gethllsym('Raku', 'MD_PBF');
-#                                        unless nqp::istype($param, $PositionalBindFailover) {
-#                                            $type_mismatch := 1;
-#                                        }
-#                                    } else {
-#                                        $type_mismatch := 1;
-#                                    }
-#                                }
-#                            }
-#                            ++$i;
-#                        }
             }
         }
         else {


### PR DESCRIPTION
One of the big changes in approach in `new-disp` is that we cache at callsites rather than at destinations. That enables all kinds of performance improvements, but it is less good for callsites that are megamorphic (encounter a huge variety in the arguments used for dispatch, for example a method call where there are numerous different types or method names called).

This PR gets us doing better in a number of such situations: upon detecting a callsite is heading megamorphic, it changes strategy. These approaches are largely those taken in NQP's dispatchers, which mostly derive from the assumption that even if there is huge variance at a callsite at the value level, there will typically be a lot less (or almost no) variance at the meta level (for example, all the types are a `ClassHOW`).