### PR TITLE
Implement nominalizable transparency for definites

### DIFF
--- a/src/Perl6/Metamodel/ClassHOW.nqp
+++ b/src/Perl6/Metamodel/ClassHOW.nqp
@@ -35,7 +35,7 @@ class Perl6::Metamodel::ClassHOW
 
     my $archetypes := Perl6::Metamodel::Archetypes.new(
         :nominal(1), :inheritable(1), :augmentable(1) );
-    method archetypes() {
+    method archetypes($obj?) {
         $archetypes
     }
 

--- a/src/Perl6/Metamodel/CoercionHOW.nqp
+++ b/src/Perl6/Metamodel/CoercionHOW.nqp
@@ -13,12 +13,14 @@ class Perl6::Metamodel::CoercionHOW
     has $!archetypes;
 
 
-    method archetypes() {
+    method archetypes($obj?) {
         unless nqp::isconcrete($!archetypes) {
-            my $generic := $!target_type.HOW.archetypes.generic || $!constraint_type.HOW.archetypes.generic;
+            my $generic := 
+                $!target_type.HOW.archetypes($!target_type).generic 
+                || $!constraint_type.HOW.archetypes($!constraint_type).generic;
             $!archetypes := Perl6::Metamodel::Archetypes.new(
                 :coercive, :nominalizable, :$generic,
-                definite => $!target_type.HOW.archetypes.definite,
+                definite => $!target_type.HOW.archetypes($!target_type).definite,
             );
         }
         $!archetypes
@@ -37,7 +39,7 @@ class Perl6::Metamodel::CoercionHOW
 
     method set_target_type($target_type) {
         $!target_type := $target_type;
-        $!nominal_target := $!target_type.HOW.archetypes.nominalizable
+        $!nominal_target := $!target_type.HOW.archetypes($!target_type).nominalizable
                                 ?? $!target_type.HOW.nominalize($!target_type)
                                 !! $!target_type;
     }
@@ -67,7 +69,7 @@ class Perl6::Metamodel::CoercionHOW
     }
 
     method nominalize($coercion_type) {
-        $!target_type.HOW.archetypes.nominalizable
+        $!target_type.HOW.archetypes($!target_type).nominalizable
             ?? $!target_type.HOW.nominalize($!target_type)
             !! $!target_type
     }
@@ -75,11 +77,11 @@ class Perl6::Metamodel::CoercionHOW
     method instantiate_generic($coercion_type, $type_env) {
         return $coercion_type unless $!archetypes.generic;
         my $ins_target :=
-            $!target_type.HOW.archetypes.generic
+            $!target_type.HOW.archetypes($!target_type).generic
                 ?? $!target_type.HOW.instantiate_generic($!target_type, $type_env)
                 !! $!target_type;
         my $ins_constraint :=
-            $!constraint_type.HOW.archetypes.generic
+            $!constraint_type.HOW.archetypes($!constraint_type).generic
                 ?? $!constraint_type.HOW.instantiate_generic($!constraint_type, $type_env)
                 !! $!constraint_type;
         self.new_type($ins_target, $ins_constraint);
@@ -126,7 +128,7 @@ class Perl6::Metamodel::CoercionHOW
     method !coerce_TargetType($obj, $value) {
         my $constraintHOW := $!constraint_type.HOW;
         $value := $constraintHOW.coerce($!constraint_type, $value)
-          if nqp::can((my $archetypes := $constraintHOW.archetypes), 'coercive')
+          if nqp::can((my $archetypes := $constraintHOW.archetypes($!constraint_type)), 'coercive')
           && $archetypes.coercive;
 
         my $nominal_target := $!nominal_target;

--- a/src/Perl6/Metamodel/ConcreteRoleHOW.nqp
+++ b/src/Perl6/Metamodel/ConcreteRoleHOW.nqp
@@ -25,7 +25,7 @@ class Perl6::Metamodel::ConcreteRoleHOW
     has $!composed;
 
     my $archetypes := Perl6::Metamodel::Archetypes.new( :nominal(1), :composable(1) );
-    method archetypes() {
+    method archetypes($obj?) {
         $archetypes
     }
 

--- a/src/Perl6/Metamodel/CurriedRoleHOW.nqp
+++ b/src/Perl6/Metamodel/CurriedRoleHOW.nqp
@@ -36,18 +36,18 @@ class Perl6::Metamodel::CurriedRoleHOW
     my $archetypes_ng := Perl6::Metamodel::Archetypes.new( :nominal(1), :composable(1), :inheritalizable(1), :parametric(1) );
     method !choose_archetype() {
         for @!pos_args {
-            if $_.HOW.archetypes.generic {
+            if $_.HOW.archetypes($_).generic {
                 return $archetypes_g;
             }
         }
         for %!named_args {
-            if $_.value.HOW.archetypes.generic {
+            if $_.value.HOW.archetypes($_.value).generic {
                 return $archetypes_g;
             }
         }
         $archetypes_ng
     }
-    method archetypes() {
+    method archetypes($obj?) {
         if nqp::isconcrete(self) {
             $!archetypes := self.'!choose_archetype'() unless $!archetypes;
             return $!archetypes;
@@ -159,12 +159,12 @@ class Perl6::Metamodel::CurriedRoleHOW
         my @new_pos;
         my %new_named;
         for @!pos_args {
-            @new_pos.push($_.HOW.archetypes.generic ??
+            @new_pos.push($_.HOW.archetypes($_).generic ??
                 $_.HOW.instantiate_generic($_, $type_env) !!
                 $_);
         }
         for %!named_args {
-            %new_named{$_.key} := $_.value.HOW.archetypes.generic ??
+            %new_named{$_.key} := $_.value.HOW.archetypes($_).generic ??
                 $_.value.HOW.instantiate_generic($_.value, $type_env) !!
                 $_.value;
         }
@@ -242,7 +242,7 @@ class Perl6::Metamodel::CurriedRoleHOW
         }
         if nqp::can($checkee.HOW, 'role_typecheck_list') {
             for $checkee.HOW.role_typecheck_list($checkee) {
-                if nqp::istype($_.HOW, self.WHAT) && !$_.HOW.archetypes.generic {
+                if nqp::istype($_.HOW, self.WHAT) && !$_.HOW.archetypes($_).generic {
                     if nqp::decont($_.HOW.curried_role($_)) =:= $crdc {
                         @cands.push($_);
                     }

--- a/src/Perl6/Metamodel/EnumHOW.nqp
+++ b/src/Perl6/Metamodel/EnumHOW.nqp
@@ -45,7 +45,7 @@ class Perl6::Metamodel::EnumHOW
 
     my $archetypes := Perl6::Metamodel::Archetypes.new( :nominal(1), :composalizable(1),
                                                         :augmentable(1) );
-    method archetypes() {
+    method archetypes($obj?) {
         $archetypes
     }
 

--- a/src/Perl6/Metamodel/GenericHOW.nqp
+++ b/src/Perl6/Metamodel/GenericHOW.nqp
@@ -6,7 +6,7 @@ class Perl6::Metamodel::GenericHOW
     does Perl6::Metamodel::Naming
 {
     my $archetypes := Perl6::Metamodel::Archetypes.new( :generic(1) );
-    method archetypes() {
+    method archetypes($obj?) {
         $archetypes
     }
 

--- a/src/Perl6/Metamodel/ModuleHOW.nqp
+++ b/src/Perl6/Metamodel/ModuleHOW.nqp
@@ -9,7 +9,7 @@ class Perl6::Metamodel::ModuleHOW
     has $!composed;
 
     my $archetypes := Perl6::Metamodel::Archetypes.new( );
-    method archetypes() {
+    method archetypes($obj?) {
         $archetypes
     }
 

--- a/src/Perl6/Metamodel/NativeHOW.nqp
+++ b/src/Perl6/Metamodel/NativeHOW.nqp
@@ -13,7 +13,7 @@ class Perl6::Metamodel::NativeHOW
     has $!composed;
 
     my $archetypes := Perl6::Metamodel::Archetypes.new( :nominal(1) );
-    method archetypes() {
+    method archetypes($obj?) {
         $archetypes
     }
 

--- a/src/Perl6/Metamodel/NativeRefHOW.nqp
+++ b/src/Perl6/Metamodel/NativeRefHOW.nqp
@@ -14,7 +14,7 @@ class Perl6::Metamodel::NativeRefHOW
     has $!repr_composed;
 
     my $archetypes := Perl6::Metamodel::Archetypes.new( :nominal(1), :inheritable(1) );
-    method archetypes() {
+    method archetypes($obj?) {
         $archetypes
     }
 

--- a/src/Perl6/Metamodel/Nominalizable.nqp
+++ b/src/Perl6/Metamodel/Nominalizable.nqp
@@ -17,7 +17,7 @@ role Perl6::Metamodel::Nominalizable {
 
             # If the immediate wrappee is a nominalizable then bypass the request
             return $my_wrappee.HOW."!find_wrappee"($my_wrappee, %kind_of, :$lookup)
-                if $my_wrappee.HOW.archetypes.nominalizable;
+                if $my_wrappee.HOW.archetypes($my_wrappee).nominalizable;
 
             # Don't be aggressive if it's about introspection purposes
             return nqp::null() if $lookup;

--- a/src/Perl6/Metamodel/PackageHOW.nqp
+++ b/src/Perl6/Metamodel/PackageHOW.nqp
@@ -7,8 +7,8 @@ class Perl6::Metamodel::PackageHOW
 {
     has $!composed;
 
-    my $archetypes := Perl6::Metamodel::Archetypes.new( );
-    method archetypes() {
+    my $archetypes := Perl6::Metamodel::Archetypes.new();
+    method archetypes($obj?) {
         $archetypes
     }
 

--- a/src/Perl6/Metamodel/ParametricRoleGroupHOW.nqp
+++ b/src/Perl6/Metamodel/ParametricRoleGroupHOW.nqp
@@ -24,7 +24,7 @@ class Perl6::Metamodel::ParametricRoleGroupHOW
     has @!nonsignatured;
 
     my $archetypes := Perl6::Metamodel::Archetypes.new( :nominal(1), :composable(1), :inheritalizable(1), :parametric(1) );
-    method archetypes() {
+    method archetypes($obj?) {
         $archetypes
     }
 

--- a/src/Perl6/Metamodel/ParametricRoleHOW.nqp
+++ b/src/Perl6/Metamodel/ParametricRoleHOW.nqp
@@ -25,7 +25,7 @@ class Perl6::Metamodel::ParametricRoleHOW
     has $!specialize_lock;
 
     my $archetypes := Perl6::Metamodel::Archetypes.new( :nominal(1), :composable(1), :inheritalizable(1), :parametric(1) );
-    method archetypes() {
+    method archetypes($obj?) {
         $archetypes
     }
 
@@ -216,7 +216,7 @@ class Perl6::Metamodel::ParametricRoleHOW
         # Roles done by this role need fully specializing also.
         for self.roles_to_compose($obj) {
             my $ins := my $r := $_;
-            if $_.HOW.archetypes.generic {
+            if $_.HOW.archetypes($_).generic {
                 $ins := $ins.HOW.instantiate_generic($ins, $type_env);
                 unless $ins.HOW.archetypes.parametric {
                     my $target-name := $obj.HOW.name($obj);
@@ -239,7 +239,7 @@ class Perl6::Metamodel::ParametricRoleHOW
         # the case they're generic (role Foo[::T] is T { })
         for self.parents($obj, :local(1)) {
             my $p := $_;
-            if $p.HOW.archetypes.generic {
+            if $p.HOW.archetypes($p).generic {
                 $p := $p.HOW.instantiate_generic($p, $type_env);
             }
             $conc.HOW.add_parent($conc, $p, :hides(self.hides_parent($obj, $_)));
@@ -249,7 +249,7 @@ class Perl6::Metamodel::ParametricRoleHOW
         # punning case, since roles are the way we get generic types).
         if self.is_array_type($obj) {
             my $at := self.array_type($obj);
-            if $at.HOW.archetypes.generic {
+            if $at.HOW.archetypes($at).generic {
                 $at := $at.HOW.instantiate_generic($at, $type_env);
             }
             $conc.HOW.set_array_type($conc, $at);

--- a/src/Perl6/Metamodel/SubsetHOW.nqp
+++ b/src/Perl6/Metamodel/SubsetHOW.nqp
@@ -16,9 +16,9 @@ class Perl6::Metamodel::SubsetHOW
 
     has $!archetypes;
 
-    method archetypes() {
+    method archetypes($obj?) {
         unless nqp::isconcrete($!archetypes) {
-            my $refinee_archetypes := $!refinee.HOW.archetypes;
+            my $refinee_archetypes := $!refinee.HOW.archetypes($!refinee);
             my $generic := $refinee_archetypes.generic
                             || (nqp::defined($!refinement)
                                 && nqp::can($!refinement, 'is_generic')
@@ -53,7 +53,7 @@ class Perl6::Metamodel::SubsetHOW
     }
 
     method set_of($obj, $refinee) {
-        my $archetypes := $refinee.HOW.archetypes;
+        my $archetypes := $refinee.HOW.archetypes($refinee);
         if $archetypes.generic {
             nqp::die("Use of a generic as 'of' type of a subset is not implemented yet")
         }
@@ -97,7 +97,7 @@ class Perl6::Metamodel::SubsetHOW
     }
 
     method nominalize($obj) {
-        $!refinee.HOW.archetypes.nominalizable
+        $!refinee.HOW.archetypes($!refinee).nominalizable
             ?? $!refinee.HOW.nominalize($!refinee)
             !! $!refinee
     }
@@ -123,7 +123,7 @@ class Perl6::Metamodel::SubsetHOW
         nqp::hllboolfor(
             nqp::istype($checkee, $!refinee) &&
             (nqp::isnull($!refinement)
-             || ($!refinee.HOW.archetypes.coercive
+             || ($!refinee.HOW.archetypes($!refinee).coercive
                     ?? nqp::istrue($!refinement.ACCEPTS($!refinee.HOW.coerce($!refinee, $checkee)))
                     !! nqp::istrue($!refinement.ACCEPTS($checkee)))),
             "Raku")

--- a/src/Perl6/Optimizer.nqp
+++ b/src/Perl6/Optimizer.nqp
@@ -1580,10 +1580,10 @@ my class SmartmatchOptimizer {
         # - the type is a generic
         return nqp::null()
             if !nqp::can($sm_type_how, 'archetypes')
-                || $sm_type_how.archetypes.generic;
+                || $sm_type_how.archetypes($sm_type).generic;
 
         my $sm_is_subset :=
-            $sm_type_how.archetypes.nominalizable
+            $sm_type_how.archetypes($sm_type).nominalizable
             && !nqp::isnull($sm_type_how.wrappee-lookup($sm_type, :subset));
 
         note("Try typematch over RHS ", $sm_type.HOW.name($sm_type)) if $!debug;
@@ -1600,7 +1600,7 @@ my class SmartmatchOptimizer {
                 ", ast returns: ", $lhs.ast.returns.HOW.name($lhs.ast.returns),
                 "), constant substitution is possible") if $!debug;
 
-            return nqp::null() if $lhs.value.HOW.archetypes.generic;
+            return nqp::null() if $lhs.value.HOW.archetypes($lhs.value).generic;
 
             # Wrap into try because for if there a user-defined `where`-block involved into typematching it might throw.
             # Consider this case a failed typematch and proceed further.
@@ -4571,7 +4571,7 @@ class Perl6::Optimizer {
 
                 my $invocant_type := $signature.params.AT-POS(0).type;
                 # Skip a method with :D if requested
-                next if $invocant_type.HOW.archetypes.definite
+                next if $invocant_type.HOW.archetypes($invocant_type).definite
                         && $invocant_type.HOW.definite($invocant_type);
             }
 

--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -2052,10 +2052,10 @@ class Perl6::World is HLL::World {
         # If type does LanguageRevision then check what language it was created with. Otherwise base decision on the
         # current compiler.
         my $v-how := $v.HOW;
-        !$v-how.archetypes.coercive
+        !$v-how.archetypes($v).coercive
         && (nqp::can($v-how, 'lang-rev-before') ?? $v-how.lang-rev-before($v, 'e') !! self.lang-rev-before('e'))
             ?? self.maybe-definite-how-base($v)
-            !! ($v.HOW.archetypes.nominalizable
+            !! ($v.HOW.archetypes($v).nominalizable
                 ?? $v.HOW.nominalize($v)
                 !! $v)
     }
@@ -2164,7 +2164,7 @@ class Perl6::World is HLL::World {
         if nqp::istype($varast, QAST::Var) {
             $varast.scope('lexical');
             $varast.returns(%cont_info<bind_constraint>);
-            if %cont_info<bind_constraint>.HOW.archetypes.generic {
+            if %cont_info<bind_constraint>.HOW.archetypes(%cont_info<bind_constraint>).generic {
                 $varast := QAST::Op.new(
                     :op('callmethod'), :name('instantiate_generic'),
                     QAST::Op.new( :op('p6var'), $varast ),
@@ -2245,7 +2245,7 @@ class Perl6::World is HLL::World {
         if %param_info<type_generic> {
             $flags := $flags + $SIG_ELEM_TYPE_GENERIC;
         }
-        if $paramerter_type.HOW.archetypes.coercive {
+        if $paramerter_type.HOW.archetypes($paramerter_type).coercive {
             $flags := $flags + $SIG_ELEM_IS_COERCIVE;
         }
         if %param_info<default_is_literal> {

--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -35,7 +35,7 @@ my class BOOTSTRAPATTR {
     method positional_delegate() { 0 }
     method associative_delegate() { 0 }
     method build() { }
-    method is_generic() { $!type.HOW.archetypes.generic }
+    method is_generic() { $!type.HOW.archetypes($!type).generic }
     method instantiate_generic($type_environment) {
         my $ins := $!type.HOW.instantiate_generic($!type, $type_environment);
         self.new(:name($!name), :box_target($!box_target), :type($ins))
@@ -1192,11 +1192,11 @@ class ContainerDescriptor does Perl6::Metamodel::Explaining {
     method set_dynamic($dynamic) { $!dynamic := $dynamic; self }
 
     method is_generic() {
-        $!of.HOW.archetypes.generic
+        $!of.HOW.archetypes($!of).generic
     }
 
     method is_default_generic() {
-        $!default.HOW.archetypes.generic
+        $!default.HOW.archetypes($!default).generic
     }
 
     method instantiate_generic($type_environment) {
@@ -1716,7 +1716,10 @@ BEGIN {
                 Attribute, '$!package');
             my $build := nqp::getattr(nqp::decont($dcself),
                 Attribute, '$!build_closure');
-            nqp::hllboolfor($type.HOW.archetypes.generic || $package.HOW.archetypes.generic || nqp::defined($build), "Raku");
+            nqp::hllboolfor(
+                $type.HOW.archetypes($type).generic 
+                || $package.HOW.archetypes($package).generic 
+                || nqp::defined($build), "Raku");
         }));
     Attribute.HOW.add_method(Attribute, 'instantiate_generic', nqp::getstaticcode(sub ($self, $type_environment) {
             my $dcself   := nqp::decont($self);
@@ -1726,7 +1729,7 @@ BEGIN {
             my $avc      := nqp::getattr($dcself, Attribute, '$!auto_viv_container');
             my $bc       := nqp::getattr($dcself, Attribute, '$!build_closure');
             my $ins      := nqp::clone($dcself);
-            if $type.HOW.archetypes.generic {
+            if $type.HOW.archetypes($type).generic {
                 nqp::bindattr($ins, Attribute, '$!type',
                     $type.HOW.instantiate_generic($type, $type_environment));
                 my $cd_ins := $cd.instantiate_generic($type_environment);
@@ -1738,7 +1741,7 @@ BEGIN {
                 nqp::bindattr($avc_copy, @avc_mro[$i], '$!descriptor', $cd_ins);
                 nqp::bindattr($ins, Attribute, '$!auto_viv_container', $avc_copy);
             }
-            if $pkg.HOW.archetypes.generic {
+            if $pkg.HOW.archetypes($pkg).generic {
                 nqp::bindattr($ins, Attribute, '$!package',
                     $pkg.HOW.instantiate_generic($pkg, $type_environment));
             }
@@ -1765,7 +1768,7 @@ BEGIN {
             nqp::getattr($dcself, Scalar, '$!descriptor').instantiate_generic(
                 $type_environment));
         my $val := nqp::getattr($dcself, Scalar, '$!value');
-        if $val.HOW.archetypes.generic {
+        if $val.HOW.archetypes($val).generic {
             nqp::bindattr($dcself, Scalar, '$!value',
                 $val.HOW.instantiate_generic($val, $type_environment));
         }
@@ -1789,7 +1792,7 @@ BEGIN {
                     $val := $desc.default if nqp::eqaddr($val.WHAT, Nil);
                     my $type := $desc.of;
                     if nqp::eqaddr($type, Mu) || nqp::istype($val, $type) {
-                        if $type.HOW.archetypes.coercive {
+                        if $type.HOW.archetypes($type).coercive {
                             my $coercion_type := $type.HOW.wrappee($type, :coercion);
 #?if moar
                             nqp::bindattr($cont, Scalar, '$!value', nqp::dispatch('raku-coercion', $coercion_type, $val));
@@ -2026,7 +2029,7 @@ BEGIN {
             }
             nqp::bindattr($ins, Signature, '@!params', @ins_params);
             my $returns := nqp::getattr($self, Signature, '$!returns');
-            if !nqp::isnull($returns) && $returns.HOW.archetypes.generic {
+            if !nqp::isnull($returns) && $returns.HOW.archetypes($returns).generic {
                 nqp::bindattr($ins, Signature, '$!returns',
                     $returns.HOW.instantiate_generic($returns, $type_environment));
             }
@@ -2083,8 +2086,8 @@ BEGIN {
             my $ap   := nqp::getattr($self, Parameter, '$!attr_package');
             my $sigc := nqp::getattr($self, Parameter, '$!signature_constraint');
             nqp::hllboolfor(
-                $type.HOW.archetypes.generic
-                || (!nqp::isnull($ap) && $ap.HOW.archetypes.generic)
+                $type.HOW.archetypes($type).generic
+                || (!nqp::isnull($ap) && $ap.HOW.archetypes($ap).generic)
                 || (nqp::defined($sigc) && $sigc.is_generic),
                 "Raku")
         }));
@@ -2099,12 +2102,12 @@ BEGIN {
             my $sigc     := nqp::getattr($self, Parameter, '$!signature_constraint');
             my $ins_type := $type;
             my $ins_cd   := $cd;
-            if $type.HOW.archetypes.generic {
+            if $type.HOW.archetypes($type).generic {
                 $ins_type := $type.HOW.instantiate_generic($type, $type_environment);
                 $ins_cd   := nqp::isnull($cd) ?? $cd !! $cd.instantiate_generic($type_environment);
             }
             my $ins_ap :=
-                !nqp::isnull($ap) && $ap.HOW.archetypes.generic
+                !nqp::isnull($ap) && $ap.HOW.archetypes($ap).generic
                     ?? $ap.HOW.instantiate_generic($ap, $type_environment)
                     !! $ap;
             my $ins_sigc :=
@@ -2112,12 +2115,12 @@ BEGIN {
                     ?? $sigc.instantiate_generic($type_environment)
                     !! $sigc;
             my int $flags := nqp::getattr_i($ins, Parameter, '$!flags');
-            unless $ins_type.HOW.archetypes.generic {
+            unless $ins_type.HOW.archetypes($ins_type).generic {
                 if $flags +& $SIG_ELEM_TYPE_GENERIC {
                     nqp::bindattr_i($ins, Parameter, '$!flags', $flags - $SIG_ELEM_TYPE_GENERIC);
                 }
             }
-            my $archetypes := $ins_type.HOW.archetypes;
+            my $archetypes := $ins_type.HOW.archetypes($ins_type);
             if nqp::can($archetypes, 'coercive') && $archetypes.coercive {
                 nqp::bindattr_i($ins, Parameter, '$!flags', $flags +| $SIG_ELEM_IS_COERCIVE);
             }
@@ -2683,7 +2686,7 @@ BEGIN {
                     else {
                         my $ptype :=
                             nqp::getattr($param, Parameter, '$!type');
-                        if $ptype.HOW.archetypes.coercive {
+                        if $ptype.HOW.archetypes($ptype).coercive {
                             my $coercion_type := $ptype.HOW.wrappee($ptype, :coercion);
                             $ptype := $coercion_type.HOW.constraint_type($coercion_type);
                         }

--- a/src/core.c/Code.pm6
+++ b/src/core.c/Code.pm6
@@ -83,7 +83,7 @@ my class Code { # declared in BOOTSTRAP
         # (e.g. types set to or parameterized by captured types.)
         my sub strip_parm (Parameter:D $parm, :$make_optional = False) {
             my $type := $parm.type;
-            my $type_coercive := $type.HOW.archetypes.coercive;
+            my $type_coercive := $type.^archetypes.coercive;
             my @types = $type_coercive
                             ?? ($type.^target_type.^name, $type.^constraint_type.^name)
                             !! $type.^name;

--- a/src/core.c/Numeric.pm6
+++ b/src/core.c/Numeric.pm6
@@ -6,7 +6,7 @@ my role Numeric {
     multi method Numeric(Numeric:U:) {
         self.Mu::Numeric; # issue a warning
         # We need to be specific about coercions to make `Numeric() == 0` working as specced.
-        (self.HOW.archetypes.coercive ?? self.^nominalize !! self).new
+        (self.^archetypes.coercive ?? self.^nominalize !! self).new
     }
 
     multi method ACCEPTS(Numeric:D: Any:D \a) {

--- a/src/core.c/Parameter.pm6
+++ b/src/core.c/Parameter.pm6
@@ -231,7 +231,7 @@ my class Parameter { # declared in BOOTSTRAP
         $flags +|= $SIG_ELEM_IS_COPY        if $is-copy;
         $flags +|= $SIG_ELEM_IS_RAW         if $is-raw;
         $flags +|= $SIG_ELEM_IS_RW          if $is-rw;
-        $flags +|= $SIG_ELEM_IS_COERCIVE    if $!type.HOW.archetypes.coercive;
+        $flags +|= $SIG_ELEM_IS_COERCIVE    if $!type.^archetypes.coercive;
 
         $!variable_name = $name if $name;
         $!flags = $flags;
@@ -323,9 +323,9 @@ my class Parameter { # declared in BOOTSTRAP
     method type(Parameter:D: --> Mu) { $!type }
 
     # XXX Must be marked as DEPRECATED
-    method coerce_type(Parameter:D: --> Mu) { $!type.HOW.archetypes.coercive ?? $!type.^target_type !! Mu }
+    method coerce_type(Parameter:D: --> Mu) { $!type.^archetypes.coercive ?? $!type.^target_type !! Mu }
 
-    method nominal_type(Parameter:D: --> Mu) { $!type.HOW.archetypes.nominalizable ?? $!type.^nominalize !! $!type }
+    method nominal_type(Parameter:D: --> Mu) { $!type.^archetypes.nominalizable ?? $!type.^nominalize !! $!type }
 
     method named_names(Parameter:D: --> List:D) {
         nqp::if(
@@ -663,7 +663,7 @@ multi sub infix:<eqv>(Parameter:D $a, Parameter:D $b) {
     # different compunits the curryings would be different typeobject instances.
     return False
         unless
-            (atype.HOW.archetypes.generic && btype.HOW.archetypes.generic)
+            (atype.^archetypes.generic && btype.^archetypes.generic)
             || (nqp::istype(atype, btype)
                 && nqp::istype(btype, atype));
 

--- a/src/core.c/Routine.pm6
+++ b/src/core.c/Routine.pm6
@@ -289,7 +289,7 @@ my class Routine { # declared in BOOTSTRAP
             if $U || $D {
                 next unless nqp::istype(&cand, Method) || nqp::istype(&cand, Submethod);
                 my $invocant-type := &cand.signature.params[0].type;
-                my $is-definite := $invocant-type.HOW.archetypes.definite && $invocant-type.^definite;
+                my $is-definite := $invocant-type.^archetypes.definite && $invocant-type.^definite;
                 next unless ($U && !$is-definite) || ($D && $is-definite);
             }
             return False unless &cand.file.starts-with: 'SETTING::';

--- a/src/core.c/traits.pm6
+++ b/src/core.c/traits.pm6
@@ -15,7 +15,7 @@ my class Pod::Block::Declarator { ... }
 proto sub trait_mod:<is>(Mu $, |) {*}
 multi sub trait_mod:<is>(Mu:U $child, Mu:U $parent) {
     if $parent.HOW.archetypes.inheritable()
-        || ($child.HOW.archetypes.parametric && $parent.HOW.archetypes.generic)
+        || ($child.HOW.archetypes.parametric && $parent.^archetypes.generic)
     {
         $child.^add_parent($parent);
     }


### PR DESCRIPTION
The following will now produce correct true output:

```raku
    subset Foo of Int();
    say Foo:D.^archetypes.coercive;
```

Also note the use of `.^archetypes` notation.

The target is achieved by parameterizing definites with an additional argument and adding optional `$obj` positional parameter, akin to many other user-land accessible methods invoked via `.^` notation.

The additional parameterization argument is an index built from definite's base type `coercive` and `generic` values by considering them as bits and doiing `($coercive +< 1) +| $generic`. The index is then pulled from the typeobject parameterization arguments and used to choose the right archetypes instance from a list of predefined
`Perl6::Metamodel::Archetype` instances.

In particular, this commit fixes a case like the following:

```raku
    role R[::T, $default] {
        has T:D $.a = $default;
    }
    class C does R[Int, 42] { }
```

Prior this was failing due to `T:D` was not instantiated a was failing type check.

Many other cases of using definite generics are supposedely to be fixed
too.