### PR TITLE
Add rotor-like capability to Str.comb

### DIFF
--- a/src/core.e/Str.pm6
+++ b/src/core.e/Str.pm6
@@ -1,0 +1,14 @@
+augment class Str {
+    multi method comb(Str:D: Pair:D $what, $limit = *, :$partial) {
+        my int $size = $what.key;
+        my int $step = $size + $what.value;
+        $step = 1 if $step < 1;
+        $size <= 1 && (nqp::istype($limit,Whatever) || $limit == Inf)
+          ?? self.comb
+          !! Seq.new:
+               Rakudo::Iterator.NGrams: self, $size, $limit, $step, $partial
+
+    }
+}
+
+# vim: expandtab shiftwidth=4

--- a/tools/templates/6.e/core_sources
+++ b/tools/templates/6.e/core_sources
@@ -6,6 +6,7 @@ src/core.e/PseudoStash.pm6
 src/core.e/Grammar.pm6
 src/core.e/EXPORTHOW.pm6
 src/core.e/Int.pm6
+src/core.e/Str.pm6
 src/core.e/array_multislice.pm6
 src/core.e/hash_multislice.pm6
 src/core.e/Rakudo/Internals/Sprintf.pm6


### PR DESCRIPTION
By specifying a Pair with size and step, similar to List.rotor. E.g., to generate trigrams of a string, use .comb(3 => -2):

   say "abcdef".comb(3 => -2); # abc bcd cde def

Takes an optional :partial flag to also generate partial substrings (less than the specified size):

   say "abcde".comb(3 => -2, :partial); # abc bcd cde de e

To make sure it is opt-in, this only works on 6.e.