### PR TITLE
Make handles on attribute of type object more natural

### DIFF
--- a/src/core.c/traits.pm6
+++ b/src/core.c/traits.pm6
@@ -454,7 +454,12 @@ multi sub trait_mod:<handles>(Attribute:D $target, $thunk) {
 
         method add_delegator_method($attr: Mu $pkg, $meth_name, $call_name) {
             my $meth := method (|c) is rw {
-                $attr.get_value(self)."$call_name"(|c)
+                (nqp::isconcrete(self)
+                  ?? $attr.get_value(self)
+                  !! nqp::decont(nqp::getattr(
+                         nqp::decont($attr),Attribute,'$!auto_viv_container'
+                     ))
+                )."$call_name"(|c)
             };
             $meth.set_name($meth_name);
             $pkg.^add_method($meth_name, $meth);


### PR DESCRIPTION
Instead of dying with: "Cannot look up attributes in a Foo type
object".  The error message is confusing, take this example:

    class A { has Int $.foo handles <Str> }; (my A $a).Str

To the casual observer, calling .Str on a type object should just
work: there are no attributes in play.  *IF* we want to have that
behaviour, then we should probably mention the name of the actual
attribute.

But I think it is better to assume a decontainerized uninitialized
attribute in that case to more mimic the actual situation.  That
changes it into a warning in this case:

    Use of uninitialized value of type Int in string context.
    Methods .^name, .raku, .gist, or .say can be used to stringify it to something meaningful.

It will definitely make using "handles" much more user friendly.