### PR TITLE
Make coercions up to 1.6x as fast

### DIFF
--- a/src/Perl6/Metamodel/CoercionHOW.nqp
+++ b/src/Perl6/Metamodel/CoercionHOW.nqp
@@ -113,106 +113,134 @@ class Perl6::Metamodel::CoercionHOW
     # Coercion protocol method.
     method coerce($obj, $value) {
         nqp::istype($value, $!target_type)
-          ?? $value
-          !! self.actually_coerce($obj, $value)
+          ?? $value                             # already done
+          !! self."!coerce_TargetType"($obj, $value)
     }
 
-    method actually_coerce($obj, $value) {
-        # Support nested coercions
-        if nqp::can($!constraint_type.HOW.archetypes, 'coercive')
-            && $!constraint_type.HOW.archetypes.coercive
-        {
-            $value := $!constraint_type.HOW.coerce($!constraint_type, $value);
-        }
+    # Attempt coercion on TargetType
+    method !coerce_TargetType($obj, $value) {
+        my $constraint    := $!constraint_type;
+        my $constraintHOW := $constraint.HOW;
+        $value := $constraintHOW.coerce($constraint, $value)
+          if nqp::can((my $archetypes := $constraintHOW.archetypes), 'coercive')
+          && $archetypes.coercive;
 
-        my $hint;
-        my $coerced_value := nqp::null();
-        my $value_type := nqp::what($value);
-        my $coercion_method;
+        my $nominal_target := $!nominal_target;
+        nqp::istype($value, $constraint)
+          ?? nqp::defined(
+               my $method := nqp::tryfindmethod(
+                 nqp::what($value),
+                 $nominal_target.HOW.name($nominal_target)
+               )
+             ) && (nqp::istype((my $coerced := $method($value)),$!target_type)
+                    || nqp::istype($coerced, nqp::gethllsym('Raku', 'Failure'))
+                  )
+            ?? $coerced
+            !! self."!coerce_COERCE"($obj, $value, $nominal_target)
+          !! self."!invalid_type"($value)
+    }
 
-        if nqp::istype($value, $!constraint_type) {
-            my $method;
+    # Handle errors
+    method !invalid($value, $hint) {
+        my $from-type := nqp::what($value);
+        Perl6::Metamodel::Configuration.throw_or_die(
+          'X::Coerce::Impossible',
+          "Impossible coercion from "
+            ~ $from-type.HOW.name($from-type)
+            ~ " into "
+            ~ $!target_type.HOW.name($!target_type)
+            ~ ": $hint",
+          :target-type($!target_type),
+          :$from-type,
+          :$hint
+        )
+    }
 
-            # First we try $value.TargetType() approach
-            $coercion_method := $!nominal_target.HOW.name($!nominal_target);
-            $method := nqp::tryfindmethod($value_type, $coercion_method);
-            if nqp::defined($method) {
-                $coerced_value := $method($value);
-            }
+    # Handle invalid type on accepting
+    method !invalid_type($value) {
+        self."!invalid"(
+          $value, 
+          "value is of unacceptable type " ~ $value.HOW.name($value)
+        )
+    }
 
-            my $nominal_target := $!nominal_target.HOW.archetypes.composable
-                                    ?? $!nominal_target.HOW.pun($!nominal_target)
-                                    !! $!nominal_target;
+    # Attempt coercion with TargetType.COERCE($value).
+    method !coerce_COERCE($obj, $value, $nominal_target) {
+        nqp::defined(
+          my $method := nqp::tryfindmethod(
+            (my $HOW := $nominal_target.HOW).archetypes.composable
+              ?? ($nominal_target := $HOW.pun($nominal_target))
+              !! $nominal_target,
+            'COERCE'
+          )
+        ) && nqp::can($method, 'cando')
+          && $method.cando($nominal_target, $value)
+          ?? (
+               nqp::istype(
+                 (my $coerced_value := $method($nominal_target, $value)),
+                 $!target_type
+               ) || nqp::istype(
+                      $coerced_value,
+                      nqp::gethllsym('Raku', 'Failure')
+                    )
+             )
+            ?? $coerced_value
+            !! self."!invalid_coercion"($value, 'COERCE', $coerced_value)
+          !! self."!coerce_new"($obj, $value, $nominal_target)
+    }
 
-            # Then try TargetType.COERCE($value).
-            if nqp::isnull($coerced_value) {
-                $method := nqp::tryfindmethod($nominal_target, $coercion_method := 'COERCE');
-                if nqp::defined($method) && nqp::can($method, 'cando') && $method.cando($nominal_target, $value) {
-                    $coerced_value := $method($nominal_target, $value);
-                }
-            }
+    # Handle invalid coercion
+    method !invalid_coercion($value, $method_name, $coerced_value) {
+        self."!invalid"(
+          $value,
+          "method $method_name returned "
+             ~ (nqp::defined($coerced_value)
+                 ?? "an instance of "
+                 !! "a type object "
+               )
+             ~ $coerced_value.HOW.name($coerced_value)
+        )
+    }
 
-            # And eventually fall back to new.
-            if nqp::isnull($coerced_value) {
-                $method := nqp::tryfindmethod($nominal_target, $coercion_method := 'new');
-                if nqp::defined($method) && nqp::can($method, 'cando') && $method.cando($nominal_target, $value) {
-                    # There should be no signifacnt performance penalty on this path because if method call ever throws
-                    # then this is gonna result in an exception one way or another.
-                    my $exception;
-                    try {
-                        my $*COERCION-TYPE := $obj; # Provide context information to the method 'new'
-                        $coerced_value := $method($nominal_target, $value);
-                        CATCH {
-                            my $exception_obj := nqp::getpayload($!);
+    # Attempt to coerce via TargetType.new
+    method !coerce_new($obj, $value, $nominal_target) {
+        if nqp::defined(
+            my $method := nqp::tryfindmethod($nominal_target, 'new')
+        ) && nqp::can($method, 'cando')
+          && $method.cando($nominal_target, $value) {
+            # There should be no significant performance penalty on this path
+            # because if method call ever throws then this is going to result
+            # in an exception one way or another.
+            my $exception;
+            my $coerced_value;
+            try {
+                CATCH {
+                    my $exception_obj := nqp::getpayload($!);
 
-                            unless $exception_obj.HOW.name($exception_obj) eq 'X::Constructor::Positional' {
-                                $exception := $!;
-                            }
-                        }
+                    if $exception_obj.HOW.name($exception_obj)
+                      ne 'X::Constructor::Positional' {
+                        $exception := $!;
                     }
-                    if nqp::defined($exception) {
-                        nqp::rethrow($exception);
-                    }
                 }
+
+                # Provide context information to the method 'new'
+                my $*COERCION-TYPE := $obj;
+                $coerced_value := $method($nominal_target, $value);
+
+                return $coerced_value
+                  if nqp::istype($coerced_value, $!target_type)
+                    || nqp::istype(
+                         $coerced_value,
+                         nqp::gethllsym('Raku', 'Failure')
+                       )
             }
+            nqp::defined($exception)
+              ?? nqp::rethrow($exception)
+              !! self."!invalid_coercion"($value, 'new', $coerced_value)
         }
         else {
-            $hint := "value is of unacceptable type " ~ $value.HOW.name($value);
+            self."!invalid"($value, "no acceptable coercion method found")
         }
-
-        my $coerced_decont := nqp::decont($coerced_value);
-        # Fail for either no coercion method found or wrong type returned, except for Failure kind of return which we
-        # must bypass as it carries some useful information about another error.
-        if nqp::isnull($coerced_value)
-            || !(nqp::istype($coerced_decont, $!target_type)
-                || nqp::istype($coerced_decont, nqp::gethllsym('Raku', 'Failure')))
-        {
-            my $target_type_name := $!target_type.HOW.name($!target_type);
-            my $value_type_name := $value_type.HOW.name($value_type);
-            unless $hint {
-                if nqp::isnull($coerced_value) {
-                    $hint := "no acceptable coercion method found";
-                }
-                else {
-                    my $coerced_name := $coerced_decont.HOW.name($coerced_decont);
-                    $hint := "method " ~ $coercion_method ~ " returned "
-                                ~ (nqp::defined($coerced_decont) ?? "an instance of" !! "a type object")
-                                ~ " " ~ $coerced_name;
-                }
-            }
-            Perl6::Metamodel::Configuration.throw_or_die(
-                'X::Coerce::Impossible',
-                "Impossible coercion from "
-                    ~ $value_type_name
-                    ~ " into " ~ $target_type_name
-                    ~ ": " ~ $hint,
-                :target-type($!target_type),
-                :from-type($value_type),
-                :$hint
-            )
-        }
-
-        $coerced_value
     }
 
     # Methods needed by Perl6::Metamodel::Nominalizable


### PR DESCRIPTION
- calling method named after type, e.g. Int() -> .Int: 1.6x as fast
- calling .COERCE: 4% faster
- calling .new:    3% faster

This has been achieved by breaking up the large "coerce" method into
several (private) methods, allowing the fast path (the .Int case) to
have to do a lot less.  The outer "coerce" method has a check for
already the correct type.  Since that is small enough to get inlined,
one wonders whether the current dispatch check on coercing is really
needed, and if removed, would result in smaller bytecode at the call
site, with potentially earlier / better inlining.

Use of intermediate variables has also been done extensively to
reduce repeated attribute and method calls.

All error handling is put into separate private methods to
allow the bytecode for the normal path to be smaller.

All is spectest clean, and error messages should be identical to
before this commit.