### PR TITLE
Remove largely unknown flags from installed raku script shims

### DIFF
--- a/src/core.c/CompUnit/RepositoryRegistry.pm6
+++ b/src/core.c/CompUnit/RepositoryRegistry.pm6
@@ -302,13 +302,9 @@ class CompUnit::RepositoryRegistry {
         Nil
     }
 
-    method run-script($script, :$name, :$auth, :$ver, :$api) {
-        shift @*ARGS if $name;
-        shift @*ARGS if $auth;
-        shift @*ARGS if $ver;
-
+    method run-script($script) {
         my @installations = $*REPO.repo-chain.grep(CompUnit::Repository::Installation);
-        my @metas = @installations.map({ .files("bin/$script", :$name, :$auth, :$ver).head }).grep(*.defined);
+        my @metas = @installations.map({ .files("bin/$script").head }).grep(*.defined);
         unless +@metas {
             @metas = flat @installations.map({ .files("bin/$script").Slip }).grep(*.defined);
             if +@metas {


### PR DESCRIPTION
A mostly unknown feature of the bin script shims CURI installs is that it allows choosing the distribution to load the script from, which allows loading an e.g. older version of some script. However to do so required using the :$name :$auth :$ver :$api arguments which prevents any installed raku bin script from taking any arguments of those names; the shim scripts breaks things such as providing a bin/foo --ver that outputs version information. This change removes those arguments until a better solution can be implemented.