### PR TITLE
Remove nqp-home/lib and rakudo-home/lib from vm search paths

### DIFF
--- a/src/vm/moar/ModuleLoaderVMConfig.nqp
+++ b/src/vm/moar/ModuleLoaderVMConfig.nqp
@@ -2,8 +2,6 @@ role Perl6::ModuleLoaderVMConfig {
     method vm_search_paths() {
         my @search_paths;
         @search_paths.push(nqp::gethllsym('default', 'SysConfig').rakudo-home() ~ '/lib');
-        # XXX CHEAT: Goes away when we implement :from<nqp>.
-        @search_paths.push(nqp::gethllsym('default', 'SysConfig').nqp-home() ~ '/lib');
         @search_paths
     }
 

--- a/src/vm/moar/ModuleLoaderVMConfig.nqp
+++ b/src/vm/moar/ModuleLoaderVMConfig.nqp
@@ -1,7 +1,6 @@
 role Perl6::ModuleLoaderVMConfig {
     method vm_search_paths() {
         my @search_paths;
-        @search_paths.push(nqp::gethllsym('default', 'SysConfig').rakudo-home() ~ '/lib');
         @search_paths
     }
 


### PR DESCRIPTION
`vm_search_path` used to provide some library paths for MoarVM that are now provided by other methods. This removes these redundant search paths for MoarVM similar to what we do for the JavaScript back end.