### PR TITLE
Make set-env.sh script work on MacOS

### DIFF
--- a/tools/build/binary-release/assets/Linux/scripts/set-env.sh
+++ b/tools/build/binary-release/assets/Linux/scripts/set-env.sh
@@ -39,7 +39,7 @@ RAKUDO_PATH0="$DIR/bin"
 RAKUDO_PATH1="$DIR/share/perl6/site/bin"
 STUFF_DONE=false
 for RPATH in $RAKUDO_PATH1 $RAKUDO_PATH0 ; do
-    if echo "$NEW_PATH" | /bin/grep -vEq "(^|:)$RPATH($|:)" ; then
+    if echo "$NEW_PATH" | grep -vEq "(^|:)$RPATH($|:)" ; then
         NEW_PATH="$RPATH:$NEW_PATH"
         STUFF_DONE=true
     fi

--- a/tools/build/binary-release/assets/MacOS/scripts/set-env.sh
+++ b/tools/build/binary-release/assets/MacOS/scripts/set-env.sh
@@ -39,7 +39,7 @@ RAKUDO_PATH0="$DIR/bin"
 RAKUDO_PATH1="$DIR/share/perl6/site/bin"
 STUFF_DONE=false
 for RPATH in $RAKUDO_PATH1 $RAKUDO_PATH0 ; do
-    if echo "$NEW_PATH" | /bin/grep -vEq "(^|:)$RPATH($|:)" ; then
+    if echo "$NEW_PATH" | grep -vEq "(^|:)$RPATH($|:)" ; then
         NEW_PATH="$RPATH:$NEW_PATH"
         STUFF_DONE=true
     fi


### PR DESCRIPTION
The script depends on the grep program and had a hard coded path that
didn't match on MacOS. No need for an absolute path, so just remove.

Fix suggested by sdondley.

Fixes #4696

@sdondley Could you have a look?