### PR TITLE
Revert "Make unsuccessful connect fail rather than die"

### DIFF
--- a/src/core.c/IO/Socket/INET.pm6
+++ b/src/core.c/IO/Socket/INET.pm6
@@ -113,7 +113,6 @@ my class IO::Socket::INET does IO::Socket {
 #?endif
         }
         elsif $!type == SOCK_STREAM {
-            CATCH { return .Failure }
             nqp::connect($PIO, nqp::unbox_s($!host), nqp::unbox_i($!port), nqp::decont_i($!family));
         }
 


### PR DESCRIPTION
Reverts rakudo/rakudo#4957 - breaks the specs, unfortunately. We need to find out a way to implement it for 6.e.