### PR TITLE
RakuAST: Implement `FIRST` using AST

### DIFF
--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -790,13 +790,6 @@ class RakuAST::ScopePhaser {
     }
 
     method IMPL-STUB-PHASERS(RakuAST::Resolver $resolver, RakuAST::IMPL::Context $context) {
-        if $!FIRST && ! $!is-loop-body {
-            $resolver.add-worry:
-                $resolver.build-exception: 'X::AdHoc',
-                    :payload("FIRST phasers only apply in loop bodies.\n"
-                     ~ "Please use 'once' in place of 'FIRST' for once-only semantics on regular blocks");
-        }
-
         if $!let {
             $!let.IMPL-CHECK($resolver, $context, False);
             $!let.IMPL-STUB-CODE($resolver, $context);

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -3,7 +3,10 @@ class RakuAST::CaptureSource
   is RakuAST::Node { }
 
 # Everything that can appear as an expression does RakuAST::Expression.
+# Furthermore, since every expression can exist as statement, consider
+# us a RakuAST::Blorst since we may easily find ourselves where blorsts go.
 class RakuAST::Expression
+  is RakuAST::Blorst
   is RakuAST::IMPL::ImmediateBlockUser
 {
     # All expressions can be thunked - that is, compiled such that they get

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -403,6 +403,10 @@ class RakuAST::Infix
         }
         $op(|@operands)
     }
+
+    method dump-markers() {
+        '【' ~ $!operator ~ '】'
+    }
 }
 
 class RakuAST::Feed

--- a/src/Raku/ast/name.rakumod
+++ b/src/Raku/ast/name.rakumod
@@ -190,6 +190,10 @@ class RakuAST::Name
         Nil
     }
 
+    method dump-markers() {
+        '【' ~ self.canonicalize ~ '】'
+    }
+
     method IMPL-IS-NQP-OP() {
         nqp::elems($!parts) == 2 && nqp::istype($!parts[0], RakuAST::Name::Part::Simple) && $!parts[0].name eq 'nqp'
             ?? $!parts[1].name

--- a/src/Raku/ast/statementprefixes.rakumod
+++ b/src/Raku/ast/statementprefixes.rakumod
@@ -424,7 +424,9 @@ class RakuAST::StatementPrefix::Supply
 # Done by all phasers. Serves as little more than a marker for phasers, for
 # easing locating them all.
 class RakuAST::StatementPrefix::Phaser
-  is RakuAST::StatementPrefix { }
+  is RakuAST::StatementPrefix {
+    method dump-markers() { '🛸' }
+}
 
 # Done by all phasers that don't produce a result.
 class RakuAST::StatementPrefix::Phaser::Sinky

--- a/src/Raku/ast/statementprefixes.rakumod
+++ b/src/Raku/ast/statementprefixes.rakumod
@@ -637,21 +637,7 @@ class RakuAST::StatementPrefix::Phaser::First
         my $trigger-lookup := $trigger-var.generate-lookup;
         $attach-block.add-generated-lexical-declaration($trigger-var);
 
-        unless nqp::istype($blorst, RakuAST::Block) {
-            $blorst := nqp::istype($blorst, RakuAST::Statement)
-                        ??
-                RakuAST::Block.new:
-                    :body(RakuAST::Blockoid.new:
-                        RakuAST::StatementList.new:
-                            $blorst)
-                        !!
-                RakuAST::Block.new:
-                    :body(RakuAST::Blockoid.new:
-                        RakuAST::StatementList.new:
-                            RakuAST::Statement::Expression.new:
-                                :expression($blorst));
-        }
-
+        $blorst := $blorst.as-block;
         $blorst.body.statement-list.add-statement:
             RakuAST::Statement::Expression.new:
                 :expression(RakuAST::ApplyInfix.new:

--- a/src/Raku/ast/statements.rakumod
+++ b/src/Raku/ast/statements.rakumod
@@ -1,7 +1,25 @@
 # Block or statement, used in statement prefixes which can take either a
-# block or a statement.
+# block or a statement (or an expression, which can always go in a
+# RakuAST::Statement::Expression)
 class RakuAST::Blorst
-  is RakuAST::Node { }
+  is RakuAST::Node {
+    method as-block() {
+        nqp::istype(self, RakuAST::Block)
+            ?? self
+            !! nqp::istype(self, RakuAST::Statement)
+                        ??
+                RakuAST::Block.new:
+                    :body(RakuAST::Blockoid.new:
+                        RakuAST::StatementList.new: self)
+                        !!
+                RakuAST::Block.new:
+                    :body(RakuAST::Blockoid.new:
+                        RakuAST::StatementList.new:
+                            RakuAST::Statement::Expression.new:
+                                :expression(self));
+    }
+}
+
 
 # Something that can be the target of a contextualizer.
 class RakuAST::Contextualizable

--- a/src/Raku/ast/variable-access.rakumod
+++ b/src/Raku/ast/variable-access.rakumod
@@ -75,6 +75,10 @@ class RakuAST::Var::Lexical
     method IMPL-INTERPRET(RakuAST::IMPL::InterpContext $ctx) {
         self.resolution.compile-time-value
     }
+
+    method dump-markers() {
+        '【' ~ self.name ~ '】'
+    }
 }
 
 # A lexical variable lookup, but assumed to resolve to a compile time

--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -1022,6 +1022,10 @@ class RakuAST::VarDeclaration::Simple
     }
 
     method needs-sink-call() { False }
+
+    method dump-markers() {
+        '【' ~ self.name ~ '】'
+    }
 }
 
 # Subclass to mark that the declaration was automatically generated.


### PR DESCRIPTION
The primary commit message is as follows:

```
RakuAST: Implement FIRST phaser as an AST construct

It turns out that there is no need to even dip into QAST in order
to implement the `FIRST` phaser, which was particularly tricky
because it depended on so-called "extops" that are particularly
hard to arrange in pure QAST (`p6setfirstflag` and `p6takefirstflag`,
for the curious).

It turns out (nine++) that we can simply arrange for this construct
at an AST level, by emulating something like:

{
  state $triggered;
  unless $triggered {
    # ... the actual content of the FIRST phaser block
    $triggered = True
  }
}()

This feels like a much more natural implementation and it really
shows off what a difference RakuAST can already make to code generation.
```

Passes one additional spectest:

```
t/spec/S04-phasers/first.t ........................................ ok
```