### PR TITLE
Only assign to caller's $/ during a regex subsititution if it's writable

### DIFF
--- a/src/core.c/Str.pm6
+++ b/src/core.c/Str.pm6
@@ -1812,7 +1812,7 @@ my class Str does Stringy { # declared in BOOTSTRAP
             # fast path for something like `s:g[ \w+ ] = "foo"`
             if !fancy && !callable {
                 for (nqp::istype(matches, Capture) ?? flat matches !! matches.list) -> $m {
-                    cds = $m;
+                    cds = $m if nqp::isrwcont(cds);
                     nqp::push_s(
                       $result,nqp::substr($str,$prev,nqp::unbox_i($m.from) - $prev)
                     );
@@ -1823,7 +1823,7 @@ my class Str does Stringy { # declared in BOOTSTRAP
             }
             else {
                 for (nqp::istype(matches, Capture) ?? flat matches !! matches.list) -> $m {
-                    cds = $m if SDS;
+                    cds = $m if nqp::isrwcont(cds) && SDS;
                     nqp::push_s(
                       $result,nqp::substr($str,$prev,nqp::unbox_i($m.from) - $prev)
                     );


### PR DESCRIPTION
https://github.com/rakudo/rakudo/pull/4807 removed a `try` before the
assignment that was added in 14c1a6f58a73ed0ab92f3fb379e332f682afa916
because I couldn't find an example that needed it. However, that broke
YAMLish (it was doing a subsititution in an actions method). However, a
`try` is overkill here, and we can just make the cheaper check for
writability.