### PR TITLE
[WIP] Enhance interop of generics, roles, and classes, Raku or nqp

### DIFF
--- a/src/Perl6/Metamodel/CurriedRoleHOW.nqp
+++ b/src/Perl6/Metamodel/CurriedRoleHOW.nqp
@@ -242,7 +242,7 @@ class Perl6::Metamodel::CurriedRoleHOW
         }
         if nqp::can($checkee.HOW, 'role_typecheck_list') {
             for $checkee.HOW.role_typecheck_list($checkee) {
-                if nqp::istype($_.HOW, self.WHAT) && !$_.HOW.archetypes.generic {
+                if nqp::istype($_.HOW, self.WHAT) {
                     if nqp::decont($_.HOW.curried_role($_)) =:= $crdc {
                         @cands.push($_);
                     }

--- a/src/Perl6/Metamodel/CurriedRoleHOW.nqp
+++ b/src/Perl6/Metamodel/CurriedRoleHOW.nqp
@@ -212,7 +212,7 @@ class Perl6::Metamodel::CurriedRoleHOW
             return 1
         }
         for @!parent_typecheck_list -> $parent {
-            if nqp::istype($decont, $parent) {
+            if nqp::istype($parent, $decont) {
                 return 1
             }
         }

--- a/src/Perl6/Metamodel/CurriedRoleHOW.nqp
+++ b/src/Perl6/Metamodel/CurriedRoleHOW.nqp
@@ -24,7 +24,7 @@ class Perl6::Metamodel::CurriedRoleHOW
     does Perl6::Metamodel::InvocationProtocol
 {
     has $!curried_role;
-    has $!candidate;                # Will contain matching candidate from curried role group
+    has $!binding;                  # Will contain matching candidate from curried role group
     has @!pos_args;
     has %!named_args;
     has @!role_typecheck_list;
@@ -81,25 +81,22 @@ class Perl6::Metamodel::CurriedRoleHOW
         nqp::settypecheckmode($type, 2);
     }
 
+    method bind($obj, $curry = $obj) {
+        $!curried_role.HOW.bind($!curried_role, $curry)
+    }
+
     method parameterize_roles($obj) {
-        my @pos_args;
-        nqp::push(@pos_args, $obj);
-        for @!pos_args {
-            nqp::push(@pos_args, $_);
-        }
-        if nqp::istype($!curried_role.HOW, Perl6::Metamodel::ParametricRoleGroupHOW) {
-            $!candidate := $!curried_role.HOW.select_candidate($!curried_role, @pos_args, %!named_args);
-            my $candidate-how := $!candidate.HOW;
+        my $binding_how := nqp::how_nd(my $binding := self.bind($obj));
 
-            self.set_language_revision($obj, $candidate-how.language-revision($!candidate));
-
-            my $type_env;
+        unless $binding_how =:= self {
+            my $type_env := nqp::null();
             try {
-                my @result := $candidate-how.body_block($!candidate)(|@pos_args, |%!named_args);
-                $type_env := @result[1];
+                my @result := $binding_how.body_block($binding)($obj, |@!pos_args, |%!named_args);
+                $type_env := @result[1] // nqp::null();
             }
-            for $candidate-how.roles($!candidate, :!transitive) -> $role {
-                if $role.HOW.archetypes.generic && $type_env {
+
+            for $binding_how.roles($binding, :!transitive) -> $role {
+                if nqp::isconcrete($type_env) && $role.HOW.archetypes.generic {
                     $role := $role.HOW.instantiate_generic($role, $type_env);
                 }
                 unless $role.HOW.archetypes.generic || $role.HOW.archetypes.parametric {
@@ -114,44 +111,45 @@ class Perl6::Metamodel::CurriedRoleHOW
                 }
                 self.add_role($obj, $role);
             }
-            # Contrary to roles, we only consider generic parents. I.e. cases like:
-            # role R[::T] is T {}
-            if $type_env {
-                for $candidate-how.parents($!candidate, :local) -> $parent {
-                    if $parent.HOW.archetypes.generic {
-                        my $ins := $parent.HOW.instantiate_generic($parent, $type_env);
-                        nqp::push(@!parent_typecheck_list, $ins)
-                    }
+
+            my @ptl;
+            for $binding_how.parents($binding, :local) -> $parent {
+                if nqp::isconcrete($type_env) && $parent.HOW.archetypes.generic {
+                    $parent := $parent.HOW.instantiate_generic($parent, $type_env);
                 }
+                nqp::push(@ptl, $parent);
             }
+            @!parent_typecheck_list := @ptl;
         }
-        self.update_role_typecheck_list($obj);
+
+        if $binding_how =:= self {
+            $!binding := nqp::null();
+        }
+        else {
+            self.set_language_revision($obj, $binding_how.language-revision($binding));
+            $!binding := $binding;
+        }
+
+        self.update_role_typecheck_list($obj)
+    }
+
+    method is_composite($obj) {
+        nqp::isconcrete($!binding // nqp::null())
     }
 
     method update_role_typecheck_list($obj) {
         my @rtl;
-        nqp::push(@rtl, $!curried_role);
-        # XXX Not sure if it makes sense adding roles from group into the type checking.
-        # for $!curried_role.HOW.role_typecheck_list($obj) {
-        #     nqp::push(@rtl, $_);
-        # }
         for self.roles_to_compose($obj) -> $role {
-            my $how := $role.HOW;
-            if $how.archetypes.composable() || $how.archetypes.composalizable() {
-                nqp::push(@rtl, $role);
-                for $how.role_typecheck_list($role) {
-                    nqp::push(@rtl, $_);
-                }
-            }
+            nqp::push(@rtl, $role);
+            nqp::splice(@rtl, $role.HOW.role_typecheck_list($role), nqp::elems(@rtl), 0);
         }
-        @!role_typecheck_list := @rtl;
+        @!role_typecheck_list := @rtl
     }
 
     method complete_parameterization($obj) {
         unless $!is_complete {
             $!is_complete := 1;
             self.parameterize_roles($obj);
-            self.update_role_typecheck_list($obj);
         }
     }
 
@@ -184,6 +182,10 @@ class Perl6::Metamodel::CurriedRoleHOW
         @!pos_args
     }
 
+    method role_named_arguments($obj) {
+        %!named_args
+    }
+
     method roles($obj, :$transitive = 1, :$mro = 0) {
         self.complete_parameterization($obj);
         self.roles-ordered($obj, self.roles_to_compose($obj), :$transitive, :$mro)
@@ -194,12 +196,29 @@ class Perl6::Metamodel::CurriedRoleHOW
         @!role_typecheck_list
     }
 
+    # $checkee must always be decont'ed
+    method type_check_roles($obj, $checkee) {
+        for self.roles_to_compose($obj) -> $role {
+            if nqp::istype_nd(nqp::decont($role), $checkee) {
+                return 1;
+            }
+        }
+        0
+    }
+
+    # $checkee must always be decont'ed
+    method type_check_parents($obj, $checkee) {
+        for @!parent_typecheck_list -> $parent {
+            if nqp::istype_nd(nqp::decont($parent), $checkee) {
+                return 1;
+            }
+        }
+        0
+    }
+
     method type_check($obj, $checkee) {
         my $decont := nqp::decont($checkee);
         if $decont =:= $obj.WHAT {
-            return 1;
-        }
-        if $decont =:= $!curried_role {
             return 1;
         }
         for self.pretending_to_be() {
@@ -207,21 +226,10 @@ class Perl6::Metamodel::CurriedRoleHOW
                 return 1;
             }
         }
-        self.complete_parameterization($obj) unless $!is_complete;
-        if !($!candidate =:= NQPMu) && $!candidate.HOW.type_check_parents($!candidate, $decont) {
-            return 1
-        }
-        for @!parent_typecheck_list -> $parent {
-            if nqp::istype($parent, $decont) {
-                return 1
-            }
-        }
-        for @!role_typecheck_list -> $role {
-            if nqp::istype($role, $decont) {
-                return 1;
-            }
-        }
-        0
+        self.complete_parameterization($obj);
+        self.type_check_roles($obj, $decont)
+            || self.type_check_parents($obj, $decont)
+            || $decont =:= $!curried_role
     }
 
     method accepts_type($obj, $checkee) {
@@ -276,6 +284,10 @@ class Perl6::Metamodel::CurriedRoleHOW
 
     method is-implementation-detail($obj) {
         $!curried_role.is-implementation-detail($obj)
+    }
+
+    method mro($obj) {
+        [$obj]
     }
 }
 

--- a/src/Perl6/Metamodel/CurriedRoleHOW.nqp
+++ b/src/Perl6/Metamodel/CurriedRoleHOW.nqp
@@ -168,7 +168,7 @@ class Perl6::Metamodel::CurriedRoleHOW
                 $_.value.HOW.instantiate_generic($_.value, $type_env) !!
                 $_.value;
         }
-        self.new_type($!curried_role, |@new_pos, |%new_named)
+        $!curried_role.HOW.parameterize($!curried_role, |@new_pos, |%new_named)
     }
 
     method specialize($obj, $first_arg) {

--- a/src/Perl6/Metamodel/CurriedRoleHOW.nqp
+++ b/src/Perl6/Metamodel/CurriedRoleHOW.nqp
@@ -216,12 +216,8 @@ class Perl6::Metamodel::CurriedRoleHOW
                 return 1
             }
         }
-        for @!role_typecheck_list {
-            my $dr := nqp::decont($_);
-            if $decont =:= $dr {
-                return 1;
-            }
-            if nqp::istype($dr, $decont) {
+        for @!role_typecheck_list -> $role {
+            if nqp::istype($role, $decont) {
                 return 1;
             }
         }
@@ -259,9 +255,7 @@ class Perl6::Metamodel::CurriedRoleHOW
                     my int $i := -1;
                     my int $ok := 1;
                     while ($i := $i + 1) < $num_args {
-                        unless    nqp::eqaddr(nqp::decont(@!pos_args[$i]), nqp::decont(@try_args[$i]))
-                               || @!pos_args[$i].ACCEPTS(@try_args[$i])
-                        {
+                        unless @!pos_args[$i].ACCEPTS(@try_args[$i]) {
                             $ok := 0;
                             $i := $num_args;
                         }

--- a/src/Perl6/Metamodel/GenericHOW.nqp
+++ b/src/Perl6/Metamodel/GenericHOW.nqp
@@ -23,7 +23,8 @@ class Perl6::Metamodel::GenericHOW
         my $meta := self.new();
         my $obj := nqp::settypehll(nqp::newtype($meta, 'Uninstantiable'), 'Raku');
         $meta.set_name($obj, $name);
-        $obj
+        nqp::settypecheckmode($obj,
+            nqp::const::TYPE_CHECK_NEEDS_ACCEPTS)
     }
 
     method instantiate_generic($obj, $type_environment) {
@@ -35,8 +36,8 @@ class Perl6::Metamodel::GenericHOW
     method compose($obj) {
     }
 
-    method type_check($obj, $checkee) {
-        0
+    method accepts_type($obj, $checkee) {
+        1
     }
 }
 

--- a/src/Perl6/Metamodel/GenericHOW.nqp
+++ b/src/Perl6/Metamodel/GenericHOW.nqp
@@ -4,6 +4,7 @@
 # of these confers genericity on the holder.
 class Perl6::Metamodel::GenericHOW
     does Perl6::Metamodel::Naming
+    does Perl6::Metamodel::MethodDelegation
 {
     my $archetypes := Perl6::Metamodel::Archetypes.new( :generic(1) );
     method archetypes() {
@@ -32,10 +33,6 @@ class Perl6::Metamodel::GenericHOW
     }
 
     method compose($obj) {
-    }
-
-    method find_method($obj, $name) {
-        nqp::null()
     }
 
     method type_check($obj, $checkee) {

--- a/src/Perl6/Metamodel/ParametricRoleGroupHOW.nqp
+++ b/src/Perl6/Metamodel/ParametricRoleGroupHOW.nqp
@@ -155,14 +155,6 @@ class Perl6::Metamodel::ParametricRoleGroupHOW
 
     method type_check($obj, $checkee) {
         my $decont := nqp::decont($checkee);
-        if $decont =:= $obj.WHAT {
-            return 1;
-        }
-        for self.pretending_to_be() {
-            if $decont =:= nqp::decont($_) {
-                return 1;
-            }
-        }
         for @!role_typecheck_list {
             if $decont =:= nqp::decont($_) {
                 return 1;

--- a/src/Perl6/Metamodel/ParametricRoleHOW.nqp
+++ b/src/Perl6/Metamodel/ParametricRoleHOW.nqp
@@ -114,7 +114,7 @@ class Perl6::Metamodel::ParametricRoleHOW
     # $checkee must always be decont'ed
     method type_check_parents($obj, $checkee) {
         for self.parents($obj, :local) -> $parent {
-            if nqp::istype($checkee, $parent) {
+            if nqp::istype($parent, $checkee) {
                 return 1;
             }
         }
@@ -135,7 +135,7 @@ class Perl6::Metamodel::ParametricRoleHOW
             }
         }
         for self.roles_to_compose($obj) {
-            if nqp::istype($decont, $_) {
+            if nqp::istype($_, $decont) {
                 return 1;
             }
         }

--- a/src/Perl6/Metamodel/ParametricRoleHOW.nqp
+++ b/src/Perl6/Metamodel/ParametricRoleHOW.nqp
@@ -49,7 +49,9 @@ class Perl6::Metamodel::ParametricRoleHOW
     }
 
     method parameterize($obj, *@pos_args, *%named_args) {
-        $currier.new_type($obj, |@pos_args, |%named_args)
+        $!in_group
+            ?? nqp::how_nd($!group).parameterize($!group, |@pos_args, |%named_args)
+            !! $currier.new_type($obj, |@pos_args, |%named_args)
     }
 
     method set_body_block($obj, $block) {

--- a/src/Perl6/Metamodel/ParametricRoleHOW.nqp
+++ b/src/Perl6/Metamodel/ParametricRoleHOW.nqp
@@ -18,7 +18,7 @@ class Perl6::Metamodel::ParametricRoleHOW
 {
     has $!composed;
     has $!body_block;
-    has $!in_group;
+    has int $!in_group;
     has $!group;
     has $!signatured;
     has @!role_typecheck_list;
@@ -67,8 +67,8 @@ class Perl6::Metamodel::ParametricRoleHOW
     }
 
     method set_group($obj, $group) {
-        $!group := $group;
         $!in_group := 1;
+        $!group := $group
     }
 
     method group($obj) {
@@ -79,21 +79,7 @@ class Perl6::Metamodel::ParametricRoleHOW
         my $obj := nqp::decont($the-obj);
 
         self.set_language_version($obj);
-
-        my @rtl;
-        if $!in_group {
-            @rtl.push($!group);
-        }
-        for self.roles_to_compose($obj) {
-            my $how := $_.HOW;
-            if $how.archetypes.composable || $how.archetypes.composalizable {
-                @rtl.push($_);
-                for $_.HOW.role_typecheck_list($_) {
-                    @rtl.push($_);
-                }
-            }
-        }
-        @!role_typecheck_list := @rtl;
+        self.update_role_typecheck_list($obj);
 #?if !moar
         self.compose_invocation($obj);
 #?endif
@@ -105,6 +91,18 @@ class Perl6::Metamodel::ParametricRoleHOW
         $!composed
     }
 
+    method update_role_typecheck_list($obj) {
+        my @rtl := [$!group] if $!in_group;
+        for self.roles_to_compose($obj) -> $role {
+            my $how := $role.HOW;
+            if $how.archetypes.composable || $how.archetypes.composalizable {
+                nqp::push(@rtl, $role);
+                nqp::splice(@rtl, $role.HOW.role_typecheck_list($role), nqp::elems(@rtl), 0);
+            }
+        }
+        @!role_typecheck_list := @rtl;
+    }
+
     method roles($obj, :$transitive = 1, :$mro) {
         self.roles-ordered($obj, self.roles_to_compose($obj), :$transitive, :$mro);
     }
@@ -114,9 +112,19 @@ class Perl6::Metamodel::ParametricRoleHOW
     }
 
     # $checkee must always be decont'ed
+    method type_check_roles($obj, $checkee) {
+        for self.roles_to_compose($obj) -> $role {
+            if nqp::istype_nd(nqp::decont($role), $checkee) {
+                return 1;
+            }
+        }
+        0
+    }
+
+    # $checkee must always be decont'ed
     method type_check_parents($obj, $checkee) {
         for self.parents($obj, :local) -> $parent {
-            if nqp::istype($parent, $checkee) {
+            if nqp::istype_nd(nqp::decont($parent), $checkee) {
                 return 1;
             }
         }
@@ -124,11 +132,8 @@ class Perl6::Metamodel::ParametricRoleHOW
     }
 
     method type_check($obj, $checkee) {
-        my $decont := nqp::decont($checkee);
+        my $decont := $checkee.WHAT;
         if $decont =:= $obj.WHAT {
-            return 1;
-        }
-        if $!in_group && $decont =:= $!group {
             return 1;
         }
         for self.pretending_to_be() {
@@ -136,12 +141,13 @@ class Perl6::Metamodel::ParametricRoleHOW
                 return 1;
             }
         }
-        for self.roles_to_compose($obj) {
-            if nqp::istype($_, $decont) {
-                return 1;
-            }
-        }
-        self.type_check_parents($obj, $decont);
+        $!in_group && $decont =:= $!group
+            || self.type_check_roles($obj, $decont)
+            || self.type_check_parents($obj, $decont)
+    }
+
+    method bind($obj, $curry) {
+        $obj
     }
 
     method specialize($obj, *@pos_args, *%named_args) {

--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -4394,6 +4394,9 @@ Perl6::Metamodel::PackageHOW.delegate_methods_to(Any);
 Perl6::Metamodel::ModuleHOW.pretend_to_be([Any, Mu]);
 Perl6::Metamodel::ModuleHOW.delegate_methods_to(Any);
 
+# Generics need ACCEPTS.
+Perl6::Metamodel::GenericHOW.delegate_methods_to(Mu);
+
 #?if !moar
 # Make roles handle invocations.
 my $role_invoke_handler := nqp::getstaticcode(sub ($self, *@pos, *%named) {

--- a/src/core.c/Buf.pm6
+++ b/src/core.c/Buf.pm6
@@ -14,12 +14,13 @@ enum Endian (
 my role Blob[::T = uint8] does Positional[T] does Stringy is repr('VMArray') is array_type(T) { ... }
 
 #- start of generated part of Blob Signed role -------------------------------
-#- Generated on 2022-03-08T14:31:37+01:00 by ./tools/build/makeBLOB_ROLES.raku
+#- Generated on 2022-05-06T08:15:00-03:00 by tools/build/makeBLOB_ROLES.raku
 #- PLEASE DON'T CHANGE ANYTHING BELOW THIS LINE
 
 my role SignedBlob[::T] is repr('VMArray') is array_type(T) is implementation-detail {
-    method !push-List(str $action, ::?CLASS:D $to, \from) {
+    method !push-List(str $action, ::?CLASS:D \to, \from) {
         my Mu $reified := nqp::getattr(from,List,'$!reified');
+        my Mu $to      := nqp::decont(to);
         if nqp::isconcrete($reified) {
             my int $elems = nqp::elems($reified);
             my int $j     = nqp::elems($to);
@@ -39,8 +40,9 @@ my role SignedBlob[::T] is repr('VMArray') is array_type(T) is implementation-de
         }
         $to
     }
-    method !push-iterator(str $action, ::?CLASS:D $to, Iterator:D $iter) {
+    method !push-iterator(str $action, ::?CLASS:D \to, Iterator:D $iter) {
         my int $i;
+        my Mu  $to := nqp::decont(to);
         nqp::until(
           nqp::eqaddr((my $got := $iter.pull-one),IterationEnd),
           nqp::if(
@@ -64,12 +66,13 @@ my role SignedBlob[::T] is repr('VMArray') is array_type(T) is implementation-de
       int        $i     is copy,
       int        $elems is copy,
       int        $values,
-      ::?CLASS:D $to,
+      ::?CLASS:D \to,
                  \from
     ) {
         --$i;  # went one too far
         $elems = $elems + $values;
-        my int $j = -1;
+        my int $j   = -1;
+        my Mu  $to := nqp::decont(to);
         if from.^array_type.^unsigned {
             nqp::bindpos_i($to,$i,nqp::atpos_u(from, ++$j % $values))
               while nqp::islt_i(++$i,$elems);
@@ -80,10 +83,11 @@ my role SignedBlob[::T] is repr('VMArray') is array_type(T) is implementation-de
         }
         $to
     }
-    method !spread(::?CLASS:D $to, \from) {
-        my int $values = nqp::elems(from);
-        my int $elems = nqp::elems($to) - $values;
-        my int $i     = -$values;
+    method !spread(::?CLASS:D \to, \from) {
+        my int $values  = nqp::elems(from);
+        my Mu  $to     := nqp::decont(to);
+        my int $elems   = nqp::elems($to) - $values;
+        my int $i       = -$values;
         nqp::splice($to,from,$i,$values)
           while nqp::isle_i($i = $i + $values,$elems);
 
@@ -194,12 +198,13 @@ my role SignedBlob[::T] is repr('VMArray') is array_type(T) is implementation-de
 #- PLEASE DON'T CHANGE ANYTHING ABOVE THIS LINE
 #- end of generated part of Blob Signed role ---------------------------------
 #- start of generated part of Blob Unsigned role -------------------------------
-#- Generated on 2022-03-08T14:31:37+01:00 by ./tools/build/makeBLOB_ROLES.raku
+#- Generated on 2022-05-06T08:15:00-03:00 by tools/build/makeBLOB_ROLES.raku
 #- PLEASE DON'T CHANGE ANYTHING BELOW THIS LINE
 
 my role UnsignedBlob[::T] is repr('VMArray') is array_type(T) is implementation-detail {
-    method !push-List(str $action, ::?CLASS:D $to, \from) {
+    method !push-List(str $action, ::?CLASS:D \to, \from) {
         my Mu $reified := nqp::getattr(from,List,'$!reified');
+        my Mu $to      := nqp::decont(to);
         if nqp::isconcrete($reified) {
             my int $elems = nqp::elems($reified);
             my int $j     = nqp::elems($to);
@@ -219,8 +224,9 @@ my role UnsignedBlob[::T] is repr('VMArray') is array_type(T) is implementation-
         }
         $to
     }
-    method !push-iterator(str $action, ::?CLASS:D $to, Iterator:D $iter) {
+    method !push-iterator(str $action, ::?CLASS:D \to, Iterator:D $iter) {
         my int $i;
+        my Mu  $to := nqp::decont(to);
         nqp::until(
           nqp::eqaddr((my $got := $iter.pull-one),IterationEnd),
           nqp::if(
@@ -244,12 +250,13 @@ my role UnsignedBlob[::T] is repr('VMArray') is array_type(T) is implementation-
       int        $i     is copy,
       int        $elems is copy,
       int        $values,
-      ::?CLASS:D $to,
+      ::?CLASS:D \to,
                  \from
     ) {
         --$i;  # went one too far
         $elems = $elems + $values;
-        my int $j = -1;
+        my int $j   = -1;
+        my Mu  $to := nqp::decont(to);
         if from.^array_type.^unsigned {
             nqp::bindpos_u($to,$i,nqp::atpos_u(from, ++$j % $values))
               while nqp::islt_i(++$i,$elems);
@@ -260,10 +267,11 @@ my role UnsignedBlob[::T] is repr('VMArray') is array_type(T) is implementation-
         }
         $to
     }
-    method !spread(::?CLASS:D $to, \from) {
-        my int $values = nqp::elems(from);
-        my int $elems = nqp::elems($to) - $values;
-        my int $i     = -$values;
+    method !spread(::?CLASS:D \to, \from) {
+        my int $values  = nqp::elems(from);
+        my Mu  $to     := nqp::decont(to);
+        my int $elems   = nqp::elems($to) - $values;
+        my int $i       = -$values;
         nqp::splice($to,from,$i,$values)
           while nqp::isle_i($i = $i + $values,$elems);
 

--- a/src/core.c/Parameter.pm6
+++ b/src/core.c/Parameter.pm6
@@ -665,12 +665,9 @@ multi sub infix:<eqv>(Parameter:D $a, Parameter:D $b) {
     my \btype = nqp::getattr($b,Parameter,'$!type');
     # (atype is btype) && (btype is atype) ensures type equivalence. Works for different curryings of a parametric role
     # which are parameterized with the same argument. nqp::eqaddr is not applicable here because if coming from
-    # different compunits the curryings would be different typeobject instances.
-    return False
-        unless
-            (atype.HOW.archetypes.generic && btype.HOW.archetypes.generic)
-            || (nqp::istype(atype, btype)
-                && nqp::istype(btype, atype));
+    # different compunits the curryings would be different typeobject instances. In other words, we have an invariant
+    # typecheck.
+    return False unless (nqp::istype(atype, btype) && nqp::istype(btype, atype));
 
     # different flags
     return False

--- a/src/core.c/Parameter.pm6
+++ b/src/core.c/Parameter.pm6
@@ -29,6 +29,7 @@ my class Parameter { # declared in BOOTSTRAP
     my constant $SIG_ELEM_IS_CAPTURE         = 1 +< 15;
     my constant $SIG_ELEM_UNDEFINED_ONLY     = 1 +< 16;
     my constant $SIG_ELEM_DEFINED_ONLY       = 1 +< 17;
+    my constant $SIG_ELEM_TYPE_GENERIC       = 1 +< 19;
     my constant $SIG_ELEM_DEFAULT_IS_LITERAL = 1 +< 20;
     my constant $SIG_ELEM_SLURPY_ONEARG      = 1 +< 24;
     my constant $SIG_ELEM_CODE_SIGIL         = 1 +< 25;
@@ -636,6 +637,10 @@ my class Parameter { # declared in BOOTSTRAP
           nqp::isnull(@!post_constraints) &&
           nqp::isnull($!sub_signature) &&
           nqp::isnull($!signature_constraint))
+    }
+
+    method declared_generic(Parameter:D: --> Bool:D) {
+        nqp::hllbool(nqp::bitand_i($!flags,$SIG_ELEM_TYPE_GENERIC))
     }
 
     method set_why(Parameter:D: $why --> Nil) {

--- a/src/core.c/Signature.pm6
+++ b/src/core.c/Signature.pm6
@@ -26,6 +26,35 @@ my class Signature { # declared in BOOTSTRAP
         self
     }
 
+    # A mapping of generic parameters to any known type signature.
+    my class Generics does Associative[Mu, Parameter:D] is repr<VMHash> {
+        method new(::?CLASS:_: --> ::?CLASS:D) {
+            nqp::create(self)
+        }
+
+        method STORE(::?CLASS:D: Parameter:D $param) {
+            my $type := $param.type;
+            nqp::bindkey(self, $_, $type) for $param.type_captures;
+            $type
+        }
+
+        method EXISTS-KEY(::?CLASS:D: Parameter:D $param --> Bool:D) {
+            $param.declared_generic
+        }
+
+        method AT-KEY(::?CLASS:D: Parameter:D $param is copy) {
+            my $topic := $param.type;
+            nqp::while(
+              ($topic.HOW.archetypes.generic),
+              ($topic := nqp::atkey(self, (my $type := $topic).^name)));
+            $type
+        }
+
+        method elems(::?CLASS:D: --> Int:D) {
+            nqp::elems(self)
+        }
+    }
+
     multi method ACCEPTS(Signature:D: Mu \topic) {
         nqp::hllbool(nqp::istrue(try self.ACCEPTS: topic.Capture))
     }
@@ -42,10 +71,14 @@ my class Signature { # declared in BOOTSTRAP
         my @r-pos-queue;
         my %r-named-queue;
 
+        my %r-generics is Generics;
+        my %l-generics is Generics;
+
         my $r-pos-sink   := False;
         my $r-named-sink := False;
 
         for @r-params -> $r-param is raw {
+            %r-generics = $r-param;
             if $r-param.positional {
                 if $r-param.slurpy {
                     $r-pos-sink := True;
@@ -56,7 +89,11 @@ my class Signature { # declared in BOOTSTRAP
                     # predicted when such parameters exist in the topic too.
                     my $l-param := @l-params[$l-params - $todo];
                     if $l-param.positional and not $l-param.slurpy {
-                        return False unless $l-param ~~ $r-param;
+                        %l-generics = $l-param;
+                        return False
+                            if not $r-param.ACCEPTS($l-param)
+                               and not $r-param.declared_generic || $l-param.declared_generic
+                                   or not %r-generics.AT-KEY($r-param).ACCEPTS(%l-generics.AT-KEY: $l-param);
                         $todo := $todo - 1;
                     }
                     else {
@@ -81,13 +118,19 @@ my class Signature { # declared in BOOTSTRAP
         }
 
         for @l-params.tail: $todo -> $l-param is raw {
+            %l-generics = $l-param;
+
             state %r-to-l-named{Mu};
             if $l-param.positional {
                 if $l-param.slurpy {
                     return False unless $r-pos-sink;
                 }
                 elsif @r-pos-queue {
-                    return False unless $l-param ~~ @r-pos-queue.shift;
+                    my $r-param := @r-pos-queue.shift;
+                    return False
+                        if not $r-param.ACCEPTS($l-param)
+                           and not $r-param.declared_generic || $l-param.declared_generic
+                               or not %r-generics.AT-KEY($r-param).ACCEPTS(%l-generics.AT-KEY: $l-param);
                 }
                 else {
                     return False unless $r-pos-sink;
@@ -102,10 +145,13 @@ my class Signature { # declared in BOOTSTRAP
                     for $l-param.named_names -> $name is raw {
                         if %r-named-queue{$name}:exists {
                             my $r-param := %r-named-queue{$name}:delete;
-                            return False unless $l-param ~~ $r-param;
                             return False
-                                if %r-to-l-named{$r-param}:exists and not
-                                   %r-to-l-named{$r-param} =:= $l-param;
+                                if not $r-param.ACCEPTS($l-param)
+                                   and not $r-param.declared_generic || $l-param.declared_generic
+                                        or not %r-generics.AT-KEY($r-param).ACCEPTS(%l-generics.AT-KEY: $l-param);
+                            return False
+                                if %r-to-l-named{$r-param}:exists
+                                   and not %r-to-l-named{$r-param} =:= $l-param;
                             %r-to-l-named{$r-param} := $l-param;
                             $found := True;
                         }

--- a/tools/build/makeBLOB_ROLES.raku
+++ b/tools/build/makeBLOB_ROLES.raku
@@ -58,8 +58,9 @@ while @lines {
     say Q:to/SOURCE/.subst(/ '#' (\w+) '#' /, -> $/ { %mapper{$0} }, :g).chomp;
 
 my role #name#[::T] is repr('VMArray') is array_type(T) is implementation-detail {
-    method !push-List(str $action, ::?CLASS:D $to, \from) {
+    method !push-List(str $action, ::?CLASS:D \to, \from) {
         my Mu $reified := nqp::getattr(from,List,'$!reified');
+        my Mu $to      := nqp::decont(to);
         if nqp::isconcrete($reified) {
             my int $elems = nqp::elems($reified);
             my int $j     = nqp::elems($to);
@@ -79,8 +80,9 @@ my role #name#[::T] is repr('VMArray') is array_type(T) is implementation-detail
         }
         $to
     }
-    method !push-iterator(str $action, ::?CLASS:D $to, Iterator:D $iter) {
+    method !push-iterator(str $action, ::?CLASS:D \to, Iterator:D $iter) {
         my int $i;
+        my Mu  $to := nqp::decont(to);
         nqp::until(
           nqp::eqaddr((my $got := $iter.pull-one),IterationEnd),
           nqp::if(
@@ -104,12 +106,13 @@ my role #name#[::T] is repr('VMArray') is array_type(T) is implementation-detail
       int        $i     is copy,
       int        $elems is copy,
       int        $values,
-      ::?CLASS:D $to,
+      ::?CLASS:D \to,
                  \from
     ) {
         --$i;  # went one too far
         $elems = $elems + $values;
-        my int $j = -1;
+        my int $j   = -1;
+        my Mu  $to := nqp::decont(to);
         if from.^array_type.^unsigned {
             nqp::bindpos_#postfix#($to,$i,nqp::atpos_u(from, ++$j % $values))
               while nqp::islt_i(++$i,$elems);
@@ -120,10 +123,11 @@ my role #name#[::T] is repr('VMArray') is array_type(T) is implementation-detail
         }
         $to
     }
-    method !spread(::?CLASS:D $to, \from) {
-        my int $values = nqp::elems(from);
-        my int $elems = nqp::elems($to) - $values;
-        my int $i     = -$values;
+    method !spread(::?CLASS:D \to, \from) {
+        my int $values  = nqp::elems(from);
+        my Mu  $to     := nqp::decont(to);
+        my int $elems   = nqp::elems($to) - $values;
+        my int $i       = -$values;
         nqp::splice($to,from,$i,$values)
           while nqp::isle_i($i = $i + $values,$elems);
 


### PR DESCRIPTION
If generic role and generic signature signature typechecks are busted, maybe generic typechecks are busted too. In giving it the capacity to perform a typecheck in a more Raku-ish means, however, old errors seen from https://github.com/rakudo/rakudo/pull/4478 reappear. This PR makes a poor starting point because I wind up spinning off into two directions simultaneously past where I left off:

- `accepts_type` leads into problems with generics and enhancements to `Signature.ACCEPTS`/`Parameter.ACCEPTS` and syntax that can be made because of it. nqp needs to mirror Rakudo here, which has its own set of problems to begin with.
- Changing archetypes checks leads into a game of cat and mouse against the MOP as a whole. The gist is Inherit(aliza)bility and compos(aliza)bility can be made more robust if given protocol, but this brings HOWs behaving as composers or children, e.g. enums, into the picture when they wouldn't need to be otherwise (and again, nqp reflects). This is more problem-solving territory.

There's a way to split this in half, taking only the former changes (and thus a portion of the bug fixes) for now.

## Bug Fixes

As before, subtyping of generics is OK:

```raku
role Foo[Any ::T] { }
role Bar[::T] does Foo[T] { }
```

```raku
role Foo[Any ::T] { }
role Bar[::T] is Foo[T] { }
```

But composalizability/inheritalizability is ignored, and thus the following is still **not** valid:

```raku
role OfIndex[Enumeration ::T] does T { }
enum Index <A B C>;
OfIndex[Index]
```

Roles should behave OK as-is, but only because they typecheck similarly enough to their puns and pun to the same metaobject upon method dispatch.

## Typechecks

```raku
enum Index <A B C>;
class Foo does Index { }
Foo ~~ Index
```

This should *not* be a MOP-enforced typecheck. `Index` implies `NumericEnumeration` and thus `Enumeration`, which `Foo` doesn't do because it's an `Index` coercer.

```raku
class Foo is Buf[uint8] is repr<VMArray> { }
Foo ~~ Blob[uint8];
```

Now valid.

```raku
class Foo is Buf is repr<VMArray> { }
Foo ~~ Buf[uint8];
```

This is a bizarre type... I'm not sure how `Buf`  can guarantee `Buf[uint8]` specifically. Remember, `Buf` refers to the role *group*, not the empty parameterization of `Buf`, which remains empty as far as the MOP is concerned because type argument defaults are applied so late.

## Issues

This is prompted by https://github.com/rakudo/rakudo/issues/4915 and the many problems with typechecks I've gotten annoyed by over the years. https://github.com/rakudo/rakudo/issues/4935 is prompted by this, and the noted behaviour is replicated here.

## Tests

I'm aware this breaks two tests in `t/02-rakudo/13-exceptions`  and `t/spec/S02-names-vars/names.t` to do with the following syntax:

```raku
my ::T $
```

Which was presumed to be invalid before. I haven't done anything about this yet.

Only MoarVM is tested thus far.

## Todo

- [ ] Specialization could probably gain a lot from a more prominent curried role by this point.
- [ ] Raku roles and NQP roles should expose more compatible introspection metamethods in order for custom HOWs to behave as expected for parent, roles, methods, and attributes.
- [ ] `my ::T $` needs taking care of.
- [ ] Iffy typecheck/composition hacks in the setting need review.

May add more items as I think of them.