### PR TITLE
RakuAST: Several `*` tidbits

### DIFF
--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -814,6 +814,8 @@ class RakuAST::MetaInfix
              )
           !! True
     }
+
+    method IMPL-CURRIES { self.infix.IMPL-CURRIES }
 }
 
 # An assign meta-operator, operator on another infix.

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -1612,15 +1612,16 @@ class RakuAST::ApplyPrefix
     method PERFORM-BEGIN(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
         if nqp::bitand_i($!prefix.IMPL-CURRIES, 1) {
             if nqp::istype($!operand, RakuAST::Term::Whatever) {
-                nqp::bindattr(self, RakuAST::ApplyPrefix, '$!operand', RakuAST::Var::Lexical.new('$_'));
-                self.IMPL-CURRY($resolver, $context, '$_');
-                $!operand.resolve-with($resolver);
+                my $param := self.IMPL-CURRY(
+                    $resolver, $context, QAST::Node.unique('$whatevercode_arg')
+                ).IMPL-LAST-PARAM;
+                nqp::bindattr(self, RakuAST::ApplyPrefix, '$!operand', $param.target.generate-lookup);
             }
         }
         if nqp::bitand_i($!prefix.IMPL-CURRIES, 2) {
             if $!operand.IMPL-CURRIED {
                 my @params := $!operand.IMPL-UNCURRY;
-                my $curried := self.IMPL-CURRY($resolver, $context, @params.shift.target.lexical-name);
+                my $curried := self.IMPL-CURRY($resolver, $context, '');
                 for @params {
                     $curried.IMPL-ADD-PARAM($_.target.lexical-name);
                     $curried.IMPL-CHECK($resolver, $context, True);

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -1216,8 +1216,7 @@ class RakuAST::ApplyInfix
                 for "left", "right" {
                     my $operand := $child."$_"();
                     next unless nqp::istype($operand, RakuAST::Term::Whatever);
-                    my $param-name := QAST::Node.unique('$whatevercode_arg');
-                    my $param := $curried.IMPL-ADD-PARAM($param-name);
+                    my $param := $curried.IMPL-ADD-PARAM(QAST::Node.unique('$whatevercode_arg'));
                     $curried.IMPL-CHECK($resolver, $context, True);
                     $child."set-$_"($param.target.generate-lookup);
                 }
@@ -2082,8 +2081,9 @@ class RakuAST::ApplyPostfix
             if nqp::istype($!operand, RakuAST::Term::Whatever)
                 || (nqp::istype($!postfix, RakuAST::ApplyPostfix) && nqp::istype($!postfix.operand, RakuAST::Term::Whatever))
             {
-                my $whatever-name := QAST::Node.unique('$whatevercode_arg');
-                my $param := self.IMPL-CURRY($resolver, $context, $whatever-name).IMPL-LAST-PARAM;
+                my $param := self.IMPL-CURRY(
+                    $resolver, $context, QAST::Node.unique('$whatevercode_arg')
+                ).IMPL-LAST-PARAM;
                 nqp::bindattr(self, RakuAST::ApplyPostfix, '$!operand', $param.target.generate-lookup);
             }
         }

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -1234,11 +1234,7 @@ class RakuAST::ApplyInfix
         if nqp::bitand_i($CURRIES, 2) && (my $curried := $left.IMPL-CURRIED) {
             my $params := $left.IMPL-UNCURRY;
             if self.IMPL-CURRIED {
-                if nqp::istype($left, RakuAST::ApplyInfix) && $left.infix.properties.precedence gt $infix-precedence {
-                    for self.IMPL-UNCURRY { $params.unshift($_) }
-                } else {
-                    for self.IMPL-UNCURRY { $params.push($_) }
-                }
+                for self.IMPL-UNCURRY { $params.push($_) }
             }
             self.IMPL-CURRY($resolver, $context, '') unless self.IMPL-CURRIED;
             $curried := self.IMPL-CURRIED;

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -1166,12 +1166,7 @@ class RakuAST::ApplyInfix
             #       - * f * f *
             # This check accounts for the former case. The latter case is already covered because the toplevel
             # ApplyInfix is directly whateverable.
-            return True if nqp::istype($_, RakuAST::Circumfix::Parentheses)
-                        && (my $statement-expression := $_.semilist.statements.AT-POS(0))
-                        && nqp::istype($statement-expression, RakuAST::Statement::Expression)
-                        && (my $expression := $statement-expression.expression)
-                        && nqp::istype($expression, RakuAST::ApplyInfix)
-                        && (nqp::istype($expression.left, RakuAST::Term::Whatever) || nqp::istype($expression.right, RakuAST::Term::Whatever))
+            return True if nqp::istype($_, RakuAST::Circumfix::Parentheses) && $_.IMPL-CONTAINS-CURRYABLE-APPLY-INFIX()
         }
         False
     }
@@ -1630,11 +1625,7 @@ class RakuAST::ApplyPrefix
                 }
             }
             elsif nqp::istype($operand, RakuAST::Circumfix::Parentheses)
-                    && (my $statement-expression := $operand.semilist.statements.AT-POS(0))
-                    && nqp::istype($statement-expression, RakuAST::Statement::Expression)
-                    && (my $expression := $statement-expression.expression)
-                    && nqp::istype($expression, RakuAST::ApplyInfix)
-                    && $expression.IMPL-CURRIED
+                && (my $expression := $operand.IMPL-CURRIED-APPLY-INFIX)
             {
                 my @params := $expression.IMPL-UNCURRY;
                 my $curried := self.IMPL-CURRY($resolver, $context, '');


### PR DESCRIPTION
This PR doesn't move the needle on spectests but it does clean things up and adresses a failing test in `t/spec/S02-types/whatever.t`.