### PR TITLE
Make &[max] and &[min] return RHS for ties

### DIFF
--- a/src/core.c/Any-iterable-methods.pm6
+++ b/src/core.c/Any-iterable-methods.pm6
@@ -2564,18 +2564,18 @@ BEGIN Attribute.^compose;
 proto sub infix:<min>(|) is pure {*}
 multi sub infix:<min>(Mu:D \a, Mu:U) { a }
 multi sub infix:<min>(Mu:U, Mu:D \b) { b }
-multi sub infix:<min>(Mu:D \a, Mu:D \b) { (a cmp b) < 0 ?? a !! b }
+multi sub infix:<min>(Mu:D \a, Mu:D \b) { (a cmp b) ≥ 0 ?? b !! a }
 multi sub infix:<min>(Int:D $a, Int:D $b) {
-    nqp::islt_i(nqp::cmp_I($a,$b),0) ?? $a !! $b
+    nqp::isgt_i(nqp::cmp_I($a,$b),0) ?? $b !! $a
 }
 multi sub infix:<min>(int $a, int $b) {
-    nqp::islt_i(nqp::cmp_i($a,$b),0) ?? $a !! $b
+    nqp::isgt_i(nqp::cmp_i($a,$b),0) ?? $b !! $a
 }
 multi sub infix:<min>(Num:D $a, Num:D $b) {
-    nqp::islt_i(nqp::cmp_n($a,$b),0) ?? $a !! $b
+    nqp::isgt_i(nqp::cmp_n($a,$b),0) ?? $b !! $a
 }
 multi sub infix:<min>(num $a, num $b) {
-    nqp::islt_i(nqp::cmp_n($a,$b),0) ?? $a !! $b
+    nqp::isgt_i(nqp::cmp_n($a,$b),0) ?? $b !! $a
 }
 multi sub infix:<min>(+args is raw) { args.min }
 
@@ -2586,18 +2586,18 @@ multi sub min(+args)        { args.min      }
 proto sub infix:<max>(|) is pure {*}
 multi sub infix:<max>(Mu:D \a, Mu:U) { a }
 multi sub infix:<max>(Mu:U, Mu:D \b) { b }
-multi sub infix:<max>(Mu:D \a, Mu:D \b) { (a cmp b) > 0 ?? a !! b }
+multi sub infix:<max>(Mu:D \a, Mu:D \b) { (a cmp b) ≤ 0 ?? b !! a }
 multi sub infix:<max>(Int:D $a, Int:D $b) {
-    nqp::isgt_i(nqp::cmp_I($a,$b),0) ?? $a !! $b
+    nqp::islt_i(nqp::cmp_I($a,$b),0) ?? $b !! $a
 }
 multi sub infix:<max>(int $a, int $b) {
-    nqp::isgt_i(nqp::cmp_i($a,$b),0) ?? $a !! $b
+    nqp::islt_i(nqp::cmp_i($a,$b),0) ?? $b !! $a
 }
 multi sub infix:<max>(Num:D $a, Num:D $b) {
-    nqp::isgt_i(nqp::cmp_n($a,$b),0) ?? $a !! $b
+    nqp::islt_i(nqp::cmp_n($a,$b),0) ?? $b !! $a
 }
 multi sub infix:<max>(num $a, num $b) {
-    nqp::isgt_i(nqp::cmp_n($a,$b),0) ?? $a !! $b
+    nqp::islt_i(nqp::cmp_n($a,$b),0) ?? $b !! $a
 }
 multi sub infix:<max>(+args) { args.max }
 


### PR DESCRIPTION
`&[max] `and `&[min] `both have List associativity, which means that

```raku
$a max $b max $c
```

should be the same as

```raku
max $a, $b, $c
```

However, in the case of ties, this was not true: `&max` would return the first argument with that value, whereas `&[max]` would return its LHS. For example, before this PR:

```raku
    max 0, False # OUTPUT: «0»
    0  max False # OUTPUT: «False»
```

These two lines should return the same value, and `&max'`s behavior seems to be preferable under logic similar to stability in sorting.

This PR changes `&[max]` so that it returns its RHS in the case of ties.  It also makes corresponding changes to `&[max]` candidates where
ties between different values aren't possible (e.g., if `$a` and `$b` are both native `int`s) to avoid confusing differences in adjacent lines of code.

This PR has no spectest fallout; once it's merged, I can add a Roast test confirming `&[max]`'s behavior for ties.  See also Raku/problem-solving#313 for additional background. 