### PR TITLE
Remove unused transcode compiler option

### DIFF
--- a/src/main.nqp
+++ b/src/main.nqp
@@ -78,7 +78,7 @@ sub MAIN(*@ARGS) {
         }
     }
     my $*STACK-ID := 0;
-    $comp.command_line(@ARGS, :encoding('utf8'), :transcode('ascii iso-8859-1'), |%defaults);
+    $comp.command_line(@ARGS, :encoding('utf8'), |%defaults);
 
     # do all the necessary actions at the end, if any
     if nqp::gethllsym('Raku', '&THE_END') -> $THE_END {

--- a/src/rakudo-debug.nqp
+++ b/src/rakudo-debug.nqp
@@ -506,7 +506,7 @@ sub MAIN(*@ARGS) {
     my $*DEBUG_HOOKS := Perl6::DebugHooks.new();
 
     # Enter the compiler.
-    $comp.command_line(@ARGS, :encoding('utf8'), :transcode('ascii iso-8859-1'));
+    $comp.command_line(@ARGS, :encoding('utf8'));
 
     # Run any END blocks before exiting.
     for nqp::gethllsym('Raku', '@END_PHASERS') {


### PR DESCRIPTION
This appears to have only been used by Parrot. Every other backend has their apply_transcodings function in nqp return the original input without any modifications. This change stops passing the transcoding option.