### PR TITLE
Fix an LTA error message on passing Seq to a List parameter

### DIFF
--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -322,7 +322,7 @@ my class Binder {
 
                 # If the expected type is Positional, see if we need to do the
                 # positional bind failover.
-                if nqp::istype($param_type, $Positional) && nqp::istype($oval, $PositionalBindFailover) {
+                if nqp::eqaddr($param_type, $Positional) && nqp::istype($oval, $PositionalBindFailover) {
                     $oval := $oval.cache;
                 }
 


### PR DESCRIPTION
This is the correct solution for #4864. The previous attempt of fixing binding by changing parameter type `Positional` equality check to `isa` check resulted in #4948 and that should've been expected.

The problem with `isa` check is that we only give special meaning to the `Positional` role and must not do so for consuming classes or their descendants.