### PR TITLE
Do JS backend check only once

### DIFF
--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -175,6 +175,8 @@ sub levenshtein_candidate_heuristic(@candidates, $target) {
     }
 }
 
+my $backend-is-js := nqp::null;
+
 # This builds upon the HLL::World to add the specifics needed by Rakudo.
 class Perl6::World is HLL::World {
 
@@ -2599,7 +2601,10 @@ class Perl6::World is HLL::World {
             }
 
             my $code_obj := nqp::getcodeobj(nqp::curcode());
-            unless nqp::getcomp('Raku').backend.name eq 'js' {
+            unless nqp::ifnull(
+              $backend-is-js,
+              $backend-is-js := nqp::getcomp('Raku').backend.name eq 'js'
+            ) {
                 # Temporarly disabled for js untill we figure the bug out
                 unless nqp::isnull($code_obj) {
                     return $code_obj(|@pos, |%named);

--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -175,8 +175,6 @@ sub levenshtein_candidate_heuristic(@candidates, $target) {
     }
 }
 
-my $backend-is-js := nqp::null;
-
 # This builds upon the HLL::World to add the specifics needed by Rakudo.
 class Perl6::World is HLL::World {
 
@@ -2601,15 +2599,12 @@ class Perl6::World is HLL::World {
             }
 
             my $code_obj := nqp::getcodeobj(nqp::curcode());
-            unless nqp::ifnull(
-              $backend-is-js,
-              $backend-is-js := nqp::getcomp('Raku').backend.name eq 'js'
-            ) {
-                # Temporarly disabled for js untill we figure the bug out
-                unless nqp::isnull($code_obj) {
-                    return $code_obj(|@pos, |%named);
-                }
+#?if !js
+            # Temporarly disabled for js untill we figure the bug out
+            unless nqp::isnull($code_obj) {
+                return $code_obj(|@pos, |%named);
             }
+#?endif
 
             $precomp(|@pos, |%named);
         });

--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -2600,7 +2600,7 @@ class Perl6::World is HLL::World {
 
             my $code_obj := nqp::getcodeobj(nqp::curcode());
 #?if !js
-            # Temporarly disabled for js untill we figure the bug out
+            # Temporarily disabled for js until we figure the bug out
             unless nqp::isnull($code_obj) {
                 return $code_obj(|@pos, |%named);
             }


### PR DESCRIPTION
Unfortunately, it is not possible to make this a constant apparently,
as the nqp::getcomp('Raku') returns a VMnull.