### PR TITLE
Make class A does B{ } error more awesome

### DIFF
--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -339,8 +339,8 @@ role STD {
     method missing($what) {
         self.typed_panic('X::Syntax::Missing', :$what);
     }
-    method NYI($feature) {
-        self.typed_panic('X::Comp::NYI', :$feature)
+    method NYI($feature, *%opts) {
+        self.typed_panic('X::Comp::NYI', :$feature, |%opts)
     }
 
     token experimental($feature) {
@@ -3166,7 +3166,10 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
             <.unsp>?
             [
                 <?[{]> <?{ $is_type }>
-                <whence=.postcircumfix> <.NYI('Autovivifying object closures')>
+                <whence=.postcircumfix> <.NYI(
+                  'Autovivifying object closures',
+                  perhaps => 'you forgot a space before the { '
+                )>
             ]?
             <.unsp>?
             [
@@ -3376,7 +3379,10 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
             '[' ~ ']' <arglist>
             <.explain_mystery> <.cry_sorrows>
         ]?
-        <.unsp>? [ <?before '{'> <whence=.postcircumfix> <.NYI('Autovivifying object closures')> ]?
+        <.unsp>? [ <?before '{'> <whence=.postcircumfix> <.NYI(
+          'Autovivifying object closures',
+          perhaps => 'you forgot a space before the { '
+        )> ]?
         <.unsp>? [ <?[(]> '(' ~ ')' [<.ws> [<accept=.typename> || $<accept_any>=<?>] <.ws>] ]?
         [<.ws> 'of' <.ws> <typename> ]?
         [

--- a/src/core.c/Exception.pm6
+++ b/src/core.c/Exception.pm6
@@ -940,10 +940,12 @@ my class X::NYI is Exception {
     has $.feature;
     has $.did-you-mean;
     has $.workaround;
+    has $.perhaps;
     method message() {
         my $msg = ($.feature ?? $.feature ~ " not" !! "Not") ~ " yet implemented. Sorry.";
-        $msg ~= "\nDid you mean: {$.did-you-mean.gist}?" if $.did-you-mean;
-        $msg ~= "\nWorkaround: $.workaround" if $.workaround;
+        $msg ~= "\nDid you mean: $_?" with $.did-you-mean;
+        $msg ~= "\nPerhaps $_?"       with $.perhaps;
+        $msg ~= "\nWorkaround: $_"    with $.workaround;
         $msg
     }
 }


### PR DESCRIPTION
Adds the line "Perhaps you forgot a space before the { ?" to the
otherwise rather obscure error message caused by lack of whitespace
between the role name and the opening curly

    $ raku -e 'role A{ ... }; class B does A{ ... }'
    ===SORRY!=== Error while compiling -e
    Autovivifying object closures not yet implemented. Sorry.
    Perhaps you forgot a space before the { ?
    at -e:1
    ------> role A{ ... }; class B does A{ ... }⏏<EOL>

Also adds a "perhaps" attribute to X::NYI.