### PR TITLE
Add a Str.substr-before method.

### DIFF
--- a/src/core.c/Cool.pm6
+++ b/src/core.c/Cool.pm6
@@ -171,6 +171,11 @@ my class Cool { # declared in BOOTSTRAP
         (SELF = self.Str).substr-rw(from, want)
     }
 
+    proto method substr-before(|) {*}
+    multi method substr-before(Cool:D: Cool:D $before, Int:D $pos = 0) {
+        self.Str.substr-before($before.Str, $pos)
+    }
+
     proto method substr-eq(|) {*}
     multi method substr-eq(Cool:D:
       Cool:D $needle, :i(:$ignorecase)!, :m(:$ignoremark) --> Bool:D) {

--- a/src/core.c/Str.pm6
+++ b/src/core.c/Str.pm6
@@ -248,6 +248,12 @@ my class Str does Stringy { # declared in BOOTSTRAP
         )
     }
 
+    multi method substr-before(Str:D $before, Int:D $pos = 0) {
+        (my int $left = nqp::index(self, $before, $pos)) > -1
+          ?? nqp::substr(self, $pos, $left - $pos)
+          !! Nil
+    }
+
     multi method substr-eq(Str:D:
       Str:D $needle, Int:D $pos, :i(:$ignorecase)!, :m(:$ignoremark)
     --> Bool:D) {


### PR DESCRIPTION
Returns the substring that is before a given string in a
string. Effectively a shortcut to:

    with $string.match(/ .*? )> '$before') {
        .Str
    }
    else {
        Nil
    }

But does not use the regex engine, so is up to 5x as fast.

Also a proof of concept, with support for regex and :ignorecase and :ignoremark to be added.