### PR TITLE
Implement sub rotor

### DIFF
--- a/src/core.e/Any-iterable-methods.pm6
+++ b/src/core.e/Any-iterable-methods.pm6
@@ -1,0 +1,9 @@
+proto sub rotor(|) {*}
+multi sub rotor(Int:D $batch, \thing, *%_) {
+    thing.rotor($batch, |%_)
+}
+# We have to emulate :(*@ [@list, \tail]) because the grammar wont cut it.
+multi sub rotor(**@cycle-and-thing, *%_) {
+    @cycle-and-thing.tail.rotor(@cycle-and-thing.head(*-1), |%_)
+}
+

--- a/t/02-rakudo/03-corekeys-6e.t
+++ b/t/02-rakudo/03-corekeys-6e.t
@@ -405,6 +405,7 @@ my @expected = (
     Q{&return-rw},
     Q{&reverse},
     Q{&rindex},
+    Q{&rotor},
     Q{&rmdir},
     Q{&roll},
     Q{&roots},

--- a/t/02-rakudo/03-corekeys.t
+++ b/t/02-rakudo/03-corekeys.t
@@ -796,6 +796,7 @@ my @allowed =
         Q{&next},
         Q{&postcircumfix:<[; ]>},
         Q{&postcircumfix:<{; }>},
+        Q{&rotor},
         Q{CORE-SETTING-REV},
         Q{Grammar},
         Q{PseudoStash},

--- a/t/02-rakudo/04-settingkeys-6e.t
+++ b/t/02-rakudo/04-settingkeys-6e.t
@@ -402,6 +402,7 @@ my %allowed = (
     Q{&return-rw},
     Q{&reverse},
     Q{&rindex},
+    Q{&rotor},
     Q{&rmdir},
     Q{&roll},
     Q{&roots},

--- a/t/02-rakudo/07-implementation-detail-6.e.t
+++ b/t/02-rakudo/07-implementation-detail-6.e.t
@@ -28,7 +28,7 @@ my @lower = ("",<<
   not note one open ord ords pair pairs parse-base parse-names
   permutations pick pop prepend print printf proceed produce
   prompt push put rand redo reduce rename repeated repl return
-  return-rw reverse rindex rmdir roll roots rotate round roundrobin
+  return-rw reverse rotor rindex rmdir roll roots rotate round roundrobin
   run samecase samemark samewith say sec sech set shell shift sign
   signal sin sinh sleep sleep-timer sleep-until slip slurp so sort
   splice split sprintf spurt sqrt squish srand subbuf-rw substr

--- a/tools/templates/6.e/core_sources
+++ b/tools/templates/6.e/core_sources
@@ -6,3 +6,4 @@ src/core.e/EXPORTHOW.pm6
 src/core.e/array_multislice.pm6
 src/core.e/hash_multislice.pm6
 src/core.e/Rakudo/Internals/Sprintf.pm6
+src/core.e/Any-iterable-methods.pm6


### PR DESCRIPTION
For reasons unknown there is no functional counterpart to `method rotor`. As this method is often used in chains, it should also be possible to use with feed operators. The implemention enclosed aims to do so.

Tests and use cases:

```
use v6.*;
use Test;

is-deeply rotor(2, (1,2,3,4)), ((1, 2), (3, 4)), 'sub rotor with batch-size';
is-deeply rotor(2 => -1, (1,2,3,4)), ((1, 2), (2, 3), (3, 4)), 'sub rotor with overlapping batch';
my @a = <a b c d e>;
is-deeply rotor(3, @a, :partial), (("a", "b", "c"), ("d", "e")), 'sub rotor with batch and partial completion';

1,2,3,4
==> rotor(2 => -1, 3 => 1)
==> my @b;
is-deeply @b, [(1, 2), (2, 3, 4)], 'sub rotor with 2-level feed operator';

<a b c d e>
==> rotor(3, :partial)
==> my @c;
is-deeply @c, [<a b c>, <d e>], 'sub rotor with feed operator and named argument';
```