### PR TITLE
Remove some no longer needed CALL-MEs

### DIFF
--- a/src/core.c/Dateish.pm6
+++ b/src/core.c/Dateish.pm6
@@ -9,8 +9,6 @@ my role Dateish {
         IO::Path.new(~self)
     }
 
-    method CALL-ME(Dateish:U: \dateish) { self.new(dateish) }
-
     # this sub is also used by DAYS-IN-MONTH, which is used by other types
     sub IS-LEAP-YEAR(int $y --> Bool:D) {
         $y %% 4 and not $y %% 100 or $y %% 400

--- a/src/core.c/List.pm6
+++ b/src/core.c/List.pm6
@@ -911,10 +911,6 @@ my class List does Iterable does Positional { # declared in BOOTSTRAP
 
     multi method Supply(List:D: --> Supply:D) { Supply.from-list(self) }
 
-    method CALL-ME(List:U: |c) {
-        self.new(|c);
-    }
-
     multi method is-lazy(List:D: --> Bool:D) {
         nqp::if(
           nqp::isconcrete($!todo),

--- a/src/core.c/Slip.pm6
+++ b/src/core.c/Slip.pm6
@@ -6,7 +6,6 @@ my class Slip { # is List
     multi method defined (Slip:D: --> Bool:D) { self.Bool }
 
     multi method Slip(Slip:D:) { self }
-    method CALL-ME (+args)     { args.Slip }
     multi method raku(Slip:D: --> Str:D) {
         nqp::if(
           nqp::eqaddr(self,Empty),


### PR DESCRIPTION
I'm not exactly sure as of when these aren't needed, but likely after
new-disp landed.

Rakudo builds ok and passes `make m-test m-spectest`.