### PR TITLE
Introduce RAKUDO_GC_EVERY environment variable

### DIFF
--- a/src/core.c/ThreadPoolScheduler.pm6
+++ b/src/core.c/ThreadPoolScheduler.pm6
@@ -596,6 +596,9 @@ my class ThreadPoolScheduler does Scheduler {
                 my num $per-core;
                 my num $per-core-util;
                 my num $smooth-per-core-util = 0e0;
+                my int $ticks;
+                my int $gc-every =
+                  (%*ENV<RAKUDO_GC_EVERY> // 0x7fffffffffffffff).Int;
 
                 scheduler-debug "Supervisor thinks there are $cpu-cores CPU cores";
                 loop {
@@ -612,6 +615,7 @@ my class ThreadPoolScheduler does Scheduler {
                     # Wait until the next time we should check how things
                     # are.
                     nqp::sleep(SUPERVISION_INTERVAL);
+                    nqp::force_gc() unless nqp::mod_i(++$ticks,$gc-every);
 
                     # Work out the delta of CPU usage since last supervision
                     # and the time period that measurement spans.


### PR DESCRIPTION
This affects whether a GC run will be forced for every N ThreadPoolScheduler supervisor runs (which is usually at about 100/second).  A value of 1 thus would force GC runs 100x/second, whereas a value of 100 would force a GC run every second.

Note that for this to work, the supervisor must actually be running. The simplest way to force that is, is doing a `start { }`.

The default for RAKUDO_GC_EVERY is effectively to never do an additional GC run.

One could think about starting the supervisor automatically if RAKUDO_GC_EVERY is explicitely specified.