### PR TITLE
Keep version file when cleaning an installation

### DIFF
--- a/lib/CompUnit/Repository/Staging.rakumod
+++ b/lib/CompUnit/Repository/Staging.rakumod
@@ -91,7 +91,6 @@ class CompUnit::Repository::Staging is CompUnit::Repository::Installation {
     }
     method remove-artifacts(CompUnit::Repository::Staging:D: --> Nil) {
         my $io := self.prefix;
-        really-unlink($io.child("version"));
         really-unlink(.IO) for Rakudo::Internals.DIR-RECURSE(
           $io.absolute, :file(*.ends-with(".lock"))
         );


### PR DESCRIPTION
This commit changes the CompUnit::Repository::Staging.remove-artifacts method to not remove a repo's `version` file.  This file is required to allow subsequent installations to the same directory; its absence caused `install-dist.raku` to fail in odd ways (see issue #4907).  From searching the codebase, I believe that `install-dist.raku` is the only user of the `remove-artifacts` method, so this change shouldn't have much impact.

(If anyone knows a reason why removing the `version` file is essential, please speak up; AFAIK, it should be harmless at worst)