### PR TITLE
Add a Str.substr-after method

### DIFF
--- a/src/core.c/Cool.pm6
+++ b/src/core.c/Cool.pm6
@@ -171,6 +171,11 @@ my class Cool { # declared in BOOTSTRAP
         (SELF = self.Str).substr-rw(from, want)
     }
 
+    proto method substr-after(|) {*}
+    multi method substr-after(Cool:D: Cool:D $after, Int:D $pos = 0) {
+        self.Str.substr-after($after.Str, $pos)
+    }
+
     proto method substr-eq(|) {*}
     multi method substr-eq(Cool:D:
       Cool:D $needle, :i(:$ignorecase)!, :m(:$ignoremark) --> Bool:D) {

--- a/src/core.c/Str.pm6
+++ b/src/core.c/Str.pm6
@@ -248,6 +248,13 @@ my class Str does Stringy { # declared in BOOTSTRAP
         )
     }
 
+    multi method substr-after(Str:D: Str:D $after, Int:D $pos = 0) {
+        my int $right = nqp::index(self, $after, $pos);
+        $right > -1
+          ?? nqp::substr(self, $right + nqp::chars($after))
+          !! Nil
+    }
+
     multi method substr-eq(Str:D:
       Str:D $needle, Int:D $pos, :i(:$ignorecase)!, :m(:$ignoremark)
     --> Bool:D) {


### PR DESCRIPTION
Returns the substring that is after a given string in a
string. Effectively a shortcut to:

    with $string.match(/ '$after' <( .* /) {
        .Str
    }
    else {
        Nil
    }

But does not use the regex engine, so is up to 5x as fast.

Proof of concept.  If accepted, support for regex and :ignorecase and :ignoremark will be added.