### PR TITLE
Add Int/Real coercing versions of `infix:<div|mod>`

### DIFF
--- a/src/core.c/Int.rakumod
+++ b/src/core.c/Int.rakumod
@@ -347,6 +347,12 @@ multi sub infix:<div>(Int:D $a, Int:D $b --> Int:D) {
 multi sub infix:<div>(int  $a, int  $b --> int)  { nqp::div_i($a, $b) }
 multi sub infix:<div>(uint $a, uint $b --> uint) { nqp::div_i($a, $b) }
 
+multi sub infix:<div>($a, $b --> Int:D) {
+    $b.Int
+      ?? nqp::div_I($a.Int,$b.Int,Int)
+      !! X::Numeric::DivideByZero.new(:using<div>, :numerator($a)).Failure
+}
+
 multi sub infix:<%>(Int:D $a, Int:D $b --> Int:D) {
     nqp::isbig_I($a) || nqp::isbig_I($b)
       ?? $b

--- a/src/core.c/Real.rakumod
+++ b/src/core.c/Real.rakumod
@@ -160,6 +160,7 @@ multi sub prefix:<->(Real:D $a) { -$a.Bridge }
 # so fails on differing types."  Thus no casts here.
 proto sub infix:<mod>($, $, *%) is pure {*}
 multi sub infix:<mod>(Real:D $a, Real:D $b) { $a - ($a div $b) * $b }
+multi sub infix:<mod>($a, $b) { $a.Real - ($a.Real div $b.Real) * $b.Real }
 
 multi sub abs(Real:D $a) { $a < 0 ?? -$a !! $a }
 


### PR DESCRIPTION
This makes them consistent with the other operators, so e.g., `say "6"
div 3` now prints `2`, instead of
`Calling infix:<div>(Str, Int) will never work with any of these multi signatures:
    (Int:D \a, Int:D \b --> Int:D)
    (int $a, int $b --> int)
    (uint $a, uint $b --> uint)`

Fixes https://github.com/Raku/problem-solving/issues/326

Rakudo builds ok and passes `make m-test m-spectest`.