### PR TITLE
Improve error when `make` encounters non-Match $/

### DIFF
--- a/src/core.c/Exception.pm6
+++ b/src/core.c/Exception.pm6
@@ -2902,6 +2902,14 @@ my class X::Item is Exception {
     method message { "Cannot index {$.aggregate.^name} with $.index" }
 }
 
+my class X::Make::MatchRequired is Exception {
+    has $!got is built(:bind) is default(Nil);
+    method got() { $!got }
+    method message() {
+        "The make function expects \$/ to contain a Match, but it contains $!got.^name()"
+    }
+}
+
 my class X::Multi::Ambiguous is Exception {
     has $.dispatcher;
     has @.ambiguous;

--- a/src/core.c/Match.pm6
+++ b/src/core.c/Match.pm6
@@ -330,7 +330,10 @@ multi sub infix:<eqv>(Match:D $a, Match:D $b) {
 
 
 sub make(Mu \made) {
-    nqp::bindattr(nqp::decont(nqp::getlexcaller('$/')),Match,'$!made',made)
+    my $slash := nqp::decont(nqp::getlexcaller('$/'));
+    nqp::istype($slash, Match)
+        ?? nqp::bindattr($slash,Match,'$!made',made)
+        !! X::Make::MatchRequired.new(:got($slash)).throw
 }
 
 


### PR DESCRIPTION
Since `make` tries to do a low-level bind directly into $/, if it
instead sees a different object, the error isn't too informative.

This most typically comes up when folks do re-parsing in action
methods, give the parameter normally called `$/` another name, and
then end up doing other matches, which result in Nil (failed match)
or List (global match) in `$/`. Hopefully this message will provide a
better indication of what is going on.

Motivated by https://stackoverflow.com/questions/71656640.