### PR TITLE
Add Any.decont and decont() sub

### DIFF
--- a/src/core.e/Any-iterable-methods.pm6
+++ b/src/core.e/Any-iterable-methods.pm6
@@ -21,6 +21,9 @@ augment class Any {
         snitch-on SELF;
         SELF
     }
+
+    proto method decont(|) {*}
+    multi method decont(Any:) { self }
 }
 
 proto sub rotor(|) {*}
@@ -45,5 +48,8 @@ multi sub snitch(&snitch-on, \SELF) is raw {
     snitch-on SELF;
     SELF
 }
+
+proto sub decont(|) {*}
+multi sub decont($value) { $value.decont }
 
 # vim: expandtab shiftwidth=4

--- a/t/02-rakudo/03-corekeys-6e.t
+++ b/t/02-rakudo/03-corekeys-6e.t
@@ -142,6 +142,7 @@ my @expected = (
     Q{&cotanh},
     Q{&cross},
     Q{&dd},
+    Q{&decont},
     Q{&deepmap},
     Q{&defined},
     Q{&die},

--- a/t/02-rakudo/03-corekeys.t
+++ b/t/02-rakudo/03-corekeys.t
@@ -797,6 +797,7 @@ my @allowed =
         Q{$=pod},
         Q{$_},
         Q{$¢},
+        Q{&decont},
         Q{&last},
         Q{&next},
         Q{&postcircumfix:<[; ]>},

--- a/t/02-rakudo/04-settingkeys-6e.t
+++ b/t/02-rakudo/04-settingkeys-6e.t
@@ -139,6 +139,7 @@ my %allowed = (
     Q{&cotanh},
     Q{&cross},
     Q{&dd},
+    Q{&decont},
     Q{&deepmap},
     Q{&defined},
     Q{&die},

--- a/t/02-rakudo/07-implementation-detail-6.e.t
+++ b/t/02-rakudo/07-implementation-detail-6.e.t
@@ -19,10 +19,10 @@ my @lower = ("",<<
   atomic-fetch-inc atomic-fetch-sub atomic-inc-fetch atomic-sub-fetch
   await bag cache callframe callsame callwith cas categorize ceiling
   chars chdir chmod chomp chop chown chr chrs cis classify close comb
-  combinations copy cos cosec cosech cosh cotan cotanh deepmap defined
-  die dir done duckmap elems emit end exit exp expmod fail fc first
-  flat flip floor full-barrier get getc gist goto grep hash head index
-  indices indir is-prime item join keys kv last lastcall lc leave
+  combinations copy cos cosec cosech cosh cotan cotanh decont deepmap
+  defined die dir done duckmap elems emit end exit exp expmod fail fc
+  first flat flip floor full-barrier get getc gist goto grep hash head
+  index indices indir is-prime item join keys kv last lastcall lc leave
   lines link list log log10 log2 lsb make map max min minmax mix
   mkdir move msb next nextcallee nextsame nextwith nodemap none
   not note one open ord ords pair pairs parse-base parse-names


### PR DESCRIPTION
Over the past weeks it has become clear that `<>` as a way to decontainerize, is very hard to understand for beginners, and very hard to make findable in the documentation (because you will mostly find it under postcircumfix handling).

This introduces an explicit `.decont` method on objects, and a `decont(value)` sub that will call the `.decont` method on the given value.  It is set up as a multi, so that classes can implement their own deconting logic.