### PR TITLE
[WIP] Make some enhancements to Semaphore

### DIFF
--- a/src/core.c/Semaphore.pm6
+++ b/src/core.c/Semaphore.pm6
@@ -1,15 +1,21 @@
 my class Semaphore is repr('Semaphore') {
-    method new(int $permits) {
-        nqp::box_i($permits, Semaphore);
+    method new(::?CLASS:_: uint $permits) {
+        nqp::box_u($permits, Semaphore);
     }
-    method acquire() {
+    method acquire(::?CLASS:D: --> Nil) {
         nqp::semacquire(self);
     }
-    method try_acquire(--> Bool:D) {
+    method try_acquire(::?CLASS:D: --> Bool:D) {
         nqp::hllbool(nqp::semtryacquire(self))
     }
-    method release() {
+    method release(::?CLASS:D: --> Nil) {
         nqp::semrelease(self);
+    }
+    method Int(::?CLASS:D: --> Int:D) {
+        nqp::unbox_u(self)
+    }
+    multi method Numeric(::?CLASS:D:) {
+        self.Int
     }
 }
 


### PR DESCRIPTION
- Summarized in https://github.com/MoarVM/MoarVM/pull/1714.
- A `Semaphore` boxes a `uint` now...
- ...exposed by `Semaphore.Int`/`Semaphore.Numeric`.
- Passes `t/spec/S17-lowlevel/semaphore.t` on WSL2 OpenSUSE Tumbleweed, but needs more tests evidently.