### PR TITLE
Add a help function to the repl

### DIFF
--- a/src/core.c/REPL.pm6
+++ b/src/core.c/REPL.pm6
@@ -407,6 +407,19 @@ HELP
                     return $!control-not-allowed;
                 }
 
+                when X::Undeclared::Symbols {
+                    if .unk_routines -> %unk_routines {
+                        if %unk_routines<help> && $code.words -> @words {
+                            if @words.shift eq 'help' {
+                                (REPL.help)(|@words);
+                                return;
+                            }
+                        }
+                    }
+                    exception = $_;
+                    return;
+                }
+
                 default {
                     exception = $_;
                     return;
@@ -420,10 +433,7 @@ HELP
             }
 
             self.compiler.eval(
-              q/my &help := REPL.help;/
-              ~ $code
-                .subst(/^ help \s+ <( \w+ $$/, { "'$/'" })
-                .subst(/ '$*' \d+ /, { '@*_[' ~ $/.substr(2) ~ ']' }, :g),
+              $code.subst(/ '$*' \d+ /, { '@*_[' ~ $/.substr(2) ~ ']' }, :g),
               |%adverbs
             )
         }


### PR DESCRIPTION
Which is basically a call to a "help" multi sub.  Which can be set
externally with a &*HELP dynamic variable.

This is a concept: the texts need to be fleshed out.  The basic idea
is that you can enter "help" at the REPL prompt to get some help
page.  And "help foo" to get help on the "foo" subject.

Just entering "help" or "help foo" where "foo" is not recognized,
should list all available functions.

This functions by compiling in a "help" sub in any code that is being
evaluated.  Any "help foo" string is converted to "help 'foo'" to allow
it being dispatched correctly.

Suggestions for texts / features are welcome.