### PR TITLE
Streamline Distribution::Resource

### DIFF
--- a/src/core.c/Distribution/Resource.pm6
+++ b/src/core.c/Distribution/Resource.pm6
@@ -4,81 +4,31 @@ class Distribution::Resource {
     has $.dist-id;
     has $.key;
 
-    method IO() {
+    # delegate appropriate IO::Path methods to the resource IO::Path object
+    has IO::Path $.IO is built(False) handles <
+      absolute is-absolute relative is-relative parts volume dirname
+      basename extension open resolve slurp lines comb split words copy
+    >;
+
+    method TWEAK() {
         my $repo := self.repo-name
-            ?? CompUnit::RepositoryRegistry.repository-for-name(self.repo-name)
-            !! CompUnit::RepositoryRegistry.repository-for-spec(self.repo);
-        $repo.resource(self.dist-id, "resources/$.key")
+          ?? CompUnit::RepositoryRegistry.repository-for-name($!repo-name)
+          !! CompUnit::RepositoryRegistry.repository-for-spec($!repo);
+        $!IO := $repo.resource($!dist-id, "resources/$!key")
     }
 
     method platform-library-name() {
-        my $library = self.IO;
-        ($library ~~ /\.<.alpha>+$/ or $library ~~ /\.so(\.<.digit>+)+$/) #Already a full name?
+        my $library := self.IO;
+        # Already a full name?
+        ($library ~~ /\.<.alpha>+$/ or $library ~~ /\.so(\.<.digit>+)+$/)
             ??  $library
             !!  $*VM.platform-library-name($library)
     }
 
-    # delegate appropriate IO::Path methods to the resource IO::Path object
-    multi method Str(::?CLASS:D: |c) {
-        self.IO.Str(|c)
-    }
-    multi method gist(::?CLASS:D: |c) {
-        self.IO.gist(|c)
-    }
-    multi method raku(::?CLASS:D: |c) {
-        self.IO.raku(|c)
-    }
-    method absolute(|c) {
-        self.IO.absolute(|c)
-    }
-    method is-absolute(|c) {
-        self.IO.is-absolute(|c)
-    }
-    method relative(|c) {
-        self.IO.relative(|c)
-    }
-    method is-relative(|c) {
-        self.IO.is-relative(|c)
-    }
-    method parts(|c) {
-        self.IO.parts(|c)
-    }
-    method volume(|c) {
-        self.IO.volume(|c)
-    }
-    method dirname(|c) {
-        self.IO.dirname(|c)
-    }
-    method basename(|c) {
-        self.IO.basename(|c)
-    }
-    method extension(|c) {
-        self.IO.extension(|c)
-    }
-    method open(|c) {
-        self.IO.open(|c)
-    }
-    method resolve(|c) {
-        self.IO.resolve(|c)
-    }
-    method slurp(|c) {
-        self.IO.slurp(|c)
-    }
-    method lines(|c) {
-        self.IO.lines(|c)
-    }
-    method comb(|c) {
-        self.IO.comb(|c)
-    }
-    method split(|c) {
-        self.IO.split(|c)
-    }
-    method words(|c) {
-        self.IO.words(|c)
-    }
-    method copy(|c) {
-        self.IO.copy(|c)
-    }
+    # multis cannot be handled transparently by $!IO (yet)
+    multi method Str(::?CLASS:D:  |c) { $!IO.Str(|c)  }
+    multi method gist(::?CLASS:D: |c) { $!IO.gist(|c) }
+    multi method raku(::?CLASS:D: |c) { $!IO.raku(|c) }
 }
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
- this is mostly about maintainability
- introduce private IO attribute set in TWEAK
- use "handles" trait on it to auto-generate many accessors
- use direct attribute access
- Str/gist/raku still have manual code on account of them being multis
  and their behaviour is different when called on type object