### PR TITLE
Fix method put failing on junctions

### DIFF
--- a/src/core.c/Junction.pm6
+++ b/src/core.c/Junction.pm6
@@ -284,6 +284,10 @@ my class Junction { # declared in BOOTSTRAP
         $!type ~ '(' ~ nqp::join(', ',$rakus) ~ ')'
     }
 
+    multi method put() {
+        self.THREAD: { .put }
+    }
+
     method CALL-ME(|c) {
         my \storage     := nqp::getattr(self, Junction, '$!eigenstates');
         my int $elems    = nqp::elems(storage);

--- a/src/core.c/io_operators.pm6
+++ b/src/core.c/io_operators.pm6
@@ -104,7 +104,9 @@ multi sub put() {
 }
 multi sub put(Junction:D \j) {
     my $out := $*OUT;
-    j.THREAD: { $out.print: nqp::concat(.Str,$out.nl-out) }
+    j.THREAD: { nqp::istype($_, Junction)
+                    ?? put($_)
+                    !! $out.print: nqp::concat(.Str,$out.nl-out) }
 }
 multi sub put(\x) {
     $_ := $*OUT;


### PR DESCRIPTION
Resolves #4742. Aside of plain throwing `(1|2).put` also fix recursive cases when a junction is an eigenstate of another junction.