### PR TITLE
Implement coercion via new-disp and re-consider return typechecking dispatcher

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -9674,6 +9674,14 @@ class Perl6::Actions is HLL::Actions does STDActions {
                             QAST::Op.new(
                                 :op('bind'),
                                 QAST::Var.new(:name($name), :scope('local')),
+#?if moar
+                                QAST::Op.new(
+                                    :op<dispatch>,
+                                    QAST::SVal.new(:value<raku-coercion>),
+                                    QAST::Var.new(:name($low_param_type), :scope<local>),
+                                    QAST::Var.new(:name($name), :scope<local>))))));
+#?endif
+#?if !moar
                                 QAST::Op.new(
                                     :op('callmethod'),
                                     :name('coerce'),
@@ -9682,6 +9690,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
                                         QAST::Var.new(:name($low_param_type), :scope('local'))),
                                     QAST::Var.new(:name($low_param_type), :scope('local')),
                                     QAST::Var.new(:name($name), :scope('local')))))));
+#?endif
             }
             elsif nqp::can($ptype_archetypes, 'coercive') && $ptype_archetypes.coercive {
                 $decont_name_invalid := 1;
@@ -9700,12 +9709,21 @@ class Perl6::Actions is HLL::Actions does STDActions {
                         QAST::Op.new(
                             :op('bind'),
                             QAST::Var.new( :name($name), :scope('local') ),
+#?if moar
+                            QAST::Op.new(
+                                :op<dispatch>,
+                                QAST::SVal.new(:value<raku-coercion>),
+                                QAST::WVal.new(:value($param_type)),
+                                QAST::Var.new(:name($name), :scope<local>)))));
+#?endif
+#?if !moar
                             QAST::Op.new(
                                 :op('callmethod'),
                                 :name('coerce'),
                                 QAST::WVal.new(:value($param_type.HOW)),
                                 QAST::WVal.new(:value($param_type)),
                                 QAST::Var.new( :name($name), :scope('local') )))));
+#?endif
             }
 
             # If it's optional, do any default handling.

--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -1791,7 +1791,12 @@ BEGIN {
                     if nqp::eqaddr($type, Mu) || nqp::istype($val, $type) {
                         if $type.HOW.archetypes.coercive {
                             my $coercion_type := $type.HOW.wrappee($type, :coercion);
+#?if moar
+                            nqp::bindattr($cont, Scalar, '$!value', nqp::dispatch('raku-coercion', $coercion_type, $val));
+#?endif
+#?if !moar
                             nqp::bindattr($cont, Scalar, '$!value', $coercion_type.HOW.coerce($coercion_type, $val));
+#?endif
                         }
                         else {
                             nqp::bindattr($cont, Scalar, '$!value', $val);

--- a/src/vm/moar/dispatchers.nqp
+++ b/src/vm/moar/dispatchers.nqp
@@ -3743,22 +3743,22 @@ nqp::dispatch('boot-syscall', 'dispatcher-register', 'raku-isinvokable', -> $cap
     # Coercion protocol
 
     # Coerce by target method name. I.e. $value.TargetType.
-    my $coerce-by-type-method := -> $coercion, $value, $method, $nominal_target, $target_type {
+    my $coerce-by-type-method := nqp::getstaticcode(-> $coercion, $value, $method, $nominal_target, $target_type {
         nqp::istype((my $coerced_value := $method($value)), $target_type)
             || nqp::istype($coerced_value, nqp::gethllsym('Raku', 'Failure'))
             ?? $coerced_value
             !! nqp::how($coercion)."!invalid_coercion"(
                 $value, nqp::how_nd($nominal_target).name($nominal_target), $coerced_value)
-    }
+    });
 
-    my $coerce-COERCE := -> $coercion, $value, $method, $nominal_target, $target_type {
+    my $coerce-COERCE := nqp::getstaticcode(-> $coercion, $value, $method, $nominal_target, $target_type {
         nqp::istype((my $coerced_value := $method($nominal_target, $value)), $target_type)
             || nqp::istype($coerced_value, nqp::gethllsym('Raku', 'Failure'))
             ?? $coerced_value
             !! nqp::how($coercion)."!invalid_coercion"($value, 'COERCE', $coerced_value)
-    };
+    });
 
-    my $coerce-new := -> $coercion, $value, $method, $nominal_target, $target_type {
+    my $coerce-new := nqp::getstaticcode(-> $coercion, $value, $method, $nominal_target, $target_type {
         my $exception;
         my $coerced_value := nqp::null();
         try {
@@ -3780,7 +3780,7 @@ nqp::dispatch('boot-syscall', 'dispatcher-register', 'raku-isinvokable', -> $cap
                 || nqp::istype($coerced_value, nqp::gethllsym('Raku', 'Failure'))
                 ?? $coerced_value
                 !! nqp::how($coercion)."!invalid_coercion"($value, 'new', $coerced_value)
-    };
+    });
 
     nqp::dispatch('boot-syscall', 'dispatcher-register', 'raku-coercion', -> $capture {
         # The dispatch receives:

--- a/t/02-rakudo/18-pseudostash.t
+++ b/t/02-rakudo/18-pseudostash.t
@@ -14,12 +14,11 @@ plan 3;
         is-run "use v6.$rev;\nmy \$foo = q<This is 6.$rev>;\n"
                 ~ q:to/TEST-CODE/,
                     my class C {
-                        method COERCE(Int $v) {
+                        method FALLBACK($,|) {
                             print CALLER::CLIENT::MY::<$foo>;
-                            C.new;
                         }
                     };
-                    C(42);
+                    C.fubar;
                     TEST-CODE
                 "CLIENT:: doesn't fail on NQP packages for 6.$rev",
                 :out("This is 6.$rev"),

--- a/t/09-moar/00-misc.t
+++ b/t/09-moar/00-misc.t
@@ -2,7 +2,7 @@ use lib <t/packages/>;
 use Test;
 use Test::Helpers;
 
-plan 7;
+plan 5;
 
 # https://github.com/rakudo/rakudo/issues/1534
 {
@@ -18,22 +18,16 @@ lives-ok { class C { }; await start { for ^10_0000 { C.^set_name('B') } } xx 4 }
 {
     use nqp;
     nqp::srand(1);
-    my $first  := nqp::rand_I(100,Int);
-    my $second := nqp::rand_I(100,Int);
+    my @first  := nqp::rand_I(100,Int), nqp::rand_I(100,Int);
     nqp::srand(1);
-    is-deeply nqp::rand_I(100,Int), $first,
-      'does srand produce same rand_I values 1';
-    is-deeply nqp::rand_I(100,Int), $second,
-      'does srand produce same rand_I values 2';
+    my @second := nqp::rand_I(100,Int), nqp::rand_I(100,Int);
+    is-deeply @second, @first, 'does srand produce same rand_I values';
 
     nqp::srand(1);
-    $first  := nqp::rand_n(100e0);
-    $second := nqp::rand_n(100e0);
+    @first  := nqp::rand_n(100e0), nqp::rand_n(100e0);
     nqp::srand(1);
-    is-deeply nqp::rand_n(100e0), $first,
-      'does srand produce same rand_n values 1';
-    is-deeply nqp::rand_n(100e0), $second,
-      'does srand produce same rand_n values 2';
+    @second := nqp::rand_n(100e0), nqp::rand_n(100e0);
+    is-deeply @second, @first, 'does srand produce same rand_n values';
 }
 
 lives-ok


### PR DESCRIPTION
All cases covered except for `Type1(Type2())` where recursive dispatching is required.

As to the return typechecking, the following is now valid:

```raku
    subset SmallValue of Rat:D where *.abs < 0.5;
    sub small-value($v --> SmallValue()) { $x }
    say small-value("0.2"); # 0.2
    small-value("1.3"); # will throw
```