### PR TITLE
Add var name to typecheck error for constants

### DIFF
--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -351,8 +351,9 @@ class RakuAST::VarDeclaration::Constant
               self.get-implicit-lookups.AT-POS(0).resolution.compile-time-value;
 
             unless nqp::istype(nqp::what($!value), $type) {
+                my $name := nqp::getattr_s(self, RakuAST::VarDeclaration::Constant, '$!name');
                 self.add-sorry($resolver.build-exception('X::Comp::TypeCheck',
-                  operation => 'constant declaration',
+                  operation => 'constant declaration of ' ~ ($name || '<anon>'),
                   expected  => $type,
                   got       => $!value
                 ));


### PR DESCRIPTION
The initial RakuAST implementation was added in e9f438f5aab716017d2a63c1e093273f8101db6b and this just adds the name of the variable to the message in the same manner as the legacy implementation. No change to passing tests or spectests.