### PR TITLE
Move CompUnit::Repository::Staging into core

### DIFF
--- a/src/core.c/CompUnit/Repository/Staging.pm6
+++ b/src/core.c/CompUnit/Repository/Staging.pm6
@@ -1,0 +1,73 @@
+class CompUnit::Repository::Staging is CompUnit::Repository::Installation {
+    has Str $.name;
+    has CompUnit::Repository $!parent;
+
+    submethod TWEAK (--> Nil) {
+       $!parent = self.next-repo;
+       self.register-name;
+    }
+
+    method register-name(CompUnit::Repository::Staging:D:) {
+        CompUnit::RepositoryRegistry.register-name($!name, self);
+    }
+
+    method unregister-name(CompUnit::Repository::Staging:D: --> Nil) {
+        CompUnit::RepositoryRegistry.register-name($!name, $!parent);
+    }
+
+
+    method short-id(--> Str:D) { 'staging' }
+
+    method path-spec(CompUnit::Repository::Staging:D: --> Str:D) {
+        self.^name ~ '#name(' ~ $!name ~ ')#' ~ self.prefix.absolute
+    }
+
+    method source-file(CompUnit::Repository::Staging:D:
+      Str:D $name
+    --> IO::Path) {
+        my $file := self.prefix.add($name);
+        $file.e ?? $file !! $!parent.source-file($name)
+    }
+
+    method resource(CompUnit::Repository::Staging:D:
+      $dist-id, $key
+    ) {
+        # check if the dist is installed here
+        try self.distribution($dist-id)
+          # we have the dist, so it's safe to access the resource the normal way
+          ?? callsame()
+          # lookup failed, so it's probably not installed here but in the parent
+          !! $!parent.resource($dist-id, $key)
+    }
+
+    method remove-artifacts(CompUnit::Repository::Staging:D: --> Nil) {
+        my $io := self.prefix;
+        $io.child($_).unlink for <
+          version repo.lock precomp/.lock
+        >;
+    }
+
+    method deploy(CompUnit::Repository::Staging:D: --> Nil) {
+        my $from    := self.prefix.absolute;
+        my $relpath := $from.chars;
+        my $to      := $!parent.prefix;
+
+        for Rakudo::Internals.DIR-RECURSE($from) -> $path {
+            my $destination := $to.add($path.substr($relpath));
+            $destination.parent.mkdir;
+            $path.IO.copy: $destination;
+        }
+    }
+
+    sub self-destruct(IO::Path:D $io --> Nil) {
+        .d ?? self-destruct($_) !! .unlink for $io.dir;
+        $io.rmdir;
+    }
+    method self-destruct(CompUnit::Repository::Staging:D: --> Nil) {
+        my $prefix = self.prefix;
+        return unless $prefix.d;
+        self-destruct $prefix;
+    }
+}
+
+# vim: expandtab shiftwidth=4

--- a/src/core.c/CompUnit/RepositoryRegistry.pm6
+++ b/src/core.c/CompUnit/RepositoryRegistry.pm6
@@ -2,6 +2,7 @@ class CompUnit::Repository::FileSystem   { ... }
 class CompUnit::Repository::Installation { ... }
 class CompUnit::Repository::AbsolutePath { ... }
 class CompUnit::Repository::Unknown      { ... }
+class CompUnit::Repository::Staging      { ... }
 class CompUnit::Repository::NQP { ... }
 class CompUnit::Repository::Perl5 { ... }
 
@@ -384,6 +385,7 @@ class CompUnit::RepositoryRegistry {
       'ap',     CompUnit::Repository::AbsolutePath,
       'nqp',    CompUnit::Repository::NQP,
       'perl5',  CompUnit::Repository::Perl5,
+      'staging', CompUnit::Repository::Staging,
 #?if js
       'nodejs', CompUnit::Repository::NodeJs,
 #?endif

--- a/tools/build/install-core-dist.raku
+++ b/tools/build/install-core-dist.raku
@@ -1,5 +1,3 @@
-my constant Staging = "lib/CompUnit/Repository/Staging.rakumod".IO.slurp.EVAL;
-
 my %provides = 
     "Test"                          => "lib/Test.rakumod",
     "NativeCall"                    => "lib/NativeCall.rakumod",
@@ -9,7 +7,6 @@ my %provides =
     "Pod::To::Text"                 => "lib/Pod/To/Text.rakumod",
     "newline"                       => "lib/newline.rakumod",
     "experimental"                  => "lib/experimental.rakumod",
-    "CompUnit::Repository::Staging" => "lib/CompUnit/Repository/Staging.rakumod",
     "Telemetry"                     => "lib/Telemetry.rakumod",
     "snapper"                       => "lib/snapper.rakumod",
     "safe-snapper"                  => "lib/safe-snapper.rakumod",
@@ -28,18 +25,18 @@ if Compiler.backend eq 'moar' {
     %provides<SIL>              = "lib/SIL.rakumod";
 }
 
-my $prefix := @*ARGS[0];
-my $REPO := PROCESS::<$REPO> := Staging.new(
-    :$prefix
-    :next-repo(
-        # Make CompUnit::Repository::Staging available to precomp processes
-        CompUnit::Repository::Installation.new(
-            :$prefix
-            :next-repo(CompUnit::RepositoryRegistry.repository-for-name('core')),
-        )
-    ),
+my $core-repo = CompUnit::RepositoryRegistry.repository-for-name('core');
+my $core-repo-prefix = $core-repo.prefix;
+my $staging-prefix = $*TMPDIR.add('staging');
+
+my $REPO := PROCESS::<$REPO> := CompUnit::Repository::Staging.new(
+    :prefix($staging-prefix),
+    :next-repo($core-repo), # Make CompUnit::Repository::Staging available to precomp processes
     :name('core'),
 );
+
+$REPO.self-destruct();
+
 $REPO.install(
     Distribution::Hash.new(
         {
@@ -53,23 +50,9 @@ $REPO.install(
     :force,
 );
 
-# Precompile CompUnit::Repository::Staging again to give it a source path relative to perl#
-my $core-dist := $REPO.resolve(
-    CompUnit::DependencySpecification.new(
-      :short-name<CompUnit::Repository::Staging>)
-).distribution;
-
-my $source-id :=
-  $core-dist.meta<provides><CompUnit::Repository::Staging>.values.head<file>;
-my $source      := $REPO.prefix.child('sources').child($source-id);
-my $source-file := $source.relative($REPO.prefix);
-
-$REPO.precomp-repository.precompile(
-        $source,
-        CompUnit::PrecompilationId.new($source-id),
-        :source-name("core#$source-file (CompUnit::Repository::Staging)"),
-        :force,
-);
+$REPO.remove-artifacts();
+$REPO.deploy();
+$REPO.self-destruct();
 
 note "    Installed {%provides.elems} core modules in {now - INIT now} seconds!";
 

--- a/tools/install-dist.p6
+++ b/tools/install-dist.p6
@@ -32,7 +32,6 @@ It is recommended to set the environment variable 'RAKUDO_RERESOLVE_DEPENDENCIES
 
 
 use v6.c;
-use CompUnit::Repository::Staging;
 
 # Distribution::Path ignores META.info files, but we can manually set it
 sub find-meta-file($dir) {

--- a/tools/install-dist.raku
+++ b/tools/install-dist.raku
@@ -1,7 +1,5 @@
 #!/usr/bin/env raku
 
-use CompUnit::Repository::Staging;
-
 # packagers preference candidate
 multi sub MAIN(
   IO() :from(:$dist-prefix) = '.',

--- a/tools/templates/6.c/core_sources
+++ b/tools/templates/6.c/core_sources
@@ -234,6 +234,7 @@ src/core.c/CompUnit/Repository/AbsolutePath.pm6
 src/core.c/CompUnit/Repository/NQP.pm6
 src/core.c/CompUnit/Repository/Perl5.pm6
 src/core.c/CompUnit/Repository/Unknown.pm6
+src/core.c/CompUnit/Repository/Staging.pm6
 src/core.c/WalkList.pm6
 @if(backend==jvm
 src/vm/jvm/CompUnit/Repository/Java.pm6

--- a/tools/templates/Makefile-backend-common.in
+++ b/tools/templates/Makefile-backend-common.in
@@ -233,7 +233,8 @@ check_@backend_abbr@_nqp_version: @@script(check-nqp-version.pl)@@
 	$(NOECHO)@nfpq($(BASE_DIR)/@bpm(RUNNER)@)@ @bpm(RUNNER_OPTS)@ @shquot(@script(upgrade-repository.raku)@)@ @nfpq($(DESTDIR)$(RAKUDO_HOME)/core)@
 	$(NOECHO)@nfpq($(BASE_DIR)/@bpm(RUNNER)@)@ @bpm(RUNNER_OPTS)@ @shquot(@script(upgrade-repository.raku)@)@ @nfpq($(DESTDIR)$(RAKUDO_HOME)/vendor)@
 	$(NOECHO)@nfpq($(BASE_DIR)/@bpm(RUNNER)@)@ @bpm(RUNNER_OPTS)@ @shquot(@script(upgrade-repository.raku)@)@ @nfpq($(DESTDIR)$(RAKUDO_HOME)/site)@
-	$(NOECHO)@nfpq($(BASE_DIR)/@bpm(RUNNER)@)@ @bpm(RUNNER_OPTS)@ @shquot(@script(install-core-dist.raku)@)@ @nfpq($(DESTDIR)$(RAKUDO_HOME)/core)@
+	$(NOECHO)@nfpq($(BASE_DIR)/@bpm(RUNNER)@)@ @bpm(RUNNER_OPTS)@ @shquot(@script(upgrade-repository.raku)@)@ @nfpq($(DESTDIR)$(RAKUDO_HOME)/core)@
+	$(NOECHO)@nfpq($(BASE_DIR)/@bpm(RUNNER)@)@ @bpm(RUNNER_OPTS)@ @shquot(@script(install-core-dist.raku)@)@
 
 @backend_prefix@-install:: @backend_prefix@-all @backend_prefix@-install-pre @backend_prefix@-install-main @backend_prefix@-install-post
 	@echo(+++ @uc(@backend@)@ BACKEND INSTALLED)@

--- a/tools/templates/Makefile-backend-common.in
+++ b/tools/templates/Makefile-backend-common.in
@@ -233,8 +233,7 @@ check_@backend_abbr@_nqp_version: @@script(check-nqp-version.pl)@@
 	$(NOECHO)@nfpq($(BASE_DIR)/@bpm(RUNNER)@)@ @bpm(RUNNER_OPTS)@ @shquot(@script(upgrade-repository.raku)@)@ @nfpq($(DESTDIR)$(RAKUDO_HOME)/core)@
 	$(NOECHO)@nfpq($(BASE_DIR)/@bpm(RUNNER)@)@ @bpm(RUNNER_OPTS)@ @shquot(@script(upgrade-repository.raku)@)@ @nfpq($(DESTDIR)$(RAKUDO_HOME)/vendor)@
 	$(NOECHO)@nfpq($(BASE_DIR)/@bpm(RUNNER)@)@ @bpm(RUNNER_OPTS)@ @shquot(@script(upgrade-repository.raku)@)@ @nfpq($(DESTDIR)$(RAKUDO_HOME)/site)@
-	$(NOECHO)@nfpq($(BASE_DIR)/@bpm(RUNNER)@)@ @bpm(RUNNER_OPTS)@ @shquot(@script(upgrade-repository.raku)@)@ @nfpq($(DESTDIR)$(RAKUDO_HOME)/core)@
-	$(NOECHO)@nfpq($(BASE_DIR)/@bpm(RUNNER)@)@ @bpm(RUNNER_OPTS)@ @shquot(@script(install-core-dist.raku)@)@
+	$(NOECHO)@nfpq($(BASE_DIR)/@bpm(RUNNER)@)@ @bpm(RUNNER_OPTS)@ @shquot(@script(install-core-dist.raku)@)@ @nfpq($(DESTDIR)$(RAKUDO_HOME)/core)@
 
 @backend_prefix@-install:: @backend_prefix@-all @backend_prefix@-install-pre @backend_prefix@-install-main @backend_prefix@-install-post
 	@echo(+++ @uc(@backend@)@ BACKEND INSTALLED)@


### PR DESCRIPTION
Move `CompUnit::Repository::Staging` from core modules into rakudo core


Currently the process of installing a module requires precompiling the module two times, first precompilation is for running tests and the second happens when the module gets installed into its destination repository.

`CompUnit::Repository::Staging` helps avoiding the double precompilation process by first installing the module into a Staging repo then use the repo to run tests, and if tests pass we can copy the precompiled files to the destination repository.

The problem (as I understand it):
Some test files include additional `lib` repos (e.g. `use lib 'lib'`), this alters the `repo-chain` and `Staging` is not the head of the chain anymore, so the test file will try to load the module, this triggers a precompilation process for the included `'lib'` (not sure why it does not try to load it from `.next-repo` before start precompiling).

The triggered precompilation [process](https://github.com/rakudo/rakudo/blob/master/src/core.c/CompUnit/PrecompilationRepository.pm6#L433), does not know about `CompUnit::Repository::Staging` because it is not in core. (exist as core module but not `use`ed for the new process)

Fix #4799