### PR TITLE
Add a IterationBuffer.new(iterable) candidate

### DIFF
--- a/src/core.c/IterationBuffer.pm6
+++ b/src/core.c/IterationBuffer.pm6
@@ -11,6 +11,12 @@
 # of Raku. Do NOT add any checks and validation to methods in here. They
 # need to remain trivially inlinable for performance reasons.
 my class IterationBuffer {
+
+    multi method new(IterationBuffer:U: Iterable:D \iterable) {
+        iterable.iterator.push-all(my \buffer := nqp::create(self));
+        buffer
+    }
+
     method clear(IterationBuffer:D: --> Nil) {
         nqp::setelems(self, 0)
     }


### PR DESCRIPTION
To facilitate initializing iteration buffers.  Makes

    IterationBuffer.new(<a b c d e f g h i j>);

about 2x as fast as:

    my $b := IterationBuffer.new;
    $b.push($_) for <a b c d e f g h i j>;
    $b