### PR TITLE
Handle uncontainerized type objects as invocant to `AT-POS` better

### DIFF
--- a/src/core.c/Any.pm6
+++ b/src/core.c/Any.pm6
@@ -281,7 +281,15 @@ my class Any { # declared in BOOTSTRAP
 
     proto method AT-POS(|) is nodal {*}
     multi method AT-POS(Any:U \SELF: Int:D \pos) is raw {
-        nqp::p6scalarfromcertaindesc(ContainerDescriptor::VivifyArray.new(SELF, pos))
+        nqp::iscont(SELF)
+          ?? nqp::p6scalarfromcertaindesc(
+               ContainerDescriptor::VivifyArray.new(SELF, pos)
+             )
+          !! pos
+            ?? X::OutOfRange.new(
+                 :what($*INDEX // 'Index'), :got(pos), :range<0..0>
+               ).Failure
+            !! SELF
     }
     multi method AT-POS(Any:U: Num:D \pos) is raw {
         nqp::isnanorinf(pos)


### PR DESCRIPTION
If the invocant is a container, nothing changes.
If the invocant is a type object, then look at the index. If the index is greater than 0, then Failure.
Else consider the type object as a single element list, so return the invocant.