### PR TITLE
Introduce `Dateish.days-in-year` method

### DIFF
--- a/src/core.c/Dateish.pm6
+++ b/src/core.c/Dateish.pm6
@@ -23,8 +23,21 @@ my role Dateish {
         nqp::atpos_i($days-in-month,$month) ||
           ($month == 2 ?? 28 + IS-LEAP-YEAR($year) !! Nil );
     }
-    method days-in-month(Dateish:D: --> Int:D) {
+
+    proto method days-in-month(|) {*}
+    multi method days-in-month(Dateish: Int:D $year, Int:D $month --> Int:D) {
+        self!DAYS-IN-MONTH($year,$month)
+    }
+    multi method days-in-month(Dateish:D: --> Int:D) {
         self!DAYS-IN-MONTH($!year,$!month)
+    }
+
+    proto method days-in-year(|) {*}
+    multi method days-in-year(Dateish: Int:D $year --> Int:D) {
+        365 + IS-LEAP-YEAR($year)
+    }
+    multi method days-in-year(Dateish:D: --> Int:D) {
+        365 + IS-LEAP-YEAR($!year)
     }
 
     method !year-Str(--> Str:D) {


### PR DESCRIPTION
Which can be called both as a class method (while specifying the year) as well as an instance method (without specifying a year).

Made the days-in-month method follow the same pattern: callable as a class method, specifying the year and month, or as an instance method (without specifying any arguments).