### PR TITLE
Make "raku" the authority of core modules

### DIFF
--- a/tools/build/install-core-dist.raku
+++ b/tools/build/install-core-dist.raku
@@ -44,7 +44,7 @@ $REPO.install(
     Distribution::Hash.new(
         {
             name     => 'CORE',
-            auth     => 'perl',
+            auth     => 'raku',
             ver      => $*RAKU.version.Str,
             provides => %provides,
         },


### PR DESCRIPTION
Seems to me that "perl" is a bit...  outdated.  And changing it to "raku" doesn't break any tests.