### PR TITLE
Implement a reliable approach to experimental RakuAST

### DIFF
--- a/lib/experimental.rakumod
+++ b/lib/experimental.rakumod
@@ -1,11 +1,7 @@
 use nqp;
 
 package EXPORT::rakuast {
-    # This code can be removed once RakuAST is stable and
-    #   use experimental :rakuast;
-    # is no longer necessary to be able to access the RakuAST classes
-    # and their functionality.
-    OUR::<RakuAST> := nqp::getcurhllsym('RakuAST');
+    # Do nothing, just provide the tag.
 }
 
 package EXPORT::cached {

--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -1390,9 +1390,9 @@ class Perl6::Actions is HLL::Actions does STDActions {
             stderr().print($world.group_exception().gist());
         }
 
-        unless $*COMPILING_CORE_SETTING || $*WANT_RAKUAST {
-            my $ex := $*W.find_symbol(['X', 'Experimental']).new(:feature<RakuAST>, :use<rakuast>);
-            $*W.add_object_if_no_sc($ex);
+        unless $*COMPILING_CORE_SETTING || $*WANT_RAKUAST || $world.have_outer {
+            my $ex := $*W.find_symbol_in_setting(['X', 'Experimental']).new(:feature<RakuAST>, :use<rakuast>);
+            $world.add_object_if_no_sc($ex);
             $*UNIT_OUTER[0].push(
                 QAST::Op.new(
                     :op<bind>,

--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -1390,6 +1390,23 @@ class Perl6::Actions is HLL::Actions does STDActions {
             stderr().print($world.group_exception().gist());
         }
 
+        unless $*COMPILING_CORE_SETTING || $*WANT_RAKUAST {
+            my $ex := $*W.find_symbol(['X', 'Experimental']).new(:feature<RakuAST>, :use<rakuast>);
+            $*W.add_object_if_no_sc($ex);
+            $*UNIT_OUTER[0].push(
+                QAST::Op.new(
+                    :op<bind>,
+                    QAST::Var.new( :name<RakuAST>, :scope<lexical>, :decl<var>),
+                    QAST::Op.new(
+                        :op<callmethod>,
+                        :name<new>,
+                        QAST::Var.new( :name<Failure>, :scope<lexical> ),
+                        QAST::WVal.new(:value($ex))
+                    )
+                )
+            );
+        }
+
         if %*COMPILING<%?OPTIONS><p> { # also covers the -np case, like Perl
             $mainline[1] := QAST::Stmt.new(wrap_option_p_code($/, $mainline[1]));
         }
@@ -10865,9 +10882,9 @@ Did you mean a call like '"
             $world.throw($/, ['X', 'NoSuchSymbol'], symbol => join('::', @name));
         }
         my $type := $world.find_symbol(@name);
-        my $is_generic := 
-            nqp::can($type.HOW, "archetypes") 
-            && nqp::can($type.HOW.archetypes($type), "generic") 
+        my $is_generic :=
+            nqp::can($type.HOW, "archetypes")
+            && nqp::can($type.HOW.archetypes($type), "generic")
             && $type.HOW.archetypes($type).generic;
         my $past;
         if $is_generic || nqp::isnull(nqp::getobjsc($type)) || istype($type.HOW,$/.how('package')) {

--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -1391,8 +1391,8 @@ class Perl6::Actions is HLL::Actions does STDActions {
         }
 
         unless $*COMPILING_CORE_SETTING || $*WANT_RAKUAST || $world.have_outer {
-            my $ex := $*W.find_symbol_in_setting(['X', 'Experimental']).new(:feature<RakuAST>, :use<rakuast>);
-            $world.add_object_if_no_sc($ex);
+            my $Exception := $*W.find_symbol_in_setting(['X', 'Experimental']);
+            $world.add_object_if_no_sc($Exception);
             $*UNIT_OUTER[0].push(
                 QAST::Op.new(
                     :op<bind>,
@@ -1401,10 +1401,12 @@ class Perl6::Actions is HLL::Actions does STDActions {
                         :op<callmethod>,
                         :name<new>,
                         QAST::Var.new( :name<Failure>, :scope<lexical> ),
-                        QAST::WVal.new(:value($ex))
-                    )
-                )
-            );
+                        QAST::Op.new(
+                            :op<callmethod>,
+                            :name<new>,
+                            QAST::WVal.new(:value($Exception)),
+                            QAST::SVal.new(:value<RakuAST>, :named<feature>),
+                            QAST::SVal.new(:value<rakuast>, :named<use> )))));
         }
 
         if %*COMPILING<%?OPTIONS><p> { # also covers the -np case, like Perl

--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -796,6 +796,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         :my %*SIG_INFO;                            # information about recent signature
         :my $*CAN_LOWER_TOPIC := 1;                # true if we optimize the $_ lexical away
         :my $*MAY_USE_RETURN := 0;                 # true if the current routine may use return
+        :my $*WANT_RAKUAST := 0;                   # if `use experimental :rakuast` is in effect
 
         # Various interesting scopes we'd like to keep to hand.
         :my $*GLOBALish;

--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -545,6 +545,8 @@ class Perl6::World is HLL::World {
         $!in_unit_parse
     }
 
+    method have_outer() { $!have_outer }
+
     method add_check($check) {
         @!CHECKs := [] unless @!CHECKs;
         @!CHECKs.unshift($check);

--- a/src/core.c/RakuAST/Deparse.pm6
+++ b/src/core.c/RakuAST/Deparse.pm6
@@ -527,7 +527,7 @@ class RakuAST::Deparse {
     }
 
     multi method deparse(RakuAST::Postcircumfix::LiteralHashIndex:D $ast --> str) {
-        self.deparse($ast.index)  
+        self.deparse($ast.index)
     }
 
     multi method deparse(RakuAST::Postfix:D $ast --> str) {
@@ -1527,5 +1527,7 @@ class RakuAST::Deparse {
         $ast.value.raku
     }
 }
+
+nqp::bindhllsym('Raku', 'DEPARSE', RakuAST::Deparse);
 
 # vim: expandtab shiftwidth=4

--- a/src/core.c/Rakudo/Internals.pm6
+++ b/src/core.c/Rakudo/Internals.pm6
@@ -1786,6 +1786,10 @@ my class Rakudo::Internals {
     method NEXT-ID(--> Int:D) {
         cas $next-id, { nqp::add_I(nqp::decont($_), 1, Int) }
     }
+
+    method DEPARSE(Mu \node) {
+        nqp::gethllsym('Raku', 'DEPARSE').new.deparse(node)
+    }
 }
 
 # expose the number of bits a native int has

--- a/src/core.c/Stash.pm6
+++ b/src/core.c/Stash.pm6
@@ -24,13 +24,6 @@ my class Stash { # declared in BOOTSTRAP
                ContainerDescriptor::BindHashKey.new(Mu, self, $key)
              )
     }
-
-    method !fail-not-found($key) {
-        (self.Str eq 'must-use-experimental-rakuast'
-          ?? "Must do a 'use experimental :rakuast' to access RakuAST::$key.substr(1)"
-          !! "Could not find symbol '$key' in '{self}'"
-        ).Failure
-    }
     multi method AT-KEY(Stash:D: Str() $key, :$global_fallback!) is raw {
         my \storage := nqp::getattr(self,Map,'$!storage');
         nqp::if(
@@ -41,7 +34,7 @@ my class Stash { # declared in BOOTSTRAP
             nqp::if(
               nqp::existskey(GLOBAL.WHO,$key),
               nqp::atkey(GLOBAL.WHO,$key),
-              self!fail-not-found($key)
+              "Could not find symbol '$key' in '{self}'".Failure
             ),
             nqp::p6scalarfromdesc(
               ContainerDescriptor::BindHashKey.new(Mu, self, $key)

--- a/src/core.c/core_epilogue.pm6
+++ b/src/core.c/core_epilogue.pm6
@@ -135,24 +135,6 @@ BEGIN .^compose for
 
 BEGIN Metamodel::ClassHOW.exclude_parent(Mu);
 
-# This code can be removed once RakuAST is stable and
-#   use experimental :rakuast;
-# is no longer necessary to be able to access the RakuAST classes
-# and their functionality.
-{
-    my Mu $ctx := nqp::getattr(CORE::, PseudoStash, '$!ctx');
-    my class must-use-experimental-rakuast is Nil { }
-    until nqp::isnull($ctx) {
-        my $pad := nqp::ctxlexpad($ctx);
-        if nqp::existskey($pad, 'CORE-SETTING-REV') {
-            nqp::bindcurhllsym('RakuAST',RakuAST);
-            nqp::bindkey($pad,'RakuAST',must-use-experimental-rakuast);
-            last;
-        }
-        $ctx := nqp::ctxouterskipthunks($ctx);
-    }
-}
-
 {YOU_ARE_HERE}
 
 # vim: expandtab shiftwidth=4

--- a/tools/templates/6.c/core_sources
+++ b/tools/templates/6.c/core_sources
@@ -250,6 +250,7 @@ src/core.c/REPL.pm6
 src/core.c/WrappedJSObject.pm6)@
 src/core.c/Rakudo/Metaops.pm6
 src/core.c/Rakudo/Internals/PostcircumfixAdverbs.pm6
+src/core.c/RakuAST/Deparse.pm6
 src/core.c/unicodey.pm6
 src/core.c/RakuAST/Deparse.pm6
 src/core.c/core_epilogue.pm6

--- a/tools/templates/6.c/core_sources
+++ b/tools/templates/6.c/core_sources
@@ -250,7 +250,6 @@ src/core.c/REPL.pm6
 src/core.c/WrappedJSObject.pm6)@
 src/core.c/Rakudo/Metaops.pm6
 src/core.c/Rakudo/Internals/PostcircumfixAdverbs.pm6
-src/core.c/RakuAST/Deparse.pm6
 src/core.c/unicodey.pm6
 src/core.c/RakuAST/Deparse.pm6
 src/core.c/core_epilogue.pm6


### PR DESCRIPTION
Do it via compiler this time. No modification to the `experimental.rakumod` is needed except that the module must provide the `:rakuast` tag. It is dummy for now, but might be used in the future for extra useful work.

The actual logic now is to install `Failure`-bound `RakuAST` symbol without the `use experimental :rakuast`. And raise a compile-time error whenever used without the statement.

`RakuAST::Deparse` is back into the core.

Changed the logic of `Rakudo::Internals.DEPARSE` from explicitly printing deparse result to returning it as a string. It is up to the caller what to do with it.