### PR TITLE
Add INSIDE_EMACS environment variable

### DIFF
--- a/docs/line-editor.pod
+++ b/docs/line-editor.pod
@@ -40,6 +40,12 @@ This specifies the preferred line editor to use; valid values are C<Readline>,
 C<Linenoise>, C<LineEditor>, and C<none>.  A value of C<none> is useful if you
 want to avoid the recommendation message upon REPL startup.
 
+=item INSIDE_EMACS
+
+This disables line editor while execcuting REPL inside Emacs, see for further
+reference:
+https://www.gnu.org/software/emacs/manual/html_node/emacs/Interactive-Shell.html
+
 =back
 
 =cut

--- a/src/core.c/REPL.pm6
+++ b/src/core.c/REPL.pm6
@@ -249,6 +249,8 @@ do {
         }
 
         sub mixin-line-editor($self) {
+            return $self but FallbackBehavior if  %*ENV<INSIDE_EMACS>;
+
             my %editor-to-mixin = (
                 :Linenoise(&mixin-linenoise),
                 :Readline(&mixin-readline),


### PR DESCRIPTION
I experiment some problems when running raku REPL Inside emacs whith the Line Editors activated, I think that is better to disable Line editor  checking the environment variable INSIDE_EMACS 