### PR TITLE
Make unsuccessful connect fail rather than die

### DIFF
--- a/src/core.c/IO/Socket/INET.pm6
+++ b/src/core.c/IO/Socket/INET.pm6
@@ -113,6 +113,7 @@ my class IO::Socket::INET does IO::Socket {
 #?endif
         }
         elsif $!type == SOCK_STREAM {
+            CATCH { return .Failure }
             nqp::connect($PIO, nqp::unbox_s($!host), nqp::unbox_i($!port), nqp::decont_i($!family));
         }
 


### PR DESCRIPTION
Spotted in https://stackoverflow.com/questions/72639883/how-to-deal-with-exceptions-in-iosocketinet

There is no documentation or tests covering the behaviour of a failed
connect.  It is actually the nqp::connect that throws (which turns out
also to be not documented BTW).

Having it return a Failure feels more natural indeed.