### PR TITLE
Consider META6.json contents when calculating CURFS id

### DIFF
--- a/src/core.c/CompUnit/Repository/FileSystem.pm6
+++ b/src/core.c/CompUnit/Repository/FileSystem.pm6
@@ -57,12 +57,13 @@ class CompUnit::Repository::FileSystem
     method id() {
         ⚛$!id // cas $!id, {
             $_ // do with self!distribution -> $distribution {
+                my $meta6 := Rakudo::Internals::JSON.to-json: :sorted-keys, $distribution.meta.hash;
                 my $parts :=
                     grep { .defined }, (.id with self.next-repo), slip # slip next repo id into hash parts to be hashed together
                     map  { nqp::sha1($_) },
                     map  { $distribution.content($_).open(:enc<iso-8859-1>).slurp(:close) },
                     $distribution.meta<provides>.values.unique.sort;
-                nqp::sha1($parts.join(''));
+                nqp::sha1($meta6 ~ $parts.join(''));
             }
         }
     }


### PR DESCRIPTION
Currently when the contents of META6.json change, precompilation may not reoccur and thus a stale $?DISTRIBUTION may be getting used. This takes the contents of the META6.json into consideration when checksumming for differences, which should avoid such a situation.