### PR TITLE
Streamline Distribution::Resources

### DIFF
--- a/src/core.c/Distribution/Resources.pm6
+++ b/src/core.c/Distribution/Resources.pm6
@@ -1,9 +1,9 @@
 role CompUnit::Repository { ... }
 
 class Distribution::Resources does Associative {
-    has Str $.dist-id;
-    has Str $.repo;
-    has Str $.repo-name;
+    has Str $.dist-id   is built(False);
+    has Str $.repo      is built(False);
+    has Str $.repo-name is built(False);
 
     proto method BUILD(|) {*}
 
@@ -13,26 +13,41 @@ class Distribution::Resources does Associative {
             $!repo-name = Str;
         }
     }
-
     multi method BUILD(:$!dist-id, :$repo, Str :$!repo-name --> Nil) { }
     multi method BUILD(:$!dist-id, Str :$!repo, :$repo-name --> Nil) { }
 
-    method from-precomp() {
-        if %*ENV<RAKUDO_PRECOMP_DIST> -> \dist {
-            my %data := Rakudo::Internals::JSON.from-json: dist;
-            self.new(:repo(%data<repo>), :repo-name(%data<repo-name>), :dist-id(%data<dist-id>))
+    # Alternate instantiator called from Actions.nqp during compilation
+    # of %?RESOURCES
+    method from-precomp(Distribution::Resources:U:) {
+        if %*ENV<RAKUDO_PRECOMP_DIST> -> $dist {
+            my %data := Rakudo::Internals::JSON.from-json: $dist;
+            self.new:
+              :repo(%data<repo>),
+              :repo-name(%data<repo-name>),
+              :dist-id(%data<dist-id>);
         }
         else {
             Nil
         }
     }
 
-    method AT-KEY($key) {
+    multi method AT-KEY(Distribution::Resources:D: $key) {
         Distribution::Resource.new(:$.repo, :$.repo-name, :$.dist-id, :$key)
     }
 
-    method Str() {
-        Rakudo::Internals::JSON.to-json: {:$.repo, :$.repo-name, :$.dist-id}
+    multi method Str(Distribution::Resources:D:) {
+        Rakudo::Internals::JSON.to-json: {:$!repo, :$!repo-name, :$!dist-id}
+    }
+
+    # More sensible error messages if %?RESOURCES are trying to be changed
+    multi method ASSIGN-KEY(Distribution::Resources:D: $key, Mu) {
+        die "Cannot assign to key '$key' in an immutable " ~ self.^name;
+    }
+    multi method BIND-KEY(Distribution::Resources:D: $key, Mu) {
+        die "Cannot bind to key '$key' in an immutable " ~ self.^name;
+    }
+    multi method DELETE-KEY(Distribution::Resources:D: $key) {
+        die "Cannot remove key '$key' in an immutable " ~ self.^name;
     }
 }
 

--- a/src/core.c/Distribution/Resources.pm6
+++ b/src/core.c/Distribution/Resources.pm6
@@ -18,7 +18,7 @@ class Distribution::Resources does Associative {
 
     # Alternate instantiator called from Actions.nqp during compilation
     # of %?RESOURCES
-    method from-precomp(Distribution::Resources:U:) {
+    method from-precomp(Distribution::Resources:U:) is implementation-detail {
         if %*ENV<RAKUDO_PRECOMP_DIST> -> $dist {
             my %data := Rakudo::Internals::JSON.from-json: $dist;
             self.new:


### PR DESCRIPTION
- mark all attributes as not being built, as BUILD handles them
- leave comment as to why "from-precomp" exists
- tighten up signatures
- made AT-KEY/Str a multi to handle calls with type objects properly
- add ASSIGN/BIND/DELETE-KEY methods with appropriate error messages