### PR TITLE
Introduce :smartcase named argument

### DIFF
--- a/src/core.c/Str.pm6
+++ b/src/core.c/Str.pm6
@@ -157,6 +157,19 @@ my class Str does Stringy { # declared in BOOTSTRAP
         self.chop($chopping.Int)
     }
 
+    multi method starts-with(Str:D: Str:D $needle, :$smartcase! --> Bool:D) {
+        self.starts-with(
+          $needle,
+          :ignorecase($smartcase && nqp::iseq_i(
+            nqp::chars($needle),
+            nqp::findcclass(                      #?js: NFG
+              nqp::const::CCLASS_UPPERCASE,
+              $needle,0,nqp::chars($needle)
+            )
+          ))
+        )
+    }
+
     multi method starts-with(Str:D:
       Str:D $needle, :i(:$ignorecase)!, :m(:$ignoremark)
     --> Bool:D) {


### PR DESCRIPTION
In principle for all string related functions that also have :ignorecase.
In this commit, only "starts-with" has been equipped with it.  Basically
it operates as :ignorecase if the needle does **not** have any uppercase
characters.  Otherwise it is ignored.

    say "Foo".starts-with("foo",:smartcase);  # True
    say "Foo".starts-with("Foo",:smartcase);  # True
    say "foo".starts-with("Foo",:smartcase);  # False

If accepted, this PR will be expanded to cover all appropriate methods.