### PR TITLE
Make Capture an object type

### DIFF
--- a/src/core.c/Capture.pm6
+++ b/src/core.c/Capture.pm6
@@ -15,33 +15,6 @@ my class Capture { # declared in BOOTSTRAP
         nqp::bindattr(self,Capture,'%!hash', $source-hash) if nqp::ishash($source-hash);
     }
 
-    multi method WHICH (Capture:D: --> ValueObjAt:D) {
-        my Mu $WHICH := nqp::list_s(nqp::eqaddr(self.WHAT,Capture) ?? 'Capture' !! nqp::unbox_s(self.^name));
-        if nqp::isconcrete(@!list) && nqp::elems(@!list) {
-            nqp::push_s($WHICH, '|');
-            my Mu $list := nqp::clone(@!list);
-            nqp::while(
-              nqp::elems($list),
-              nqp::stmts(
-                (my Mu \value = nqp::shift($list)),
-                nqp::push_s($WHICH, '('),
-                nqp::push_s($WHICH, nqp::unbox_s(value.VAR.WHICH)),
-                nqp::push_s($WHICH, ')')
-              )
-            );
-        }
-        if nqp::isconcrete(%!hash) && nqp::elems(%!hash) {
-            nqp::push_s($WHICH, '|');
-            for nqp::hllize(%!hash).keys.sort -> str \key {
-                nqp::push_s($WHICH, key);
-                nqp::push_s($WHICH, '(');
-                nqp::push_s($WHICH, nqp::unbox_s(nqp::atkey(%!hash,key).WHICH));
-                nqp::push_s($WHICH, ')');
-            }
-        }
-        nqp::box_s(nqp::join('',$WHICH),ValueObjAt)
-    }
-
     multi method AT-KEY(Capture:D: Str() $key) is raw {
         nqp::isconcrete(%!hash)
           ?? nqp::ifnull(nqp::atkey(%!hash,$key), Nil)


### PR DESCRIPTION
Rather than a value type, which it is **not** as it can have mutable elements.  See https://github.com/Raku/problem-solving/issues/372 for more information.

This causes:
- t/spec/S14-roles/attributes-6e.t
- t/spec/S14-roles/composition.t

to fail.  Both seem to be related to WALK incorrectly assuming equivalence at some level.