### PR TITLE
Fix storing of typed Hashes from a list

### DIFF
--- a/src/core.c/Hash.pm6
+++ b/src/core.c/Hash.pm6
@@ -60,11 +60,11 @@ my class Hash { # declared in BOOTSTRAP
           nqp::p6scalarwithvalue($!descriptor,value),
         )
     }
-    method !STORE_MAP(\map --> Nil) {
-        my $iter := nqp::iterator(nqp::getattr(map,Map,'$!storage'));
+    method PUSH_FROM_MAP(\target --> Nil) is implementation-detail {
+        my $iter := nqp::iterator(nqp::getattr(self,Map,'$!storage'));
         nqp::while(
           $iter,
-          self.STORE_AT_KEY(
+          target.STORE_AT_KEY(
             nqp::iterkey_s(nqp::shift($iter)),nqp::iterval($iter)
           )
         );
@@ -94,7 +94,7 @@ my class Hash { # declared in BOOTSTRAP
             ),
             nqp::if(
               (nqp::istype($x,Map) && nqp::not_i(nqp::iscont($x))),
-              $temp!STORE_MAP($x),
+              $x.PUSH_FROM_MAP($temp),
               nqp::if(
                 nqp::eqaddr(($y := $iter.pull-one),IterationEnd),
                 nqp::if(

--- a/src/core.c/Hash/Object.pm6
+++ b/src/core.c/Hash/Object.pm6
@@ -33,6 +33,20 @@ my role Hash::Object[::TValue, ::TKey] does Associative[TValue] {
         )
     }
 
+    method PUSH_FROM_MAP(\target --> Nil) is implementation-detail {
+        my $iter := nqp::iterator(nqp::getattr(self,Map,'$!storage'));
+        nqp::while(
+          $iter,
+          nqp::stmts(
+            (my $pair := nqp::iterval(nqp::shift($iter))),
+            target.STORE_AT_KEY(
+              nqp::getattr($pair,Pair,'$!key'),
+              nqp::getattr($pair,Pair,'$!value'),
+            )
+          )
+        );
+    }
+
     method ASSIGN-KEY(::?CLASS:D: TKey \key, Mu \assignval) is raw {
         my \storage  := nqp::getattr(self, Map, '$!storage');
         my \WHICH    := key.WHICH;


### PR DESCRIPTION
Prior to this commit, a Hash with typed keys ("hash object") couldn't be
properly stored in another Hash, typed or untyped, if it appeared in a
list. This is a regression from July 2016,
commit https://github.com/rakudo/rakudo/commit/ecfb956bcf92488106a85f9462731095db11dfed .
In the affected timespan, the behavior was the following:

my %h{Any} = foo => 'bar', 12 => 'baz';
my %copy = (%h, );

The copy got recreated as the internal, `$!storage` representation.
Because of the current default implementation of `.hash`, the problem
appeared also when calling the `.hash` method on a list that contained a
"hash object", or enforcing hash context upon them with %().

STORE_AT_KEY is the method that takes care of creating an entry for an
implementation of a Hash, transforming the key and the value in a way the
underlying `$!storage` BOOTHash can hold them. When different
implementations of Hash are stored into another Hash (previously done with
the STORE_MAP method), this needs to be taken into account.

This commit fixes the problem by replacing non-dispatching STORE_MAP calls
with a PUSH_FROM_MAP method that needs to be provided for those
implementations of a Hash that have their own mapping to `$!storage`,
that is, typically the core implementations that have their own
STORE_AT_KEY. This PUSH_FROM_MAP knows how STORE_AT_KEY needs to be
called with regards to all of the elements retrieved from the Hash object
it's invoked on, meaning that all STORE_AT_KEY calls will happen with the
right arguments, at the cost of only one dispatch to the right PUSH_FROM_MAP
candidate.

Fixes #5165 