### PR TITLE
expose $!file and $!line in Label

### DIFF
--- a/src/core.c/Label.pm6
+++ b/src/core.c/Label.pm6
@@ -15,13 +15,23 @@ my class Label {
         nqp::bindattr($obj, Label, '$!postmatch', nqp::p6box_s($postmatch));
         $obj
     }
+
     method name() {
         $!name
+    }
+    method file() {
+        $!file
+    }
+    method line() {
+        $!line
     }
 
     method goto(*@)  { NYI("{self.^name}.goto()").throw; }
     method leave(*@) { NYI("{self.^name}.leave()").throw; }
 
+    method Str(Label:D:) {
+        "$!name $!file:$!line"
+    }
     multi method gist(Label:D:) {
         my ($red,$clear,$green,$yellow,$eject) = Rakudo::Internals.error-rcgye;
         "Label<$!name>(at $!file:$!line, '$green$!prematch$yellow$eject$red$!name$green$!postmatch$clear')"


### PR DESCRIPTION
To aid introspection and allow self referencing warnings/error messages, expose `$!file` and `$!line`. Make `Label.Str` useful.

Tests:

```
use nqp;
a-label: my $line = $?LINE; my $file = nqp::getlexdyn('$?FILES');

is a-label.line, $line, 'exposed $!line in Label';
is a-label.file, $file, 'exposed $!file in Label';
is a-label.Str, "{a-label.name} $file:$line", 'expose $!file and $!line in Label.Str';
```