### PR TITLE
Further improvements to smartmatch dispatcher

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -7459,18 +7459,9 @@ class Perl6::Actions is HLL::Actions does STDActions {
             QAST::Var.new( :name($result_var), :scope('local'), :decl('var') ),
             QAST::Op.new(
                 :op<dispatch>,
-                QAST::SVal.new( :value<raku-smartmatch-topicalized> ),
-                QAST::Op.new(
-                    :op<decont>,
-                    WANTED(QAST::Var.new( :name('$_'), :scope('lexical') ),'sm')),
+                QAST::SVal.new( :value<raku-smartmatch> ),
                 WANTED(QAST::Var.new( :name('$_'), :scope('lexical') ),'sm'),
-                QAST::Op.new(
-                    :op<decont>,
-                    QAST::Op.new(
-                        :op('bind'),
-                        QAST::Var.new( :name($rhs_local), :scope('local'), :decl('var') ),
-                        $rhs )),
-                QAST::Var.new( :name($rhs_local), :scope('local') ),
+                $rhs,
                 QAST::IVal.new( :value( $negated ?? -1 !! $boolify ) )
             )
         );

--- a/src/Perl6/Optimizer.nqp
+++ b/src/Perl6/Optimizer.nqp
@@ -2156,7 +2156,6 @@ my class SmartmatchOptimizer {
 #?if !moar
             # If we know RHS type then we can possibly simplify the actual SM op withing `locallifetime` to plain
             # .ACCEPTS(...).Bool unless RHS is or can be a Regex
-            my $rhs_type := $rhs.infer-type(:guaranteed);
             if nqp::isnull($result)
                 && $boolified
                 && !$rhs.can-be($!symbols.Regex)


### PR DESCRIPTION
- Don't require decontainerized versions of LHS/RHS. Track `Scalar` `$!value` instead when necessary. This could make guarding a little bit slower for containers but overall gain in performance is expected because on the call site we get rid of:

  * one extra local variable
  * two `decont` ops
  * two extra arguments

  On the dispatch side we use less code and less `drop-arg` dispatch calls.

- Also, `replace-arg` dispatcher is used where possible instead of `drop`+`insert` pair.

- Fixed a bug where omitting of a guard in explicit ACCEPTS branch resulted in too aggressive caching

- Whenever no static optimization is possible in `optimize_chain`, instead of falling back to the original QAST node replace it with a call to the `raku-smartmatch` dispatcher to possibly get a run-time optimization.
