### PR TITLE
Fallbacks with MRO

### DIFF
--- a/src/Perl6/Metamodel/ClassHOW.nqp
+++ b/src/Perl6/Metamodel/ClassHOW.nqp
@@ -294,7 +294,7 @@ class Perl6::Metamodel::ClassHOW
     # Handles the various dispatch fallback cases we have.
     method find_method_fallback($obj, $name) {
         # If the object is a junction, need to do a junction dispatch.
-        if $obj.WHAT =:= $junction_type && $junction_autothreader {
+        if nqp::istype($obj.WHAT, $junction_type) && $junction_autothreader {
             my $p6name := nqp::hllizefor($name, 'Raku');
             return -> *@pos_args, *%named_args {
                 $junction_autothreader($p6name, |@pos_args, |%named_args)


### PR DESCRIPTION
Previously fallbacks were only searched for the immediate class, none of its parents was considered. Get this fixed and make code like the following work:

```raku
        class Foo {
            has Date $.a handles(*);
        }
        class Bar is Foo { }
        say Bar.new.yyyy-mm-dd;
```