### PR TITLE
Re-imagine CompUnit::Repository::Spec.from-string

### DIFF
--- a/src/core.c/CompUnit/Repository/Spec.pm6
+++ b/src/core.c/CompUnit/Repository/Spec.pm6
@@ -1,36 +1,52 @@
 class CompUnit::Repository::Spec {
-    has $.short-id;
+    has Str:D $.short-id is required;
+    has Str:D $.Str      is required;
+    has Str:D $.path = "";
     has %.options;
-    has $.path;
-    has $.Str;
-    method from-string(Str:D $spec, :$default-short-id = 'file') {
-        return unless $spec.chars;
-        # something we understand
-        if $spec.contains('#') {
-            if $spec ~~ /^
-              <before .>
-              [
-                $<type>=[ <.ident>+ % '::' ]
-                $<options>=[ '#' $<option-name>=\w+
-                  <[ < ( [ { ]> $<option-value>=<[\w-]>+? <[ > ) \] } ]>
-                ]*
-                '#'
-              ]?
-              $<path>=.*
-            $/ {
-                my $short-id := ~($<type> // $default-short-id);
-                my $path := $*SPEC.canonpath(~$<path>);
-                self.new(
-                    :$short-id,
-                    :options(%($<option-name>>>.Str Z=> $<option-value>>>.Str)),
-                    :$path,
-                    :Str($short-id ~ $<options> ~ '#' ~ $path)
-                );
+
+    method from-string(str $spec, str :$default-short-id = 'file') {
+
+# Examples:
+#  perl5#
+#  inst#/Foo/Bar/rakudo/gen/build_rakudo_home/core
+#  CompUnit::Repository::Staging#name(core)#/Foo/Bar/rakudo/install/share/perl6/core
+
+        if nqp::chars($spec) {                 # at least some kind of spec
+            my $parts := nqp::split("#",$spec);
+            if nqp::elems($parts) == 1 {       # no # found
+                my str $path = PROCESS::<$SPEC>.canonpath($spec);
+                self.new: :short-id($default-short-id), :$path,
+                  Str => $default-short-id ~ '#' ~ $path
             }
-        }
-        else {
-            my $path := $*SPEC.canonpath($spec);
-            self.new(:short-id($default-short-id), :$path, :Str($default-short-id ~ '#' ~ $path))
+            else {                             # found at least one #
+                nqp::pop($parts)
+                  unless nqp::chars(nqp::atpos($parts,nqp::elems($parts) - 1));
+                my str $short-id = nqp::shift($parts);
+
+                if nqp::elems($parts) {        # has a path
+                    my str $path = nqp::pop($parts) // "";
+                    if nqp::elems($parts) -> int $nr-options {  # has options
+                        my %options;
+                        my int $i = -1;
+                        while ++$i < $nr-options {
+                            %options{$0} := $1.Str
+                              if nqp::atpos($parts,$i).match: / ^
+                                (<[\w-]>+)
+                                <[ <([{ ]>
+                                (<[\w-]>+)
+                                <[ >)\]} ]>
+                              $ /;
+                        }
+                        self.new: :$short-id, :$path, :Str($spec), :%options
+                    }
+                    else {                     # short-id and just a path
+                        self.new: :$short-id, :$path, :Str($spec)
+                    }
+                }
+                else {                         # short-id without path
+                    self.new: :$short-id, :Str($short-id ~ "#")
+                }
+            }
         }
     }
 }

--- a/src/core.c/CompUnit/Repository/Spec.pm6
+++ b/src/core.c/CompUnit/Repository/Spec.pm6
@@ -33,7 +33,7 @@ class CompUnit::Repository::Spec {
                               if nqp::atpos($parts,$i).match: / ^
                                 (<[\w-]>+)
                                 <[ <([{ ]>
-                                (<[\w-]>+)
+                                (<-[ >)\]} ]>+)
                                 <[ >)\]} ]>
                               $ /;
                         }


### PR DESCRIPTION
This was using regular expressions and meta ops, for code that is
really pretty simple (apart from the option partsing).  Since this
is being called multiple times for *every* pre-compilation, it seems
to make sense to streamline this code and with fewer regexes and
no meta-ops.

Underlying reason was that another upcoming fix broke because
meta-ops were being used *before* the Rakudo::Metaops mapper had
been initialized.