### PR TITLE
Fix test description for unknown modifier

### DIFF
--- a/t/02-rakudo/14-revisions.t
+++ b/t/02-rakudo/14-revisions.t
@@ -31,7 +31,7 @@ subtest "Modifiers", {
         :err(rx:s/TESTDEPR modifier is deprecated for Raku v6\.d/);
     is-run
         q[use v6.d.NOMOD; print CORE-SETTING-REV],
-        "Deprecated modifier generates a warning",
+        "Unknown modifier dies",
         :exitcode(1),
         :err(rx:s/No compiler available for Raku v6'.'d'.'NOMOD/);
 }


### PR DESCRIPTION
It looks like the test description has been copied from the previous
sub-test in commit 3f25ba9212 (which added these tests).