### PR TITLE
Streamline CompUnit::Repository::Distribution

### DIFF
--- a/src/core.c/CompUnit/Repository/Distribution.pm6
+++ b/src/core.c/CompUnit/Repository/Distribution.pm6
@@ -53,7 +53,7 @@ class CompUnit::Repository::Distribution does Distribution {
         }
     }
 
-    method serialize(--> Str:D) {
+    method serialize(--> Str:D) is implementation-detail {
         Rakudo::Internals::JSON.to-json: {:$.repo, :$.repo-name, :$.dist-id}
     }
 

--- a/src/core.c/CompUnit/Repository/Distribution.pm6
+++ b/src/core.c/CompUnit/Repository/Distribution.pm6
@@ -1,61 +1,67 @@
 # A distribution passed to `CURI.install()` will get encapsulated in this
 # class, which normalizes the meta6 data and adds identifiers/content-id
 class CompUnit::Repository::Distribution does Distribution {
-    has Distribution $!dist handles <content prefix>;
-    has $!meta;
-    has $.repo;
-    has $.dist-id;
-    has $.repo-name;
+    has Distribution $.dist      is built(:bind) handles <content prefix>;
+    has              $.repo      is built(:bind);
+    has              $.dist-id   is built(:bind);
+    has              $.repo-name is built(:bind);
+    has              %.meta      is built(False);
 
-    submethod TWEAK(|) {
-        my $meta = $!dist.meta.hash;
-        $meta<ver>  //= $meta<version>;
-        $meta<auth> //= $meta<authority> // $meta<author>;
-        $!meta = $meta;
+    method TWEAK(--> Nil) {
+        my %meta := $!dist.meta.hash;
+        %meta<ver>  //= %meta<version> // '';
+        %meta<auth> //= %meta<authority> // %meta<author> // '';
+        %meta<api>  //= '';
+        %!meta := %meta;
 
-        $!repo-name //= $!repo.name if nqp::can($!repo,"name") && $!repo.name;
-        $!repo = $!repo.path-spec if $!repo.defined && $!repo !~~ Str;
+        $!repo-name := $!repo.name
+          if nqp::not_i(nqp::isconcrete($!repo-name))
+          && nqp::can($!repo,"name");
+        $!repo := $!repo.path-spec
+          if nqp::isconcrete($!repo)
+          && nqp::not_i(nqp::istype($!repo,Str));
     }
 
-    submethod BUILD(:$!dist, :$!repo, :$!dist-id, :$!repo-name --> Nil) { }
-
-    method new(Distribution $dist, *%_) {
+    method new(Distribution:D $dist
+    --> CompUnit::Repository::Distribution:D) {
         self.bless(:$dist, |%_)
     }
 
-    method meta { $!meta }
+    method id(--> Str:D) { nqp::sha1(self.Str) }
 
-    method Str() {
-        return "{$.meta<name>}"
-        ~ ":ver<{$.meta<ver>   // ''}>"
-        ~ ":auth<{$.meta<auth> // ''}>"
-        ~ ":api<{$.meta<api>   // ''}>";
-    }
+    # Alternate instantiator called from Actions.nqp during compilation
+    # of $?DISTRIBUTION
+    method from-precomp(CompUnit::Repository::Distribution:U:
+    --> CompUnit::Repository::Distribution:D) is implementation-detail {
+        if %*ENV<RAKUDO_PRECOMP_DIST> -> $json {
+            my %data := Rakudo::Internals::JSON.from-json: $json;
+            my $name := %data<repo-name>;
+            my $spec := %data<repo>;  # XXX badly named field?
+            my $id   := %data<dist-id>;
 
-    method id() {
-        return nqp::sha1(self.Str);
-    }
-
-    method from-precomp(CompUnit::Repository::Distribution:U: --> CompUnit::Repository::Distribution) {
-        if %*ENV<RAKUDO_PRECOMP_DIST> -> \dist {
-            my %data := Rakudo::Internals::JSON.from-json: dist;
-            my $repo := %data<repo-name>
-                ?? CompUnit::RepositoryRegistry.repository-for-name(%data<repo-name>)
-                !! CompUnit::RepositoryRegistry.repository-for-spec(%data<repo>);
-            my $dist := $repo.distribution(%data<dist-id>);
-            self.new($dist, :repo(%data<repo>), :repo-name(%data<repo-name>), :dist-id(%data<dist-id>));
+            my $repo := $name
+              ?? CompUnit::RepositoryRegistry.repository-for-name($name)
+              !! CompUnit::RepositoryRegistry.repository-for-spec($spec);
+            self.bless:
+              :dist($repo.distribution($id)),
+              :repo($spec),
+              :repo-name($name),
+              :dist-id($id);
         }
         else {
             Nil
         }
     }
 
-    method serialize() {
+    method serialize(--> Str:D) {
         Rakudo::Internals::JSON.to-json: {:$.repo, :$.repo-name, :$.dist-id}
     }
 
-    method raku {
-        self.^name ~ ".new({$!dist.raku}, repo => {$!repo.raku}, repo-name => {$!repo-name.raku})";
+    multi method Str(CompUnit::Repository::Distribution:D:--> Str:D) {
+        "%!meta<name>:ver<%!meta<ver>>:auth<%!meta<auth>>:api<%!meta<api>>"
+    }
+    multi method raku(CompUnit::Repository::Distribution:D:--> Str:D) {
+        self.^name ~ ".new($!dist.raku(), repo => $!repo.raku(), repo-name => $!repo-name.raku())"
     }
 }
 


### PR DESCRIPTION
- remove BUILD, binding of attributes handled by "is bind"
- bind the meta to a % instead, set defaults in TWEAK
- tighten up signatures
- remove unneccessary returns
- mark method as implementation-detail and mention why
- don't bother calling .new if you can directly call .bless
- remove scopes from various stringifications