### PR TITLE
Improve error msg for traits passed invalid args

### DIFF
--- a/src/core.c/Exception.pm6
+++ b/src/core.c/Exception.pm6
@@ -1044,7 +1044,7 @@ my role X::Trait is Exception {
 }
 my class X::Trait::Invalid does X::Trait {
     has $.name;       # target of trait, e.g., '$foo' in `$foo is rw`
-    has $.reason;     # reason the the trait was invalid (optional)
+    has $.reason;     # reason the trait was invalid (optional)
     method message () {
         "Cannot use '$.type $.subtype' on $.declaring '$.name'"
          ~($!reason ?? " because:\n$!reason.indent(4)" !! '.');

--- a/src/core.c/Exception.pm6
+++ b/src/core.c/Exception.pm6
@@ -1037,33 +1037,33 @@ my class X::Worry::Precedence::Range is X::Worry {
     }
 }
 
-my class X::Trait::Invalid is Exception {
+my role X::Trait is Exception {
     has $.type;       # is, will, of etc.
     has $.subtype;    # wrong subtype being tried
-    has $.declaring;  # variable, sub, parameter, etc.
-    has $.name;       # '$foo', '@bar', etc.
+    has $.declaring;  # variable, sub, parameter, etc. (optional)
+}
+my class X::Trait::Invalid does X::Trait {
+    has $.name;       # target of trait, e.g., '$foo' in `$foo is rw`
+    has $.reason;     # reason the the trait was invalid (optional)
     method message () {
-        "Cannot use '$.type $.subtype' on $.declaring '$.name'."
+        "Cannot use '$.type $.subtype' on $.declaring '$.name'"
+         ~($!reason ?? " because:\n$!reason.indent(4)" !! '.');
     }
 }
+my class X::Comp::Trait::Invalid is X::Trait::Invalid does X::Comp { };
 
-my class X::Trait::Unknown is Exception {
-    has $.type;       # is, will, of etc.
-    has $.subtype;    # wrong subtype being tried
-    has $.declaring;  # variable, sub, parameter, etc.
+my class X::Trait::Unknown does X::Trait {
     method message () {
         "Can't use unknown trait '{
             try { $.type } // "unknown type"
         }' -> '{
             try { $.subtype } // "unknown subtype"
-        }' in a$.declaring declaration."
+        }' in $.declaring declaration."
     }
 }
 my class X::Comp::Trait::Unknown is X::Trait::Unknown does X::Comp { };
 
-my class X::Trait::NotOnNative is Exception {
-    has $.type;       # is, will, of etc.
-    has $.subtype;    # wrong subtype being tried
+my class X::Trait::NotOnNative does X::Trait {
     has $.native;     # type of native (optional)
     method message () {
         "Can't use trait '$.type $.subtype' on a native"
@@ -1072,10 +1072,7 @@ my class X::Trait::NotOnNative is Exception {
 }
 my class X::Comp::Trait::NotOnNative is X::Trait::NotOnNative does X::Comp { };
 
-my class X::Trait::Scope is Exception {
-    has $.type;       # is, will, of etc.
-    has $.subtype;    # export
-    has $.declaring;  # type name of the object
+my class X::Trait::Scope does X::Trait {
     has $.scope;      # not supported (but used) scope
     has $.supported;  # hint about what is allowed instead
     method message () {


### PR DESCRIPTION
Resolves  #4785.

Previously, traits called with invalid arguments would throw an `X::Trait::Unknown` error, which was confusing when the trait _was_
known.  With this PR, they'll now throw an `X::Trait::Invalid` error instead.

To correctly distinguish between unknown traits and invalidly called traits, we also now generate a list of known traits via introspection
rather than relying on a list of hard-coded traits.  This has the added benefit of generating more helpful `X::Trait::Unknown` error
messages when non-core traits have been defined (and eliminates the need to update the hard-coded list).

This PR also includes minor refactoring of the `X::Trait::*` code factor out some duplicated attributes into a role.  This refactoring introduces very minor spectest breakage: Two regression tests in [S12-attributes/instance.t](https://github.com/Raku/roast/blob/master/S12-attributes/instance.t#L693-L706) test the exact value of an attribute, and changing that value from `n attribute` to `an attribute` broke those tests.  I've prepared a corresponding Roast PR.