### PR TITLE
Remove deprecated Proc.status

### DIFF
--- a/src/core.c/Proc.pm6
+++ b/src/core.c/Proc.pm6
@@ -201,22 +201,6 @@ my class Proc {
         ($!exitcode +< 8) +| $!signal
     }
 
-    # see https://github.com/rakudo/rakudo/issues/1366
-    # should be deprecated and removed
-    proto method status(|) {*}
-    multi method status($new_status)
-      is DEPRECATED('exitcode and/or signal methods (status is to be removed in 2022.06)')
-    {
-        $!exitcode = $new_status +> 8;
-        $!signal   = $new_status +& 0xFF;
-    }
-    multi method status(Proc:D:)
-      is DEPRECATED('exitcode and/or signal methods (status is to be removed in 2022.06)')
-    {
-        self!wait-for-finish;
-        ($!exitcode +< 8) +| $!signal
-    }
-
     multi method Numeric(Proc:D:) {
         self!wait-for-finish;
         $!exitcode

--- a/t/04-nativecall/CompileTestLib.rakumod
+++ b/t/04-nativecall/CompileTestLib.rakumod
@@ -47,8 +47,8 @@ sub compile_cpp_test_lib($name) is export {
     my (@fails, $succeeded);
     for @cmds -> $cmd {
         my $proc = shell("$cmd 2>&1", :out);
-        my $output = $proc.out.slurp-rest;
-        if $proc.out.close.status {
+        my $output = $proc.out.slurp(:close);
+        if $proc.status {
             @fails.push: "Running '$cmd':\n$output"
         }
         else {

--- a/t/04-nativecall/CompileTestLib.rakumod
+++ b/t/04-nativecall/CompileTestLib.rakumod
@@ -46,9 +46,9 @@ sub compile_cpp_test_lib($name) is export {
 
     my (@fails, $succeeded);
     for @cmds -> $cmd {
-        my $handle = shell("$cmd 2>&1", :out);
-        my $output = $handle.out.slurp-rest;
-        if $handle.out.close.status {
+        my $proc = shell("$cmd 2>&1", :out);
+        my $output = $proc.out.slurp-rest;
+        if $proc.out.close.status {
             @fails.push: "Running '$cmd':\n$output"
         }
         else {

--- a/t/04-nativecall/CompileTestLib.rakumod
+++ b/t/04-nativecall/CompileTestLib.rakumod
@@ -48,12 +48,12 @@ sub compile_cpp_test_lib($name) is export {
     for @cmds -> $cmd {
         my $proc = shell("$cmd 2>&1", :out);
         my $output = $proc.out.slurp(:close);
-        if $proc.status {
-            @fails.push: "Running '$cmd':\n$output"
-        }
-        else {
+        if so $proc {
             $succeeded = 1;
             last
+        }
+        else {
+            @fails.push: "Running '$cmd':\n$output"
         }
     }
     fail @fails.join('=' x 80 ~ "\n") unless $succeeded;


### PR DESCRIPTION
Proc.status wasn't intended to be part of the public api and was deprecated (see #1366). Per the existing deprecation message, this method should have been deleted a year ago. This change follows through on the deprecation message and deletes Proc.status.