### PR TITLE
Update the meta info of the core

### DIFF
--- a/src/core.c/Compiler.pm6
+++ b/src/core.c/Compiler.pm6
@@ -16,7 +16,7 @@ class Compiler does Systemic {
     submethod TWEAK(--> Nil) {
         # https://github.com/rakudo/rakudo/issues/3436
         nqp::bind($!name,'rakudo');
-        nqp::bind($!auth,'The Perl Foundation');
+        nqp::bind($!auth,'Yet Another Society');
 
         # looks like: 2018.01-50-g8afd791c1
         nqp::bind($!version,Version.new(nqp::p6box_s(nqp::atkey($compiler,'version'))))

--- a/tools/build/install-core-dist.raku
+++ b/tools/build/install-core-dist.raku
@@ -40,12 +40,13 @@ my $REPO := PROCESS::<$REPO> := Staging.new(
     ),
     :name('core'),
 );
+my $compiler := Compiler.new;
 $REPO.install(
     Distribution::Hash.new(
         {
-            name     => 'CORE',
-            auth     => 'perl',
-            ver      => $*RAKU.version.Str,
+            name     => $compiler.name,
+            auth     => $compiler.auth,
+            ver      => $compiler.version,
             provides => %provides,
         },
         prefix => $*CWD,


### PR DESCRIPTION
- in Compiler, auth to Yet Another Society, the official name of TPF
- in install-core-dist.raku, use the info from Compiler

Mostly because it felt better to have the info in the META match
what is in Compiler, and to be more specific in Compiler now that
there is no Perl in the name anymore.