### PR TITLE
Make `$(;)` return an empty list as it should be

### DIFF
--- a/src/Raku/ast/statements.rakumod
+++ b/src/Raku/ast/statements.rakumod
@@ -416,13 +416,14 @@ class RakuAST::StatementSequence
     method IMPL-TO-QAST(RakuAST::IMPL::QASTContext $context) {
         my @statements := self.code-statements;
         my int $n := nqp::elems(@statements);
-        if $n == 1 {
-            nqp::atpos(@statements, 0).IMPL-TO-QAST($context)
-        }
-        elsif $n == 0 {
+        if $n == 0 || $n == 1 && nqp::istype(nqp::atpos(@statements, 0),
+                    RakuAST::Statement::Empty) {
             my $name :=
               self.get-implicit-lookups.AT-POS(0).resolution.lexical-name;
             QAST::Op.new(:op('call'), :$name);
+        }
+        elsif $n == 1 {
+            nqp::atpos(@statements, 0).IMPL-TO-QAST($context)
         }
         else {
             my $stmts := self.IMPL-SET-NODE(QAST::Stmts.new, :key);


### PR DESCRIPTION
StatementSequence does return an empty list when there are no children, but it failed to treat Statement::Empty as a non-element and thus created a list with one Nil element (that's what Statement::Empty generates).

Fixes one test in `t/spec/S02-types/list.t` but gains no new files:

    is $(;).elems, 0, '$(;) parses, and is empty';

This is roughly equivalent to the change that fixed the same problem on the legacy backend:

https://github.com/rakudo/rakudo/commit/726d2fa