### PR TITLE
Make some enhancements to atomic integers

### DIFF
--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -3998,6 +3998,7 @@ BEGIN {
 }
 EXPORT::DEFAULT.WHO<NQPMatchRole> := NQPMatchRole;
 EXPORT::DEFAULT.WHO<NQPdidMATCH> := NQPdidMATCH;
+EXPORT::DEFAULT.WHO<Counter> := Counter;
 
 #?if !moar
 # Set up various type mappings.

--- a/src/core.c/core_epilogue.pm6
+++ b/src/core.c/core_epilogue.pm6
@@ -18,6 +18,7 @@ BEGIN {
     Perl6::Metamodel::MultiDispatcher.HOW.compose(Perl6::Metamodel::MultiDispatcher);
     Perl6::Metamodel::WrapDispatcher.HOW.compose(Perl6::Metamodel::WrapDispatcher);
 #?endif
+    Counter.HOW.reparent(Counter, Any);
 }
 
 BEGIN {


### PR DESCRIPTION
- Introduce the nqp-ish, semaphore-ish, serializable `Counter` class for the MOP's sake.
- Consider giving the JVM and JS backends atomicops.
- Tests need adjustment due to the new symbol.
- Takes the place of https://github.com/rakudo/rakudo/pull/4990.