### PR TITLE
Enable onlystar proto wrapping

### DIFF
--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -2442,6 +2442,7 @@ BEGIN {
     Routine.HOW.add_attribute(Routine, Attribute.new(:name<$!flags>, :type(int), :package(Routine)));
     Routine.HOW.add_attribute(Routine, Attribute.new(:name<$!inline_info>, :type(Mu), :package(Routine)));
     Routine.HOW.add_attribute(Routine, Attribute.new(:name<$!package>, :type(Mu), :package(Routine)));
+    Routine.HOW.add_attribute(Routine, Attribute.new(:name<$!is-wrapped>, :type(int), :package(Routine)));
     Routine.HOW.add_attribute(Routine, scalar_attr('@!dispatch_order', List, Routine, :!auto_viv_container));
 #?if !moar
     Routine.HOW.add_attribute(Routine, Attribute.new(:name<$!dispatch_cache>, :type(Mu), :package(Routine)));
@@ -2451,6 +2452,10 @@ BEGIN {
             my $dc_self   := nqp::decont($self);
             my $disp_list := nqp::getattr($dc_self, Routine, '@!dispatchees');
             nqp::hllboolfor(nqp::defined($disp_list), "Raku");
+        }));
+    Routine.HOW.add_method(Routine, 'is-wrapped', nqp::getstaticcode(sub ($self) {
+            my $dc_self   := nqp::decont($self);
+            nqp::hllboolfor(nqp::getattr($dc_self, Routine, '$!is-wrapped'), "Raku");
         }));
     Routine.HOW.add_method(Routine, 'add_dispatchee', nqp::getstaticcode(sub ($self, $dispatchee) {
             my $dc_self   := nqp::decont($self);

--- a/src/core.c/Routine.pm6
+++ b/src/core.c/Routine.pm6
@@ -102,7 +102,7 @@ my class Routine { # declared in BOOTSTRAP
                 nqp::bindattr($handle, WrapHandle, '$!dispatcher', $!dispatcher);
                 nqp::bindattr($handle, WrapHandle, '$!wrapper', &wrapper);
                 nqp::bindattr($handle, WrapHandle, '$!routine', self);
-                $!is-wrapped := 1;
+                nqp::bindattr_i(self, Routine, '$!is-wrapped', 1);
                 $handle
             }
             method CALL-ME(|c) is raw {
@@ -113,7 +113,7 @@ my class Routine { # declared in BOOTSTRAP
             method update_wrapped_state {
                 nqp::bindattr_i(
                     nqp::decont(self), Routine, '$!is-wrapped',
-                    nqp::isgt_i(nqp::elems($!dispatcher.candidates), 1));
+                    nqp::isgt_i($!dispatcher.candidates.elems, 1));
             }
         }
 

--- a/src/core.c/Routine.pm6
+++ b/src/core.c/Routine.pm6
@@ -77,15 +77,16 @@ my class Routine { # declared in BOOTSTRAP
 
     method soft(--> Nil) { }
 
-    method is-wrapped(--> False) { }
-
 #?if !moar
     method wrap(&wrapper) {
         my class WrapHandle {
             has $!dispatcher;
             has $!wrapper;
+            has $!routine;
             method restore() {
-                nqp::hllbool($!dispatcher.remove($!wrapper));
+                my $success = nqp::hllbool($!dispatcher.remove($!wrapper));
+                $!routine.update_wrapped_state;
+                $success;
             }
         }
         my role Wrapped {
@@ -100,6 +101,8 @@ my class Routine { # declared in BOOTSTRAP
                 my $handle := nqp::create(WrapHandle);
                 nqp::bindattr($handle, WrapHandle, '$!dispatcher', $!dispatcher);
                 nqp::bindattr($handle, WrapHandle, '$!wrapper', &wrapper);
+                nqp::bindattr($handle, WrapHandle, '$!routine', self);
+                $!is-wrapped := 1;
                 $handle
             }
             method CALL-ME(|c) is raw {
@@ -107,7 +110,11 @@ my class Routine { # declared in BOOTSTRAP
             }
             method WRAPPERS() { IterationBuffer.new($!dispatcher.candidates) }
             method soft(--> True) { }
-            method is-wrapped(--> Bool) { $!dispatcher.candidates > 1 }
+            method update_wrapped_state {
+                nqp::bindattr_i(
+                    nqp::decont(self), Routine, '$!is-wrapped',
+                    nqp::isgt_i(nqp::elems($!dispatcher.candidates), 1));
+            }
         }
 
         # We can't wrap a hardened routine (that is, one that's been
@@ -141,6 +148,7 @@ my class Routine { # declared in BOOTSTRAP
                 ?? nqp::clone($!wrappers)
                 !! IterationBuffer.new;
             nqp::unshift($new-wrappers, &wrapper);
+            nqp::bindattr_i(nqp::decont(self), Routine, '$!is-wrapped', 1);
             $!wrappers := $new-wrappers;
         }
         method REMOVE-WRAPPER(&wrapper --> Bool) {
@@ -158,9 +166,11 @@ my class Routine { # declared in BOOTSTRAP
                 $i++;
             }
             $!wrappers := $new-wrappers if $found;
+            nqp::bindattr_i(
+                nqp::decont(self), Routine, '$!is-wrapped',
+                nqp::isgt_i(nqp::elems($!wrappers), 1));
             $found
         }
-        method is-wrapped(--> Bool) { nqp::elems($!wrappers) > 1 }
     }
     my class WrapHandle {
         has &!routine;


### PR DESCRIPTION
Try to make better dispatching decisions over wrapped routines by adding `$!is-wrapped` attribute to `Routine` and guarding over it. This should work better because this way wrapped routine path is not taken when all wrappers are removed.