### PR TITLE
Implement lazy 'handles' trait application for methods

### DIFF
--- a/src/Perl6/Metamodel/MethodContainer.nqp
+++ b/src/Perl6/Metamodel/MethodContainer.nqp
@@ -52,6 +52,11 @@ role Perl6::Metamodel::MethodContainer {
         %!cache := {};
         @!method_order[+@!method_order] := $code_obj;
         @!method_names[+@!method_names] := $name;
+
+        # See if trait `handles` has been applied and we can use it on the target type
+        if nqp::can($code_obj, 'apply_handles') && nqp::can($obj.HOW, 'find_method_fallback') {
+            $code_obj.apply_handles($obj);
+        }
     }
 
     # Gets the method hierarchy.


### PR DESCRIPTION
Apply only when a method is added to a HOW capable of doing fallbacks which is currently `ClassHOW` only.

Also enables all same `handles` formats as the attribute version supports. I.e., `*`, `**`, pairs.

Fixes #4983