### PR TITLE
Avoid loss in precision on FatRat .Str conversion

### DIFF
--- a/src/core.c/Rational.pm6
+++ b/src/core.c/Rational.pm6
@@ -137,7 +137,7 @@ my role Rational[::NuT = Int, ::DeT = ::("NuT")] does Real {
                          ?? 6
                          !! (nqp::chars(nqp::tostr_I($!denominator))
                               + nqp::chars(nqp::tostr_I(whole))
-                              + 1
+                              + 5
                             )
                    )
               !! nqp::islt_I($!numerator,0)                      # no fract val


### PR DESCRIPTION
Get some more digits for the case when denominator length is smaller than expected.
Fixes #5108

In a FatRat it is common for the denominator to be a power of 10 with as many digits as there are significant digits represented in decimal. But in those "lucky" cases where the denominator is significantly smaller, you end up losing some digits during the conversion, as it happens in the issue annotated.

Detailed analysis of the denominator and fractional part would be expensive, so asking for a few more digits, which will be trivially removed by Rational!STRINGIFY, avoids performance loss.

I add four more in the logic used in denominators of length less than six.
