### PR TITLE
Streamline CompUnit::Repository::AbsolutePath

### DIFF
--- a/src/core.c/CompUnit/Repository/AbsolutePath.pm6
+++ b/src/core.c/CompUnit/Repository/AbsolutePath.pm6
@@ -1,53 +1,70 @@
 class CompUnit::Repository::AbsolutePath does CompUnit::Repository {
-    has %!loaded;
+    has Lock $!lock;
+    has      $!loaded;
 
-    method need(CompUnit::DependencySpecification $spec,
-                CompUnit::PrecompilationRepository $precomp = self.precomp-repository()
-        --> CompUnit:D)
-    {
-        return self.next-repo.need($spec, $precomp) if self.next-repo;
-        X::CompUnit::UnsatisfiedDependency.new(:specification($spec)).throw;
+    method TWEAK(--> Nil) {
+        $!loaded := nqp::hash;
+        $!lock   := Lock.new;
     }
 
-    method load(IO::Path:D $file --> CompUnit:D) {
-        if $file.is-absolute {
+    method need(CompUnit::Repository::AbsolutePath:D:
+      CompUnit::DependencySpecification $spec,
+      CompUnit::PrecompilationRepository $precomp = self.precomp-repository()
+    --> CompUnit:D) {
+        (my $repo := self.next-repo)
+          ?? $repo.need($spec, $precomp)
+          !! X::CompUnit::UnsatisfiedDependency.new(:specification($spec)).throw
+    }
 
-            # We have a $file when we hit: require "PATH" or use/require Foo:file<PATH>;
-            my $precompiled =
-              $file.Str.ends-with(Rakudo::Internals.PRECOMP-EXT);
+    method load(CompUnit::Repository::AbsolutePath:D:
+      IO::Path:D $file
+    --> CompUnit:D) {
+        if $file.is-absolute && $file.f {
 
-            if $file.f {
-                return %!loaded{$file} = CompUnit.new(
-                    :handle(
-                        $precompiled
-                            ?? CompUnit::Loader.load-precompilation-file($file)
-                            !! CompUnit::Loader.load-source-file($file)
-                    ),
-                    :short-name($file.Str),
-                    :repo(self),
-                    :repo-id($file.Str),
-                    :$precompiled,
-                );
+            # we have a $file when we hit: require "PATH"
+            # or use/require Foo:file<PATH>;
+            my $key := $file.Str;
+            $!lock.protect: {
+                nqp::ifnull(
+                  nqp::atkey($!loaded,$key),
+                  nqp::stmts(
+                    (my $precompiled :=
+                      $key.ends-with(Rakudo::Internals.PRECOMP-EXT)),
+                    nqp::bindkey($!loaded,$key,CompUnit.new(
+                      :handle($precompiled
+                        ?? CompUnit::Loader.load-precompilation-file($file)
+                        !! CompUnit::Loader.load-source-file($file)
+                      ),
+                      :short-name($key),
+                      :repo(self),
+                      :repo-id($key),
+                      :$precompiled
+                    ))
+                  )
+                )
             }
         }
-
-        return self.next-repo.load($file) if self.next-repo;
-        die("Could not find $file in:\n" ~ $*REPO.repo-chain.map(*.path-spec).join("\n").indent(4));
+        elsif self.next-repo -> $repo {
+            $repo.load($file)
+        }
+        else {
+            die "Could not find $file in:\n"
+              ~ $*REPO.repo-chain.map(*.path-spec).join("\n").indent(4);
+        }
     }
 
-    method loaded(--> Iterable:D) {
-        return %!loaded.values;
+    method loaded(CompUnit::Repository::AbsolutePath:D: --> Iterable:D) {
+        my $loaded := $!lock.protect: { nqp::clone($!loaded) }
+        nqp::p6bindattrinvres(
+          nqp::create(Map),Map,'$!storage',$loaded
+        ).values
     }
 
-    method id() {
-        'ap'
-    }
+    method id(--> Str:D) { 'ap' }
 
-    method path-spec() {
-        'ap#'
-    }
+    method path-spec(--> Str:D) { 'ap#' }
 
-    multi method gist(CompUnit::Repository::AbsolutePath:D:) {
+    multi method gist(CompUnit::Repository::AbsolutePath:D:--> Str:D) {
         self.path-spec
     }
 }


### PR DESCRIPTION
- make sure that the cache is thread safe
- make sure the cache actually caches
- less repeated method calls
- tighten up signatures