### PR TITLE
Respect CUPR.may-precomp() in CURI

### DIFF
--- a/src/core.c/CompUnit/Repository/Installation.pm6
+++ b/src/core.c/CompUnit/Repository/Installation.pm6
@@ -326,13 +326,14 @@ sub MAIN(:$name, :$auth, :$ver, *@, *%) {
         # identity changes with every installation of a dist.
         $!id = Any;
 
-        if $precompile {
+        my $precomp := self.precomp-repository;
+
+        if $precompile && $precomp.may-precomp() {
             my $head := $*REPO;
             CATCH { PROCESS::<$REPO> := $head }
             # Precomp files should only depend on downstream repos
             PROCESS::<$REPO> := self;
 
-            my $precomp = self.precomp-repository;
             my $repo-prefix = self!repo-prefix;
             my $*DISTRIBUTION = CompUnit::Repository::Distribution.new($dist, :repo(self), :$dist-id);
             my $*RESOURCES = Distribution::Resources.new(:repo(self), :$dist-id);


### PR DESCRIPTION
CompUnit::PrecompilationRepository.may-precomp() can be used to check if something should try to precompile using said repo. It is used in CUPR in its try-load method to determine if it should try to precompile a file when loading, which often happens with a CURFS type repository. However, CURI.install also tries to precompile files, but it does not check may-precomp() before doing so. This means there is no central place to enable or disable precompiling.

This updates CURI to only precompile modules during install if may-precomp() is True.