### PR TITLE
Remove unneeded/confusing can('prec') checks

### DIFF
--- a/src/core.c/traits.pm6
+++ b/src/core.c/traits.pm6
@@ -218,26 +218,20 @@ multi sub trait_mod:<is>(Routine:D $r, :prec(%spec)!) {
     0;
 }
 # three other trait_mod sub for equiv/tighter/looser in operators.pm6
-multi sub trait_mod:<is>(Routine:D $r, :&equiv!) {
-    nqp::can(&equiv, 'prec')
-        ?? trait_mod:<is>($r, :prec(&equiv.prec))
-        !! die "Routine given to equiv does not appear to be an operator";
+multi sub trait_mod:<is>(Routine:D $r, Code :$equiv!) {
+    trait_mod:<is>($r, :prec($equiv.prec));
     $r.prec<assoc>:delete;
 }
-multi sub trait_mod:<is>(Routine:D $r, :&tighter!) {
-    die "Routine given to tighter does not appear to be an operator"
-        unless nqp::can(&tighter, 'prec');
-    if !nqp::can($r, 'prec') || ($r.prec<prec> // "") !~~ /<[@:]>/ {
-        trait_mod:<is>($r, :prec(&tighter.prec))
+multi sub trait_mod:<is>(Routine:D $r, Code :$tighter!) {
+    if $r.prec<prec> !~~ /<[@:]>/ {
+        trait_mod:<is>($r, :prec($tighter.prec))
     }
     $r.prec<prec> && ($r.prec<prec> := $r.prec<prec>.subst: '=', '@=');
     $r.prec<assoc>:delete;
 }
-multi sub trait_mod:<is>(Routine:D $r, :&looser!) {
-    die "Routine given to looser does not appear to be an operator"
-        unless nqp::can(&looser, 'prec');
-    if !nqp::can($r, 'prec') || ($r.prec<prec> // "") !~~ /<[@:]>/ {
-        trait_mod:<is>($r, :prec(&looser.prec))
+multi sub trait_mod:<is>(Routine:D $r, Code :$looser!) {
+    if $r.prec<prec> !~~ /<[@:]>/ {
+        trait_mod:<is>($r, :prec($looser.prec))
     }
     $r.prec<prec> && ($r.prec<prec> := $r.prec<prec>.subst: '=', ':=');
     $r.prec<assoc>:delete;


### PR DESCRIPTION
This builds on commits caba0d3 and a7ccfc6 (admittedly not that promptly! @lizmat  made those commits in 2017).  The prior commits moved the `.prec` method to Code to avoid needing to check whether various functions `can('prec')`; this PR removes six such `can('prec')` checks in the `is equiv`, `is tighter` and `is looser` traits.

Three of the six checks were literally unnecessary because they were on a Routine (which is guaranteed to have Code's prec method).  The
other 3 were on variables with a Callable (`&`) type constraint and thus could technically have been necessary in the rare case that someone
passed a non-Code callable.  However, even in that edge case, the check generated a confusing error message that suggested the trait
needed to be given an operator (when, in reality, any Code will do).

To address this edge case, this commit changes the parameter type constraint from Callable to Code, which has the same effect but
avoids the confusing error message.  (The replacement error message is also slightly confusing, but that confusing message is addressed by #4786).