### PR TITLE
[JVM] Add missing $obj? to Perl6::Metamodel::JavaHOW.archetypes

### DIFF
--- a/src/vm/jvm/Perl6/Metamodel/JavaHOW.nqp
+++ b/src/vm/jvm/Perl6/Metamodel/JavaHOW.nqp
@@ -6,7 +6,7 @@ class Perl6::Metamodel::JavaHOW
     does Perl6::Metamodel::MethodContainer
 {
     my $archetypes := Perl6::Metamodel::Archetypes.new( :nominal );
-    method archetypes() {
+    method archetypes($obj?) {
         $archetypes
     }
 


### PR DESCRIPTION
Allows for `t/03-jvm/01-interop.t` to pass once more.