### PR TITLE
Make X::TypeCheck::Assignment message better

### DIFF
--- a/src/core.c/Exception.pm6
+++ b/src/core.c/Exception.pm6
@@ -2725,7 +2725,7 @@ my class X::TypeCheck::Assignment is X::TypeCheck {
     method message {
         my $symbol := $!symbol // $!desc.name;
         my $to = $symbol.defined && $symbol ne '$'
-            ?? " to $symbol" !! "";
+            ?? " to {"an element of " if $symbol.starts-with("@" | "%")}$symbol" !! "";
         my $is-itself := nqp::eqaddr(self.expected, self.got);
         my $expected = $is-itself
             ?? "expected type $.expectedn cannot be itself"


### PR DESCRIPTION
If we're assigning to an '@' or '%' sigiled container, mention that the problem is with an element of the container. Potentially addresses #5110 so now something like `my Map %m = "abc", "def";` says `Type check failed in assignment to an element of %m; expected Map but got Str ("def")` instead of just `Type check failed in assignment to %m; expected Map but got Str ("def")`.