### PR TITLE
RakuAST: implement `for { } otherwise { }`

### DIFF
--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -637,13 +637,21 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
         );
     }
 
+    # Handling of for / otherwise
+    method statement-control:sym<for>($/) {
+        self.attach: $/, Nodify('Statement','For').new(
+          source    => $<EXPR>.ast,
+          body      => $<pointy-block>.ast,
+          otherwise => $<otherwise> ?? $<otherwise>.ast !! Mu
+        );
+    }
+
     # Handling of simple control statements that take a block
     method statement-control:sym<default>($/) { self.takes-none($/,'Default') }
     method statement-control:sym<CATCH>($/)   { self.takes-none($/,'Catch')   }
     method statement-control:sym<CONTROL>($/) { self.takes-none($/,'Control') }
 
     # Handling of simple control statements that take a pointy block
-    method statement-control:sym<for>($/)   { self.takes-source($/,'For')   }
     method statement-control:sym<given>($/) { self.takes-source($/,'Given') }
     method statement-control:sym<unless>($/)  { self.takes-cond($/,'Unless')  }
     method statement-control:sym<when>($/)    { self.takes-cond($/,'When')    }

--- a/src/Raku/Grammar.nqp
+++ b/src/Raku/Grammar.nqp
@@ -1340,6 +1340,7 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
         :my $*BORG := {};
         <EXPR>
         <pointy-block>
+        [ otherwise $<otherwise>=<.pointy-block> ]?
     }
 
     # Handle repeat ... while | until


### PR DESCRIPTION
I was looking at what would need to be done to port the [`Slang::Otherwise`](https://raku.land/zef:elcaro/Slang::Otherwise) module to work with RakuAST, and realized it was probably less work to just implement the functionality in the Raku grammar.

This does:
- Implement a :otherwise argument to RakuAST::Statement::For
- Adapts the QAST generation accordingly if an otherwise was found
- Adds preliminary grammar support for "otherwise"

This does NOT adapt .raku or .DEPARSE yet.

It also doesn't answer the question on whether "otherwise" should be a 6.e feature, or should also be available in 6.c and 6.d.  It feels that it should also be available in 6.c and 6.d so that users of the Slang::Otherwise module can just remove it, and/or have the Slang::Otherwise module not do anything if it spots that it is being called with the Raku grammar.