### PR TITLE
Fix rare deadlocks during supply setup

### DIFF
--- a/src/core.c/Lock/Async.rakumod
+++ b/src/core.c/Lock/Async.rakumod
@@ -150,7 +150,7 @@ my class Lock::Async {
             # Lock is already held on the stack, so we're recursing. Queue.
             $try-acquire.then({
                 self!run-with-updated-recursion-list(&code);
-            });
+            }, :synchronous);
         }
         else {
             # Lock is held but by something else. Await its availability.

--- a/src/core.c/Rakudo/Supply.rakumod
+++ b/src/core.c/Rakudo/Supply.rakumod
@@ -1,56 +1,6 @@
 class Rakudo::Supply {
     my constant ADD_WHENEVER_PROMPT = Mu.new;
 
-    class CachedAwaitHandle does Awaitable {
-        has $.get-await-handle;
-    }
-
-    class BlockAddWheneverAwaiter does Awaiter {
-        has $!continuations;
-
-        method await(Awaitable:D $a) {
-            my $handle := $a.get-await-handle;
-            if $handle.already {
-                $handle.success
-                    ?? $handle.result
-                    !! $handle.cause.rethrow
-            }
-            else {
-                my $reawaitable := CachedAwaitHandle.new(get-await-handle => $handle);
-                $!continuations := nqp::list() unless nqp::isconcrete($!continuations);
-                nqp::continuationcontrol(0, ADD_WHENEVER_PROMPT, nqp::getattr(-> Mu \c {
-                    nqp::push($!continuations, -> $delegate-awaiter {
-                        nqp::continuationinvoke(c, nqp::getattr({
-                            $delegate-awaiter.await($reawaitable);
-                        }, Code, '$!do'));
-                    });
-                }, Code, '$!do'));
-            }
-        }
-
-        method await-all(Iterable:D \i) {
-            $!continuations := nqp::list() unless nqp::isconcrete($!continuations);
-            nqp::continuationcontrol(0, ADD_WHENEVER_PROMPT, nqp::getattr(-> Mu \c {
-                nqp::push($!continuations, -> $delegate-awaiter {
-                    nqp::continuationinvoke(c, nqp::getattr({
-                        $delegate-awaiter.await-all(i);
-                    }, Code, '$!do'));
-                });
-            }, Code, '$!do'));
-        }
-
-        method take-all() {
-            if nqp::isconcrete($!continuations) {
-                my \result = $!continuations;
-                $!continuations := Mu;
-                result
-            }
-            else {
-                Empty
-            }
-        }
-    }
-
     class BlockState {
         has &.emit;
         has &.done;
@@ -60,7 +10,6 @@ class Rakudo::Supply {
         has $!lock;
         has %!active-taps;
         has $.run-async-lock;
-        has $.awaiter;
 
         method new(:&emit!, :&done!, :&quit!) {
             self.CREATE!SET-SELF(&emit, &done, &quit)
@@ -73,7 +22,6 @@ class Rakudo::Supply {
             $!active = 1;
             $!lock := Lock.new;
             $!run-async-lock := Lock::Async.new;
-            $!awaiter := BlockAddWheneverAwaiter.CREATE;
             self
         }
 
@@ -172,48 +120,43 @@ class Rakudo::Supply {
             # closure-clone it once per Supply block, not once per whenever.
             sub add-whenever($supply, &whenever-block) {
                 my $tap;
-                $state.run-async-lock.with-lock-hidden-from-recursion-check: {
-                    my $*AWAITER := $state.awaiter;
-                    nqp::continuationreset(ADD_WHENEVER_PROMPT, nqp::getattr({
-                        $supply.tap(
-                            tap => {
-                                $tap := $_;
-                                $state.add-active-tap($tap);
-                            },
-                            -> \value {
-                                self!run-supply-code(&whenever-block, value, $state,
-                                    &add-whenever, $tap)
-                            },
-                            done => {
-                                $state.delete-active-tap($tap);
-                                my @phasers := &whenever-block.phasers('LAST');
-                                if @phasers {
-                                    self!run-supply-code({ .() for @phasers }, Nil, $state,
-                                        &add-whenever, $tap)
-                                }
-                                $tap.close;
-                                self!deactivate-one($state);
-                            },
-                            quit => -> \ex {
-                                $state.delete-active-tap($tap);
-                                my $handled := False;
-                                self!run-supply-code({
-                                    my $phaser := &whenever-block.phasers('QUIT')[0];
-                                    if $phaser.DEFINITE {
-                                        $handled := $phaser(ex) === Nil;
-                                    }
-                                    if !$handled && $state.get-and-zero-active() {
-                                        $state.quit().(ex) if $state.quit;
-                                        $state.teardown();
-                                    }
-                                }, Nil, $state, &add-whenever, $tap);
-                                if $handled {
-                                    $tap.close;
-                                    self!deactivate-one($state);
-                                }
-                            });
-                    }, Code, '$!do'));
-                }
+                $supply.tap(
+                    tap => {
+                        $tap := $_;
+                        $state.add-active-tap($tap);
+                    },
+                    -> \value {
+                        self!run-supply-code(&whenever-block, value, $state,
+                            &add-whenever, $tap)
+                    },
+                    done => {
+                        $state.delete-active-tap($tap);
+                        my @phasers := &whenever-block.phasers('LAST');
+                        if @phasers {
+                            self!run-supply-code({ .() for @phasers }, Nil, $state,
+                                &add-whenever, $tap)
+                        }
+                        $tap.close;
+                        self!deactivate-one($state);
+                    },
+                    quit => -> \ex {
+                        $state.delete-active-tap($tap);
+                        my $handled := False;
+                        self!run-supply-code({
+                            my $phaser := &whenever-block.phasers('QUIT')[0];
+                            if $phaser.DEFINITE {
+                                $handled := $phaser(ex) === Nil;
+                            }
+                            if !$handled && $state.get-and-zero-active() {
+                                $state.quit().(ex) if $state.quit;
+                                $state.teardown();
+                            }
+                        }, Nil, $state, &add-whenever, $tap);
+                        if $handled {
+                            $tap.close;
+                            self!deactivate-one($state);
+                        }
+                    });
                 $tap
             }
 
@@ -238,8 +181,7 @@ class Rakudo::Supply {
         }
 
         method !run-supply-code(&code, \value, BlockState $state, &add-whenever, $tap) {
-            my @run-after;
-            my $queued := $state.run-async-lock.protect-or-queue-on-recursion: {
+            $state.run-async-lock.protect-or-queue-on-recursion: {
                 my &*ADD-WHENEVER := &add-whenever;
                 $state.active > 0 and nqp::handle(code(value),
                     'EMIT', $state.run-emit(),
@@ -247,27 +189,6 @@ class Rakudo::Supply {
                     'CATCH', $state.run-catch(),
                     'LAST', $state.run-last($tap, &code),
                     'NEXT', 0);
-                @run-after = $state.awaiter.take-all;
-            }
-            if $queued.defined {
-                $queued.then({ self!run-add-whenever-awaits(@run-after) });
-            }
-            else {
-                self!run-add-whenever-awaits(@run-after);
-            }
-        }
-
-        method !run-add-whenever-awaits(@run-after --> Nil) {
-            if @run-after {
-                my $nested-awaiter := BlockAddWheneverAwaiter.CREATE;
-                my $delegate-awaiter := $*AWAITER;
-                while @run-after.elems {
-                    my $*AWAITER := $nested-awaiter;
-                    nqp::continuationreset(ADD_WHENEVER_PROMPT, nqp::getattr({
-                        @run-after.shift()($delegate-awaiter);
-                    }, Code, '$!do'));
-                    @run-after.append($nested-awaiter.take-all);
-                }
             }
         }
 


### PR DESCRIPTION
This fixes rakudo/rakudo#5141 and Raku/problem-solving#364.
`make test` and `make spectest` both pass.

In https://github.com/rakudo/rakudo/commit/26a9c313297a21c11ac30f02349497822686f507
a mechanism to solve deadlocks during supply / whenever setup was
introduced. In that implementation whenever a lock during setup
was hit a continuation would be taken and put into a list for later
processing. That list was then processed in order. If new locks were
encountered they were appended to the list. I was possible to end up
in a situation where the first continuation waited for a lock the
second continuation in the list held.

Later on in https://github.com/rakudo/rakudo/commit/547839200a772e26ea164e9d1fd8c9cd4a5c2d9f
a different mechanism to deal with deadlocks caused by recursion during
supply / whenever processing was introduced. That mechanism is far
simpler and neither involves continuations nor overwriting `$*AWAITER`.

It seems (this is not proven) that a precondition for deadlocks to
appear during supply / whenever setup is recursion locking. So the
second simpler mechanism is able to replace the first. This change does
just that. The first mechanism is removed leaving only the second.

A positive side-effect (apart from solving the rare deadlocks) is
that the whenever setup process is simpler and easier to reason about.
Especially locks unrelated to the supplies do not influence the setup
process anymore.