### PR TITLE
Add "use named-anywhere" as a pragma

### DIFF
--- a/lib/named-anywhere.rakumod
+++ b/lib/named-anywhere.rakumod
@@ -1,0 +1,12 @@
+# The sole purpose of this module is to make it easier to activate
+# the possibility of having MAIN accept named arguments anywhere on
+# the command line.
+
+with %*SUB-MAIN-OPTS -> %opts {
+    %opts<named-anywhere> = True;
+}
+else {
+    PROCESS::<%SUB-MAIN-OPTS> = :named-anywhere;
+}
+
+# vim: expandtab shiftwidth=4

--- a/tools/build/install-core-dist.raku
+++ b/tools/build/install-core-dist.raku
@@ -17,6 +17,7 @@ my %provides =
     "snapper"                       => "lib/snapper.rakumod",
     "safe-snapper"                  => "lib/safe-snapper.rakumod",
     "BUILDPLAN"                     => "lib/BUILDPLAN.rakumod",
+    "named-anywhere"                => "lib/named-anywhere.rakumod",
 ;
 
 %provides<NativeCall::Dispatcher> = "lib/NativeCall/Dispatcher.rakumod"


### PR DESCRIPTION
In an attempt to make the "use named arguments on the command line
at any location" feature more rememberable and accessible.

Sets named-anywhere key in the %*SUB-MAIN-OPTS has if it already
exists, or creates it in PROCESS:: with the named-anywhere key set
in it.