### PR TITLE
Add a Str.substr-between method

### DIFF
--- a/src/core.c/Cool.pm6
+++ b/src/core.c/Cool.pm6
@@ -171,6 +171,13 @@ my class Cool { # declared in BOOTSTRAP
         (SELF = self.Str).substr-rw(from, want)
     }
 
+    proto method substr-between(|) {*}
+    multi method substr-between(Cool:D:
+      Cool:D $before, Cool:D $after
+    --> Bool:D) {
+        self.Str.substr-between($before.Str, $after.Str)
+    }
+
     proto method substr-eq(|) {*}
     multi method substr-eq(Cool:D:
       Cool:D $needle, :i(:$ignorecase)!, :m(:$ignoremark) --> Bool:D) {

--- a/src/core.c/Str.pm6
+++ b/src/core.c/Str.pm6
@@ -248,6 +248,23 @@ my class Str does Stringy { # declared in BOOTSTRAP
         )
     }
 
+    multi method substr-between(Str:D $before, Str:D $after, Int:D $pos = 0) {
+        my int $left = nqp::index(self, $before, $pos);
+        if $left > -1 {
+            my int $right = nqp::index(self, $after, $left);
+            if $right > -1 {
+                my int $offset = $left + nqp::chars($before);
+                nqp::substr(self, $offset, $right - $offset)
+            }
+            else {
+                Nil
+            }
+        }
+        else {
+            Nil
+        }
+    }
+
     multi method substr-eq(Str:D:
       Str:D $needle, Int:D $pos, :i(:$ignorecase)!, :m(:$ignoremark)
     --> Bool:D) {


### PR DESCRIPTION
Returns the substring that is between the two given strings in a
string.  Effectively a shortcut to:

    with $string.match(/ '$before' <( .*? )> '$after') {
        .Str
    }
    else {
        Nil
    }

But does not use the regex engine, so is up to 5x as fast.

This is a proof of concept.  If so accepted, support for regexes for before / after and support for :ignorecase and :ignoremark could be added.