### PR TITLE
Rename `Pod::Data` to `Hashray`

### DIFF
--- a/src/Raku/ast/compunit.rakumod
+++ b/src/Raku/ast/compunit.rakumod
@@ -244,7 +244,7 @@ class RakuAST::CompUnit
         nqp::ifnull(
           $!data-content,
           nqp::bindattr(self,RakuAST::CompUnit,'$!data-content',
-            RakuAST::Doc::Block.PodData
+            RakuAST::Doc::Block.Hashray
           )
         )
     }

--- a/src/core.c/RakuAST/Fixups.pm6
+++ b/src/core.c/RakuAST/Fixups.pm6
@@ -3,7 +3,7 @@ my class RakuAST::LegacyPodify { ... }
 # A class that acts as a Hash as well as an Array, with $=data semantics.
 # This needs to live rather late to have "handles" support actually working
 # in the setting.
-my class Pod::Data does Iterable {
+my class Hashray does Iterable {
     has %.Hash handles <
       AT-KEY ASSIGN-KEY BIND-KEY EXISTS-KEY DELETE-KEY Map
       keys kv pairs anti-pairs
@@ -582,8 +582,8 @@ augment class RakuAST::Doc::Paragraph {
 
 augment class RakuAST::Doc::Block {
 
-    # return a new Pod::Data class instance
-    method PodData() { Pod::Data.new }
+    # return a new Hashray class instance
+    method Hashray() { Hashray.new }
 
     # conceptual leading whitespace of first element
     method leading-whitespace() {

--- a/t/02-rakudo/03-corekeys-6c.t
+++ b/t/02-rakudo/03-corekeys-6c.t
@@ -547,6 +547,7 @@ my @expected = (
   Q{Grammar},
   Q{HardRoutine},
   Q{Hash},
+  Q{Hashray},
   Q{Hyper},
   Q{HyperConfiguration},
   Q{HyperSeq},

--- a/t/02-rakudo/03-corekeys-6d.t
+++ b/t/02-rakudo/03-corekeys-6d.t
@@ -547,6 +547,7 @@ my @expected = (
     Q{Grammar},
     Q{HardRoutine},
     Q{Hash},
+    Q{Hashray},
     Q{Hyper},
     Q{HyperConfiguration},
     Q{HyperSeq},

--- a/t/02-rakudo/03-corekeys-6e.t
+++ b/t/02-rakudo/03-corekeys-6e.t
@@ -556,6 +556,7 @@ my @expected = (
     Q{Grammar},
     Q{HardRoutine},
     Q{Hash},
+    Q{Hashray},
     Q{Hyper},
     Q{HyperConfiguration},
     Q{HyperSeq},

--- a/t/02-rakudo/03-corekeys.t
+++ b/t/02-rakudo/03-corekeys.t
@@ -550,6 +550,7 @@ my @allowed =
       Q{Grammar},
       Q{HardRoutine},
       Q{Hash},
+      Q{Hashray},
       Q{Hyper},
       Q{HyperConfiguration},
       Q{HyperSeq},

--- a/t/02-rakudo/04-settingkeys-6c.t
+++ b/t/02-rakudo/04-settingkeys-6c.t
@@ -547,6 +547,7 @@ my %allowed = (
     Q{Grammar},
     Q{HardRoutine},
     Q{Hash},
+    Q{Hashray},
     Q{Hyper},
     Q{HyperConfiguration},
     Q{HyperSeq},

--- a/t/02-rakudo/04-settingkeys-6e.t
+++ b/t/02-rakudo/04-settingkeys-6e.t
@@ -554,6 +554,7 @@ my %allowed = (
     Q{Grammar},
     Q{HardRoutine},
     Q{Hash},
+    Q{Hashray},
     Q{Hyper},
     Q{HyperConfiguration},
     Q{HyperSeq},


### PR DESCRIPTION
Because it is a more generally useful data structure.

The Hashray acts as a Hash when accessed as an Associative.  And as an Array when accessed as a Positional.

Methods that access as Hash:
```
      AT-KEY ASSIGN-KEY BIND-KEY EXISTS-KEY DELETE-KEY Map
      keys kv pairs anti-pairs
```
Methods that access as Array:
```
      AT-POS ASSIGN-POS BIND-POS EXISTS-POS DELETE-POS List
      values push pop shift unshift splice slice iterator
```