### PR TITLE
Slightly speedup exponentiation by Ints

### DIFF
--- a/src/core.c/Int.pm6
+++ b/src/core.c/Int.pm6
@@ -379,18 +379,24 @@ multi sub infix:<%%>(int $a, int $b --> Bool:D) {
     nqp::hllbool(nqp::iseq_i(nqp::mod_i($a, $b), 0))
 }
 
+my constant UINT64_UPPER = nqp::pow_I(2, 64, Num, Int);
+
 multi sub infix:<**>(Int:D $a, Int:D $b --> Real:D) {
-    my $power := nqp::pow_I($a,nqp::if($b >= 0,$b,-$b),Num,Int);
-    # when a**b is too big nqp::pow_I returns Inf
-    nqp::istype($power, Num)
-      ?? Failure.new(
-          $b >= 0 ?? X::Numeric::Overflow.new !! X::Numeric::Underflow.new
-         )
-      !! $b >= 0
-        ?? $power
-        !! ($power := 1 / $power) == 0 && $a != 0
-          ?? Failure.new(X::Numeric::Underflow.new)
-          !! $power
+    my $power;
+    if nqp::isge_I($b, 0) {
+        $power := nqp::pow_I($a, $b, Num, Int);
+        # when a**b is too big nqp::pow_I returns Inf
+        nqp::istype($power, Int)
+            ?? $power
+            !! Failure.new(X::Numeric::Overflow.new)
+    }
+    else {
+        $power := nqp::pow_I($a, nqp::neg_I($b, Int), Num, Int);
+        # when a**b is too big nqp::pow_I returns Inf
+        nqp::istype($power, Num) || (nqp::isge_I($power, UINT64_UPPER) && nqp::isne_I($a, 0))
+            ?? Failure.new(X::Numeric::Underflow.new)
+            !! 1 / $power
+    }
 }
 
 multi sub infix:<**>(int $a, int $b --> int) {

--- a/src/core.c/Rat.pm6
+++ b/src/core.c/Rat.pm6
@@ -31,8 +31,6 @@ my class Rat is Cool does Rational[Int, Int] {
     }
 }
 
-my constant UINT64_UPPER = nqp::pow_I(2, 64, Num, Int);
-
 my class FatRat is Cool does Rational[Int, Int] {
     method FatRat(FatRat:D:) { self }
     method Rat(FatRat:D:) {


### PR DESCRIPTION
Only perform the `$b > 0` check once and check for underflow before
creating the Rat for negative powers.

Also, for `$foo ** 2`, re-write into `$foo * $foo`.

(All with `MVM_SPESH_BLOCKING=1`):
`my $a; loop (my Int $i = 0; $i <= 10_000_000_000; $i += 1000) { $a := $i ** 2 }; say now - INIT now` drops from ~4.52s to ~3.15s.
`my $a; loop (my Int $i = 0; $i <= 10_000_000_000; $i += 1000) { $a := $i ** 3 }; say now - INIT now` drops from ~4.76s to ~4.55s.
`my $a; loop (my Int $i = 0; $i <= 1_000_000_000; $i += 1000) { $a := $i ** -2 }; say now - INIT now` drops from ~1.45s to ~1.41s.

Rakudo builds ok and passes `make m-test m-spectest`.