### PR TITLE
Very simple ACCEPTS for Int:D vs Int:D

### DIFF
--- a/src/core.c/Int.pm6
+++ b/src/core.c/Int.pm6
@@ -26,8 +26,8 @@ my class Int does Real { # declared in BOOTSTRAP
         )
     }
 
-    multi method ACCEPTS(Int:D: Int:D \other, --> Bool:D) {
-        nqp::hllbool(nqp::iseq_I(self, nqp::decont(other)))
+    multi method ACCEPTS(Int:D: Int:D $other, --> Bool:D) {
+        nqp::hllbool(nqp::iseq_I(self, $other))
     }
 
     proto method new(|) {*}

--- a/src/core.c/Int.pm6
+++ b/src/core.c/Int.pm6
@@ -26,6 +26,10 @@ my class Int does Real { # declared in BOOTSTRAP
         )
     }
 
+    multi method ACCEPTS(Int:D: Int:D \other, --> Bool:D) {
+        nqp::hllbool(nqp::iseq_I(self, nqp::decont(other)))
+    }
+
     proto method new(|) {*}
     multi method new(Any:U $type) {
         die "Cannot create an Int from a '$type.^name()' type object";


### PR DESCRIPTION
Otherwise running ACCEPTS on an Enum goes via Numeric's ACCEPTS,
which first calls to .Numeric to coerce, and has checks for nan
and inf on top of the numeric value comparison.

This new candidate has a bytecode small enough to be inlined, as
opposed to the Numeric ACCEPTS method.

my test code was

`rakudo -e 'enum lmao <first second third fourth>; sub do-my-bidding { for ^2000 { when first { print ">." }; when second { print "." }; when third { print "." }; when fourth { print ".\n" } } }; for ^1000 { do-my-bidding }'`

This results in about four times 2000 calls to Numeric's ACCEPTS for every call to `do-my-bidding`. Before it ran in about 9.5 seconds, now it runs in about 1.7 seconds.