### PR TITLE
Allow Dateish *day* parameter to be a Callable / Whatever

### DIFF
--- a/src/core.c/Date.pm6
+++ b/src/core.c/Date.pm6
@@ -54,33 +54,30 @@ my class Date does Dateish {
           !! self!wrong-oor($year, $month, $day)
     }
 
+    method !day-not-Int($year, $month, $day --> Int:D) {
+        my $DIM := self!DAYS-IN-MONTH($year,$month);
+        nqp::istype($day,Whatever)
+          ?? $DIM
+          !! nqp::istype($day,Callable)
+            ?? $day($DIM) 
+            !! $day.Int
+    }
+
     proto method new(|) {*}
     multi method new(Date:
-      Int:D() $year, Int:D() $month, &day, :&formatter
+      Int:D() $year, Int:D() $month, $day is copy, :&formatter
     --> Date:D) {
-        my $day := day(self!DAYS-IN-MONTH($year, $month));
+        $day = self!day-not-Int($year, $month, $day)
+          unless nqp::istype($day,Int);
         nqp::eqaddr(self.WHAT,Date)
           ?? nqp::create(self)!SET-SELF($year, $month, $day, &formatter)
           !! self!bless($year, $month, $day, &formatter, %_)
     }
     multi method new(Date:
-      Int:D() $year, Int:D() $month, Int:D() $day, :&formatter
+      Int:D() :$year!, Int:D() :$month = 1, :$day is copy = 1, :&formatter
     --> Date:D) {
-        nqp::eqaddr(self.WHAT,Date)
-          ?? nqp::create(self)!SET-SELF($year, $month, $day, &formatter)
-          !! self!bless($year, $month, $day, &formatter, %_)
-    }
-    multi method new(Date:
-      Int:D() :$year!, Int:D() :$month = 1, :&day!, :&formatter
-    --> Date:D) {
-        my $day := day(self!DAYS-IN-MONTH($year, $month));
-        nqp::eqaddr(self.WHAT,Date)
-          ?? nqp::create(self)!SET-SELF($year, $month, $day, &formatter)
-          !! self!bless($year, $month, $day, &formatter, %_)
-    }
-    multi method new(Date:
-      Int:D() :$year!, Int:D() :$month = 1, Int:D() :$day = 1, :&formatter
-    --> Date:D) {
+        $day = self!day-not-Int($year, $month, $day)
+          unless nqp::istype($day,Int);
         nqp::eqaddr(self.WHAT,Date)
           ?? nqp::create(self)!SET-SELF($year, $month, $day, &formatter)
           !! self!bless($year, $month, $day, &formatter, %_)

--- a/src/core.c/Date.pm6
+++ b/src/core.c/Date.pm6
@@ -56,8 +56,24 @@ my class Date does Dateish {
 
     proto method new(|) {*}
     multi method new(Date:
+      Int:D() $year, Int:D() $month, &day, :&formatter
+    --> Date:D) {
+        my $day := day(self!DAYS-IN-MONTH($year, $month));
+        nqp::eqaddr(self.WHAT,Date)
+          ?? nqp::create(self)!SET-SELF($year, $month, $day, &formatter)
+          !! self!bless($year, $month, $day, &formatter, %_)
+    }
+    multi method new(Date:
       Int:D() $year, Int:D() $month, Int:D() $day, :&formatter
     --> Date:D) {
+        nqp::eqaddr(self.WHAT,Date)
+          ?? nqp::create(self)!SET-SELF($year, $month, $day, &formatter)
+          !! self!bless($year, $month, $day, &formatter, %_)
+    }
+    multi method new(Date:
+      Int:D() :$year!, Int:D() :$month = 1, :&day!, :&formatter
+    --> Date:D) {
+        my $day := day(self!DAYS-IN-MONTH($year, $month));
         nqp::eqaddr(self.WHAT,Date)
           ?? nqp::create(self)!SET-SELF($year, $month, $day, &formatter)
           !! self!bless($year, $month, $day, &formatter, %_)

--- a/src/core.c/DateTime.pm6
+++ b/src/core.c/DateTime.pm6
@@ -164,7 +164,7 @@ my class DateTime does Dateish {
     method !new-from-positional(DateTime:
       Int() $year,
       Int() $month,
-            $day is copy,  # can also be a Callable
+            $day is copy,  # can also be a Callable / Whatever
       Int() $hour,
       Int() $minute,
             $second,       # can have fractional seconds
@@ -173,7 +173,11 @@ my class DateTime does Dateish {
             %extra,
     --> DateTime:D) {
         my $DIM := self!DAYS-IN-MONTH($year,$month);
-        $day = nqp::istype($day,Callable) ?? $day($DIM) !! $day.Int;
+        $day = nqp::istype($day,Whatever)
+          ?? $DIM
+          !! nqp::istype($day,Callable)
+            ?? $day($DIM)
+            !! $day.Int;
 
         self!oor("Month",$month,"1..12")
           if nqp::islt_I(nqp::decont($month),1)

--- a/src/core.c/DateTime.pm6
+++ b/src/core.c/DateTime.pm6
@@ -164,19 +164,21 @@ my class DateTime does Dateish {
     method !new-from-positional(DateTime:
       Int() $year,
       Int() $month,
-      Int() $day,
+            $day is copy,  # can also be a Callable
       Int() $hour,
       Int() $minute,
-            $second,  # can have fractional seconds
+            $second,       # can have fractional seconds
       Int() $timezone,
             &formatter,
             %extra,
     --> DateTime:D) {
+        my $DIM := self!DAYS-IN-MONTH($year,$month);
+        $day = nqp::istype($day,Callable) ?? $day($DIM) !! $day.Int;
+
         self!oor("Month",$month,"1..12")
           if nqp::islt_I(nqp::decont($month),1)
           || nqp::isgt_I(nqp::decont($month),12);
 
-        my $DIM := self!DAYS-IN-MONTH($year,$month);
         self!oor("Day",$day,"1..$DIM")
           if nqp::islt_I(nqp::decont($day),1)
           || nqp::isgt_I(nqp::decont($day),$DIM);


### PR DESCRIPTION
When creating a Date or DateTime object, you sometimes want to
specify the day from the end of the month in the given year.
You can do that now by for x, similar to end-of-array indexing:

    my $date = Date.today;
    say $date.clone(day => $date.days-in-month - x);

This is nice, but it means needing to create a Date/DateTime object
before getting your intended Date/DateTime object.

With this PR, you can also specify a `Whatever` for the day parameter
to get the last day of the month:
````raku
    say Date.new(2022, 3, *);  # 2022-03-31
````
or a `Callable` to get days from the end of the month:
````raku
    say Date.new(2022, 3, *-2);  # 2022-03-29
````
where the * represents the number of days in the month in that year.