### PR TITLE
Don't mangle with exception backtrace

### DIFF
--- a/src/core.c/CompUnit/Loader.pm6
+++ b/src/core.c/CompUnit/Loader.pm6
@@ -14,7 +14,7 @@ class CompUnit::Loader is repr('Uninstantiable') {
         CATCH {  # use CATCH instead of LEAVE: makes the normal flow faster
             default {
                 nqp::bindhllsym('Raku','GLOBAL',$original-GLOBAL);
-                .throw;
+                .rethrow;
             }
         }
 

--- a/src/core.c/CompUnit/PrecompilationRepository.pm6
+++ b/src/core.c/CompUnit/PrecompilationRepository.pm6
@@ -81,7 +81,7 @@ class CompUnit::PrecompilationRepository::Default
         CATCH {
             default {
                 nqp::bindhllsym('Raku', 'GLOBAL', $preserve_global);
-                .throw;
+                .rethrow;
             }
         }
         $!RMD("Loading precompiled\n$unit")


### PR DESCRIPTION
`.throw` was previously used causing re-written backtrace. Since both fixed locations are not actually producing exceptions but using `CATCH` to do a last-second fix for the `GLOBAL` HLL symbol, trace-preserving `.rethrow` makes better sense.