### PR TITLE
Use better default for nativesize in Buf/Blob gist

### DIFF
--- a/src/core.c/Buf.pm6
+++ b/src/core.c/Buf.pm6
@@ -351,7 +351,7 @@ my role Blob[::T = uint8] does Positional[T] does Stringy is repr('VMArray') is 
 
     multi method gist(Blob:D:) {
         # (u)int don't have a nativesize, so just assume 64-bit for them
-        my int $nativesize = nqp::div_i(T.^nativesize // int64.^nativesize, 4) || 1;
+        my int $nativesize = nqp::div_i(T.^nativesize // $?BITS, 4) || 1;
 
         my int $todo = nqp::elems(self) min nqp::div_i(200,$nativesize);
         my int $i   = -1;


### PR DESCRIPTION
Instead of just picking 64 bits if the type doen't have a populated
nativesize, use the size that the Rakudo compiler was built with.

Kaiepi++

Rakudo builds ok and passes `make m-test m-spectest`.