### PR TITLE
Add missing precedence info for some infix ops

### DIFF
--- a/src/core.c/precedence.pm6
+++ b/src/core.c/precedence.pm6
@@ -64,6 +64,10 @@ BEGIN {
     trait_mod:<is>(&infix:<+&>,  :prec($multiplicative));
     trait_mod:<is>(&infix:<~&>,  :prec($multiplicative));
     trait_mod:<is>(&infix:<?&>,  :prec($multiplicative));
+    trait_mod:<is>(&infix:«+<»,  :prec($multiplicative));
+    trait_mod:<is>(&infix:«+>»,  :prec($multiplicative));
+    trait_mod:<is>(&infix:«~<»,  :prec($multiplicative));
+    trait_mod:<is>(&infix:«~>»,  :prec($multiplicative));
 
     trait_mod:<is>(&infix:<%%>,  :prec($iffy));
 


### PR DESCRIPTION
This fixes the segfault uncovered by 71c62e7. Because `&infix:«+<»`
didn't have its precedence set, therefore the call to `.prec` went
through Code's `method prec`, which simple returns `my %`. For some
reason this is an HLL hash in the optimizer, so the atkey call in MoarVM
has problems. It shouldn't have segfaulted and probably still needs a
fix, but this change in Rakudo should happen regardless.

Fixes the failure in [MessagePack](https://modules.raku.org/dist/MessagePack) found by Blin in https://github.com/rakudo/rakudo/issues/4724.