### PR TITLE
Fix segfaults when multiple threads initialize dynamics

### DIFF
--- a/src/Perl6/Metamodel/Stashing.nqp
+++ b/src/Perl6/Metamodel/Stashing.nqp
@@ -4,6 +4,7 @@ role Perl6::Metamodel::Stashing {
         unless nqp::isnull($stash_type) {
             my $attr_type := Perl6::Metamodel::Configuration.stash_attr_type;
             my $stash := nqp::create($stash_type);
+            nqp::bindattr($stash, $stash_type, '$!lock', NQPLock.new);
             nqp::bindattr($stash, $attr_type, '$!storage', my %symbols);
             nqp::bindattr_s($stash, $stash.WHAT, '$!longname',
                 $type_obj.HOW.name($type_obj));

--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -3663,9 +3663,11 @@ BEGIN {
 
     # Set up Stash type, which is really just a hash with a name.
     # class Stash is Hash {
-	#     has str $!longname;
+    #     has str $!longname;
+    #     has $!lock;
     Stash.HOW.add_parent(Stash, Hash);
     Stash.HOW.add_attribute(Stash, Attribute.new(:name<$!longname>, :type(str), :package(Stash)));
+    Stash.HOW.add_attribute(Stash, Attribute.new(:name<$!lock>, :type(Any), :package(Stash)));
     Stash.HOW.compose_repr(Stash);
 
     # Configure the stash type.

--- a/src/core.c/CallFrame.pm6
+++ b/src/core.c/CallFrame.pm6
@@ -21,7 +21,7 @@ my class CallFrame {
             )
           ),
           ($!my :=
-            nqp::p6bindattrinvres(nqp::create(Stash),Map,'$!storage',$ctx)),
+            nqp::p6bindattrinvres(Stash.new,Map,'$!storage',$ctx)),
           self
         )
     }

--- a/src/core.c/CompUnit/Handle.pm6
+++ b/src/core.c/CompUnit/Handle.pm6
@@ -40,7 +40,7 @@ class CompUnit::Handle {
             my $EXPORT := nqp::atkey($module, 'EXPORT');
             nqp::istype($EXPORT.WHO, Stash)
                 ?? $EXPORT.WHO
-                !! nqp::p6bindattrinvres(nqp::create(Stash), Map, '$!storage', $EXPORT.WHO);
+                !! nqp::p6bindattrinvres(Stash.new, Map, '$!storage', $EXPORT.WHO);
         }
         else {
             Nil
@@ -56,7 +56,7 @@ class CompUnit::Handle {
             my $who := $EXPORTHOW.WHO;
             nqp::istype($who, Stash)
                 ?? $who
-                !! nqp::p6bindattrinvres(nqp::create(Stash), Map, '$!storage', $who);
+                !! nqp::p6bindattrinvres(Stash.new, Map, '$!storage', $who);
         }
         else {
             Nil


### PR DESCRIPTION
When multiple threads try to access an uninitialized dynamic like $*PROGRAM-NAME
at the same time, they all will run the initialization code. This is mostly
benign (just a little wasteful) but the actual assignment into the PROCESS::
stash may lead to segfault as that's unsafe writing into a hash. Indeed, this
not only affects PROCESS variables, but stashes in general. Since stashes are
usually global data, any write access (e.g. when loading modules) can lead to
threading issues.

Since we can assume stashes to be read-mostly data structures, we fix this by
cloning the stash's storage, modifying that and replacing the storage while
holding a lock to protect against other concurrent writers. This way read
access will be safe without further concurrency protections.