### PR TITLE
Replace nqp::attrinited with a descriptor-based approach

### DIFF
--- a/lib/BUILDPLAN.rakumod
+++ b/lib/BUILDPLAN.rakumod
@@ -132,7 +132,7 @@ sub showop(@actions --> Str:D) {
         my $reason = @actions[3] === 1
           ?? "it is required"
           !! @actions[3];
-        qq/die "because $reason" unless nqp::attrinited(obj,$type,$attr)/
+        qq/die "because $reason" unless nqp::p6attrinited(nqp::getattr(obj,$type,$attr))/
     }
     elsif $op == 9 {
         "nqp::getattr(obj,$type,$attr) := initializer-code()"

--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -994,7 +994,13 @@ register_op_desugar('time_n', -> $qast {
             )
         }
         else {
-            nqp::die('TODO port to other backends');
+            QAST::Op.new(
+                :op('callmethod'), :name('check'),
+                QAST::WVal.new(
+                    :value(nqp::gethllsym('Raku', 'UninitializedAttributeChecker'))
+                ),
+                $qast[0]
+            )
         }
     });
 }

--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -989,7 +989,7 @@ sub can-use-p6forstmt($block) {
     my $block_type := $*W.find_single_symbol('Block', :setting-only);
     return 1 unless nqp::istype($code, $block_type);
     my $p := nqp::getattr($code, $block_type, '$!phasers');
-    nqp::isnull($p) ||
+    !nqp::ishash($p) ||
         !(nqp::existskey($p, 'FIRST') || nqp::existskey($p, 'LAST') || nqp::existskey($p, 'NEXT'))
 }
 
@@ -2107,7 +2107,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
         my $code := $loop[1].ann('code_object');
         my $block_type := $*W.find_single_symbol('Block', :setting-only);
         my $phasers := nqp::getattr($code, $block_type, '$!phasers');
-        if nqp::isnull($phasers) {
+        if !nqp::ishash($phasers) {
             $loop[1] := pblock_immediate($loop[1]);
         }
         else {
@@ -4391,7 +4391,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
         # Cannot inline things with custom invocation handler or phasers.
         return 0 if nqp::can($code, 'CALL-ME');
         my $phasers := nqp::getattr($code,$*W.find_single_symbol('Block', :setting-only),'$!phasers');
-        return 0 unless nqp::isnull($phasers) || !$phasers;
+        return 0 unless !nqp::ishash($phasers) || !$phasers;
 
         # Make sure the block has the common structure we expect
         # (decls then statements).

--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -980,6 +980,24 @@ register_op_desugar('time_n', -> $qast {
         }
     });
 }
+{
+    my $is_moar;
+    register_op_desugar('p6attrinited', -> $qast {
+        unless nqp::isconcrete($is_moar) {
+            $is_moar := nqp::getcomp('Raku').backend.name eq 'moar';
+        }
+        if $is_moar {
+            QAST::Op.new(
+                :op('dispatch'), :returns(int),
+                QAST::SVal.new( :value('raku-is-attr-inited') ),
+                $qast[0]
+            )
+        }
+        else {
+            nqp::die('TODO port to other backends');
+        }
+    });
+}
 
 sub can-use-p6forstmt($block) {
     my $past_block := $block.ann('past_block');

--- a/src/Perl6/Metamodel/BUILDPLAN.nqp
+++ b/src/Perl6/Metamodel/BUILDPLAN.nqp
@@ -28,6 +28,9 @@ role Perl6::Metamodel::BUILDPLAN {
     #   12 same as 0, but init to nqp::hash if value absent (nqp only)
     #   13 same as 0 but *bind* the received value + optional type constraint
     #   14 same as 4 but *bind* the default value + optional type constraint
+    #   15 die if a required int attribute is 0
+    #   16 die if a required num attribute is 0e0
+    #   17 die if a required str attribute is null_s (will be '' in the future)
     method create_BUILDPLAN($obj) {
         # First, we'll create the build plan for just this class.
         my @plan;
@@ -128,7 +131,10 @@ role Perl6::Metamodel::BUILDPLAN {
         # Ensure that any required attributes are set
         for @attrs {
             if nqp::can($_, 'required') && $_.required {
-                nqp::push(@plan,[8, $obj, $_.name, $_.required]);
+                my $type := $_.type;
+                my int $primspec := nqp::objprimspec($type);
+                my int $op := $primspec ?? 14 + $primspec !! 8;
+                nqp::push(@plan,[$op, $obj, $_.name, $_.required]);
                 nqp::deletekey(%attrs_untouched, $_.name);
             }
         }

--- a/src/Perl6/Optimizer.nqp
+++ b/src/Perl6/Optimizer.nqp
@@ -796,7 +796,7 @@ my class BlockVarOptimizer {
                         for $type.HOW.mro($type) -> $mro_entry {
                             for $mro_entry.HOW.attributes($mro_entry, :local) -> $attr {
                                 my str $name := $attr.name;
-                                if nqp::attrinited($qv, $mro_entry, $name) {
+                                if $name eq '$!descriptor' || $name eq '$!value' {
                                     $setup := QAST::Op.new(
                                         :op('p6bindattrinvres'),
                                         $setup,

--- a/src/Perl6/Optimizer.nqp
+++ b/src/Perl6/Optimizer.nqp
@@ -2565,7 +2565,7 @@ class Perl6::Optimizer {
           ?? nqp::getattr($code, $block, '$!phasers')
           !! nqp::null();
         if $count == 1
-          && nqp::isnull($phasers)
+          && !nqp::ishash($phasers)
           && %range_bounds{$c2.name}($c2) -> @fls {
             if $reverse {
                 my $tmp := @fls[0];

--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -3881,13 +3881,15 @@ class Perl6::World is HLL::World {
                         elsif $code == 8 {
 
 # nqp::unless(
-#   nqp::attrinited(self,Foo,'$!a'),
+#   nqp::p6attrinited(nqp::getattr(self,Foo,'$!a')),
 #   X::Attribute::Required.new(name => '$!a', why => (value))
 # ),
                             $stmts.push(
                               QAST::Op.new( :op<unless>,
-                                QAST::Op.new( :op<attrinited>,
-                                  $!self, $class, $attr
+                                QAST::Op.new( :op<p6attrinited>,
+                                  QAST::Op.new( :op<getattr>,
+                                    $!self, $class, $attr
+                                  )
                                 ),
                                 QAST::Op.new( :op<callmethod>, :name<throw>,
                                   QAST::Op.new( :op<callmethod>, :name<new>,

--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -3734,17 +3734,14 @@ class Perl6::World is HLL::World {
                         # 4 = set opaque with default if not set yet
                         elsif $code == 4 || $code == 14 {
 
-# nqp::unless(
-#   nqp::attrinited(self,Foo,'$!a'),
-                            my $unless := QAST::Op.new( :op<unless>,
-                                QAST::Op.new( :op<attrinited>,
-                                  $!self, $class, $attr
-                                )
-                            );
-
 # nqp::getattr(self,Foo,'$!a')
                             my $getattr := QAST::Op.new( :op<getattr>,
                               $!self, $class, $attr
+                            );
+# nqp::unless(
+#   nqp::p6attrinited(nqp::getattr(self,Foo,'$!a')),
+                            my $unless := QAST::Op.new( :op<unless>,
+                                QAST::Op.new( :op<p6attrinited>, $getattr )
                             );
 
                             my $initializer := nqp::istype(

--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -2737,7 +2737,7 @@ class Perl6::World is HLL::World {
         my $block_type := self.find_single_symbol('Block', :setting-only);
         if nqp::istype($code, $block_type) {
             my %phasers := nqp::getattr($code, $block_type, '$!phasers');
-            unless nqp::isnull(%phasers) {
+            if nqp::ishash(%phasers) {
                 if nqp::existskey(%phasers, 'PRE') {
                     $code_past[0].push(QAST::Op.new( :op('p6setpre') ));
                     $code_past[0].push(self.run_phasers_code($code, $code_past, $block_type, 'PRE'));

--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -1431,6 +1431,8 @@ class ContainerDescriptor::UninitializedAttribute {
     method instantiate_generic($type_environment) {
         self.new(self.next.instantiate_generic($type_environment))
     }
+    method is_generic() { self.next.is_generic }
+    method is_default_generic() { self.next.is_default_generic }
 }
 
 # We stick all the declarative bits inside of a BEGIN, so they get

--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -2166,7 +2166,7 @@ BEGIN {
     #     has Mu $!phasers;                # phasers for this block
     #     has Mu $!why;
     Block.HOW.add_parent(Block, Code);
-    Block.HOW.add_attribute(Block, BOOTSTRAPATTR.new(:name<$!phasers>, :type(Mu), :package(Block)));
+    Block.HOW.add_attribute(Block, Attribute.new(:name<$!phasers>, :type(Mu), :package(Block), :auto_viv_primitive(nqp::null())));
     Block.HOW.add_attribute(Block, scalar_attr('$!why', Mu, Block, :!auto_viv_container));
     Block.HOW.add_method(Block, 'clone', nqp::getstaticcode(sub ($self) {
             my $dcself := nqp::decont($self);

--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -1454,10 +1454,16 @@ my class UninitializedAttributeChecker {
                 $desc := nqp::getattr($attr, Scalar, '$!descriptor');
             }
             elsif nqp::istype_nd($attr, Array) {
-                $desc := nqp::getattr($attr, Array, '$!descriptor');
+                my $storage := nqp::getattr($attr, List, '$!reified');
+                unless nqp::isconcrete($storage) && nqp::elems($storage) {
+                    $desc := nqp::getattr($attr, Array, '$!descriptor');
+                }
             }
             elsif nqp::istype_nd($attr, Hash) {
-                $desc := nqp::getattr($attr, Hash, '$!descriptor');
+                my $storage := nqp::getattr($attr, Map, '$!storage');
+                unless nqp::isconcrete($storage) && nqp::elems($storage) {
+                    $desc := nqp::getattr($attr, Hash, '$!descriptor');
+                }
             }
             else {
                 try {

--- a/src/core.c/Array.pm6
+++ b/src/core.c/Array.pm6
@@ -266,6 +266,8 @@ my class Array { # declared in BOOTSTRAP
 
     proto method STORE(Array:D: |) {*}
     multi method STORE(Array:D: Iterable:D \iterable --> Array:D) {
+        $!descriptor := $!descriptor.next
+            if nqp::eqaddr($!descriptor.WHAT, ContainerDescriptor::UninitializedAttribute);
         my \buffer = nqp::create(IterationBuffer);
         nqp::if(
           nqp::iscont(iterable),
@@ -298,6 +300,8 @@ my class Array { # declared in BOOTSTRAP
         nqp::p6bindattrinvres(self,List,'$!reified',buffer)
     }
     multi method STORE(Array:D: QuantHash:D \qh --> Array:D) {
+        $!descriptor := $!descriptor.next
+            if nqp::eqaddr($!descriptor.WHAT, ContainerDescriptor::UninitializedAttribute);
         my \buffer = nqp::create(IterationBuffer);
         nqp::iscont(qh)
           ?? nqp::push(buffer,nqp::p6scalarwithvalue($!descriptor,qh))
@@ -308,6 +312,8 @@ my class Array { # declared in BOOTSTRAP
         nqp::p6bindattrinvres(self,List,'$!reified',buffer)
     }
     multi method STORE(Array:D: Mu \item --> Array:D) {
+        $!descriptor := $!descriptor.next
+            if nqp::eqaddr($!descriptor.WHAT, ContainerDescriptor::UninitializedAttribute);
         nqp::push(
           (my \buffer = nqp::create(IterationBuffer)),
           nqp::p6scalarwithvalue($!descriptor, item)

--- a/src/core.c/Bag.pm6
+++ b/src/core.c/Bag.pm6
@@ -29,9 +29,7 @@ my class Bag does Baggy {
         )
     }
     method total(Bag:D: --> Int:D) {
-        nqp::attrinited(self,Bag,'$!total')
-          ?? $!total
-          !! ($!total := Rakudo::QuantHash.BAG-TOTAL($!elems))
+        $!total // ($!total := Rakudo::QuantHash.BAG-TOTAL($!elems))
     }
 
 

--- a/src/core.c/Block.pm6
+++ b/src/core.c/Block.pm6
@@ -11,8 +11,7 @@ my class Block { # declared in BOOTSTRAP
     method returns(Block:D:) { nqp::getattr(self,Code,'$!signature').returns }
 
     method add_phaser(Str:D \name, &block --> Nil) {
-        $!phasers := nqp::hash
-          unless nqp::attrinited(self,Block,'$!phasers');
+        $!phasers := nqp::hash unless nqp::ishash($!phasers);
 
         my str $name = name;
         nqp::bindkey($!phasers,$name,nqp::create(PhasersList))
@@ -35,7 +34,7 @@ my class Block { # declared in BOOTSTRAP
     # there only is one, or a Callable that will call all of the phasers.
     method callable_for_phaser(str $name) {
         nqp::if(
-          nqp::attrinited(self,Block,'$!phasers')
+          nqp::ishash($!phasers)
             && (my \phasers := nqp::atkey($!phasers,$name)),
           nqp::if(
             nqp::iseq_i(nqp::elems(phasers),1),
@@ -54,8 +53,7 @@ my class Block { # declared in BOOTSTRAP
     }
 
     method fire_if_phasers(str $name --> Nil) {
-        if nqp::attrinited(self,Block,'$!phasers')
-          && nqp::atkey($!phasers,$name) -> \phasers {
+        if nqp::ishash($!phasers) && nqp::atkey($!phasers,$name) -> \phasers {
             my int $i = -1;
             nqp::while(
               nqp::islt_i(($i = nqp::add_i($i,1)),nqp::elems(phasers)),
@@ -76,11 +74,11 @@ my class Block { # declared in BOOTSTRAP
     }
 
     method has-phasers() {
-        nqp::hllbool(nqp::attrinited(self,Block,'$!phasers'))
+        nqp::hllbool(nqp::ishash($!phasers))
     }
     method has-loop-phasers() {
         nqp::hllbool(
-          nqp::attrinited(self,Block,'$!phasers')
+          nqp::ishash($!phasers)
             && (    nqp::existskey($!phasers,'NEXT')
                  || nqp::existskey($!phasers,'LAST')
                  || nqp::existskey($!phasers,'FIRST')
@@ -89,12 +87,12 @@ my class Block { # declared in BOOTSTRAP
     }
 
     method has-phaser(Str:D \name) {
-        nqp::hllbool(nqp::attrinited(self,Block,'$!phasers')
+        nqp::hllbool(nqp::ishash($!phasers)
           && nqp::existskey($!phasers,nqp::unbox_s(name)))
     }
 
     method phasers(Str:D $name) {
-        nqp::attrinited(self,Block,'$!phasers')
+        nqp::ishash($!phasers)
           && nqp::existskey($!phasers,nqp::unbox_s($name))
           ?? nqp::p6bindattrinvres(nqp::create(List),List,'$!reified',
                nqp::atkey($!phasers,nqp::unbox_s($name)))

--- a/src/core.c/Capture.pm6
+++ b/src/core.c/Capture.pm6
@@ -11,9 +11,8 @@ my class Capture { # declared in BOOTSTRAP
         nqp::bindattr(self, Capture, '@!list',
           nqp::getattr(nqp::decont(@list.list), List, '$!reified'))
             if $elems;
-        nqp::bindattr(self,Capture,'%!hash',
-          nqp::getattr(nqp::decont(%hash),Map,'$!storage'))
-            if nqp::attrinited(nqp::decont(%hash),Map,'$!storage')
+        my Mu $source-hash := nqp::getattr(nqp::decont(%hash), Map, '$!storage');
+        nqp::bindattr(self,Capture,'%!hash', $source-hash) if nqp::ishash($source-hash);
     }
 
     multi method WHICH (Capture:D: --> ValueObjAt:D) {

--- a/src/core.c/Hash.pm6
+++ b/src/core.c/Hash.pm6
@@ -72,6 +72,8 @@ my class Hash { # declared in BOOTSTRAP
 
     proto method STORE(|) {*}
     multi method STORE(Hash:D: \to_store) {
+        $!descriptor := $!descriptor.next
+            if nqp::eqaddr($!descriptor.WHAT, ContainerDescriptor::UninitializedAttribute);
         my $temp := nqp::p6bindattrinvres(
           nqp::clone(self),   # make sure we get a possible descriptor as well
           Map,
@@ -112,6 +114,8 @@ my class Hash { # declared in BOOTSTRAP
         nqp::p6bindattrinvres(self,Map,'$!storage',$storage)
     }
     multi method STORE(Hash:D: \keys, \values) {
+        $!descriptor := $!descriptor.next
+            if nqp::eqaddr($!descriptor.WHAT, ContainerDescriptor::UninitializedAttribute);
         my \iterkeys   := keys.iterator;
         my \itervalues := values.iterator;
         nqp::bindattr(self,Map,'$!storage',nqp::hash);

--- a/src/core.c/Mix.pm6
+++ b/src/core.c/Mix.pm6
@@ -53,14 +53,10 @@ my class Mix does Mixy {
         )
     }
     method total(Mix:D: --> Real:D) {
-        nqp::attrinited(self,Mix,'$!total')
-          ?? $!total
-          !! ($!total := Rakudo::QuantHash.MIX-TOTAL($!elems))
+        $!total // ($!total := Rakudo::QuantHash.MIX-TOTAL($!elems))
     }
     method !total-positive(Mix:D: --> Real:D) {
-        nqp::attrinited(self,Mix,'$!total-positive')
-          ?? $!total-positive
-          !! ($!total-positive := Rakudo::QuantHash.MIX-TOTAL-POSITIVE($!elems))
+        $!total-positive // ($!total-positive := Rakudo::QuantHash.MIX-TOTAL-POSITIVE($!elems))
     }
 
 #--- selection methods

--- a/src/core.c/Mu.pm6
+++ b/src/core.c/Mu.pm6
@@ -365,8 +365,48 @@ my class Mu { # declared in BOOTSTRAP
                                       )
                                     )
                                   ),
-                                  die('Invalid ' ~ self.^name ~ ".BUILDALL plan: $code"),
-                  ))))))))))),
+
+                                  nqp::if(
+                                    nqp::iseq_i($code,15),
+                                    nqp::unless(   # 15
+                                      nqp::getattr_i(self,
+                                        nqp::atpos($task,1),
+                                        nqp::atpos($task,2)
+                                      ),
+                                      X::Attribute::Required.new(
+                                        name => nqp::atpos($task,2),
+                                        why  => nqp::atpos($task,3)
+                                      ).throw
+                                    ),
+
+                                    nqp::if(
+                                      nqp::iseq_i($code,16),
+                                      nqp::unless(   # 16
+                                        nqp::getattr_n(self,
+                                          nqp::atpos($task,1),
+                                          nqp::atpos($task,2)
+                                        ),
+                                        X::Attribute::Required.new(
+                                          name => nqp::atpos($task,2),
+                                          why  => nqp::atpos($task,3)
+                                        ).throw
+                                      ),
+
+                                      nqp::if(
+                                        nqp::iseq_i($code,17),
+                                        nqp::if(   # 17
+                                          nqp::isnull_s(nqp::getattr_s(self,
+                                            nqp::atpos($task,1),
+                                            nqp::atpos($task,2)
+                                          )),
+                                          X::Attribute::Required.new(
+                                            name => nqp::atpos($task,2),
+                                            why  => nqp::atpos($task,3)
+                                          ).throw
+                                        ),
+
+                                        die('Invalid ' ~ self.^name ~ ".BUILDALL plan: $code"),
+                  )))))))))))))),
 
                   nqp::if(                       # 0
                     nqp::existskey($init,nqp::atpos($task,3)),

--- a/src/core.c/Mu.pm6
+++ b/src/core.c/Mu.pm6
@@ -943,9 +943,8 @@ my class Mu { # declared in BOOTSTRAP
                 my $package := $attr.package;
 
                 nqp::bindattr($cloned, $package, $name,
-                  nqp::clone(nqp::getattr($cloned, $package, $name).VAR)
-                ) if nqp::attrinited(self, $package, $name)
-                    and nqp::not_i(nqp::objprimspec($attr.type));
+                  nqp::clone_nd(nqp::getattr($cloned, $package, $name))
+                ) unless nqp::objprimspec($attr.type);
 
                 my $acc_name := substr($name,2);
                 nqp::getattr($cloned, $package, $name) =
@@ -958,12 +957,10 @@ my class Mu { # declared in BOOTSTRAP
                 unless nqp::objprimspec($attr.type) {
                     my $name     := $attr.name;
                     my $package  := $attr.package;
-                    if nqp::attrinited(self, $package, $name) {
-                        my $attr_val := nqp::getattr($cloned, $package, $name);
-                        nqp::bindattr($cloned,
-                          $package, $name, nqp::clone($attr_val.VAR))
-                            if nqp::iscont($attr_val);
-                    }
+                    my $attr_val := nqp::getattr($cloned, $package, $name);
+                    nqp::bindattr($cloned,
+                      $package, $name, nqp::clone_nd($attr_val))
+                        if nqp::iscont($attr_val);
                 }
             }
         }

--- a/src/core.c/Mu.pm6
+++ b/src/core.c/Mu.pm6
@@ -269,9 +269,11 @@ my class Mu { # declared in BOOTSTRAP
                       nqp::if(
                         nqp::iseq_i($code,8),
                         nqp::unless(             # 8
-                          nqp::attrinited(self,
-                            nqp::atpos($task,1),
-                            nqp::atpos($task,2)
+                          nqp::p6attrinited(
+                            nqp::getattr(self,
+                              nqp::atpos($task,1),
+                              nqp::atpos($task,2)
+                            )
                           ),
                           X::Attribute::Required.new(
                             name => nqp::atpos($task,2),
@@ -511,9 +513,11 @@ my class Mu { # declared in BOOTSTRAP
                       nqp::if(
                         nqp::iseq_i($code,8),
                         nqp::unless(             # 8
-                          nqp::attrinited(self,
-                            nqp::atpos($task,1),
-                            nqp::atpos($task,2)
+                          nqp::p6attrinited(
+                            nqp::getattr(self,
+                              nqp::atpos($task,1),
+                              nqp::atpos($task,2)
+                            )
                           ),
                           X::Attribute::Required.new(
                             name => nqp::atpos($task,2),

--- a/src/core.c/Mu.pm6
+++ b/src/core.c/Mu.pm6
@@ -192,9 +192,11 @@ my class Mu { # declared in BOOTSTRAP
                 nqp::if(
                   nqp::iseq_i($code,4),
                   nqp::unless(                   # 4
-                    nqp::attrinited(self,
-                      nqp::atpos($task,1),
-                      nqp::atpos($task,2)
+                    nqp::p6attrinited(
+                      nqp::getattr(self,
+                        nqp::atpos($task,1),
+                        nqp::atpos($task,2)
+                      )
                     ),
                     nqp::if(
                       nqp::istype(nqp::atpos($task,3),Block),
@@ -330,9 +332,11 @@ my class Mu { # declared in BOOTSTRAP
                                 nqp::if(
                                   nqp::iseq_i($code,14),
                                   nqp::unless(   # 14
-                                    nqp::attrinited(self,
-                                      nqp::atpos($task,1),
-                                      nqp::atpos($task,2)
+                                    nqp::p6attrinited(
+                                      nqp::getattr(self,
+                                        nqp::atpos($task,1),
+                                        nqp::atpos($task,2)
+                                      )
                                     ),
                                     nqp::bindattr(self,
                                       nqp::atpos($task,1),
@@ -430,9 +434,11 @@ my class Mu { # declared in BOOTSTRAP
                 nqp::if(
                   nqp::iseq_i($code,4),
                   nqp::unless(                   # 4
-                    nqp::attrinited(self,
-                      nqp::atpos($task,1),
-                      nqp::atpos($task,2)
+                    nqp::p6attrinited(
+                      nqp::getattr(self,
+                        nqp::atpos($task,1),
+                        nqp::atpos($task,2)
+                      )
                     ),
                     nqp::if(
                       nqp::istype(nqp::atpos($task,3),Block),
@@ -590,9 +596,11 @@ my class Mu { # declared in BOOTSTRAP
                                   nqp::if(
                                     nqp::iseq_i($code,14),
                                     nqp::unless( # 14
-                                      nqp::attrinited(self,
-                                        nqp::atpos($task,1),
-                                        nqp::atpos($task,2)
+                                      nqp::p6attrinited(
+                                        nqp::getattr(self,
+                                          nqp::atpos($task,1),
+                                          nqp::atpos($task,2)
+                                        )
                                       ),
                                       nqp::bindattr(self,
                                         nqp::atpos($task,1),nqp::atpos($task,2),

--- a/src/core.c/metaops.pm6
+++ b/src/core.c/metaops.pm6
@@ -246,6 +246,7 @@ multi sub METAOP_REDUCE_RIGHT(\op, \triangle) {
                 method !SET-SELF(\op,\list,\count,\index) {
                     $!op := op;
                     $!reified := nqp::getattr(list,List,'$!reified');
+                    $!result := nqp::null;
                     $!count = count;
                     $!i = index;
                     self
@@ -255,7 +256,11 @@ multi sub METAOP_REDUCE_RIGHT(\op, \triangle) {
                 }
                 method pull-one() is raw {
                     nqp::if(
-                      nqp::attrinited(self,self.WHAT,'$!result'),
+                      nqp::isnull($!result),
+                      ($!result := nqp::atpos(
+                        $!reified,
+                        ($!i = nqp::sub_i($!i,1))
+                      )),
                       nqp::stmts(
                         (my $args := nqp::list($!result)),
                         nqp::until(
@@ -268,11 +273,7 @@ multi sub METAOP_REDUCE_RIGHT(\op, \triangle) {
                           ($!result := op.(|nqp::hllize($args))),
                           IterationEnd
                         )
-                      ),
-                      ($!result := nqp::atpos(
-                        $!reified,
-                        ($!i = nqp::sub_i($!i,1))
-                      ))
+                      )
                     )
                 }
             }.new(op,$v,$count,$i),
@@ -298,22 +299,23 @@ multi sub METAOP_REDUCE_RIGHT(\op, \triangle) {
                 method !SET-SELF(\op,\list,\count) {
                     $!op := op;
                     $!reified := nqp::getattr(list,List,'$!reified');
+                    $!result := nqp::null;
                     $!i = count;
                     self
                 }
                 method new(\op,\li,\co) { nqp::create(self)!SET-SELF(op,li,co) }
                 method pull-one() is raw {
                     nqp::if(
-                      nqp::attrinited(self,self.WHAT,'$!result'),
+                      nqp::isnull($!result),
+                      ($!result := nqp::atpos(
+                        $!reified,
+                        ($!i = nqp::sub_i($!i,1))
+                      )),
                       nqp::if(
                         nqp::isge_i(($!i = nqp::sub_i($!i,1)),0),
                         ($!result := $!op.(nqp::atpos($!reified,$!i),$!result)),
                         IterationEnd
-                      ),
-                      ($!result := nqp::atpos(
-                        $!reified,
-                        ($!i = nqp::sub_i($!i,1))
-                      ))
+                      )
                     )
                 }
             }.new(op,$v,$i),


### PR DESCRIPTION
As noted in #4624, this code:

```
class Box {
    has Any:D $.value is required;
    submethod BUILD(::?CLASS:D:) { $!value }
}.new
```

Does not throw an error in current Rakudo. Today, object attributes are lazily vivified to `Scalar` (or `Array` or `Hash`) containers on first read (noting that attributes are typically assigned, and thus `$!value = 42` - or the equivalent done in by `BUILDALL` - is actually a read of the attribute). This has rarely been a problem, because there's usually little desire to go reading an attribute during a `BUILD`, but it's feasible one may want to, and then the current behavior is a surprise.

More awkward from my perspective is that it forces lazy vivification of attributes upon us, and thus every attribute access has to do a `NULL` check and then have logic to deal with the consequences of it being null, which bulks up the code the JIT produces for attribute access (really it should just be 1 or 2 assembly instructions, but in reality it's usually also a branch). Further, I'm planning to get back to working on more advanced escape analysis shortly, and trying to track auto-vivification status there too makes a hard job harder (especially at control flow merges).

A while back I got an idea for an alternative scheme. Since the interesting question here is "was it assigned to", and assignment's semantics are always determined on the `$!descriptor` of the container, we could:

1. Initialize attributes with a default value or `is required` to have a `$!descriptor` indicating that the attribute is uninitialized
2. On assignment, replace the descriptor with the real one (noting that typically a given program point with be monomorphic in needing to do this). Due to the way assignment is done by a dispatcher on MoarVM that matches on descriptor anyway, this is almost free.
3. Check if the descriptor got replaced to decide if the attribute was assigned or not.

This passes all but one spectest, which involves an `is required` attribute of type `str`, which of course has no container. It seems that `nqp::attrinited` doesn't actually care if there's an object attribute there or not, so it worked more through luck than judgement. I can find a mitigation for that. I've also tested it against a few larger things and so far seen no regressions. Really, though, it'll need a :pancakes: run against the ecosystem to tell to what degree we can get away with this change. Other feedback on the approach is welcome.

