### PR TITLE
Don't need to use _I version of nqp::radix...

### DIFF
--- a/src/core.c/CompUnit/PrecompilationRepository.pm6
+++ b/src/core.c/CompUnit/PrecompilationRepository.pm6
@@ -482,7 +482,7 @@ Need to re-check dependencies.")
         my $seen := nqp::hash;
 
         for nqp::join('',$out).lines.unique -> str $outstr {
-            if nqp::atpos(nqp::radix_I(16,$outstr,0,0,Int),2) == 40
+            if nqp::atpos(nqp::radix(16,$outstr,0,0),2) == 40
               && nqp::eqat($outstr,"\0",40)
               && nqp::chars($outstr) > 41 {
                 my $dependency :=


### PR DESCRIPTION
just to check that the given string is composed of hex characters.