### PR TITLE
Fix unneeded dependency check

### DIFF
--- a/src/core.c/CompUnit/PrecompilationRepository.pm6
+++ b/src/core.c/CompUnit/PrecompilationRepository.pm6
@@ -247,7 +247,7 @@ Need to re-check dependencies.")
                 self.store.store-repo-id(
                   $compiler-id,
                   $precomp-unit.id,
-                  :repo-id($unit-id)
+                  :repo-id($REPO-id)
                 );
                 self.store.unlock;
             }


### PR DESCRIPTION
Commit 199888abedfe843996 in March 2020 borked the setting of the
repo-id.  This caused unneeded dependency checking for installed
modules, and a slowdown of e.g. loading NativeCall of about 80 msecs.

Now, the slowdown will only occur the first time after installation,
when the repo-id is now updated correctly so that a subsequent loading
will not have to do dependency checks.

Spotted by nine++ after looking into https://github.com/rakudo/rakudo/issues/4900