### PR TITLE
Cleanup scope exit-handling

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -4418,7 +4418,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
         # them. No parameters also means no inlining.
         return 0 unless @params;
 
-        my $world   := $*W;
+        my $world  := $*W;
         my $Param  := $world.find_single_symbol_in_setting('Parameter');
         my @p_objs := nqp::getattr($sig, $world.find_single_symbol_in_setting('Signature'), '@!params');
         my %arg_placeholders;

--- a/src/Perl6/Optimizer.nqp
+++ b/src/Perl6/Optimizer.nqp
@@ -3895,7 +3895,7 @@ class Perl6::Optimizer {
           ?? nqp::getattr($code, $block, '$!phasers')
           !! nqp::null();
         if $count == 1
-          && !nqp::ishash($phasers)
+          && !nqp::isconcrete($phasers)
           && %range_bounds{$c2.name}($c2) -> @fls {
             if $reverse {
                 my $tmp := @fls[0];

--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -2312,9 +2312,8 @@ BEGIN {
                 nqp::setcodeobj($do_cloned, $cloned);
 #?if !jvm
                 my $phasers := nqp::getattr($dcself, Block, '$!phasers');
-                if nqp::isconcrete($phasers) {
-                    $dcself."!clone_phasers"($cloned, $phasers);
-                }
+                $dcself."!clone_phasers"($cloned, $phasers)
+                  if nqp::ishash($phasers);
 #?endif
                 my $compstuff := nqp::getattr($dcself, Code, '@!compstuff');
                 unless nqp::isnull($compstuff) {
@@ -2383,10 +2382,10 @@ BEGIN {
 #?endif
         }));
     Block.HOW.add_method(Block, '!capture_phasers', nqp::getstaticcode(sub ($self) {
-            my $dcself    := nqp::decont($self);
+            my $dcself  := nqp::decont($self);
 #?if !jvm
-            my $phasers   := nqp::getattr($dcself, Block, '$!phasers');
-            if nqp::isconcrete($phasers) {
+            my $phasers := nqp::getattr($dcself, Block, '$!phasers');
+            if nqp::ishash($phasers) {
                 my @next := nqp::atkey($phasers, 'NEXT');
                 if nqp::islist(@next) {
                     my int $i := -1;
@@ -4055,93 +4054,114 @@ nqp::sethllconfig('Raku', nqp::hash(
     },
     'exit_handler', -> $coderef, $resultish {
         unless nqp::p6inpre() {
-            my %phasers :=
-              nqp::getattr(nqp::getcodeobj($coderef),Block,'$!phasers');
-            my @leaves := nqp::atkey(%phasers, '!LEAVE-ORDER');
-            my @posts  := nqp::atkey(%phasers, 'POST');
-            my @exceptions;
-            unless nqp::isnull(@leaves) {
+            # when we get here, we assume the $!phasers attribut is concrete.
+            # if it is *not* a hash, it is a lone LEAVE phaser, the most
+            # commenly used phaser (in the core at least).
+            my $phasers := nqp::getattr(
+              nqp::getcodeobj($coderef),Block,'$!phasers'
+            );
 
-                # only have a single LEAVEish phaser, so no frills needed
-                if nqp::elems(@leaves) == 1 && nqp::elems(%phasers) == 1 {
-#?if jvm
-                    nqp::decont(nqp::atpos(@leaves,0))();
-#?endif
-#?if !jvm
-                    nqp::p6capturelexwhere(
-                      nqp::decont(nqp::atpos(@leaves,0)).clone)();
-#?endif
-                    # don't bother to CATCH, there can only be one exception
-                }
-
-                # slow path here
-                else {
-                    my @keeps  := nqp::atkey(%phasers, 'KEEP');
-                    my @undos  := nqp::atkey(%phasers, 'UNDO');
+            # slow path here
+            if nqp::ishash($phasers) {
+                my @leaves := nqp::atkey($phasers, '!LEAVE-ORDER');
+                my @posts  := nqp::atkey($phasers, 'POST');
+                my @exceptions;
+                unless nqp::isnull(@leaves) {
+                    my @keeps  := nqp::atkey($phasers, 'KEEP');
+                    my @undos  := nqp::atkey($phasers, 'UNDO');
                     my int $n := nqp::elems(@leaves);
                     my int $i := -1;
-                    my int $run;
-                    my $phaser;
-                    while ++$i < $n {
-                        $phaser := nqp::decont(nqp::atpos(@leaves, $i));
-                        $run := 1;
-                        unless nqp::isnull(@keeps) {
-                            for @keeps {
-                                if nqp::eqaddr(nqp::decont($_),$phaser) {
-                                    $run := !nqp::isnull($resultish) &&
-                                             nqp::isconcrete($resultish) &&
-                                             $resultish.defined;
-                                    last;
-                                }
-                            }
-                        }
-                        unless nqp::isnull(@undos) {
-                            for @undos {
-                                if nqp::eqaddr(nqp::decont($_),$phaser) {
-                                    $run := nqp::isnull($resultish) ||
-                                            !nqp::isconcrete($resultish) ||
-                                            !$resultish.defined;
-                                    last;
-                                }
-                            }
-                        }
-                        if $run {
+
+                    # fast leave path
+                    if nqp::isnull(@leaves) && nqp::isnull(@undos) {
+                        while ++$i < $n {
+                            CATCH { nqp::push(@exceptions, $_) }
 #?if jvm
-                            $phaser();
+                            nqp::atpos(@leaves, $i))();
 #?endif
 #?if !jvm
-                            nqp::p6capturelexwhere($phaser.clone())();
+                            nqp::p6capturelexwhere(
+                              nqp::atpos(@leaves, $i).clone()
+                            )();
 #?endif
-                            CATCH { nqp::push(@exceptions, $_) }
+                        }
+                    }
+
+                    # slow leave paths
+                    else {
+                        my int $run;
+                        my $phaser;
+                        while ++$i < $n {
+                            $phaser := nqp::atpos(@leaves, $i);
+                            $run := 1;
+                            unless nqp::isnull(@keeps) {
+                                for @keeps {
+                                    if nqp::eqaddr($_,$phaser) {
+                                        $run := !nqp::isnull($resultish) &&
+                                                 nqp::isconcrete($resultish) &&
+                                                 $resultish.defined;
+                                        last;
+                                    }
+                                }
+                            }
+                            unless nqp::isnull(@undos) {
+                                for @undos {
+                                    if nqp::eqaddr($_,$phaser) {
+                                        $run := nqp::isnull($resultish) ||
+                                                !nqp::isconcrete($resultish) ||
+                                                !$resultish.defined;
+                                        last;
+                                    }
+                                }
+                            }
+                            if $run {
+                                CATCH { nqp::push(@exceptions, $_) }
+#?if jvm
+                                $phaser();
+#?endif
+#?if !jvm
+                                nqp::p6capturelexwhere($phaser.clone())();
+#?endif
+                            }
                         }
                     }
                 }
-            }
 
-            unless nqp::isnull(@posts) {
-                my $value := nqp::ifnull($resultish,Mu);
-                my int $n := nqp::elems(@posts);
-                my int $i := -1;
-                while ++$i < $n {
+                unless nqp::isnull(@posts) {
+                    my $value := nqp::ifnull($resultish,Mu);
+                    my int $n := nqp::elems(@posts);
+                    my int $i := -1;
+                    while ++$i < $n {
 #?if jvm
-                    nqp::atpos(@posts, $i)($value);
+                        nqp::atpos(@posts, $i)($value);
 #?endif
 #?if !jvm
-                    nqp::p6capturelexwhere(nqp::atpos(@posts,$i).clone)($value);
+                        nqp::p6capturelexwhere(nqp::atpos(@posts,$i).clone)($value);
 #?endif
-                    CATCH { nqp::push(@exceptions, $_); last; }
+                        CATCH { nqp::push(@exceptions, $_); last; }
+                    }
+                }
+
+                if @exceptions {
+                    nqp::elems(@exceptions) > 1
+                      ?? Perl6::Metamodel::Configuration.throw_or_die(
+                           'X::PhaserExceptions',
+                           "Multiple exceptions were thrown by LEAVE/POST phasers",
+                           :exceptions(@exceptions)
+                         )
+                      !! nqp::rethrow(@exceptions[0]);
                 }
             }
 
-            if @exceptions {
-                if nqp::elems(@exceptions) > 1 {
-                    Perl6::Metamodel::Configuration.throw_or_die(
-                        'X::PhaserExceptions',
-                        "Multiple exceptions were thrown by LEAVE/POST phasers",
-                        :exceptions(@exceptions)
-                    );
-                }
-                nqp::rethrow(@exceptions[0]);
+            # only have a lone LEAVE phaser, so no frills needed
+            # don't bother to CATCH, there can only be one exception
+            else {
+#?if jvm
+                $phasers();
+#?endif
+#?if !jvm
+                nqp::p6capturelexwhere($phasers.clone)();
+#?endif
             }
         }
     },

--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -4056,7 +4056,7 @@ nqp::sethllconfig('Raku', nqp::hash(
         unless nqp::p6inpre() {
             # when we get here, we assume the $!phasers attribut is concrete.
             # if it is *not* a hash, it is a lone LEAVE phaser, the most
-            # commenly used phaser (in the core at least).
+            # commonly used phaser (in the core at least).
             my $phasers := nqp::getattr(
               nqp::getcodeobj($coderef),Block,'$!phasers'
             );

--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -4074,24 +4074,32 @@ nqp::sethllconfig('Raku', nqp::hash(
 
                     for @leaves -> $phaser {
                         CATCH { nqp::push(@exceptions, $_) }
+
+                        # a KEEP/UNDO phaser
                         if nqp::islist($phaser) {
                             my $name := nqp::atpos($phaser,0);
                             if ($name eq 'KEEP' && $valid)
                               || ($name eq 'UNDO' && !$valid) {
-                                $phaser := nqp::atpos($phaser,1);
-                            }
-                            else {
-                                next;
+#?if jvm
+                                nqp::atpos($phaser,1)();
+#?endif
+#?if !jvm
+                                nqp::p6capturelexwhere(
+                                  nqp::atpos($phaser,1).clone
+                                )();
+#?endif
                             }
                         }
 
-                        # an ordinary LEAVE phaser, or firing KEEP/UNDO phaser
+                        # an ordinary LEAVE phaser
+                        else {
 #?if jvm
-                        $phaser();
+                            $phaser();
 #?endif
 #?if !jvm
-                        nqp::p6capturelexwhere($phaser.clone)();
+                            nqp::p6capturelexwhere($phaser.clone)();
 #?endif
+                        }
                     }
                 }
 

--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -4077,7 +4077,7 @@ nqp::sethllconfig('Raku', nqp::hash(
                         while ++$i < $n {
                             CATCH { nqp::push(@exceptions, $_) }
 #?if jvm
-                            nqp::atpos(@leaves, $i))();
+                            nqp::atpos(@leaves, $i)();
 #?endif
 #?if !jvm
                             nqp::p6capturelexwhere(

--- a/src/core.c/Block.pm6
+++ b/src/core.c/Block.pm6
@@ -58,7 +58,14 @@ my class Block { # declared in BOOTSTRAP
             $!phasers := nqp::hash unless nqp::isconcrete($!phasers);
 
             if nqp::iseq_s($name,'KEEP') || nqp::iseq_s($name,'UNDO') {
-                self.unshift-phaser('!LEAVE-ORDER', &block);
+                nqp::unshift(
+                  nqp::ifnull(
+                    nqp::atkey($!phasers,'!LEAVE-ORDER'),
+                    nqp::bindkey(
+                      $!phasers,'!LEAVE-ORDER',nqp::create(IterationBuffer))
+                  ),
+                  nqp::list($name,&block)
+                );
                 self.unshift-phaser($name, &block);
             }
             else {

--- a/t/02-rakudo/03-corekeys-6c.t
+++ b/t/02-rakudo/03-corekeys-6c.t
@@ -611,7 +611,6 @@ my @expected = (
   Q{ParallelSequence},
   Q{Parameter},
   Q{Perl},
-  Q{PhasersList},
   Q{Planned},
   Q{Pod},
   Q{Positional},

--- a/t/02-rakudo/03-corekeys-6d.t
+++ b/t/02-rakudo/03-corekeys-6d.t
@@ -611,7 +611,6 @@ my @expected = (
     Q{ParallelSequence},
     Q{Parameter},
     Q{Perl},
-    Q{PhasersList},
     Q{Planned},
     Q{Pod},
     Q{Positional},

--- a/t/02-rakudo/03-corekeys-6e.t
+++ b/t/02-rakudo/03-corekeys-6e.t
@@ -614,7 +614,6 @@ my @expected = (
     Q{ParallelSequence},
     Q{Parameter},
     Q{Perl},
-    Q{PhasersList},
     Q{Planned},
     Q{Pod},
     Q{Positional},

--- a/t/02-rakudo/03-corekeys.t
+++ b/t/02-rakudo/03-corekeys.t
@@ -614,7 +614,6 @@ my @allowed =
       Q{ParallelSequence},
       Q{Parameter},
       Q{Perl},
-      Q{PhasersList},
       Q{Planned},
       Q{Pod},
       Q{Positional},

--- a/t/02-rakudo/04-settingkeys-6c.t
+++ b/t/02-rakudo/04-settingkeys-6c.t
@@ -611,7 +611,6 @@ my %allowed = (
     Q{ParallelSequence},
     Q{Parameter},
     Q{Perl},
-    Q{PhasersList},
     Q{Planned},
     Q{Pod},
     Q{Positional},

--- a/t/02-rakudo/04-settingkeys-6e.t
+++ b/t/02-rakudo/04-settingkeys-6e.t
@@ -612,7 +612,6 @@ my %allowed = (
     Q{ParallelSequence},
     Q{Parameter},
     Q{Perl},
-    Q{PhasersList},
     Q{Planned},
     Q{Pod},
     Q{Positional},


### PR DESCRIPTION
An optimization to handle a single LEAVEish phaser block, was broken.
This meant that all block exits that had any phaser, would take the
slow path.

Instead if a block contains *only* a single LEAVE phaser, a super fast
path is taken on exiting the block, without needing any hash lookups.
This e.g. reduces the overhead of Lock.protect by 20%.  And there are
4 of these for *every* startup of rakudo.

This commit changes / fixes the following:
- Block.$!phasers now either is not concrete (no phasers), contains
  a block (a single LEAVE phaser), or contains a hash with phasers (as
  before)
- the Block API for phasers remains the same, handling the new meanings
  of the $!phasers attribute transparently
- The add phaser handling code has been adapted to support the lone
  LEAVE phaser case
- the exit-handler only gets called if $!phasers is concrete: it
  now only has to check whether it is a hash (if not, take the fast
  path, directly executing what is in $!phasers).
- the slow exit-handler path also has a fast path for scopes that
  have leavish phasers, but no KEEP / UNDO phasers
- unnecessary deconting has been remove from the exit handler.
- the PhasersList class has been removed: it predated the IterationBuffer
  class, and it was basically just that.  Changing that, simplified
  HLLizing some Block phaser API calls
- the brittle handling of scopes by the "will" trait on variables, has
  been changed to dynamically search for the variable in question