### PR TITLE
Improve flow of calling set-env.sh from a script

### DIFF
--- a/tools/build/binary-release/assets/Linux/README.md
+++ b/tools/build/binary-release/assets/Linux/README.md
@@ -22,6 +22,11 @@ Users of the Fish shell users type:
 
     eval (/path/to/this/folder/scripts/set-env.sh --fish)
 
+To automatically add the relevant paths to your shell on startup, add the
+following to `~/.bash_profile` or your equivalent:
+
+    eval "$(/path/to/this/folder/scripts/set-env.sh --quiet)"
+
 To start an interactive Raku environment call `raku` without an argument
 
     raku

--- a/tools/build/binary-release/assets/Linux/scripts/set-env.sh
+++ b/tools/build/binary-release/assets/Linux/scripts/set-env.sh
@@ -2,37 +2,55 @@
 
 # Sourced from https://stackoverflow.com/a/29835459/1975049
 rreadlink() (
-  target=$1 fname= targetDir= CDPATH=
-  { \unalias command; \unset -f command; } >/dev/null 2>&1
-  [ -n "$ZSH_VERSION" ] && options[POSIX_BUILTINS]=on
-  while :; do
-      [ -L "$target" ] || [ -e "$target" ] || { command printf '%s\n' "ERROR: '$target' does not exist." >&2; return 1; }
-      command cd "$(command dirname -- "$target")" || exit 1
-      fname=$(command basename -- "$target")
-      [ "$fname" = '/' ] && fname=''
-      if [ -L "$fname" ]; then
-        target=$(command ls -l "$fname")
-        target=${target#* -> }
-        continue
-      fi
-      break
-  done
-  targetDir=$(command pwd -P)
-  if [ "$fname" = '.' ]; then
-    command printf '%s\n' "${targetDir%/}"
-  elif  [ "$fname" = '..' ]; then
-    command printf '%s\n' "$(command dirname -- "${targetDir}")"
-  else
-    command printf '%s\n' "${targetDir%/}/$fname"
-  fi
+    target=$1 fname= targetDir= CDPATH=
+    { \unalias command; \unset -f command; } >/dev/null 2>&1
+    [ -n "$ZSH_VERSION" ] && options[POSIX_BUILTINS]=on
+    while :; do
+        [ -L "$target" ] || [ -e "$target" ] || { command printf '%s\n' "ERROR: '$target' does not exist." >&2; return 1; }
+        command cd "$(command dirname -- "$target")" || exit 1
+        fname=$(command basename -- "$target")
+        [ "$fname" = '/' ] && fname=''
+        if [ -L "$fname" ]; then
+            target=$(command ls -l "$fname")
+            target=${target#* -> }
+            continue
+        fi
+        break
+    done
+    targetDir=$(command pwd -P)
+    if [ "$fname" = '.' ]; then
+        command printf '%s\n' "${targetDir%/}"
+    elif  [ "$fname" = '..' ]; then
+        command printf '%s\n' "$(command dirname -- "${targetDir}")"
+    else
+        command printf '%s\n' "${targetDir%/}/$fname"
+    fi
 )
 
 EXEC=$(rreadlink "$0")
 DIR=$(dirname $(dirname "$EXEC"))
 
-echo "echo '                           Adding Rakudo to PATH';"
-echo "echo '                          =======================';"
-echo "echo '';"
+while [ $# -gt 0 ]; do
+    case $1 in
+        "--fish")
+            FISH=true
+            ;;
+        "--quiet")
+            QUIET=true
+            ;;
+    esac
+    shift
+done
+
+my_echo() {
+    if [ "$QUIET" != true ]; then
+        echo "$1"
+    fi
+}
+
+my_echo "echo '                           Adding Rakudo to PATH';"
+my_echo "echo '                          =======================';"
+my_echo "echo '';"
 
 NEW_PATH=$PATH
 RAKUDO_PATH0="$DIR/bin"
@@ -46,18 +64,18 @@ for RPATH in $RAKUDO_PATH1 $RAKUDO_PATH0 ; do
 done
 
 if $STUFF_DONE ; then
-    if [ "$1" = "--fish" ] ; then
+    if [ "$FISH" = true ]; then
         NEW_PATH=$(echo "$NEW_PATH" | sed "s/:/ /g")
         echo "set -x PATH $NEW_PATH;"
     else
         echo "export PATH='$NEW_PATH';"
     fi
-    echo "echo 'Paths successfully added.';"
+    my_echo "echo 'Paths successfully added.';"
 else
-    echo "echo 'Paths already set. Nothing to do.';"
+    my_echo "echo 'Paths already set. Nothing to do.';"
 fi
 
-echo "echo '';
+my_echo "echo '';
 echo '================================================================================';
 echo ' =========                                                             __   __';
 echo '  ||_|_||                =============================                (  \,/  )';

--- a/tools/build/binary-release/assets/MacOS/README.md
+++ b/tools/build/binary-release/assets/MacOS/README.md
@@ -22,6 +22,11 @@ Users of the Fish shell users type:
 
     eval (/path/to/this/folder/scripts/set-env.sh --fish)
 
+To automatically add the relevant paths to your shell on startup, add the
+following to `~/.bash_profile` or your equivalent:
+
+    eval "$(/path/to/this/folder/scripts/set-env.sh --quiet)"
+
 To start an interactive Raku environment call `raku` without an argument
 
     raku

--- a/tools/build/binary-release/assets/MacOS/scripts/set-env.sh
+++ b/tools/build/binary-release/assets/MacOS/scripts/set-env.sh
@@ -2,37 +2,55 @@
 
 # Sourced from https://stackoverflow.com/a/29835459/1975049
 rreadlink() (
-  target=$1 fname= targetDir= CDPATH=
-  { \unalias command; \unset -f command; } >/dev/null 2>&1
-  [ -n "$ZSH_VERSION" ] && options[POSIX_BUILTINS]=on
-  while :; do
-      [ -L "$target" ] || [ -e "$target" ] || { command printf '%s\n' "ERROR: '$target' does not exist." >&2; return 1; }
-      command cd "$(command dirname -- "$target")" || exit 1
-      fname=$(command basename -- "$target")
-      [ "$fname" = '/' ] && fname=''
-      if [ -L "$fname" ]; then
-        target=$(command ls -l "$fname")
-        target=${target#* -> }
-        continue
-      fi
-      break
-  done
-  targetDir=$(command pwd -P)
-  if [ "$fname" = '.' ]; then
-    command printf '%s\n' "${targetDir%/}"
-  elif  [ "$fname" = '..' ]; then
-    command printf '%s\n' "$(command dirname -- "${targetDir}")"
-  else
-    command printf '%s\n' "${targetDir%/}/$fname"
-  fi
+    target=$1 fname= targetDir= CDPATH=
+    { \unalias command; \unset -f command; } >/dev/null 2>&1
+    [ -n "$ZSH_VERSION" ] && options[POSIX_BUILTINS]=on
+    while :; do
+        [ -L "$target" ] || [ -e "$target" ] || { command printf '%s\n' "ERROR: '$target' does not exist." >&2; return 1; }
+        command cd "$(command dirname -- "$target")" || exit 1
+        fname=$(command basename -- "$target")
+        [ "$fname" = '/' ] && fname=''
+        if [ -L "$fname" ]; then
+            target=$(command ls -l "$fname")
+            target=${target#* -> }
+            continue
+        fi
+        break
+    done
+    targetDir=$(command pwd -P)
+    if [ "$fname" = '.' ]; then
+        command printf '%s\n' "${targetDir%/}"
+    elif  [ "$fname" = '..' ]; then
+        command printf '%s\n' "$(command dirname -- "${targetDir}")"
+    else
+        command printf '%s\n' "${targetDir%/}/$fname"
+    fi
 )
 
 EXEC=$(rreadlink "$0")
 DIR=$(dirname $(dirname "$EXEC"))
 
-echo "echo '                           Adding Rakudo to PATH';"
-echo "echo '                          =======================';"
-echo "echo '';"
+while [ $# -gt 0 ]; do
+    case $1 in
+        "--fish")
+            FISH=true
+            ;;
+        "--quiet")
+            QUIET=true
+            ;;
+    esac
+    shift
+done
+
+my_echo() {
+    if [ "$QUIET" != true ]; then
+        echo "$1"
+    fi
+}
+
+my_echo "echo '                           Adding Rakudo to PATH';"
+my_echo "echo '                          =======================';"
+my_echo "echo '';"
 
 NEW_PATH=$PATH
 RAKUDO_PATH0="$DIR/bin"
@@ -46,18 +64,18 @@ for RPATH in $RAKUDO_PATH1 $RAKUDO_PATH0 ; do
 done
 
 if $STUFF_DONE ; then
-    if [ "$1" = "--fish" ] ; then
+    if [ "$FISH" = true ]; then
         NEW_PATH=$(echo "$NEW_PATH" | sed "s/:/ /g")
         echo "set -x PATH $NEW_PATH;"
     else
         echo "export PATH='$NEW_PATH';"
     fi
-    echo "echo 'Paths successfully added.';"
+    my_echo "echo 'Paths successfully added.';"
 else
-    echo "echo 'Paths already set. Nothing to do.';"
+    my_echo "echo 'Paths already set. Nothing to do.';"
 fi
 
-echo "echo '';
+my_echo "echo '';
 echo '================================================================================';
 echo ' =========                                                             __   __';
 echo '  ||_|_||                =============================                (  \,/  )';


### PR DESCRIPTION
Add instructions on how to call set-env.sh from .bash_profile and similar.
Introduce `--quiet` flag to make the script quiet.