### PR TITLE
Put CATCH blocks at the start of the scope

### DIFF
--- a/src/core.c/Backtrace.pm6
+++ b/src/core.c/Backtrace.pm6
@@ -278,6 +278,14 @@ my class Backtrace {
     method nice(Backtrace:D: :$oneline) {
         my $setting = %*ENV<RAKUDO_BACKTRACE_SETTING>;
         try {
+            CATCH {
+                default {
+                    return "<Internal error while creating backtrace: $_.message() $_.backtrace.full().\n"
+                        ~ "Please report this as a bug (mail to rakudobug@perl.org)\n",
+                        ~ "and re-run with the --ll-exception command line option\n"
+                        ~ "to get more information about your error>";
+                }
+            }
             my @frames;
             my Int $i = self.next-interesting-index(-1);
             while $i.defined {
@@ -297,14 +305,6 @@ my class Backtrace {
                 }
                 last if $oneline;
                 $i = self.next-interesting-index($i, :$setting);
-            }
-            CATCH {
-                default {
-                    return "<Internal error while creating backtrace: $_.message() $_.backtrace.full().\n"
-                        ~ "Please report this as a bug (mail to rakudobug@perl.org)\n",
-                        ~ "and re-run with the --ll-exception command line option\n"
-                        ~ "to get more information about your error>";
-                }
             }
             @frames.join;
         }

--- a/src/core.c/CompUnit/PrecompilationRepository.pm6
+++ b/src/core.c/CompUnit/PrecompilationRepository.pm6
@@ -79,18 +79,18 @@ class CompUnit::PrecompilationRepository::Default
     }
 
     method !load-handle-for-path(CompUnit::PrecompilationUnit:D $unit) {
-        $!RMD("Loading precompiled\n$unit")
-          if $!RMD;
-
         my $preserve_global := nqp::ifnull(nqp::gethllsym('Raku','GLOBAL'),Mu);
-        my $handle := CompUnit::Loader.load-precompilation-file($unit.bytecode-handle);
-        nqp::bindhllsym('Raku', 'GLOBAL', $preserve_global);
         CATCH {
             default {
                 nqp::bindhllsym('Raku', 'GLOBAL', $preserve_global);
                 .throw;
             }
         }
+        $!RMD("Loading precompiled\n$unit")
+          if $!RMD;
+
+        my $handle := CompUnit::Loader.load-precompilation-file($unit.bytecode-handle);
+        nqp::bindhllsym('Raku', 'GLOBAL', $preserve_global);
         $handle
     }
 

--- a/src/core.c/CompUnit/Repository/Perl5.pm6
+++ b/src/core.c/CompUnit/Repository/Perl5.pm6
@@ -5,6 +5,11 @@ class CompUnit::Repository::Perl5 does CompUnit::Repository {
         --> CompUnit:D)
     {
         if $spec.from eq 'Perl5' {
+            CATCH {
+                when X::CompUnit::UnsatisfiedDependency {
+                    X::NYI::Available.new(:available('Inline::Perl5'), :feature('Perl 5')).throw;
+                }
+            }
             my $compunit = $*REPO.need(CompUnit::DependencySpecification.new(:short-name<Inline::Perl5>));
             my $perl5 := $compunit.handle.globalish-package<Inline>.WHO<Perl5>.default_perl5;
 
@@ -23,12 +28,6 @@ class CompUnit::Repository::Perl5 does CompUnit::Repository {
                 :repo-id($spec.short-name),
                 :from($spec.from),
             );
-
-            CATCH {
-                when X::CompUnit::UnsatisfiedDependency {
-                    X::NYI::Available.new(:available('Inline::Perl5'), :feature('Perl 5')).throw;
-                }
-            }
         }
 
         return self.next-repo.need($spec, $precomp) if self.next-repo;

--- a/src/core.c/CurrentThreadScheduler.pm6
+++ b/src/core.c/CurrentThreadScheduler.pm6
@@ -36,8 +36,8 @@ my class CurrentThreadScheduler does Scheduler {
           (self && self.uncaught_handler) // -> $ex { self.handle_uncaught($ex) };
 
         for 1 .. $times {
-            code();
             CATCH { default { catch($_) } };
+            code();
         }
         class { method cancel() {} }
     }

--- a/src/core.c/Encoding/Decoder/Builtin.pm6
+++ b/src/core.c/Encoding/Decoder/Builtin.pm6
@@ -69,10 +69,10 @@ augment class Rakudo::Internals {
                 $decoder.add-bytes($_);
                 my $available;
                 {
-                    $available = $decoder.consume-available-chars();
                     CATCH {
                         $valid = False;
                     }
+                    $available = $decoder.consume-available-chars();
                 }
                 emit $available if $available ne '';
                 LAST {

--- a/src/core.c/Exception.pm6
+++ b/src/core.c/Exception.pm6
@@ -85,8 +85,8 @@ my class Exception {
     method fail(Exception:D:) {
         try self.throw;
         my $fail := Failure.new($!);
-        nqp::throwpayloadlexcaller(nqp::const::CONTROL_RETURN, $fail);
         CATCH { $fail.exception.throw }
+        nqp::throwpayloadlexcaller(nqp::const::CONTROL_RETURN, $fail);
     }
 
     method is-compile-time(--> False) { }

--- a/src/core.c/Failure.pm6
+++ b/src/core.c/Failure.pm6
@@ -142,41 +142,41 @@ multi sub fail(--> Nil) {
 
     my $fail := Failure.new( $payload ~~ Exception
       ?? $payload !! X::AdHoc.new(:$payload));
+    CATCH { $fail.exception.throw }
 
     nqp::throwpayloadlexcaller(nqp::const::CONTROL_RETURN, $fail);
-    CATCH { $fail.exception.throw }
 }
 multi sub fail(Exception:U $e --> Nil) {
     my $fail := Failure.new(
         X::AdHoc.new(:payload("Failed with undefined " ~ $e.^name))
     );
-    nqp::throwpayloadlexcaller(nqp::const::CONTROL_RETURN, $fail);
     CATCH { $fail.exception.throw }
+    nqp::throwpayloadlexcaller(nqp::const::CONTROL_RETURN, $fail);
 }
 multi sub fail($payload --> Nil) {
     my $fail := Failure.new( $payload ~~ Exception
       ?? $payload
       !! X::AdHoc.new(:$payload)
     );
-    nqp::throwpayloadlexcaller(nqp::const::CONTROL_RETURN, $fail);
     CATCH { $fail.exception.throw }
+    nqp::throwpayloadlexcaller(nqp::const::CONTROL_RETURN, $fail);
 }
 multi sub fail(|cap (*@msg) --> Nil) {
     my $fail := Failure.new(X::AdHoc.from-slurpy(|cap));
-    nqp::throwpayloadlexcaller(nqp::const::CONTROL_RETURN, $fail);
     CATCH { $fail.exception.throw }
+    nqp::throwpayloadlexcaller(nqp::const::CONTROL_RETURN, $fail);
 }
 multi sub fail(Failure:U $f --> Nil) {
     my $fail := Failure.new(
         X::AdHoc.new(:payload("Failed with undefined " ~ $f.^name))
     );
-    nqp::throwpayloadlexcaller(nqp::const::CONTROL_RETURN, $fail);
     CATCH { $fail.exception.throw }
+    nqp::throwpayloadlexcaller(nqp::const::CONTROL_RETURN, $fail);
 }
 multi sub fail(Failure:D $fail --> Nil) {
     $fail.handled = 0;
-    nqp::throwpayloadlexcaller(nqp::const::CONTROL_RETURN, $fail);
     CATCH { $fail.exception.throw }
+    nqp::throwpayloadlexcaller(nqp::const::CONTROL_RETURN, $fail);
 }
 
 multi sub die(Failure:D $f --> Nil) {

--- a/src/core.c/IO/Handle.pm6
+++ b/src/core.c/IO/Handle.pm6
@@ -629,10 +629,6 @@ my class IO::Handle {
     method lock(IO::Handle:D:
         Bool:D :$non-blocking = False, Bool:D :$shared = False --> True
     ) {
-#?if moar
-        self!forget-about-closing;
-#?endif
-        nqp::lockfh($!PIO, 0x10*$non-blocking + $shared);
         CATCH { default {
 #?if moar
             self!remember-to-close;
@@ -641,6 +637,10 @@ my class IO::Handle {
                 :lock-type( 'non-' x $non-blocking ~ 'blocking, '
                     ~ ($shared ?? 'shared' !! 'exclusive') );
         }}
+#?if moar
+        self!forget-about-closing;
+#?endif
+        nqp::lockfh($!PIO, 0x10*$non-blocking + $shared);
     }
 
     method unlock(IO::Handle:D: --> True) {

--- a/src/core.c/IO/Path.pm6
+++ b/src/core.c/IO/Path.pm6
@@ -437,19 +437,23 @@ my class IO::Path is Cool does IO {
     }
 
     method rename(IO::Path:D: IO() $to, :$createonly --> True) {
+        CATCH { default {
+            fail X::IO::Rename.new:
+                :from($!os-path), :to($to.absolute), :os-error(.Str);
+        }}
         $createonly and $to.e and fail X::IO::Rename.new:
             :from($.absolute),
             :to($to.absolute),
             :os-error(':createonly specified and destination exists');
 
         nqp::rename($.absolute, nqp::unbox_s($to.absolute));
-        CATCH { default {
-            fail X::IO::Rename.new:
-                :from($!os-path), :to($to.absolute), :os-error(.Str);
-        }}
     }
 
     method copy(IO::Path:D: IO() $to, :$createonly --> True) {
+        CATCH { default {
+            fail X::IO::Copy.new:
+                :from($!os-path), :to($to.absolute), :os-error(.Str)
+        }}
         # add fix for issue #3971 where attempt to copy a dir
         # to a file clobbers the file.
         self.d and $to.f and fail X::IO::Copy.new:
@@ -470,11 +474,6 @@ my class IO::Path is Cool does IO {
             X::IO::Copy.new(:from($from-abs), :to($to-abs),
                 :os-error('source and target are the same')).fail,
             nqp::copy($from-abs, $to-abs));
-
-        CATCH { default {
-            fail X::IO::Copy.new:
-                :from($!os-path), :to($to.absolute), :os-error(.Str)
-        }}
     }
 
     method move(IO::Path:D: |c --> True) {
@@ -485,33 +484,33 @@ my class IO::Path is Cool does IO {
     }
 
     method chmod(IO::Path:D: Int() $mode --> True) {
-        nqp::chmod($.absolute, nqp::unbox_i($mode));
         CATCH { default {
             fail X::IO::Chmod.new(
               :path($!os-path), :$mode, :os-error(.Str) );
         }}
+        nqp::chmod($.absolute, nqp::unbox_i($mode));
     }
     method unlink(IO::Path:D: --> True) {
-        nqp::unlink($.absolute);
         CATCH { default {
             fail X::IO::Unlink.new( :path($!os-path), os-error => .Str );
         }}
+        nqp::unlink($.absolute);
     }
 
     method symlink(IO::Path:D: IO() $name, Bool :$absolute = True --> True) {
-        nqp::symlink($absolute ?? $.absolute !! ~self , nqp::unbox_s($name.absolute));
         CATCH { default {
             fail X::IO::Symlink.new:
                 :target($!os-path), :name($name.absolute), :os-error(.Str);
         }}
+        nqp::symlink($absolute ?? $.absolute !! ~self , nqp::unbox_s($name.absolute));
     }
 
     method link(IO::Path:D: IO() $name --> True) {
-        nqp::link($.absolute, $name.absolute);
         CATCH { default {
             fail X::IO::Link.new:
                 :target($!os-path), :name($name.absolute), :os-error(.Str);
         }}
+        nqp::link($.absolute, $name.absolute);
     }
 
     method mkdir(IO::Path:D: Int() $mode = 0o777) {
@@ -527,10 +526,10 @@ my class IO::Path is Cool does IO {
     }
 
     method rmdir(IO::Path:D: --> True) {
-        nqp::rmdir($.absolute);
         CATCH { default {
             fail X::IO::Rmdir.new(:path($!os-path), os-error => .Str);
         }}
+        nqp::rmdir($.absolute);
     }
 
 

--- a/src/core.c/IO/Socket/Async.pm6
+++ b/src/core.c/IO/Socket/Async.pm6
@@ -237,6 +237,13 @@ my class IO::Socket::Async {
             my $host-vow = $socket-host.vow;
             my $port-vow = $socket-port.vow;
             $lock.protect: {
+                CATCH {
+                    default {
+                        tap($tap = ListenSocket.new({ Nil },
+                            :$VMIO-tobe, :$socket-host, :$socket-port)) unless $tap;
+                        quit($_);
+                    }
+                }
                 my $cancellation := nqp::asynclisten(
                     $!scheduler.queue(:hint-affinity),
                     -> Mu \client-socket, Mu \err, Mu \peer-host, Mu \peer-port,
@@ -286,13 +293,6 @@ my class IO::Socket::Async {
                     $p
                 }, :$VMIO-tobe, :$socket-host, :$socket-port;
                 tap($tap);
-                CATCH {
-                    default {
-                        tap($tap = ListenSocket.new({ Nil },
-                            :$VMIO-tobe, :$socket-host, :$socket-port)) unless $tap;
-                        quit($_);
-                    }
-                }
             }
             $tap
         }

--- a/src/core.c/JavaScriptScheduler.pm6
+++ b/src/core.c/JavaScriptScheduler.pm6
@@ -26,8 +26,8 @@ my class JavaScriptScheduler does Scheduler {
           self.uncaught_handler // -> $ex { self.handle_uncaught($ex) };
 
         for 1 .. $times {
-            code();
             CATCH { default { catch($_) } };
+            code();
         }
         class { method cancel() {} }
     }

--- a/src/core.c/Mu.pm6
+++ b/src/core.c/Mu.pm6
@@ -1363,10 +1363,10 @@ sub DUMP(|args (*@args, :$indent-step = 4, :%ctx?)) { # is implementation-detail
 
             my @pieces;
             {
+                CATCH { default { @pieces.push: '...' } }
                 for $topic.pairs {
                     @pieces.push: $_.key ~ ' => ' ~ DUMP($_.value, :$indent-step, :%ctx);
                 }
-                CATCH { default { @pieces.push: '...' } }
             }
 
             @pieces.DUMP-PIECES($id ~ '(', :$indent-step);

--- a/src/core.c/REPL.pm6
+++ b/src/core.c/REPL.pm6
@@ -387,6 +387,10 @@ do {
             reset;
 
             REPL: loop {
+                # Why doesn't the catch-default in repl-eval catch all?
+                CATCH {
+                    default { say $_; reset }
+                }
                 my $newcode = self.repl-read(~$prompt);
                 last if $no-exit and $newcode and $newcode eq 'exit';
 
@@ -442,12 +446,6 @@ do {
                     $previous-evals.push: $output<>;
                 }
                 reset;
-
-                # Why doesn't the catch-default in repl-eval catch all?
-                CATCH {
-                    default { say $_; reset }
-                }
-
             }
 
             self.teardown;
@@ -471,13 +469,12 @@ do {
 
         method repl-print(Mu $value --> Nil) {
             my $method := %*ENV<RAKU_REPL_OUTPUT_METHOD> // "gist";
-            nqp::can($value,$method)
-              and say $value."$method"()
-              or say "(low-level object `$value.^name()`)";
-
             CATCH {
                 default { say ."$method"() }
             }
+            nqp::can($value,$method)
+              and say $value."$method"()
+              or say "(low-level object `$value.^name()`)";
         }
 
         method history-file(--> Str:D) {

--- a/src/core.c/Rakudo/Internals.pm6
+++ b/src/core.c/Rakudo/Internals.pm6
@@ -1724,16 +1724,16 @@ my class Rakudo::Internals {
     method PERL5() {
         $P5 //= do {
             {
+                CATCH {
+                    #X::Eval::NoSuchLang.new(:$lang).throw;
+                    .note;
+                }
                 my $compunit := $*REPO.need(
                   CompUnit::DependencySpecification.new(
                     :short-name<Inline::Perl5>
                   )
                 );
                 GLOBAL.WHO.merge-symbols($compunit.handle.globalish-package);
-                CATCH {
-                    #X::Eval::NoSuchLang.new(:$lang).throw;
-                    .note;
-                }
             }
             ::("Inline::Perl5").default_perl5
         }

--- a/src/core.c/Rakudo/Internals/HyperRaceSharedImpl.pm6
+++ b/src/core.c/Rakudo/Internals/HyperRaceSharedImpl.pm6
@@ -112,14 +112,14 @@ class Rakudo::Internals::HyperRaceSharedImpl {
     }
     method sink(\hyper, $source --> Nil) {
         if hyper.DEFINITE {
-            my $sink = Sink.new(:$source);
-            Rakudo::Internals::HyperPipeline.start($sink, hyper.configuration);
-            $*AWAITER.await($sink.complete);
             CATCH {
                 unless nqp::istype($_, X::HyperRace::Died) {
                     ($_ but X::HyperRace::Died(Backtrace.new(5))).rethrow
                 }
             }
+            my $sink = Sink.new(:$source);
+            Rakudo::Internals::HyperPipeline.start($sink, hyper.configuration);
+            $*AWAITER.await($sink.complete);
         }
     }
 

--- a/src/core.c/Rakudo/Internals/RaceToIterator.pm6
+++ b/src/core.c/Rakudo/Internals/RaceToIterator.pm6
@@ -22,9 +22,6 @@ my class Rakudo::Internals::RaceToIterator does Rakudo::Internals::HyperJoiner d
     has IterationBuffer $!current-items = EMPTY_BUFFER;
     method pull-one() {
         until nqp::elems(nqp::decont($!current-items)) { # Handles empty batches
-            my $batch = $!batches.receive;
-            self.batch-used();
-            $!current-items = $batch.items;
             CATCH {
                 when X::Channel::ReceiveOnClosed {
                     return IterationEnd;
@@ -33,6 +30,9 @@ my class Rakudo::Internals::RaceToIterator does Rakudo::Internals::HyperJoiner d
                     ($_ but X::HyperRace::Died(Backtrace.new(5))).rethrow
                 }
             }
+            my $batch = $!batches.receive;
+            self.batch-used();
+            $!current-items = $batch.items;
         }
         nqp::shift(nqp::decont($!current-items))
     }

--- a/src/core.c/Rakudo/Supply.pm6
+++ b/src/core.c/Rakudo/Supply.pm6
@@ -466,13 +466,13 @@ class Rakudo::Supply {
             my $t := Tap.new;
             tap($t);
             try {
-                emit(&!block());
-                done();
                 CATCH {
                     default {
                         quit($_);
                     }
                 }
+                emit(&!block());
+                done();
             }
             $t
         }

--- a/src/core.c/Supply-factories.pm6
+++ b/src/core.c/Supply-factories.pm6
@@ -61,8 +61,8 @@
             $lock.protect: {
                 my $cancellation = $!scheduler.cue(
                     {
-                        $lock.protect: { emit $i++ };
                         CATCH { $cancellation.cancel if $cancellation }
+                        $lock.protect: { emit $i++ };
                     },
                     :every($!interval), :in($!delay)
                 );
@@ -373,13 +373,13 @@
                             {
                                 $lock.protect: { $last_cancellation = Nil; }
                                 try {
-                                    emit(value);
                                     CATCH {
                                         default {
                                             quit($_);
                                             self!cleanup($cleaned-up, $source-tap);
                                         }
                                     }
+                                    emit(value);
                                 }
                             });
                     }

--- a/src/core.c/Variable.pm6
+++ b/src/core.c/Variable.pm6
@@ -51,7 +51,6 @@ multi sub trait_mod:<is>(Variable:D $v, Mu :$default!) {
 
     my $descriptor;
     {
-        $descriptor := nqp::getattr($var, $what.^mixin_base, '$!descriptor');
         CATCH {
             my $native = $v.native($what);
             $native
@@ -64,6 +63,7 @@ multi sub trait_mod:<is>(Variable:D $v, Mu :$default!) {
               !! $v.throw('X::Comp::NYI',
                      :feature("is default on shaped $what.raku()"))
         }
+        $descriptor := nqp::getattr($var, $what.^mixin_base, '$!descriptor');
     }
 
     my $of := $descriptor.of;
@@ -83,7 +83,6 @@ multi sub trait_mod:<is>(Variable:D $v, :$dynamic!) {
     my $var  := $v.var;
     my $what := $var.VAR.WHAT;
     {
-        nqp::getattr($var,$what.^mixin_base,'$!descriptor').set_dynamic($dynamic);
         CATCH {
             my $native = $v.native($what);
             $native
@@ -93,6 +92,7 @@ multi sub trait_mod:<is>(Variable:D $v, :$dynamic!) {
               !! $v.throw('X::Comp::NYI',
                      :feature("is dynamic on shaped $what.raku()"))
         }
+        nqp::getattr($var,$what.^mixin_base,'$!descriptor').set_dynamic($dynamic);
     }
 }
 multi sub trait_mod:<is>(Variable:D $v, :$export!) {


### PR DESCRIPTION
CATCH blocks affect the **entire** scope they're in.  So they should
be as close to the start of the scope they're in, so that you realize
that they can fire well before you think they'd might fire.

This did not change the Rakudo::Internals::JSON class, as that is
being kept in sync with JSON::Fast.