### PR TITLE
Fix gisting a Buf or Blob parameterized with an unsized type

### DIFF
--- a/src/core.c/Buf.pm6
+++ b/src/core.c/Buf.pm6
@@ -350,8 +350,10 @@ my role Blob[::T = uint8] does Positional[T] does Stringy is repr('VMArray') is 
     );
 
     multi method gist(Blob:D:) {
-        my int $todo =
-          nqp::elems(self) min nqp::div_i(200,nqp::div_i(T.^nativesize,4) || 1);
+        # (u)int don't have a nativesize, so just assume 64-bit for them
+        my int $nativesize = nqp::div_i(T.^nativesize // int64.^nativesize, 4) || 1;
+
+        my int $todo = nqp::elems(self) min nqp::div_i(200,$nativesize);
         my int $i   = -1;
         my $chunks := nqp::list_s;
 
@@ -360,7 +362,7 @@ my role Blob[::T = uint8] does Positional[T] does Stringy is repr('VMArray') is 
           nqp::stmts(
             (my int $elem   = nqp::atpos_i(self,$i)),
             (my     $chunk := nqp::list_s),
-            (my int $size   = nqp::div_i(T.^nativesize,4) || 1),
+            (my int $size   = $nativesize),
             nqp::while(
               nqp::isgt_i($size,0),
               nqp::stmts(


### PR DESCRIPTION
The unsized natives don't have their $!nativesize set, so just assume
64-bit for them.

Rakudo builds ok and passes `make m-test m-spectest`. The example @dogbert17++ showed (`sub a (int $a) { Blob[int].new($a) }; say a 12;`) now prints `Blob[int]:0x<000000000000000C>` instead of dying with `Cannot unbox a type object (NQPMu) to int.`.