### PR TITLE
RakuAST: Fix FIRST phaser not firing

### DIFF
--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -515,6 +515,9 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
         my $block := $*BLOCK;
         $block.replace-signature($signature.ast) if $signature;
         $block.replace-body($<blockoid>.ast);
+        if $*IN-LOOP {
+            $block.set-is-loop-body;
+        }
         $block.ensure-begin-performed($*R, $*CU.context);
         self.attach: $/, $block;
     }

--- a/src/Raku/Grammar.nqp
+++ b/src/Raku/Grammar.nqp
@@ -1279,6 +1279,7 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
         {}
         :my $*GOAL := '{';
         :my $*BORG := {};
+        :my $*IN-LOOP := 1;
         <EXPR>
         <pointy-block>
     }
@@ -1355,6 +1356,7 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
         <.vetPerlForSyntax>
         :my $*GOAL := '{';
         :my $*BORG := {};
+        :my $*IN-LOOP := 1;
         <EXPR>
         <pointy-block>
     }
@@ -1368,6 +1370,7 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
           | [<.block-while>|<.block-until>{$*WHILE := 'Until'}]<.kok>
             :my $*GOAL := '{';
             :my $*BORG := {};
+            :my $*IN-LOOP := 1;
             <EXPR>
             <pointy-block>
           | <pointy-block>
@@ -1428,6 +1431,7 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
             || <.malformed: "loop spec">
           ]
         ]?
+        :my $*IN-LOOP := 1;
         <block>
     }
 

--- a/src/Raku/ast/statements.rakumod
+++ b/src/Raku/ast/statements.rakumod
@@ -944,7 +944,7 @@ class RakuAST::Statement::Loop
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
         self.IMPL-WRAP-LIST([
-            RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('Nil')),
+            RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('Nil'))
         ])
     }
 


### PR DESCRIPTION
This is currently only working with loops, which matches what the base compiler does.

It also recommends (well, demands, really) the more-sensible-for-the-use-case `once` statement prefix. This should be done via a worry but currently that mechanism is not working from this code path.