### PR TITLE
Don't instantiate CompUnit::PrecompilationRepository::None

### DIFF
--- a/src/core.c/CompUnit/PrecompilationRepository.pm6
+++ b/src/core.c/CompUnit/PrecompilationRepository.pm6
@@ -15,7 +15,7 @@ role CompUnit::PrecompilationRepository {
 }
 
 BEGIN CompUnit::PrecompilationRepository::<None> :=
-  CompUnit::PrecompilationRepository.new;
+  CompUnit::PrecompilationRepository;
 
 class CompUnit { ... }
 class CompUnit::PrecompilationRepository::Default


### PR DESCRIPTION
The role does not contain any attributes, so the punned class does
not need to be instantiated.