### PR TITLE
Introduce $*WARNINGS and ENV<RAKU_WARNINGS>

### DIFF
--- a/src/core.c/Int.pm6
+++ b/src/core.c/Int.pm6
@@ -1,4 +1,3 @@
-
 my class Rat { ... }
 my class X::Cannot::Capture       { ... }
 my class X::Numeric::DivideByZero { ... }

--- a/src/core.c/Int.pm6
+++ b/src/core.c/Int.pm6
@@ -1,3 +1,4 @@
+
 my class Rat { ... }
 my class X::Cannot::Capture       { ... }
 my class X::Numeric::DivideByZero { ... }

--- a/src/core.c/Process.pm6
+++ b/src/core.c/Process.pm6
@@ -93,6 +93,14 @@ Rakudo::Internals.REGISTER-DYNAMIC: '$*HOME', {
     PROCESS::<$HOME> := $HOME # bind container so Nil default is kept
 }
 
+Rakudo::Internals.REGISTER-DYNAMIC: '$*WARNINGS', {
+    PROCESS::<$WARNINGS> := (my $what := %*ENV<RAKU_WARNINGS>)
+      ?? nqp::istype((my $lookup := ::("CX::Warn::$what.tc()")),Failure)
+        ?? $lookup.throw
+        !! $lookup
+      !! CX::Warn;
+}
+
 {
     sub fetch($what) {
         once if !Rakudo::Internals.IS-WIN && try { qx/LC_MESSAGES=POSIX id/ } -> $id {


### PR DESCRIPTION
Introduces 5 new classes that provide different behaviours for warnings

-  CX::Warn::Quietly - do not show warnings, similar to quietly
-  CX::Warn::Fatal - immediately throw a warning as an exception
-  CX::Warn::Verbose - immediately show warnings with complete backtrace
-  CX::Warn::Collect - collect warnings until END, then show with frequencies
-  CX::Warn::Debug - show warnings with complete backtrace and debugging info

The behaviour can be set by setting the new dynamic variable `$*WARNINGS` to any of these classes (CX::Warn for normal behaviour), with the exception of `CX::Warn::Debug` which *must* be instantiated.

The default behaviour of a process can be set with the `RAKU_WARNINGS` environment variable, which should have any of "quietly", "fatal", "verbose", or "collect" specified. No specification defaults to the current behaviour.

Custom behaviour can also be made by creating one's own `CX::Warn::Foo` class, which should have a WARN method taking the warning message and a `Backtrace` object. That method is then expected to do the right thing, and return `Nil`.  Such custom classes can also be activated with `RAKU_WARNINGS=foo`.

I also tried making this a v6.e feature only, but that ran into all sorts of scoping issues. So until these are better understood, this is now implemented as a 6.c feature.

The `CX::Warn::Debug` class is special in that it must be instantiated, and as such cannot be activated from an environment variable.  The `.new` method takes any number of *variables* and will show the name of the variable and its value every time a warning is issued.

    my $foo = 42;
    my $*WARNINGS = CX::Warn::Debug.new($foo);
    warn "bar";

will note:

    $foo = 42
    bar
      in ...