### PR TITLE
Add a Str.rinse method

### DIFF
--- a/src/core.c/Cool.pm6
+++ b/src/core.c/Cool.pm6
@@ -171,6 +171,11 @@ my class Cool { # declared in BOOTSTRAP
         (SELF = self.Str).substr-rw(from, want)
     }
 
+    proto method rinse(|) {*}
+    multi method rinse(Cool:D: Cool:D $dirt, Int:D $pos = 0) {
+        self.Str.rinse($dirt.Str, $pos)
+    }
+
     proto method substr-eq(|) {*}
     multi method substr-eq(Cool:D:
       Cool:D $needle, :i(:$ignorecase)!, :m(:$ignoremark) --> Bool:D) {

--- a/src/core.c/Str.pm6
+++ b/src/core.c/Str.pm6
@@ -248,6 +248,15 @@ my class Str does Stringy { # declared in BOOTSTRAP
         )
     }
 
+    multi method rinse(Str:D: Str:D $dirt, Int:D $pos = 0) {
+        $pos
+          ?? nqp::concat(
+               nqp::substr(self,0,$pos),
+               nqp::join("",nqp::split($dirt,nqp::substr(self,$pos)))
+             )
+          !! nqp::join("",nqp::split($dirt,self))
+    }
+
     multi method substr-eq(Str:D:
       Str:D $needle, Int:D $pos, :i(:$ignorecase)!, :m(:$ignoremark)
     --> Bool:D) {


### PR DESCRIPTION
Returns the substring that cleansed of the given string.
Effectively a shortcut to:

     $string.subst($dirt, :global);

but a bit faster.  At least this may be more semantically
pleasing.

If accepted, could have support for regexes added.  This would then most likely still be faster than the equivalent `.subst` because no `Match` objects would have to be made.