### PR TITLE
Add a `.warn` method to exceptions

### DIFF
--- a/src/core.c/Exception.pm6
+++ b/src/core.c/Exception.pm6
@@ -72,6 +72,11 @@ my class Exception {
         nqp::setpayload($!ex, self);
         nqp::rethrow($!ex)
     }
+    method warn(Exception:D:) {
+        nqp::setmessage($!ex, nqp::unbox_s(self.message));
+        nqp::setextype($!ex, nqp::const::CONTROL_WARN);
+        nqp::rethrow($!ex);
+    }
 
     method !maybe-set-control(--> Nil) {
         if nqp::istype(self, X::Control) {


### PR DESCRIPTION
This will allow one to turn an exception into a warning:

    $ raku -e 'CATCH { .warn }; say "before"; die "foo"; say "after"'
    before
    foo
      in block <unit> at -e line 1
    after

Inspired by Xliff: https://irclogs.raku.org/raku/2022-09-23.html#10:45