### PR TITLE
Fix orphaned trailing Pod declarands 

### DIFF
--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -4951,6 +4951,7 @@ if $*COMPILING_CORE_SETTING {
             }
             unless $*PRECEDING_DECL =:= Mu {
                 Perl6::Pod::document(self.MATCH, $*PRECEDING_DECL, $pod_block, :trailing);
+                $pod_block.set_docee($*PRECEDING_DECL);
             }
         }
     }


### PR DESCRIPTION
set-docee() was being called by Actions sub declare_variable(), which handles
leading declarator, but not by Grammar method attach_trailing_docs, which
handles trailing declarators.

fixes #4866.