### PR TITLE
Remove support for use experimental :collation

### DIFF
--- a/lib/experimental.rakumod
+++ b/lib/experimental.rakumod
@@ -192,13 +192,4 @@ package EXPORT::pack {
     OUR::{'&pack'}           := &pack;
 }
 
-package EXPORT::collation {
-    # this is no longer experimental, but keep the package to prevent
-    # code that caters to this and earlier versions of compilers from
-    # breaking
-    #
-    # XXX TODO: should be fine to remove on 2019-12. There is also a test
-    # in t/02-rakudo/99-misc.t that will need to be removed too at the time
-}
-
 # vim: expandtab shiftwidth=4

--- a/t/02-rakudo/99-misc.t
+++ b/t/02-rakudo/99-misc.t
@@ -139,7 +139,6 @@ group-of 2 => 'collation experiment' => {
     is-run ｢$*COLLATION.set: :primary; print 'pass'｣,
         :out<pass>, '$*COLLATION.set no longer requires experimental pragma';
     is-run ｢
-        use experimental :collation;
         $*COLLATION.set: :primary;
         print 'pass'
     ｣, :out<pass>, :compiler-args[<-I lib>], 'we can still use the pragma (to support old code)';


### PR DESCRIPTION
It is now supported by default, and was marked to be deleted in
2019, so seems to have ample sunsetting time for this feature.