### PR TITLE
Fix exponentiation by large negative Ints and speedup exponentiation by any sized negative Ints

### DIFF
--- a/src/core.c/Int.pm6
+++ b/src/core.c/Int.pm6
@@ -389,7 +389,7 @@ multi sub infix:<**>(Int:D $a, Int:D $b --> Real:D) {
         !! X::Numeric::Overflow.new.Failure
       # when a**b is too big nqp::pow_I returns Inf
       !! nqp::istype(($power := nqp::pow_I($a,nqp::neg_I($b,Int),Num,Int)),Num) ||
-         (($power := CREATE_RATIONAL_FROM_INTS(1, $power, Int, Int)) == 0 && nqp::isne_I($a,0))
+         (nqp::istype(($power := CREATE_RATIONAL_FROM_INTS(1, $power, Int, Int)),Num) && nqp::iseq_n($power,0e0) && nqp::isne_I($a,0))
         ?? X::Numeric::Underflow.new.Failure
         !! $power
 }

--- a/src/core.c/Int.pm6
+++ b/src/core.c/Int.pm6
@@ -382,21 +382,16 @@ multi sub infix:<%%>(int $a, int $b --> Bool:D) {
 }
 
 multi sub infix:<**>(Int:D $a, Int:D $b --> Real:D) {
-    my $power;
-    if nqp::isge_I($b, 0) {
-        $power := nqp::pow_I($a, $b, Num, Int);
-        # when a**b is too big nqp::pow_I returns Inf
-        nqp::istype($power, Int)
-            ?? $power
-            !! X::Numeric::Overflow.new.Failure
-    }
-    else {
-        $power := nqp::pow_I($a, nqp::neg_I($b, Int), Num, Int);
-        # when a**b is too big nqp::pow_I returns Inf
-        nqp::istype($power, Num) || (($power := CREATE_RATIONAL_FROM_INTS(1, $power, Int, Int)) == 0 && nqp::isne_I($a, 0))
-            ?? X::Numeric::Underflow.new.Failure
-            !! $power
-    }
+    nqp::isge_I($b,0)
+      # when a**b is too big nqp::pow_I returns Inf
+      ?? nqp::istype((my $power := nqp::pow_I($a,$b,Num,Int)),Int)
+        ?? $power
+        !! X::Numeric::Overflow.new.Failure
+      # when a**b is too big nqp::pow_I returns Inf
+      !! nqp::istype(($power := nqp::pow_I($a,nqp::neg_I($b,Int),Num,Int)),Num) ||
+         (($power := CREATE_RATIONAL_FROM_INTS(1, $power, Int, Int)) == 0 && nqp::isne_I($a,0))
+        ?? X::Numeric::Underflow.new.Failure
+        !! $power
 }
 
 multi sub infix:<**>(int $a, int $b --> int) {

--- a/src/core.c/Int.pm6
+++ b/src/core.c/Int.pm6
@@ -381,8 +381,6 @@ multi sub infix:<%%>(int $a, int $b --> Bool:D) {
     nqp::hllbool(nqp::iseq_i(nqp::mod_i($a, $b), 0))
 }
 
-my constant UINT64_UPPER = nqp::pow_I(2, 64, Num, Int);
-
 multi sub infix:<**>(Int:D $a, Int:D $b --> Real:D) {
     my $power;
     if nqp::isge_I($b, 0) {
@@ -390,14 +388,14 @@ multi sub infix:<**>(Int:D $a, Int:D $b --> Real:D) {
         # when a**b is too big nqp::pow_I returns Inf
         nqp::istype($power, Int)
             ?? $power
-            !! Failure.new(X::Numeric::Overflow.new)
+            !! X::Numeric::Overflow.new.Failure
     }
     else {
         $power := nqp::pow_I($a, nqp::neg_I($b, Int), Num, Int);
         # when a**b is too big nqp::pow_I returns Inf
-        nqp::istype($power, Num) || (nqp::isge_I($power, UINT64_UPPER) && nqp::isne_I($a, 0))
-            ?? Failure.new(X::Numeric::Underflow.new)
-            !! 1 / $power
+        nqp::istype($power, Num) || (($power := CREATE_RATIONAL_FROM_INTS(1, $power, Int, Int)) == 0 && nqp::isne_I($a, 0))
+            ?? X::Numeric::Underflow.new.Failure
+            !! $power
     }
 }
 

--- a/src/core.c/Rat.pm6
+++ b/src/core.c/Rat.pm6
@@ -31,6 +31,8 @@ my class Rat is Cool does Rational[Int, Int] {
     }
 }
 
+my constant UINT64_UPPER = nqp::pow_I(2, 64, Num, Int);
+
 my class FatRat is Cool does Rational[Int, Int] {
     method FatRat(FatRat:D:) { self }
     method Rat(FatRat:D:) {


### PR DESCRIPTION
and speedup exponentiation by any sized negative Ints. The fix is to
revert the incorrect underflow check added in 6f6fd1f76f and the speedup
comes from bypassing `&infix:</>` when creating the `1 / $power` Rational
since we have some knowledge about the values. Also switch to use
`.Failure` on the exceptions for smaller bytecode (though `&infix:<**>`
is still too large to inline).

Rakudo builds ok and passes `make m-test m-spectest m-stresstest`. @usev6++ for spotting the problem.