### PR TITLE
Subclasses of .Date(Time) coercion

### DIFF
--- a/src/core.c/DateTime.pm6
+++ b/src/core.c/DateTime.pm6
@@ -600,7 +600,13 @@ my class DateTime does Dateish {
     proto method Date() {*}
     multi method Date(DateTime:D: --> Date:D) { Date.new($!year,$!month,$!day) }
     multi method Date(DateTime:U: --> Date:U) { Date }
-    method DateTime() { self }
+    method DateTime() { 
+        nqp::eqaddr(self.WHAT,DateTime)
+          ?? self
+          !! nqp::create(DateTime)!SET-SELF:
+               $!year, $!month, $!day, $!hour, $!minute, $!second,
+               $!timezone, &!formatter
+    }
 
     multi method raku(DateTime:D: --> Str:D) {
         self.^name


### PR DESCRIPTION
Calling .Date on a subclass of Date, and .DateTime on a subclass
of DateTime, returned the object itself even if it was a subclass.

This commit makes sure that if you call .Date(Time) on a subclass
of Date(Time), you will actually get the appropriate Date(Time)
object.

This should remove the need of subclasses to provide this logic,
such as e.g. in Games::TauStation::DateTime.

If accepted, this should probably also be done for all core class
coercers.