### PR TITLE
Change SetHash.values() from `is rw` to `is raw`

### DIFF
--- a/src/core.c/SetHash.pm6
+++ b/src/core.c/SetHash.pm6
@@ -155,7 +155,7 @@ my class SetHash does Setty {
         has $!elems is built(:bind);
         has $!keys  is built(:bind) is built(False) =
           Rakudo::Internals.IterationSet2keys($!elems);
-        method pull-one() is rw {
+        method pull-one() is raw {
             nqp::elems($!keys)
               ?? proxy(nqp::shift_s($!keys),$!elems)
               !! IterationEnd


### PR DESCRIPTION
Doesn't change the semantics, but makes it consistent with
(Mix|Bag)Hash.values().

Rakudo builds ok and passes `make m-test m-spectest`.