### PR TITLE
Many improvements to smartmatching and given/when

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -7390,6 +7390,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
                             $rhs ),
                         WANTED(QAST::Var.new( :name('$_'), :scope('lexical') ),'sm'));
         $sm_call.annotate('smartmatch_accepts', 1);
+        $sm_call.annotate('smartmatch_negated', $negated);
 
         if $negated {
             $sm_call := QAST::Op.new( :op('call'), :name('&prefix:<!>'), $sm_call );
@@ -7419,10 +7420,12 @@ class Perl6::Actions is HLL::Actions does STDActions {
                             :op('callmethod'),
                             :name('Bool'),
                             $rvar ))));
+            $sm_call.annotate('smartmatch_boolified', 1);
         }
 
         QAST::Op.new(
             :op('locallifetime'),
+            :node($/),
             QAST::Stmt.new(
                 # Stash original $_.
                 QAST::Op.new( :op('bind'),

--- a/src/Perl6/Optimizer.nqp
+++ b/src/Perl6/Optimizer.nqp
@@ -1188,7 +1188,8 @@ my class Operand {
 
     method value-type() {
         self.value-analyze;
-        nqp::what($!value)
+        # We need this ternary for JVM where otherwise it may throw on VMNull in $!value
+        nqp::isnull($!value) ?? nqp::null() !! nqp::what($!value)
     }
 
     method value-kind() {

--- a/src/Perl6/Optimizer.nqp
+++ b/src/Perl6/Optimizer.nqp
@@ -1580,9 +1580,9 @@ my class SmartmatchOptimizer {
         # and it doesn't succeed, that creates an expensive Backtrace that we just
         # end up throwing away
         if $method eq 'Numeric' {
-            my $fail-or-mu := QAST::Op.new( :op('hllbool'), QAST::IVal.new( :value(1) ) );
-            $fail-or-mu.named('fail-or-mu');
-            $method_call.push($fail-or-mu);
+            my $fail-or-nil := QAST::Op.new( :op('hllbool'), QAST::IVal.new( :value(1) ) );
+            $fail-or-nil.named('fail-or-nil');
+            $method_call.push($fail-or-nil);
         }
 
         # Make sure we're not comparing against a type object, since those could
@@ -2605,7 +2605,7 @@ class Perl6::Optimizer {
 
         # Warn for something like `my $a = 2.rand.Int; say "a = " ~ $a ?? "true" !! "false";`, which
         # will just print 'true' because the entire expression `"a = " ~ $a` is being evaluated by the
-        # ternary instead of just the `$a` (the correct form is `"a = " ~ ($a ?? "true" !! "false"`)). 
+        # ternary instead of just the `$a` (the correct form is `"a = " ~ ($a ?? "true" !! "false"`)).
         if $optype eq 'if' && $op.name eq '&infix:<??>' &&
               nqp::istype($op[0], QAST::Op) && ($op[0].op eq 'call' || $op[0].op eq 'callstatic') &&
               nqp::index($op[0].name, '&infix:') == 0 && $!symbols.is_from_core($op[0].name) &&

--- a/src/core.c/Bool.pm6
+++ b/src/core.c/Bool.pm6
@@ -24,7 +24,7 @@ BEGIN {
 }
 BEGIN {
     Bool.^add_multi_method('Bool',    my multi method Bool(Bool:U:)    { Bool::False });
-    Bool.^add_multi_method('ACCEPTS', my multi method ACCEPTS(Bool:U: \topic ) { nqp::istype(topic, Bool) });
+    Bool.^add_multi_method('ACCEPTS', my multi method ACCEPTS(Bool:U: \topic ) { nqp::hllbool(nqp::istype(topic, self)) });
     Bool.^add_multi_method('gist',    my multi method gist(Bool:U:)    { '(Bool)' });
     Bool.^add_multi_method('raku', my multi method raku(Bool:U:) { 'Bool' });
 

--- a/src/core.c/Exception.pm6
+++ b/src/core.c/Exception.pm6
@@ -2360,6 +2360,17 @@ my class X::Range::InvalidArg is Exception {
     }
 }
 
+my class X::Range::Incomparable is Exception {
+    has $.topic;
+    has $.endpoint;
+    has $.what-endpoint;
+    method message() {
+        "Value of type '" ~ $.topic.^name
+        ~ "' cannot be compared with range $.what-endpoint of type '"
+        ~ $.endpoint.^name ~ "'"
+    }
+}
+
 my class X::Sequence::Deduction is Exception {
     has $.from;
     method message() {

--- a/src/core.c/Int.pm6
+++ b/src/core.c/Int.pm6
@@ -1,4 +1,4 @@
-my class Rat { ... } 
+my class Rat { ... }
 my class X::Cannot::Capture       { ... }
 my class X::Numeric::DivideByZero { ... }
 my class X::NYI::BigInt { ... }

--- a/src/core.c/Match.pm6
+++ b/src/core.c/Match.pm6
@@ -235,7 +235,7 @@ my class Match is Capture is Cool does NQPMatchRole {
     multi method Numeric(Match:D:) {
         self.Str.Numeric
     }
-    multi method ACCEPTS(Match:D: Any $) { self }
+    multi method ACCEPTS(Match:D: Mu) { self }
 
     method prematch(Match:D:) {
         nqp::substr(self.target,0,$!from)

--- a/src/core.c/Str.pm6
+++ b/src/core.c/Str.pm6
@@ -1551,10 +1551,10 @@ my class Str does Stringy { # declared in BOOTSTRAP
     }
 
 #?if moar
-    proto method match(|) {*}
+    proto method match(Any, |) {*}
 #?endif
 #?if !moar
-    proto method match(|) { $/ := nqp::getlexcaller('$/'); {*} }
+    proto method match(Any, |) { $/ := nqp::getlexcaller('$/'); {*} }
 #?endif
     multi method match(Cool:D $pattern, |c) {
         $/ := nqp::getlexcaller('$/');

--- a/tools/templates/Makefile-backend-common.in
+++ b/tools/templates/Makefile-backend-common.in
@@ -175,7 +175,7 @@ check_@backend_abbr@_nqp_version: @@script(check-nqp-version.pl)@@
 @comp(@bsm(RAKUDO_M)@: 	@use_prereqs(@nfp(@bpm(BUILD_DIR)@/Metamodel.nqp)@)@ @bsm(RAKUDO_OPS)@)@
 @comp(@bsm(RAKUDO_ML)@: 	@use_prereqs(@nfp(@bpm(BUILD_DIR)@/ModuleLoader.nqp)@)@ @nfp(gen/nqp-version)@)@
 @comp(@bsm(RAKUDO_OPS)@:	@use_prereqs(@nfp(@bpm(BUILD_DIR)@/Ops.nqp)@)@ @bpm(RAKUDO_OPS_EXTRA)@ @nfp(gen/nqp-version)@)@
-@comp(@bsm(RAKUDO_O)@:	@use_prereqs(@nfp(@bpm(BUILD_DIR)@/Optimizer.nqp)@)@ @bsm(RAKUDO_OPS)@)@
+@comp(@bsm(RAKUDO_O)@:	@use_prereqs(@nfp(@bpm(BUILD_DIR)@/Optimizer.nqp)@)@ @bsm(RAKUDO_OPS)@ @bsm(RAKUDO_M)@)@
 @comp(@bsm(RAKUDO_P)@: 	@use_prereqs(@nfp(@bpm(BUILD_DIR)@/Pod.nqp)@)@ @nfp(gen/nqp-version)@)@
 @comp(@bsm(RAKUDO_W)@: 	@use_prereqs(@nfp(@bpm(BUILD_DIR)@/World.nqp)@)@ @bsm(RAKUDO_ML)@ @bsm(RAKUDO_OPS)@ @bsm(RAKUDO_P)@)@
 


### PR DESCRIPTION
- Junctions are now welcome on RHS and as `when` topic
- `when` now uses optimized code unless the topic is a Junction. Falls back to `ACCEPTS`+`Bool` in the latter case.
- smartmatch optimization is now more elaborate about its arguments. It implicitly `Bool`-ifies `ACCEPTS` return value unless its LHS is a regex or negation is to be done.
- more optimizations for literal and type matching

Overall, with this PR it must not be a problem if `ACCEPTS` gets autothreaded and results in a junctionized return. Either it will be collapsed with boolification where smartmatch semantics is expected, or junctionized outcome of a regex match is expected.