### PR TITLE
Allow optional : on LHS of signature binding declaration

### DIFF
--- a/src/core.c/Exception.pm6
+++ b/src/core.c/Exception.pm6
@@ -1659,6 +1659,23 @@ my class X::Syntax::Variable::Initializer does X::Syntax {
     method message() { "Cannot use variable $!name in declaration to initialize itself" }
 }
 
+my class X::Syntax::Variable::SignatureAssignment does X::Syntax {
+    method message() {
+        "Cannot use assignment when declaring a variable via signature binding.\n"
+        ~"    Did you mean to use binding?  If so, use `:=` instead of `=`.\n"
+        ~"    Or did you mean to use list assignment?  If so, don't use `:(...)`\n"
+        ~"      (the signature literal syntax) on the left-hand side."
+    }
+}
+
+my class X::Syntax::Variable::SignatureWithoutInitializer does X::Syntax {
+    method message {
+        "Variable declaration using a signature literal requires an initializer.\n"
+        ~"    Did you mean to declare a list of variables with `(...)` instead of\n"
+        ~"    a signature literal with `:(...)`?"
+    }
+}
+
 
 my class X::Syntax::Variable::Twigil does X::Syntax {
     has $.what = 'variable';


### PR DESCRIPTION
When using signature binding during variable declaration, the normal syntax is

```raku
my ($a, $b) := (42, 47);
```

The `($a, $b)` on the LHS creates a Signature, which then has 42 and 47 bound to its parameters following the normal signature-binding
process.  But why does `($a, $b)` create a Signature rather than a List?  Normally, the syntax for creating a Signature is `:(...)`, not
`(...)`.

Raku lets us omit the `:` here because we're binding to a list of variables in the context of declaring those variables and, as
S03#Signature-objects says, a declaration context makes the signature-literal's `:` optional (though the `(` and `)` are still
required).  This makes perfect sense, because there's no way Raku can bind to a list of variables on the LHS *other* than by treating the
LHS as a Signature and binding the RHS to it.  So the `:` is a bit redundant in context, and Raku's decision to make it optional is
well-justified.

Currently, however, the `:` is **not** optional – it's forbidden. Prior to this commit, the following incorrectly throws an
X::Syntax::Malformed error:

```raku
my :($a, $b) := (42, 47);
```

This commit fixes that error and gives the line the semantics described in S03 – that is, exactly the same signature-binding
semantics that it would have without the optional `:`.

In addition to being a bugfix that restores apparently intended behavior, allowing `my :($a, $b) := (42, 47)` as a (slightly) more
verbose alternative to `my ($a, $b) := (42, 47)` has a few advantages:

  1. It allows the user to more clearly express their intent that the LHS is a Signature.
  2. Because the user has communicated their intent, Raku can provide helpful error messages rather than silently doing something
     unintended.
  3. It makes Raku's semantics easier to explain to new users – because `my ($a, $b) := (42, 47)` is shorthand for `my :($a, $b) := (42, 47)`, it's confusing that the non-shorthand version isn't allowed.  In particular, the Raku docs have often been confusingly imprecise about variable-declaration signature binding, often calling it "destructuring assignment". I can't be sure, but I believe that normal signature literal syntax not being allowed during variable-declaration signature binding likely contributed to this confusion.

To implement the helpful error messages described in (2), this commit adds two error as shown below.  First, an X::Syntax::Variable::SignatureAssignment error that is thrown when a user tries to *assign* (rather than bind) to a variable-declaration
signature:

```raku
# without `:`
my (@a0, $b0) = ([1, 2], 3); # Unintended list assignment
note $b0; # OUTPUT: «(Any)»

# with `:`
my :(@a, $b) = ([1, 2], 3);
# ===SORRY!=== Error while compiling file.raku
# use assignment when declaring a variable via signature binding.
# Did you mean to use binding?  If so, use `:=` instead of `=`.
# Or did you mean to use list assignment?  If so, don't use `:(...)`
#    (the signature literal syntax) on the left-hand side.
# at file.raku:4
# ------> my :($a, $b)⏏ = (1, 2);
```

Second, an X::Syntax::Variable::SignatureWithoutInitializer error that's thrown when a user tries to use variable-declaration signature
binding without a RHS to bind to the Signature:

```raku
# without `:`
my ($a0, $b0); # Unintended list declaration of mutable variables

# with `:`
my :($a, $b);
# OUTPUT: ===SORRY!=== Error while compiling file.raku
# Variable declaration using a signature literal requires an initializer.
#     Did you mean to declare a list of variables with `(...)` instead of
#     a signature literal with `:(...)`?
# at file.raku:8
# ------> my :($a, $b)⏏;
```

Resolves #4789