### PR TITLE
Implement `use experimental :rakuast`

### DIFF
--- a/lib/RakuAST/Deparse.rakumod
+++ b/lib/RakuAST/Deparse.rakumod
@@ -6,6 +6,13 @@
 # method expects an instance if a subclass of a RakuAST::Node as the first
 # positional parameter.
 
+# This code can be removed once RakuAST is stable and
+#   use experimental :rakuast;
+# is no longer necessary to be able to access the RakuAST classes
+# and their functionality.
+use nqp;
+my constant RakuAST = nqp::gethllsym('Raku','RakuAST');
+
 class RakuAST::Deparse {
     has str $.before-comma = ' ';
     has str $.after-comma  = ' ';

--- a/lib/experimental.rakumod
+++ b/lib/experimental.rakumod
@@ -1,6 +1,10 @@
 use nqp;
 
 package EXPORT::rakuast {
+    # This code can be removed once RakuAST is stable and
+    #   use experimental :rakuast;
+    # is no longer necessary to be able to access the RakuAST classes
+    # and their functionality.
     OUR::<RakuAST> := nqp::getcurhllsym('RakuAST');
 }
 

--- a/lib/experimental.rakumod
+++ b/lib/experimental.rakumod
@@ -1,5 +1,9 @@
 use nqp;
 
+package EXPORT::rakuast {
+    OUR::<RakuAST> := nqp::getcurhllsym('RakuAST');
+}
+
 package EXPORT::cached {
     multi sub trait_mod:<is>(Routine $r, :$cached!) {
         my %cache;

--- a/lib/experimental.rakumod
+++ b/lib/experimental.rakumod
@@ -5,7 +5,13 @@ package EXPORT::rakuast {
     #   use experimental :rakuast;
     # is no longer necessary to be able to access the RakuAST classes
     # and their functionality.
-    OUR::<RakuAST> := nqp::getcurhllsym('RakuAST');
+    my \RakuAST := nqp::getcurhllsym('RakuAST');
+
+    require ::("RakuAST::Deparse");
+    use nqp;
+    nqp::bindcurhllsym('DEPARSE',::("RakuAST::Deparse"));
+
+    OUR::<RakuAST> := RakuAST;
 }
 
 package EXPORT::cached {

--- a/src/core.c/Any.pm6
+++ b/src/core.c/Any.pm6
@@ -592,10 +592,14 @@ sub dd(|c) {  # is implementation-detail
 
     my Mu $args := nqp::p6argvmarray();
     if nqp::elems($args) {
+        # This code can be removed once RakuAST is stable and
+        #   use experimental :rakuast;
+        # is no longer necessary to be able to access the RakuAST classes
+        # and their functionality.
         while $args {
             my $var  := nqp::shift($args);
             if nqp::istype($var,RakuAST::Node) {
-                note $var.DEPARSE.chomp;
+                Rakudo::Internals.DEPARSE($var);
             }
             else {
                 my $name := ! nqp::istype($var.VAR, Failure) && try $var.VAR.name;

--- a/src/core.c/Stash.pm6
+++ b/src/core.c/Stash.pm6
@@ -24,6 +24,13 @@ my class Stash { # declared in BOOTSTRAP
                ContainerDescriptor::BindHashKey.new(Mu, self, $key)
              )
     }
+
+    method !fail-not-found($key) {
+        (self.Str eq 'must-use-experimental-rakuast'
+          ?? "Must do a 'use experimental :rakuast' to access RakuAST::$key.substr(1)"
+          !! "Could not find symbol '$key' in '{self}'"
+        ).Failure
+    }
     multi method AT-KEY(Stash:D: Str() $key, :$global_fallback!) is raw {
         my \storage := nqp::getattr(self,Map,'$!storage');
         nqp::if(
@@ -34,7 +41,7 @@ my class Stash { # declared in BOOTSTRAP
             nqp::if(
               nqp::existskey(GLOBAL.WHO,$key),
               nqp::atkey(GLOBAL.WHO,$key),
-              "Could not find symbol '$key' in '{self}'".Failure
+              self!fail-not-found($key)
             ),
             nqp::p6scalarfromdesc(
               ContainerDescriptor::BindHashKey.new(Mu, self, $key)

--- a/src/core.c/core_epilogue.pm6
+++ b/src/core.c/core_epilogue.pm6
@@ -141,17 +141,20 @@ BEGIN Metamodel::ClassHOW.exclude_parent(Mu);
 # and their functionality.
 {
     my Mu $ctx := nqp::getattr(CORE::, PseudoStash, '$!ctx');
+    my class must-use-experimental-rakuast is Nil { }
     until nqp::isnull($ctx) {
         my $pad := nqp::ctxlexpad($ctx);
         if nqp::existskey($pad, 'CORE-SETTING-REV') {
             nqp::bindcurhllsym('RakuAST',RakuAST);
-            nqp::bindkey($pad,'RakuAST',Nil);
+            nqp::bindkey($pad,'RakuAST',must-use-experimental-rakuast);
             last;
         }
         $ctx := nqp::ctxouterskipthunks($ctx);
     }
 }
 augment class Rakudo::Internals {
+    # This code needs to live late, as at compilation time of
+    # "sub dd", the ::() lookup doesn't work yet
     method DEPARSE($var) {
         require ::("RakuAST::Deparse");
         nqp::bindcurhllsym("DEPARSE",::("RakuAST::Deparse"));

--- a/src/core.c/core_epilogue.pm6
+++ b/src/core.c/core_epilogue.pm6
@@ -135,6 +135,19 @@ BEGIN .^compose for
 
 BEGIN Metamodel::ClassHOW.exclude_parent(Mu);
 
+{
+    my Mu $ctx := nqp::getattr(CORE::, PseudoStash, '$!ctx');
+    until nqp::isnull($ctx) {
+        my $pad := nqp::ctxlexpad($ctx);
+        if nqp::existskey($pad, 'CORE-SETTING-REV') {
+            nqp::bindcurhllsym('RakuAST',RakuAST);
+            nqp::bindkey($pad,'RakuAST',Nil);
+            last;
+        }
+        $ctx := nqp::ctxouterskipthunks($ctx);
+    }
+}
+
 {YOU_ARE_HERE}
 
 # vim: expandtab shiftwidth=4

--- a/src/core.c/core_epilogue.pm6
+++ b/src/core.c/core_epilogue.pm6
@@ -135,6 +135,10 @@ BEGIN .^compose for
 
 BEGIN Metamodel::ClassHOW.exclude_parent(Mu);
 
+# This code can be removed once RakuAST is stable and
+#   use experimental :rakuast;
+# is no longer necessary to be able to access the RakuAST classes
+# and their functionality.
 {
     my Mu $ctx := nqp::getattr(CORE::, PseudoStash, '$!ctx');
     until nqp::isnull($ctx) {

--- a/src/core.c/core_epilogue.pm6
+++ b/src/core.c/core_epilogue.pm6
@@ -151,6 +151,13 @@ BEGIN Metamodel::ClassHOW.exclude_parent(Mu);
         $ctx := nqp::ctxouterskipthunks($ctx);
     }
 }
+augment class Rakudo::Internals {
+    method DEPARSE($var) {
+        require ::("RakuAST::Deparse");
+        nqp::bindcurhllsym("DEPARSE",::("RakuAST::Deparse"));
+        note $var.DEPARSE.chomp;
+    }
+}
 
 {YOU_ARE_HERE}
 

--- a/src/core.c/core_prologue.pm6
+++ b/src/core.c/core_prologue.pm6
@@ -10,7 +10,6 @@ my class List { ... }
 my class Map { ... }
 my class Match { ... }
 my class Failure { ... }
-my class RakuAST::Deparse { ... }
 my class Rakudo::Deprecations { ... }
 my class Rakudo::Internals { ... }
 my class Rakudo::Internals::JSON { ... }
@@ -43,9 +42,6 @@ my role Hash::Object { ... }
 BEGIN nqp::bindhllsym('Raku', 'Iterable', Iterable);
 nqp::bindhllsym('Raku', 'Iterable', Iterable);
 nqp::bindhllsym('Raku', 'Failure', Failure);
-
-# Make deparsing possible with the .DEPARSE method from NQP
-nqp::bindhllsym('Raku','DEPARSE',RakuAST::Deparse);
 
 BEGIN {
     # Ensure routines with traits using mixins applied to them typecheck as Callable.

--- a/src/core.e/Formatter.pm6
+++ b/src/core.e/Formatter.pm6
@@ -451,7 +451,7 @@ class Formatter {
 
             my $size = size($/);
             my $ast  = ast-call-sub("unsigned-int", parameter($/));
-            
+
             # handle zero padding / left / right justification
             if $size {
                 $ast = ast-call-sub(

--- a/src/core.e/Formatter.pm6
+++ b/src/core.e/Formatter.pm6
@@ -99,6 +99,10 @@ grammar Formatter::Syntax {
 }
 
 class Formatter {
+    # This code can be removed once RakuAST is stable and
+    #   use experimental :rakuast;
+    # is no longer necessary to be able to access the RakuAST classes
+    # and their functionality.
     my constant RakuAST = nqp::getcurhllsym('RakuAST');
 
     # class to be used with Grammar to turn format into array of pieces of code

--- a/src/core.e/Formatter.pm6
+++ b/src/core.e/Formatter.pm6
@@ -99,6 +99,7 @@ grammar Formatter::Syntax {
 }
 
 class Formatter {
+    my constant RakuAST = nqp::getcurhllsym('RakuAST');
 
     # class to be used with Grammar to turn format into array of pieces of code
     class Actions {

--- a/t/12-rakuast/call.t
+++ b/t/12-rakuast/call.t
@@ -1,4 +1,5 @@
 use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
 use Test;
 
 plan 18;

--- a/t/12-rakuast/circumfix.t
+++ b/t/12-rakuast/circumfix.t
@@ -1,4 +1,5 @@
 use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
 use Test;
 
 plan 7;

--- a/t/12-rakuast/code.t
+++ b/t/12-rakuast/code.t
@@ -1,4 +1,5 @@
 use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
 use Test;
 
 plan 11;

--- a/t/12-rakuast/contextualizer.t
+++ b/t/12-rakuast/contextualizer.t
@@ -1,4 +1,5 @@
 use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
 use Test;
 
 plan 4;

--- a/t/12-rakuast/errors.t
+++ b/t/12-rakuast/errors.t
@@ -1,3 +1,4 @@
+use experimental :rakuast;
 use Test;
 
 plan 1;

--- a/t/12-rakuast/literals.t
+++ b/t/12-rakuast/literals.t
@@ -1,4 +1,5 @@
 use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
 use Test;
 
 plan 8;

--- a/t/12-rakuast/meta-operators.t
+++ b/t/12-rakuast/meta-operators.t
@@ -1,4 +1,5 @@
 use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
 use Test;
 
 plan 4;

--- a/t/12-rakuast/name.t
+++ b/t/12-rakuast/name.t
@@ -1,4 +1,5 @@
 use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
 use Test;
 
 plan 6;

--- a/t/12-rakuast/operators.t
+++ b/t/12-rakuast/operators.t
@@ -1,4 +1,5 @@
 use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
 use Test;
 
 plan 23;

--- a/t/12-rakuast/package.t
+++ b/t/12-rakuast/package.t
@@ -1,4 +1,5 @@
 use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
 use Test;
 
 plan 11;

--- a/t/12-rakuast/pair.t
+++ b/t/12-rakuast/pair.t
@@ -1,4 +1,5 @@
 use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
 use Test;
 
 plan 6;

--- a/t/12-rakuast/regex.t
+++ b/t/12-rakuast/regex.t
@@ -1,4 +1,5 @@
 use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
 use Test;
 
 plan 41;

--- a/t/12-rakuast/signature.t
+++ b/t/12-rakuast/signature.t
@@ -1,4 +1,5 @@
 use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
 use Test;
 
 plan 14;

--- a/t/12-rakuast/statement-mods.t
+++ b/t/12-rakuast/statement-mods.t
@@ -1,4 +1,5 @@
 use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
 use Test;
 
 plan 13;

--- a/t/12-rakuast/statementprefixes.t
+++ b/t/12-rakuast/statementprefixes.t
@@ -1,4 +1,5 @@
 use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
 use Test;
 
 plan 15;

--- a/t/12-rakuast/statements.t
+++ b/t/12-rakuast/statements.t
@@ -1,4 +1,5 @@
 use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
 use Test;
 
 plan 26; # Do not change this file to done-testing

--- a/t/12-rakuast/strings.t
+++ b/t/12-rakuast/strings.t
@@ -1,4 +1,5 @@
 use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
 use Test;
 
 plan 13;

--- a/t/12-rakuast/stubs.t
+++ b/t/12-rakuast/stubs.t
@@ -1,4 +1,5 @@
 use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
 use Test;
 
 plan 6;

--- a/t/12-rakuast/terms.t
+++ b/t/12-rakuast/terms.t
@@ -1,4 +1,5 @@
 use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
 use Test;
 
 plan 11;

--- a/t/12-rakuast/var.t
+++ b/t/12-rakuast/var.t
@@ -1,4 +1,5 @@
 use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
 use Test;
 
 plan 37;

--- a/tools/build/install-core-dist.raku
+++ b/tools/build/install-core-dist.raku
@@ -14,6 +14,7 @@ my %provides =
     "snapper"                       => "lib/snapper.rakumod",
     "safe-snapper"                  => "lib/safe-snapper.rakumod",
     "BUILDPLAN"                     => "lib/BUILDPLAN.rakumod",
+    "RakuAST::Deparse"              => "lib/RakuAST/Deparse.rakumod",
 ;
 
 %provides<NativeCall::Dispatcher> = "lib/NativeCall/Dispatcher.rakumod"

--- a/tools/templates/6.c/core_sources
+++ b/tools/templates/6.c/core_sources
@@ -251,5 +251,4 @@ src/core.c/WrappedJSObject.pm6)@
 src/core.c/Rakudo/Metaops.pm6
 src/core.c/Rakudo/Internals/PostcircumfixAdverbs.pm6
 src/core.c/unicodey.pm6
-src/core.c/RakuAST/Deparse.pm6
 src/core.c/core_epilogue.pm6


### PR DESCRIPTION
This pretty hacky approach fetches the RakuAST type object at the end of the core.c compilation, and stashes that with bindcurhllsym. It then replaces the CORE::<RakuAST> entry with Nil, causing all lookups for RakuAST classes to fail from thereon.

It also lexically enables RakuAST again in the 6.e Formatter class to keep that working.

And it adds an entry in lib/experimental that basically makes the original RakuAST type object visible again.