### PR TITLE
[JVM] Fix breakage with "use v6.e.PREVIEW"

### DIFF
--- a/src/Perl6/Compiler.nqp
+++ b/src/Perl6/Compiler.nqp
@@ -40,7 +40,13 @@ class Perl6::Compiler is HLL::Compiler {
                 }
 
                 # This can be micro-optimized by using nqp::create + nqp::bindattr, but does it make any sense?
+#?if jvm
+                # Version.new tries to coerce argument to Str, and that doesn't work with BOOTStr.
+                return $Version.new(nqp::hllizefor($vstr,'Raku'));
+#?endif
+#?if !jvm
                 return $Version.new($vstr);
+#?endif
             }
             @parts
         }

--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -616,7 +616,13 @@ class Perl6::World is HLL::World {
 
         for @can_ver_reversed -> $can-ver {
             # Skip if tried version doesn't match the wanted one
+#?if jvm
+            # Version.new tries to coerce argument to Str, and that doesn't work with BOOTStr.
+            next unless $vWant.ACCEPTS: my $vCan := $Version.new: nqp::box_s($can-ver, self.find_single_symbol_in_setting('Str'));
+#?endif
+#?if !jvm
             next unless $vWant.ACCEPTS: my $vCan := $Version.new: $can-ver;
+#?endif
 
             my $vCanElems := $vCan.parts.elems;
             my $can_rev := nqp::unbox_i($vCan.parts.AT-POS(0));


### PR DESCRIPTION
After a recent rework of language versioning (merge commit a815b5ca12) the JVM backend started to throw an error when it encountered

  use v6.e.PREVIEW;

The underlying reason seemed to be a BOOTStr leaking out in two places when trying to create new version objects.

My change to src/Perl6/World.nqp kind of reverts a change made in e1a7ca6227 for the jvm backend. (I've restrained from putting the call to "find_single_symbol_in_setting" above the for loop, so that the diff between the code for the jvm backend and the other backends is smaller.)