### PR TITLE
Support Terminal::LineEditor in the Raku REPL

### DIFF
--- a/docs/line-editor.pod
+++ b/docs/line-editor.pod
@@ -9,9 +9,11 @@ provide much of the same functionality.
 
 =head2 AVAILABLE EDITORS
 
-Right now, there are new line editor modules available: C<Readline> and C<Linenoise>.
-They have roughly the same functionality, but C<Linenoise> provides tab completion,
-and C<Readline> has an easier time with multibyte input.
+Right now, there are three line editor modules available: C<Readline>,
+C<Linenoise>, and C<LineEditor> (installed via C<Terminal::LineEditor>).  They
+have roughly the same functionality, but C<Linenoise> provides tab completion,
+while C<Readline> and C<LineEditor> both have an easier time with multibyte
+input.
 
 =head2 ENVIRONMENT VARIABLES
 
@@ -27,13 +29,16 @@ This disables multi-line input for the REPL if truthy.
 =item RAKUDO_HIST
 
 This specifies the location of the history file used by the line editor; the
-default is C<~/.perl6/rakudo-history>.
+default is C<~/.raku/rakudo-history>.  Before Rakudo version 2020.02 the
+default was C<~/.perl6/rakudo-history>.  If the older default file exists and
+the newer one does not, it will be automatically migrated.
+
 
 =item RAKUDO_LINE_EDITOR
 
 This specifies the preferred line editor to use; valid values are C<Readline>,
-C<Linenoise>, and C<none>.  A value of C<none> is useful if you want to avoid
-the recommendation message upon REPL startup.
+C<Linenoise>, C<LineEditor>, and C<none>.  A value of C<none> is useful if you
+want to avoid the recommendation message upon REPL startup.
 
 =back
 

--- a/docs/running.pod
+++ b/docs/running.pod
@@ -157,8 +157,8 @@ emitted.
 =item C<RAKUDO_LINE_EDITOR>
 
 This specifies the preferred line editor to use; valid values are C<Readline>,
-C<Linenoise>, and none. A value of none is useful if you want to avoid the
-recommendation message upon REPL startup.
+C<Linenoise>, C<LineEditor>, and C<none>. A value of C<none> is useful if you
+want to avoid the recommendation message upon REPL startup.
 
 =item C<RAKUDO_DISABLE_MULTILINE>
 
@@ -166,10 +166,10 @@ If set to 1, will disable multiline input for the REPL.
 
 =item C<RAKUDO_HIST>
 
-This specifies the location of the history file used by the
-line editor; the default is C<~/.raku/rakudo-history>.
-Before Rakudo version 2020.02 the default was
-C<~/.perl6/rakudo-history>.
+This specifies the location of the history file used by the line editor; the
+default is C<~/.raku/rakudo-history>.  Before Rakudo version 2020.02 the
+default was C<~/.perl6/rakudo-history>.  If the older default file exists and
+the newer one does not, it will be automatically migrated.
 
 =back
 

--- a/src/core.c/REPL.pm6
+++ b/src/core.c/REPL.pm6
@@ -102,13 +102,17 @@ do {
 
     my role TerminalLineEditorBehavior[$WHO] {
         my $cli-input = $WHO<CLIInput>;
-        my $cli = $cli-input.new;
+        my $cli;
 
-        # method completions-for-line(Str $line, int $cursor-index) { ... }
+        method completions-for-line(Str $line, int $cursor-index) { ... }
 
         method history-file(--> Str:D) { ... }
 
         method init-line-editor {
+            my sub get-completions($contents, $pos) {
+                eager self.completions-for-line($contents, $pos)
+            }
+            $cli = $cli-input.new(:&get-completions);
             $cli.load-history($.history-file);
         }
 
@@ -117,6 +121,7 @@ do {
         }
 
         method repl-read(Mu \prompt) {
+            self.update-completions;
             my $line = $cli.prompt(prompt);
 
             if $line.defined && $line.match(/\S/) {

--- a/src/core.c/REPL.pm6
+++ b/src/core.c/REPL.pm6
@@ -198,7 +198,8 @@ do {
         has $!need-more-input = {};
         has $!control-not-allowed = {};
 
-        sub do-mixin($self, Str $module-name, $behavior, Str :$fallback, Bool :$classlike) {
+        sub do-mixin($self, Str $module-name, $behavior, :@extra-modules,
+                     Str :$fallback, Bool :$classlike) {
             my Bool $problem = False;
             try {
                 CATCH {
@@ -217,6 +218,7 @@ do {
                     }
                 }
 
+                (require ::($_)) for @extra-modules;
                 my $module = do require ::($module-name);
                 my $who = $classlike ?? $module.WHO !! $module.WHO<EXPORT>.WHO<ALL>.WHO;
                 my $new-self = $self but $behavior.^parameterize($who);
@@ -236,10 +238,9 @@ do {
         }
 
         sub mixin-terminal-lineeditor($self, |c) {
-            (try require ::('Terminal::LineEditor::RawTerminalInput')) === Nil
-                 and return ( Any, False );
-            do-mixin($self, 'Terminal::LineEditor',
-                     TerminalLineEditorBehavior, :classlike, |c)
+            do-mixin($self, 'Terminal::LineEditor', TerminalLineEditorBehavior,
+                     :extra-modules('Terminal::LineEditor::RawTerminalInput',),
+                     :classlike, |c)
         }
 
         sub mixin-line-editor($self) {

--- a/t/02-rakudo/repl.t
+++ b/t/02-rakudo/repl.t
@@ -8,7 +8,8 @@ plan 47;
 my $eof = $*DISTRO.is-win ?? "'^Z'" !! "'^D'";
 my $*REPL-SCRUBBER = -> $_ is copy {
     $_ = .lines.skip(4).join("\n");
-    s/^^ "You may want to `zef install Readline` or `zef install Linenoise`"
+    s/^^ "You may want to `zef install Readline`, `zef install Linenoise`,"
+        " or `zef install Terminal::LineEditor`"
         " or use rlwrap for a line editor\n\n"//;
     s/^^ "To exit type 'exit' or $eof\n"//;
     s:g/ ^^ "> "  //; # Strip out the prompts
@@ -164,12 +165,13 @@ is-run-repl ['Nil'], /Nil/, 'REPL outputs Nil as a Nil';
     skip 'Result differs on OSX';
     # is-run-repl ['say "hi"'], {
     #     .subst(:g, /\W+/, '') eq
-    #     'YoumaywanttozefinstallReadlineorzefinstallLinenoise'
+    #     'YoumaywanttozefinstallReadlinezefinstallLinenoise'
+    #     ~ 'orzefinstallTerminalLineEditor'
     #     ~ 'oruserlwrapforalineeditor' ~ 'ToexittypeexitorD' ~ 'hi'
     # }, 'REPL session does not have unexpected stuff';
 
-    ## XXX TODO: need to write tests that exercise the REPL with Linenoise
-    # and Readline installed. Particular things to check:
+    ## XXX TODO: need to write tests that exercise the REPL with Linenoise,
+    # Readline, and Terminal::LineEditor installed. Particular things to check:
     # 1. History file can be made on all OSes:
     #    https://github.com/rakudo/rakudo/commit/b4fa6d6792dd02424d2182b73c31a071cddc0b8e
     # 2. Test REPL does not show errors when $*HOME is not set:


### PR DESCRIPTION
Together, these 4 commits:

* Extend the internal Raku REPL line editor API to support:
  * OO-style line editor modules (originally only C-wrapper style APIs were supported)
  * Line editors that require loading multiple modules
* Add initial support for `RAKUDO_LINE_EDITOR=LineEditor`
  * Includes scrolling single line input, history load/save/prev/next, and undo
  * Does NOT yet support tab completion, history search, or command-line hints
  * Default keyboard map is slightly more complete than Linenoise (e.g. undo support), but not as complete as Readline
* Makes `Terminal::LineEditor` the lowest-priority line editor in the auto-sensing list before going to final fallback
  * (Based on the principle of least surprise if another module installs `Terminal::LineEditor` as a dependency, which several of mine are likely to in the future.)
* Update messages, docs, and tests to mention LineEditor anywhere that *both* Linenoise and Readline are mentioned
  * Since the history file is mentioned in the same places, make sure all places mention both old and new history file locations, and that the old one will be auto-migrated
