### PR TITLE
Turn junctions into value objects

### DIFF
--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -3780,6 +3780,7 @@ BEGIN {
     Junction.HOW.add_parent(Junction, Mu);
     Junction.HOW.add_attribute(Junction, scalar_attr('$!eigenstates', Mu, Junction));
     Junction.HOW.add_attribute(Junction, scalar_attr('$!type', str, Junction));
+    Junction.HOW.add_attribute(Junction, Attribute.new(:name<$!WHICH>, :type(ValueObjAt), :package(Junction)));
     Junction.HOW.compose_repr(Junction);
 
     # class Bool is Int {

--- a/src/core.c/Junction.pm6
+++ b/src/core.c/Junction.pm6
@@ -176,6 +176,22 @@ my class Junction { # declared in BOOTSTRAP
         )
     }
 
+    multi method WHICH(Junction:D: --> ValueObjAt:D) {
+        nqp::if(
+            nqp::defined($!WHICH),
+            $!WHICH,
+            ($!WHICH := nqp::box_s(
+                nqp::concat(
+                    nqp::if(
+                        nqp::eqaddr(self.WHAT, Junction),
+                        'Junction|',
+                        nqp::concat(nqp::unbox_s(self.^name), '|')
+                    ),
+                    nqp::sha1(self.gist)
+                ),
+                ValueObjAt )));
+    }
+
     multi method ACCEPTS(Junction:U: Junction:D --> True) { }
     multi method ACCEPTS(Junction:D \SELF: Junction:D \topic) {
         topic.BOOLIFY-ACCEPTS(self)


### PR DESCRIPTION
This may serve many purposes like classification/categorization over junctions; or ensuring a junction we have is the one we expect.

Resolves Raku/problem-solving#311