### PR TITLE
"numeric comparisons" with coercion rather than overload

### DIFF
--- a/src/core.c/Date.pm6
+++ b/src/core.c/Date.pm6
@@ -404,15 +404,15 @@ my class Date does Dateish {
           !! nqp::create(Date)!SET-SELF($!year, $!month, $!day, &!formatter)
     }
     
-    method Int() {
+    multi method Int(Date:D:) {
         self.daycount
     }
     
-    method Numeric() {
+    multi method Numeric(Date:D:) {
         self.daycount
     }
     
-    method Real() {
+    multi method Real(Date:D:) {
         self.daycount
     }
     

--- a/src/core.c/Date.pm6
+++ b/src/core.c/Date.pm6
@@ -404,15 +404,15 @@ my class Date does Dateish {
           !! nqp::create(Date)!SET-SELF($!year, $!month, $!day, &!formatter)
     }
     
-    multi method Int(Date:D:) {
+    multi method Int(Date:D: --> Int:D) {
         self.daycount
     }
     
-    multi method Numeric(Date:D:) {
+    multi method Numeric(Date:D: --> Int:D) {
         self.daycount
     }
     
-    multi method Real(Date:D:) {
+    multi method Real(Date:D: --> Int:D) {
         self.daycount
     }
     

--- a/src/core.c/Date.pm6
+++ b/src/core.c/Date.pm6
@@ -403,6 +403,19 @@ my class Date does Dateish {
           ?? self
           !! nqp::create(Date)!SET-SELF($!year, $!month, $!day, &!formatter)
     }
+    
+    method Int() {
+        self.daycount
+    }
+    
+    method Numeric() {
+        self.daycount
+    }
+    
+    method Real() {
+        self.daycount
+    }
+    
 }
 
 multi sub infix:<+>(Date:D $date, Int:D $x --> Date:D) {
@@ -419,24 +432,6 @@ multi sub infix:<->(Date:D $a, Date:D $b --> Int:D) {
 }
 multi sub infix:<cmp>(Date:D $a, Date:D $b) {
     $a.daycount cmp $b.daycount
-}
-multi sub infix:«<=>»(Date:D $a, Date:D $b) {
-    $a.daycount <=> $b.daycount
-}
-multi sub infix:<==>(Date:D $a, Date:D $b --> Bool:D) {
-    $a.daycount == $b.daycount
-}
-multi sub infix:«<=»(Date:D $a, Date:D $b --> Bool:D) {
-    $a.daycount <= $b.daycount
-}
-multi sub infix:«<»(Date:D $a, Date:D $b --> Bool:D) {
-    $a.daycount < $b.daycount
-}
-multi sub infix:«>=»(Date:D $a, Date:D $b --> Bool:D) {
-    $a.daycount >= $b.daycount
-}
-multi sub infix:«>»(Date:D $a, Date:D $b --> Bool:D) {
-    $a.daycount > $b.daycount
 }
 
 proto sub sleep($?, *%) {*}


### PR DESCRIPTION
Overloads of "numeric comparison" operators are not only severely undocumented but they also defeat the purpose of having separate operators based on different types: why have specialized and generic operator types if a randomly chosen one will get overloads anyway?

It seemed sane and the least breaking to keep the behavior but actually make it a "numeric comparison", backed up by a reasonable, public and documented integer representation: days relative to Modified Julian Day.

(It could be discussed if a "numeric comparison" is even adequate for Dates, given that they rather look like custom objects - but that would immediately a breaking change and it's not the right time for rallying off in that direction.)