### PR TITLE
Make sub version of min/max/minmax on Ranges consistent

### DIFF
--- a/src/core.c/Range.pm6
+++ b/src/core.c/Range.pm6
@@ -856,4 +856,8 @@ multi sub infix:<cmp>(Range:D \a, Num(Real) $b) { a cmp ($b..$b) }
 multi sub infix:<cmp>(Positional \a, Range:D \b) { a cmp b.list }
 multi sub infix:<cmp>(Range:D \a, Positional \b) { a.list cmp b }
 
+multi sub max   (Range:D $range) { $range.max    }
+multi sub min   (Range:D $range) { $range.min    }
+multi sub minmax(Range:D $range) { $range.minmax }
+
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
with the method equivalent.  Since "min" and "max" are attributes on the Range object, they will *always* reflect the "left" and "right" values in the Range (even for Ranges such as (10..-10).

There were no sub versions of min/max/minmax for Ranges, so they followed Iterable logic.  Which would give different results from the method version.  And rather unexpected ones as well:

    say max 10..-10;  # -Inf, because (10..-10).list is an empty List
    say max ^3;       # 2, because (^3).list is (0,1,2)