### PR TITLE
Allow :from<Raku> in identities

### DIFF
--- a/src/core.c/CompUnit/DependencySpecification.pm6
+++ b/src/core.c/CompUnit/DependencySpecification.pm6
@@ -43,7 +43,7 @@ class CompUnit::DependencySpecification {
     method !stringify() {
         my $parts := nqp::list_s($!short-name);
         nqp::push_s($parts,":from<$!from>")
-          if $!from ne 'Perl6';
+          if $!from ne 'Raku' && $!from ne 'Perl6';
         nqp::push_s($parts,":ver<$!version-matcher>")
           if nqp::defined($!version-matcher);
         nqp::push_s($parts,":auth<$!auth-matcher>")
@@ -64,7 +64,7 @@ class CompUnit::DependencySpecification {
           "CompUnit::DependencySpecification.new(:short-name<$!short-name>"
         );
         nqp::push_s($parts,",:from<$!from>")
-          if $!from ne 'Perl6';
+          if $!from ne 'Raku' && $!from ne 'Perl6';
         nqp::push_s($parts,",:version-matcher<$!version-matcher>")
           if nqp::defined($!version-matcher);
         nqp::push_s($parts,",:auth-matcher<$!auth-matcher>")

--- a/src/core.c/CompUnit/Repository/FileSystem.pm6
+++ b/src/core.c/CompUnit/Repository/FileSystem.pm6
@@ -174,7 +174,7 @@ class CompUnit::Repository::FileSystem
         ));
     }
     multi method candidates(CompUnit::DependencySpecification $spec) {
-        return Empty unless $spec.from eq 'Perl6';
+        return Empty unless $spec.from eq 'Raku' | 'Perl6';
 
         my $distribution = self!distribution;
 

--- a/src/core.c/CompUnit/Repository/Installation.pm6
+++ b/src/core.c/CompUnit/Repository/Installation.pm6
@@ -479,7 +479,7 @@ sub MAIN(:$name, :$auth, :$ver, *@, *%) {
             api-matcher     => $api,
     }
     multi method candidates(CompUnit::DependencySpecification:D $spec) {
-        if $spec.from eq 'Perl6'
+        if $spec.from eq 'Raku' | 'Perl6'
           # $lookup is a file system resource that acts as a fast meta data
           # lookup for a given module short name.
           && (my $lookup = self!short-dir.add(nqp::sha1($spec.short-name))).e {


### PR DESCRIPTION
This allows identities to be specified with :from<Raku> so that we
can start migrating from the current default of "Perl6".  Note that
this does **not** make "Raku" the default yet, as some modules in
the ecosystem might still check for "Perl6" explicitely.

Creation of CompUnit and CompUnit::DependencySpecification objects
should be next (as well as their creation from World)