### PR TITLE
Make "string" but False eqv "string" but False

### DIFF
--- a/src/core.c/operators.pm6
+++ b/src/core.c/operators.pm6
@@ -102,6 +102,12 @@ sub GENERATE-ROLE-FROM-VALUE($val) is implementation-detail {
 multi sub infix:<but>(Mu \obj, Mu:D $val) is raw {
     obj.clone.^mixin(GENERATE-ROLE-FROM-VALUE($val));
 }
+multi sub infix:<but>(Mu \obj, Bool:D $value) is raw {
+    my role ButBool[Bool $value] {
+        method Bool { $value }
+    }
+    obj.clone.^mixin(ButBool[$value]);
+}
 multi sub infix:<but>(Mu:D \obj, **@roles) {
     my \real-roles := eager @roles.map: -> \rolish {
         rolish.DEFINITE ?? GENERATE-ROLE-FROM-VALUE(rolish) !!


### PR DESCRIPTION
This doesn't actually fix the general case, only the `but Bool` case. In practice they're by far the most common case.

In particular the following cases are now all true:

say "foo" but False eqv "foo" but False;
say "foo" but False === "foo" but False;
say "foo" but False !eqv "foo" but True;
say "foo" but False !=== "foo" but True;

The only other semi-common case would be `but Str`, which could be implemented in a similar way.