### PR TITLE
Introduce the IGNORE phaser

### DIFF
--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -1393,6 +1393,8 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
     token statement_prefix:sym<BEGIN>   { :my %*MYSTERY; <sym><.kok> <blorst> <.explain_mystery> <.cry_sorrows> }
     token statement_prefix:sym<COMPOSE> { <sym><.kok> <blorst> }
     token statement_prefix:sym<TEMP>    { <sym><.kok> <blorst> }
+    token statement_prefix:sym<IGNORE>  { <sym><.kok> <blorst> }
+
     token statement_prefix:sym<CHECK>   { <sym><.kok> <blorst> }
     token statement_prefix:sym<INIT>    { <sym><.kok> <blorst> }
     token statement_prefix:sym<ENTER>   { <sym><.kok> <blorst> }


### PR DESCRIPTION
This phaser will allow you to have the *runtime* completely ignore a statement or a block.  Any code inside the IGNORE phaser **will** be checked for syntax and legality, but will **not** cause any bytecode to be generated.

This allows a developer to de-activate code (semi-)permanently, while ensuring that the code inside this phaser remains in sync with the rest of the code (which would not be the case if the de-activated code would live on as comments).