### PR TITLE
Consider Positional/Associative type parameters in optional defaults

### DIFF
--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -662,14 +662,15 @@ my class Binder {
 
         # Otherwise, go by sigil to pick the correct default type of value.
         else {
+            my $type := nqp::getattr($param, Parameter, '$!type');
             if $flags +& $SIG_ELEM_ARRAY_SIGIL {
-                nqp::create(Array)
+                nqp::create($type =:= Positional ?? Array !! Array.HOW.parameterize(Array, $type.of));
             }
             elsif $flags +& $SIG_ELEM_HASH_SIGIL {
-                nqp::create(Hash)
+                nqp::create($type =:= Associative ?? Hash !! Hash.HOW.parameterize(Hash, $type.of, $type.keyof));
             }
             else {
-                nqp::getattr($param, Parameter, '$!type');
+                $type
             }
         }
     }


### PR DESCRIPTION
We need to copy type parameters for this; thankfully, the type of the `@`/`%` must be `Positional`/`Associative`, whose parameters correspond to `Array`/`Hash`'s, so methods for these are already defined.

Allows the following signatures to produce a typechecking error for `$a` instead of `@l` or `%h`:

```raku
:(Str :@l, Str :$a)
:(Str :%h, Str :$a)
:(Str @l?, Str :$a)
:(Str %h?, Str :$a)
```

Preserving:

```raku
:(:@l, Str :$a)
:(:%h, Str :$a)
```

No new tests as of yet.

Fixes https://github.com/rakudo/rakudo/issues/4647.