### PR TITLE
Don't guard over non-Routine types

### DIFF
--- a/src/vm/moar/dispatchers.nqp
+++ b/src/vm/moar/dispatchers.nqp
@@ -1395,9 +1395,11 @@ nqp::dispatch('boot-syscall', 'dispatcher-register', 'raku-meth-deferral',
                     $track_chain, DeferralChain, '$!code');
                 nqp::dispatch('boot-syscall', 'dispatcher-guard-literal', $track_method);
                 nqp::dispatch('boot-syscall', 'dispatcher-guard-type', $track_method);
-                my $track_is-wrapped := nqp::dispatch('boot-syscall', 'dispatcher-track-attr',
-                    $track_method, Routine, '$!is-wrapped');
-                nqp::dispatch('boot-syscall', 'dispatcher-guard-literal', $track_is-wrapped);
+                if nqp::istype($chain.code, Routine) {
+                    my $track_is-wrapped := nqp::dispatch('boot-syscall', 'dispatcher-track-attr',
+                        $track_method, Routine, '$!is-wrapped');
+                    nqp::dispatch('boot-syscall', 'dispatcher-guard-literal', $track_is-wrapped);
+                }
 
                 # Now perform the action needed based upon the kind of resumption
                 # we have.


### PR DESCRIPTION
Sometimes a code object in deferral chain could happen to be a `NQPRoutine` instance. Make sure we don't try accessing `$!is-wrapped` attribute then.