### PR TITLE
Add Any(iterable).isa-none(type) method

### DIFF
--- a/src/core.c/Any-iterable-methods.pm6
+++ b/src/core.c/Any-iterable-methods.pm6
@@ -2357,6 +2357,17 @@ Consider using a block if any of these are necessary for your mapping code."
         Seq.new(Rakudo::Iterator.Rotor(self.iterator,@cycle,$partial))
     }
 
+    proto method isa-none(|) {*}
+    multi method isa-none(Any:D: Mu $type --> Bool:D) {
+        my $iterator := self.iterator;
+        nqp::until(
+          nqp::eqaddr((my $pulled := $iterator.pull-one),IterationEnd)
+            || nqp::istype($pulled.WHAT,$type),
+          nqp::null
+        );
+        nqp::hllbool(nqp::eqaddr($pulled,IterationEnd))
+    }
+
     proto method nodemap(|) is nodal {*}
     multi method nodemap(Associative:D: &op) {
         self.new.STORE: self.keys, self.values.nodemap(&op), :INITIALIZE


### PR DESCRIPTION
This returns a boolean whether none of the values produced by the iterable
match the given type. Intended to be used in e.g. constraints such as:
````raku
sub foo(@a where .isa-none(Str))
````
as an alternative to:
````raku
sub foo(@a where .none ~~ Str)
````
This is the logical counterpart of `Any.isa-any` from https://github.com/rakudo/rakudo/pull/4631