### PR TITLE
Make log and sqrt handle negative values mathematically correct

### DIFF
--- a/src/core.c/Complex.pm6
+++ b/src/core.c/Complex.pm6
@@ -117,7 +117,7 @@ my class Complex is Cool does Numeric {
     method cis(Complex:D:) {
         self.cos + self.sin*Complex.new(0,1)
     }
-    method sqrt(Complex:D:) {
+    multi method sqrt(Complex:D:) {
         my Num $abs = self.abs;
         my Num $re = (($abs + self.re)/2).sqrt;
         my Num $im = (($abs - self.re)/2).sqrt;

--- a/src/core.c/Cool.pm6
+++ b/src/core.c/Cool.pm6
@@ -1,11 +1,13 @@
 my class Cool { # declared in BOOTSTRAP
     # class Cool is Any
 
+    proto method sqrt() {*}
+    multi method sqrt(Cool:D:) { self.Numeric.sqrt }
+
     ## numeric methods
 
     method abs()  { self.Numeric.abs }
     method conj()  { self.Numeric.conj }
-    method sqrt()  { self.Numeric.sqrt }
     method sign()  { self.Real.sign }
     method rand() { self.Num.rand }
     method sin()  { self.Numeric.sin }

--- a/src/core.c/Int.pm6
+++ b/src/core.c/Int.pm6
@@ -91,7 +91,7 @@ my class Int does Real { # declared in BOOTSTRAP
             !! self.Real::Bridge
     }
 
-    method sqrt(Int:D: --> Num:D) {
+    multi method sqrt(Int:D: --> Num:D) {
         nqp::p6box_n(nqp::sqrt_n(nqp::tonum_I(self)))
     }
 

--- a/src/core.c/Num.pm6
+++ b/src/core.c/Num.pm6
@@ -144,7 +144,6 @@ my class Num does Real { # declared in BOOTSTRAP
         self.log() / base.log();
     }
 
-    proto method sqrt(|) {*}
     multi method sqrt(Num:D: ) {
         nqp::p6box_n(nqp::sqrt_n(nqp::unbox_n(self)));
     }

--- a/src/core.c/Real.pm6
+++ b/src/core.c/Real.pm6
@@ -6,7 +6,6 @@ my role Real does Numeric {
     method abs()  { self < 0 ?? -self !! self }
     method sign(Real:D:) { self > 0 ?? 1 !! self < 0 ?? -1 !! 0 }
     method conj(Real:D:) { self }
-    method sqrt() { self.Bridge.sqrt }
     method rand() { self.Bridge.rand }
     method sin()  { self.Bridge.sin }
     method asin() { self.Bridge.asin }
@@ -37,6 +36,8 @@ my role Real does Numeric {
     method acotanh() { self.Bridge.acotanh }
     method floor() { self.Bridge.floor }
     method ceiling() { self.Bridge.ceiling }
+
+    multi method sqrt(Real:D:) { self.Bridge.sqrt }
 
     proto method round(|) {*}
     multi method round(Real:D:) {

--- a/src/core.e/Complex.pm6
+++ b/src/core.e/Complex.pm6
@@ -1,7 +1,37 @@
+augment class Int {
+    multi method sqrt(Int:D:) is default {
+        nqp::islt_I(self,0)
+          ?? Complex.new(
+               0,
+               nqp::p6box_n(nqp::sqrt_n(nqp::abs_n(nqp::tonum_I(self))))
+             )
+          !! nqp::p6box_n(nqp::sqrt_n(nqp::tonum_I(self)))
+    }
+}
+
+augment class Num {
+    multi method log(Num:D:) is default {
+        nqp::islt_n(self,0e0)
+          ?? Complex.new(
+               nqp::p6box_n(nqp::log_n(nqp::abs_n(nqp::unbox_n(self)))),
+               pi
+             )
+          !! nqp::p6box_n(nqp::log_n(nqp::unbox_n(self)));
+    }
+
+    multi method sqrt(Num:D:) is default {
+        nqp::islt_n(self,0e0)
+          ?? Complex.new(
+               0,
+               nqp::p6box_n(nqp::sqrt_n(nqp::abs_n(nqp::unbox_n(self))))
+             )
+          !! nqp::p6box_n(nqp::sqrt_n(nqp::unbox_n(self)));
+    }
+}
+
 augment class Complex {
     method sign(Complex:D: --> Complex:D) {
-        my $abs = self.abs;
-        $abs == 0 ?? 0i !! self / $abs
+        $_ == 0 ?? 0i !! self / $_ given self.abs;
     }
 }
 


### PR DESCRIPTION
- in 6.e only
- make sqrt a multi
- add a new sqrt candidate handling negative values
- add a new log candidate handling negative values

Note that the use of "is default" in these new candidates is needed to resolve dispatch ambiguities.  This is really a stopgap measure for now, hopefully we can dispatch on language version soon!