### PR TITLE
Fix potential concurrent hash access race condition

### DIFF
--- a/src/core.c/CompUnit/PrecompilationRepository.rakumod
+++ b/src/core.c/CompUnit/PrecompilationRepository.rakumod
@@ -39,6 +39,7 @@ class CompUnit::PrecompilationRepository::Default
     my $loaded        := nqp::hash;
     my $resolved      := nqp::hash;
     my $loaded-lock   := Lock.new;
+    my $resolved-lock := Lock.new;
     my $first-repo-id;
 
     my constant $compiler-id =
@@ -180,7 +181,7 @@ Need to re-check dependencies.")
 
             if $resolve {
                 my str $serialized-id = $dependency.serialize;
-                $loaded-lock.protect: {
+                $resolved-lock.protect: {
                     nqp::ifnull(
                       nqp::atkey($resolved,$serialized-id),
                       nqp::bindkey($resolved,$serialized-id, do {

--- a/src/core.c/CompUnit/PrecompilationRepository.rakumod
+++ b/src/core.c/CompUnit/PrecompilationRepository.rakumod
@@ -180,19 +180,20 @@ Need to re-check dependencies.")
 
             if $resolve {
                 my str $serialized-id = $dependency.serialize;
-                nqp::ifnull(
-                  nqp::atkey($resolved,$serialized-id),
-                  nqp::if(do {
-                        my $comp-unit := $REPO.resolve($dependency.spec);
-                        $!RMD("Old id: $dependency.id(), new id: {
-                            $comp-unit and $comp-unit.repo-id
-                        }")
-                          if $!RMD;
+                $loaded-lock.protect: {
+                    nqp::ifnull(
+                      nqp::atkey($resolved,$serialized-id),
+                      nqp::bindkey($resolved,$serialized-id, do {
+                            my $comp-unit := $REPO.resolve($dependency.spec);
+                            $!RMD("Old id: $dependency.id(), new id: {
+                                $comp-unit and $comp-unit.repo-id
+                            }") if $!RMD;
 
-                        $comp-unit and $comp-unit.repo-id eq $dependency.id
-                    },
-                    $loaded-lock.protect({ nqp::bindkey($resolved,$serialized-id, 1) }),
-                    (return False)));
+                            return False unless $comp-unit and $comp-unit.repo-id eq $dependency.id;
+                            True;
+                        })
+                    );
+                }
             }
 
             my $dependency-precomp := @precomp-stores


### PR DESCRIPTION
This fixes a potential race condition in `CompUnit::PrecompilationRepository` where two threads could race each other to read and write to a hash.