### PR TITLE
Fix for storing parameterised hashes as items

### DIFF
--- a/src/core.c/Hash.pm6
+++ b/src/core.c/Hash.pm6
@@ -64,10 +64,12 @@ my class Hash { # declared in BOOTSTRAP
         my $iter := nqp::iterator(nqp::getattr(map,Map,'$!storage'));
         nqp::while(
           $iter,
-          self.STORE_AT_KEY(
-            nqp::iterkey_s(nqp::shift($iter)),nqp::iterval($iter)
-          )
+          map.PUT_FROM_ITER(nqp::shift($iter), self)
         );
+    }
+
+    method PUT_FROM_ITER(Mu \iter, \target --> Nil) is implementation-detail {
+        target.STORE_AT_KEY(nqp::iterkey_s(iter),nqp::iterval(iter))
     }
 
     proto method STORE(|) {*}

--- a/src/core.c/Hash/Object.pm6
+++ b/src/core.c/Hash/Object.pm6
@@ -33,6 +33,11 @@ my role Hash::Object[::TValue, ::TKey] does Associative[TValue] {
         )
     }
 
+    method PUT_FROM_ITER(Mu \iter, \target --> Nil) {
+        my \actual-pair = nqp::iterval(iter);
+        target.STORE_AT_KEY(nqp::getattr(actual-pair, Pair, '$!key'), nqp::getattr(actual-pair, Pair, '$!value'))
+    }
+
     method ASSIGN-KEY(::?CLASS:D: TKey \key, Mu \assignval) is raw {
         my \storage  := nqp::getattr(self, Map, '$!storage');
         my \WHICH    := key.WHICH;


### PR DESCRIPTION
Belongs to https://github.com/rakudo/rakudo/issues/5165.

STORE_AT_KEY receives high level key-value arguments, they might not be available from the underlying `$!storage` directly. The classes/roles that implement STORE_AT_KEY (and hence know how their `$!storage` is composed), should also know and provide how to interpret a BOOTIter entry back to a high-level key-value pair. Another solution could be to expose and overload STORE_MAP directly for the subtypes.