### PR TITLE
Restore .meta behaviour

### DIFF
--- a/src/core.c/CompUnit/Repository/Distribution.pm6
+++ b/src/core.c/CompUnit/Repository/Distribution.pm6
@@ -28,6 +28,7 @@ class CompUnit::Repository::Distribution does Distribution {
     }
 
     method id(--> Str:D) { nqp::sha1(self.Str) }
+    method meta(CompUnit::Repository::Distribution:D:) { %!meta.item }
 
     # Alternate instantiator called from Actions.nqp during compilation
     # of $?DISTRIBUTION

--- a/src/core.c/Distribution/Path.pm6
+++ b/src/core.c/Distribution/Path.pm6
@@ -51,6 +51,7 @@ class Distribution::Path does Distribution::Locally {
         }
     }
 
+    method meta(Distribution::Path:D:) { %!meta.item }
     method raku(--> Str:D) {
        self.^name ~ ".new($!prefix.raku(), meta-file => $!meta-file.raku())"
     }


### PR DESCRIPTION
on CompUnit::Repository::Distribution and Distribution::Path.

These were recently changed to return an unitemized hash, but
apparently there's code out there that depended on the itemization
behaviour.