### PR TITLE
Precomp Pipeline: Fix building on CentOS 7

### DIFF
--- a/tools/build/binary-release/build-linux.sh
+++ b/tools/build/binary-release/build-linux.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-# This script should be allowed to run sudo in a CentOS 6 installation (a
+# This script should be allowed to run sudo in a CentOS 7 installation (a
 # container will do just fine).
 # For some strange reason the environment variables are lost when running this
 # script with `sudo` in azure pipelines. So we just do sudo ourselves for the
@@ -15,8 +15,16 @@ echo "========= Updating CentOS 7"
 sudo yum -y update
 sudo yum clean all
 
+echo "========= install a new enough gcc"
+sudo yum -y install centos-release-scl
+sudo yum -y install devtoolset-8
+# Somehow scl_source fails on Azure CI (but works in an identical local container).
+# So just skip scl_source entirely and just source the target file directly.
+#source scl_source enable devtoolset-8
+source /opt/rh/devtoolset-8/enable
+
 echo "========= Downloading dependencies"
-sudo yum -y install curl git perl perl-core gcc make
+sudo yum -y install curl git perl perl-core
 
 echo "========= Downloading release"
 curl -o rakudo.tgz $RELEASE_URL
@@ -35,7 +43,7 @@ echo "========= Installing Rakudo"
 make install
 
 echo "========= Testing Rakudo"
-rm -r t/spec
+rm -fr t/spec
 prove -e install/bin/raku -vlr t
 
 echo "========= Cloning Zef"


### PR DESCRIPTION
On CentOS 7 latest GCC you can get is 4.8.5. But latest Rakudo 2023.05 contains a libuv that depends on c11 atomics which are first available in GCC 4.9.