### PR TITLE
Add :slip named argument to roundrobin()

### DIFF
--- a/src/core.c/List.pm6
+++ b/src/core.c/List.pm6
@@ -1610,8 +1610,11 @@ multi sub infix:<Z>(+lol --> Seq:D) {
 my constant &zip := &infix:<Z>;
 
 proto sub roundrobin(|) {*}
-multi sub roundrobin(+lol --> Seq:D) {
-    Seq.new(Rakudo::Iterator.RoundrobinIterables(lol))
+multi sub roundrobin(+lol, :$slip --> Seq:D) {
+    Seq.new($slip
+      ?? Rakudo::Iterator.RoundrobinIterablesSlipped(lol)
+      !! Rakudo::Iterator.RoundrobinIterables(lol)
+    )
 }
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
When set, it will generate separate values from the lists, rather
than Lists.  Basically, the same as:

    roundrobin(...).map: *.Slip

but much more effcient as no intermediate Lists / Slips need to be
created.