### PR TITLE
Consuming class must provide implementation of stubs

### DIFF
--- a/src/core.c/Sequence.pm6
+++ b/src/core.c/Sequence.pm6
@@ -33,11 +33,7 @@ my role PositionalBindFailover {
           !! List.from-iterator(self.iterator)
     }
 
-    method iterator() {
-        die "Method 'iterator' must be implemented by "
-          ~ self.^name
-          ~ " because it is required by roles: PositionalBindFailover";
-    }
+    method iterator() { ... }
 }
 nqp::p6configposbindfailover(Positional, PositionalBindFailover); # Binder
 Routine.'!configure_positional_bind_failover'(Positional, PositionalBindFailover); # Multi-dispatch


### PR DESCRIPTION
This commit changes the way the check for stubbed methods is performed
on classes that consume roles.  Before, if the class could provide a
method for the stub, **even if it was from an inherited class**, it
would be accepted.  This behaviour makes:

    role A { method WALK { ... } }.^pun;

work, while:

    role A { method STAND { ... } }.^pun;
    # Method 'STAND' must be implemented by A because it is required by roles: A

fails.  And that's just because Mu actually defines a WALK method.
Which implies that removing such an internal method such as "WALK" from
Mu, has the danger of breaking people's code *at compile time*.

So I feel this behaviour is inconsistent: the class that is consuming
a role should *itself* provide a stubbed method.  Which could well be
something like:

    role A { method list { ... } }
    class B does A { method list(|) { nextsame } }

Similar to solving collisions.  This semantic is implemented by this
commit.  Furthermore it has improved error reporting on unimplemented
stub methods, by not just giving up on the first, but instead collect
all offenses and format this into a more usable message:

    role A {
        method a {...}
        method b {...}
    }
    role B {
        method c {...}
    }
    class C does A does B { }
    ===SORRY!=== Error while compiling -e
    The following methods must be implemented:
      for class 'C':
        'c' required by role 'B'
        'a', 'b' required by role 'A'

This change breaks *one* spectest.  And this can be golfed to:

    QuantHash.does(Associative)
    # The following methods must be implemented:
    #   for class 'QuantHash':
    #     'hash', 'Hash', 'Map' required by role 'QuantHash'

which appears to be improper handling at:

    https://github.com/rakudo/rakudo/blob/master/src/vm/moar/dispatchers.nqp#L819

where it appears it is deciding incorrectly that the invocant should
be punned.