### PR TITLE
Add .stem method to IO::Path for 6.e

### DIFF
--- a/src/core.e/IO/Path.pm6
+++ b/src/core.e/IO/Path.pm6
@@ -1,0 +1,14 @@
+augment class IO::Path {
+    method stem(IO::Path:D: --> Str:D) {
+        my str $basename = self.basename;
+        my int $index = nqp::index($basename,'.');
+        $index == -1 ?? $basename !! nqp::substr($basename,0,$index)
+    }
+    method suffix(IO::Path:D: --> Str:D) {
+        my str $basename = self.basename;
+        my int $index = nqp::index($basename,'.');
+        $index == -1 ?? '' !! nqp::substr($basename,$index + 1)
+    }
+}
+
+# vim: expandtab shiftwidth=4

--- a/src/core.e/IO/Path.pm6
+++ b/src/core.e/IO/Path.pm6
@@ -1,13 +1,15 @@
 augment class IO::Path {
-    method stem(IO::Path:D: --> Str:D) {
+    method stem(IO::Path:D: $parts = * --> Str:D) {
         my str $basename = self.basename;
-        my int $index = nqp::index($basename,'.');
-        $index == -1 ?? $basename !! nqp::substr($basename,0,$index)
-    }
-    method suffix(IO::Path:D: --> Str:D) {
-        my str $basename = self.basename;
-        my int $index = nqp::index($basename,'.');
-        $index == -1 ?? '' !! nqp::substr($basename,$index + 1)
+        (my @indices := indices($basename, '.'))
+          ?? nqp::substr(
+               $basename,
+               0,
+               nqp::istype($parts,Whatever) || $parts > @indices
+                ?? @indices[0]
+                !! @indices[@indices - $parts]
+             )
+          !! $basename
     }
 }
 

--- a/tools/templates/6.e/core_sources
+++ b/tools/templates/6.e/core_sources
@@ -6,6 +6,7 @@ src/core.e/PseudoStash.pm6
 src/core.e/Grammar.pm6
 src/core.e/EXPORTHOW.pm6
 src/core.e/Int.pm6
+src/core.e/IO/Path.pm6
 src/core.e/array_multislice.pm6
 src/core.e/hash_multislice.pm6
 src/core.e/Rakudo/Internals/Sprintf.pm6


### PR DESCRIPTION
"stem" takes the number of extension levels to remove.
By default all, * and Inf accepted as arguments.

    say "foo/bar.tar.gz".IO.stem;    # bar
    say "foo/bar.tar.gz".IO.stem(1);  # bar.tar