### PR TITLE
Remove CATCH from CompUnit::Loader.load-source

### DIFF
--- a/src/core.c/CompUnit/Loader.pm6
+++ b/src/core.c/CompUnit/Loader.pm6
@@ -12,18 +12,10 @@ class CompUnit::Loader is repr('Uninstantiable') {
     method load-source(Blob:D $bytes --> CompUnit::Handle:D) {
 
         my $original-GLOBAL := nqp::ifnull(nqp::gethllsym('Raku','GLOBAL'),Mu);
-        CATCH {
-            default {
-                nqp::bindhllsym('Raku','GLOBAL',$original-GLOBAL);
-                .throw;
-            }
-        }
+        LEAVE nqp::bindhllsym('Raku','GLOBAL',$original-GLOBAL);
 
-        my $handle   := CompUnit::Handle.new;
-        my $*CTXSAVE := $handle;
+        my $handle := my $*CTXSAVE := CompUnit::Handle.new;
         nqp::getcomp('Raku').compile($bytes.decode)();      # compile *and* run
-
-        nqp::bindhllsym('Raku','GLOBAL',$original-GLOBAL);
         $handle
     }
 


### PR DESCRIPTION
It occurred to me that the CATCH was merely there for restoring the
value in hllsym('Raku','GLOBAL') and then rethrow.  And have the same
done on exit.  Feels to me a single LEAVE phaser would do that with
less code.