### PR TITLE
CURI: pre-compile longest names first

### DIFF
--- a/src/core.c/CompUnit/Repository/Installation.pm6
+++ b/src/core.c/CompUnit/Repository/Installation.pm6
@@ -283,12 +283,13 @@ sub MAIN(:$name, :$auth, :$ver, *@, *%) {
             my %done;
 
             my $compiler-id = CompUnit::PrecompilationId.new-without-check($*RAKU.compiler.id);
-            for %provides.sort {
+            my @provides = %provides.sort(*.key).reverse;
+            for @provides {
                 my $id = CompUnit::PrecompilationId.new-without-check($_.value.values[0]<file>);
                 $precomp.store.delete($compiler-id, $id);
             }
 
-            for %provides.sort {
+            for @provides {
                 my $id = $_.value.values[0]<file>;
                 my $source = $sources-dir.add($id);
                 my $source-file = $repo-prefix ?? $repo-prefix ~ $source.relative($.prefix) !! $source;


### PR DESCRIPTION
The idea being that the longest names have fewer dependenencies
(in general).  Also make sure that we only sort the entries once.

It would probably be better if we could specify an order in which
modules should be pre-compiled.  But alas, the current META6.json
format is a hash, so without order.  And we need some sort of order
to get reproducible builds.