### PR TITLE
Get around a problem where a module duplicates method objects

### DIFF
--- a/src/Perl6/Metamodel/MethodContainer.nqp
+++ b/src/Perl6/Metamodel/MethodContainer.nqp
@@ -14,7 +14,7 @@ role Perl6::Metamodel::MethodContainer {
     has %!cache;
 
     # Add a method.
-    method add_method($obj, $name, $code_obj) {
+    method add_method($obj, $name, $code_obj, :$handles = 1) {
         # Ensure we haven't already got it.
         $code_obj := nqp::decont($code_obj);
         $name := nqp::decont_s($name);
@@ -45,6 +45,23 @@ role Perl6::Metamodel::MethodContainer {
             %!methods{$name} := $code_obj;
         }
 
+        # See if trait `handles` has been applied and we can use it on the target type.
+        # XXX Also skip this step if method is being added under a different name but the original code object has been
+        # installed earlier. This step is here until Method::Also incorporates support for :!handles argument.
+        if $handles
+            && nqp::can($code_obj, 'apply_handles') 
+            && nqp::can($obj.HOW, 'find_method_fallback') 
+        {
+            my $do_apply := 1;
+            for @!method_order {
+                if $_ =:= $code_obj {
+                    $do_apply := 0;
+                    last
+                }
+            }
+            $code_obj.apply_handles($obj) if $do_apply;
+        }
+
         # Adding a method means any cache is no longer authoritative.
         if nqp::can(self, "invalidate_method_caches") {
             self.invalidate_method_caches($obj);
@@ -52,11 +69,6 @@ role Perl6::Metamodel::MethodContainer {
         %!cache := {};
         @!method_order[+@!method_order] := $code_obj;
         @!method_names[+@!method_names] := $name;
-
-        # See if trait `handles` has been applied and we can use it on the target type
-        if nqp::can($code_obj, 'apply_handles') && nqp::can($obj.HOW, 'find_method_fallback') {
-            $code_obj.apply_handles($obj);
-        }
     }
 
     # Gets the method hierarchy.

--- a/src/Perl6/Metamodel/MultiMethodContainer.nqp
+++ b/src/Perl6/Metamodel/MultiMethodContainer.nqp
@@ -111,6 +111,9 @@ role Perl6::Metamodel::MultiMethodContainer {
                     nqp::push(@new_protos, $proto);
                 }
             }
+            if nqp::can($code, 'apply_handles') && nqp::can($obj.HOW, 'find_method_fallback') {
+                $code.apply_handles($obj);
+            }
             $i := $i + 1;
         }
         for @new_protos {

--- a/src/core.c/traits.pm6
+++ b/src/core.c/traits.pm6
@@ -453,7 +453,7 @@ multi sub trait_mod:<handles>(Attribute:D $target, $thunk) {
         }
 
         method add_delegator_method($attr: Mu $pkg, $meth_name, $call_name) {
-            my $meth := method (|c) is rw {
+            my $meth := anon method (|c) is rw {
                 (nqp::isconcrete(self)
                   ?? $attr.get_value(self)
                   !! nqp::decont(nqp::getattr(
@@ -539,7 +539,7 @@ multi sub trait_mod:<handles>(Method:D $m, &thunk) {
         }
 
         method add_delegator_method(&code_obj: Mu $pkg, $meth_name, $call_name) {
-            my $meth := method (|c) is rw {
+            my $meth := anon method (|c) is rw {
                 &code_obj(self)."$call_name"(|c)
             };
             $meth.set_name($meth_name);


### PR DESCRIPTION
If the method is delegating then metamodel invokes `apply_handles` for
each its copy in the method table causing 'method is already defined'
error for delegations. For now it is only `Method::Also` is known which
does this kind of duplication.

The fix is implemented with an additional `:$handles` argument. If true
then no attempt to call `apply_handles` is done.

Until `Method::Also` incorporates support for this argument a workaround
step is done where we make sure that the method object hasn't been
previously installed in the table. This step is to be eliminated as soon
as use of `:!handles` argument is ensured where necessary.

Also added support for using `handles` on multi-candidates. For the
moment this support is also suceptible to the method object duplication
problem. But there is no simple fix for this, so just hoping for
`:!handles` again.