### PR TITLE
Deprecate including an ambiguous .pm module file

### DIFF
--- a/src/core.c/CompUnit/Repository/FileSystem.pm6
+++ b/src/core.c/CompUnit/Repository/FileSystem.pm6
@@ -326,6 +326,18 @@ class CompUnit::Repository::FileSystem
         # make sure .rakumod has precedence over .pm6 and .pm
         $_ = .<rakumod> // .<pm6> // .<pm> for %provides.values;
 
+        # The .pm file extension can also match perl modules. We should encourage users
+        # to stop using it for their raku code so we don't waste cycles sha1ing their
+        # source code or attempt to precompile them.
+        if %provides.values.grep(*.ends-with('.pm')) {
+            DEPRECATED(
+                "the .rakumod extension for raku modules, or include a META6.json file that explicitly declares each raku module file",
+                :what(".pm file extension in raku library path"),
+                :file(self.path-spec),
+                :line(0),
+            );
+        }
+
         Distribution::Hash.new(:$prefix, %(
           name      => ~$!prefix,  # must make up a name when using -Ilib
           ver       => '*',


### PR DESCRIPTION
We need to know when raku source files have changed for the purposes of precompilation. However, when a user includes a library path (i.e. -Ilib, -I/home/foo) that does not contain a META6.json file we might end up erroneously considering perl module files (which also use .pm) as raku files. While this is mostly harmless, it does waste some cpu and io. This adds a deprecation message when this ambiguous situation occurs so that in the future we might be able to remove support for the .pm extension altogether.

Resolves #1846