### PR TITLE
Add IO::Path.under-version-control method in 6.e

### DIFF
--- a/src/core.e/IO/Path.pm6
+++ b/src/core.e/IO/Path.pm6
@@ -1,0 +1,12 @@
+augment class IO::Path {
+    method under-version-control(IO::Path:D: --> Bool:D) {
+        my $io = self.resolve;
+        (my $parent := $io.parent.resolve) eqv $io
+          ?? (return False)
+          !! ($io = $parent)
+          until $io.add(".git").d;
+        True
+    }
+}
+
+# vim: expandtab shiftwidth=4

--- a/tools/templates/6.e/core_sources
+++ b/tools/templates/6.e/core_sources
@@ -6,6 +6,7 @@ src/core.e/PseudoStash.pm6
 src/core.e/Grammar.pm6
 src/core.e/EXPORTHOW.pm6
 src/core.e/Int.pm6
+src/core.e/IO/Path.pm6
 src/core.e/array_multislice.pm6
 src/core.e/hash_multislice.pm6
 src/core.e/Rakudo/Internals/Sprintf.pm6


### PR DESCRIPTION
Returns True if the invocant appears to be under version control.
This is currently defined as it having a sibling ".git" directory,
or any of its parents having a ".git" directory.

Can be handy for CLI scripts before they do massive changes on a
file system: being under version control provides a bigger chance of
reversibility if something went wrong.