### PR TITLE
Remove the $?COMPILATION-ID constant

### DIFF
--- a/src/Perl6/Compiler.nqp
+++ b/src/Perl6/Compiler.nqp
@@ -13,12 +13,6 @@ class Perl6::Compiler is HLL::Compiler {
         nqp::gethllsym('default', 'SysConfig').rakudo-build-config();
     }
 
-    method compilation-id() {
-        my class IDHolder { }
-        BEGIN { (IDHolder.WHO)<$ID> := $*W.handle }
-        $IDHolder::ID
-    }
-
     method version() {
         nqp::say(self.version_string);
         nqp::exit(0);

--- a/src/core.c/VM.pm6
+++ b/src/core.c/VM.pm6
@@ -1,9 +1,3 @@
-my constant $?COMPILATION-ID :=
-  nqp::p6box_s(nqp::sha1(nqp::concat(
-    $*W.handle,
-    nqp::getcomp('Raku').compilation-id
-  )));
-
 class VM does Systemic {
 #?if moar
     has $.config         is built(:bind) = nqp::backendconfig;

--- a/t/02-rakudo/03-corekeys-6c.t
+++ b/t/02-rakudo/03-corekeys-6c.t
@@ -11,7 +11,6 @@ my @expected = (
   Q{$/},
   Q{$=pod},
   Q{$?BITS},
-  Q{$?COMPILATION-ID},
   Q{$?NL},
   Q{$?TABSTOP},
   Q{$_},

--- a/t/02-rakudo/03-corekeys-6d.t
+++ b/t/02-rakudo/03-corekeys-6d.t
@@ -11,7 +11,6 @@ my @expected = (
     Q{$/},
     Q{$=pod},
     Q{$?BITS},
-    Q{$?COMPILATION-ID},
     Q{$?NL},
     Q{$?TABSTOP},
     Q{$_},

--- a/t/02-rakudo/03-corekeys-6e.t
+++ b/t/02-rakudo/03-corekeys-6e.t
@@ -11,7 +11,6 @@ my @expected = (
     Q{$/},
     Q{$=pod},
     Q{$?BITS},
-    Q{$?COMPILATION-ID},
     Q{$?NL},
     Q{$?TABSTOP},
     Q{$_},

--- a/t/02-rakudo/03-corekeys.t
+++ b/t/02-rakudo/03-corekeys.t
@@ -13,7 +13,6 @@ my @allowed =
       Q{$/},
       Q{$=pod},
       Q{$?BITS},
-      Q{$?COMPILATION-ID},
       Q{$?NL},
       Q{$?TABSTOP},
       Q{$_},

--- a/t/02-rakudo/04-settingkeys-6c.t
+++ b/t/02-rakudo/04-settingkeys-6c.t
@@ -11,7 +11,6 @@ my %allowed = (
     Q{$/},
     Q{$=pod},
     Q{$?BITS},
-    Q{$?COMPILATION-ID},
     Q{$?NL},
     Q{$?TABSTOP},
     Q{$_},

--- a/t/02-rakudo/04-settingkeys-6e.t
+++ b/t/02-rakudo/04-settingkeys-6e.t
@@ -10,7 +10,6 @@ my %allowed = (
     Q{$/},
     Q{$=pod},
     Q{$?BITS},
-    Q{$?COMPILATION-ID},
     Q{$?NL},
     Q{$?TABSTOP},
     Q{$_},


### PR DESCRIPTION
- it is not used anywhere
- it is only tested for its existence
- it is not documented