### PR TITLE
Fix some cases of coercion over containerized values

### DIFF
--- a/src/Perl6/Metamodel/CoercionHOW.nqp
+++ b/src/Perl6/Metamodel/CoercionHOW.nqp
@@ -113,7 +113,7 @@ class Perl6::Metamodel::CoercionHOW
     # Coercion protocol method.
     method coerce($obj, $value) {
 #?if moar
-        nqp::dispatch('raku-coercion', $obj, $value)
+        nqp::dispatch('raku-coercion', nqp::decont($obj), $value)
 #?endif
 #?if !moar
         nqp::istype($value, $!target_type)

--- a/src/vm/moar/dispatchers.nqp
+++ b/src/vm/moar/dispatchers.nqp
@@ -556,48 +556,6 @@ nqp::dispatch('boot-syscall', 'dispatcher-register', 'raku-sink', -> $capture {
     }
 });
 
-# Coercion dispatcher. The first argument is the value to coerce, the second
-# is what to coerce it into.
-{
-    sub coercion_error($from_name, $to_name) {
-        nqp::die("Unable to coerce the from $from_name to $to_name; " ~
-            "no coercion method defined");
-    }
-
-    nqp::dispatch('boot-syscall', 'dispatcher-register', 'raku-coerce', -> $capture {
-        my $to_coerce := nqp::captureposarg($capture, 0);
-        my $coerce_type := nqp::captureposarg($capture, 1);
-
-        # See if there is a method named for the type.
-        my str $to_name := nqp::how_nd($coerce_type).name($coerce_type);
-        my $coerce_method := nqp::decont(nqp::how_nd($to_coerce).find_method($to_coerce, $to_name));
-        if nqp::isconcrete($coerce_method) {
-            # Delegate to the resolved method call dispatcher. We need to drop
-            # the arg of the coercion type, then insert three args:
-            # 1. The method we resolved to.
-            # 2. The type object of the coercion type (used in deferral)
-            # 3. The name of the method (used in deferral)
-            my $without_coerce_type := nqp::dispatch('boot-syscall', 'dispatcher-drop-arg',
-                    $capture, 1);
-            my $meth_capture := nqp::dispatch('boot-syscall',
-                'dispatcher-insert-arg-literal-obj',
-                nqp::dispatch('boot-syscall',
-                    'dispatcher-insert-arg-literal-obj',
-                    nqp::dispatch('boot-syscall',
-                        'dispatcher-insert-arg-literal-str',
-                        $without_coerce_type,
-                        0, $to_name),
-                    0, nqp::what(to_coerce)),
-                0, $coerce_method);
-            nqp::dispatch('boot-syscall', 'dispatcher-delegate',
-                    'raku-meth-call-resolved', $meth_capture);
-        }
-        else {
-            coercion_error(nqp::how_nd($to_coerce).name($to_coerce), $to_name);
-        }
-    });
-}
-
 # A standard call (such as `func($arg)`, `$obj($arg)`, etc.) It receives the
 # decontainerized callee as the first argument, followed by the arguments. Its
 # primary purpose is to deal with multi dispatch vs. single dispatch and then


### PR DESCRIPTION
- The dispatcher itself never expects a containerized coercer, but it was possible for the metamodel to bypass a container
- The scalar case of value was considerd, but `Proxy` has been overlooked; if there be any other kind of container it should be handled appropriately too