### PR TITLE
Ensure correct path separator is used

### DIFF
--- a/tools/templates/Makefile-backend-common.in
+++ b/tools/templates/Makefile-backend-common.in
@@ -183,9 +183,9 @@ check_@backend_abbr@_nqp_version: @@script(check-nqp-version.pl)@@
 @gencat(@nfp(@bpm(BUILD_DIR)@/rakudo-debug.nqp)@:	@nfp(src/rakudo-debug.nqp)@ @nfp(@bpm(BUILD_DIR)@/main-version.nqp)@)@
 
 # compile Raku AST specs into NQP
-gen/ast.nqp: @bsm(RAKU_AST_SOURCES)@ tools/build/raku-ast-compiler.nqp
+@nfp(gen/ast.nqp)@: @bsm(RAKU_AST_SOURCES)@ @nfp(tools/build/raku-ast-compiler.nqp)@
 	@echo(+++ Generating	$@)@
-	$(NOECHO)@bpm(NQP)@ tools/build/raku-ast-compiler.nqp @bsm(RAKU_AST_SOURCES)@ > gen/ast.nqp
+	$(NOECHO)@bpm(NQP)@ @nfp(tools/build/raku-ast-compiler.nqp)@ @bsm(RAKU_AST_SOURCES)@ >@nfp(gen/ast.nqp)@
 
 # Generate precompilations
 @comp(@bsm(RAKUDO_A)@: 	@use_prereqs(@nfp(@bpm(BUILD_DIR)@/Actions.nqp)@)@ @bsm(RAKUDO_P)@ @bsm(RAKUDO_OPS)@)@


### PR DESCRIPTION
Previously unix-style `\` was incorrectly assumed.