### PR TITLE
Fix repo-chain changes check

### DIFF
--- a/src/core.c/CompUnit/PrecompilationRepository.pm6
+++ b/src/core.c/CompUnit/PrecompilationRepository.pm6
@@ -159,7 +159,7 @@ Need to re-check dependencies.")
 
         if $REPO-id ne $first-repo-id {
             $!RMD("Repo chain changed:
-  $repo-id
+  $REPO-id
   $first-repo-id
 Need to re-check dependencies.")
               if $!RMD;

--- a/src/core.c/CompUnit/PrecompilationRepository.pm6
+++ b/src/core.c/CompUnit/PrecompilationRepository.pm6
@@ -157,7 +157,7 @@ Need to re-check dependencies.")
             $resolve := True;
         }
 
-        if $unit-id ne $first-repo-id {
+        if $REPO-id ne $first-repo-id {
             $!RMD("Repo chain changed:
   $unit-id
   $first-repo-id

--- a/src/core.c/CompUnit/PrecompilationRepository.pm6
+++ b/src/core.c/CompUnit/PrecompilationRepository.pm6
@@ -159,7 +159,7 @@ Need to re-check dependencies.")
 
         if $REPO-id ne $first-repo-id {
             $!RMD("Repo chain changed:
-  $unit-id
+  $repo-id
   $first-repo-id
 Need to re-check dependencies.")
               if $!RMD;


### PR DESCRIPTION
It was incorrectly checking the compilation unit ID against the
what is considered the original first REPO.id in the chain.  It
should be checking against the *current* first REPO.id!