### PR TITLE
Fix role typechecking over its parent class

### DIFF
--- a/src/Perl6/Metamodel/ParametricRoleHOW.nqp
+++ b/src/Perl6/Metamodel/ParametricRoleHOW.nqp
@@ -114,7 +114,7 @@ class Perl6::Metamodel::ParametricRoleHOW
     # $checkee must always be decont'ed
     method type_check_parents($obj, $checkee) {
         for self.parents($obj, :local) -> $parent {
-            if nqp::istype($checkee, $parent) {
+            if nqp::istype($parent, $checkee) {
                 return 1;
             }
         }


### PR DESCRIPTION
Further fixes #2714. Unfortunate misordering of arguments in a call to `nqp::istype` resulted in roles always matching their direct parent only but failing with parents of parents, or with roles consumed by any parent.