### PR TITLE
Fix argument for call to archetypes

### DIFF
--- a/src/Perl6/Metamodel/CurriedRoleHOW.nqp
+++ b/src/Perl6/Metamodel/CurriedRoleHOW.nqp
@@ -164,7 +164,7 @@ class Perl6::Metamodel::CurriedRoleHOW
                 $_);
         }
         for %!named_args {
-            %new_named{$_.key} := $_.value.HOW.archetypes($_).generic ??
+            %new_named{$_.key} := $_.value.HOW.archetypes($_.value).generic ??
                 $_.value.HOW.instantiate_generic($_.value, $type_env) !!
                 $_.value;
         }


### PR DESCRIPTION
This buglet sneaked in with 71de22321d where an optional positional parameter for archetypes was introduced. Similar to other methods of the metamodel API the first argument should be the object that HOW was invoked upon.