### PR TITLE
Abstract virtual core META6.json into a module

### DIFF
--- a/lib/Rakudo/CORE/META.rakumod
+++ b/lib/Rakudo/CORE/META.rakumod
@@ -1,0 +1,38 @@
+unit class Rakudo::CORE;
+
+our %META = BEGIN { 
+    my %provides = 
+      "Test"                          => "lib/Test.rakumod",
+      "NativeCall"                    => "lib/NativeCall.rakumod",
+      "NativeCall::Types"             => "lib/NativeCall/Types.rakumod",
+      "NativeCall::Compiler::GNU"     => "lib/NativeCall/Compiler/GNU.rakumod",
+      "NativeCall::Compiler::MSVC"    => "lib/NativeCall/Compiler/MSVC.rakumod",
+      "Pod::To::Text"                 => "lib/Pod/To/Text.rakumod",
+      "newline"                       => "lib/newline.rakumod",
+      "experimental"                  => "lib/experimental.rakumod",
+      "CompUnit::Repository::Staging" => "lib/CompUnit/Repository/Staging.rakumod",
+      "Telemetry"                     => "lib/Telemetry.rakumod",
+      "snapper"                       => "lib/snapper.rakumod",
+      "safe-snapper"                  => "lib/safe-snapper.rakumod",
+      "BUILDPLAN"                     => "lib/BUILDPLAN.rakumod",
+      "Rakudo::CORE::META"            => "lib/Rakudo/CORE/META.rakumod",
+    ;
+
+    if Compiler.backend eq 'moar' {
+        %provides<MoarVM::Profiler> = "lib/MoarVM/Profiler.rakumod";
+        %provides<MoarVM::Spesh>    = "lib/MoarVM/Spesh.rakumod";
+        %provides<MoarVM::SL>       = "lib/MoarVM/SL.rakumod";
+        %provides<SL>               = "lib/SL.rakumod";
+        %provides<MoarVM::SIL>      = "lib/MoarVM/SIL.rakumod";
+        %provides<SIL>              = "lib/SIL.rakumod";
+    }
+
+    %(
+      name     => 'CORE',
+      auth     => 'perl',
+      ver      => $*RAKU.version.Str,
+      provides => %provides,
+    )
+}
+
+# vim: expandtab sw=4

--- a/tools/build/install-core-dist.raku
+++ b/tools/build/install-core-dist.raku
@@ -2,31 +2,7 @@ use v6.d;
 
 use lib <lib>;
 use CompUnit::Repository::Staging;
-
-my %provides = 
-    "Test"                          => "lib/Test.rakumod",
-    "NativeCall"                    => "lib/NativeCall.rakumod",
-    "NativeCall::Types"             => "lib/NativeCall/Types.rakumod",
-    "NativeCall::Compiler::GNU"     => "lib/NativeCall/Compiler/GNU.rakumod",
-    "NativeCall::Compiler::MSVC"    => "lib/NativeCall/Compiler/MSVC.rakumod",
-    "Pod::To::Text"                 => "lib/Pod/To/Text.rakumod",
-    "newline"                       => "lib/newline.rakumod",
-    "experimental"                  => "lib/experimental.rakumod",
-    "CompUnit::Repository::Staging" => "lib/CompUnit/Repository/Staging.rakumod",
-    "Telemetry"                     => "lib/Telemetry.rakumod",
-    "snapper"                       => "lib/snapper.rakumod",
-    "safe-snapper"                  => "lib/safe-snapper.rakumod",
-    "BUILDPLAN"                     => "lib/BUILDPLAN.rakumod",
-;
-
-if Compiler.backend eq 'moar' {
-    %provides<MoarVM::Profiler> = "lib/MoarVM/Profiler.rakumod";
-    %provides<MoarVM::Spesh>    = "lib/MoarVM/Spesh.rakumod";
-    %provides<MoarVM::SL>       = "lib/MoarVM/SL.rakumod";
-    %provides<SL>               = "lib/SL.rakumod";
-    %provides<MoarVM::SIL>      = "lib/MoarVM/SIL.rakumod";
-    %provides<SIL>              = "lib/SIL.rakumod";
-}
+use Rakudo::CORE::META;
 
 my $prefix := @*ARGS[0];
 my $REPO := PROCESS::<$REPO> := CompUnit::Repository::Staging.new(
@@ -42,12 +18,7 @@ my $REPO := PROCESS::<$REPO> := CompUnit::Repository::Staging.new(
 );
 $REPO.install(
     Distribution::Hash.new(
-        {
-            name     => 'CORE',
-            auth     => 'perl',
-            ver      => $*RAKU.version.Str,
-            provides => %provides,
-        },
+        %Rakudo::CORE::META,
         prefix => $*CWD,
     ),
     :force,
@@ -64,6 +35,7 @@ my $source-id :=
 my $source      := $REPO.prefix.child('sources').child($source-id);
 my $source-file := $source.relative($REPO.prefix);
 
+
 $REPO.precomp-repository.precompile(
         $source,
         CompUnit::PrecompilationId.new($source-id),
@@ -71,6 +43,6 @@ $REPO.precomp-repository.precompile(
         :force,
 );
 
-note "    Installed {%provides.elems} core modules in {now - INIT now} seconds!";
+note "    Installed {%Rakudo::CORE::META<provides>.elems} core modules in {now - INIT now} seconds!";
 
 # vim: expandtab sw=4


### PR DESCRIPTION
The install-core-dist.raku script kept the information about which files are actually part of the Rakudo core distribution to itself.

This commit extracts that information into a separate module, so that other programs can get at the meta information in a reliable manner.

This adds a `lib/Rakudo/CORE/META.rakumod` file that makes the meta information available in `%Rakudo::CORE::META` when loaded.

````raku
use Rakudo::CORE::META;
say "Contains %Rakudo::CORE::META<provides>elems() modules";
````