### PR TITLE
Treat <<!=>> special

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -8118,9 +8118,9 @@ class Perl6::Actions is HLL::Actions does STDActions {
     sub make_hyperop($/) {
         my $base     := $<infixish>;
         my $basesym  := ~ $base<OPER>;
-        my $basepast := $base.ast
-                          ?? $base.ast[0]
-                          !! QAST::Var.new(:name("&infix" ~ $*W.canonicalize_pair('', $basesym)),
+        my $basepast := $base.ast && $basesym ne '!='
+          ?? $base.ast[0]
+          !! QAST::Var.new(:name("&infix" ~ $*W.canonicalize_pair('', $basesym)),
                                            :scope<lexical>);
         my $hpast    := QAST::Op.new(:op<call>, :name<&METAOP_HYPER>, WANTED($basepast,'hyperop'));
         if $<opening> eq '<<' || $<opening> eq '«' {


### PR DESCRIPTION
In response to https://github.com/rakudo/rakudo/issues/4838

The applied fix feels hacky, but != *is* the only op that is
actually implemented as an op, and not as meta-handling applied
to an op.  Suggestions for better fix welcome!