### PR TITLE
Make add_constant lookup setting symbols only

### DIFF
--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -3034,7 +3034,7 @@ class Perl6::World is HLL::World {
         }
 
         # Find type object for the box typed we'll create.
-        my $type_obj := self.find_symbol(nqp::split('::', $type));
+        my $type_obj := self.find_symbol(nqp::split('::', $type), :setting-only);
 
         # Go by the primitive type we're boxing. Need to create
         # the boxed value and also code to produce it.


### PR DESCRIPTION
The compiler is only uses this method with core types. Limiting lookups to setting only prevents LTA errors in user code.

Fixes #4711