### PR TITLE
[JVM] Add extra check for GLOBAL being null

### DIFF
--- a/src/core.c/stubs.rakumod
+++ b/src/core.c/stubs.rakumod
@@ -49,12 +49,13 @@ sub DYNAMIC(str $name, @deprecation?) is raw {  # is implementation-detail
           value,
           nqp::stmts(
             (my str $pkgname = nqp::replace($name,1,1,'')),
-            nqp::ifnull(
-              nqp::atkey(GLOBAL.WHO,$pkgname),
+            nqp::if(
+              nqp::isnull(GLOBAL) || nqp::isnull(my \res := nqp::atkey(GLOBAL.WHO,$pkgname)),
               nqp::ifnull(
                 nqp::atkey(PROCESS.WHO,$pkgname),
                 Rakudo::Internals.INITIALIZE-DYNAMIC($name, @deprecation)
-              )
+              ),
+              res
             )
           )
         )


### PR DESCRIPTION
This fixes a NullPointerException on the JVM backend for code like

  use v6.c.UNKNOWN

That code does not blow up on MoarVM. But still, it looks plausible to check for null before calling a method and relying on the backend to handle that gracefully.