### PR TITLE
Streamline CompUnit::Repository::Perl5

### DIFF
--- a/src/core.c/CompUnit/Repository/Perl5.pm6
+++ b/src/core.c/CompUnit/Repository/Perl5.pm6
@@ -1,5 +1,5 @@
 class CompUnit::Repository::Perl5 does CompUnit::Repository {
-    my $perl5-dependency :=
+    my constant $perl5-dependency =
       CompUnit::DependencySpecification.new(:short-name<Inline::Perl5>);
 
     method need(CompUnit::Repository::Perl5:D:

--- a/src/core.c/CompUnit/Repository/Perl5.pm6
+++ b/src/core.c/CompUnit/Repository/Perl5.pm6
@@ -25,9 +25,9 @@ class CompUnit::Repository::Perl5 does CompUnit::Repository {
             my $short-name := $spec.short-name;
             my $handle := $perl5.require(
               $short-name,
-              $spec.version-matcher !== True
-                ?? $spec.version-matcher.Numi
-                !! Num,
+              $spec.version-matcher =:= True
+                ?? Num
+                !! $spec.version-matcher.Num,
               :handle
             );
             CompUnit.new:

--- a/src/core.c/CompUnit/Repository/Perl5.pm6
+++ b/src/core.c/CompUnit/Repository/Perl5.pm6
@@ -4,7 +4,7 @@ class CompUnit::Repository::Perl5 does CompUnit::Repository {
 
     method need(CompUnit::Repository::Perl5:D:
       CompUnit::DependencySpecification $spec,
-      CompUnit::PrecompilationRepository $precomp,
+      CompUnit::PrecompilationRepository $precomp?,
     --> CompUnit:D) {
         if $spec.from eq 'Perl5' {
             CATCH {


### PR DESCRIPTION
- tighten signatures
- fewer repeated method calls
- tighten signatures
- move CATCH block to start of applicable scope
- only create Perl 5 dependency specifications once in a process