### PR TITLE
Use simpler code for correct `.length` suggestions test

### DIFF
--- a/t/05-messages/01-errors.t
+++ b/t/05-messages/01-errors.t
@@ -193,7 +193,7 @@ subtest 'non-ASCII digits > 7 in leading-zero-octal warning' => {
     throws-like '[].length      ', Exception, '.length on List',
         :message{ .contains: 'elems' & none <chars codes graphs>     };
 
-    throws-like 'class {}.length', Exception, '.length on non-Cool',
+    throws-like 'bag(1).length  ', Exception, '.length on non-Cool',
         :message{ .contains: <elems chars codes>.all & none 'graphs' };
 
     throws-like 'length 42      ', Exception, '&length',


### PR DESCRIPTION
The existing code causes tons of `WARNING: unhandled Failure detected in
DESTROY`.