### PR TITLE
Add X::Temporal::OutOfRange

### DIFF
--- a/src/core.c/Dateish.pm6
+++ b/src/core.c/Dateish.pm6
@@ -49,7 +49,7 @@ my role Dateish {
 
     # shortcut for out of range throwing
     method !oor($what, $got, $range) {
-        X::OutOfRange.new(:$what, :$got, :$range).throw
+        X::Temporal::OutOfRange.new(:$what, :$got, :$range).throw
     }
 
     # shortcut for invalid format throwing

--- a/src/core.c/Exception.pm6
+++ b/src/core.c/Exception.pm6
@@ -2959,6 +2959,9 @@ my class X::DateTime::InvalidDeltaUnit does X::Temporal {
         "Cannot use unit $.unit with Date.delta";
     }
 }
+my class X::Temporal::OutOfRange is X::OutOfRange does X::Temporal {
+}
+
 
 my class X::Eval::NoSuchLang is Exception {
     has $.lang;


### PR DESCRIPTION
X::Temporal is documented as «A common exception type for all errors related to DateTime or Date», however when an invalid date is given an X::OutOfRange is thrown instead. This adds a X::Temporal::OutOfRange that is both, to satisfy the documented requirements.

This fixes #3847