### PR TITLE
 RakuAST: Migrate to WhateverApplicable

### DIFF
--- a/src/Raku/ast/circumfix.rakumod
+++ b/src/Raku/ast/circumfix.rakumod
@@ -15,6 +15,32 @@ class RakuAST::Circumfix::Parentheses
         $obj
     }
 
+    # Generally needs to be called before children are visited, which is when the Apply*
+    # expressions implement their currying. After that happens, any RakuAST::Term::Whatever
+    # operands will have been converted to RakuAST::Var::Lexical. At that stage, the below
+    # IMPL-SINGLE-CURRIED-EXPRESSION is the appropriate check.
+    method IMPL-CONTAINS-SINGULAR-CURRYABLE-EXPRESSION() {
+        nqp::elems($!semilist.IMPL-UNWRAP-LIST($!semilist.statements)) == 1
+            && (my $statement-expression := $!semilist.statements.AT-POS(0))
+            && nqp::istype($statement-expression, RakuAST::Statement::Expression)
+            && (my $expression := $statement-expression.expression)
+            && nqp::istype($expression, RakuAST::WhateverApplicable)
+            && $expression.IMPL-SHOULD-CURRY-DIRECTLY
+                ?? $expression
+                !! Nil
+    }
+
+    method IMPL-SINGULAR-CURRIED-EXPRESSION() {
+        nqp::elems($!semilist.IMPL-UNWRAP-LIST($!semilist.statements)) == 1
+            && (my $statement-expression := $!semilist.statements.AT-POS(0))
+            && nqp::istype($statement-expression, RakuAST::Statement::Expression)
+            && (my $expression := $statement-expression.expression)
+            && nqp::istype($expression, RakuAST::WhateverApplicable)
+            && $expression.IMPL-CURRIED
+                ?? $expression
+                !! Nil
+    }
+
     method IMPL-EXPR-QAST(RakuAST::IMPL::QASTContext $context) {
         $!semilist.IMPL-TO-QAST($context)
     }

--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -2664,9 +2664,9 @@ class RakuAST::CurryThunk
         ])
     }
 
-    method IMPL-ADD-PARAM(str $param_name) {
+    method IMPL-ADD-PARAM(str $param-name) {
         my $param := RakuAST::Parameter.new(
-            target => RakuAST::ParameterTarget::Var.new($param_name)
+            target => RakuAST::ParameterTarget::Var.new($param-name)
         );
         nqp::push($!parameters, $param);
         self.IMPL-UPDATE-SIGNATURE;


### PR DESCRIPTION
(tl;dr -- +4 spectests!)

This allows a top-down approach to searching for other
`WhateverApplicable` nodes, building up a list of applicable child
nodes to curry across. This simplifies the actual implementation
of the "currying question" inside of the `Apply*` code significantly
while also covering the creation of deeply nested (or otherwise weird)
`WhateverCode` objects.

This isn't to imply that this implementation is "simple"... anything
as complex as the `*` in Raku is going to be a bit of a mind warp to
comprehend, let alone implement.

