### PR TITLE
special cases should not be suggested like real methods

### DIFF
--- a/src/core.c/Exception.pm6
+++ b/src/core.c/Exception.pm6
@@ -283,7 +283,7 @@ my class X::Method::NotFound is Exception {
             }
 
             # handle special unintrospectable cases
-            for <HOW WHAT WHO> -> $method_name {
+            for <HOW WHAT WHO>.grep(* ne $.method) -> $method_name {
                 find_public_suggestion($.method, $method_name);
             }
         }


### PR DESCRIPTION
Currently, ` class X::Method::NotFound` may suggest introspection macros as if they where real methods and by doing so, suggest the very method that is missing.

```
    say Any."WHAT"();
```

## OUTPUT
```
No such method 'WHAT' for invocant of type 'Any'.  Did you mean any of
these: 'WHAT', 'WHO', 'WHY', 'flat'?
```

As discussed [here](https://irclogs.raku.org/raku/2023-07-22.html#16:44), this is wrong.

## Test
```
use v6.*;
use Test;

my $a = 42;
my @test;

for <HOW WHAT WHO> -> $m {
    try { say $a."$m"(); CATCH { default { @test.push: $m => .message.match(/(<$m>)/).list.elems } } }
}

ok @test».value.all == 1, ‘introspection macros wont be suggested like real methods’;
```