### PR TITLE
Micro-optimize ADD-PAIRS-TO-BAG ...

### DIFF
--- a/src/core.c/Rakudo/QuantHash.pm6
+++ b/src/core.c/Rakudo/QuantHash.pm6
@@ -1246,18 +1246,12 @@ my class Rakudo::QuantHash {
               )
             ),
             nqp::if(               # not a Pair
-              nqp::existskey(
-                elems,
-                ($which := $pulled.WHICH)
-              ),
-              nqp::stmts(
-                ($pair := nqp::atkey(elems,$which)),
-                nqp::bindattr(     # seen before, so increment
-                  $pair,
-                  Pair,
-                  '$!value',
-                  nqp::getattr($pair,Pair,'$!value') + 1
-                )
+              ($pair := nqp::atkey(elems,($which := $pulled.WHICH))),
+              nqp::bindattr(     # seen before, so increment
+                $pair,
+                Pair,
+                '$!value',
+                nqp::getattr($pair,Pair,'$!value') + 1
               ),
               self.BIND-TO-TYPED-MIX(  # new, create new Pair
                 elems, $which, $pulled, 1, type

--- a/src/core.c/Rakudo/QuantHash.pm6
+++ b/src/core.c/Rakudo/QuantHash.pm6
@@ -813,18 +813,12 @@ my class Rakudo::QuantHash {
               $value.throw         # value cannot be made Int, so throw
             ),
             nqp::if(               # not a Pair
-              nqp::existskey(
-                elems,
-                ($which := $pulled.WHICH)
-              ),
-              nqp::stmts(
-                ($pair := nqp::atkey(elems,$which)),
-                nqp::bindattr(     # seen before, so increment
-                  $pair,
-                  Pair,
-                  '$!value',
-                  nqp::getattr($pair,Pair,'$!value') + 1
-                )
+              ($pair := nqp::atkey(elems,($which := $pulled.WHICH))),
+              nqp::bindattr(     # seen before, so increment
+                $pair,
+                Pair,
+                '$!value',
+                nqp::getattr($pair,Pair,'$!value') + 1
               ),
               self.BIND-TO-TYPED-BAG(    # new, create new Pair
                 elems, $which, $pulled, 1, type


### PR DESCRIPTION
by turning an nqp::if(nqp::existskey,nqp::atkey) into just an
nqp::if(nqp::atkey).

Rakudo builds ok and passes `make m-test m-spectest`.

My benchmark (`say "big.txt".IO.slurp.lc.words.Bag.elems`, where "big.txt" has 75,161 words and is 6.2mb) drops from ~0.97s to ~0.92s and from ~7.5b instructions to ~7.2b instructions.