### PR TITLE
Fix role parameterization over generics

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -6576,8 +6576,11 @@ class Perl6::Actions is HLL::Actions does STDActions {
                 my $ast := $<arglist>.ast;
                 wantall($past, 'name');
                 for @($ast) {
-                    unless $_.has_compile_time_value {
+                    if !$_.has_compile_time_value
+                        || (my $value_type := nqp::what($_.compile_time_value)).HOW.archetypes($value_type).generic
+                    {
                         $all_compile_time := 0;
+                        last;
                     }
                 }
                 if $all_compile_time {


### PR DESCRIPTION
When parameterization is taking place over a generic it must be done at run-time.

Make the following code work as expected:

```
role A[::T] {
    method a { A[T] }
}
say A[Int].a ~~ A[Int];
```