### PR TITLE
Add `IO::Path.created` returning the `Instant` a path was created

### DIFF
--- a/src/core.c/IO/Path.pm6
+++ b/src/core.c/IO/Path.pm6
@@ -809,6 +809,12 @@ my class IO::Path is Cool does IO {
           !! self!does-not-exist("z")
     }
 
+    method created(IO::Path:D: --> Instant:D) {
+        Rakudo::Internals.FILETEST-E(self.absolute)  # sets $!os-path
+          ?? Instant.from-posix(Rakudo::Internals.FILETEST-CREATED($!os-path))
+          !! self!does-not-exist("created")
+    }
+
     method modified(IO::Path:D: --> Instant:D) {
         Rakudo::Internals.FILETEST-E(self.absolute)  # sets $!os-path
           ?? Instant.from-posix(Rakudo::Internals.FILETEST-MODIFIED($!os-path))

--- a/src/core.c/Rakudo/Internals.pm6
+++ b/src/core.c/Rakudo/Internals.pm6
@@ -1464,6 +1464,9 @@ my class Rakudo::Internals {
         nqp::iseq_i(nqp::stat(abspath,nqp::const::STAT_FILESIZE),0)
     }
 
+    method FILETEST-CREATED(str \abspath) is raw {
+        nqp::stat_time(abspath,nqp::const::STAT_CREATETIME)
+    }
     method FILETEST-MODIFIED(str \abspath) is raw {
         nqp::stat_time(abspath,nqp::const::STAT_MODIFYTIME)
     }


### PR DESCRIPTION
Or returns a `Failure` if the path does not exist.  Why this wssn't
done before, I don't quite understand, as the NQP support appears
to exist on all backends.