### PR TITLE
Implement smartmatch as a dispatcher

### DIFF
--- a/src/Perl6/Optimizer.nqp
+++ b/src/Perl6/Optimizer.nqp
@@ -1598,7 +1598,7 @@ my class SmartmatchOptimizer {
         # overrides CORE's methods.
         note("Typematch over ", $sm_type.HOW.name($sm_type), " can be reduced to nqp::istype") if $!debug;
 
-        # For 'when' statement it is sufficient to get native 0 or 1. Otherwise we need to boolilfy.
+        # For 'when' statement it is sufficient to get native 0 or 1. Otherwise we need to boolify.
         $sm_ast := QAST::Op.new( :op<istype>, $lhs.ast, $rhs.ast );
         $sm_ast := QAST::Op.new( :op<not_i>, $sm_ast ) if $negated;
         $in-when ?? $sm_ast !! QAST::Op.new( :op<hllbool>, $sm_ast )
@@ -1898,6 +1898,7 @@ my class SmartmatchOptimizer {
                 );
 
                 # If topic can the method then we invoke it. Otherwise fall back to ACCEPTS to throw an exception
+                # TODO Code for new-disp
                 $method_ast := QAST::Op.new(
                     :op<if>,
                     QAST::Op.new(
@@ -2072,9 +2073,7 @@ my class SmartmatchOptimizer {
     method locate_smartmatch_ACCEPTS($ast) {
         for @($ast) -> $child {
             next if nqp::istype($child, QAST::Want);
-            return $child if nqp::istype($child, QAST::Op)
-                                && nqp::iseq_s($child.op, 'callmethod')
-                                && $child.ann('smartmatch_accepts');
+            return $child if nqp::istype($child, QAST::Op) && $child.ann('smartmatch_accepts');
             note("AST child is not a QAST node! AST:\n", $ast.dump(4)) unless nqp::istype($child, QAST::Node);
             my $found := self.locate_smartmatch_ACCEPTS($child);
             return $found if nqp::defined($found);
@@ -2110,7 +2109,12 @@ my class SmartmatchOptimizer {
         if nqp::defined($sm_accepts) {
             # LHS, which becomes smartmatch topic, is used before the ACCEPTS call in statements passed to locallifetime op.
             my $lhs := Operand.new($op[0][1][1], $!optimizer, $!symbols, :name<LHS>);
+#?if !moar
             my $rhs := Operand.new($sm_accepts[0][1], $!optimizer, $!symbols, :name<RHS>);
+#?endif
+#?if moar
+            my $rhs := Operand.new($sm_accepts[2], $!optimizer, $!symbols, :name<RHS>);
+#?endif
             my $negated := $sm_accepts.ann('smartmatch_negated');
             my $boolified := $op[0][2].ann('smartmatch_boolified');
 
@@ -2127,14 +2131,17 @@ my class SmartmatchOptimizer {
             note("Post-typematch attempt result is ", $result.HOW.name($result)) if $!debug;
 
             if nqp::isnull($result) && ($sm_op := self.maybe_pair($lhs, $rhs, $sm_accepts, :$negated)) {
+#?if !moar
                 # When maybe_pair succeeds it means the RHS is certainly not a Regex. Hence we can remove the check and
                 # replace QAST::Stmts wrapper with the binding to sm_result_<n> local.
                 # Pull out the binding op and replace stmts; not needed in case of !~~
                 $op[0][2] := $op[0][2][0] unless $negated;
+#?endif
                 $op[0][2][1] := $sm_op;    # Replace the second binding argument with the optimized AST.
                 $result := $op; # No further optimizations are possible
             }
 
+#?if !moar
             # If we know RHS type then we can possibly simplify the actual SM op withing `locallifetime` to plain
             # .ACCEPTS(...).Bool unless RHS is or can be a Regex
             my $rhs_type := $rhs.infer-type(:guaranteed);
@@ -2156,6 +2163,7 @@ my class SmartmatchOptimizer {
                 $op[0][2] := $bind_ast;
                 $result := $op;
             }
+#?endif
         }
 
         $result := $op unless nqp::defined($result);

--- a/src/core.c/Junction.pm6
+++ b/src/core.c/Junction.pm6
@@ -404,9 +404,9 @@ my class Junction { # declared in BOOTSTRAP
     # method invocations. Note that this can only be used with classes using the default ACCEPTS method from the core as
     # only with it we can guarantee the default handling of junctions.
     proto method BOOLIFY-ACCEPTS(|) is implementation-detail {*}
-    multi method BOOLIFY-ACCEPTS(Junction:U --> True) {}
-    multi method BOOLIFY-ACCEPTS(Mu \matcher) {
-        nqp::hllbool(
+    multi method BOOLIFY-ACCEPTS(Junction:U, $negate?) { nqp::hllbool(nqp::isfalse($negate)) }
+    multi method BOOLIFY-ACCEPTS(Mu \matcher, $negate?) {
+        my $matches :=
           nqp::stmts(
             (my int $elems = nqp::elems($!eigenstates)),
             (my int $i),
@@ -456,8 +456,8 @@ my class Junction { # declared in BOOTSTRAP
                 )
               )
             )
-          )
-        )
+          );
+        nqp::hllbool(nqp::if($negate, nqp::not_i($matches), $matches))
     }
 }
 

--- a/src/core.c/Match.pm6
+++ b/src/core.c/Match.pm6
@@ -232,6 +232,10 @@ my class Match is Capture is Cool does NQPMatchRole {
     multi method Bool(Match:U: --> False) { }
     multi method Bool(Match:D:) { nqp::hllbool($!pos >= $!from) }
 
+    proto method not(|) {*}
+    multi method not(Match:U: --> True) { }
+    multi method not(Match:D:) { nqp::hllbool($!pos < $!from) }
+
     multi method Numeric(Match:D:) {
         self.Str.Numeric
     }

--- a/src/core.c/Routine.pm6
+++ b/src/core.c/Routine.pm6
@@ -17,10 +17,10 @@ my class Routine { # declared in BOOTSTRAP
     #     has @!dispatch_order;
     #     has Mu $!dispatch_cache;
 
-    method candidates() {
-        self.is_dispatcher ??
-            nqp::hllize(@!dispatchees) !!
-            (self,)
+    method candidates(Bool :$local = True, Bool() :$with-proto) {
+        $local
+            ?? (self.is_dispatcher ?? nqp::hllize(@!dispatchees) !! (self,))
+            !! Seq.new(self.iterator(:candidates, :!local, :$with-proto))
     }
 
     proto method cando(|) {*}
@@ -105,6 +105,7 @@ my class Routine { # declared in BOOTSTRAP
             method CALL-ME(|c) is raw {
                 $!dispatcher.enter(|c);
             }
+            method WRAPPERS() { IterationBuffer.new($!dispatcher.candidates) }
             method soft(--> True) { }
             method is-wrapped(--> Bool) { $!dispatcher.candidates > 1 }
         }
@@ -204,6 +205,98 @@ my class Routine { # declared in BOOTSTRAP
 
     method leave(*@) {
         X::NYI.new(:feature("{self.^name}.leave()")).throw;
+    }
+
+    my class CandidateIterator does Iterator {
+        has $!routine;
+        has Mu $!candidates;
+        has int $!pos;
+        has Mu $!backlog;
+        has $!local;
+        has $!with-proto;
+
+        method !SET-SELF($routine, $!local, $!with-proto) {
+            self!SET-FROM-CANDIDATE($routine);
+            $!backlog := nqp::list();
+            self
+        }
+
+        method new(Routine:D $routine, $local, $with-proto) {
+            nqp::create(self)!SET-SELF($routine, $local, $with-proto)
+        }
+
+        method !SET-FROM-CANDIDATE($routine) {
+            $!routine := nqp::decont($routine);
+            $!pos = 0;
+            my $candidates;
+            if nqp::istype($!routine, Routine) {
+                if $!routine.?is-wrapped {
+                    $candidates := $!routine.WRAPPERS;
+                }
+                elsif $!routine.?is_dispatcher {
+                    $candidates := nqp::getattr($!routine, Routine, '@!dispatchees');
+                    $!pos = -1 if $!with-proto;
+                }
+            }
+            if nqp::defined($candidates) {
+                $!candidates := $candidates;
+            }
+            else {
+                $!candidates := nqp::list($!routine);
+            }
+        }
+
+        method pull-one() {
+            my $cand := Nil;
+            while nqp::eqaddr($cand, Nil) {
+                while $!pos >= nqp::elems($!candidates) {
+                    return IterationEnd unless nqp::elems($!backlog);
+                    my $state := nqp::pop($!backlog);
+                    $!candidates := nqp::atpos($state, 0);
+                    $!pos = nqp::atpos($state, 1);
+                    $!routine := nqp::atpos($state, 2);
+                }
+
+                my $pos = $!pos;
+                ++$!pos;
+                if $pos == -1 {
+                    $cand := $!routine;
+                }
+                else {
+                    $cand := nqp::atpos($!candidates, $pos);
+                }
+
+                if !$!local
+                    && ( $cand.?is-wrapped
+                        || ($pos > -1 && $cand.?is_dispatcher) )
+                {
+                    nqp::push($!backlog, nqp::list($!candidates, nqp::unbox_i($!pos), $!routine));
+                    self!SET-FROM-CANDIDATE($cand);
+                    $cand := Nil;
+                }
+            }
+            $cand
+        }
+
+        method is-lazy(--> True) {}
+    }
+
+    method iterator(Bool :$candidates, Bool() :$local, Bool() :$with-proto) {
+        return self.Mu::iterator unless $candidates && (self.is_dispatcher || self.is-wrapped);
+        CandidateIterator.new(self, $local, $with-proto)
+    }
+
+    method IS-SETTING-ONLY(:$U, :$D, :$with-proto --> Bool:D) is implementation-detail {
+        for self.candidates(:!local, :$with-proto) -> &cand {
+            if $U || $D {
+                next unless nqp::istype(&cand, Method) || nqp::istype(&cand, Submethod);
+                my $invocant-type := &cand.signature.params[0].type;
+                my $is-definite := $invocant-type.HOW.archetypes.definite && $invocant-type.^definite;
+                next unless ($U && !$is-definite) || ($D && $is-definite);
+            }
+            return False unless &cand.file.starts-with: 'SETTING::';
+        }
+        True
     }
 }
 

--- a/src/vm/moar/dispatchers.nqp
+++ b/src/vm/moar/dispatchers.nqp
@@ -2378,7 +2378,7 @@ nqp::dispatch('boot-syscall', 'dispatcher-register', 'raku-multi-core',
                 nqp::dispatch('boot-syscall', 'dispatcher-set-resume-state-literal', Exhausted);
             }
 
-            # Resume next disaptcher, if any, otherwise hand back Nil.
+            # Resume next dispatcher, if any, otherwise hand back Nil.
             nil-or-callwith-propagation-terminal($capture);
         }
     });
@@ -3392,3 +3392,318 @@ nqp::dispatch('boot-syscall', 'dispatcher-register', 'raku-isinvokable', -> $cap
         $capture, 0, nqp::istype($callee, Code));
     nqp::dispatch('boot-syscall', 'dispatcher-delegate', 'boot-constant', $delegate);
 });
+
+{
+    # Smartmatch support
+
+    my $hllbool     := nqp::getstaticcode(-> $prim { nqp::hllboolfor(nqp::istrue($prim), 'Raku') });
+    my $hllbool_not := nqp::getstaticcode(-> $prim { nqp::hllboolfor(nqp::not_i(nqp::istrue($prim)), 'Raku') });
+
+    sub is-routine-setting-only($routine, :$U = 0, :$D = 0) {
+        if nqp::istype($routine, Routine) {
+            return nqp::istrue(
+                $routine.IS-SETTING-ONLY(
+                    U => $hllbool($U),
+                    D => $hllbool($D),
+                    with-proto => $hllbool(1)));
+        }
+        elsif nqp::istype($routine, Code) {
+            return nqp::istrue($routine.file.starts-with('SETTING::'));
+        }
+        # Non-Raku code objects are considered coming from the setting
+        1
+    }
+
+    sub is-method-setting-only($type, str $method-name, :$U = 0, :$D = 0) {
+        my $method := nqp::tryfindmethod($type, $method-name);
+        return 0 unless nqp::defined($method);
+        is-routine-setting-only($method, :$U, :$D)
+    }
+
+    nqp::dispatch('boot-syscall', 'dispatcher-register', 'raku-boolify', -> $capture {
+        my $arg-spec := nqp::captureposprimspec($capture, 0);
+        my $arg;
+        if $arg-spec == 1 {
+            $arg := nqp::captureposarg_i($capture, 0);
+        }
+        elsif $arg-spec == 2 {
+            $arg := nqp::captureposarg_n($capture, 0);
+        }
+        elsif $arg-spec == 3 {
+            $arg := nqp::captureposarg_s($capture, 0);
+        }
+        else {
+            $arg := nqp::captureposarg($capture, 0);
+        }
+        my $track_arg := nqp::dispatch('boot-syscall', 'dispatcher-track-arg', $capture, 0);
+        my $explicit-call := 0;
+        if nqp::isconcrete($arg) {
+            if $arg-spec {
+                nqp::dispatch('boot-syscall', 'dispatcher-guard-concreteness', $track_arg);
+                nqp::dispatch('boot-syscall', 'dispatcher-guard-type', $track_arg);
+                nqp::dispatch('boot-syscall', 'dispatcher-delegate', 'boot-code-constant',
+                    nqp::dispatch('boot-syscall', 'dispatcher-insert-arg-literal-obj', $capture, 0, $hllbool)
+                );
+            }
+            elsif nqp::istype($arg, Bool) {
+                nqp::dispatch('boot-syscall', 'dispatcher-guard-concreteness', $track_arg);
+                nqp::dispatch('boot-syscall', 'dispatcher-guard-type', $track_arg);
+                nqp::dispatch('boot-syscall', 'dispatcher-delegate', 'boot-value', $capture);
+            }
+            else {
+                $explicit-call := 1;
+            }
+        }
+        elsif is-method-setting-only($arg, 'Bool', :U) {
+            # For non-concrete objects default method Bool candidate would always produce False.
+            nqp::dispatch('boot-syscall', 'dispatcher-guard-concreteness', $track_arg);
+            nqp::dispatch('boot-syscall', 'dispatcher-guard-type', $track_arg);
+            nqp::dispatch('boot-syscall', 'dispatcher-delegate', 'boot-value',
+                nqp::dispatch('boot-syscall', 'dispatcher-insert-arg-literal-obj',
+                    $capture, 0, $hllbool(0)
+                )
+            );
+        }
+        else {
+            $explicit-call := 1;
+        }
+        if $explicit-call {
+            # There is no need to guard for type when fallback to method call
+            nqp::dispatch('boot-syscall', 'dispatcher-delegate', 'raku-meth-call',
+                nqp::dispatch('boot-syscall', 'dispatcher-insert-arg-literal-str',
+                    nqp::dispatch('boot-syscall', 'dispatcher-insert-arg-literal-obj', $capture, 0, nqp::what($arg)),
+                    1, 'Bool'));
+        }
+    });
+
+    my &smartmatch-code := nqp::getstaticcode(-> $topic, $rhs {
+        nqp::dispatch('raku-boolify', $rhs.ACCEPTS($topic))
+    });
+    my &negate-smartmatch-code := nqp::getstaticcode(-> $topic, $rhs {
+        $rhs.ACCEPTS($topic).not
+    });
+
+    my sub find-core-symbol(str $sym, :$ctx, :$revision) {
+        unless nqp::isconcrete($ctx) {
+            $ctx := nqp::ctxcaller(nqp::ctx());
+        }
+        my $core-rev-sym := 'CORE-SETTING-REV';
+        while nqp::isnull(nqp::getlexrel($ctx, $core-rev-sym)) {
+            $ctx := nqp::ctxcaller($ctx);
+        }
+        until nqp::isnull($ctx) {
+            my $lexpad := nqp::ctxlexpad($ctx);
+            if nqp::existskey($lexpad, $core-rev-sym) {
+                last unless nqp::isconcrete($revision)
+                            && nqp::isne_s(nqp::atkey($lexpad, $core-rev-sym), $revision);
+            }
+            $ctx := nqp::ctxouterskipthunks($ctx);
+        }
+        nqp::die("No symbol '" ~ $sym ~ "' found in CORE" ~ ($revision ?? "." ~ $revision !! "")) if nqp::isnull($ctx);
+        nqp::getlexrel($ctx, $sym)
+    }
+
+    nqp::dispatch('boot-syscall', 'dispatcher-register', 'raku-smartmatch-topicalized', -> $capture {
+        # The dispatch receives:
+        # - topic(lhs) deconted value
+        # - lhs with containerization preserved
+        # - rhs deconted value
+        # - rhs with containerization preserved
+        # - boolification flag)
+        # boolification flag can either be -1 to negate, 0 to return as-is, 1 to boolify
+        my $Match               := find-core-symbol('Match', :ctx(nqp::ctxcaller(nqp::ctx())));
+        my $lhs                 := nqp::captureposarg($capture, 0);
+        my $rhs                 := nqp::captureposarg($capture, 2);
+        my $boolification       := nqp::captureposarg_i($capture, 4);
+        my $track-lhs           := nqp::dispatch('boot-syscall', 'dispatcher-track-arg', $capture, 0);
+        my $track-rhs           := nqp::dispatch('boot-syscall', 'dispatcher-track-arg', $capture, 2);
+        # my $track-boolification := nqp::dispatch('boot-syscall', 'dispatcher-track-arg', $capture, 4);
+
+        my $explicit-accepts := 1;
+
+        my sub drop-cont-args() {
+            nqp::dispatch('boot-syscall', 'dispatcher-drop-arg',
+                nqp::dispatch('boot-syscall', 'dispatcher-drop-arg', $capture, 3),  # RHS
+                1)                                                                  # LHS
+        }
+
+        my sub drop-decont-args() {
+            nqp::dispatch('boot-syscall', 'dispatcher-drop-arg',
+                nqp::dispatch('boot-syscall', 'dispatcher-drop-arg', $capture, 2),  # RHS
+                0)                                                                  # LHS
+        }
+
+        if $boolification == 0 {
+            if nqp::isconcrete_nd($rhs) && nqp::istype_nd($rhs, Junction) {
+                # Make sure to collapse a Junction.
+                # nqp::dispatch('boot-syscall', 'dispatcher-guard-literal', $track-boolification);
+                nqp::dispatch('boot-syscall', 'dispatcher-guard-concreteness', $track-rhs);
+                nqp::dispatch('boot-syscall', 'dispatcher-guard-type', $track-rhs);
+                $capture := drop-cont-args();
+                nqp::dispatch('boot-syscall', 'dispatcher-delegate', 'raku-meth-call',
+                    nqp::dispatch('boot-syscall', 'dispatcher-insert-arg-literal-str',
+                        nqp::dispatch('boot-syscall', 'dispatcher-insert-arg-literal-obj',
+                            nqp::dispatch('boot-syscall', 'dispatcher-drop-arg',
+                                nqp::dispatch('boot-syscall', 'dispatcher-drop-arg', $capture, 2), # boolification flag
+                                0), # LHS
+                            0, nqp::what($rhs)),
+                        1, 'Bool'));
+                $explicit-accepts := 0;
+            }
+            elsif nqp::isconcrete_nd($rhs) && nqp::istype_nd($rhs, List) {
+                # A list must be reified in order to fire up any code embedded into regexes
+                # nqp::dispatch('boot-syscall', 'dispatcher-guard-literal', $track-boolification);
+                nqp::dispatch('boot-syscall', 'dispatcher-guard-concreteness', $track-rhs);
+                nqp::dispatch('boot-syscall', 'dispatcher-guard-type', $track-rhs);
+                my $method-capture :=
+                    nqp::dispatch('boot-syscall', 'dispatcher-drop-arg',
+                        nqp::dispatch('boot-syscall', 'dispatcher-drop-arg',
+                            drop-decont-args(), 2), # boolification flag
+                        0); # LHS
+
+                nqp::dispatch('boot-syscall', 'dispatcher-delegate', 'raku-meth-call',
+                    nqp::dispatch('boot-syscall', 'dispatcher-insert-arg-literal-str',
+                        nqp::dispatch('boot-syscall', 'dispatcher-insert-arg-literal-obj',
+                            $method-capture, 0, nqp::what($rhs)),
+                        1, 'eager'));
+                $explicit-accepts := 0;
+            }
+            elsif nqp::istype_nd($rhs, Nil) {
+                # nqp::dispatch('boot-syscall', 'dispatcher-guard-literal', $track-boolification);
+                nqp::dispatch('boot-syscall', 'dispatcher-guard-type', $track-rhs);
+                nqp::dispatch('boot-syscall', 'dispatcher-delegate', 'boot-value',
+                    nqp::dispatch('boot-syscall', 'dispatcher-insert-arg-literal-obj',
+                        $capture, 0, nqp::hllboolfor(0, 'Raku')));
+                $explicit-accepts := 0;
+            }
+            else {
+                # nqp::dispatch('boot-syscall', 'dispatcher-guard-literal', $track-boolification);
+                nqp::dispatch('boot-syscall', 'dispatcher-guard-type', $track-rhs);
+                # Bypass is normally used with Regex-kind of RHS and it is not specced wether the smartmatch result must
+                # be deconted in this case. Therefore we better return what we've got on RHS as-is.
+                $capture := drop-decont-args();
+                nqp::dispatch('boot-syscall', 'dispatcher-delegate', 'boot-value',
+                    nqp::dispatch('boot-syscall', 'dispatcher-drop-arg', $capture, 0));
+                $explicit-accepts := 0;
+            }
+        }
+        elsif nqp::istype_nd($lhs, Junction)
+            && nqp::isconcrete_nd($lhs)
+            && !(nqp::isconcrete_nd($rhs) && (nqp::istype_nd($rhs, Junction)
+                    || ($boolification == 1 && nqp::istype_nd($rhs, Regex))))
+            && is-method-setting-only($rhs, 'ACCEPTS', :D)
+        {
+            # nqp::dispatch('boot-syscall', 'dispatcher-guard-literal', $track-boolification);
+            nqp::dispatch('boot-syscall', 'dispatcher-guard-type', $track-lhs);
+            nqp::dispatch('boot-syscall', 'dispatcher-guard-concreteness', $track-lhs);
+            nqp::dispatch('boot-syscall', 'dispatcher-guard-type', $track-rhs);
+            nqp::dispatch('boot-syscall', 'dispatcher-guard-concreteness', $track-rhs);
+            my $method-capture := nqp::dispatch('boot-syscall', 'dispatcher-drop-arg', drop-decont-args(), 2);
+            $method-capture :=
+                nqp::dispatch('boot-syscall', 'dispatcher-insert-arg-literal-obj',
+                    $method-capture, 0, nqp::what($lhs));
+            $method-capture :=
+                nqp::dispatch('boot-syscall', 'dispatcher-insert-arg-literal-str',
+                    $method-capture, 1, 'BOOLIFY-ACCEPTS');
+            $method-capture :=
+                nqp::dispatch('boot-syscall', 'dispatcher-insert-arg-literal-obj',
+                    $method-capture, 4, nqp::hllboolfor($boolification == -1, 'Raku'));
+
+            nqp::dispatch('boot-syscall', 'dispatcher-delegate', 'raku-meth-call', $method-capture);
+            $explicit-accepts := 0;
+        }
+        else {
+            if nqp::isconcrete_nd($rhs) {
+                if $boolification < 0 {
+                    if nqp::istype_nd($rhs, Bool) {
+                        # nqp::dispatch('boot-syscall', 'dispatcher-guard-literal', $track-boolification);
+                        nqp::dispatch('boot-syscall', 'dispatcher-guard-type', $track-rhs);
+                        nqp::dispatch('boot-syscall', 'dispatcher-guard-literal', $track-rhs);
+                        nqp::dispatch('boot-syscall', 'dispatcher-delegate', 'boot-value',
+                            nqp::dispatch('boot-syscall', 'dispatcher-insert-arg-literal-obj', $capture, 0, $hllbool_not($rhs)));
+                        $explicit-accepts := 0;
+                    }
+                    elsif nqp::istype_nd($rhs, $Match) {
+                        # nqp::dispatch('boot-syscall', 'dispatcher-guard-literal', $track-boolification);
+                        nqp::dispatch('boot-syscall', 'dispatcher-guard-concreteness', $track-rhs);
+                        nqp::dispatch('boot-syscall', 'dispatcher-guard-type', $track-rhs);
+                        nqp::dispatch('boot-syscall', 'dispatcher-delegate', 'raku-meth-call',
+                            nqp::dispatch('boot-syscall', 'dispatcher-insert-arg-literal-str',
+                                nqp::dispatch('boot-syscall', 'dispatcher-drop-arg',
+                                    nqp::dispatch('boot-syscall', 'dispatcher-drop-arg',
+                                        nqp::dispatch('boot-syscall', 'dispatcher-drop-arg', $capture, 4), # boolification flag
+                                        1), # LHS
+                                    0), # deconted LHS
+                                1, 'not'));
+                        $explicit-accepts := 0;
+                    }
+                }
+                elsif nqp::istype_nd($rhs, Bool) || nqp::istype_nd($rhs, $Match) {
+                    # nqp::dispatch('boot-syscall', 'dispatcher-guard-literal', $track-boolification);
+                    nqp::dispatch('boot-syscall', 'dispatcher-guard-concreteness', $track-rhs);
+                    nqp::dispatch('boot-syscall', 'dispatcher-guard-type', $track-rhs);
+                    nqp::dispatch('boot-syscall', 'dispatcher-delegate', 'boot-value',
+                        nqp::dispatch('boot-syscall', 'dispatcher-drop-arg',
+                            nqp::dispatch('boot-syscall', 'dispatcher-drop-arg',
+                                nqp::dispatch('boot-syscall', 'dispatcher-drop-arg', $capture, 2), # deconted RHS
+                                1), # LHS
+                            0)); # deconted LHS
+                    $explicit-accepts := 0;
+                }
+            }
+            elsif is-method-setting-only($rhs, 'ACCEPTS', :U) { # Non-concrete RHS
+                # A typeobject on RHS with default ACCEPTS can be reduced to nqp::istype, unless LHS is a concrete Junction
+                nqp::dispatch('boot-syscall', 'dispatcher-guard-concreteness', $track-rhs);
+                nqp::dispatch('boot-syscall', 'dispatcher-guard-type', $track-rhs);
+                # nqp::dispatch('boot-syscall', 'dispatcher-guard-literal', $track-boolification);
+                nqp::dispatch('boot-syscall', 'dispatcher-guard-type', $track-lhs);
+
+                my $matches := try nqp::istype_nd($lhs, $rhs);
+                $matches := $boolification < 0 ?? $hllbool_not($matches) !! $hllbool($matches);
+                nqp::dispatch('boot-syscall', 'dispatcher-delegate', 'boot-value',
+                    nqp::dispatch('boot-syscall', 'dispatcher-insert-arg-literal-obj', $capture, 0, $matches));
+
+                $explicit-accepts := 0;
+            }
+        }
+
+        if $explicit-accepts {
+            if $boolification == 0 || (nqp::isconcrete_nd($rhs) && $boolification > -1 && nqp::istype_nd($rhs, Regex)) {
+                # Do not boolify over a Regex RHS
+                # nqp::dispatch('boot-syscall', 'dispatcher-guard-literal', $track-boolification);
+                if $boolification > 0 {
+                    nqp::dispatch('boot-syscall', 'dispatcher-guard-concreteness', $track-rhs);
+                    nqp::dispatch('boot-syscall', 'dispatcher-guard-type', $track-rhs);
+                }
+
+                # First, drop everything except for LHS
+                my $method-capture :=
+                    nqp::dispatch('boot-syscall', 'dispatcher-drop-arg',
+                        nqp::dispatch('boot-syscall', 'dispatcher-drop-arg',
+                            drop-decont-args(), 2), # boolification flag
+                        1); # RHS
+                # Then prepare for raku-meth-call: deconted RHS, method name, RHS, LHS
+                $method-capture :=
+                    nqp::dispatch('boot-syscall', 'dispatcher-insert-arg-literal-obj',
+                        $method-capture, 0, nqp::what($rhs));
+                $method-capture :=
+                    nqp::dispatch('boot-syscall', 'dispatcher-insert-arg-literal-str',
+                        $method-capture, 1, 'ACCEPTS');
+                $method-capture :=
+                    nqp::dispatch('boot-syscall', 'dispatcher-insert-arg',
+                        $method-capture, 2,
+                        nqp::dispatch('boot-syscall', 'dispatcher-track-arg', $capture, 3)); # RHS
+
+                nqp::dispatch('boot-syscall', 'dispatcher-delegate', 'raku-meth-call', $method-capture);
+            }
+            else {
+                my $sm-code := $boolification < 0 ?? &negate-smartmatch-code !! &smartmatch-code;
+                $capture := drop-decont-args();
+                nqp::dispatch('boot-syscall', 'dispatcher-delegate', 'boot-code-constant',
+                    nqp::dispatch('boot-syscall', 'dispatcher-insert-arg-literal-obj',
+                        nqp::dispatch('boot-syscall', 'dispatcher-drop-arg', $capture, 2), # boolify flag
+                        0, $sm-code));
+            }
+        }
+    });
+}


### PR DESCRIPTION
Try to optimize some special cases whenever possible by means of utilizing new-disp. This PR introduces:

- `raku-boolify` dispatcher, implementing optimized universal HLL-boolification of both native- and HLL-types
- `raku-smartmatch-topicalized` dispatcher, used in place of the default `.ACCEPTS.Bool` chain
- optimized method `not` on `Match` which doesn't fall back to method `Bool`

Supporting additions which have value on their own:

- extended iterator on `Routine` which allows to (deep-)iterate over all possible candidates
- method `candidates` of `Routine` got two named parameters: `:local`, which is true by default, and `:with-proto`
- method `iterator` of `Routine` also got the above two nameds and additional boolean `:candidates` parameter
- implementation-detail method `IS-SETTING-ONLY` on `Routine` which ensures that all routine candidates are defined by the setting

None of the above additions changes the default `Routine` behaviors.

The meaning of the named parameters are:

- `:candidates` makes `Routine` iterator to iterate over candidates whereas the default behavior is to iterate over the routine itself only
- `:!local` triggers iteration not only over the local candidates (dispatchees), but to consider wrappers too; whereas a wrapper is a multi on its own, it's candidates are considered too. Happens recursively, so no matter how deep the wrapping/multi goes.
- `:with-proto` includes protos into the iteration too