### PR TITLE
Introduce // as a definedness prefix operator in 6.e

### DIFF
--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -3510,7 +3510,10 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         ]
     }
 
-    token quote:sym</null/> { '/' \s* '/' <.typed_panic: "X::Syntax::Regex::NullRegex"> }
+    token quote:sym</null/> {
+        <?{ nqp::getcomp('Raku').language_revision lt 'e' }>
+        '/' \s* '/' <.typed_panic: "X::Syntax::Regex::NullRegex">
+    }
     token quote:sym</ />  {
         :my %*RX;
         :my $*INTERPOLATE := 1;
@@ -4096,6 +4099,10 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         <?before \d+ <?before \. <.?alpha> > <.worry: "Precedence of ^ is looser than method call; please parenthesize"> >?
     }
     token prefix:sym<⚛>   { <sym>  <O(|%symbolic_unary)> }
+    token prefix:sym<//>  {
+        <?{ nqp::getcomp('Raku').language_revision ge 'e' }>
+        <sym> <O(|%symbolic_unary)>
+    }
 
     token infix:sym<*>    { <sym>  <O(|%multiplicative)> }
     token infix:sym<×>    { <sym>  <O(|%multiplicative)> }

--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -3511,8 +3511,11 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
     }
 
     token quote:sym</null/> {
-        <?{ nqp::getcomp('Raku').language_revision lt 'e' }>
-        '/' \s* '/' <.typed_panic: "X::Syntax::Regex::NullRegex">
+        :my $rev := nqp::getcomp('Raku').language_revision;
+          <?{ $rev lt 'e' }>
+          '/' \s* '/' <.typed_panic: "X::Syntax::Regex::NullRegex">
+        | <?{ $rev ge 'e' }>
+          '/' \s+ '/' <.typed_panic: "X::Syntax::Regex::NullRegex">
     }
     token quote:sym</ />  {
         :my %*RX;

--- a/src/core.e/control.pm6
+++ b/src/core.e/control.pm6
@@ -1,4 +1,7 @@
 multi sub next(\x --> Nil) { THROW(nqp::const::CONTROL_NEXT, x) }
 multi sub last(\x --> Nil) { THROW(nqp::const::CONTROL_LAST, x) }
 
+proto sub prefix:<//>($) {*}
+multi sub prefix:<//>(\a) { a.defined }
+
 # vim: expandtab shiftwidth=4

--- a/src/core.e/control.pm6
+++ b/src/core.e/control.pm6
@@ -1,7 +1,7 @@
 multi sub next(\x --> Nil) { THROW(nqp::const::CONTROL_NEXT, x) }
 multi sub last(\x --> Nil) { THROW(nqp::const::CONTROL_LAST, x) }
 
-proto sub prefix:<//>($) {*}
+proto sub prefix:<//>($) is pure {*}
 multi sub prefix:<//>(\a) { a.defined }
 
 # vim: expandtab shiftwidth=4

--- a/t/02-rakudo/03-corekeys-6e.t
+++ b/t/02-rakudo/03-corekeys-6e.t
@@ -387,6 +387,7 @@ my @expected = (
     Q{&prefix:<~>},
     Q{&prefix:<~^>},
     Q{&prefix:<−>},
+    Q{&prefix:<//>},
     Q{&prefix:<⚛>},
     Q{&prepend},
     Q{&print},

--- a/t/02-rakudo/03-corekeys.t
+++ b/t/02-rakudo/03-corekeys.t
@@ -800,6 +800,7 @@ my @allowed =
         Q{&next},
         Q{&postcircumfix:<[; ]>},
         Q{&postcircumfix:<{; }>},
+        Q{&prefix:<//>},
         Q{&rotor},
         Q{&snip},
         Q{&term:<nano>},

--- a/t/02-rakudo/04-settingkeys-6e.t
+++ b/t/02-rakudo/04-settingkeys-6e.t
@@ -384,6 +384,7 @@ my %allowed = (
     Q{&prefix:<~>},
     Q{&prefix:<~^>},
     Q{&prefix:<−>},
+    Q{&prefix:<//>},
     Q{&prefix:<⚛>},
     Q{&prepend},
     Q{&print},


### PR DESCRIPTION
As suggested by Leon Timmermans in:
  https://twitter.com/leon_timmermans/status/1560416910101172225

This also disables the "null regex not allowed" error in 6.e, because
otherwise the // prefix operator wouldn't get past parsing.