### PR TITLE
Introducing $*EXIT and $*EXCEPTION dynvars

### DIFF
--- a/src/core.c/Exception.pm6
+++ b/src/core.c/Exception.pm6
@@ -522,6 +522,8 @@ do {
     sub print_exception(|) {
         my Mu $ex := nqp::atpos(nqp::p6argvmarray(), 0);
         my $e := EXCEPTION($ex);
+        $*EXIT      = 1;
+        $*EXCEPTION = $e;
 
         if %*ENV<PERL6_EXCEPTIONS_HANDLER> -> $handler {
             my $class := ::("Exceptions::$handler");

--- a/src/core.c/Rakudo/Internals.pm6
+++ b/src/core.c/Rakudo/Internals.pm6
@@ -1825,10 +1825,13 @@ my constant $?BITS = nqp::isgt_i(nqp::add_i(2147483648, 1), 0) ?? 64 !! 32;
 }
 
 # we need this to run *after* the mainline of Rakudo::Internals has run
+PROCESS::<$EXIT> = 0;
+PROCESS::<$EXCEPTION> = Exception;
 Rakudo::Internals.REGISTER-DYNAMIC: '&*EXIT', {
     PROCESS::<&EXIT> := sub exit($status) {
         state $exit = $status;  # first call to exit sets value
 
+        $*EXIT = $exit;
         nqp::getcurhllsym('&THE_END')()
           ?? $exit
           !! nqp::exit(nqp::unbox_i($exit.Int))

--- a/t/08-performance/05-processkeys.t
+++ b/t/08-performance/05-processkeys.t
@@ -8,6 +8,8 @@ my $allowed = (
   Q{$CORE-SETTING-REV},
   Q{$DISTRO},
   Q{$ERR},
+  Q{$EXCEPTION},
+  Q{$EXIT},
   Q{$IN},
   Q{$OUT},
   Q{$PID},


### PR DESCRIPTION
Main intent is that these will be used inside an END block to check
whether the program is exiting through an exception or not.

$*EXIT is set to the currently known exit() value, 1 if an exception
occurred, 0 if no exception occurred, N when an exit(N) was executed.

$*EXCEPTION will contain an Exception object if the program is
ending because of an exception.  Will contain the Exception type object
otherwise.

Example:
````
$ raku -e 'END { say $*EXIT; dd $_ with $*EXCEPTION; exit 42 }; die'
Died
  in block <unit> at -e line 1

1
X::AdHoc.new(payload => "Died")
$ echo $?
42