### PR TITLE
Categorize exceptions thrown by role appliers

### DIFF
--- a/src/Perl6/Metamodel/RoleToClassApplier.nqp
+++ b/src/Perl6/Metamodel/RoleToClassApplier.nqp
@@ -55,11 +55,14 @@ my class RoleToClassApplier {
         for @collisions {
             if $_.private {
                 unless has_private_method($target, $_.name) {
-                    nqp::die("Private method '" ~ $_.name ~
-                        "' must be resolved by class " ~
-                        $target.HOW.name($target) ~
-                        " because it exists in multiple roles (" ~
-                        nqp::join(", ", $_.roles) ~ ")");
+                    Perl6::Metamodel::Configuration.throw_or_die(
+                        'X::Role::Unresolved::Private',
+                        "Private method '" ~ $_.name
+                        ~ "' must be resolved by class " ~ $target.HOW.name($target)
+                        ~ " because it exists in multiple roles (" ~ nqp::join(", ", $_.roles) ~ ")",
+                        :method($_),
+                        :$target,
+                    )
                 }
             }
             elsif nqp::isconcrete($_.multi) {
@@ -72,20 +75,26 @@ my class RoleToClassApplier {
                     }
                 }
                 unless $match {
-                    nqp::die("Multi method '" ~ $_.name ~ "' with signature " ~
-                        $_.multi.signature.raku ~ " must be resolved by class " ~
-                        $target.HOW.name($target) ~
-                        " because it exists in multiple roles (" ~
-                        nqp::join(", ", $_.roles) ~ ")");
+                    Perl6::Metamodel::Configuration.throw_or_die(
+                        'X::Role::Unresolved::Multi',
+                        "Multi method '" ~ $_.name ~ "' with signature "
+                        ~ $_.multi.signature.raku ~ " must be resolved by class " ~ $target.HOW.name($target)
+                        ~ " because it exists in multiple roles (" ~ nqp::join(", ", $_.roles) ~ ")",
+                        :method($_),
+                        :$target
+                    )
                 }
             }
             else {
                 unless has_method($target, $_.name, 1) {
-                    nqp::die("Method '" ~ $_.name ~
-                        "' must be resolved by class " ~
-                        $target.HOW.name($target) ~
-                        " because it exists in multiple roles (" ~
-                        nqp::join(", ", $_.roles) ~ ")");
+                    Perl6::Metamodel::Configuration.throw_or_die(
+                        'X::Role::Unresolved::Method',
+                        "Method '" ~ $_.name
+                        ~ "' must be resolved by class " ~ $target.HOW.name($target)
+                        ~ " because it exists in multiple roles (" ~ nqp::join(", ", $_.roles) ~ ")",
+                        :method($_),
+                        :$target
+                    )
                 }
             }
         }
@@ -184,9 +193,13 @@ my class RoleToClassApplier {
                     unless $satisfaction {
                         my $name := $req.name;
                         my $sig := $req.code.signature.raku;
-                        nqp::die("Multi method '$name' with signature $sig must be implemented by " ~
-                            $!target.HOW.name($!target) ~
-                            " because it is required by a role");
+                        Perl6::Metamodel::Configuration.throw_or_die(
+                            'X::Role::Unimplemented::Multi',
+                            "Multi method '$name' with signature $sig must be implemented by "
+                            ~ $!target.HOW.name($!target) ~ " because it is required by a role",
+                            :method($req),
+                            :target($!target)
+                        )
                     }
                 }
             }
@@ -196,8 +209,14 @@ my class RoleToClassApplier {
         my @attributes := $!to_compose_meta.attributes($!to_compose, :local(1));
         for @attributes {
             if $!target.HOW.has_attribute($!target, $_.name) {
-                nqp::die("Attribute '" ~ $_.name ~ "' already exists in the class '" ~
-                    $!target.HOW.name($!target) ~ "', but a role also wishes to compose it");
+                Perl6::Metamodel::Configuration.throw_or_die(
+                    'X::Role::Attribute::Exists',
+                    "Attribute '" ~ $_.name
+                    ~ "' already exists in the class '" ~ $!target.HOW.name($!target)
+                    ~ "', but a role also wishes to compose it",
+                    :target($!target),
+                    :attribute($_)
+                )
             }
             $!target.HOW.add_attribute($!target, $_);
         }

--- a/src/core.c/Attribute.pm6
+++ b/src/core.c/Attribute.pm6
@@ -18,7 +18,7 @@ my class Attribute { # declared in BOOTSTRAP
     #     has $!required;
     #     has Mu $!container_initializer;
     #     has Attribute $!original;
-    #     has Attribute $!composed;
+    #     has int $!composed;
 
     method compose(Mu $package, :$compiler_services) {
         return if $!composed;

--- a/src/core.c/Exception.pm6
+++ b/src/core.c/Exception.pm6
@@ -1750,6 +1750,79 @@ my class X::Role::Group::Documenting is Exception {
     }
 }
 
+my role X::RoleApplier is Exception {
+    has Mu $.target is required;
+}
+
+my role X::RoleApplier::Method {
+    # This attribute could either be of MultiToIncorporate or Collisions classes, depending on particular exception
+    # kind. Both a MOP classes without `item` method.  Thefore the attribute must be accessed either as $!method or as
+    # self.method, not $.method.
+    has Mu $.method is required;
+}
+
+my class X::Role::Unimplemented::Multi does X::RoleApplier does X::RoleApplier::Method {
+    method message() {
+        "Multi method '" ~ self.method.name
+        ~ "' with signature " ~ self.method.code.signature.raku
+        ~ " must be implemented by " ~ self.target.^name
+        ~ " because it is required by a role"
+    }
+}
+
+my class X::Role::Unresolved does X::RoleApplier does X::RoleApplier::Method {
+    method must-be-resolved {
+        ~ "' must be resolved by class " ~ $!target.^name
+        ~ " because it exists in multiple roles ("
+        ~ nqp::hllizefor($!method.roles, 'Raku').join(", ")
+        ~ ")"
+    }
+}
+
+my class X::Role::Unresolved::Private is X::Role::Unresolved {
+    method message {
+        "Private method '" ~ self.method.name ~ self.must-be-resolved
+    }
+}
+
+my class X::Role::Unresolved::Multi is X::Role::Unresolved {
+    method message {
+        "Multi method '" ~ self.method.name
+        ~ "' with signature " ~ self.method.multi.signature.raku
+        ~ self.must-be-resolved
+    }
+}
+
+my class X::Role::Unresolved::Method is X::Role::Unresolved {
+    method message {
+        "Method '" ~ self.method.name ~ self.must-be-resolved
+    }
+}
+
+my role X::Role::Attribute does X::RoleApplier {
+    has Attribute:D $.attribute is required;
+}
+
+my class X::Role::Attribute::Exists does X::Role::Attribute {
+    method message {
+        "Attribute '" ~ $!attribute.name
+        ~ "' already exists in the class '" ~ self.target.^name
+        ~ "', but a role also wishes to compose it"
+    }
+}
+
+my class X::Role::Attribute::Conflicts does X::Role::Attribute {
+    # Conflicting roles
+    has Mu $.from1 is required;
+    has Mu $.from2 is required;
+    method message {
+        "Attribute '" ~ $!attribute.name
+        ~ "' conflicts in role '" ~ self.target.^name
+        ~ "' composition: declared in both '" ~ $!from1.^name
+        ~ "' and '" ~ $!from2.^name ~ "'"
+    }
+}
+
 my class X::Syntax::Comment::Embedded does X::Syntax {
     method message() { "Opening bracket required for #` comment" }
 }


### PR DESCRIPTION
This is one more step in replacing plain `nqp::die` calls with specific exceptions using `Perl6::Metamodel::Configuration.throw_or_die`. Affected are `Perl6::Metamodel::RoleToRoleApplier` and `Perl6::Metamodel::RoleToClassApplier`.

Alongside with categorization `RoleToRoleApplier` has been slightly optimized to get rid of a nested loop which was re-scanning target role attributes for each role applied. Instead a temporary hash of already existing/added attributes is used.