### PR TITLE
Fix typo'd missing : in .nominal_type signature

### DIFF
--- a/src/core.c/Parameter.pm6
+++ b/src/core.c/Parameter.pm6
@@ -325,7 +325,7 @@ my class Parameter { # declared in BOOTSTRAP
     # XXX Must be marked as DEPRECATED
     method coerce_type(Parameter:D: --> Mu) { $!type.HOW.archetypes.coercive ?? $!type.^target_type !! Mu }
 
-    method nominal_type(Parameter:D --> Mu) { $!type.HOW.archetypes.nominalizable ?? $!type.^nominalize !! $!type }
+    method nominal_type(Parameter:D: --> Mu) { $!type.HOW.archetypes.nominalizable ?? $!type.^nominalize !! $!type }
 
     method named_names(Parameter:D: --> List:D) {
         nqp::if(


### PR DESCRIPTION
The `Parameter.nominal_type method` had a signature that clearly intended to constrain the invocation to be `:D`, but was missing the
trailing `:`.

Fixing this issue causes a TODO'ed Roast test to pass; I'll fix that in a companion PR. 