### PR TITLE
Add "is-monotonically-increasing" method to Iterators

### DIFF
--- a/src/core.c/Iterator.pm6
+++ b/src/core.c/Iterator.pm6
@@ -55,13 +55,13 @@ my role Iterator {
         )
     }
 
-    # Pushes things until we hit a lazy iterator (one whose is-lazy method returns
-    # True). The default works well for non-composite iterators (that is, those
-    # that don't trigger the evaluation of other iterators): it looks at the
-    # lazy property of itself, and if it's true, does nothing, otherwise it
-    # calls push-all. If all values the iterator can produce are pushed, then
-    # IterationEnd should be returned. Otherwise, return something else (Mu
-    # will do fine).
+    # Pushes things until we hit a lazy iterator (one whose is-lazy method
+    # returns True). The default works well for non-composite iterators (that
+    # is, those that don't trigger the evaluation of other iterators): it
+    # looks at the lazy property of itself, and if it's true, does nothing,
+    # otherwise it calls push-all. If all values the iterator can produce are
+    # pushed, then IterationEnd should be returned. Otherwise, return
+    # something else (Mu will do fine).
     method push-until-lazy(\target) {
         nqp::unless(
           self.is-lazy,
@@ -110,6 +110,10 @@ my role Iterator {
     # but *not* true for iterators that typically return keys and/or values
     # from a hash.
     method is-deterministic(--> True) { }
+
+    # Whether the iterator will produce values in a monotonically increasing
+    # manner, when being compared with infix cmp.
+    method is-monotonically-increasing(--> False) { }
 }
 
 # The PredictiveIterator role is a refinement of the Iterator role for those

--- a/src/core.c/Rakudo/Iterator.pm6
+++ b/src/core.c/Rakudo/Iterator.pm6
@@ -769,6 +769,7 @@ class Rakudo::Iterator {
             $!i = $i;
         }
         method count-only(--> Int:D) { $!n - $!i }
+        method is-monotonically-increasing(--> True) { }
         method sink-all(--> IterationEnd) { $!i = $!n }
     }
     method CharFromTo(\min,\max,\excludes-min,\excludes-max) {
@@ -2099,6 +2100,7 @@ class Rakudo::Iterator {
             $batch-size
         }
         method is-lazy(--> True) { }
+        method is-monotonically-increasing(--> True) { }
         method sink-all(--> IterationEnd) { }
     }
     my class IntRange does PredictiveIterator {
@@ -2142,6 +2144,7 @@ class Rakudo::Iterator {
             $!i = $i;                # make sure pull-one ends
         }
         method count-only(--> Int:D) { $!last - $!i + nqp::isgt_i($!i,$!last) }
+        method is-monotonically-increasing(--> True) { }
         method sink-all(--> IterationEnd) { $!i = $!last }
     }
     method IntRange(\from,\to) {
@@ -4358,6 +4361,7 @@ class Rakudo::Iterator {
             $i
         }
         method is-lazy(--> True) { }
+        method is-monotonically-increasing(--> True) { }
     }
     method SuccFromInf(\i) { SuccFromInf.new(i) }
 
@@ -4401,6 +4405,7 @@ class Rakudo::Iterator {
             }
             $!i = $e.succ;
         }
+        method is-monotonically-increasing(--> True) { }
         method sink-all(--> IterationEnd) { $!i = $!e.succ }
     }
     method SuccFromTo(\i,\exclude,\e) { SuccFromTo.new(i,exclude,e) }

--- a/src/core.c/Range.pm6
+++ b/src/core.c/Range.pm6
@@ -144,7 +144,8 @@ my class Range is Cool does Iterable does Positional {
         method !SET-SELF(\i)  { $!i = i - 1; self }
         method new(\i)    { nqp::create(self)!SET-SELF(i) }
         method pull-one() { ++$!i }
-        method is-lazy()  { True  }
+        method is-lazy(--> True)  { }
+        method is-monotonically-increasing(--> True) { }
     }
 
     method iterator() {
@@ -733,6 +734,13 @@ my class Range is Cool does Iterable does Positional {
           !! $!excludes-min || $!excludes-max
             ?? "Cannot return minmax on Range with excluded ends".Failure
             !! ($!min,$!max)
+    }
+
+    multi method sort(Range:D:) {
+        my $iterator := self.iterator;
+        $iterator.is-monotonically-increasing
+          ?? Seq.new($iterator)
+          !! self.list.sort
     }
 }
 


### PR DESCRIPTION
Returns False by default.  If returning True, then .sort() can pass on the underlying iterator unchanged in a new Seq.

Added many Range iterators to set that, so that now:

    say (1..*).sort;  # (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14...

will work, rather than throwing because the underlying iterator is lazy.