### PR TITLE
Make Array.List with holes respect .default

### DIFF
--- a/src/core.c/Array.pm6
+++ b/src/core.c/Array.pm6
@@ -429,26 +429,36 @@ my class Array { # declared in BOOTSTRAP
             !! Rakudo::Iterator.Empty
     }
 
-    multi method List(Array:D: :$view --> List:D) {  # :view is implementation-detail
+    multi method List(Array:D: :$view! --> List:D) is implementation-detail {
+        self.is-lazy    # reifies
+          ?? self.throw-iterator-cannot-be-lazy('.List')
+          !! nqp::isconcrete(my $reified := nqp::getattr(self,List,'$!reified'))
+            ?? $reified.List
+            !! nqp::create(List)
+    }
+    multi method List(Array:D: --> List:D) {
         nqp::if(
           self.is-lazy,                           # can't make a List
           self.throw-iterator-cannot-be-lazy('.List'),
-
           nqp::if(                                # all reified
             nqp::isconcrete(my $reified := nqp::getattr(self,List,'$!reified')),
-            nqp::if(
-              $view,                              # assume no change in array
-              $reified.List,
-              nqp::stmts(                         # make cow copy
-                (my int $elems = nqp::elems($reified)),
-                (my $cow := nqp::setelems(nqp::create(IterationBuffer),$elems)),
-                (my int $i = -1),
-                nqp::while(
-                  nqp::islt_i(++$i,$elems),
-                  nqp::bindpos($cow,$i,nqp::ifnull(nqp::decont(nqp::atpos($reified,$i)),Nil)),
-                ),
-                $cow.List
-              )
+            nqp::stmts(                           # make cow copy
+              (my int $elems = nqp::elems($reified)),
+              (my $cow := nqp::setelems(nqp::create(IterationBuffer),$elems)),
+              nqp::unless(
+                nqp::isconcrete(my $default := $!descriptor.default),
+                ($default := Nil)
+              ),
+              (my int $i = -1),
+              nqp::while(
+                nqp::islt_i(++$i,$elems),
+                nqp::bindpos(
+                  $cow,
+                  $i,
+                  nqp::ifnull(nqp::decont(nqp::atpos($reified,$i)),$default)
+                )
+              ),
+              $cow.List
             ),
             nqp::create(List)                     # was empty, is empty
           )


### PR DESCRIPTION
Spotted by gfldex++ at https://irclogs.raku.org/raku-dev/2022-06-27.html#21:28
this commit will honour any (defined) default value of the Array.

However, after 12d7d5b48add8347eb119 a test for .List **always** returning
Nil was codified in t/spec/S32-array/delete.t .  In retrospect, I think
this is wrong, since a Slip is a specialization of List.  And I also think
that the current implementatation of Array.Slip is actually erroneous,
as it doesn't reify as .List does.

For performance, the ":view" implementation-detail functionality is now
handled by a separate candidate (as as such, properly marked as an
implementation-detail).