### PR TITLE
Fix removing proxies in native calls

### DIFF
--- a/lib/NativeCall/Dispatcher.rakumod
+++ b/lib/NativeCall/Dispatcher.rakumod
@@ -1,10 +1,45 @@
 use NativeCall::Types;
 
 use nqp;
-sub raku-native-dispatch-deproxy($callee, **@args) {
-    $callee(|@args) # implicitly fetches values from proxies
+
+my sub raku-nativecall-deproxy(Mu $capture is raw) {
+    my $callee := nqp::captureposarg($capture, 1);
+    # The resume init state drops the remover.
+    nqp::dispatch('boot-syscall', 'dispatcher-set-resume-init-args',
+        nqp::dispatch('boot-syscall', 'dispatcher-drop-arg', $capture, 0));
+
+    # We then invoke the remover with the arguments (so need to drop the
+    # original invokee).
+    nqp::dispatch('boot-syscall', 'dispatcher-delegate', 'boot-code-constant',
+        nqp::dispatch('boot-syscall', 'dispatcher-drop-arg', $capture, 1));
 }
-my &raku-nativecall := -> $capture is raw {
+
+my sub raku-nativecall-deproxy-resume(Mu $capture is raw) {
+    my $track_kind := nqp::dispatch('boot-syscall', 'dispatcher-track-arg', $capture, 0);
+    nqp::dispatch('boot-syscall', 'dispatcher-guard-literal', $track_kind);
+    my int $kind = nqp::captureposarg_i($capture, 0);
+
+    if $kind == nqp::const::DISP_DECONT {
+        my $orig-capture := nqp::dispatch('boot-syscall', 'dispatcher-get-resume-init-args');
+        my $track_callee := nqp::dispatch('boot-syscall', 'dispatcher-track-arg',
+            $orig-capture, 0);
+        nqp::dispatch('boot-syscall', 'dispatcher-guard-literal', $track_callee);
+        my $callee := nqp::captureposarg($orig-capture, 0);
+        my $capture-delegate := nqp::dispatch('boot-syscall',
+            'dispatcher-insert-arg-literal-obj',
+            nqp::dispatch('boot-syscall', 'dispatcher-drop-arg', $capture, 0), 0, $callee);
+        nqp::dispatch('boot-syscall', 'dispatcher-delegate', 'raku-nativecall', $capture-delegate);
+    }
+}
+
+my $do := nqp::getattr(&raku-nativecall-deproxy, Code, '$!do');
+nqp::forceouterctx($do, nqp::getattr(MY::, PseudoStash, '$!ctx'));
+my $do-resume := nqp::getattr(&raku-nativecall-deproxy-resume, Code, '$!do');
+nqp::forceouterctx($do-resume, nqp::getattr(MY::, PseudoStash, '$!ctx'));
+nqp::dispatch('boot-syscall', 'dispatcher-register', 'raku-nativecall-deproxy', $do, $do-resume);
+
+my $PROXY-READERS := nqp::gethllsym('Raku', 'PROXY-READERS');
+my sub raku-nativecall(Mu $capture is raw) {
     my $track_callee := nqp::dispatch('boot-syscall', 'dispatcher-track-arg', $capture, 0);
     nqp::dispatch('boot-syscall', 'dispatcher-guard-literal', $track_callee);
     my $callee := nqp::captureposarg($capture, 0);
@@ -15,8 +50,48 @@ my &raku-nativecall := -> $capture is raw {
     my int $readonly = nqp::getattr_i($signature, Signature, '$!readonly');
     my int $pos-args = nqp::captureposelems($args);
     my int $i = 0;
-    my int $continue = 1;
-    while $i < $pos-args and $continue {
+
+    my $non-scalar := nqp::list_i();
+    while $i < $pos-args {
+        if nqp::captureposprimspec($args, $i) == 0 {
+            my $value := nqp::captureposarg($args, $i);
+            if nqp::isconcrete_nd($value) &&
+                nqp::iscont($value) && !nqp::istype_nd($value, Scalar) &&
+                !(nqp::iscont_i($value) || nqp::iscont_n($value) || nqp::iscont_s($value))
+            {
+                nqp::push_i($non-scalar, nqp::unbox_i($i));
+            }
+        }
+        $i++;
+    }
+    if nqp::elems($non-scalar) {
+        # Establish guards on types of all positionals, but not on the values
+        # inside of them if they are Scalar containers; we just need to make
+        # sure we have the appropriate tuple of Proxy vs non-Proxy for the
+        # Proxy removal code we'll invoke.
+        $i = 0;
+        while $i < $pos-args {
+            if nqp::captureposprimspec($args, $i) == 0 {
+                my $track-arg := nqp::dispatch('boot-syscall', 'dispatcher-track-arg', $args, nqp::unbox_i($i));
+                nqp::dispatch('boot-syscall', 'dispatcher-guard-type', $track-arg);
+            }
+            $i++;
+        }
+
+        # Need to strip the Proxy arguments and then try again. Produce a
+        # proxy reader code object to do so, insert it as the first arg,
+        # and delegate to a dispatcher to manage reading the args and
+        # then retrying with the outcome.
+        my $reader := $PROXY-READERS.reader-for($args, $non-scalar);
+        my $capture-delegate := nqp::dispatch('boot-syscall',
+            'dispatcher-insert-arg-literal-obj', $capture, 0, nqp::getattr($reader, Code, '$!do'));
+        nqp::dispatch('boot-syscall', 'dispatcher-delegate', 'raku-nativecall-deproxy',
+            $capture-delegate);
+        return;
+    }
+
+    $i = 0;
+    while $i < $pos-args {
         # If it should be passed read only, and it's an object...
         if nqp::captureposprimspec($args, $i) == 0 {
             # If it's in a Scalar container...
@@ -62,74 +137,64 @@ my &raku-nativecall := -> $capture is raw {
                     $arg := nqp::decont($arg);
                 }
             }
-            elsif nqp::isconcrete_nd($arg) && nqp::istype_nd($arg, Proxy) {
-                $args := nqp::dispatch('boot-syscall', 'dispatcher-insert-arg-literal-obj',
-                    $args, 0, $callee);
-                $args := nqp::dispatch('boot-syscall', 'dispatcher-insert-arg-literal-obj',
-                    $args, 0, &raku-native-dispatch-deproxy);
-                nqp::dispatch('boot-syscall', 'dispatcher-delegate', 'raku-invoke', $args);
-                $continue = 0;
-            }
 
-            if $continue {
-                my $param = $callee.signature.params[$i];
-                unless $param.rw or nqp::isrwcont($arg) {
-                    if $param.type ~~ Int or $param.type.REPR eq 'CPointer' {
-                        if nqp::isconcrete_nd($arg) {
-                            $track-value := nqp::dispatch('boot-syscall', 'dispatcher-track-unbox-int',
-                                $track-value);
-                            $args := nqp::dispatch('boot-syscall', 'dispatcher-insert-arg',
-                                nqp::dispatch('boot-syscall', 'dispatcher-drop-arg', $args, nqp::unbox_i($i)),
-                                nqp::unbox_i($i), $track-value);
-                        }
-                        else {
-                            $args := nqp::dispatch('boot-syscall', 'dispatcher-insert-arg-literal-int',
-                                nqp::dispatch('boot-syscall', 'dispatcher-drop-arg', $args, nqp::unbox_i($i)),
-                                nqp::unbox_i($i), 0); # 0 or NULL for undefined args
-                        }
+            my $param = $callee.signature.params[$i];
+            unless $param.rw or nqp::isrwcont($arg) {
+                if $param.type ~~ Int or $param.type.REPR eq 'CPointer' {
+                    if nqp::isconcrete_nd($arg) {
+                        $track-value := nqp::dispatch('boot-syscall', 'dispatcher-track-unbox-int',
+                            $track-value);
+                        $args := nqp::dispatch('boot-syscall', 'dispatcher-insert-arg',
+                            nqp::dispatch('boot-syscall', 'dispatcher-drop-arg', $args, nqp::unbox_i($i)),
+                            nqp::unbox_i($i), $track-value);
                     }
-                    elsif $param.type ~~ Num {
-                        if nqp::isconcrete_nd($arg) {
-                            $track-value := nqp::dispatch('boot-syscall', 'dispatcher-track-unbox-num',
-                                $track-value);
-                            $args := nqp::dispatch('boot-syscall', 'dispatcher-insert-arg',
-                                nqp::dispatch('boot-syscall', 'dispatcher-drop-arg', $args, nqp::unbox_i($i)),
-                                nqp::unbox_i($i), $track-value);
-                        }
-                        else {
-                            $args := nqp::dispatch('boot-syscall', 'dispatcher-insert-arg-literal-num',
-                                nqp::dispatch('boot-syscall', 'dispatcher-drop-arg', $args, nqp::unbox_i($i)),
-                                nqp::unbox_i($i), NaN);
-                        }
+                    else {
+                        $args := nqp::dispatch('boot-syscall', 'dispatcher-insert-arg-literal-int',
+                            nqp::dispatch('boot-syscall', 'dispatcher-drop-arg', $args, nqp::unbox_i($i)),
+                            nqp::unbox_i($i), 0); # 0 or NULL for undefined args
                     }
-                    elsif $param.type ~~ Str and not $cstr {
-                        if nqp::isconcrete_nd($arg) {
-                            $track-value := nqp::dispatch('boot-syscall', 'dispatcher-track-unbox-str',
-                                $track-value);
-                            $args := nqp::dispatch('boot-syscall', 'dispatcher-insert-arg',
-                                nqp::dispatch('boot-syscall', 'dispatcher-drop-arg', $args, nqp::unbox_i($i)),
-                                nqp::unbox_i($i), $track-value);
-                        }
-                        else {
-                            $args := nqp::dispatch('boot-syscall', 'dispatcher-insert-arg-literal-int',
-                                nqp::dispatch('boot-syscall', 'dispatcher-drop-arg', $args, nqp::unbox_i($i)),
-                                nqp::unbox_i($i), 0); # NULL for undefined args
-                        }
+                }
+                elsif $param.type ~~ Num {
+                    if nqp::isconcrete_nd($arg) {
+                        $track-value := nqp::dispatch('boot-syscall', 'dispatcher-track-unbox-num',
+                            $track-value);
+                        $args := nqp::dispatch('boot-syscall', 'dispatcher-insert-arg',
+                            nqp::dispatch('boot-syscall', 'dispatcher-drop-arg', $args, nqp::unbox_i($i)),
+                            nqp::unbox_i($i), $track-value);
+                    }
+                    else {
+                        $args := nqp::dispatch('boot-syscall', 'dispatcher-insert-arg-literal-num',
+                            nqp::dispatch('boot-syscall', 'dispatcher-drop-arg', $args, nqp::unbox_i($i)),
+                            nqp::unbox_i($i), NaN);
+                    }
+                }
+                elsif $param.type ~~ Str and not $cstr {
+                    if nqp::isconcrete_nd($arg) {
+                        $track-value := nqp::dispatch('boot-syscall', 'dispatcher-track-unbox-str',
+                            $track-value);
+                        $args := nqp::dispatch('boot-syscall', 'dispatcher-insert-arg',
+                            nqp::dispatch('boot-syscall', 'dispatcher-drop-arg', $args, nqp::unbox_i($i)),
+                            nqp::unbox_i($i), $track-value);
+                    }
+                    else {
+                        $args := nqp::dispatch('boot-syscall', 'dispatcher-insert-arg-literal-int',
+                            nqp::dispatch('boot-syscall', 'dispatcher-drop-arg', $args, nqp::unbox_i($i)),
+                            nqp::unbox_i($i), 0); # NULL for undefined args
                     }
                 }
             }
         }
         $i++;
     }
-    if $continue {
-        my $new_capture := nqp::dispatch('boot-syscall',
-            'dispatcher-insert-arg-literal-obj',
-            $args, 0, nqp::decont($callee.rettype));
-        my $delegate_capture := nqp::dispatch('boot-syscall', 'dispatcher-insert-arg-literal-obj',
-            $new_capture, 0, $callee.call);
-        nqp::dispatch('boot-syscall', 'dispatcher-delegate', 'boot-foreign-code', $delegate_capture);
-    }
+
+    my $new_capture := nqp::dispatch('boot-syscall',
+        'dispatcher-insert-arg-literal-obj',
+        $args, 0, nqp::decont($callee.rettype));
+    my $delegate_capture := nqp::dispatch('boot-syscall', 'dispatcher-insert-arg-literal-obj',
+        $new_capture, 0, $callee.call);
+    nqp::dispatch('boot-syscall', 'dispatcher-delegate', 'boot-foreign-code', $delegate_capture);
 };
-my $do := nqp::getattr(&raku-nativecall, Code, '$!do');
+
+$do := nqp::getattr(&raku-nativecall, Code, '$!do');
 nqp::forceouterctx($do, nqp::getattr(MY::, PseudoStash, '$!ctx'));
 nqp::dispatch('boot-syscall', 'dispatcher-register', 'raku-nativecall', $do);

--- a/src/vm/moar/dispatchers.nqp
+++ b/src/vm/moar/dispatchers.nqp
@@ -1496,6 +1496,7 @@ class ProxyReaderFactory {
     }
 }
 my $PROXY-READERS := ProxyReaderFactory.new;
+nqp::bindhllsym('Raku', 'PROXY-READERS', $PROXY-READERS);
 
 # The core of multi dispatch. Once we are here, either there was a simple
 # proto that we don't need to inovke, or we already did invoke the proto.

--- a/t/04-nativecall/02-simple-args.c
+++ b/t/04-nativecall/02-simple-args.c
@@ -69,6 +69,17 @@ DLLEXPORT int TakeAString(char *pass_msg)
     return 0;
 }
 
+static int pass = 0;
+DLLEXPORT int TakeAStringThenNull(int64_t dummy, char *pass_msg)
+{
+    pass++;
+    if ((pass % 2 == 0) && pass_msg != NULL && 0 == strcmp(pass_msg, "ok 6 - passed a string"))
+        return 6;
+    if ((pass % 2 == 1) && pass_msg == NULL)
+        return 6;
+    return 0;
+}
+
 static char *cached_str = NULL;
 DLLEXPORT void SetString(char *str) {
     cached_str = str;

--- a/t/04-nativecall/08-callbacks.c
+++ b/t/04-nativecall/08-callbacks.c
@@ -55,3 +55,8 @@ DLLEXPORT int CheckReturnsStruct(Struct *(*cb)()) {
     if(strcmp(s->str, "Tweedledum, tweedledee")) return 2;
     return 8;
 }
+
+static int pass = 0;
+DLLEXPORT int CheckChangingCallback(int (*cb)()) {
+    return cb() - pass++;
+}

--- a/t/04-nativecall/08-callbacks.t
+++ b/t/04-nativecall/08-callbacks.t
@@ -5,7 +5,7 @@ use CompileTestLib;
 use NativeCall;
 use Test;
 
-plan(11);
+plan(13);
 
 compile_test_lib('08-callbacks');
 
@@ -28,6 +28,7 @@ sub TakeStructCallback(&cb (Struct)) is native('./08-callbacks') { * }
 sub CheckReturnsFloat(&cb (--> num64))   returns int32 is native('./08-callbacks') { * }
 sub CheckReturnsStr(&cb (--> Str))       returns int32 is native('./08-callbacks') { * }
 sub CheckReturnsStruct(&cb (--> Struct)) returns int32 is native('./08-callbacks') { * }
+sub CheckChangingCallback(&cb (--> int)) returns int32 is native('./08-callbacks') { * }
 
 sub simple_callback() {
     pass 'simple callback';
@@ -71,5 +72,9 @@ TakeStructCallback(&struct_callback);
 is CheckReturnsFloat(&return_float),   6, 'callback returned a float to C';
 is CheckReturnsStr(&return_str),       7, 'callback returned a string to C';
 is CheckReturnsStruct(&return_struct), 8, 'callback returned a struct to C';
+
+for -> { 0 }, -> { 1 } -> \callback {
+    is CheckChangingCallback(callback), 0 ;
+}
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
While removing proxies by passing args through a slurpy was clever and very
little code, it had the unfortunate side effect of containerizing those
arguments. This would then lead to issues when the same callsite could pass
defined and undefined objects for the same parameter.

Fix by replacing the clever but slow and buggy implementation with usage of the
ProxyReaderFactory that Rakudo also uses for multi dispatch. This will make
calls correcter, faster and get rid of the raku-native-dispatch-deproxy frame
in the callstack (and backtraces).