### PR TITLE
Remove deprecated --nqp-lib option

### DIFF
--- a/src/Perl6/Compiler.nqp
+++ b/src/Perl6/Compiler.nqp
@@ -220,10 +220,6 @@ class Perl6::Compiler is HLL::Compiler {
             %options<doc> := 'Text';
         }
 
-        if nqp::existskey(%options, 'nqp-lib') {
-            note('Option `--nqp-lib` is deprecated, has no effect and will be removed in 2021.06.');
-        }
-
         my $argiter := nqp::iterator(@args);
         nqp::shift($argiter) if $argiter && !nqp::defined(%options<e>);
         nqp::bindhllsym('Raku', '$!ARGITER', $argiter);

--- a/src/main.nqp
+++ b/src/main.nqp
@@ -39,7 +39,6 @@ my @clo := $comp.commandline_options();
 @clo.push('c');
 @clo.push('I=s');
 @clo.push('M=s');
-@clo.push('nqp-lib=s');
 @clo.push('rakudo-home=s');
 
 #?if js

--- a/src/rakudo-debug.nqp
+++ b/src/rakudo-debug.nqp
@@ -473,7 +473,6 @@ sub MAIN(*@ARGS) {
     @clo.push('c');
     @clo.push('I=s');
     @clo.push('M=s');
-    @clo.push('nqp-lib=s');
 
     # Set up module loading trace
     my @*MODULES := [];


### PR DESCRIPTION
The --nqp-lib option has had no effect for years, and it was supposed to be removed long ago. This removes any remaining --nqp-lib option related code.