### PR TITLE
Optimize more cases of p6decontrv ops

### DIFF
--- a/src/Perl6/Optimizer.nqp
+++ b/src/Perl6/Optimizer.nqp
@@ -2832,6 +2832,9 @@ class Perl6::Optimizer {
             # as appropriate, which may avoid a boxing. Same for QAST::WVal
             # if we can see the value is not containerized.
             my $last_stmt := get_last_stmt($value);
+            if nqp::istype($last_stmt, QAST::Want) {
+                $last_stmt := $last_stmt[0];
+            }
             if nqp::istype($last_stmt, QAST::Op) {
                 my str $last_op := $last_stmt.op;
                 if $last_op eq 'hllbool' || nqp::eqat($last_op, 'I', -1) {


### PR DESCRIPTION
If there's a QAST::Want in a QAST::Op(p6decontrv), try to optimize based on
the child of the QAST::Want. This turns the optimized version of `inc-a()` in
`my int $a = 0; sub inc-a() { ++$a };` into essentially the same as the
optimized version of `my int $a = 0; sub inc-a() { $a = $a + 1 };`,
i.e., `decont_i + assign_i + add_i` instead of `p6decontrv + assign_i +
add_i`.

Rakudo builds ok and passes `make m-test m-spectest`. This example `MVM_SPESH_BLOCKING=1 raku -MSIL -e 'my int $a = 0; sub inc-a() { ++$a }; my int $i = 0; while ++$i < 100_000_000 { inc-a(); }; say now - INIT now; say($a)'` shows `inc-a()` now only 40 bytes, down from 48 bytes. However, runtime and instruction count seems unchanged.