### PR TITLE
Specify base of non base 10 invalid numbers

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -1187,14 +1187,16 @@ class Perl6::Actions is HLL::Actions does STDActions {
 
     sub string_to_int($src, int $base, int $chars) {
         my $res := nqp::radix($base, ~$src, 0, 2);
-        $src.panic("'$src' is not a valid number")
+        $src.panic("'$src' is not a valid number"
+                   ~ (nqp::iseq_i($base, 10) ?? '' !! " in base $base"))
             unless nqp::iseq_i(nqp::atpos($res, 2), $chars);
         nqp::box_i(nqp::atpos($res, 0), $*W.find_single_symbol('Int'));
     }
 
     sub string_to_bigint($src, int $base, int $chars) {
         my $res := nqp::radix_I($base, ~$src, 0, 2, $*W.find_single_symbol('Int'));
-        $src.panic("'$src' is not a valid number")
+        $src.panic("'$src' is not a valid number"
+                   ~ (nqp::iseq_i($base, 10) ?? '' !! " in base $base"))
             unless nqp::iseq_i(nqp::unbox_i(nqp::atpos($res, 2)), $chars);
         nqp::atpos($res, 0);
     }

--- a/src/Perl6/Pod.nqp
+++ b/src/Perl6/Pod.nqp
@@ -346,7 +346,8 @@ class Perl6::Pod {
     sub string_to_bigint($src, int $base, int $chars) {
         # code copied from Actions.nqp and locally modified
         my $res := nqp::radix_I($base, ~$src, 0, 2, $*W.find_single_symbol('Int'));
-        $src.panic("'$src' is not a valid number")
+        $src.panic("'$src' is not a valid number"
+                   ~ (nqp::iseq_i($base, 10) ?? '' !! " in base $base"))
             unless nqp::iseq_i(nqp::unbox_i(nqp::atpos($res, 2)), $chars);
         nqp::atpos($res, 0);
     }


### PR DESCRIPTION
Raku prints numbers in base 10 even when they were entered in another base.  As a result, entering invalid numbers in other bases would result in mildly entertaining (but also LTA) error messages such as:

```raku
0b42;
# OUTPUT:
# ===SORRY!=== Error while compiling -e
# '42' is not a valid number
```
This commit adds the text `" in base $base"` to the error message when the base isn't 10.  In theory, this could still present a LTA error message for bases > 10.  However, I don't believe bases > 10 ever produce a "not a valid number" exception.  (They either report a compile-time `X::Str::Numeric` (which already specifies the base) or a compile-time `X::Backslash::UnrecognizedSequence`, which prints the invalid line.)