### PR TITLE
RakuAST: implement recursive regexes

### DIFF
--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -3084,6 +3084,18 @@ class Raku::RegexActions is HLL::Actions does Raku::CommonActions {
         self.attach: $/, self.r('Regex', 'Assertion', 'CharClass').new(|@asts);
     }
 
+    method assertion:sym<~~>($/) {
+        if $<num> {
+            $/.panic('Sorry, ~~ regex assertion with a capture is not yet implemented');
+        }
+        elsif $<desigilname> {
+            $/.panic('Sorry, ~~ regex assertion with a capture is not yet implemented');
+        }
+        else {
+            self.attach: $/, self.r('Regex', 'Assertion', 'RECURSE').new($/);
+        }
+    }
+
     method cclass_elem($/) {
         my int $negated := $<sign> eq '-';
         if $<name> {

--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -3092,7 +3092,7 @@ class Raku::RegexActions is HLL::Actions does Raku::CommonActions {
             $/.panic('Sorry, ~~ regex assertion with a capture is not yet implemented');
         }
         else {
-            self.attach: $/, self.r('Regex', 'Assertion', 'RECURSE').new($/);
+            self.attach: $/, self.r('Regex', 'Assertion', 'Recurse').new($/);
         }
     }
 

--- a/src/Raku/Grammar.nqp
+++ b/src/Raku/Grammar.nqp
@@ -4068,6 +4068,12 @@ grammar Raku::RegexGrammar is QRegex::P6Regex::Grammar does Raku::Common {
         ]
     }
 
+    token assertion:sym<~~> {
+        <sym>
+        <!RESTRICTED>
+        [ <?[>]> | $<num>=[\d+] | <desigilname=.LANG('MAIN','desigilname')> ]
+    }
+
     token codeblock {
         :my $*ESCAPEBLOCK := 1;
         <!RESTRICTED>

--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -1838,6 +1838,14 @@ class RakuAST::RegexThunk
             :blocktype('declaration_static'),
             QAST::Var.new( :decl('var'), :scope('local'), :name('self') ),
             QAST::Var.new( :decl('var'), :scope('lexical'), :name('$¢') ),
+            QAST::Op.new(
+              :op('bind'),
+              QAST::Var.new(:name('$?REGEX'), :scope<lexical>, :decl('var')),
+              QAST::Op.new(
+                  :op('getcodeobj'),
+                  QAST::Op.new( :op('curcode') )
+              )
+            ),
             $slash.IMPL-QAST-DECL($context),
             QAST::Var.new(
                 :decl('param'), :scope('local'), :name('__lowered_param'),

--- a/src/Raku/ast/regex.rakumod
+++ b/src/Raku/ast/regex.rakumod
@@ -1465,6 +1465,25 @@ class RakuAST::Regex::Assertion::CharClass
     }
 }
 
+class RakuAST::Regex::Assertion::RECURSE
+  is RakuAST::Regex::Assertion
+{
+  has RakuAST::Regex::Term $.node;
+
+  method new(RakuAST::Regex $node) {
+    my $obj := nqp::create(self);
+    nqp::bindattr($obj, RakuAST::Regex::Assertion::RECURSE, '$!node', $node);
+    $obj;
+  }
+
+  method IMPL-REGEX-QAST(RakuAST::IMPL::QASTContext $context, %mods) {
+     QAST::Regex.new:
+        :rxtype<subrule>, :subtype<method>,
+        QAST::NodeList.new( QAST::SVal.new( :value('RECURSE') ), :node($!node));
+  }
+
+}
+
 # The base of all user-defined character class elements.
 class RakuAST::Regex::CharClassElement
   is RakuAST::Node

--- a/src/Raku/ast/regex.rakumod
+++ b/src/Raku/ast/regex.rakumod
@@ -1465,14 +1465,14 @@ class RakuAST::Regex::Assertion::CharClass
     }
 }
 
-class RakuAST::Regex::Assertion::RECURSE
+class RakuAST::Regex::Assertion::Recurse
   is RakuAST::Regex::Assertion
 {
   has RakuAST::Regex::Term $.node;
 
   method new(RakuAST::Regex $node) {
     my $obj := nqp::create(self);
-    nqp::bindattr($obj, RakuAST::Regex::Assertion::RECURSE, '$!node', $node);
+    nqp::bindattr($obj, RakuAST::Regex::Assertion::Recurse, '$!node', $node);
     $obj;
   }
 

--- a/src/core.c/RakuAST/Deparse.pm6
+++ b/src/core.c/RakuAST/Deparse.pm6
@@ -58,6 +58,7 @@ class RakuAST::Deparse {
 
     method regex-assertion-pass(--> '<?>') { }
     method regex-assertion-fail(--> '<!>') { }
+    method regex-assertion-recurse(--> '<~~>') { }
 
     method regex-backtrack-frugal( --> '?')  { }
     method regex-backtrack-ratchet(--> ':')  { }
@@ -957,6 +958,10 @@ class RakuAST::Deparse {
 
     multi method deparse(RakuAST::Regex::Assertion::Pass $ --> Str:D) {
         $.regex-assertion-pass
+    }
+
+    multi method deparse(RakuAST::Regex::Assertion::RECURSE $ --> Str:D) {
+        $.regex-assertion-recurse
     }
 
     multi method deparse(

--- a/src/core.c/RakuAST/Deparse.pm6
+++ b/src/core.c/RakuAST/Deparse.pm6
@@ -960,7 +960,7 @@ class RakuAST::Deparse {
         $.regex-assertion-pass
     }
 
-    multi method deparse(RakuAST::Regex::Assertion::RECURSE $ --> Str:D) {
+    multi method deparse(RakuAST::Regex::Assertion::Recurse $ --> Str:D) {
         $.regex-assertion-recurse
     }
 

--- a/src/core.c/RakuAST/Raku.pm6
+++ b/src/core.c/RakuAST/Raku.pm6
@@ -607,6 +607,10 @@ augment class RakuAST::Node {
         self!nameds: <negated block>
     }
 
+    multi method raku(RakuAST::Regex::Assertion::Recurse:D: --> Str:D) {
+        self!positional(self.node)
+    }
+
 #- Regex::B --------------------------------------------------------------------
 
     multi method raku(RakuAST::Regex::BackReference::Positional:D: --> Str:D) {

--- a/t/12-rakuast/regex-assertion.rakutest
+++ b/t/12-rakuast/regex-assertion.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 25;
+plan 26;
 
 my $ast;
 my $deparsed;
@@ -447,6 +447,29 @@ subtest 'Assertion with interpolated block works' => {
     );
     is-deeply $deparsed, '/ o <{ "o" }> /', 'deparse';
     match-ok "foo", 'oo';
+}
+
+subtest 'Assertion with recursive ast works' => {
+    # /o [ <~~> | a ] /"
+
+    my $dummy = RakuAST::QuotedRegex.new(body =>
+        RakuAST::Regex::Sequence.new(
+          RakuAST::Regex::Literal.new("o")
+          )
+    );
+
+    ast RakuAST::Regex::Sequence.new(
+      RakuAST::Regex::Literal.new("o"),
+      RakuAST::Regex::Group.new(
+          RakuAST::Regex::Alternation.new(
+            RakuAST::Regex::Assertion::Recurse.new($dummy),
+            RakuAST::Regex::Literal.new("a")
+          ),
+      )
+     );
+
+    is-deeply $deparsed, '/ o [<~~> | a] /', 'deparse';
+    match-ok "ooa", "ooa";
 }
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
Hi Folks,

This adds RakuAST support for the recursive regex token, <~~>.

Sample output is below.  This is my first RakuAST PR, so I'm looking for guidance about any aspects of this PR that still need some work.

Here's the relevant spec test:

https://github.com/Raku/roast/blob/master/S05-metasyntax/angle-brackets.t#L285

Thanks!

```
$ RAKUDO_RAKUAST=1 raku -e "say '1.2.' ~~ /\d+\. <~~> | <?>/"
｢1.2.｣
$ RAKUDO_RAKUAST=1 raku --target=ast -e "say '1.2.' ~~ /\d+\. <~~> | <?>/"
CompUnit 𝄞 -e:1 ⎡say '1.2.' ~~ /\\d+\\. <~~> | <?>/⎤
  StatementList 𝄞 -e:1 ⎡say '1.2.' ~~ /\\d+\\. <~~> | <?>/⎤
    Statement::Expression ⚓▪𝄞 -e:1 ⎡say '1.2.' ~~ /\\d+\\. <~~> | <?>/⎤
      Call::Name  ⎡say '1.2.' ~~ /\\d+\\. <~~> | <?>/⎤
        Name  ⎡say⎤
        ArgList  ⎡'1.2.' ~~ /\\d+\\. <~~> | <?>/⎤
          ApplyInfix  ⎡~~⎤
            QuotedString  ⎡1.2.⎤
              StrLiteral
            Infix  ⎡~~⎤
            QuotedRegex  ⎡/\\d+\\. <~~> | <?>/⎤
              Regex::Alternation  ⎡\\d+\\. <~~> | <?>⎤
                Regex::Sequence  ⎡\\d+\\. <~~> ⎤
                  Regex::QuantifiedAtom  ⎡\\d+⎤
                    Regex::CharClass::Digit  ⎡d⎤
                    Regex::Quantifier::OneOrMore  ⎡+⎤
                  Regex::Literal
                  Regex::Assertion::RECURSE  ⎡~~⎤
                Regex::Assertion::Pass  ⎡?⎤
```