### PR TITLE
Make Iterable.hyper|race take undef as a default

### DIFF
--- a/src/core.c/IO/Socket/INET.pm6
+++ b/src/core.c/IO/Socket/INET.pm6
@@ -113,6 +113,7 @@ my class IO::Socket::INET does IO::Socket {
 #?endif
         }
         elsif $!type == SOCK_STREAM {
+            CATCH { return .Failure }
             nqp::connect($PIO, nqp::unbox_s($!host), nqp::unbox_i($!port), nqp::decont_i($!family));
         }
 

--- a/src/core.c/Iterable.pm6
+++ b/src/core.c/Iterable.pm6
@@ -30,13 +30,17 @@ my role Iterable {
     }
 
     method hyper(
-      Int(Cool) :$batch  = 64,
-      Int(Cool) :$degree = Kernel.cpu-cores-but-one,
+      Int(Cool) :$batch,
+      Int(Cool) :$degree,
     ) {
 #?if !js
         HyperSeq.new:
           configuration =>
-            HyperConfiguration.new(:$degree, :$batch, :method<hyper>),
+            HyperConfiguration.new(
+              :batch($batch // 64),
+              :degree($degree // Kernel.cpu-cores-but-one),
+              :method<hyper>
+            ),
           work-stage-head =>
             Rakudo::Internals::HyperIteratorBatcher.new(:$.iterator)
 #?endif
@@ -46,13 +50,17 @@ my role Iterable {
     }
 
     method race(
-      Int(Cool) :$batch  = 64,
-      Int(Cool) :$degree = Kernel.cpu-cores-but-one,
+      Int(Cool) :$batch,
+      Int(Cool) :$degree,
     ) {
 #?if !js
         RaceSeq.new:
           configuration =>
-            HyperConfiguration.new(:$degree, :$batch, :method<race>),
+            HyperConfiguration.new(
+              :batch($batch // 64),
+              :degree($degree // Kernel.cpu-cores-but-one),
+              :method<race>
+            ),
           work-stage-head =>
             Rakudo::Internals::HyperIteratorBatcher.new(:$.iterator)
 #?endif


### PR DESCRIPTION
This changes the behaviour of `.hyper` / `.race` when given an undefined
value for `:batch` / `:degree`.  Before, this was an error.  With this
commit, it will assume the default values.
    
This makes it much easier to let e.g. CLI's manage defaults for
`:degree` and `:batch`, without needing to know what the defaults
actually are.  Just accept `--degree` and `--batch` without default
values, and pass them on.
