### PR TITLE
Don't blindly make a Version object for vN

### DIFF
--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -732,7 +732,10 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
     }
 
     token version {
-        <?before v\d+\w*> 'v' $<vstr>=[<vnum>+ % '.' '+'?]
+        <?before v\d+\w*
+            [ '.' \d
+              || <!{ $*W.is_lexical(~$/) }> ]>
+        'v' $<vstr>=[<vnum>+ % '.' '+'?]
         <!before '-'|\'> # cheat because of LTM fail
     }
 


### PR DESCRIPTION
First look up whether there's a lexical symbol for it, and use that
if we found it.  Should fix #3919