### PR TITLE
Re-introduce $?COMPILATION-ID

### DIFF
--- a/src/Perl6/Compiler.nqp
+++ b/src/Perl6/Compiler.nqp
@@ -13,6 +13,12 @@ class Perl6::Compiler is HLL::Compiler {
         nqp::gethllsym('default', 'SysConfig').rakudo-build-config();
     }
 
+    method compilation-id() {
+        my class IDHolder { }
+        BEGIN { (IDHolder.WHO)<$ID> := $*W.handle }
+        $IDHolder::ID
+    }
+
     method version() {
         nqp::say(self.version_string);
         nqp::exit(0);

--- a/src/core.c/CompUnit/PrecompilationRepository.pm6
+++ b/src/core.c/CompUnit/PrecompilationRepository.pm6
@@ -36,8 +36,8 @@ class CompUnit::PrecompilationRepository::Default
     my $loaded-lock   := Lock.new;
     my $first-repo-id;
 
-    my $compiler-id :=
-      CompUnit::PrecompilationId.new-without-check(Compiler.id);
+    my constant $compiler-id =
+      CompUnit::PrecompilationId.new-without-check($?COMPILATION-ID);
 
     method try-load(
       CompUnit::PrecompilationDependency::File:D $dependency,

--- a/src/core.c/Compiler.pm6
+++ b/src/core.c/Compiler.pm6
@@ -1,17 +1,24 @@
-class Compiler does Systemic {
-    my constant $id = nqp::p6box_s(nqp::sha1(
-        $*W.handle.Str
-        ~ nqp::atkey(nqp::gethllsym(
-        'default', 'SysConfig').rakudo-build-config(), 'source-digest')
-    ));
+my constant $?COMPILATION-ID = nqp::box_s(
+  nqp::sha1(
+    $*W.handle.Str ~ nqp::atkey(
+      nqp::gethllsym('default', 'SysConfig').rakudo-build-config,
+      'source-digest'
+    )
+  ),
+  Str
+);
 
-    my Mu $compiler := nqp::gethllsym('default', 'SysConfig')
-        .rakudo-build-config();
+class Compiler does Systemic {
+    my constant $compiler = nqp::getcomp("Raku");
+    my constant $config =
+      nqp::gethllsym('default','SysConfig').rakudo-build-config;
 
     # XXX Various issues with this stuff on JVM
-    has $.id is built(:bind) = nqp::ifnull(nqp::atkey($compiler,'id'),$id);
-    has $.release is built(:bind) = nqp::atkey($compiler,'release-number');
-    has $.codename is built(:bind) = nqp::atkey($compiler, 'codename');
+    has $.id       is built(:bind) = $?COMPILATION-ID;
+    has $.release  is built(:bind) =
+      BEGIN nqp::ifnull(nqp::atkey($config,'release-number'),"");
+    has $.codename is built(:bind) =
+      BEGIN nqp::ifnull(nqp::atkey($config,'codename'),"");
 
     submethod TWEAK(--> Nil) {
         # https://github.com/rakudo/rakudo/issues/3436
@@ -19,40 +26,40 @@ class Compiler does Systemic {
         nqp::bind($!auth,'The Perl Foundation');
 
         # looks like: 2018.01-50-g8afd791c1
-        nqp::bind($!version,Version.new(nqp::p6box_s(nqp::atkey($compiler,'version'))))
-          unless $!version;
+        nqp::bind($!version,BEGIN Version.new(
+          nqp::box_s(nqp::atkey($config,'version'),Str)
+        )) unless $!version;
     }
 
-    method backend() {
-        nqp::getcomp("Raku").backend.name
-    }
+    method backend() { BEGIN $compiler.backend.name }
 
     proto method id(|) {*}
-    multi method id(Compiler:U:) { nqp::ifnull(nqp::atkey($compiler,'id'),$id) }
+    multi method id(Compiler:U:) { $?COMPILATION-ID }
     multi method id(Compiler:D:) { $!id }
 
     method verbose-config(:$say) {
-        my $compiler := nqp::getcomp("Raku");
-        my $backend  := $compiler.backend;
-        my $name     := $backend.name;
+        my constant $backend = $compiler.backend;
+        my constant $name    = $backend.name;
 
         my $items := nqp::list_s;
         nqp::push_s($items,$name ~ '::' ~ .key ~ '=' ~ .value)
-          for $backend.config;
+          for BEGIN $backend.config;
 
-        my $language := $compiler.language;
+        my $language := BEGIN $compiler.language;
         nqp::push_s($items,$language ~ '::' ~ .key ~ '=' ~ .value)
-          for $compiler.config;
+          for BEGIN $compiler.config;
 
         nqp::push_s(
           $items,
           'repo::chain=' ~ (try $*REPO.repo-chain.map( *.gist ).join(" ")) // ''
         );
 
-        nqp::push_s($items,"distro::$_={ $*DISTRO."$_"() // '' }")
+        my $distro := $*DISTRO;
+        nqp::push_s($items,"distro::$_=" ~ ($distro."$_"() // ''))
           for <auth desc is-win name path-sep release signature version>;
 
-        nqp::push_s($items,"kernel::$_={ $*KERNEL."$_"() // '' }")
+        my $kernel := $*KERNEL;
+        nqp::push_s($items,"kernel::$_=" ~ ($kernel."$_"() // ''))
           for <arch archname auth bits desc
                hardware name release signature version>;
 
@@ -86,9 +93,7 @@ class Compiler does Systemic {
         }
     }
 
-    method supports-op($opname) {
-        nqp::getcomp("Raku").supports-op($opname)
-    }
+    method supports-op(str $name) { $compiler.supports-op($name) }
 }
 
 # vim: expandtab shiftwidth=4

--- a/t/02-rakudo/03-corekeys-6c.t
+++ b/t/02-rakudo/03-corekeys-6c.t
@@ -11,6 +11,7 @@ my @expected = (
   Q{$/},
   Q{$=pod},
   Q{$?BITS},
+  Q{$?COMPILATION-ID},
   Q{$?NL},
   Q{$?TABSTOP},
   Q{$_},

--- a/t/02-rakudo/03-corekeys-6d.t
+++ b/t/02-rakudo/03-corekeys-6d.t
@@ -11,6 +11,7 @@ my @expected = (
     Q{$/},
     Q{$=pod},
     Q{$?BITS},
+    Q{$?COMPILATION-ID},
     Q{$?NL},
     Q{$?TABSTOP},
     Q{$_},

--- a/t/02-rakudo/03-corekeys-6e.t
+++ b/t/02-rakudo/03-corekeys-6e.t
@@ -11,6 +11,7 @@ my @expected = (
     Q{$/},
     Q{$=pod},
     Q{$?BITS},
+    Q{$?COMPILATION-ID},
     Q{$?NL},
     Q{$?TABSTOP},
     Q{$_},

--- a/t/02-rakudo/03-corekeys.t
+++ b/t/02-rakudo/03-corekeys.t
@@ -13,6 +13,7 @@ my @allowed =
       Q{$/},
       Q{$=pod},
       Q{$?BITS},
+      Q{$?COMPILATION-ID},
       Q{$?NL},
       Q{$?TABSTOP},
       Q{$_},

--- a/t/02-rakudo/04-settingkeys-6c.t
+++ b/t/02-rakudo/04-settingkeys-6c.t
@@ -11,6 +11,7 @@ my %allowed = (
     Q{$/},
     Q{$=pod},
     Q{$?BITS},
+    Q{$?COMPILATION-ID},
     Q{$?NL},
     Q{$?TABSTOP},
     Q{$_},

--- a/t/02-rakudo/04-settingkeys-6e.t
+++ b/t/02-rakudo/04-settingkeys-6e.t
@@ -10,6 +10,7 @@ my %allowed = (
     Q{$/},
     Q{$=pod},
     Q{$?BITS},
+    Q{$?COMPILATION-ID},
     Q{$?NL},
     Q{$?TABSTOP},
     Q{$_},

--- a/tools/cleanup-precomps.raku
+++ b/tools/cleanup-precomps.raku
@@ -1,0 +1,19 @@
+#!/usr/bin/env raku
+
+#| Remove old precomp files from the repository chain
+unit sub MAIN();
+
+sub unlink-recursively(IO::Path:D $io, :$keep --> Nil) {
+    .d
+      ?? .basename ne $?COMPILATION-ID
+        ?? unlink-recursively($_)
+        !! Nil
+      !! .unlink for $io.dir;
+    $io.rmdir unless $keep;
+}
+
+for $*REPO.repo-chain -> $repo {
+    unlink-recursively(.add("precomp"), :keep) with $repo.?prefix;
+}
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
- but now properly, as the name of the directory in "precomp" where
  this version of Rakudo will look for precompiled files.
- use it in CompUnit::PrecompilationRepository
- since this is compile-time information, make it constants where possible
- add tools/cleanup-precomps.raku script for removing all precomp
  directories that are unreachable for this version of Rakudo