### PR TITLE
Don't suggest method of the same name as "not found"

### DIFF
--- a/src/core.c/Exception.pm6
+++ b/src/core.c/Exception.pm6
@@ -245,7 +245,7 @@ my class X::Method::NotFound is Exception {
                     }
                 }
                 else {
-                    find_public_suggestion($.method, $method_name);
+                    find_public_suggestion($.method, $method_name) if nqp::can(::($.typename), $method_name);
                 }
             }
 

--- a/src/core.c/Exception.pm6
+++ b/src/core.c/Exception.pm6
@@ -215,11 +215,7 @@ my class X::Method::NotFound is Exception {
 
         my $public_suggested = 0;
         sub find_public_suggestion($before, $after --> Nil) {
-            if $before.fc eq $after.fc {
-                $public_suggested = 1;
-                %suggestions{$after} = 0;  # assume identity
-            }
-            else {
+            if $before.fc ne $after.fc {
                 my $dist := StrDistance.new(
                   before => $before.fc,
                   after  => $after.fc

--- a/src/core.c/Exception.pm6
+++ b/src/core.c/Exception.pm6
@@ -240,7 +240,7 @@ my class X::Method::NotFound is Exception {
 
                 if $.method eq $method_name {
                     unless $identity-found-already {
-                        @!tips.push: "Found a method of the same name on another type, perhaps you called it on a container?";
+                        @!tips.push: "Found '$.method' on type '$!invocant.^name()', but perhaps you actually called it on a container?";
                         $identity-found-already = True;
                     }
                 }

--- a/src/core.c/Mu.pm6
+++ b/src/core.c/Mu.pm6
@@ -1025,6 +1025,7 @@ my class Mu { # declared in BOOTSTRAP
               typename => type.^name,
               :private,
               :in-class-call(nqp::eqaddr(nqp::what(SELF), nqp::getlexcaller('$?CLASS'))),
+              :containerized(nqp::iscont(SELF)),
             ).throw;
     }
 
@@ -1056,6 +1057,7 @@ my class Mu { # declared in BOOTSTRAP
               invocant => SELF,
               method   => name,
               typename => SELF.^name,
+              :containerized(nqp::iscont(SELF)),
             ).throw;
         }
         $results.List


### PR DESCRIPTION
Instead of setting the score to 0, don't even add it to the suggestions.
If there are no other suggestions, before we could still use it, leading
to this example `my Int $a; $a.VAR.abs` giving this silly output:
`No such method 'abs' for invocant of type 'Scalar'.  Did you mean 'abs'?`
Now it just says `No such method 'abs' for invocant of type 'Scalar'`

Rakudo builds ok and passes `make m-test m-spectest`.