### PR TITLE
RakuAST: Get 'once' statement prefix fully working

### DIFF
--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -160,7 +160,7 @@ class RakuAST::Code
         # fixed up as needed.
         $block.code_object($code-obj);
 
-        my @compstuff := nqp::getattr($code-obj, Code, '@!compstuff');
+        my @compstuff := nqp::getattr($code-obj, Code, '@!compstuff') || [];
         my $cuid := $!cuid;
         $block.set-cuid($!cuid);
 

--- a/src/Raku/ast/statementprefixes.rakumod
+++ b/src/Raku/ast/statementprefixes.rakumod
@@ -348,19 +348,30 @@ class RakuAST::StatementPrefix::Blorst
 # The `once` statement prefix.
 class RakuAST::StatementPrefix::Once
   is RakuAST::StatementPrefix::Blorst
+  is RakuAST::BeginTime
 {
+    has str $!state-name;
+
     method type() { "once" }
 
+    method PERFORM-BEGIN(Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
+        my $state-name := QAST::Node.unique('once_');
+        nqp::bindattr_s(self, RakuAST::StatementPrefix::Once, '$!local-name', $state-name);
+        $resolver.current-scope.add-generated-lexical-declaration:
+            RakuAST::VarDeclaration::Simple.new:    :desigilname(RakuAST::Name.from-identifier: $state-name),
+                                                    :scope('state'),
+                                                    :sigil('');
+    }
+
     method IMPL-EXPR-QAST(RakuAST::IMPL::QASTContext $context) {
-        my $sym := QAST::Node.unique('once_');
         QAST::Op.new(:op<decont>,
           QAST::Op.new(:op<if>,
             QAST::Op.new(:op<p6stateinit>),
             QAST::Op.new(:op<p6store>,
-              QAST::Var.new(:name($sym), :scope<lexical>),
+              QAST::Var.new(:name($!state-name), :scope<lexical>),
               QAST::Op.new(:op<call>, self.IMPL-CLOSURE-QAST($context))
             ),
-            QAST::Var.new(:name($sym), :scope<lexical>)
+            QAST::Var.new(:name($!state-name), :scope<lexical>)
           )
         )
     }


### PR DESCRIPTION
This fixes #5341 .

Unfortunately no new spectests pass.