### PR TITLE
Add CompUnit::DependencySpecification.lookup-id method

### DIFF
--- a/src/core.c/CompUnit/DependencySpecification.pm6
+++ b/src/core.c/CompUnit/DependencySpecification.pm6
@@ -84,6 +84,9 @@ class CompUnit::DependencySpecification {
           ValueObjAt
         )
     }
+
+    # basename inside the short-dir
+    method lookup-id(--> Str:D) { nqp::sha1($!short-name) }
 }
 
 # vim: expandtab shiftwidth=4

--- a/src/core.c/CompUnit/Repository/Installation.pm6
+++ b/src/core.c/CompUnit/Repository/Installation.pm6
@@ -482,7 +482,7 @@ sub MAIN(:$name, :$auth, :$ver, *@, *%) {
         if $spec.from eq 'Perl6'
           # $lookup is a file system resource that acts as a fast meta data
           # lookup for a given module short name.
-          && (my $lookup = self!short-dir.add(nqp::sha1($spec.short-name))).e {
+          && (my $lookup = self!short-dir.add($spec.lookup-id)).e {
 
             my $auth-matcher    := $spec.auth-matcher;
             my $version-matcher := $spec.version-matcher;


### PR DESCRIPTION
And use it.   I guess technically any CUR can devise its own way of
encoding a shortname lookup into a filename, but it feels that it
being in the CUDS is more appropriate.