### PR TITLE
Increase max heap space to 6G for building jvm rakudo

### DIFF
--- a/tools/templates/jvm/Makefile.in
+++ b/tools/templates/jvm/Makefile.in
@@ -6,7 +6,7 @@ NQP_PREFIX  = @nqp_prefix@
 @bpv(NQP)@       = @shquot(@j_nqp@)@
 @bpv(NQP_BIN)@       = @nfp(@j_nqp@)@
 # TODO Try to reduce memory usage, https://github.com/rakudo/rakudo/issues/5186
-@bpv(NQP_RR)@    = $(JAVA) -Xmx4G -cp @q(@nfp(./blib)@@cpsep@@nop($(BLD_NQP_JARS))@@cpsep@rakudo-runtime.jar@cpsep@@nop($(SYSROOT))@@abs2rel(@nqp_classpath@)@)@ nqp
+@bpv(NQP_RR)@    = $(JAVA) -Xmx6G -cp @q(@nfp(./blib)@@cpsep@@nop($(BLD_NQP_JARS))@@cpsep@rakudo-runtime.jar@cpsep@@nop($(SYSROOT))@@abs2rel(@nqp_classpath@)@)@ nqp
 @bpv(RUN_RAKUDO_SCRIPT)@ = rakudo-j-build
 @bpv(RUN_RAKUDO)@ = @shquot(@perl@)@ @bpm(RUN_RAKUDO_SCRIPT)@
 


### PR DESCRIPTION
This allows building rakudo on the jvm to compile the setting once again.