### PR TITLE
Make IO::Handle.Supply read character-by-character

### DIFF
--- a/src/core.c/IO/Handle.pm6
+++ b/src/core.c/IO/Handle.pm6
@@ -560,7 +560,7 @@ my class IO::Handle {
         $result
     }
 
-    multi method Supply(IO::Handle:D: :$size = $*DEFAULT-READ-ELEMS --> Supply:D) {
+    multi method Supply(IO::Handle:D: :$size = 1 --> Supply:D) {
         if $!decoder { # handle is in character mode
             supply {
                 my int $chars = $size;


### PR DESCRIPTION
Otherwise it will only emit any data once 64k bytes are read, which means a construct like $handle.Supply.lines will not DWIM at all.

This fixes #5189. It' not terribly efficient but at least it's correct.