### PR TITLE
Streamline Distribution::Hash a bit

### DIFF
--- a/src/core.c/Distribution/Hash.pm6
+++ b/src/core.c/Distribution/Hash.pm6
@@ -2,7 +2,7 @@ class Distribution::Hash does Distribution::Locally {
     has $.meta is built(:bind);
 
     method new($meta, :$prefix) { self.bless(:$meta, :$prefix) }
-    method raku {
+    multi method raku(Distribution::Hash:D:) {
         self.^name ~ ".new($!meta.raku(), prefix => $!prefix.raku())";
     }
 }

--- a/src/core.c/Distribution/Hash.pm6
+++ b/src/core.c/Distribution/Hash.pm6
@@ -1,10 +1,9 @@
 class Distribution::Hash does Distribution::Locally {
-    has $!meta;
-    submethod BUILD(:$!meta, :$!prefix --> Nil) { }
-    method new($hash, :$prefix) { self.bless(:meta($hash), :$prefix) }
-    method meta { $!meta }
+    has $.meta is built(:bind);
+
+    method new($meta, :$prefix) { self.bless(:$meta, :$prefix) }
     method raku {
-        self.^name ~ ".new({$!meta.raku}, prefix => {$!prefix.raku})";
+        self.^name ~ ".new($!meta.raku(), prefix => $!prefix.raku())";
     }
 }
 

--- a/src/core.c/Distribution/Locally.pm6
+++ b/src/core.c/Distribution/Locally.pm6
@@ -1,5 +1,5 @@
 role Distribution::Locally does Distribution {
-    has IO::Path $.prefix;
+    has IO::Path $.prefix is built(:bind);
 
     method content(Str:D $address --> IO::Handle:D) {
         my $handle := IO::Handle.new: path => IO::Path.new:


### PR DESCRIPTION
- use "is built(:bind)" to bind, rather than an empty BUILD method
- rename positional in new for easier blessing
- lose explicit meta method (now auto-generated)
- don't use scopes in .raku creation