### PR TITLE
Add "use show-precompilation" as a pragma

### DIFF
--- a/lib/show-precompilation.rakumod
+++ b/lib/show-precompilation.rakumod
@@ -1,0 +1,6 @@
+# The sole purpose of this module is to make it easier to activate the
+# logic for showing precompilation progress.
+
+%*ENV<RAKUDO_PRECOMPILATION_PROGRESS> = 1;
+
+# vim: expandtab shiftwidth=4

--- a/tools/build/install-core-dist.raku
+++ b/tools/build/install-core-dist.raku
@@ -17,6 +17,7 @@ my %provides =
     "snapper"                       => "lib/snapper.rakumod",
     "safe-snapper"                  => "lib/safe-snapper.rakumod",
     "BUILDPLAN"                     => "lib/BUILDPLAN.rakumod",
+    "show-precompilation"           => "lib/show-precompilation.rakumod",
 ;
 
 %provides<NativeCall::Dispatcher> = "lib/NativeCall/Dispatcher.rakumod"


### PR DESCRIPTION
Activates the RAKUDO_PRECOMPILATION_PROGRESS environment variable,
perhaps making this feature a little more rememberable / accessible.