### PR TITLE
Make the max number of threads depend on number of cores

### DIFF
--- a/src/core.c/ThreadPoolScheduler.pm6
+++ b/src/core.c/ThreadPoolScheduler.pm6
@@ -782,9 +782,9 @@ my class ThreadPoolScheduler does Scheduler {
 
     submethod BUILD(
       Int() :$!initial_threads = 0,
-      Int() :$!max_threads = %*ENV<RAKUDO_MAX_THREADS> // Kernel.cpu-cores * 8;
-        --> Nil
-    ) {
+      Int() :$!max_threads =
+        %*ENV<RAKUDO_MAX_THREADS> // (Kernel.cpu-cores * 8 max 64)
+    --> Nil) {
         die "Initial thread pool threads ($!initial_threads) must be less than or equal to maximum threads ($!max_threads)"
             if $!initial_threads > $!max_threads;
 

--- a/src/core.c/ThreadPoolScheduler.pm6
+++ b/src/core.c/ThreadPoolScheduler.pm6
@@ -781,8 +781,8 @@ my class ThreadPoolScheduler does Scheduler {
     }
 
     submethod BUILD(
-        Int :$!initial_threads = 0,
-        Int :$!max_threads = (%*ENV<RAKUDO_MAX_THREADS> // 64).Int
+      Int() :$!initial_threads = 0,
+      Int() :$!max_threads = %*ENV<RAKUDO_MAX_THREADS> // Kernel.cpu-cores * 8;
         --> Nil
     ) {
         die "Initial thread pool threads ($!initial_threads) must be less than or equal to maximum threads ($!max_threads)"


### PR DESCRIPTION
Previously, this was set to 64.  Clearly, should be dependent
on actual number of cores available.  For now, the maximum is set
to 8 times the number of cores, based on the previous value an the
more common 4-8 core hardware that was available when that maximum
was originally set.