### PR TITLE
Make generics work with return type in signature

### DIFF
--- a/src/Perl6/Metamodel/DefiniteHOW.nqp
+++ b/src/Perl6/Metamodel/DefiniteHOW.nqp
@@ -68,9 +68,9 @@ class Perl6::Metamodel::DefiniteHOW
 
     method nominalize($obj) {
         my $base_type := $obj.HOW.base_type($obj);
-        $base_type.HOW.archetypes.nominal ??
-            $base_type !!
-            $base_type.HOW.nominalize($base_type)
+        $base_type.HOW.archetypes($base_type).nominalizable
+            ?? $base_type.HOW.nominalize($base_type)
+            !! $base_type
     }
 
     method instantiate_generic($definite_type, $type_env) {
@@ -83,9 +83,9 @@ class Perl6::Metamodel::DefiniteHOW
 
     #~ # Should have the same methods of the base type that we refine.
     #~ # (For the performance win, work out a way to steal its method cache.)
-    method find_method($definite_type, $name) {
+    method find_method($definite_type, $name, *%c) {
         my $base_type := self.base_type($definite_type);
-        $base_type.HOW.find_method($base_type, $name)
+        $base_type.HOW.find_method($base_type, $name, |%c)
     }
 
     method find_method_qualified($definite_type, $qtype, $name) {

--- a/src/Perl6/Metamodel/SubsetHOW.nqp
+++ b/src/Perl6/Metamodel/SubsetHOW.nqp
@@ -105,8 +105,8 @@ class Perl6::Metamodel::SubsetHOW
     # Should have the same methods of the (eventually nominal) type
     # that we refine. (For the performance win, work out a way to
     # steal its method cache.)
-    method find_method($obj, $name) {
-        $!refinee.HOW.find_method($!refinee, $name)
+    method find_method($obj, $name, *%c) {
+        $!refinee.HOW.find_method($!refinee, $name, |%c)
     }
 
     # Do check when we're on LHS of smartmatch (e.g. Even ~~ Int).

--- a/src/core.c/Rational.pm6
+++ b/src/core.c/Rational.pm6
@@ -91,7 +91,7 @@ my role Rational[::NuT = Int, ::DeT = ::("NuT")] does Real {
         !! self!divide-by-zero('ceiling')
     }
 
-    method Int(--> Int:D) {
+    method Int(Rational:D: --> Int:D) {
         $!denominator
           ?? self.truncate
           !! self!divide-by-zero('Int')

--- a/src/vm/moar/Perl6/Ops.nqp
+++ b/src/vm/moar/Perl6/Ops.nqp
@@ -413,8 +413,9 @@ $ops.add_hll_op('Raku', 'p6typecheckrv', -> $qastcomp, $op {
             $qastcomp.as_mast($op[0])
         }
         else {
+            my $is_generic := $type.HOW.archetypes($type).generic;
             my $type_ast;
-            if $type.HOW.archetypes($type).generic {
+            if $is_generic {
                 $type_ast :=
                     QAST::Op.new(
                         :op<callmethod>,
@@ -431,7 +432,8 @@ $ops.add_hll_op('Raku', 'p6typecheckrv', -> $qastcomp, $op {
                 :op('dispatch'),
                 QAST::SVal.new( :value('raku-rv-typecheck') ),
                 QAST::Op.new( :op('p6box'), $op[0] ),
-                $type_ast
+                $type_ast,
+                QAST::IVal.new(:value($is_generic))
             ))
         }
     }

--- a/src/vm/moar/Perl6/Ops.nqp
+++ b/src/vm/moar/Perl6/Ops.nqp
@@ -413,11 +413,25 @@ $ops.add_hll_op('Raku', 'p6typecheckrv', -> $qastcomp, $op {
             $qastcomp.as_mast($op[0])
         }
         else {
+            my $type_ast;
+            if $type.HOW.archetypes($type).generic {
+                $type_ast :=
+                    QAST::Op.new(
+                        :op<callmethod>,
+                        :name<instantiate_generic>,
+                        QAST::Op.new(:op<how>, QAST::WVal.new(:value($type))),
+                        QAST::WVal.new(:value($type)),
+                        QAST::Op.new(:op<curlexpad>)
+                    );
+            }
+            else {
+                $type_ast := QAST::WVal.new( :value($type) );
+            }
             $qastcomp.as_mast(QAST::Op.new(
                 :op('dispatch'),
                 QAST::SVal.new( :value('raku-rv-typecheck') ),
                 QAST::Op.new( :op('p6box'), $op[0] ),
-                QAST::WVal.new( :value($type) )
+                $type_ast
             ))
         }
     }

--- a/src/vm/moar/dispatchers.nqp
+++ b/src/vm/moar/dispatchers.nqp
@@ -3890,8 +3890,21 @@ nqp::dispatch('boot-syscall', 'dispatcher-register', 'raku-isinvokable', -> $cap
         # Dispatcher arguments:
         # - return value
         # - type
+        # - "is generic" flag
         # If the type is Mu or unset, then nothing is needed except identity.
         my $type := nqp::captureposarg($capture, 1);
+        my $is_generic := nqp::captureposarg_i($capture, 2);
+
+        # If the type has been instantiated from a generic then we'd need to track over it too.
+        if $is_generic {
+            my $track-ret-type := nqp::dispatch('boot-syscall', 'dispatcher-track-arg', $capture, 1);
+            nqp::dispatch('boot-syscall', 'dispatcher-guard-type', $track-ret-type);
+        }
+
+        # We will never need the $is_generic argument, but otherwise the captrue is used to call checker subs where the 
+        # third argument is not anticipated.
+        $capture := nqp::dispatch('boot-syscall', 'dispatcher-drop-arg', $capture, 2);
+
         if nqp::isnull($type) || $type =:= Mu {
             nqp::dispatch('boot-syscall', 'dispatcher-delegate', 'boot-value',
                 nqp::dispatch('boot-syscall', 'dispatcher-drop-arg', $capture, 1))


### PR DESCRIPTION
Code return type can now use a type capture and its derivatives. E.g., the following will now work as expected:

```raku
    sub foo(::T, $a --> T) { $a }
```

`T` can be used in combination with smiley typing and coercion.

A couple of linked problems has been resolved too.