### PR TITLE
Make sure that nqp::cpucores is only called once ever

### DIFF
--- a/src/core.c/Buf.pm6
+++ b/src/core.c/Buf.pm6
@@ -1,4 +1,3 @@
-my class Kernel                 { ... }
 my class X::Assignment::RO      { ... }
 my class X::Buf::AsStr          { ... }
 my class X::Buf::Pack           { ... }

--- a/src/core.c/Iterable.pm6
+++ b/src/core.c/Iterable.pm6
@@ -10,6 +10,7 @@
 my class HyperSeq { ... }
 my class RaceSeq { ... }
 my class Rakudo::Internals::HyperIteratorBatcher { ... }
+my class Kernel { ... }
 my role Iterable {
     method iterator() { ... }
 
@@ -29,8 +30,8 @@ my role Iterable {
     }
 
     method hyper(
-      Int(Cool) :$batch = 64,
-      Int(Cool) :$degree = max(nqp::cpucores() - 1,1)
+      Int(Cool) :$batch  = 64,
+      Int(Cool) :$degree = Kernel.cpu-cores-but-one;
     ) {
 #?if !js
         HyperSeq.new:
@@ -45,8 +46,8 @@ my role Iterable {
     }
 
     method race(
-      Int(Cool) :$batch = 64,
-      Int(Cool) :$degree = max(nqp::cpucores() - 1,1)
+      Int(Cool) :$batch  = 64,
+      Int(Cool) :$degree = Kernel.cpu-cores-but-one;
     ) {
 #?if !js
         RaceSeq.new:

--- a/src/core.c/Iterable.pm6
+++ b/src/core.c/Iterable.pm6
@@ -31,7 +31,7 @@ my role Iterable {
 
     method hyper(
       Int(Cool) :$batch  = 64,
-      Int(Cool) :$degree = Kernel.cpu-cores-but-one;
+      Int(Cool) :$degree = Kernel.cpu-cores-but-one,
     ) {
 #?if !js
         HyperSeq.new:
@@ -47,7 +47,7 @@ my role Iterable {
 
     method race(
       Int(Cool) :$batch  = 64,
-      Int(Cool) :$degree = Kernel.cpu-cores-but-one;
+      Int(Cool) :$degree = Kernel.cpu-cores-but-one,
     ) {
 #?if !js
         RaceSeq.new:

--- a/src/core.c/Kernel.pm6
+++ b/src/core.c/Kernel.pm6
@@ -164,13 +164,20 @@ class Kernel does Systemic {
     multi method signal(Kernel:D: Signal:D \signal --> Int:D) { signal.value }
     multi method signal(Kernel:D: Int:D    \signal --> Int:D) { signal       }
 
-    method cpu-cores(--> Int) { nqp::cpucores }
+    my int $cpu-cores;
+    proto method cpu-cores(|) {*}
+    multi method cpu-cores(--> Int) { $cpu-cores = nqp::cpucores }
+    multi method cpu-cores(:$cached! --> Int) {
+        $cached && $cpu-cores
+          ?? $cpu-cores
+          !! ($cpu-cores = nqp::cpucores)
+    }
 
     my $cpu-cores-but-one := nqp::null;
     method cpu-cores-but-one() is implementation-detail {
         nqp::ifnull(
           $cpu-cores-but-one,
-          $cpu-cores-but-one := max nqp::cpucores() - 1, 1
+          $cpu-cores-but-one := max Kernel.cpu-cores(:cached) - 1, 1
         )
     }
 

--- a/src/core.c/Kernel.pm6
+++ b/src/core.c/Kernel.pm6
@@ -164,9 +164,11 @@ class Kernel does Systemic {
     multi method signal(Kernel:D: Signal:D \signal --> Int:D) { signal.value }
     multi method signal(Kernel:D: Int:D    \signal --> Int:D) { signal       }
 
-    method cpu-cores(--> Int) is raw {
-        nqp::cpucores()
-    }
+    my int $cpu-cores = nqp::cpucores;
+    my int $cpu-cores-but-one = max $cpu-cores - 1, 1;
+
+    method cpu-cores(--> Int) { $cpu-cores }
+    method cpu-cores-but-one() is implementation-detail { $cpu-cores-but-one }
 
     method cpu-usage(--> Int) is raw {
         my int @rusage;

--- a/src/core.c/Kernel.pm6
+++ b/src/core.c/Kernel.pm6
@@ -164,20 +164,13 @@ class Kernel does Systemic {
     multi method signal(Kernel:D: Signal:D \signal --> Int:D) { signal.value }
     multi method signal(Kernel:D: Int:D    \signal --> Int:D) { signal       }
 
-    my int $cpu-cores;
-    proto method cpu-cores(|) {*}
-    multi method cpu-cores(--> Int) { $cpu-cores = nqp::cpucores }
-    multi method cpu-cores(:$cached! --> Int) {
-        $cached && $cpu-cores
-          ?? $cpu-cores
-          !! ($cpu-cores = nqp::cpucores)
-    }
+    method cpu-cores(--> Int) { nqp::cpucores }
 
     my $cpu-cores-but-one := nqp::null;
     method cpu-cores-but-one() is implementation-detail {
         nqp::ifnull(
           $cpu-cores-but-one,
-          $cpu-cores-but-one := max Kernel.cpu-cores(:cached) - 1, 1
+          $cpu-cores-but-one := max nqp::cpucores() - 1, 1
         )
     }
 

--- a/src/core.c/Kernel.pm6
+++ b/src/core.c/Kernel.pm6
@@ -164,11 +164,15 @@ class Kernel does Systemic {
     multi method signal(Kernel:D: Signal:D \signal --> Int:D) { signal.value }
     multi method signal(Kernel:D: Int:D    \signal --> Int:D) { signal       }
 
-    my int $cpu-cores = nqp::cpucores;
-    my int $cpu-cores-but-one = max $cpu-cores - 1, 1;
+    method cpu-cores(--> Int) { nqp::cpucores }
 
-    method cpu-cores(--> Int) { $cpu-cores }
-    method cpu-cores-but-one() is implementation-detail { $cpu-cores-but-one }
+    my $cpu-cores-but-one := nqp::null;
+    method cpu-cores-but-one() is implementation-detail {
+        nqp::ifnull(
+          $cpu-cores-but-one,
+          $cpu-cores-but-one := max nqp::cpucores() - 1, 1
+        )
+    }
 
     method cpu-usage(--> Int) is raw {
         my int @rusage;

--- a/src/core.c/Thread.pm6
+++ b/src/core.c/Thread.pm6
@@ -35,6 +35,11 @@ my class Thread {
       Str()  :$!name         = "<anon>"
       --> Nil
     ) {
+
+        # Make sure we have at least called nqp::cpucores once before
+        # we start any thread.  This to avoid issues on MacOS Monterey
+        Kernel.cpu-cores(:cached);
+
         constant THREAD_ERROR = 'Could not create a new Thread: ';
         my $entry := anon sub THREAD-ENTRY() {
             my $*THREAD = self;

--- a/src/core.c/Thread.pm6
+++ b/src/core.c/Thread.pm6
@@ -38,7 +38,7 @@ my class Thread {
 
         # Make sure we have at least called nqp::cpucores once before
         # we start any thread.  This to avoid issues on MacOS Monterey
-        Kernel.cpu-cores(:cached);
+        Kernel.cpu-cores-but-one;
 
         constant THREAD_ERROR = 'Could not create a new Thread: ';
         my $entry := anon sub THREAD-ENTRY() {

--- a/src/core.c/ThreadPoolScheduler.pm6
+++ b/src/core.c/ThreadPoolScheduler.pm6
@@ -536,6 +536,7 @@ my class ThreadPoolScheduler does Scheduler {
     my constant EXHAUSTED_RETRY_AFTER = 100;
     method !maybe-start-supervisor(--> Nil) {
         unless $!supervisor.DEFINITE {
+            my int $cpu-cores = Kernel.cpu-cores-but-one;
             $!supervisor = Thread.start(:app_lifetime, :name<Supervisor>, {
                 sub add-general-worker(--> Nil) {
                     $!state-lock.protect: {
@@ -579,7 +580,6 @@ my class ThreadPoolScheduler does Scheduler {
                     + nqp::atpos_i(@rusage, nqp::const::RUSAGE_STIME_MSEC);
 
                 my num @last-utils = 0e0 xx NUM_SAMPLES;
-                my int $cpu-cores = Kernel.cpu-cores-but-one;
 
                 # These definitions used to live inside the supervisor loop.
                 # Moving them out of the loop does not improve CPU usage

--- a/src/core.c/ThreadPoolScheduler.pm6
+++ b/src/core.c/ThreadPoolScheduler.pm6
@@ -535,7 +535,6 @@ my class ThreadPoolScheduler does Scheduler {
     my constant NUM_SAMPLES_NUM       = 5e0;
     my constant EXHAUSTED_RETRY_AFTER = 100;
     method !maybe-start-supervisor(--> Nil) {
-        my int $cpu-cores = max(nqp::cpucores() - 1,1);
         unless $!supervisor.DEFINITE {
             $!supervisor = Thread.start(:app_lifetime, :name<Supervisor>, {
                 sub add-general-worker(--> Nil) {
@@ -580,6 +579,7 @@ my class ThreadPoolScheduler does Scheduler {
                     + nqp::atpos_i(@rusage, nqp::const::RUSAGE_STIME_MSEC);
 
                 my num @last-utils = 0e0 xx NUM_SAMPLES;
+                my int $cpu-cores = Kernel.cpu-cores-but-one;
 
                 # These definitions used to live inside the supervisor loop.
                 # Moving them out of the loop does not improve CPU usage


### PR DESCRIPTION
It appears that nqp::cpucores can potentially be a heavy operation
(even like needing to fork() apparently on MacOS Monterey), which
may well have some adverse effects.

Therefore make sure we only call nqp::cpucores only once at startup.
Also introduce an implementation-detail Kernel.cpu-cores-but-one
method that will be one less than the number of CPU cores, with a
minimum of 1.