### PR TITLE
Add implementation-detail Compiler.cver method

### DIFF
--- a/src/core.c/CompUnit/Repository/Installation.pm6
+++ b/src/core.c/CompUnit/Repository/Installation.pm6
@@ -1,6 +1,8 @@
-class CompUnit::Repository::Installation does CompUnit::Repository::Locally does CompUnit::Repository::Installable {
+class CompUnit::Repository::Installation
+  does CompUnit::Repository::Locally
+  does CompUnit::Repository::Installable
+{
     has $!lock = Lock.new;
-    has $!cver = nqp::hllize(nqp::atkey(nqp::gethllsym('default', 'SysConfig').rakudo-build-config(), 'version'));
     has %!loaded; # cache compunit lookup for self.need(...)
     has %!seen;   # cache distribution lookup for self!matching-dist(...)
     has $!precomp;
@@ -218,7 +220,7 @@ sub MAIN(:$name, :$auth, :$ver, *@, *%) {
             %provides{ $name } = ~$file => {
                 :file($id),
                 :time(try $file.IO.modified.Num),
-                :$!cver
+                :cver(Compiler.cver)
             };
             note("Installing {$name} for {$dist.meta<name>}") if $verbose and $name ne $dist.meta<name>;
             $destination.spurt($content);

--- a/src/core.c/Compiler.pm6
+++ b/src/core.c/Compiler.pm6
@@ -7,6 +7,7 @@ class Compiler does Systemic {
 
     my Mu $compiler := nqp::gethllsym('default', 'SysConfig')
         .rakudo-build-config();
+    method cver() is implementation-detail { nqp::atkey($compiler,'version') }
 
     # XXX Various issues with this stuff on JVM
     has $.id is built(:bind) = nqp::ifnull(nqp::atkey($compiler,'id'),$id);
@@ -19,8 +20,7 @@ class Compiler does Systemic {
         nqp::bind($!auth,'The Perl Foundation');
 
         # looks like: 2018.01-50-g8afd791c1
-        nqp::bind($!version,Version.new(nqp::p6box_s(nqp::atkey($compiler,'version'))))
-          unless $!version;
+        nqp::bind($!version,self.cver.Version) unless $!version;
     }
 
     method backend() {


### PR DESCRIPTION
The raw string version of the Compiler.new.version is needed in
several places.  This commit introduces a new Compiler.cver method
that returns that raw string, and removes the private $!cver attribute
from CURI, as it was basically just the raw compiler version.

No functional changes, just less copy-and-paste and a little less
memory use for CURI instances (not that we have many of them).