### PR TITLE
Add support for RAKUDO_NO_PRECOMPILATION environment variable

### DIFF
--- a/src/core.c/CompUnit/PrecompilationRepository.pm6
+++ b/src/core.c/CompUnit/PrecompilationRepository.pm6
@@ -9,8 +9,13 @@ role CompUnit::PrecompilationRepository {
 
     method load(CompUnit::PrecompilationId $id --> Nil) { }
 
-    method may-precomp(--> True) {
-        # would be a good place to check an environment variable
+    has Bool $!may-precomp;
+    method may-precomp(--> Bool:D) {
+      nqp::if(
+        nqp::defined($!may-precomp),
+        $!may-precomp,
+        ($!may-precomp := !nqp::hllbool(nqp::if(nqp::atkey(%*ENV,'RAKUDO_NO_PRECOMPILATION'), 1, 0)))
+      )
     }
 }
 


### PR DESCRIPTION
This adds a mechanism that allows users to disable precompilation via an environment variable. It prevents rakudo from using precompilation files as well as from generating them.