### PR TITLE
Make previous values in REPL accessible with `$*N`

### DIFF
--- a/src/core.c/REPL.pm6
+++ b/src/core.c/REPL.pm6
@@ -351,7 +351,7 @@ do {
                 return $!control-not-allowed;
             }
 
-            self.compiler.eval('$_ := $*LAST-OUTPUT;' ~ $code, |%adverbs);
+            self.compiler.eval('$_ = $*LAST-OUTPUT;' ~ $code, |%adverbs);
         }
 
         method interactive_prompt() { '> ' }

--- a/t/02-rakudo/repl.t
+++ b/t/02-rakudo/repl.t
@@ -7,15 +7,16 @@ plan 47;
 
 my $eof = $*DISTRO.is-win ?? "'^Z'" !! "'^D'";
 my $*REPL-SCRUBBER = -> $_ is copy {
-    $_ = .lines.skip(4).join("\n");
-    s/^^ "You may want to `zef install Readline`, `zef install Linenoise`,"
+    .lines
+      .skip(4)
+      .join("\n")
+      .subst( /^^ "You may want to `zef install Readline`, `zef install Linenoise`,"
         " or `zef install Terminal::LineEditor`"
-        " or use rlwrap for a line editor\n\n"//;
-    s/^^ "To exit type 'exit' or $eof\n"//;
-    s:g/ ^^ "> "  //; # Strip out the prompts
-    s:g/    ">" $ //; # Strip out the final prompt
-    s:g/ ^^ "* "+ //; # Strip out the continuation-prompts
-    $_
+        " or use rlwrap for a line editor\n\n"/)
+      .subst( /^^ "To exit type 'exit' or $eof\n"/ )
+      .subst( /^^ '[' \d+ '] > '  /, :global)  # Strip out the prompts
+      .subst( /^^ "* "+ /,           :global)  # Strip out the continuation-prompts
+      .subst( /    ">" $ /,          :global)  # Strip out the final prompt
 }
 
 {


### PR DESCRIPTION
Inspired by:
  https://www.reddit.com/r/rakulang/comments/sulhq6/how_to_retrieve_the_last_result_in_the_shell_like/

This will make the following sequence work:
````
[0] > 42
42
[1] > 666
666
[2] > $*0 + $*1
708
[3] > $*2
708
> @*_
[42 666 708 708]
````