### PR TITLE
Introduce `$?UNICODE-VERSION` in 6.e

### DIFF
--- a/src/core.e/core_prologue.pm6
+++ b/src/core.e/core_prologue.pm6
@@ -4,4 +4,7 @@ use MONKEY;
 # Must preceede class declarations to allow correct recording of their respective language version.
 my constant CORE-SETTING-REV = 'e';
 
+# This constant must specify the current Unicode version being supported
+my constant $?UNICODE-VERSION = v13.0;
+
 # vim: expandtab shiftwidth=4

--- a/src/core.e/core_prologue.pm6
+++ b/src/core.e/core_prologue.pm6
@@ -1,38 +1,38 @@
 use MONKEY;
 
-# This constant must specify current CORE revision
-# Must preceede class declarations to allow correct recording of their respective language version.
+# This constant must specify current CORE revision.  Must precede class
+# declarations to allow correct recording of their respective language version
 my constant CORE-SETTING-REV = 'e';
 
-# This constant must specify the current Unicode version being supported
-my constant $?UNICODE-VERSION = do {
-    Version.new: (
-      <1.1> => 'a',
-      <2.0> => 'ẛ',
-      <2.1> => '€',
-      <3.0> => 'ϟ',
-      <3.1> => 'ϴ',
-      <3.2> => '⁇',
-      <4.0> => 'ȡ',
-      <4.1> => 'ℼ',
-      <5.0> => 'ↄ',
-      <5.1> => 'Ϗ',
-      <5.2> => 'Ɒ',
-      <6.0> => '✅',
-      <6.1> => 'Ɦ',
-      <6.2> => '₺',
-      <6.3> => 0x061C.chr,
-      <7.0> => 0x037F.chr,
-      <8.0> => 0x218A.chr,
-      <9.0> => 0xA7AE.chr,
-      <10.0> => 0x20BF.chr,
-      <11.0> => 0xA7AF.chr,
-      <12.0> => 0xA7BA.chr,
-      <12.1> => 0x32FF.chr,
-      <13.0> => 0x1F972.chr,
-      <14.0> => 0x061D.chr,
-      <15.0> => 0x0CF3.chr,
-    ).first(*.value.uniprop('Age') ne 'Unassigned', :end).key
-}
+# This constant specifies the current Unicode version being supported
+my constant $?UNICODE-VERSION = (
+   '1.1' => 'a',
+   '2.0' => 'ẛ',
+   '2.1' => '€',
+   '3.0' => 'ϟ',
+   '3.1' => 'ϴ',
+   '3.2' => '⁇',
+   '4.0' => 'ȡ',
+   '4.1' => 'ℼ',
+   '5.0' => 'ↄ',
+   '5.1' => 'Ϗ',
+   '5.2' => 'Ɒ',
+   '6.0' => '✅',
+   '6.1' => 'Ɦ',
+   '6.2' => '₺',
+   '6.3' =>  0x061C.chr,
+   '7.0' =>  0x037F.chr,
+   '8.0' =>  0x218A.chr,
+   '9.0' =>  0xA7AE.chr,
+  '10.0' =>  0x20BF.chr,
+  '11.0' =>  0xA7AF.chr,
+  '12.0' =>  0xA7BA.chr,
+  '12.1' =>  0x32FF.chr,
+  '13.0' => 0x1F972.chr,
+  '14.0' =>  0x061D.chr,
+  '15.0' =>  0x0CF3.chr,
+# PLEASE ADD NEWER UNICODE VERSIONS HERE, AS SOON AS THE UNICODE
+# CONSORTIUM HAS RELEASED A NEW VERSION
+).first(*.value.uniprop('Age') ne 'Unassigned', :end).key.Version;
 
 # vim: expandtab shiftwidth=4

--- a/src/core.e/core_prologue.pm6
+++ b/src/core.e/core_prologue.pm6
@@ -5,6 +5,34 @@ use MONKEY;
 my constant CORE-SETTING-REV = 'e';
 
 # This constant must specify the current Unicode version being supported
-my constant $?UNICODE-VERSION = v13.0;
+my constant $?UNICODE-VERSION = do {
+    Version.new: (
+      <1.1> => 'a',
+      <2.0> => 'ẛ',
+      <2.1> => '€',
+      <3.0> => 'ϟ',
+      <3.1> => 'ϴ',
+      <3.2> => '⁇',
+      <4.0> => 'ȡ',
+      <4.1> => 'ℼ',
+      <5.0> => 'ↄ',
+      <5.1> => 'Ϗ',
+      <5.2> => 'Ɒ',
+      <6.0> => '✅',
+      <6.1> => 'Ɦ',
+      <6.2> => '₺',
+      <6.3> => 0x061C.chr,
+      <7.0> => 0x037F.chr,
+      <8.0> => 0x218A.chr,
+      <9.0> => 0xA7AE.chr,
+      <10.0> => 0x20BF.chr,
+      <11.0> => 0xA7AF.chr,
+      <12.0> => 0xA7BA.chr,
+      <12.1> => 0x32FF.chr,
+      <13.0> => 0x1F972.chr,
+      <14.0> => 0x061D.chr,
+      <15.0> => 0x0CF3.chr,
+    ).first(*.value.uniprop('Age') ne 'Unassigned', :end).key
+}
 
 # vim: expandtab shiftwidth=4

--- a/t/02-rakudo/03-corekeys-6e.t
+++ b/t/02-rakudo/03-corekeys-6e.t
@@ -13,6 +13,7 @@ my @expected = (
     Q{$?BITS},
     Q{$?NL},
     Q{$?TABSTOP},
+    Q{$?UNICODE-VERSION},
     Q{$_},
     Q{$¢},
     Q{&CLONE-HASH-DECONTAINERIZED},

--- a/t/02-rakudo/03-corekeys.t
+++ b/t/02-rakudo/03-corekeys.t
@@ -798,6 +798,7 @@ my @allowed =
         Q{$!},
         Q{$/},
         Q{$=pod},
+        Q{$?UNICODE-VERSION},
         Q{$_},
         Q{$¢},
         Q{&last},

--- a/t/02-rakudo/04-settingkeys-6e.t
+++ b/t/02-rakudo/04-settingkeys-6e.t
@@ -12,6 +12,7 @@ my %allowed = (
     Q{$?BITS},
     Q{$?NL},
     Q{$?TABSTOP},
+    Q{$?UNICODE-VERSION},
     Q{$_},
     Q{&CLONE-HASH-DECONTAINERIZED},
     Q{&CLONE-LIST-DECONTAINERIZED},


### PR DESCRIPTION
Instead of doing difficult things in MoarVM or JVM, just set the constant in the setting code.  Whenever a Unicode update is to be done, updating this constant should be part of the Pull Request.