### PR TITLE
Make raku installation portable

### DIFF
--- a/src/core.c/CompUnit/Repository/Installation.pm6
+++ b/src/core.c/CompUnit/Repository/Installation.pm6
@@ -32,6 +32,9 @@ __END__
 
     my constant $raku-wrapper = '#!/usr/bin/env #raku#
 sub MAIN(:$name, :$auth, :$ver, *@, *%) {
+    my $vendor_dir = $*SPEC.catdir($?FILE.IO.dirname, '..').IO.resolve;
+    my $vendor_repo = CompUnit::Repository::Installation.new(prefix => $vendor_dir);
+    CompUnit::RepositoryRegistry.use-repository($vendor_repo);
     CompUnit::RepositoryRegistry.run-script("#name#", :$name, :$auth, :$ver);
 }';
 


### PR DESCRIPTION
- [X] Create portable installation with `zef install --prefix=yourrepohere .`
- [X] ~~Make raku/moarvm portable (use relative path to get dependencies, ship without nqp)~~ Just use https://rakudo.org/downloads
