### PR TITLE
Restore optimization for given/when with Numeric cases

### DIFF
--- a/src/Perl6/Optimizer.nqp
+++ b/src/Perl6/Optimizer.nqp
@@ -1728,7 +1728,29 @@ my class SmartmatchOptimizer {
         if $method eq 'Numeric' {
             my $fail-or-nil := QAST::Op.new( :op('hllbool'), QAST::IVal.new( :value(1) ) );
             $fail-or-nil.named('fail-or-nil');
-            $method_call.push($fail-or-nil);
+            $method_call[0].push($fail-or-nil);
+
+            # Rewrite the `$LHS.Numeric` into `my $tmp := $LHS.Numeric(:fail-or-nil); $LHS := nqp::istype($tmp, Nil) ?? NaN !! $tmp;`
+            # Since we already explicitly handle the RHS being NaN above, this is safe because NaN isn't == to anything, so
+            # when we do `$LHS == $RHS` it will always be False
+            my $tmp := QAST::Node.unique('nilee');
+            $method_call[0] :=
+                QAST::Stmts.new(
+                    QAST::Op.new(
+                        :op('bind'),
+                        QAST::Var.new( :name($tmp), :scope('local'), :decl('var') ),
+                        $method_call[0]
+                    ),
+                    QAST::Op.new(
+                        :op('if'),
+                        QAST::Op.new(
+                            :op('istype'),
+                            QAST::Var.new( :name($tmp), :scope('local') ),
+                            QAST::WVal.new( :value($!symbols.Nil) ),
+                        ),
+                        QAST::NVal.new( :value(nqp::nan) ),
+                        QAST::Var.new( :name($tmp), :scope('local') )
+                    ))
         }
 
         # Make sure we're not comparing against a type object, since those could

--- a/src/Perl6/Optimizer.nqp
+++ b/src/Perl6/Optimizer.nqp
@@ -1720,7 +1720,7 @@ my class SmartmatchOptimizer {
                     :op<callmethod>,
                     :name($method),
                     QAST::Var.new( :name($topic_name), :scope($topic_scope), :wanted(1) ) ),
-                    QAST::WVal.new( :value($!symbols.Failure) ));
+                QAST::WVal.new( :value($!symbols.Failure) ));
 
         # We don't need/want `val()` to `fail()` if `Numeric()` ends up calling it
         # and it doesn't succeed, that creates an expensive Backtrace that we just


### PR DESCRIPTION
In the case of something like `given "a string" { when 5 { say "five" };
default { say "not five" } }`, the currently-not-working optimization
attempts to turn off `.Numeric` returning an (expensive to create) Failure
via `val` when we just need to know that it didn't succeed (i.e.,
`"a string".Numeric != 5`). However, just moving the `:fail-or-nil` argument
to the correct method call causes `Use of Nil in numeric context`. So
instead change the option to return `NaN` instead of `Nil` and rename
accordingly.

However, this does mean we can't use the same optimization
when smartmatching against a Range (since `NaN` could be a valid thing
we're checking). But I suspect that this is less common of an occurance
so the tradeoff is worth it.

This test code:
```raku
my $a;
$a = do given "hi" {
    when 0 { "zero" };
    when 1 { "one" };
    when 2 { "two" };
    when 3 { "three" };
    when 4 { "four" };
    when 5 { "five" };
    when "hi" { "hello" };
    when * > 40 { "> 40" };
    default { "default" } } for ^10_000;
say now - INIT now;
say $a
```
drops from ~2s to ~0.25s.

Rakudo builds ok and passes `make m-test m-spectest`.