### PR TITLE
Get job done well for coercive nominalizeables

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -9777,10 +9777,12 @@ class Perl6::Actions is HLL::Actions does STDActions {
                         else {
                             # XXX This fails for generics because a generic has to be instantiated. I don't get this
                             # fixed because it'd take more than worth it considering the upcoming RakuAST. //vrurg
-                            $var.default(
-                                QAST::WVal.new( :value($is_coercive
-                                                        ?? $param_type.HOW.target_type($param_type)
-                                                        !! $nomtype)));
+                            my $default_type := $nomtype;
+                            if $is_coercive {
+                                my $coercion_type := $param_type.HOW.wrappee($param_type, :coercion);
+                                $default_type := $coercion_type.HOW.target_type($coercion_type);
+                            }
+                            $var.default( QAST::WVal.new( :value($default_type)) );
                         }
                     }
                 }

--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -2730,7 +2730,8 @@ BEGIN {
                     if $param.coercive {
                         nqp::push(@coerce_type_idxs, $significant_param);
                         my $param_type := nqp::getattr($param, Parameter, '$!type');
-                        nqp::push(@coerce_type_objs, $param_type.HOW.target_type($param_type));
+                        my $coercion_type := $param_type.HOW.wrappee($param_type, :coercion);
+                        nqp::push(@coerce_type_objs, $coercion_type.HOW.target_type($coercion_type));
                     }
 
                     ++$significant_param;


### PR DESCRIPTION
In two edge cases where the compiler deals with coercions `target_type` was used without ensuring that the coercive type is actually a `Metamodel::CoercionHOW`.

Both cases are about parameters: any optional and of a multi-dispatch candidate.