### PR TITLE
[JVM] Don't let signal(SIGINT) break the REPL

### DIFF
--- a/src/core.c/REPL.pm6
+++ b/src/core.c/REPL.pm6
@@ -358,11 +358,13 @@ do {
 
         method repl-loop(:$no-exit, *%adverbs) {
             my int $stopped;   # did we press CTRL-c just now?
+#?if !jvm
             signal(SIGINT).tap: {
                 exit if $stopped++;
                 say "Pressed CTRL-c, press CTRL-c again to exit";
                 print self.interactive_prompt;
             }
+#?endif
 
             say $no-exit
               ?? "Type 'exit' to leave"


### PR DESCRIPTION
The support for signals on the JVM backend is only rudimentary. The
recently introduced (cf7b4f18da) call to signal(SIGINT).tap doesn't
work on the JVM backend:

  $ ./rakudo -e 'signal(SIGINT).tap'
  Exception in thread "Thread-3" java.lang.NullPointerException
          at org.raku.nqp.runtime.IOOps$SigRunnable.run(IOOps.java:31)
          at java.base/java.lang.Thread.run(Thread.java:834)

It seems best to just skip the problematic command.