### PR TITLE
Add method 'inode'

### DIFF
--- a/src/core.c/IO/Path.pm6
+++ b/src/core.c/IO/Path.pm6
@@ -847,6 +847,18 @@ my class IO::Path is Cool does IO {
           !! self!does-not-exist("inode")
     }
 
+    method dev(IO::Path:D: --> Int:D) {
+        Rakudo::Internals.FILETEST-E(self.absolute)  # sets $!os-path
+          ?? nqp::stat($!os-path, nqp::const::STAT_PLATFORM_DEV)
+          !! self!does-not-exist("inode")
+    }
+
+    method devtype(IO::Path:D: --> Int:D) {
+        Rakudo::Internals.FILETEST-E(self.absolute)  # sets $!os-path
+          ?? nqp::stat($!os-path, nqp::const::STAT_PLATFORM_DEVTYPE)
+          !! self!does-not-exist("inode")
+    }
+
     proto method dir-with-entries(|) {*}
     multi method dir-with-entries(IO::Path:D: --> Bool:D) {
         my $handle := nqp::opendir(self.absolute);

--- a/src/core.c/IO/Path.pm6
+++ b/src/core.c/IO/Path.pm6
@@ -841,6 +841,12 @@ my class IO::Path is Cool does IO {
         }
     }
 
+    method inode(IO::Path:D: --> Int:D) {
+        Rakudo::Internals.FILETEST-E(self.absolute)  # sets $!os-path
+          ?? nqp::stat($!os-path, nqp::const::STAT_PLATFORM_INODE)
+          !! self!does-not-exist("inode")
+    }
+
     proto method dir-with-entries(|) {*}
     multi method dir-with-entries(IO::Path:D: --> Bool:D) {
         my $handle := nqp::opendir(self.absolute);


### PR DESCRIPTION
The syscall is already supported by nqp, no extra efforts needed.