### PR TITLE
Introduce `%SUB-MAIN-OPTS<numeric-suffix-as-value>`

### DIFF
--- a/src/core.c/Main.pm6
+++ b/src/core.c/Main.pm6
@@ -392,9 +392,9 @@ my sub RUN-MAIN(&main, $mainline, :$in-as-argsfiles) {
         $_ .= subst(/^ '--no-' /, '--/') for @*ARGS;
     }
 
-    # Modify args if --bar42 is acceptable as an alternative to --bar=42
+    # Modify args if -j42 is acceptable as an alternative to --j=42
     if nqp::istrue(%sub-main-opts<numeric-suffix-as-value>) {
-        $_ .= subst(/^ '-' (<alpha>+) (\d+)  /, { "--$0=$1" }) for @*ARGS;
+        $_ .= subst(/^ '-' (<alpha>) (\d+)  /, { "--$0=$1" }) for @*ARGS;
     }
 
     # Process command line arguments

--- a/src/core.c/Main.pm6
+++ b/src/core.c/Main.pm6
@@ -392,6 +392,11 @@ my sub RUN-MAIN(&main, $mainline, :$in-as-argsfiles) {
         $_ .= subst(/^ '--no-' /, '--/') for @*ARGS;
     }
 
+    # Modify args if --bar42 is acceptable as an alternative to --bar=42
+    if nqp::istrue(%sub-main-opts<numeric-suffix-as-value>) {
+        $_ .= subst(/^ '-' (<alpha>+) (\d+)  /, { "--$0=$1" }) for @*ARGS;
+    }
+
     # Process command line arguments
     my $capture := args-to-capture(&main, @*ARGS);
 

--- a/src/core.c/Main.pm6
+++ b/src/core.c/Main.pm6
@@ -394,7 +394,9 @@ my sub RUN-MAIN(&main, $mainline, :$in-as-argsfiles) {
 
     # Modify args if -j42 is acceptable as an alternative to --j=42
     if nqp::istrue(%sub-main-opts<numeric-suffix-as-value>) {
-        $_ .= subst(/^ '-' (<alpha>) (\d+) $/, { "--$0=$1" }) for @*ARGS;
+        for @*ARGS {
+            $_ = "-$_.substr(0,2)=$/" if .match: /^ '-' <.alpha> <( \d+ $/;
+        }
     }
 
     # Process command line arguments

--- a/src/core.c/Main.pm6
+++ b/src/core.c/Main.pm6
@@ -394,7 +394,7 @@ my sub RUN-MAIN(&main, $mainline, :$in-as-argsfiles) {
 
     # Modify args if -j42 is acceptable as an alternative to --j=42
     if nqp::istrue(%sub-main-opts<numeric-suffix-as-value>) {
-        $_ .= subst(/^ '-' (<alpha>) (\d+)  /, { "--$0=$1" }) for @*ARGS;
+        $_ .= subst(/^ '-' (<alpha>) (\d+) $/, { "--$0=$1" }) for @*ARGS;
     }
 
     # Process command line arguments


### PR DESCRIPTION
This allows CLI arguments of the form -j2 to be interpreted as
--j=2, making it more compatible with "normal" CLI argument interpreters