### PR TITLE
Make Int.roll/pick act as (^Int).roll/pick on 6.e

### DIFF
--- a/src/core.e/Int.pm6
+++ b/src/core.e/Int.pm6
@@ -1,0 +1,7 @@
+use MONKEY;
+augment class Int {
+    method roll(|c) { (^self).roll(|c) }
+    method pick(|c) { (^self).pick(|c) }
+}
+
+# vim: expandtab shiftwidth=4

--- a/tools/templates/6.e/core_sources
+++ b/tools/templates/6.e/core_sources
@@ -3,6 +3,7 @@ src/core.e/control.pm6
 src/core.e/PseudoStash.pm6
 src/core.e/Grammar.pm6
 src/core.e/EXPORTHOW.pm6
+src/core.e/Int.pm6
 src/core.e/array_multislice.pm6
 src/core.e/hash_multislice.pm6
 src/core.e/Rakudo/Internals/Sprintf.pm6


### PR DESCRIPTION
As an alternate solution to https://github.com/rakudo/rakudo/pull/4692

Use a language level to make sure that this new behaviour is opt-in.