### PR TITLE
Get either parametric or concrete roles in MRO when requested

### DIFF
--- a/src/Perl6/Metamodel/BaseType.nqp
+++ b/src/Perl6/Metamodel/BaseType.nqp
@@ -15,11 +15,11 @@ role Perl6::Metamodel::BaseType {
     }
 
     # Our MRO is just that of base type.
-    method mro($obj, :$roles = 0, :$unhidden = 0) {
+    method mro($obj, :$roles = 0, :$concretizations = 0, :$unhidden = 0) {
         unless @!mro {
             @!mro := nqp::list();
             @!mro[0] := $obj;
-            for $!base_type.HOW.mro($!base_type, :$roles, :$unhidden) {
+            for $!base_type.HOW.mro($!base_type, :$roles, :$concretizations, :$unhidden) {
                 @!mro.push($_);
             }
         }

--- a/src/Perl6/Metamodel/ConcreteRoleHOW.nqp
+++ b/src/Perl6/Metamodel/ConcreteRoleHOW.nqp
@@ -91,7 +91,9 @@ class Perl6::Metamodel::ConcreteRoleHOW
 
     # It makes sense for concretizations to default to MRO order of roles.
     method roles($obj, :$transitive = 1, :$mro = 1) {
-        self.roles-ordered($obj, @!roles, :$transitive, :$mro);
+        $transitive
+            ?? self.roles-ordered($obj, @!roles, :transitive, :$mro)
+            !! @!roles
     }
 
     method add_to_role_typecheck_list($obj, $type) {

--- a/src/Perl6/Metamodel/ConcreteRoleHOW.nqp
+++ b/src/Perl6/Metamodel/ConcreteRoleHOW.nqp
@@ -123,7 +123,7 @@ class Perl6::Metamodel::ConcreteRoleHOW
         nqp::settypecache($obj, @types)
     }
 
-    method mro($obj, :$roles = 0, :$unhidden = 0) {
+    method mro($obj, :$roles, :$concretizations, :$unhidden) {
         [$obj]
     }
 

--- a/src/Perl6/Metamodel/DefiniteHOW.nqp
+++ b/src/Perl6/Metamodel/DefiniteHOW.nqp
@@ -1,23 +1,6 @@
 class Perl6::Metamodel::DefiniteHOW
-    #~ does Perl6::Metamodel::Naming
     does Perl6::Metamodel::Documenting
     does Perl6::Metamodel::Nominalizable
-
-    #~ does Perl6::Metamodel::MethodDelegation
-    #~ does Perl6::Metamodel::TypePretense
-
-    #~ does Perl6::Metamodel::Stashing
-    #~ does Perl6::Metamodel::AttributeContainer
-    #~ does Perl6::Metamodel::MethodContainer
-    #~ does Perl6::Metamodel::MultiMethodContainer
-    #~ does Perl6::Metamodel::RoleContainer
-    #~ does Perl6::Metamodel::BaseType
-    #~ does Perl6::Metamodel::MROBasedMethodDispatch
-    #~ does Perl6::Metamodel::MROBasedTypeChecking
-    #~ does Perl6::Metamodel::BUILDPLAN
-    #~ does Perl6::Metamodel::BoolificationProtocol
-    #~ does Perl6::Metamodel::REPRComposeProtocol
-    #~ does Perl6::Metamodel::InvocationProtocol
 {
     my $archetypes := Perl6::Metamodel::Archetypes.new(:definite, :nominalizable(1));
     method archetypes() {
@@ -71,27 +54,6 @@ class Perl6::Metamodel::DefiniteHOW
         check_instantiated($definite_type);
         nqp::eqaddr(nqp::typeparameterat($definite_type, 1), Definite) ?? 1 !! 0
     }
-
-    #~ # Our MRO is just that of base type.
-    #~ method mro($obj) {
-        #~ unless @!mro {
-            #~ @!mro[0] := $obj;
-            #~ for $!base_type.HOW.mro($!base_type) {
-                #~ @!mro.push($_);
-            #~ }
-        #~ }
-        #~ @!mro
-    #~ }
-
-    #~ method parents($obj, :$local, :$excl, :$all) {
-        #~ my @parents := [$!base_type];
-        #~ unless $local {
-            #~ for $!base_type.HOW.parents($!base_type, :excl($excl), :all($all)) {
-                #~ @parents.push($_);
-            #~ }
-        #~ }
-        #~ @parents
-    #~ }
 
     method nominalize($obj) {
         my $base_type := $obj.HOW.base_type($obj);

--- a/src/Perl6/Metamodel/ParametricRoleHOW.nqp
+++ b/src/Perl6/Metamodel/ParametricRoleHOW.nqp
@@ -259,7 +259,7 @@ class Perl6::Metamodel::ParametricRoleHOW
         return $conc;
     }
 
-    method mro($obj, :$roles = 0, :$unhidden = 0) {
+    method mro($obj, :$roles, :$concretizations, :$unhidden) {
         [$obj]
     }
 }

--- a/src/core.c/Mu.pm6
+++ b/src/core.c/Mu.pm6
@@ -1040,7 +1040,7 @@ my class Mu { # declared in BOOTSTRAP
     }
 
     method !batch-call(Mu \SELF: \name, Capture:D \c, :$throw = False, :$reverse = False, :$roles = False) {
-        my @mro := SELF.^mro(:$roles);
+        my @mro := SELF.^mro(concretizations => $roles);
         my $results := nqp::create(IterationBuffer);
         my int $mro_high = $reverse ?? 0 !! @mro.elems - 1;
         my int $i = @mro.elems;
@@ -1143,7 +1143,7 @@ my class Mu { # declared in BOOTSTRAP
         } else {
             # Canonical, the default (just whatever the meta-class says) with us
             # on the start.
-            @classes = self.^mro(:$roles);
+            @classes = self.^mro(concretizations => $roles);
         }
 
         # Now we have classes, build method list.


### PR DESCRIPTION
Change semantics of `:roles` named parameter to returning parametric
groups instead of concretizations to make it conform to `.^roles`
methods.

Add `:concretizations` named for cases when concretizations are more
useful. For example, for methods traversal by `WALK`.