### PR TITLE
RakuAST: allow → ↔ as unicode version of -> <->

### DIFF
--- a/src/Raku/Grammar.nqp
+++ b/src/Raku/Grammar.nqp
@@ -1402,7 +1402,7 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
 
     # TODO: report the correct bracket in error message
     token postfix:sym«->» {
-        <sym>
+        $<sym>=[ '->' | '→' ]
         [
         |  ['[' | '{' | '(' ] <.obs('->(), ->{} or ->[] as postfix dereferencer', '.(), .[] or .{} to deref, or whitespace to delimit a pointy block')>
         | <.obs('-> as postfix', 'either . to call a method, or whitespace to delimit a pointy block')>
@@ -3196,7 +3196,7 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
     token twigil:sym<=> { <sym> <?before \w> }
     token twigil:sym<~> { <sym> <?before \w> }
 
-    token lambda { '->' | '<->' }
+    token lambda { '->' | '→' | '<->' | '↔' }
 
     token end-keyword {
         » <!before <.[ \( \\ ' \- ]> || \h* '=>'>


### PR DESCRIPTION
As discussed on https://github.com/rakudo/rakudo/wiki/save-me-from-ASCII