### PR TITLE
Add Any(iterable).isa-all(type) method

### DIFF
--- a/src/core.c/Any-iterable-methods.pm6
+++ b/src/core.c/Any-iterable-methods.pm6
@@ -2357,6 +2357,17 @@ Consider using a block if any of these are necessary for your mapping code."
         Seq.new(Rakudo::Iterator.Rotor(self.iterator,@cycle,$partial))
     }
 
+    proto method isa-all(|) {*}
+    multi method isa-all(Any:D: Mu $type --> Bool:D) {
+        my $iterator := self.iterator;
+        nqp::until(
+          nqp::eqaddr((my $pulled := $iterator.pull-one),IterationEnd)
+            || nqp::not_i(nqp::istype($pulled.WHAT,$type)),
+          nqp::null
+        );
+        nqp::hllbool(nqp::eqaddr($pulled,IterationEnd))
+    }
+
     proto method nodemap(|) is nodal {*}
     multi method nodemap(Associative:D: &op) {
         self.new.STORE: self.keys, self.values.nodemap(&op), :INITIALIZE


### PR DESCRIPTION
This returns a boolean whether all values produced by the iterable match the given type.  Intended to be used in e.g. constraints such as:
````raku
sub foo(@a where .isa-all(Int))
````
as an alternative to:
````raku
sub foo(@a where .all ~~ Int)
````
The .isa-all method is about 3.5x as fast as the `.all ~~ Int` approach for an array consisting of 10 `Int`s.  The efficiency increase for non-matching types will be *much* bigger, as the `isa-all` method can short-circuit on any non-matching value, which the `.all ~~ Int` approach can not.  So that would be *at least* 3.5x as fast, but potentially orders of magnitude faster for bigger arrays.