### PR TITLE
Fix handling of =input / =output pod blocks

### DIFF
--- a/lib/Pod/To/Text.rakumod
+++ b/lib/Pod/To/Text.rakumod
@@ -14,6 +14,8 @@ sub pod2text($pod) is export {
     given $pod {
         when Pod::Heading           { heading2text($pod)             }
         when Pod::Block::Code       { code2text($pod)                }
+        when Pod::Block::Input      { code2text($pod)                }
+        when Pod::Block::Output     { code2text($pod)                }
         when Pod::Block::Named      { named2text($pod)               }
         when Pod::Block::Para       { para2text($pod)                }
         when Pod::Block::Table      { table2text($pod)               }

--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -10967,7 +10967,7 @@ Did you mean a call like '"
         my $config   := $<pod_configuration>.ast;
         my @contents := $<delimited_code_content>.ast;
         @contents    := Perl6::Pod::serialize_array(@contents).compile_time_value;
-        make Perl6::Pod::serialize_object('Pod::Block::Code',
+        make Perl6::Pod::serialize_object('Pod::Block::' ~ nqp::tclc($<typ>),
                                           :@contents,:$config).compile_time_value
     }
 
@@ -11013,7 +11013,7 @@ Did you mean a call like '"
             nqp::splice(@contents, $_.ast, +@contents, 0);
         }
         @contents  := Perl6::Pod::serialize_array(@contents).compile_time_value;
-        make Perl6::Pod::serialize_object('Pod::Block::Code',
+        make Perl6::Pod::serialize_object('Pod::Block::' ~ nqp::tclc($<pod-delim-code-typ>),
                                           :@contents,:$config).compile_time_value;
     }
 
@@ -11041,7 +11041,7 @@ Did you mean a call like '"
         }
         @contents := Perl6::Pod::serialize_array(@contents).compile_time_value;
         make Perl6::Pod::serialize_object(
-            'Pod::Block::Code', :@contents
+            'Pod::Block::' ~ nqp::tclc($<pod-delim-code-typ>), :@contents
         ).compile_time_value
     }
 

--- a/src/core.c/Pod.pm6
+++ b/src/core.c/Pod.pm6
@@ -33,6 +33,8 @@ my class Pod::Block {
 my class Pod::Block::Para    is Pod::Block { }
 my class Pod::Block::Comment is Pod::Block { }
 my class Pod::Block::Code    is Pod::Block { }
+my class Pod::Block::Input   is Pod::Block { }
+my class Pod::Block::Output  is Pod::Block { }
 
 my class Pod::Block::Named is Pod::Block {
     has $.name;

--- a/src/core.c/RakuAST/LegacyPodify.pm6
+++ b/src/core.c/RakuAST/LegacyPodify.pm6
@@ -140,7 +140,7 @@ class RakuAST::LegacyPodify {
         unless $level {
             return self.podify-table($ast)
               if $type eq 'table';
-            return self.podify-code($ast)
+            return self.podify-code($ast, $type.tc)
               if $type eq 'code' | 'input' | 'output';
             return self.podify-defn($ast)
               if $type eq 'defn';
@@ -183,7 +183,7 @@ class RakuAST::LegacyPodify {
         X::NYI.new(feature => "legacy pod support for =table").throw;
     }
 
-    method podify-code(RakuAST::Doc::Block:D $ast) {
+    method podify-code(RakuAST::Doc::Block:D $ast, str $type) {
         my $contents := $ast.paragraphs.head;
 
         $contents := nqp::istype($contents,Str)
@@ -195,7 +195,7 @@ class RakuAST::LegacyPodify {
                   !! .podify
             }).List;
 
-        Pod::Block::Code.new: :$contents, :config($ast.config)
+        ::("Pod::Block::$type").new: :$contents, :config($ast.config)
     }
 
     method podify-defn(RakuAST::Doc::Block:D $ast) {

--- a/t/07-pod-to-text/02-input-output.t
+++ b/t/07-pod-to-text/02-input-output.t
@@ -61,7 +61,7 @@ say 1;
 say 2;
 =end input
 $r = $=pod[++$p];
-isa-ok $r, Pod::Block::Code;
+isa-ok $r, Pod::Block::Input;
 # code blocks should get indented 4 spaces by Pod::To::Text
 $rp = Pod::To::Text.render($r),
 is $rp,
@@ -75,7 +75,7 @@ say 1;
 say 2;
 
 $r = $=pod[++$p];
-isa-ok $r, Pod::Block::Code;
+isa-ok $r, Pod::Block::Input;
 # code blocks should get indented 4 spaces by Pod::To::Text
 $rp = Pod::To::Text.render($r),
 is $rp,
@@ -89,7 +89,7 @@ say 1;
 say 2;
 
 $r = $=pod[++$p];
-isa-ok $r, Pod::Block::Code;
+isa-ok $r, Pod::Block::Input;
 # code blocks should get indented 4 spaces by Pod::To::Text
 $rp = Pod::To::Text.render($r),
 is $rp,
@@ -106,7 +106,7 @@ say 1;
 say 2;
 =end output
 $r = $=pod[++$p];
-isa-ok $r, Pod::Block::Code;
+isa-ok $r, Pod::Block::Output;
 # code blocks should get indented 4 spaces by Pod::To::Text
 $rp = Pod::To::Text.render($r),
 is $rp,
@@ -120,7 +120,7 @@ say 1;
 say 2;
 
 $r = $=pod[++$p];
-isa-ok $r, Pod::Block::Code;
+isa-ok $r, Pod::Block::Output;
 # code blocks should get indented 4 spaces by Pod::To::Text
 $rp = Pod::To::Text.render($r),
 is $rp,
@@ -134,7 +134,7 @@ say 1;
 say 2;
 
 $r = $=pod[++$p];
-isa-ok $r, Pod::Block::Code;
+isa-ok $r, Pod::Block::Output;
 # code blocks should get indented 4 spaces by Pod::To::Text
 $rp = Pod::To::Text.render($r),
 is $rp,


### PR DESCRIPTION
Before this, =input and =output pod was indistinguishable from =code pod, because they all codegenned to Pod::Block::Code objects.

This introduces two now classes: Pod::Block::Input and Pod::Block::Output. These classes are identical to the Pod::Block::Code classes, apart from their name.  And added their handling to Pod::To::Text, identical to the Pod::Block::Code handling to remain compatible.

This change should allow legacy pod renderers to render =code, =input and =output differently.

Some tests needed adaptation because they expected the Pod::Block::Code object, rather than the new Pod::Block::Input and Pod::Block::Output objects.