### PR TITLE
Defuse a Failure

### DIFF
--- a/src/core.c/Exception.pm6
+++ b/src/core.c/Exception.pm6
@@ -252,7 +252,10 @@ my class X::Method::NotFound is Exception {
                 if $.method eq $method_name {
                     $found-types.set($method_candidate.package.^name());
                 }
-                elsif nqp::not_i(nqp::istype(type, Failure)) && nqp::can(type, $method_name) {
+                elsif nqp::istype(type, Failure) {
+                    type.so; # defuse
+                }
+                elsif nqp::can(type, $method_name) {
                     find_public_suggestion($.method, $method_name);
                 }
             }


### PR DESCRIPTION
Minor fix to the fix in #4774. It's not sufficient to react to a failure. The failure has to be defused too.

My bad to forget about this...