### PR TITLE
Relax cross-language revision role-class boundaries

### DIFF
--- a/src/Perl6/Metamodel/BUILDPLAN.nqp
+++ b/src/Perl6/Metamodel/BUILDPLAN.nqp
@@ -32,7 +32,9 @@ role Perl6::Metamodel::BUILDPLAN {
         # First, we'll create the build plan for just this class.
         my @plan;
         my @attrs := $obj.HOW.attributes($obj, :local(1));
-        my $consider-roles := !self.lang-rev-before($obj, 'e') && nqp::can(self, 'roles');
+        # When adding role's BUILD/TWEAK into the buildplan for pre-6.e classes only roles of 6.e+ origin must be
+        # considered.
+        my $only_6e_roles := $obj.HOW.lang-rev-before($obj, 'e');
 
         # Emit any container initializers. Also build hash of attrs we
         # do not touch in any of the BUILDPLAN so we can spit out vivify
@@ -72,17 +74,20 @@ role Perl6::Metamodel::BUILDPLAN {
         }
 
         sub add_from_roles($name) {
-            my @ins_roles := self.ins_roles($obj, :with-submethods-only) unless +@ins_roles;
+            my @ins_roles := self.ins_roles($obj, :with-submethods-only);
             my $i := +@ins_roles;
             while --$i >= 0 {
-                my $submeth := nqp::atkey(@ins_roles[$i].HOW.submethod_table(@ins_roles[$i]), $name);
+                my $role := @ins_roles[$i];
+                # Skip any non-6.e+ role if the target is pre-6.e
+                next if $only_6e_roles && $role.HOW.lang-rev-before($role, 'e');
+                my $submeth := nqp::atkey($role.HOW.submethod_table($role), $name);
                 if !nqp::isnull($submeth) {
                     nqp::push(@plan, $submeth);
                 }
             }
         }
 
-        add_from_roles('BUILD') if $consider-roles;
+        add_from_roles('BUILD');
 
         # Does it have its own BUILD?
         my $build := $obj.HOW.find_method($obj, 'BUILD', :no_fallback(1));
@@ -218,7 +223,7 @@ role Perl6::Metamodel::BUILDPLAN {
             }
         }
 
-        add_from_roles('TWEAK') if $consider-roles;
+        add_from_roles('TWEAK');
 
         # Does it have a TWEAK?
         my $TWEAK := $obj.HOW.find_method($obj, 'TWEAK', :no_fallback(1));

--- a/src/Perl6/Metamodel/ClassHOW.nqp
+++ b/src/Perl6/Metamodel/ClassHOW.nqp
@@ -121,9 +121,6 @@ class Perl6::Metamodel::ClassHOW
                     self.set_hidden($obj) if $ins.HOW.hidden($ins);
                     self.set_language_revision($obj, $ins.HOW.language-revision($ins), :force);
                 }
-                # Significant change of behavior on d/e revisions boundary; pre-6.e classes cannot consume 6.e roles.
-                self.check-type-compat($obj, $ins, ['e'])
-                    if nqp::istype($ins.HOW, Perl6::Metamodel::LanguageRevision);
                 @ins_roles.push($ins);
                 self.add_concretization($obj, $r, $ins);
             }

--- a/src/Perl6/Metamodel/LanguageRevision.nqp
+++ b/src/Perl6/Metamodel/LanguageRevision.nqp
@@ -54,7 +54,7 @@ role Perl6::Metamodel::LanguageRevision
 
     # Check if we're compatible with type object $type. I.e. it doesn't come from language version newer than we're
     # compatible with. For example, 6.c/d classes cannot consume 6.d roles.
-    # Because there could be more than one such boundary in the future they can be passed as an array.
+    # Because there could be more than one such boundary in the future they can be passed in as an array.
     method check-type-compat($obj, $type, @revs) {
         unless nqp::isnull(self.incompat-revisions($obj, $!lang_rev, $type.HOW.language-revision($type), @revs)) {
             Perl6::Metamodel::Configuration.throw_or_die(

--- a/src/Perl6/Metamodel/RoleToClassApplier.nqp
+++ b/src/Perl6/Metamodel/RoleToClassApplier.nqp
@@ -94,8 +94,10 @@ my class RoleToClassApplier {
     method apply() {
         my @stubs;
 
-        # Starting with v6.e submethods must not be composed in from roles.
-        my $with_submethods := $!target.HOW.lang-rev-before($!target, 'e');
+        # Only transfer submethods from pre-6.e roles into pre-6.e classes.
+        my $with_submethods := $!target.HOW.lang-rev-before($!target, 'e')
+                                && (!nqp::istype($!to_compose_meta, Perl6::Metamodel::LanguageRevision)
+                                    || $!to_compose.HOW.lang-rev-before($!to_compose, 'e'));
 
         # Compose in any methods.
         sub compose_method_table(@methods, @method_names) {


### PR DESCRIPTION
Prior to this PR 6.c/d classes were not being able to consume roles
originating from 6.e code due to differences in handling submethods.
This commit changes the situation by teaching them this art:

- pre-6.e classes respect 6.e submethod handling and do not transfer
  submethods from 6.e roles
- constructor methods `BUILD` and `TWEAK` on 6.e roles are now included
  into the build plan of pre-6.e classes

From now on the following will work as expected:

```raku
use v6.e.PREVIEW;

my $v = 42 but role {
    submethod TWEAK { say "Tweaking an Int" }
};
```