### PR TITLE
Remove dead code from MoarVM and JVM extops

### DIFF
--- a/docs/ops.markdown
+++ b/docs/ops.markdown
@@ -6,7 +6,6 @@
     - [p6bindattrinvres](#p6bindattrinvres)
     - [p6bindcaptosig](#p6bindcaptosig)
     - [p6bindsig](#p6bindsig)
-    - [p6bool](#p6bool)
     - [p6box_i](#p6box_i)
     - [p6box_n](#p6box_n)
     - [p6box_s](#p6box_s)
@@ -78,11 +77,6 @@ This desugars to:
 
 ## p6bindsig
 * p6bindsig()
-
-## p6bool
-* p6bool(Mu $value)
-
-Create a Raku Bool from $value.
 
 ## p6box_i
 * p6box_i(int $value)

--- a/docs/ops.markdown
+++ b/docs/ops.markdown
@@ -40,7 +40,6 @@
     - [p6setpre](#p6setpre)
     - [p6settypes](#p6settypes)
     - [p6sink](#p6sink)
-    - [p6sort](#p6sort)
     - [p6stateinit](#p6stateinit)
     - [p6staticouter](#p6staticouter)
     - [p6store](#p6store)
@@ -229,9 +228,6 @@ Sets the "pre" flag on the current frame.
 
 ## p6sink
 * p6sink(Mu $past)
-
-## p6sort
-* p6sort(Mu @data, Mu &comparator)
 
 ## p6stateinit
 * p6stateinit()

--- a/src/vm/js/Perl6/Ops.nqp
+++ b/src/vm/js/Perl6/Ops.nqp
@@ -90,7 +90,6 @@ $ops.add_simple_op('p6invokeunder', $ops.OBJ, [$ops.OBJ, $ops.OBJ], :side_effect
 
 $ops.add_simple_op('p6settypes', $ops.OBJ, [$ops.OBJ], :side_effects);
 $ops.add_simple_op('p6init', $ops.OBJ, [], :side_effects, -> {"nqp.extraRuntime('Raku', {$ops.quote_string($*PERL6_RUNTIME)})"});
-$ops.add_simple_op('p6bool', $ops.OBJ, [$ops.BOOL], :side_effects);
 
 $ops.add_simple_op('p6typecheckrv', $ops.OBJ, [$ops.OBJ, $ops.OBJ, $ops.OBJ], :ctx, :await);
 

--- a/src/vm/js/perl6-runtime/runtime.js
+++ b/src/vm/js/perl6-runtime/runtime.js
@@ -26,10 +26,6 @@ module.exports.load = function(nqp, CodeRef, Capture, containerSpecs) {
     return types;
   };
 
-  op.p6bool = function(value) {
-    return value ? True : False;
-  };
-
   op.p6definite = function(obj) {
     return (obj === Null || obj.$$typeObject) ? False : True;
   };

--- a/src/vm/jvm/Perl6/Ops.nqp
+++ b/src/vm/jvm/Perl6/Ops.nqp
@@ -35,7 +35,6 @@ sub register_op_desugar($name, $desugar, :$inlinable = 1, :$compiler = 'Raku') i
 
 # Raku opcode specific mappings.
 my $ops := nqp::getcomp('QAST').operations;
-$ops.map_classlib_hll_op('Raku', 'p6bigint', $TYPE_P6OPS, 'p6bigint', [$RT_NUM], $RT_OBJ, :tc);
 $ops.map_classlib_hll_op('Raku', 'p6configposbindfailover', $TYPE_P6OPS, 'p6configposbindfailover', [$RT_OBJ, $RT_OBJ], $RT_OBJ, :tc);
 $ops.map_classlib_hll_op('Raku', 'p6store', $TYPE_P6OPS, 'p6store', [$RT_OBJ, $RT_OBJ], $RT_OBJ, :tc);
 $ops.map_classlib_hll_op('Raku', 'p6definite', $TYPE_P6OPS, 'p6definite', [$RT_OBJ], $RT_OBJ, :tc);
@@ -191,7 +190,6 @@ $ops.map_classlib_hll_op('nqp', 'p6init', $TYPE_P6OPS, 'p6init', [], $RT_OBJ, :t
 $ops.map_classlib_hll_op('nqp', 'p6settypes', $TYPE_P6OPS, 'p6settypes', [$RT_OBJ], $RT_OBJ, :tc);
 $ops.map_classlib_hll_op('nqp', 'p6setitertype', $TYPE_P6OPS, 'p6setitertype', [$RT_OBJ], $RT_OBJ, :tc);
 $ops.map_classlib_hll_op('nqp', 'p6setiterbuftype', $TYPE_P6OPS, 'p6setiterbuftype', [$RT_OBJ], $RT_OBJ, :tc);
-$ops.map_classlib_hll_op('nqp', 'p6var', $TYPE_P6OPS, 'p6var', [$RT_OBJ], $RT_OBJ, :tc);
 $ops.map_classlib_hll_op('nqp', 'p6isbindable', $TYPE_P6OPS, 'p6isbindable', [$RT_OBJ, $RT_OBJ], $RT_INT, :tc);
 $ops.map_classlib_hll_op('nqp', 'p6inpre', $TYPE_P6OPS, 'p6inpre', [], $RT_INT, :tc);
 $ops.map_classlib_hll_op('nqp', 'jvmrakudointerop', $TYPE_P6OPS, 'jvmrakudointerop', [], $RT_OBJ, :tc);

--- a/src/vm/jvm/Perl6/Ops.nqp
+++ b/src/vm/jvm/Perl6/Ops.nqp
@@ -148,7 +148,6 @@ $ops.map_classlib_hll_op('Raku', 'p6finddispatcher', $TYPE_P6OPS, 'p6finddispatc
 $ops.map_classlib_hll_op('Raku', 'p6argsfordispatcher', $TYPE_P6OPS, 'p6argsfordispatcher', [$RT_OBJ], $RT_OBJ, :tc);
 $ops.map_classlib_hll_op('Raku', 'p6setautothreader', $TYPE_P6OPS, 'p6setautothreader', [$RT_OBJ], $RT_OBJ, :tc);
 $ops.map_classlib_hll_op('Raku', 'tclc', $TYPE_P6OPS, 'tclc', [$RT_STR], $RT_STR, :tc);
-$ops.map_classlib_hll_op('Raku', 'p6sort', $TYPE_P6OPS, 'p6sort', [$RT_OBJ, $RT_OBJ], $RT_OBJ, :tc);
 $ops.map_classlib_hll_op('Raku', 'p6staticouter', $TYPE_P6OPS, 'p6staticouter', [$RT_OBJ], $RT_OBJ, :tc);
 $ops.add_hll_op('Raku', 'p6invokehandler', -> $qastcomp, $op {
     $qastcomp.as_jast(QAST::Op.new( :op('call'), $op[0], $op[1] ));

--- a/src/vm/jvm/Perl6/Ops.nqp
+++ b/src/vm/jvm/Perl6/Ops.nqp
@@ -150,40 +150,6 @@ $ops.map_classlib_hll_op('Raku', 'p6setautothreader', $TYPE_P6OPS, 'p6setautothr
 $ops.map_classlib_hll_op('Raku', 'tclc', $TYPE_P6OPS, 'tclc', [$RT_STR], $RT_STR, :tc);
 $ops.map_classlib_hll_op('Raku', 'p6sort', $TYPE_P6OPS, 'p6sort', [$RT_OBJ, $RT_OBJ], $RT_OBJ, :tc);
 $ops.map_classlib_hll_op('Raku', 'p6staticouter', $TYPE_P6OPS, 'p6staticouter', [$RT_OBJ], $RT_OBJ, :tc);
-my $p6bool := -> $qastcomp, $op {
-    my $il := JAST::InstructionList.new();
-    my $exprres := $qastcomp.as_jast($op[0]);
-    $il.append($exprres.jast);
-    $*STACK.obtain($il, $exprres);
-
-    my $cond_type := $exprres.type;
-    if $cond_type == $RT_INT || $cond_type == $RT_UINT {
-        $il.append(JAST::PushIVal.new( :value(0) ));
-        $il.append(JAST::Instruction.new( :op('lcmp') ));
-    }
-    elsif $cond_type == $RT_NUM {
-        $il.append(JAST::PushNVal.new( :value(0.0) ));
-        $il.append(JAST::Instruction.new( :op('dcmpl') ));
-    }
-    elsif $cond_type == $RT_STR {
-        $il.append(JAST::Instruction.new( :op('invokestatic'),
-            $TYPE_OPS, 'istrue_s', 'Long', $TYPE_STR ));
-        $il.append(JAST::PushIVal.new( :value(0) ));
-        $il.append(JAST::Instruction.new( :op('lcmp') ));
-    }
-    else {
-        $il.append(JAST::Instruction.new( :op('aload_1') ));
-        $il.append(JAST::Instruction.new( :op('invokestatic'),
-            $TYPE_OPS, 'istrue', 'Long', $TYPE_SMO, $TYPE_TC ));
-        $il.append(JAST::PushIVal.new( :value(0) ));
-        $il.append(JAST::Instruction.new( :op('lcmp') ));
-    }
-    $il.append(JAST::Instruction.new( :op('aload'), 'tc' ));
-    $il.append(JAST::Instruction.new( :op('invokestatic'),
-        $TYPE_P6OPS, 'booleanize', $TYPE_SMO, 'I', $TYPE_TC ));
-    $ops.result($il, $RT_OBJ);
-};
-$ops.add_hll_op('Raku', 'p6bool', $p6bool);
 $ops.add_hll_op('Raku', 'p6invokehandler', -> $qastcomp, $op {
     $qastcomp.as_jast(QAST::Op.new( :op('call'), $op[0], $op[1] ));
 });
@@ -222,7 +188,6 @@ $ops.add_hll_op('Raku', 'p6sink', -> $qastcomp, $past {
 
 # Make some of them also available from NQP land, since we use them in the
 # metamodel and bootstrap.
-$ops.add_hll_op('nqp', 'p6bool', $p6bool);
 $ops.map_classlib_hll_op('nqp', 'p6init', $TYPE_P6OPS, 'p6init', [], $RT_OBJ, :tc);
 $ops.map_classlib_hll_op('nqp', 'p6settypes', $TYPE_P6OPS, 'p6settypes', [$RT_OBJ], $RT_OBJ, :tc);
 $ops.map_classlib_hll_op('nqp', 'p6setitertype', $TYPE_P6OPS, 'p6setitertype', [$RT_OBJ], $RT_OBJ, :tc);

--- a/src/vm/jvm/runtime/org/raku/rakudo/RakOps.java
+++ b/src/vm/jvm/runtime/org/raku/rakudo/RakOps.java
@@ -486,25 +486,6 @@ public final class RakOps {
             + in.substring(Character.charCount(first)).toLowerCase();
     }
 
-    private static final CallSiteDescriptor SortCSD = new CallSiteDescriptor(
-        new byte[] { CallSiteDescriptor.ARG_OBJ, CallSiteDescriptor.ARG_OBJ }, null);
-    public static SixModelObject p6sort(SixModelObject indices, final SixModelObject comparator, final ThreadContext tc) {
-        int elems = (int)indices.elems(tc);
-        SixModelObject[] sortable = new SixModelObject[elems];
-        for (int i = 0; i < elems; i++)
-            sortable[i] = indices.at_pos_boxed(tc, i);
-        Arrays.sort(sortable, new Comparator<SixModelObject>() {
-            public int compare(SixModelObject a, SixModelObject b) {
-                Ops.invokeDirect(tc, comparator, SortCSD,
-                    new Object[] { a, b });
-                return (int)Ops.result_i(tc.curFrame);
-            }
-        });
-        for (int i = 0; i < elems; i++)
-            indices.bind_pos_boxed(tc, i, sortable[i]);
-        return indices;
-    }
-
     public static long p6stateinit(ThreadContext tc) {
         return tc.curFrame.stateInit ? 1 : 0;
     }

--- a/src/vm/moar/ops/perl6_ops.c
+++ b/src/vm/moar/ops/perl6_ops.c
@@ -50,11 +50,7 @@ static void p6stateinit(MVMThreadContext *tc, MVMuint8 *cur_op) {
 }
 
 /* First FIRST, use a flag in the object header. */
-#ifdef MVM_COLLECTABLE_FLAGS1
 #define RAKUDO_FIRST_FLAG 128
-#else
-#define RAKUDO_FIRST_FLAG 16384
-#endif
 
 static MVMuint8 s_p6setfirstflag[] = {
     MVM_operand_obj | MVM_operand_write_reg,
@@ -64,11 +60,7 @@ static void p6setfirstflag(MVMThreadContext *tc, MVMuint8 *cur_op) {
     MVMObject *code_obj = GET_REG(tc, 2).o;
     if (!MVM_code_iscode(tc, code_obj))
         MVM_exception_throw_adhoc(tc, "p6setfirstflag requires a bytecode handle");
-#ifdef MVM_COLLECTABLE_FLAGS1
     code_obj->header.flags1 |= RAKUDO_FIRST_FLAG;
-#else
-    code_obj->header.flags |= RAKUDO_FIRST_FLAG;
-#endif
     GET_REG(tc, 0).o = code_obj;
 }
 
@@ -77,13 +69,8 @@ static MVMuint8 s_p6takefirstflag[] = {
 };
 static void p6takefirstflag(MVMThreadContext *tc, MVMuint8 *cur_op) {
     MVMObject *vm_code = tc->cur_frame->code_ref;
-#ifdef MVM_COLLECTABLE_FLAGS1
     if (vm_code->header.flags1 & RAKUDO_FIRST_FLAG) {
         vm_code->header.flags1 ^= RAKUDO_FIRST_FLAG;
-#else
-    if (vm_code->header.flags & RAKUDO_FIRST_FLAG) {
-        vm_code->header.flags ^= RAKUDO_FIRST_FLAG;
-#endif
         GET_REG(tc, 0).i64 = 1;
     }
     else {
@@ -164,11 +151,7 @@ static void p6invokeunder(MVMThreadContext *tc, MVMuint8 *cur_op) {
     /* Now we call the second code ref, thus meaning it'll appear to have been
      * called by the first. We set up a special return handler to properly
      * remove it. */
-#if MVM_CALLSTACK_SPECIAL_RETURN
     MVM_callstack_allocate_special_return(tc, return_from_fake, NULL, NULL, 0);
-#else
-    MVM_frame_special_return(tc, tc->cur_frame, return_from_fake, NULL, NULL, NULL);
-#endif
     tc->cur_frame->return_value = res;
     tc->cur_frame->return_type = MVM_RETURN_OBJ;
     MVM_frame_dispatch_zero_args(tc, (MVMCode *)code);


### PR DESCRIPTION
I'm getting the same Rakudo regression test failure both on this branch and master:

```
$ ./rakudo-j -Ilib t/04-nativecall/15-rw-args.t
1..22
In file included from /usr/include/stdlib.h:24:0,
                 from t/04-nativecall/15-rw-args.c:1:
/usr/include/features.h:330:4: warning: #warning _FORTIFY_SOURCE requires compiling with optimization (-O) [-Wcpp]
 #  warning _FORTIFY_SOURCE requires compiling with optimization (-O)
    ^
ok 1 - Perl's rw variable was set by C (char)
ok 2 - Perl's rw variable was passed and returned by C (char)
ok 3 - Perl's rw variable was set by C (short)
ok 4 - Perl's rw variable was passed and returned by C (short)
ok 5 - Perl's rw variable was set by C (long)
ok 6 - Perl's rw variable was passed and returned by C (long)
ok 7 - Perl's rw variable was set by C (long long)
ok 8 - Perl's rw variable was passed and returned by C (longlong)
ok 9 - Perl's rw variable was set by C (float)
ok 10 - Perl's rw variable was passed and returned by C (float)
ok 11 - Perl's rw variable was set by C (double)
ok 12 - Perl's rw variable was passed and returned by C (double)
Native call expected argument that references a native integer, but got org.raku.nqp.sixmodel.reprs.NativeRefInstanceIntLex@77ba9a99
  in block SetUChar at /home/nick/Perl/rakudo/lib/NativeCall.rakumod (NativeCall) line 390
  in block <unit> at t/04-nativecall/15-rw-args.t line 58

# You planned 22 tests, but ran 12
```

The text *Native call expected argument that references a native integer, but got* is from NQP, specitically `src/vm/jvm/runtime/org/raku/nqp/runtime/NativeCallOps.java` where `Ops.iscont_i(o) == 0`, so I infer that it relates to the recent unsigned int handling improvements. I don't know how to fix it.