### PR TITLE
Use nqp::handle instead of try

### DIFF
--- a/src/core.c/Rakudo/Internals.pm6
+++ b/src/core.c/Rakudo/Internals.pm6
@@ -1385,7 +1385,7 @@ my class Rakudo::Internals {
               nqp::chars(my str $entry = self!next),
               nqp::stmts(
                 (my str $path = nqp::concat($!abspath,$entry)),
-                (try
+                nqp::handle(
                   nqp::if(
                     $!file.ACCEPTS($entry) &&
                       nqp::stat($path,nqp::const::STAT_ISREG),
@@ -1408,7 +1408,8 @@ my class Rakudo::Internals {
                         )
                       )
                     )
-                  )
+                  ),
+                  'CATCH', 0
                 )
               )
             );


### PR DESCRIPTION
Previously we added 'try' to ignore errors from the various nqp stat calls. The rest of the code is written in nqp, so this changes that 'try' to use nqp::handle instead for a slight performance benefit.