### PR TITLE
Disallow cmp with a Junction

### DIFF
--- a/src/core.c/Exception.pm6
+++ b/src/core.c/Exception.pm6
@@ -2356,6 +2356,14 @@ my class X::Sequence::Endpoint is Exception {
     }
 }
 
+my class X::Cannot::Junction is Exception {
+    has $.junction;
+    has $.for;
+    method message() {
+        "Cannot use Junction '$.junction' $.for."
+    }
+}
+
 my class X::Cannot::Map is Exception {
     has $.what   = "(<unknown type>)";
     has $.using  = "(<an unknown expression>)";

--- a/src/core.c/Order.pm6
+++ b/src/core.c/Order.pm6
@@ -11,6 +11,20 @@ sub ORDER(int $i --> Order) is implementation-detail {
 }
 
 proto sub infix:<cmp>($, $, *% --> Order:D) is pure {*}
+# stub needed otherwise you get `Could not find symbol '&Junction' in 'X::Cannot'` at runtime
+my class X::Cannot::Junction { ... }
+multi sub infix:<cmp>(\a, Junction:D $b) {
+    X::Cannot::Junction.new(
+        junction => $b.raku,
+        for      => 'with cmp, Junctions are not comparable',
+    ).throw
+}
+multi sub infix:<cmp>(Junction:D $a, \b) {
+    X::Cannot::Junction.new(
+        junction => $a.raku,
+        for      => 'with cmp, Junctions are not comparable',
+    ).throw
+}
 multi sub infix:<cmp>(\a, \b) {
     nqp::eqaddr(nqp::decont(a), nqp::decont(b))
       ?? Same


### PR DESCRIPTION
Rakudo builds ok and passes `make m-test m-spectest`.

Now `say (9, 3, 1, any(4, 5, 6, 7, 500), "a").sort` dies with `Cannot use Junction 'any(4, 5, 6, 7, 500)' with cmp, Junctions are not comparable.` instead of printing `(a any(4, 5, 6, 7, 500) 1 3 9)`.