### PR TITLE
Fix recent regression on storing Maps

### DIFF
--- a/src/core.c/Hash.pm6
+++ b/src/core.c/Hash.pm6
@@ -60,15 +60,6 @@ my class Hash { # declared in BOOTSTRAP
           nqp::p6scalarwithvalue($!descriptor,value),
         )
     }
-    method PUSH_FROM_MAP(\target --> Nil) is implementation-detail {
-        my $iter := nqp::iterator(nqp::getattr(self,Map,'$!storage'));
-        nqp::while(
-          $iter,
-          target.STORE_AT_KEY(
-            nqp::iterkey_s(nqp::shift($iter)),nqp::iterval($iter)
-          )
-        );
-    }
 
     proto method STORE(|) {*}
     multi method STORE(Hash:D: \to_store) {

--- a/src/core.c/Map.pm6
+++ b/src/core.c/Map.pm6
@@ -383,6 +383,17 @@ my class Map does Iterable does Associative { # declared in BOOTSTRAP
           ?? self!STORE_MAP_FROM_OBJECT_HASH_DECONT(map)
           !! self!STORE_MAP_FROM_MAP_DECONT(map)
     }
+
+    method PUSH_FROM_MAP(Hash:D \target --> Nil) is implementation-detail {
+        my $iter := nqp::iterator(nqp::getattr(self,Map,'$!storage'));
+        nqp::while(
+          $iter,
+          target.STORE_AT_KEY(
+            nqp::iterkey_s(nqp::shift($iter)),nqp::iterval($iter)
+          )
+        );
+    }
+
     method !STORE_MAP(\map --> Map:D) {
         nqp::istype(map,Hash::Object)
           ?? self!STORE_MAP_FROM_OBJECT_HASH(map)


### PR DESCRIPTION
The commit that was meant to fix storage of "hash objects" into Hashes had a serious thinko: after checking for Maps, it invoked a method defined on Hashes only. This meant that after the changes

my %problem is Map = :foo;
(%problem,).hash

was failing, unable to find the PUSH_FROM_MAP method on Maps. (Ironically, even the name suggested that it should be defined on Maps.)

This commit addresses this problem by indeed moving the PUSH_FROM_MAP method to Map. For clarity, I added a type constraint to the parameter - the pushing always happens *to* a Hash, that was the dedicated purpose of the method all along.