### PR TITLE
Revert "An object will never work if native is expected"

### DIFF
--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -3323,7 +3323,6 @@ BEGIN {
                         if $got_prim == $BIND_VAL_OBJ {
                             # Object; won't do.
                             $type_mismatch := 1;
-                            $type_match_possible := 0;
                             last;
                         }
 


### PR DESCRIPTION
This reverts commit 73d5e74d96197312da62509058a0970668913bc8.

That commit turned out to be incorrect. For more background see

  https://github.com/rakudo/rakudo/issues/4823

My reasoning back then was that a compile time error would be a good
thing to have. But firstly, I didn't consider that the error message
could be inappropriate, talking about Mu in examples like this:

  $ raku -e 'multi f(int $i) { $i + $i }; my $a = 2; say f $a'
  ===SORRY!=== Error while compiling -e
  Calling foo(Mu) will never work with any of these multi signatures:
      (int $i)
  [...]

But even worse: There are cases where the types *could* match at
runtime, like here (should print "4"):

  $ raku -e 'multi f(int $i) { $i + $i }; my $a = 3; my int $b = 2; $a := $b; say f $a'