### PR TITLE
Fix `race` to actually race and not secretly hypering

### DIFF
--- a/src/core.c/HyperSeq.pm6
+++ b/src/core.c/HyperSeq.pm6
@@ -1,7 +1,7 @@
 # A HyperSeq performs batches of work in parallel, but retains order of output
 # values relative to input values.
 #?if !js
-my class HyperSeq does ParallelSequence {
+my class HyperSeq does ParallelSequence[Rakudo::Internals::HyperToIterator] {
     method hyper(HyperSeq:D:) { self }
 
     method race(HyperSeq:D:) {

--- a/src/core.c/ParallelSequence.pm6
+++ b/src/core.c/ParallelSequence.pm6
@@ -1,5 +1,5 @@
 # ParallelSequence role implements common functionality of HyperSeq and RaceSeq classes.
-my role ParallelSequence does Iterable does Sequence {
+my role ParallelSequence[::Joiner] does Iterable does Sequence {
     has HyperConfiguration $.configuration;
     has Rakudo::Internals::HyperWorkStage $!work-stage-head;
 #?if moar
@@ -22,7 +22,7 @@ my role ParallelSequence does Iterable does Sequence {
 #?if !moar
             if nqp::cas($!has-iterator, 0, 1);
 #?endif
-        my $joiner := Rakudo::Internals::HyperToIterator.new:
+        my $joiner := Joiner.new:
                         source => $!work-stage-head;
         Rakudo::Internals::HyperPipeline.start($joiner, $!configuration);
         $joiner

--- a/src/core.c/RaceSeq.pm6
+++ b/src/core.c/RaceSeq.pm6
@@ -3,7 +3,7 @@
 # the input).
 
 #?if !js
-my class RaceSeq does ParallelSequence {
+my class RaceSeq does ParallelSequence[Rakudo::Internals::RaceToIterator] {
     method hyper(RaceSeq:D:) {
         HyperSeq.new(
             :$!configuration,


### PR DESCRIPTION
This partly fixes #4899.

When running `rakudo -e 'my @input = ^100000; race for @input { my $c = (($_ % 100 != 0 ?? 500 !! 0) + 4000.rand).floor; my $proc = shell "dd if=/dev/urandom bs=4096 count=$c | gzip > /dev/null; echo done $_", :err; $proc.err.slurp(:close) }'` the following graph results on 2022.07.
![image](https://user-images.githubusercontent.com/6307078/212417858-f64cf68a-6521-4ed5-9a74-3a9dd06b65ec.png)

The regular drops are gone with this patch.

The graph still doesn't look as it should as it still drops and gets more shaky over time.