### PR TITLE
Fix cases where DESTROY is invoked on its own stack

### DIFF
--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -4224,6 +4224,12 @@ nqp::sethllconfig('Raku', nqp::hash(
         }
     },
     'finalize_handler', -> @objs {
+        # Reinstate $*STACK-ID if invoked in a specilized finalization thread.
+        # Preserve the current stack ID otherwise.
+        my $*STACK-ID :=
+            nqp::ifnull(
+                nqp::getlexreldyn(nqp::ctxcaller(nqp::ctx()), '$*STACK-ID'),
+                Perl6::Metamodel::Configuration.next_id );
         for @objs -> $o {
             for $o.HOW.destroyers($o) -> $d {
                 $d($o)

--- a/src/core.c/Rakudo/Internals.pm6
+++ b/src/core.c/Rakudo/Internals.pm6
@@ -1831,4 +1831,6 @@ proto sub exit($?, *%) {*}
 multi sub exit() { &*EXIT(0) }
 multi sub exit(Int(Any) $status) { &*EXIT($status) }
 
+Metamodel::Configuration.set_utility_class(Rakudo::Internals);
+
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
Finalization code could either be invoked as part of an existing call stack or by a dedicated GC thread. In the latter case it didn't have `$*STACK-ID` set. Now we take care of it.

Because finalization is handled by the bootstrap, it doesn't have access to `Rakudo::Internals` to use `NEXT-ID` method. By keeping in mind that it might be not the only case when `$*STACK-ID` would need to be set by NQP code, method `next_id` has been added to `Perl6::Metamodel::Configuration`. It uses `Rakudo::Internals` when available and falls back to producing negative IDs otherwise. The method is thread-safe on fallback path by employing NQPLock.