### PR TITLE
Make FatRat literals codegen as WVals

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -8394,7 +8394,17 @@ class Perl6::Actions is HLL::Actions does STDActions {
                 $partf := nqp::box_i(1, $Int);
             }
 
-            my $ast := $*W.add_constant('Rat', 'type_new', $parti, $partf, :nocache(1));
+            my $class := 'Rat';
+            if $<fatrattish> {
+                $class := 'FatRat';
+            } elsif nqp::isbig_I($parti) -> $numerator {
+                $/.typed_worry('X::Comp::Rat::Literal', :literal($/.Str),
+                  :$numerator, :denominator(nqp::isbig_I($partf)));
+            } elsif nqp::isbig_I($partf) {
+                $/.typed_worry('X::Comp::Rat::Literal', :literal($/.Str), :denominator);
+            }
+
+            my $ast := $*W.add_constant($class, 'type_new', $parti, $partf, :nocache(1));
             $ast.node($/);
             make $ast;
         }

--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -3295,8 +3295,8 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
     token dec_number {
         :dba('decimal number')
         [
-        | $<coeff> = [               '.' <frac=.decint> ] <escale>?
-        | $<coeff> = [ <int=.decint> '.' <frac=.decint> ] <escale>?
+        | $<coeff> = [               '.' <frac=.decint> ] [ <escale> | <fatrattish> ]?
+        | $<coeff> = [ <int=.decint> '.' <frac=.decint> ] [ <escale> | <fatrattish> ]?
         | $<coeff> = [ <int=.decint>                    ] <escale>
         ]
     }
@@ -3350,6 +3350,8 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
     }
 
     token escale { <[Ee]> <sign> <decint> }
+
+    token fatrattish { '.FatRat' }
 
     token sign { '+' | '-' | '−' | '' }
 

--- a/src/core.c/Exception.pm6
+++ b/src/core.c/Exception.pm6
@@ -892,6 +892,20 @@ my class X::Comp::Group is Exception {
     }
 }
 
+my class X::Comp::Rat::Literal does X::Comp {
+    has $.literal is required;
+    has $.numerator;
+    has $.denominator;
+    method message() {
+        my $message = $.numerator
+          ?? $.denominator
+            ?? "Numerator and denominator are"
+            !! "Numerator is"
+          !! "Denominator is";
+        ($message ~ " too large in literal Rat definition and will lose precision. Please consider creating a Num ({$.literal}e0) for more performance and less precision, or to create a FatRat ($.literal.FatRat) for more precision and less performance.").naive-word-wrapper
+    }
+}
+
 my role X::MOP is Exception { }
 
 my class X::Comp::BeginTime does X::Comp {


### PR DESCRIPTION
A literal as .123.FatRat was codegenned as a Rat WVal and a call to
the .FatRat method at runtime: it is now codegenned as a FatRat WVal.

Also, if a Rat literal exceeds the precision of a Rat, it will issue
a worry that mentions to either make it a Num or a FatRat.