### PR TITLE
[win]: Fix rel2abs handling of long path prefixes

### DIFF
--- a/src/core.c/IO/Spec/Win32.pm6
+++ b/src/core.c/IO/Spec/Win32.pm6
@@ -180,13 +180,7 @@ my class IO::Spec::Win32 is IO::Spec::Unix {
 
     method rel2abs (Str() $path is copy, $base? is copy, :$omit-volume) {
         nqp::if(
-          (nqp::eqat($path, ':', 1) # /^ <[A..Z a..z]> ':' [ ｢\｣ | ｢/｣ ] /
-              && ( (nqp::isge_i(($_ := nqp::ord($path)), 65) # drive letter
-                  && nqp::isle_i($_, 90))
-                || (nqp::isge_i($_, 97) && nqp::isle_i($_, 122)))
-              && ( nqp::iseq_i(($_ := nqp::ordat($path, 2)), 92) # slash
-                || nqp::iseq_i($_, 47)))
-          || 0, #($path ~~ /^ <$UNCpath>/),
+          self.is-absolute($path),
           self.canonpath($path),
           nqp::if(
             nqp::iseq_i(($_ := nqp::ord($path)), 92) # /^ ｢\｣ /


### PR DESCRIPTION
The previous behavior did not generate correct absolute paths for UNC paths (like `\\\\UNC\\share\\C:\\foo\\bar.txt`) or long/raw paths (like `\\\\?\\C:\\foo\\bar.txt`) due to the way the `rel2abs` method decides when a path is relative and thus needs to be transformed. This updates the windows version of `rel2abs` to check for absoluteness using `.is-absolute`, which allows one to get the expected results when using an e.g. long path like `IO::Path.new(q|\\\\?\\C:\\foo\\bar.txt|).IO.e`