### PR TITLE
Some optimizations for regex substitution

### DIFF
--- a/src/core.c/Str.pm6
+++ b/src/core.c/Str.pm6
@@ -1811,7 +1811,7 @@ my class Str does Stringy { # declared in BOOTSTRAP
 
             # fast path for something like `s:g[ \w+ ] = "foo"`
             if !fancy && !callable {
-                for flat matches -> $m {
+                for (nqp::istype(matches, Capture) ?? flat matches !! matches.list) -> $m {
                     cds = $m;
                     nqp::push_s(
                       $result,nqp::substr($str,$prev,nqp::unbox_i($m.from) - $prev)
@@ -1822,7 +1822,7 @@ my class Str does Stringy { # declared in BOOTSTRAP
                 nqp::p6box_s(nqp::join(nqp::unbox_s(~$replacement),$result));
             }
             else {
-                for flat matches -> $m {
+                for (nqp::istype(matches, Capture) ?? flat matches !! matches.list) -> $m {
                     cds = $m if SDS;
                     nqp::push_s(
                       $result,nqp::substr($str,$prev,nqp::unbox_i($m.from) - $prev)
@@ -1872,7 +1872,7 @@ my class Str does Stringy { # declared in BOOTSTRAP
 
         # simple string replacement
         else {
-            for flat matches -> $m {
+            for (nqp::istype(matches, Capture) ?? flat matches !! matches.list) -> $m {
                 nqp::push_s(
                   $result,nqp::substr($str,$prev,nqp::unbox_i($m.from) - $prev)
                 );

--- a/src/core.c/Str.pm6
+++ b/src/core.c/Str.pm6
@@ -1809,51 +1809,65 @@ my class Str does Stringy { # declared in BOOTSTRAP
             my \fancy         := space || case || mark || word_by_word;
             my \case-and-mark := case && mark;
 
-            for flat matches -> $m {
-                try cds = $m if SDS;
-                nqp::push_s(
-                  $result,nqp::substr($str,$prev,nqp::unbox_i($m.from) - $prev)
-                );
-
-                if fancy {
-                    my $mstr := $m.Str;
-                    my $it := ~(callable
-                      ?? (noargs ?? $replacement() !! $replacement($m))
-                      !! $replacement
+            # fast path for something like `s:g[ \w+ ] = "foo"`
+            if !fancy && !callable {
+                for flat matches -> $m {
+                    try cds = $m;
+                    nqp::push_s(
+                      $result,nqp::substr($str,$prev,nqp::unbox_i($m.from) - $prev)
                     );
-                    if word_by_word {  # all spacers delegated to word-by-word
-                        my &filter :=
-                        case-and-mark
-                        ?? -> $w,$p { $w.samemark($p).samecase($p) }
-                        !! case
-                            ?? -> $w,$p { $w.samecase($p) }
-                            !! -> $w,$p { $w.samemark($p) }
-                        nqp::push_s($result,nqp::unbox_s(
-                          $it!word-by-word($mstr,&filter,:samespace(?space))
-                        ) );
-                    }
-                    elsif case-and-mark {
-                        nqp::push_s($result,nqp::unbox_s(
-                          $it.samecase($mstr).samemark($mstr)
-                        ) );
-                    }
-                    elsif case {
-                        nqp::push_s($result,nqp::unbox_s($it.samecase(~$m)));
-                    }
-                    else { # mark
-                        nqp::push_s($result,nqp::unbox_s($it.samemark(~$m)));
-                    }
+                    $prev = nqp::unbox_i($m.to);
                 }
-                else {
-                    nqp::push_s($result,nqp::unbox_s( ~(callable
-                      ?? (noargs ?? $replacement() !! $replacement($m))
-                      !! $replacement
-                    ) ) );
-                }
-                $prev = nqp::unbox_i($m.to);
+                nqp::push_s($result,nqp::substr($str,$prev));
+                nqp::p6box_s(nqp::join(nqp::unbox_s(~$replacement),$result));
             }
-            nqp::push_s($result,nqp::substr($str,$prev));
-            nqp::p6box_s(nqp::join('',$result));
+            else {
+                for flat matches -> $m {
+                    try cds = $m if SDS;
+                    nqp::push_s(
+                      $result,nqp::substr($str,$prev,nqp::unbox_i($m.from) - $prev)
+                    );
+
+                    if fancy {
+                        my $mstr := $m.Str;
+                        my $it := ~(callable
+                          ?? (noargs ?? $replacement() !! $replacement($m))
+                          !! $replacement
+                        );
+                        if word_by_word {  # all spacers delegated to word-by-word
+                            my &filter :=
+                            case-and-mark
+                            ?? -> $w,$p { $w.samemark($p).samecase($p) }
+                            !! case
+                                ?? -> $w,$p { $w.samecase($p) }
+                                !! -> $w,$p { $w.samemark($p) }
+                            nqp::push_s($result,nqp::unbox_s(
+                              $it!word-by-word($mstr,&filter,:samespace(?space))
+                            ) );
+                        }
+                        elsif case-and-mark {
+                            nqp::push_s($result,nqp::unbox_s(
+                              $it.samecase($mstr).samemark($mstr)
+                            ) );
+                        }
+                        elsif case {
+                            nqp::push_s($result,nqp::unbox_s($it.samecase(~$m)));
+                        }
+                        else { # mark
+                            nqp::push_s($result,nqp::unbox_s($it.samemark(~$m)));
+                        }
+                    }
+                    else {
+                        nqp::push_s($result,nqp::unbox_s( ~(callable
+                          ?? (noargs ?? $replacement() !! $replacement($m))
+                          !! $replacement
+                        ) ) );
+                    }
+                    $prev = nqp::unbox_i($m.to);
+                }
+                nqp::push_s($result,nqp::substr($str,$prev));
+                nqp::p6box_s(nqp::join('',$result));
+            }
         }
 
         # simple string replacement

--- a/src/core.c/Str.pm6
+++ b/src/core.c/Str.pm6
@@ -1812,7 +1812,7 @@ my class Str does Stringy { # declared in BOOTSTRAP
             # fast path for something like `s:g[ \w+ ] = "foo"`
             if !fancy && !callable {
                 for flat matches -> $m {
-                    try cds = $m;
+                    cds = $m;
                     nqp::push_s(
                       $result,nqp::substr($str,$prev,nqp::unbox_i($m.from) - $prev)
                     );
@@ -1823,7 +1823,7 @@ my class Str does Stringy { # declared in BOOTSTRAP
             }
             else {
                 for flat matches -> $m {
-                    try cds = $m if SDS;
+                    cds = $m if SDS;
                     nqp::push_s(
                       $result,nqp::substr($str,$prev,nqp::unbox_i($m.from) - $prev)
                     );


### PR DESCRIPTION
Together, these optimizations mean that `my $t = ("errors.md.tmpl" xx 5).join(" foo "); my $page; my $s = now; for ^10_000 { $page = $t; $page ~~ s:g[ \w+ ] = "a" }; say now - $s;` goes from ~0.57 to ~0.47s and `my $t = ("errors.md.tmpl" xx 1_000).join(" foo "); my $page; my $s = now; for ^1_000 { $page = $t; $page ~~ s:g[ "foo" ] = "a" }; say now - $s;` goes from ~2.55 to ~2.00s.

Rakudo builds ok and passes `make m-test m-spectest`. However, I'm not 100% sure about the last commit, maybe @jnthn or @moritz could verify it?