### PR TITLE
Reconsider the way `$*PERL` is deprecated

### DIFF
--- a/src/core.c/Rakudo/Internals.pm6
+++ b/src/core.c/Rakudo/Internals.pm6
@@ -1124,7 +1124,7 @@ my class Rakudo::Internals {
         )
     }
     my $DYNAMIC-INITIALIZATION-LOCK := Lock.new;
-    method INITIALIZE-DYNAMIC(str $name) is raw {
+    method INITIALIZE-DYNAMIC(str $name, @deprecation?) is raw {
         my str $key = nqp::replace($name,1,1,'');
         $DYNAMIC-INITIALIZATION-LOCK.protect: {
 #my $id := nqp::p6box_i(nqp::threadid(nqp::currentthread));
@@ -1143,7 +1143,15 @@ my class Rakudo::Internals {
                      nqp::atkey($initializers,$name)
                    )
                  ) ?? dynamic-not-found($key, $name)
-                   !! $code()
+                   !! do {
+                       Rakudo::Deprecations.DEPRECATED(@deprecation[1],
+                                                       '6.' ~ @deprecation[0],
+                                                       :what($name),
+                                                       :file(@deprecation[2]),
+                                                       :line(@deprecation[3]))
+                        if @deprecation;
+                       $code()
+                   }
         }
     }
 

--- a/src/core.c/stubs.pm6
+++ b/src/core.c/stubs.pm6
@@ -30,7 +30,7 @@ my class MixHash { ... }
 my class Lock is repr('ReentrantMutex') { ... }
 my class Lock::Async { ... }
 
-sub DYNAMIC(str $name) is raw {  # is implementation-detail
+sub DYNAMIC(str $name, @deprecation?) is raw {  # is implementation-detail
 # Please leave this code here to be enable only for tracing calls to
 # dynamic variables in the setting and during setting compilation.
 #my $frame := callframe(1);
@@ -52,7 +52,7 @@ sub DYNAMIC(str $name) is raw {  # is implementation-detail
               nqp::atkey(GLOBAL.WHO,$pkgname),
               nqp::ifnull(
                 nqp::atkey(PROCESS.WHO,$pkgname),
-                Rakudo::Internals.INITIALIZE-DYNAMIC($name)
+                Rakudo::Internals.INITIALIZE-DYNAMIC($name, @deprecation)
               )
             )
           )

--- a/src/core.e/core_prologue.pm6
+++ b/src/core.e/core_prologue.pm6
@@ -4,10 +4,4 @@ use nqp;
 # Must preceede class declarations to allow correct recording of their respective language version.
 my constant CORE-SETTING-REV = 'e';
 
-# Re-register with a deprecation warning
-Rakudo::Internals.REGISTER-DYNAMIC: '$*PERL', {
-    DEPRECATED('$*RAKU', :what<$*PERL>, :2up );
-    PROCESS::<$PERL> := Raku.new;
-}, :override;
-
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
The earlier implementation wasn't taking old 6.c/6.d code into account when it comes to modules. I.e. if some 6.e code uses a 6.c/6.d module which, in turn, references `$*PERL` then the deprecation warning is issued anyway. This would be a violation of the backward compatibility rule.