### PR TITLE
Make ranges coerce LHS into a numeric if range boundaries are numeric

### DIFF
--- a/src/core.c/Str.pm6
+++ b/src/core.c/Str.pm6
@@ -794,7 +794,7 @@ my class Str does Stringy { # declared in BOOTSTRAP
          )
         )
     }
-    multi method Numeric(Str:D: Bool :$fail-or-mu --> Numeric:D) {
+    multi method Numeric(Str:D: Bool :$fail-or-nil --> Numeric:D) {
 #?if !jvm
         # check for any combining characters
         nqp::isne_i(nqp::chars(self),nqp::codes(self))
@@ -822,7 +822,7 @@ my class Str does Stringy { # declared in BOOTSTRAP
                  self,0,nqp::chars(self)
                ) == nqp::chars(self)
               ?? 0                                # just spaces
-              !! val(self, :val-or-fail, :$fail-or-mu)          # take the slow route
+              !! val(self, :val-or-fail, :$fail-or-nil)          # take the slow route
     }
 
     multi method gist(Str:D:) { self }

--- a/src/core.c/allomorphs.pm6
+++ b/src/core.c/allomorphs.pm6
@@ -264,7 +264,7 @@ multi sub val(\one-thing) is raw {
     one-thing
 }
 
-multi sub val(Str:D $MAYBEVAL, Bool :$val-or-fail, Bool :$fail-or-mu) {
+multi sub val(Str:D $MAYBEVAL, Bool :$val-or-fail, Bool :$fail-or-nil) {
     # TODO:
     # * Additional numeric styles:
     #   + fractions in [] radix notation:  :100[10,'.',53]
@@ -288,8 +288,8 @@ multi sub val(Str:D $MAYBEVAL, Bool :$val-or-fail, Bool :$fail-or-mu) {
     # string, or a failure if we're Str.Numeric
     my &parse_fail := -> \msg {
         $val-or-fail
-          ?? $fail-or-mu
-            ?? return Mu
+          ?? $fail-or-nil
+            ?? return Nil
             !! fail X::Str::Numeric.new(:source($MAYBEVAL),:reason(msg),:$pos)
           !! return $MAYBEVAL
     }


### PR DESCRIPTION
Make `"42" ~~ 20..50` work as expected.

As a side effect of this PR, smartmatching of a  `Rat` against a range (`4.2 ~~ 1..9`) gets up to 4-5 times faster. For a `Num` results are even better.

Fixes second part of #1809