### PR TITLE
Provide better error message for my %h = Callable

### DIFF
--- a/src/core.c/Hash.pm6
+++ b/src/core.c/Hash.pm6
@@ -88,14 +88,7 @@ my class Hash { # declared in BOOTSTRAP
               $x.PUSH_FROM_MAP($temp),
               nqp::if(
                 nqp::eqaddr(($y := $iter.pull-one),IterationEnd),
-                nqp::if(
-                  nqp::istype($x,Failure),
-                  $x.throw,
-                  X::Hash::Store::OddNumber.new(
-                    found => nqp::add_i(nqp::mul_i(nqp::elems($storage),2),1),
-                    last  => $x
-                  ).throw
-                ),
+                $temp.store-odd-number($x),
                 $temp.STORE_AT_KEY($x,$y)
               )
             )

--- a/src/core.c/Map.pm6
+++ b/src/core.c/Map.pm6
@@ -409,9 +409,12 @@ my class Map does Iterable does Associative { # declared in BOOTSTRAP
                  found => 2 * $elems + 1,
                  last  => $x
                ).throw
-            !! die qq:to/ERROR/;
-Cannot use a Callable as the only argument to store in a {self.^name}.
-Did you mean to store a Hash but used ';' instead of ',' to separate values?
+            !! die qq:to/ERROR/.chomp;
+Cannot use a Callable as the only argument to store in a {self.^name}.  If the
+intent was to store the contents of a Hash, one should probably use the
+%( ) hash constructor instead of \{ }.  Causes of \{ } misinterpretation:
+- using ';' instead of ',' to separate values, as these imply statements
+- using '\$_' or any placeholder variable, as they imply a block scope
 ERROR
     }
 


### PR DESCRIPTION
If it is the *only* value stored in a Map, and it is a Callable, provide an error message that points to the use of ; vs , in the contents of the Callable ({ :a; :b } versus { :a, :b }).

Addresses https://github.com/rakudo/rakudo/issues/5170

This change may actually be a performance improvement, as it reduces the binary size of the STORE methods involved, making it more likely they can be inlined.