### PR TITLE
Don't lookup $*(SPEC|CWD) for every file in dir...

### DIFF
--- a/src/core.c/CompUnit/Repository/FileSystem.pm6
+++ b/src/core.c/CompUnit/Repository/FileSystem.pm6
@@ -289,7 +289,9 @@ class CompUnit::Repository::FileSystem
     # but probably a poorly formed one.
     method !dist-from-ls {
         my $prefix := self!files-prefix;
-        my &ls := { Rakudo::Internals.DIR-RECURSE($_).map(*.IO) }
+        my $SPEC := $*SPEC;
+        my $CWD := $*CWD;
+        my &ls := { Rakudo::Internals.DIR-RECURSE($_).map({ IO::Path.new($_, :$SPEC, :$CWD) }) }
         my &to-relative := { $_.relative($prefix).subst(:g, '\\', '/') }
 
         # files is a non-spec internal field used by


### PR DESCRIPTION
when recursing through a directory given as a `-I` option. When applied on top of https://github.com/rakudo/rakudo/pull/5287, `time raku -I . -e 'use Test'` in a directory with ~113k subdirectories/files dropped from ~3.7s to ~3.5s.