### PR TITLE
Allow user-defined term `nano` for pre-6.e code

### DIFF
--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -3083,7 +3083,9 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
     token term:sym<time> { <sym> <.tok> }
 
     token term:sym<nano> {
-        <?{ nqp::getcomp('Raku').language_revision ge 'e' }> <sym> <.tok>
+        <?{ (nqp::getcomp('Raku').language_revision ge 'e')
+            || $*W.is_name(['&term:<nano>']) }>
+        <sym> <.tok>
     }
 
     token term:sym<empty_set> { "∅" <!before <.[ \( \\ ' \- ]> || \h* '=>'> }


### PR DESCRIPTION
Fix a regression detected in rakudo/rakudo#5109