### PR TITLE
Make infix:<(~+?)&> iffy

### DIFF
--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -4085,8 +4085,8 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
     token infix:sym<%>    { <sym>  <O(|%multiplicative)> }
     token infix:sym<mod>  { <sym> >> <O(|%multiplicative)> }
     token infix:sym<%%>   { <sym>  <O(|%multiplicative, :iffy(1))> }
-    token infix:sym<+&>   { <sym>  <O(|%multiplicative)> }
-    token infix:sym<~&>   { <sym>  <O(|%multiplicative)> }
+    token infix:sym<+&>   { <sym>  <O(|%multiplicative, :iffy(1))> }
+    token infix:sym<~&>   { <sym>  <O(|%multiplicative, :iffy(1))> }
     token infix:sym<?&>   { <sym>  <O(|%multiplicative, :iffy(1))> }
     token infix:sym«+<»   { <sym> [ <!{ $*IN_META }> || <?before '<<'> || <![<]> ] <O(|%multiplicative)> }
     token infix:sym«+>»   { <sym> [ <!{ $*IN_META }> || <?before '>>'> || <![>]> ] <O(|%multiplicative)> }

--- a/src/core.c/precedence.pm6
+++ b/src/core.c/precedence.pm6
@@ -61,10 +61,10 @@ BEGIN {
     trait_mod:<is>(&infix:<lcm>, :prec($multiplicative));
     trait_mod:<is>(&infix:<%>,   :prec($multiplicative));
     trait_mod:<is>(&infix:<mod>, :prec($multiplicative));
-    trait_mod:<is>(&infix:<+&>,  :prec($multiplicative));
-    trait_mod:<is>(&infix:<~&>,  :prec($multiplicative));
-    trait_mod:<is>(&infix:<?&>,  :prec($multiplicative));
 
+    trait_mod:<is>(&infix:<+&>,  :prec($iffy));
+    trait_mod:<is>(&infix:<~&>,  :prec($iffy));
+    trait_mod:<is>(&infix:<?&>,  :prec($iffy));
     trait_mod:<is>(&infix:<%%>,  :prec($iffy));
 
     trait_mod:<is>(&infix:<+>,  :prec($additive));


### PR DESCRIPTION
`?&` already was marked as such in the grammar, so make the others also to
be consistent.

`raku -e 'say 0x7 +& 0x0 ?? "hi" !! "bye"'` no longer warns `Potential
dead code, the '?? !!' is gobbling up the result of the '&infix:<+&>'
(line 1)`, which was a recent change as of 71c62e7c1121c19e7c4.

Rakudo builds ok and passes `make m-test m-spectest`.