### PR TITLE
Allow EVAL of RakuAST::Nodes without MONKEY

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -10583,7 +10583,14 @@ Did you mean a call like '"
                 $all_literal := 0 unless nqp::istype($_,QAST::SpecialArg) ||
                     nqp::istype($_,QAST::Want) && nqp::istype($_[0],QAST::WVal) && $_[1] eq 'Ss' && nqp::istype($_[2],QAST::SVal);
             }
-            $*W.throw($/, 'X::SecurityPolicy::Eval') unless $all_literal || monkey_see_no_eval($/);
+            unless $all_literal || monkey_see_no_eval($/) {
+                $args.push(
+                  QAST::WVal.new(
+                    :value($*W.find_single_symbol_in_setting('True')),
+                    :named('no-monkey')
+                  )
+                );
+            }
             $*W.cur_lexpad().no_inline(1);
         }
         WANTALL($args, 'handle_special_call_names');

--- a/src/core.c/ForeignCode.pm6
+++ b/src/core.c/ForeignCode.pm6
@@ -31,10 +31,13 @@ proto sub EVAL(
   PseudoStash :context($ctx),
   Str()       :$filename = Str,
   Bool()      :$check,
+  Bool()      :$no-monkey,
   *%_
 ) is raw {
     die "EVAL() in Raku is intended to evaluate strings or ASTs, did you mean 'try'?"
       if nqp::istype($code,Callable);
+    X::SecurityPolicy::Eval.new.throw
+      if $no-monkey && nqp::not_i(nqp::istype($code,RakuAST::Node));
 
 # TEMPORARY HACK
 $lang = 'Raku' if $lang eq 'perl6';


### PR DESCRIPTION
Since there is no danger of injection with RakuAST::Node, there's no need for "use MONKEY-SEE-NO-EVAL" if you're EVALling RakuAST nodes.

Originally, this was a compile time error.  Now it is a run-time error, because we cannot see the difference between a string and a RakuAST node at compile time.

Runtime check is achieved by setting an additional named argument "no-monkey" in the call to EVAL that will be set to True if no "use MONKEY-SEE-NO-EVAL" was seen at compile time.  The EVAL sub then checks for that flag and throws if it is true and what is being EVALled is not a RakyuAST node.