### PR TITLE
Todo failing test on Solaris

### DIFF
--- a/t/06-telemetry/01-basic.t
+++ b/t/06-telemetry/01-basic.t
@@ -25,6 +25,7 @@ my $T = T;
 isa-ok $T, Telemetry, 'did we get a Telemetry object from T';
 for <wallclock cpu max-rss> {
     todo 'JVM gives zero for max-rss', 2 if $*VM.name eq 'jvm' and $_ eq 'max-rss';
+    todo 'Solaris gives zero for max-rss - see getrusage(3C)', 2 if $*VM.osname eq 'solaris';
     ok $T{$_}, "did we get a non-zero value for $_ using AT-KEY";
     ok $T."$_"(), "did we get a non-zero value for $_ with a method";
 }


### PR DESCRIPTION
Solaris always returns 0 in max-rss. According to the NOTE in
getrusage(3C):

  The ru_maxrss, ru_ixrss, ru_idrss, and ru_isrss members of  the rusage
  structure are set to 0 in this implementation.