### PR TITLE
Fix delegation to pun

### DIFF
--- a/src/Perl6/Metamodel/RolePunning.nqp
+++ b/src/Perl6/Metamodel/RolePunning.nqp
@@ -85,7 +85,7 @@ role Perl6::Metamodel::RolePunning {
             $!made_pun := 1;
         }
 
-        my $meth := $!pun.HOW.find_method($!pun, $name);
+        my $meth := $!pun.HOW.find_method($!pun, $name, |%c);
         unless nqp::isconcrete($meth) {
             return nqp::null();
         }

--- a/src/Perl6/Metamodel/RolePunning.nqp
+++ b/src/Perl6/Metamodel/RolePunning.nqp
@@ -66,11 +66,13 @@ role Perl6::Metamodel::RolePunning {
             $!pun := self.make_pun($obj);
             $!made_pun := 1;
         }
-        unless nqp::can($!pun, $name) {
+
+        my $meth := $!pun.HOW.find_method($!pun, $name);
+        unless nqp::isconcrete($meth) {
             return nqp::null();
         }
         -> $inv, *@pos, *%named {
-            $!pun."$name"(|@pos, |%named)
+            $meth($!pun, |@pos, |%named);
         }
     }
 

--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -4422,7 +4422,10 @@ nqp::bindhllsym('Raku', 'Scalar', Scalar);
 nqp::bindhllsym('Raku', 'ScalarVAR', ScalarVAR);
 nqp::bindhllsym('Raku', 'default_cont_spec',
     Scalar.HOW.cache_get(Scalar, 'default_cont_spec'));
+
+# Stash types that may be instantiated by the Metamodel
 nqp::bindhllsym('Raku', 'Capture', Capture);
+nqp::bindhllsym('Raku', 'Proxy', Proxy);
 
 #?if jvm
 # On JVM, set up JVM interop bits.

--- a/src/vm/moar/dispatchers.nqp
+++ b/src/vm/moar/dispatchers.nqp
@@ -816,22 +816,6 @@ nqp::dispatch('boot-syscall', 'dispatcher-register', 'raku-meth-call', -> $captu
             $capture);
     }
     else {
-        # See if we're making the method lookup on a pun; if so, rewrite the args
-        # to do the call on the pun.
-        if nqp::istype($how, Perl6::Metamodel::RolePunning) &&
-                $how.is_method_call_punned($obj, $name) {
-            nqp::dispatch('boot-syscall', 'dispatcher-guard-type',
-                nqp::dispatch('boot-syscall', 'dispatcher-track-arg', $capture, 0));
-            $obj := $how.pun($obj);
-            $how := $obj.HOW;
-            $capture := nqp::dispatch('boot-syscall', 'dispatcher-insert-arg-literal-obj',
-                nqp::dispatch('boot-syscall', 'dispatcher-drop-arg', $capture, 0),
-                0, $obj);
-            $capture := nqp::dispatch('boot-syscall', 'dispatcher-insert-arg-literal-obj',
-                nqp::dispatch('boot-syscall', 'dispatcher-drop-arg', $capture, 2),
-                2, $obj);
-        }
-
         # Try to resolve the method call.
         # TODO Assorted optimizations are possible here later on to speed up some
         # kinds of dispatch, including:


### PR DESCRIPTION
If a method is called on a _containerized_ role, the call is now delegated to a `Proxy` that fetches the pun until something is stored in the container.  This resolves #4916.