### PR TITLE
Streamline CompUnit::Repository::NQP

### DIFF
--- a/src/core.c/CompUnit/Repository/NQP.pm6
+++ b/src/core.c/CompUnit/Repository/NQP.pm6
@@ -17,7 +17,7 @@ class CompUnit::Repository::NQP does CompUnit::Repository {
               :from<NQP>;
         }
         elsif self.next-repo -> $repo {
-            $repo.need($spec, self.precomp-repository)
+            $repo.need($spec, $precomp // self.precomp-repository)
         }
         else {
             X::CompUnit::UnsatisfiedDependency.new(:specification($spec)).throw;


### PR DESCRIPTION
- make the %opts hash for loading a constant
- fewer repeated method calls
- don't set up precomp repository unless it's needed
- tighten signatures