### PR TITLE
Fix error reporting for feeds

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -7511,7 +7511,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
             else {
                 my str $error := "Only routine calls or variables that can '.append' may appear on either side
 of feed operators.";
-                if nqp::istype($stage[0], QAST::Var) {
+                if nqp::istype($stage, QAST::Children) && nqp::istype($stage[0], QAST::Var) {
                     if nqp::istype($stage, QAST::Op) && $stage.op eq 'ifnull'
                       && nqp::eqat($stage[0].name, '&', 0) {
                         $error := "A feed may not sink values into a code object.


### PR DESCRIPTION
When LHS is a typeobject it is codegenned into a `QAST::WVal` which cannot be used as a positional.