### PR TITLE
Produce fewer of LTA messages, especially when coercing

### DIFF
--- a/src/Perl6/Metamodel/ParametricRoleHOW.nqp
+++ b/src/Perl6/Metamodel/ParametricRoleHOW.nqp
@@ -173,8 +173,14 @@ class Perl6::Metamodel::ParametricRoleHOW
                     }
                 }
                 if $error {
-                    nqp::die("Could not instantiate role '" ~ self.name($obj)
-                             ~ "':\n" ~ (nqp::getpayload($error) || nqp::getmessage($error)))
+                    my $exception := nqp::getpayload($error);
+                    Perl6::Metamodel::Configuration.throw_or_die(
+                        'X::Role::Instantiation',
+                        "Could not instantiate role '" ~ self.name($obj)
+                            ~ "':\n" ~ ($exception || nqp::getmessage($error)),
+                        :role($obj),
+                        :$exception
+                    )
                 }
 
                 # Use it to build a concrete role.

--- a/src/core.c/Exception.rakumod
+++ b/src/core.c/Exception.rakumod
@@ -1018,6 +1018,16 @@ my class X::Coerce::Impossible is X::Coerce {
     }
 }
 
+my class X::Coerce::Role is X::Coerce does X::Wrapper {
+    method message() {
+        "Coercion " ~ callsame()
+            ~ " died"
+            ~ self!exception-name-message
+            ~ " while trying to pun the target role"
+            ~ self!wrappee-message(:details)
+    }
+}
+
 # XXX a hack for getting line numbers from exceptions from the metamodel
 my class X::Comp::AdHoc is X::AdHoc does X::Comp {
     method is-compile-time(--> True) { }

--- a/src/core.c/Exception.rakumod
+++ b/src/core.c/Exception.rakumod
@@ -1822,8 +1822,16 @@ my class X::Syntax::Argument::MOPMacro does X::Syntax {
     method message() { "Cannot give arguments to $.macro" };
 }
 
-my class X::Role::Initialization is Exception {
+my class X::Role::Instantiation is Exception does X::Wrapper {
     has $.role;
+    method message() {
+        "Could not instantiate role '" ~ $!role.^name ~ "'"
+            ~ (self!is-raku-exception ?? " because it is died" ~ self!exception-name-message !! "")
+            ~ self!wrappee-message(:details)
+    }
+}
+
+my class X::Role::Initialization is Exception {
     method message() { "Can only supply an initialization value for a role if it has a single public attribute, but this is not the case for '{$.role.^name}'" }
 }
 

--- a/src/core.c/Exception.rakumod
+++ b/src/core.c/Exception.rakumod
@@ -100,6 +100,38 @@ my class Exception {
     }
 }
 
+my role X::Wrapper {
+    has Mu $!exception is required is built(:bind);
+    has Mu $!ex-payload;
+    has $!is-raku-exception;
+
+    method exception is raw {
+        my $ex := nqp::decont($!exception);
+        nqp::isconcrete(nqp::decont($!ex-payload))
+            ?? $!ex-payload
+            !! ($!ex-payload := nqp::istype($ex, Exception) ?? $ex !! (nqp::ifnull(nqp::getpayload($ex), $ex)))
+    }
+
+    method !is-raku-exception {
+        $!is-raku-exception //= nqp::istype(self.exception, Exception)
+    }
+
+    method !wrappee-message(:$concise, :$details) {
+        my $ex-msg := self!is-raku-exception ?? $!ex-payload.message !! nqp::getmessage($!ex-payload);
+        my $message :=
+            $concise
+                ?? $ex-msg
+                !! ($!is-raku-exception
+                    ?? $!ex-payload.gist
+                    !! $ex-msg ~ "\n" ~ Backtrace.new(nqp::backtrace($!exception)));
+        $details ?? "; exception details:\n\n" ~ $message.indent(4) !! $message
+    }
+
+    method !exception-name-message {
+        self!is-raku-exception ?? " with " ~ $!ex-payload.^name !! ""
+    }
+}
+
 my class X::SecurityPolicy is Exception {}
 
 my class X::SecurityPolicy::Eval is X::SecurityPolicy {


### PR DESCRIPTION
This is a follow up to [this IRC discussion](https://irclogs.raku.org/raku/2023-09-25.html#18:06-0001). With this PR the following snippet

```raku
role R {
    my Int $v = "aa";
}
my R() $v = 1;
```

would now produce an output like this:

```
Coercion from 'Int' into 'R' died with X::Role::Instantiation while trying to pun the target role; exception details:

    Could not instantiate role 'R' because it is died with X::TypeCheck::Assignment; exception details:

        Type check failed in assignment to $v; expected Int but got Str ("aa")
          in sub  at bad-coercion.raku line 11


  in any  at /Users/vrurg/src/Raku/rakudo/install/share/perl6/lib/Perl6/BOOTSTRAP/v6c.moarvm line 1
```

The output demonstrates two improvements at once: more detailed report of failed role instatiation and the actual message from coercion failing on a problematic role.