### PR TITLE
Fix use of CALLERS/CALLER pseudo stashes

### DIFF
--- a/lib/Test.rakumod
+++ b/lib/Test.rakumod
@@ -261,9 +261,9 @@ multi sub cmp-ok(Mu $got is raw, $op, Mu $expected is raw, $desc = '') is export
     #  #3 handles all the rest by escaping '<' and '>' with backslashes.
     #     Note: #3 doesn't eliminate #1, as #3 fails with '<' operator
     my $matcher = nqp::istype($op, Callable) ?? $op
-        !! &CALLERS::("infix:<$op>") #1
-            // &CALLERS::("infix:«$op»") #2
-            // &CALLERS::("infix:<$op.subst(/<?before <[<>]>>/, "\\", :g)>"); #3
+        !! &CALLER::LEXICAL::("infix:<$op>") #1
+            // &CALLER::LEXICAL::("infix:«$op»") #2
+            // &CALLER::LEXICAL::("infix:<$op.subst(/<?before <[<>]>>/, "\\", :g)>"); #3
 
     if $matcher {
         $ok = proclaim($matcher($got,$expected), $desc);

--- a/src/core.c/Cool.pm6
+++ b/src/core.c/Cool.pm6
@@ -412,7 +412,7 @@ my class Cool { # declared in BOOTSTRAP
     multi method trim-trailing(Cool:D:) { self.Str.trim-trailing }
 
     method EVAL(*%opts) {
-        EVAL(self, context => CALLER::, |%opts);
+        EVAL(self, context => CALLER::LEXICAL::, |%opts);
     }
 
     method Failure(Cool:D:) is hidden-from-backtrace { Failure.new(self) }

--- a/src/core.c/ForeignCode.pm6
+++ b/src/core.c/ForeignCode.pm6
@@ -54,7 +54,7 @@ $lang = 'Raku' if $lang eq 'perl6';
 
     my $*CTXSAVE; # make sure we don't use the EVAL's MAIN context for the
                     # currently compiling compilation unit
-    my $context := nqp::defined($ctx) ?? $ctx !! CALLER::;
+    my $context := nqp::defined($ctx) ?? $ctx !! CALLER::LEXICAL::;
     my $compiled;
     my $eval_ctx := nqp::getattr(nqp::decont($context), PseudoStash, '$!ctx');
 
@@ -145,7 +145,7 @@ multi sub EVAL(
 
 proto sub EVALFILE($, *%) {*}
 multi sub EVALFILE($filename, :$lang = 'Raku', :$check) {
-    EVAL slurp(:bin, $filename), :$lang, :$check, :context(CALLER::), :$filename
+    EVAL slurp(:bin, $filename), :$lang, :$check, :context(CALLER::LEXICAL::), :$filename
 }
 
 # vim: expandtab shiftwidth=4

--- a/src/core.c/ForeignCode.pm6
+++ b/src/core.c/ForeignCode.pm6
@@ -100,9 +100,7 @@ $lang = 'Raku' if $lang eq 'perl6';
 
         my $?FILES   := $filename // 'EVAL_' ~ Rakudo::Internals::EvalIdSource.next-id;
 
-        my $LANG := $context<%?LANG>:exists
-                        ?? $context<%?LANG>
-                        !! (CALLERS::<%?LANG>:exists ?? CALLERS::<%?LANG> !! Nil);
+        my $LANG := $context<%?LANG>:exists ?? $context<%?LANG> !! Nil;
         my $*INSIDE-EVAL := 1;
         $compiled := $compiler.compile:
             $code,


### PR DESCRIPTION
There is seemingly a confusion about meaning of `CALLERS` and `CALLER` namespaces. They both are currently bound to dynamic symbols only. Where they used `CALLER::LEXICAL` is more likely to do the job.