### PR TITLE
Allow for unwriteable repos wrt caching repo-ids

### DIFF
--- a/src/core.c/CompUnit/PrecompilationStore/File.pm6
+++ b/src/core.c/CompUnit/PrecompilationStore/File.pm6
@@ -213,10 +213,11 @@ class CompUnit::PrecompilationStore::File
     ) {
         my $extension := ".repo-id" ~ self!tmp-extension;
         my $repo-id-file := self!file($compiler-id, $precomp-id, :$extension);
-        $repo-id-file.spurt($repo-id);
-        really-rename
-          $repo-id-file,
-          self!file($compiler-id, $precomp-id, :extension<.repo-id>);
+        with $repo-id-file.spurt($repo-id) {
+            really-rename
+              $repo-id-file,
+              self!file($compiler-id, $precomp-id, :extension<.repo-id>);
+        }
     }
 
     method delete(


### PR DESCRIPTION
As an optimization, the first writeable repo will store the repo-id
of a use target so that it does not need to look it up for a given
repo-chain everytime.  This affects core installed modules, and any
other modules installed with CUR::Staging.

We apparently do not have any unwriteable repos in the wild, but am
pretty sure that some applications in the future will want to make
sure that they have completely locked down an installed module base
by making the repos read-only.  This commit will allow for that
situation at the expense of needing to re-check dependencies again
and again (which could be easily fixed by making the repos read-only
**after** having loaded each module affected at least once using the
repo-chain they will use in production).