### PR TITLE
Make $*DISTRO more thread safe

### DIFF
--- a/src/core.c/Distro.pm6
+++ b/src/core.c/Distro.pm6
@@ -20,101 +20,106 @@ class Distro does Systemic {
 
 # set up $*DISTRO
 Rakudo::Internals.REGISTER-DYNAMIC: '$*DISTRO', {
+    my $lock = INIT Lock.new;
+    $lock.protect: {
+        PROCESS::<$DISTRO> //= do {
 #?if jvm
-    my $properties := VM.new.properties;
-    my $name       := $properties<os.name>;
-    my $version    := $properties<os.version>;
-    my $path-sep   := $properties<path.separator>;
+            my $properties := VM.new.properties;
+            my $name       := $properties<os.name>;
+            my $version    := $properties<os.version>;
+            my $path-sep   := $properties<path.separator>;
 #?endif
 #?if !jvm
-    my $config   := VM.new.config;
-    my $name     := $config<osname>;
-    my $version  := $config<osvers>;
-    my $path-sep := $name eq 'MSWin32' ?? ';' !! ':';
+            my $config   := VM.new.config;
+            my $name     := $config<osname>;
+            my $version  := $config<osvers>;
+            my $path-sep := $name eq 'MSWin32' ?? ';' !! ':';
 #?endif
-    my Str $release := "unknown";
-    my Str $auth    := "unknown";
-    my Str $desc    := "unknown";
+            my Str $release := "unknown";
+            my Str $auth    := "unknown";
+            my Str $desc    := "unknown";
 
-    # helper sub to convert key:value lines into a hash
-    sub kv2Map(Str:D $text, str $delimiter --> Map:D) {
-        my $hash := nqp::hash;
-        for $text.lines -> str $line {
-            my $parts := nqp::split($delimiter,$line);
-            if nqp::elems($parts) > 1 {
-                nqp::bindkey(
-                  $hash,
-                  nqp::shift($parts),
-                  nqp::hllize(
-                    nqp::elems($parts) == 2
-                      ?? nqp::shift($parts)
-                      !! nqp::join($delimiter,$parts)
-                  ).trim
-                );
+            # helper sub to convert key:value lines into a hash
+            sub kv2Map(Str:D $text, str $delimiter --> Map:D) {
+                my $hash := nqp::hash;
+                for $text.lines -> str $line {
+                    my $parts := nqp::split($delimiter,$line);
+                    if nqp::elems($parts) > 1 {
+                        nqp::bindkey(
+                          $hash,
+                          nqp::shift($parts),
+                          nqp::hllize(
+                            nqp::elems($parts) == 2
+                              ?? nqp::shift($parts)
+                              !! nqp::join($delimiter,$parts)
+                          ).trim
+                        );
+                    }
+                }
+
+                nqp::p6bindattrinvres(nqp::create(Map),Map,'$!storage',$hash)
             }
-        }
 
-        nqp::p6bindattrinvres(nqp::create(Map),Map,'$!storage',$hash)
-    }
-
-    # darwin specific info
-    if $name eq 'darwin' {
-        my $lookup :=
-          kv2Map(shell("sw_vers", :out, :err).out.slurp(:close),':');
-        $name    := $_ with $lookup<ProductName>;
-        $version := $_ with $lookup<ProductVersion>;
-        $release := $_ with $lookup<BuildVersion>;
-        $auth    := 'Apple Inc.'; # presumably
+            # darwin specific info
+            if $name eq 'darwin' {
+                my $lookup :=
+                  kv2Map(shell("sw_vers", :out, :err).out.slurp(:close),':');
+                $name    := $_ with $lookup<ProductName>;
+                $version := $_ with $lookup<ProductVersion>;
+                $release := $_ with $lookup<BuildVersion>;
+                $auth    := 'Apple Inc.'; # presumably
 
 #?if !js
-        my constant $names = nqp::hash(
+                my constant $names = nqp::hash(
 #?endif
 #?if js
-        my $names := nqp::hash(
+                my $names := nqp::hash(
 #?endif
-          '10.0',  'Cheetah',
-          '10.1',  'Puma',
-          '10.2',  'Jaguar',
-          '10.3',  'Panther',
-          '10.4',  'Tiger',
-          '10.5',  'Leopard',
-          '10.6',  'Snow Leopard',
-          '10.7',  'Lion',
-          '10.8',  'Mountain Lion',
-          '10.9',  'Mavericks',
-          '10.10', 'Yosemite',
-          '10.11', 'El Capitan',
-          '10.12', 'Sierra',
-          '10.13', 'High Sierra',
-          '10.14', 'Mojave',
-          '10.15', 'Catalina',
-          '11.0',  'Big Sur',
-          '12.0',  'Monterey',
-        );
+                  '10.0',  'Cheetah',
+                  '10.1',  'Puma',
+                  '10.2',  'Jaguar',
+                  '10.3',  'Panther',
+                  '10.4',  'Tiger',
+                  '10.5',  'Leopard',
+                  '10.6',  'Snow Leopard',
+                  '10.7',  'Lion',
+                  '10.8',  'Mountain Lion',
+                  '10.9',  'Mavericks',
+                  '10.10', 'Yosemite',
+                  '10.11', 'El Capitan',
+                  '10.12', 'Sierra',
+                  '10.13', 'High Sierra',
+                  '10.14', 'Mojave',
+                  '10.15', 'Catalina',
+                  '11.0',  'Big Sur',
+                  '12.0',  'Monterey',
+                );
 
-        if nqp::atkey($names,$version.split(".").head(2).join(".")) -> $nick {
-            $desc := $nick;
+                if nqp::atkey($names,$version.split(".").head(2).join(".")) -> $nick {
+                    $desc := $nick;
+                }
+            }
+            elsif Rakudo::Internals.FILETEST-E('/etc/os-release') {
+                my $lookup := kv2Map('/etc/os-release'.IO.slurp.subst(:g,'"'),'=');
+                $name    := $_ with $lookup<ID>;
+                $auth    := $_ with $lookup<HOME_URL>;
+                $version := $_ with $lookup<VERSION>;
+                $release := $_ with $lookup<VERSION_ID>;
+                $desc    := $_ with $lookup<PRETTY_NAME>;
+            }
+            elsif $name eq 'linux' {
+                my $lookup :=
+                  kv2Map(shell(<lsb_release -a>, :out, :err).out.slurp(:close),":");
+                $auth    := $_ with $lookup<<"DISTRIBUTOR ID">>;
+                $desc    := $_ with $lookup<DESCRIPTION>;
+                $release := $_ with $lookup<RELEASE>;
+            }
+
+            $version := $version.Version;  # make sure it is a Version
+
+            Distro.new(:$name, :$version, :$release, :$auth, :$path-sep, :$desc);
         }
     }
-    elsif Rakudo::Internals.FILETEST-E('/etc/os-release') {
-        my $lookup := kv2Map('/etc/os-release'.IO.slurp.subst(:g,'"'),'=');
-        $name    := $_ with $lookup<ID>;
-        $auth    := $_ with $lookup<HOME_URL>;
-        $version := $_ with $lookup<VERSION>;
-        $release := $_ with $lookup<VERSION_ID>;
-        $desc    := $_ with $lookup<PRETTY_NAME>;
-    }
-    elsif $name eq 'linux' {
-        my $lookup :=
-          kv2Map(shell(<lsb_release -a>, :out, :err).out.slurp(:close),":");
-        $auth    := $_ with $lookup<<"DISTRIBUTOR ID">>;
-        $desc    := $_ with $lookup<DESCRIPTION>;
-        $release := $_ with $lookup<RELEASE>;
-    }
-
-    $version := $version.Version;  # make sure it is a Version
-    PROCESS::<$DISTRO> :=
-      Distro.new(:$name, :$version, :$release, :$auth, :$path-sep, :$desc);
 }
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
This prevents concurrent write attempts to `PROCESS::<$DISTRO>` when registering `$*DISTRO`.  It also avoids duplicated work in said situations, such as shell calls to `lsb_release -a`.

Fixes #4714