### PR TITLE
Fix for a lexical being localized while used in a nested scope

### DIFF
--- a/src/Perl6/Optimizer.nqp
+++ b/src/Perl6/Optimizer.nqp
@@ -3998,7 +3998,8 @@ class Perl6::Optimizer {
                         my $stmts_def := QAST::Stmts.new( $default );
                         if nqp::istype($default, QAST::Op) && $default.op eq 'getlexouter' {
                             $!block_var_stack.do('register_getlexouter_usage', $stmts_def);
-                            $var.default($stmts_def);
+                            # Don't modify the declaration in dry run, only collect the data.
+                            $var.default($stmts_def) unless $!block_var_stack.in-dry-run;
                         }
                         else {
                             self.visit_children($stmts_def);


### PR DESCRIPTION
The cause was dry run wrapping a `QAST::Var(:decl)` into a `QAST::Stmts`
casuing the full run to skip it when detecting inner usages.

Note: what is the actual purpose of the wrapping? Can't it be replaced
with an annotation?

Resolves #4850 