### PR TITLE
Add words method to Allomorph

### DIFF
--- a/src/core.c/allomorphs.pm6
+++ b/src/core.c/allomorphs.pm6
@@ -12,6 +12,10 @@ my class Allomorph is Str {
     method succ(Allomorph:D:) { self.Numeric.succ }
     method pred(Allomorph:D:) { self.Numeric.pred }
 
+    method words(Allomorph:D: |c) {
+        nqp::getattr_s(self,Str,'$!value').words(|c)
+    }
+
     method comb(Allomorph:D: |c) {
         nqp::getattr_s(self,Str,'$!value').comb(|c)
     }


### PR DESCRIPTION
This fixes the presumption that .words is like .comb(/ \S+ /).

Before: `<3>.words.raku # (IntStr.new(0, "3"),).Seq`
After: `<3>.words.raku # ("3",).Seq`