### PR TITLE
Use distribution specific comp unit ids in CURFS

### DIFF
--- a/src/core.c/CompUnit/Repository/FileSystem.pm6
+++ b/src/core.c/CompUnit/Repository/FileSystem.pm6
@@ -24,7 +24,7 @@ class CompUnit::Repository::FileSystem
     }
 
     method !comp-unit-id($name) {
-        CompUnit::PrecompilationId.new-from-string(self.id ~ $name);
+        CompUnit::PrecompilationId.new-from-string(self!distribution.id ~ $name);
     }
 
     method !precomp-stores() {


### PR DESCRIPTION
This is a corrected version of 33296d4 similar to 8fc643e except without the incorrect assumption about repo-id introduced in 02c13fa.