### PR TITLE
Switch Supply.zip to a watermark approach

### DIFF
--- a/src/core.c/Supply-coercers.pm6
+++ b/src/core.c/Supply-coercers.pm6
@@ -791,7 +791,7 @@
                         @values[$index].push(val);
                         my $new-count = @counts[$index]++;
                         emit( [[&with]] @values.map(*.shift) ) if all(@values);
-                        done if $new-count == $watermark;
+                        done if $new-count >= $watermark;
                         LAST {
                             $watermark min= @counts[$index];
                             done if all(@counts) >= $watermark;
@@ -803,7 +803,7 @@
                         @values[$index].push(val);
                         my $new-count = @counts[$index]++;
                         emit( $(@values.map(*.shift).list.eager) ) if all(@values);
-                        done if $new-count == $watermark;
+                        done if $new-count >= $watermark;
                         LAST {
                             $watermark min= @counts[$index];
                             done if all(@counts) >= $watermark;

--- a/src/core.c/Supply-coercers.pm6
+++ b/src/core.c/Supply-coercers.pm6
@@ -783,19 +783,31 @@
 
         supply {
             my @values = nqp::create(Array) xx +@s;
+            my Int @counts = 0 xx +@s;
+            my $watermark = Inf;
             for @s.kv -> $index, $supply {
                 if &with {
                     whenever $supply -> \val {
                         @values[$index].push(val);
+                        my $new-count = @counts[$index]++;
                         emit( [[&with]] @values.map(*.shift) ) if all(@values);
-                        LAST { done }
+                        done if $new-count == $watermark;
+                        LAST {
+                            $watermark min= @counts[$index];
+                            done if all(@counts) >= $watermark;
+                        }
                     }
                 }
                 else {
                     whenever $supply -> \val {
                         @values[$index].push(val);
+                        my $new-count = @counts[$index]++;
                         emit( $(@values.map(*.shift).list.eager) ) if all(@values);
-                        LAST { done }
+                        done if $new-count == $watermark;
+                        LAST {
+                            $watermark min= @counts[$index];
+                            done if all(@counts) >= $watermark;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
In https://github.com/Raku/problem-solving/issues/364 a proposed solution to a deadlock in supply setup is hindered by the failure of a spectest for Supply.zip.

Thus far we defined Supply.zip as having its reuslt Supply be `done` as soon as any input is `done`. This makes its behavior highly sensitive to the timing of its input values; as a reuslt, it may not emit all of the complete tuples of values that it feasibly could.

This change introduces a "watermark", which is the maximum number of tuples we could possibly emit. When any input `supply` becomes done, we take the number of messages that were delivered, and use that as the maximum possible number of tuples that we can emit. Any further `done`s might lower that watermark. The `supply` block as a whole is done when all input supplies reach the watermark.

This passes all current spectests. Hopefully, it will also pass when used in combination with the deadlock fix.