### PR TITLE
RakuAST: Finalize `WhateverCode` offering 

### DIFF
--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -2643,10 +2643,9 @@ class RakuAST::CurryThunk
 {
     has Mu $!parameters;
 
-    method new(str $param) {
+    method new() {
         my $obj := nqp::create(self);
         nqp::bindattr($obj, RakuAST::CurryThunk,, '$!parameters', []);
-        $obj.IMPL-ADD-PARAM($param) if $param ne '';
         $obj
     }
 
@@ -2664,12 +2663,14 @@ class RakuAST::CurryThunk
         ])
     }
 
-    method IMPL-ADD-PARAM(str $param-name) {
+    method IMPL-ADD-PARAM(Resolver $resolver, RakuAST::IMPL::QASTContext $context, str :$name) {
         my $param := RakuAST::Parameter.new(
-            target => RakuAST::ParameterTarget::Var.new($param-name)
+            # $name will usually be undefined, but sometimes we re-use references to existing * targets
+            target => RakuAST::ParameterTarget::Whatever.new($name)
         );
         nqp::push($!parameters, $param);
         self.IMPL-UPDATE-SIGNATURE;
+        self.IMPL-CHECK($resolver, $context, True);
         $param
     }
 

--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -346,6 +346,10 @@ class RakuAST::ExpressionThunk
         self.HOW.name(self)
     }
 
+    method thunk-details() {
+        ''
+    }
+
     method is-begin-performed-before-children() { False }
 
     method PERFORM-BEGIN(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
@@ -2650,7 +2654,11 @@ class RakuAST::CurryThunk
     }
 
     method thunk-kind() {
-        'Curried Whatever'
+        'WhateverCode'
+    }
+
+    method thunk-details() {
+        '⋐' ~ nqp::x('🔆', self.IMPL-NUM-PARAMS)  ~ '⋑'
     }
 
     method IMPL-THUNK-OBJECT-TYPE() {
@@ -2705,6 +2713,10 @@ class RakuAST::BlockThunk
 
     method thunk-kind() {
         'Block thunk'
+    }
+
+    method thunk-details() {
+        ''
     }
 
     method PRODUCE-IMPLICIT-DECLARATIONS() {

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -1289,11 +1289,6 @@ class RakuAST::ApplyInfix
     method is-begin-performed-after-children()  { True }
 
     method PERFORM-BEGIN-BEFORE-CHILDREN(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
-        my $infix   := $!infix;
-        my $CURRIES := $infix.IMPL-CURRIES;
-        my $left    := self.left;
-        my $right   := self.right;
-
         my $curried;
         if self.IMPL-SHOULD-CURRY-ACROSS-ALL-CHILDREN {
             $curried := self.IMPL-CURRY;
@@ -1674,8 +1669,6 @@ class RakuAST::ApplyPrefix
     method is-begin-performed-after-children()  { True }
 
     method PERFORM-BEGIN-BEFORE-CHILDREN(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
-        my $prefix  := $!prefix;
-        my $operand := $!operand;
         if self.IMPL-SHOULD-CURRY-DIRECTLY {
             nqp::bindattr(self, RakuAST::ApplyPrefix, '$!operand',
                 self.IMPL-CURRY.IMPL-ADD-PARAM($resolver, $context).target.generate-lookup);
@@ -2150,12 +2143,6 @@ class RakuAST::ApplyPostfix
 
     method is-begin-performed-before-children { True }
     method is-begin-performed-after-children  { True }
-
-    method IMPL-ALL-CHILDREN-THAT-SHOULD-CURRY() {
-        my $condition := -> $n { $n.IMPL-SHOULD-CURRY-DIRECTLY };
-        my $stopper   := -> $n { ! nqp::istype($n, RakuAST::ApplyPostfix) };
-        self.IMPL-UNWRAP-LIST(self.find-nodes-exclusive(RakuAST::WhateverApplicable, :$condition, :$stopper));
-    }
 
     method PERFORM-BEGIN-BEFORE-CHILDREN(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
         if self.IMPL-SHOULD-CURRY-DIRECTLY {

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -24,7 +24,7 @@ class RakuAST::Expression
         my $prefix := nqp::x(' ', $indent);
         my @chunks;
         self.visit-thunks(-> $thunk {
-            @chunks.push("$prefix🧠 " ~ $thunk.thunk-kind ~ "\n");
+            @chunks.push("$prefix🧠 " ~ $thunk.thunk-kind ~ " " ~ $thunk.thunk-details ~ "\n");
             $thunk.visit-children(-> $child {
                 @chunks.push($child.dump($indent + 2));
             });

--- a/src/Raku/ast/signature.rakumod
+++ b/src/Raku/ast/signature.rakumod
@@ -1462,6 +1462,17 @@ class RakuAST::ParameterTarget::Term
     }
 }
 
+class RakuAST::ParameterTarget::Whatever
+  is RakuAST::ParameterTarget::Term
+{
+    method new(str $name) {
+        my $obj := nqp::create(self);
+        nqp::bindattr($obj, RakuAST::ParameterTarget::Term, '$!name',
+            RakuAST::Name.from-identifier($name // QAST::Node.unique('$whatevercode_arg')));
+        $obj
+    }
+}
+
 # Marker for all kinds of slurpy behavior.
 class RakuAST::Parameter::Slurpy {
 

--- a/src/Raku/ast/signature.rakumod
+++ b/src/Raku/ast/signature.rakumod
@@ -1462,6 +1462,8 @@ class RakuAST::ParameterTarget::Term
     }
 }
 
+# These nodes generate their own unique names by default but can be passed existing
+# names in order to reference existing RakuAST::ParamaterTarget::Whatever nodes.
 class RakuAST::ParameterTarget::Whatever
   is RakuAST::ParameterTarget::Term
 {

--- a/src/Raku/ast/signature.rakumod
+++ b/src/Raku/ast/signature.rakumod
@@ -1473,6 +1473,14 @@ class RakuAST::ParameterTarget::Whatever
             RakuAST::Name.from-identifier($name // QAST::Node.unique('$whatevercode_arg')));
         $obj
     }
+
+    # Generate a lookup of this parameter, already resolved to this declaration.
+    method generate-lookup() {
+        my $name := nqp::getattr(self, RakuAST::ParameterTarget::Term, '$!name');
+        my $lookup := RakuAST::WhateverCode::Argument.new($name);
+        $lookup.set-resolution(self);
+        $lookup
+    }
 }
 
 # Marker for all kinds of slurpy behavior.
@@ -1646,6 +1654,10 @@ class RakuAST::ParameterDefaultThunk
 
     method thunk-kind() {
         'Parameter default'
+    }
+
+    method thunk-details() {
+        ''
     }
 
     method IMPL-THUNK-META-OBJECT-PRODUCED(Mu $code) {

--- a/src/Raku/ast/term.rakumod
+++ b/src/Raku/ast/term.rakumod
@@ -234,6 +234,37 @@ class RakuAST::Term::Whatever
     }
 }
 
+# A specialized class to act as the actual lookup for the relevant RakuAST::ParameterTarget::Whatever
+# This is what a Term::Whatever often -- but not always -- becomes.
+class RakuAST::WhateverCode::Argument
+  is RakuAST::Term
+  is RakuAST::Lookup
+{
+    has RakuAST::Name $!name;
+
+    method new(RakuAST::Name $name) {
+        my $obj := nqp::create(self);
+        nqp::bindattr($obj, RakuAST::WhateverCode::Argument, '$!name', $name);
+        $obj
+    }
+
+    method resolve-with(RakuAST::Resolver $resolver) {
+        my $resolved := $resolver.resolve-name($!name);
+        if $resolved {
+            self.set-resolution($resolved);
+        }
+        Nil
+    }
+
+    method IMPL-EXPR-QAST(RakuAST::IMPL::QASTContext $context) {
+        self.resolution.IMPL-LOOKUP-QAST($context)
+    }
+
+    method dump-markers() {
+        '🔆'
+    }
+}
+
 # The hyper whatever (**) term.
 class RakuAST::Term::HyperWhatever
   is RakuAST::Term

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -2255,6 +2255,9 @@ class RakuAST::Deparse {
         self.hsyn('var-term', $.term-whatever)
     }
 
+    multi method deparse(RakuAST::WhateverCode::Argument:D $ --> Str:D) {
+        self.hsyn('var-term', $.term-whatever)
+    }
 #- Ternary ---------------------------------------------------------------------
 
     multi method deparse(RakuAST::Ternary:D $ast --> Str:D) {
@@ -2420,7 +2423,7 @@ class RakuAST::Deparse {
 
     multi method deparse(RakuAST::Var::Lexical:D $ast --> Str:D) {
         my $name := $ast.name;
-        self.hsyn('var-lexical',$name.starts-with('$whatevercode_arg_') ?? '*' !! $name)
+        self.hsyn('var-lexical', $name)
     }
 
     multi method deparse(RakuAST::Var::Lexical::Setting:D $ast --> Str:D) {


### PR DESCRIPTION
This doesn't pass any additional spectests, but it irons out all of the currently run-able tests in `t/spec/02-types/whatever.t` (that aren't exception-via-grammar related). This means that all known parsing corners of `Whatever` currying are covered by the final form of this implementation!

It also prettifies the output of the relevant nodes. I discuss my justifications in the relevant commit message, but tl;dr: 🔆 looks like a whatever star with a hole in the center of it -- right where the eventual passed parameter will go. 

```
    Statement::Expression ⚓▪𝄞 -e:1 ⎡(* ~ (* ~ *).uc) ~ * ~ *⎤
      ApplyInfix  ⎡~⎤
        🧠 WhateverCode ⋐🔆🔆🔆🔆🔆⋑
        Infix  ⎡~⎤
        ArgList
          ApplyInfix  ⎡~⎤
            Infix  ⎡~⎤
            ArgList
              Circumfix::Parentheses  ⎡(* ~ (* ~ *).uc)⎤
                SemiList  ⎡* ~ (* ~ *).uc⎤
                  Statement::Expression  ⎡* ~ (* ~ *).uc⎤
                    ApplyInfix  ⎡~⎤
                      Infix  ⎡~⎤
                      ArgList
                        WhateverCode::Argument 🔆
                        ApplyPostfix  ⎡.uc⎤
                          ApplyInfix  ⎡~⎤
                            Infix  ⎡~⎤
                            ArgList
                              WhateverCode::Argument 🔆
                              WhateverCode::Argument 🔆
                          Call::Method  ⎡uc⎤
                            Name  ⎡uc⎤
                            ArgList
              WhateverCode::Argument 🔆
          WhateverCode::Argument 🔆
```