### PR TITLE
Simplify setting up standard handles

### DIFF
--- a/src/core.c/Encoding/Registry.pm6
+++ b/src/core.c/Encoding/Registry.pm6
@@ -68,6 +68,8 @@ my class Encoding::Registry {
             )
         }
     }
+
+    method utf8() is implementation-detail { nqp::atkey($lookup,"utf8") }
 }
 
 # vim: expandtab shiftwidth=4

--- a/src/core.c/io_operators.pm6
+++ b/src/core.c/io_operators.pm6
@@ -7,7 +7,12 @@
     my constant NL-OUT   = "\n";
     my constant ENCODING = "utf8";
 
+#?if jvm
+    my $in := do {
+#?endif
+#?if !jvm
     my $in := BEGIN {
+#?endif
         my $handle := nqp::p6bindattrinvres(
           nqp::create(IO::Handle),IO::Handle,'$!path',nqp::p6bindattrinvres(
             nqp::create(IO::Special),IO::Special,'$!what','<STDIN>'
@@ -19,7 +24,12 @@
         nqp::getattr($handle,IO::Handle,'$!encoding') = ENCODING;
         $handle
     }
+#?if jvm
+    my $out := do {
+#?endif
+#?if !jvm
     my $out := BEGIN {
+#?endif
         my $handle := nqp::p6bindattrinvres(
           nqp::create(IO::Handle),IO::Handle,'$!path',nqp::p6bindattrinvres(
             nqp::create(IO::Special),IO::Special,'$!what','<STDOUT>'
@@ -31,7 +41,12 @@
         nqp::getattr($handle,IO::Handle,'$!encoding') = ENCODING;
         $handle
     }
+#?if jvm
+    my $err := do {
+#?endif
+#?if !jvm
     my $err := BEGIN {
+#?endif
         my $handle := nqp::p6bindattrinvres(
           nqp::create(IO::Handle),IO::Handle,'$!path',nqp::p6bindattrinvres(
             nqp::create(IO::Special),IO::Special,'$!what','<STDERR>'

--- a/src/core.c/io_operators.pm6
+++ b/src/core.c/io_operators.pm6
@@ -1,5 +1,3 @@
-my class IO::ArgFiles { ... }
-
 {
     # Set up the skeletons of the IO::Handle objects that can be setup
     # at compile time.  Then, when running the mainline of the setting

--- a/src/core.c/io_operators.pm6
+++ b/src/core.c/io_operators.pm6
@@ -34,18 +34,18 @@ augment class Rakudo::Internals {
       'ERR', setup-handle('<STDERR>')
     );
 
+    my $encoding := Encoding::Registry.utf8;
+    my $encoder  := $encoding.encoder(:translate-nl);
+    my $decoder  := $encoding.decoder(:translate-nl);
     method activate-std(str $name, Mu \PIO) {
-        my \HANDLE = nqp::atkey($skeletons,$name);
+        my $handle := nqp::atkey($skeletons,$name);
         nqp::setbuffersizefh(PIO,8192) unless nqp::isttyfh(PIO);
 
-        my $encoding = Encoding::Registry.find(ENCODING);
         nqp::bindattr(
-          HANDLE,IO::Handle,'$!decoder',$encoding.decoder(:translate-nl)
+          $handle,IO::Handle,'$!decoder',$decoder
         ).set-line-separators(NL-IN);
-        nqp::bindattr(
-          HANDLE,IO::Handle,'$!encoder',$encoding.encoder(:translate-nl)
-        );
-        nqp::p6bindattrinvres(HANDLE,IO::Handle,'$!PIO',PIO)
+        nqp::bindattr($handle,IO::Handle,'$!encoder',$encoder);
+        nqp::p6bindattrinvres($handle,IO::Handle,'$!PIO',PIO)
     }
 }
 


### PR DESCRIPTION
We don't have any thread-safety issues with setting up the standard
handles, and we always use utf8-encoding for them.  So we can set them
up without thread-safety as they are all part of running the mainline.

This commit:
- adds an implementation-detail method to get the utf8 encoding object
  in an thread-unsafe manner
- caches the encoder / decoder objects, so we don't need to look them
  up again and again for the 3 standard handles
- thus removes the need for 3 Lock.protect cases

This appears to scrape off a few msecs from each rakudo startup