### PR TITLE
Speedup Instant.Num by manual inlining

### DIFF
--- a/src/core.c/Instant.pm6
+++ b/src/core.c/Instant.pm6
@@ -3,7 +3,7 @@ my class DateTime { ... }
 my class Duration {... }
 
 my class Instant is Cool does Real {
-    has Real $.tai is default(0);
+    has Int $.tai is default(0);
       # A linear count of nanoseconds since 1970-01-01T00:00:00Z, plus
       # Rakudo::Internals.initial-offset. Thus, $.tai matches TAI from 1970
       # to the present.
@@ -19,7 +19,7 @@ my class Instant is Cool does Real {
     }
 
     method to-nanos(--> Int:D) {
-        $!tai.Int
+        $!tai
     }
 
     proto method from-posix(|) {*}
@@ -51,9 +51,9 @@ my class Instant is Cool does Real {
     }
     method Bridge(Instant:   --> Num:D) { self.defined ?? self.tai.Bridge !! self.Real::Bridge }
     method Num   (Instant:D: --> Num:D) { nqp::div_n(self.to-nanos.Num, 1000000000e0)          }
-    method Rat   (Instant:D: --> Rat:D) { self.tai        }
-    method Int   (Instant:D: --> Int:D) { self.tai.Int    }
-    method narrow(Instant:D:          ) { self.tai.narrow }
+    method Rat   (Instant:D: --> Rat:D) { self.tai                                             }
+    method Int   (Instant:D: --> Int:D) { self.to-nanos div 1000000000                         }
+    method narrow(Instant:D:          ) { self.tai.narrow                                      }
 
     method Date(Instant:D:     --> Date:D)     { Date.new(self)     }
     method DateTime(Instant:D: --> DateTime:D) { DateTime.new(self) }

--- a/src/core.c/Instant.pm6
+++ b/src/core.c/Instant.pm6
@@ -50,7 +50,7 @@ my class Instant is Cool does Real {
         'Instant.from-posix(' ~ $posix.raku ~ ($flag ?? ',True)' !! ')')
     }
     method Bridge(Instant:   --> Num:D) { self.defined ?? self.tai.Bridge !! self.Real::Bridge }
-    method Num   (Instant:D: --> Num:D) { self.tai.Num    }
+    method Num   (Instant:D: --> Num:D) { nqp::div_n(self.to-nanos.Num, 1000000000e0)          }
     method Rat   (Instant:D: --> Rat:D) { self.tai        }
     method Int   (Instant:D: --> Int:D) { self.tai.Int    }
     method narrow(Instant:D:          ) { self.tai.narrow }


### PR DESCRIPTION
In the (usual) case that $!tai is actually an Int, this 5.5x faster
because it doesn't involve any Rational math.

`my num $a; $a = now.Num for ^1_000_000; say now - INIT now;`
used to take ~2.3s, now it takes ~0.34s.

Rakudo builds ok and passes `make m-test m-spectest`.