### PR TITLE
Revert relaxation of positional bind failover binding

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -9532,7 +9532,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
                         return 0 unless %info<is_invocant>;
                     }
                     else {
-                        if nqp::istype($param_type, $world.find_single_symbol_in_setting('Positional')) {
+                        if $param_type =:= $world.find_single_symbol_in_setting('Positional') {
                             $var.push(QAST::Op.new(
                                 :op('if'),
                                 QAST::Op.new(


### PR DESCRIPTION
It basically makes it impossible to create a class that does both
Sequence as well as Positional, and this in turn broke Red.