### PR TITLE
Fix of * .. non-number Range scenarios

### DIFF
--- a/src/core.c/Range.rakumod
+++ b/src/core.c/Range.rakumod
@@ -58,13 +58,11 @@ my class Range is Cool does Iterable does Positional {
     }
     multi method new(Whatever \min, \max, :$excludes-min, :$excludes-max) {
         use fatal;
-        my \max-real = max.Real;
-        nqp::create(self)!SET-SELF(-Inf,max-real,$excludes-min,$excludes-max,1);
+        nqp::create(self)!SET-SELF(-Inf,max.Real,$excludes-min,$excludes-max,1);
     }
     multi method new(\min, Whatever \max, :$excludes-min, :$excludes-max) {
         use fatal;
-        my \min-real = min.Real;
-        nqp::create(self)!SET-SELF(min-real,Inf,$excludes-min,$excludes-max,1);
+        nqp::create(self)!SET-SELF(min.Real,Inf,$excludes-min,$excludes-max,1);
     }
     multi method new(Real \min, Real(Cool) $max, :$excludes-min, :$excludes-max) {
         nqp::create(self)!SET-SELF(

--- a/src/core.c/Range.rakumod
+++ b/src/core.c/Range.rakumod
@@ -57,10 +57,14 @@ my class Range is Cool does Iterable does Positional {
         nqp::create(self)!SET-SELF(-Inf,Inf,$excludes-min,$excludes-max,1);
     }
     multi method new(Whatever \min, \max, :$excludes-min, :$excludes-max) {
-        nqp::create(self)!SET-SELF(-Inf,max,$excludes-min,$excludes-max,1);
+        use fatal;
+        my \max-real = max.Real;
+        nqp::create(self)!SET-SELF(-Inf,max-real,$excludes-min,$excludes-max,1);
     }
     multi method new(\min, Whatever \max, :$excludes-min, :$excludes-max) {
-        nqp::create(self)!SET-SELF(min,Inf,$excludes-min,$excludes-max,1);
+        use fatal;
+        my \min-real = min.Real;
+        nqp::create(self)!SET-SELF(min-real,Inf,$excludes-min,$excludes-max,1);
     }
     multi method new(Real \min, Real(Cool) $max, :$excludes-min, :$excludes-max) {
         nqp::create(self)!SET-SELF(


### PR DESCRIPTION
Resolves #5340 
The whatever-star is always inferred to mean +/- Inf in Range
constructions, therefore it makes sense to infer the same rules for it as for Inf itself. Since modifying the type constraint changed the order of the resolution of 10 .. ^20 (might be a bug in itself), I rather made a coercion to Real in the function body.