### PR TITLE
Add .rakumod files to compiler id

### DIFF
--- a/src/Raku/ast/README.md
+++ b/src/Raku/ast/README.md
@@ -42,7 +42,7 @@ quite a few other things to do that will be helpful. Specifically:
   new symbols (which, well, there are). (done, for now at least)
 * Get the compiler ID to factor in the AST nodes, so that a re-compile with
   only AST changes will invalidate previous pre-comps, so we don't have to
-  remove `lib/.precomp/` after such a build. (Difficulty: probably easy.)
+  remove `lib/.precomp/` after such a build. (done)
 * Fix build system issues (doesn't rebuild if the AST compiler changes, etc.)
   (Difficulty: well, it involves a build system...)
 * Get the AST compiler to support roles, and gradually transition the things

--- a/tools/lib/NQP/Config/Rakudo.pm
+++ b/tools/lib/NQP/Config/Rakudo.pm
@@ -797,7 +797,7 @@ sub _specs_iterate {
                     push @all_sources,
                       File::Spec->abs2rel(
                         File::Spec->catfile( $File::Find::dir, $_ ), $base_dir )
-                      if /\.(nqp|pm6)\z/;
+                      if /\.(nqp|pm6|rakumod)\z/;
                 },
                 File::Spec->catdir( $base_dir, "src" )
             );


### PR DESCRIPTION
This means a change to them will invalidate precomp files. This wasn't a
problem before rakuast because rakudo/src/* didn't have any .rakumod
files, but now it does.