### PR TITLE
Clarify let and temp operators

### DIFF
--- a/src/core.c/Array.pm6
+++ b/src/core.c/Array.pm6
@@ -1336,6 +1336,27 @@ my class Array { # declared in BOOTSTRAP
         }
     }
 
+    my class LTHandle {
+        has Mu $!reified;
+        has Mu $!todo;
+        has Mu $!descriptor;
+    }
+
+    method TEMP-LET-LOCALIZE() is raw is implementation-detail {
+        my \handle = nqp::create(LTHandle);
+        nqp::bindattr(handle, LTHandle, '$!reified', nqp::getattr(self, List, '$!reified'));
+        nqp::bindattr(handle, LTHandle, '$!todo', nqp::getattr(self, List, '$!todo'));
+        nqp::bindattr(handle, LTHandle, '$!descriptor', nqp::getattr(self, Array, '$!descriptor'));
+        self.STORE: self.clone;
+        handle
+    }
+
+    method TEMP-LET-RESTORE(\handle --> Nil) is implementation-detail {
+        nqp::bindattr(self, List, '$!reified', nqp::getattr(handle, LTHandle, '$!reified'));
+        nqp::bindattr(self, List, '$!todo', nqp::getattr(handle, LTHandle, '$!todo'));
+        nqp::bindattr(self, Array, '$!descriptor', nqp::getattr(handle, LTHandle, '$!descriptor'));
+    }
+
     method ^parameterize(Mu:U \arr, Mu \of) {
         if nqp::isconcrete(of) {
             die "Can not parameterize {arr.^name} with {of.raku}"

--- a/src/core.c/Hash/Object.pm6
+++ b/src/core.c/Hash/Object.pm6
@@ -280,6 +280,27 @@ my role Hash::Object[::TValue, ::TKey] does Associative[TValue] {
           !! nqp::create(Capture)
     }
     method Map() { self.pairs.Map }
+
+    method TEMP-LET-LOCALIZE() is raw is implementation-detail {
+        my \handle = self.TEMP-LET-GET-HANDLE;
+        my \iter = nqp::iterator(nqp::getattr(self, Map, '$!storage'));
+        nqp::bindattr(self, Map, '$!storage', my \new-storage = nqp::hash);
+        nqp::while(
+            iter,
+            nqp::stmts(
+                nqp::shift(iter),
+                # What we do here is very much stripped down versions of ASSIGN-KEY and BIND-KEY.
+                (my \p = nqp::iterval(iter)),
+                nqp::bindkey(
+                    new-storage,
+                    nqp::iterkey_s(iter),
+                    Pair.new(
+                        p.key,
+                        nqp::if( nqp::iscont(my \v = p.value),
+                                 nqp::p6assign(nqp::p6scalarfromdesc(nqp::getattr(self, Hash, '$!descriptor')), v),
+                                 v )))));
+        handle
+    }
 }
 
 # vim: expandtab shiftwidth=4

--- a/src/core.c/Rakudo/Internals.pm6
+++ b/src/core.c/Rakudo/Internals.pm6
@@ -227,19 +227,11 @@ my class Rakudo::Internals {
               nqp::iscont(cont),
               nqp::push(restore,nqp::decont(cont)),
               nqp::if(
-                nqp::istype(cont,Array),
-                nqp::push(restore,cont.clone),
-                nqp::if(
-                  nqp::istype(cont,Hash),
-                  nqp::push(restore,
-                    nqp::p6bindattrinvres(
-                      Hash.^parameterize(Mu,Mu).new,
-                      Hash, '$!descriptor',
-                      nqp::getattr(cont, Hash, '$!descriptor')).STORE: cont),
-                  nqp::stmts(
-                    nqp::pop(restore),  # lose the erroneously pushed value
-                    X::Localizer::NoContainer.new(:$localizer).throw
-                  )
+                nqp::can(cont,'TEMP-LET-LOCALIZE'),
+                nqp::push(restore,cont.TEMP-LET-LOCALIZE),
+                nqp::stmts(
+                  nqp::pop(restore),  # lose the erroneously pushed value
+                  X::Localizer::NoContainer.new(:$localizer).throw
                 )
               )
             )


### PR DESCRIPTION
Make sure they preserve and restore holes in arrays (though preserving currently depends on `clone` method implementation) and conterization of elements.

The new implementation shifts the locus of control to `Array` and `Hash` themselve, leaving it up to `Rakudo::Internals` to deal with `Scalars`. The latter was done to allow the backend VM take better care of
optimizations.

With regard to the non-scalar containers, they're expected to provide two methods: `TEMP-LET-LOCALIZE` and `TEMP-LET-RESTORE`. The first is expected to return a handle which would let `TEMP-LET-RESTORE` recover the initial state of the container. The handle object is not constrained in neither way and it is totally up to the implementation to choose what the handle is.

The reason for this new approach is that normally a container would know better how to preserve and restore its internal state. This new approach also allows for third-party containers to provide full support for `let` and `temp` operators with ease.