### PR TITLE
Optimize internal directory recursion

### DIFF
--- a/src/core.c/Rakudo/Internals.pm6
+++ b/src/core.c/Rakudo/Internals.pm6
@@ -1386,12 +1386,12 @@ my class Rakudo::Internals {
               nqp::stmts(
                 (my str $path = nqp::concat($!abspath,$entry)),
                 nqp::if(
-                  (try nqp::stat($path,nqp::const::STAT_ISREG))
-                    && $!file.ACCEPTS($entry),
+                  $!file.ACCEPTS($entry) &&
+                    (try nqp::stat($path,nqp::const::STAT_ISREG)),
                   (return $path),
                   nqp::if(
-                    (try nqp::stat($path,nqp::const::STAT_ISDIR))
-                      && $!dir.ACCEPTS($entry),
+                    $!dir.ACCEPTS($entry) &&
+                      (try nqp::stat($path,nqp::const::STAT_ISDIR)),
                     nqp::stmts(
                       nqp::if(
                         (try nqp::fileislink($path)),

--- a/src/core.c/Rakudo/Internals.pm6
+++ b/src/core.c/Rakudo/Internals.pm6
@@ -1383,21 +1383,18 @@ my class Rakudo::Internals {
         method pull-one() {
             nqp::while(
               nqp::chars(my str $entry = self!next),
-              nqp::if(
-                nqp::stat(
-                  (my str $path = nqp::concat($!abspath,$entry)),
-                  nqp::const::STAT_EXISTS
-                ),
+              nqp::stmts(
+                (my str $path = nqp::concat($!abspath,$entry)),
                 nqp::if(
-                  nqp::stat($path,nqp::const::STAT_ISREG)
+                  (try nqp::stat($path,nqp::const::STAT_ISREG))
                     && $!file.ACCEPTS($entry),
                   (return $path),
                   nqp::if(
-                    nqp::stat($path,nqp::const::STAT_ISDIR)
+                    (try nqp::stat($path,nqp::const::STAT_ISDIR))
                       && $!dir.ACCEPTS($entry),
                     nqp::stmts(
                       nqp::if(
-                        nqp::fileislink($path),
+                        (try nqp::fileislink($path)),
                         $path = IO::Path.new(
                           $path,:CWD($!abspath)).resolve.absolute
                       ),

--- a/src/core.c/Rakudo/Internals.pm6
+++ b/src/core.c/Rakudo/Internals.pm6
@@ -1385,24 +1385,26 @@ my class Rakudo::Internals {
               nqp::chars(my str $entry = self!next),
               nqp::stmts(
                 (my str $path = nqp::concat($!abspath,$entry)),
-                nqp::if(
-                  $!file.ACCEPTS($entry) &&
-                    (try nqp::stat($path,nqp::const::STAT_ISREG)),
-                  (return $path),
+                (try
                   nqp::if(
-                    $!dir.ACCEPTS($entry) &&
-                      (try nqp::stat($path,nqp::const::STAT_ISDIR)),
-                    nqp::stmts(
-                      nqp::if(
-                        (try nqp::fileislink($path)),
-                        $path = IO::Path.new(
-                          $path,:CWD($!abspath)).resolve.absolute
-                      ),
-                      nqp::unless(
-                        nqp::existskey($!seen,$path),
-                        nqp::stmts(
-                          nqp::bindkey($!seen,$path,1),
-                          nqp::push_s($!todo,$path)
+                    $!file.ACCEPTS($entry) &&
+                      nqp::stat($path,nqp::const::STAT_ISREG),
+                    (return $path),
+                    nqp::if(
+                      $!dir.ACCEPTS($entry) &&
+                        nqp::stat($path,nqp::const::STAT_ISDIR),
+                      nqp::stmts(
+                        nqp::if(
+                          nqp::fileislink($path),
+                          $path = IO::Path.new(
+                            $path,:CWD($!abspath)).resolve.absolute
+                        ),
+                        nqp::unless(
+                          nqp::existskey($!seen,$path),
+                          nqp::stmts(
+                            nqp::bindkey($!seen,$path,1),
+                            nqp::push_s($!todo,$path)
+                          )
                         )
                       )
                     )


### PR DESCRIPTION
This aims to optimize `Rakudo::Internals.DIR-RECURSE` (and thus e.g. `-Ilib` start up time) by reducing the number of `nqp::stat` calls made when doing a recursive directory search for files.