### PR TITLE
Micro optimize "self" lookup for attribute binding

### DIFF
--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -592,10 +592,8 @@ my class Binder {
         # If it's attributive, now we assign it.
         if $is_attributive {
             # Find self.
-            my $self;
-            if nqp::existskey($lexpad, 'self') {
-                $self := nqp::atkey($lexpad, 'self');
-            } else {
+            my $self := nqp::atkey($lexpad, 'self');
+            if nqp::isnull($self) {
                 if nqp::defined($error) {
                     $error[0] := "Unable to bind attributive parameter '$varname'; could not find self";
                 }


### PR DESCRIPTION
Assuming in most cases, the search is successful, it makes more sense
to just do the nqp::atkey and if that fails, then do the error handling.
Instead of first looking up whether it exists at all, and then do another
lookup if the first check is successful.