### PR TITLE
RakuAST: `FIRST` finalizations

### DIFF
--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -1229,6 +1229,10 @@ class RakuAST::Block
     method IMPL-INTERPRET(RakuAST::IMPL::InterpContext $ctx) {
         self.meta-object
     }
+
+    method as-block {
+        self
+    }
 }
 
 # A pointy block (-> $foo { ... }).

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -3,10 +3,7 @@ class RakuAST::CaptureSource
   is RakuAST::Node { }
 
 # Everything that can appear as an expression does RakuAST::Expression.
-# Furthermore, since every expression can exist as statement, consider
-# us a RakuAST::Blorst since we may easily find ourselves where blorsts go.
 class RakuAST::Expression
-  is RakuAST::Blorst
   is RakuAST::IMPL::ImmediateBlockUser
 {
     # All expressions can be thunked - that is, compiled such that they get

--- a/src/Raku/ast/statementprefixes.rakumod
+++ b/src/Raku/ast/statementprefixes.rakumod
@@ -633,6 +633,14 @@ class RakuAST::StatementPrefix::Phaser::First
     # synthetic AST generation in PERFORM-BEGIN.
     has str $!value-var-name;
 
+    # Because we are going to preserve our initial blorst for presentation / round trip
+    # via AST/DEPARSE/.raku. In EVAL, $!original-blorst will not be defined, because
+    # our original blorst is in $!blorst
+    has RakuAST::Blorst $!original-blorst;
+    method original-blorst() {
+        $!original-blorst // nqp::getattr(self, RakuAST::StatementPrefix, '$!blorst')
+    }
+
     method is-begin-performed-before-children { True }
     method is-begin-performed-after-children  { False }
 
@@ -644,6 +652,7 @@ class RakuAST::StatementPrefix::Phaser::First
 
     method PERFORM-BEGIN(Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
         my $blorst := nqp::getattr(self, RakuAST::StatementPrefix, '$!blorst');
+        nqp::bindattr(self, RakuAST::StatementPrefix::Phaser::First, '$!original-blorst', $blorst);
 
         my $True := RakuAST::Term::Name.new(RakuAST::Name.from-identifier('True'));
 

--- a/src/Raku/ast/statements.rakumod
+++ b/src/Raku/ast/statements.rakumod
@@ -1,23 +1,10 @@
 # Block or statement, used in statement prefixes which can take either a
-# block or a statement (or an expression, which can always go in a
-# RakuAST::Statement::Expression)
+# block or a statement
 class RakuAST::Blorst
   is RakuAST::Node
 {
     method as-block() {
-        nqp::istype(self, RakuAST::Block)
-            ?? self
-            !! nqp::istype(self, RakuAST::Statement)
-                        ??
-                RakuAST::Block.new:
-                    :body(RakuAST::Blockoid.new:
-                        RakuAST::StatementList.new: self)
-                        !!
-                RakuAST::Block.new:
-                    :body(RakuAST::Blockoid.new:
-                        RakuAST::StatementList.new:
-                            RakuAST::Statement::Expression.new:
-                                :expression(self));
+        nqp::die("RakuAST::Blorst classes must define 'as-block'. " ~ self.HOW.name(self) ~ " does not.")
     }
 }
 
@@ -148,6 +135,12 @@ class RakuAST::Statement
                 QAST::Op.new( :op('exception') )
             )
         )
+    }
+
+    method as-block() {
+        RakuAST::Block.new:
+            :body(RakuAST::Blockoid.new:
+                RakuAST::StatementList.new: self)
     }
 }
 

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -2105,6 +2105,11 @@ class RakuAST::Deparse {
         self.syn-phaser($ast.type) ~ ' ' ~ self.deparse($ast.blorst).chomp
     }
 
+    multi method deparse(RakuAST::StatementPrefix::Phaser::First:D $ast --> Str:D) {
+        my $*DELIMITER = '';
+        self.syn-phaser($ast.type) ~ ' ' ~ self.deparse($ast.original-blorst).chomp
+    }
+
     multi method deparse(
       RakuAST::StatementPrefix::Phaser::Post:D $ast
     --> Str:D) {

--- a/src/core.c/RakuAST/Raku.rakumod
+++ b/src/core.c/RakuAST/Raku.rakumod
@@ -1040,6 +1040,11 @@ augment class RakuAST::Node {
         self!positional(self.blorst.condition-modifier.expression)
     }
 
+     multi method raku(RakuAST::StatementPrefix::Phaser::First:D: --> Str:D) {
+        # skip the auto-generated code
+        self!positional(self.original-blorst)
+    }
+
 #- Stu -------------------------------------------------------------------------
 
     multi method raku(RakuAST::Stub:D: --> Str:D) {

--- a/t/12-rakuast/statement-phaser.rakutest
+++ b/t/12-rakuast/statement-phaser.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 35; # Do not change this file to done-testing because of END block tests
+plan 36; # Do not change this file to done-testing because of END block tests
 
 my $ast;
 my $deparsed;
@@ -1059,6 +1059,101 @@ CODE
         is-deeply EVAL($it), Nil, "$type: while loop evaluates to Nil";
         is-deeply $result, False, "$type: FIRST returns a value";
         is-deeply $run, 1, "$type: loop block ran";
+    }
+}
+
+subtest 'Subroutine with FIRST phaser block and return value' => {
+    my $run;
+    my $guard;
+    my $result;
+
+    # my $guard = True; while $guard { FIRST { is-deeply $run, 0, "inside FIRST"; $guard = False }; ++$run }
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Sub.new(
+          name => RakuAST::Name.from-identifier("s"),
+          body => RakuAST::Blockoid.new(
+            RakuAST::StatementList.new(
+              RakuAST::Statement::Expression.new(
+                expression => RakuAST::ApplyInfix.new(
+                  left  => RakuAST::Var::Lexical.new("\$guard"),
+                  infix => RakuAST::Assignment.new(:item),
+                  right => RakuAST::StatementPrefix::Phaser::First.new(
+                    RakuAST::Block.new(
+                      body => RakuAST::Blockoid.new(
+                        RakuAST::StatementList.new(
+                          RakuAST::Statement::Expression.new(
+                            expression => RakuAST::Call::Name.new(
+                              name => RakuAST::Name.from-identifier("is-deeply"),
+                              args => RakuAST::ArgList.new(
+                                RakuAST::Var::Lexical.new("\$run"),
+                                RakuAST::IntLiteral.new(0),
+                                RakuAST::QuotedString.new(
+                                  segments   => (
+                                    RakuAST::StrLiteral.new("in FIRST"),
+                                  )
+                                )
+                              )
+                            )
+                          ),
+                          RakuAST::Statement::Expression.new(
+                            expression => RakuAST::ApplyInfix.new(
+                              left  => RakuAST::Var::Lexical.new("\$guard"),
+                              infix => RakuAST::Infix.new("+"),
+                              right => RakuAST::IntLiteral.new(1)
+                            )
+                          )
+                        )
+                      )
+                    )
+                  )
+                )
+              ),
+              RakuAST::Statement::Expression.new(
+                expression => RakuAST::ApplyPostfix.new(
+                  operand => RakuAST::Var::Lexical.new("\$run"),
+                  postfix => RakuAST::Postfix.new(
+                    operator   => "++",
+                    colonpairs => $( )
+                  )
+                )
+              )
+            )
+          )
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::ApplyInfix.new(
+          left  => RakuAST::Call::Name.new(
+            name => RakuAST::Name.from-identifier("s")
+          ),
+          infix => RakuAST::Infix.new("xx"),
+          right => RakuAST::IntLiteral.new(3)
+        )
+      )
+    );
+
+    plan 13;  # FIRST tests need to be run
+    is-deeply $deparsed, Q:to/CODE/.chomp, 'deparse';
+sub s {
+    $guard = FIRST {
+        is-deeply($run, 0, "in FIRST");
+        $guard + 1
+    }
+    $run++
+}
+s() xx 3
+
+CODE
+
+    for 'AST', $ast, 'Str', $deparsed, 'Raku', EVAL($raku) -> $type, $it {
+        $run = 0;
+        $guard = 41;
+        $result = Nil;
+
+        is-deeply EVAL($it), (0,1,2), "$type: expression returns as expected";
+        is-deeply $guard, 42, "$type: FIRST returns a static value";
+        is-deeply $run, 3, "$type: loop block ran";
     }
 }
 

--- a/t/12-rakuast/statement-phaser.rakutest
+++ b/t/12-rakuast/statement-phaser.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 34; # Do not change this file to done-testing because of END block tests
+plan 35; # Do not change this file to done-testing because of END block tests
 
 my $ast;
 my $deparsed;
@@ -982,6 +982,83 @@ CODE
         $run = 0;
 
         is-deeply EVAL($it), Nil, "$type: for loop evaluates to Nil";
+    }
+}
+
+subtest 'While loop with FIRST phaser block and return value' => {
+    my $run;
+    my $guard = True;
+    my $result;
+
+    # my $guard = True; while $guard { FIRST { is-deeply $run, 0, "inside FIRST"; $guard = False }; ++$run }
+    ast RakuAST::Statement::Loop::While.new(
+          condition => RakuAST::Var::Lexical.new('$guard'),
+          body => RakuAST::Block.new(
+            body => RakuAST::Blockoid.new(
+              RakuAST::StatementList.new(
+                RakuAST::Statement::Expression.new(
+                  expression => RakuAST::ApplyInfix.new(
+                      infix => RakuAST::Assignment.new(:item),
+                      left => RakuAST::Var::Lexical.new('$result'),
+                      right => RakuAST::StatementPrefix::Phaser::First.new(
+                        RakuAST::Block.new(
+                          body => RakuAST::Blockoid.new(
+                            RakuAST::StatementList.new(
+                              RakuAST::Statement::Expression.new(
+                                expression => RakuAST::Call::Name.new(
+                                  name => RakuAST::Name.from-identifier("is-deeply"),
+                                  args => RakuAST::ArgList.new(
+                                    RakuAST::Var::Lexical.new('$run'),
+                                    RakuAST::IntLiteral.new(0),
+                                    RakuAST::StrLiteral.new('inside FIRST'),
+                                  )
+                                )
+                              ),
+                              RakuAST::Statement::Expression.new(
+                                expression => RakuAST::ApplyInfix.new(
+                                  infix => RakuAST::Assignment.new(:item),
+                                  left => RakuAST::Var::Lexical.new('$guard'),
+                                  right => RakuAST::Term::Name.new(
+                                    RakuAST::Name.from-identifier('False')
+                                  )
+                                )
+                              )
+                            )
+                          )
+                        )
+                      )
+                    )
+                  ),
+                  RakuAST::Statement::Expression.new(
+                    expression => RakuAST::ApplyPrefix.new(
+                      prefix => RakuAST::Prefix.new('++'),
+                      operand => RakuAST::Var::Lexical.new('$run')
+                    )
+                  )
+                )
+              )
+            )
+          );
+
+    plan 13;  # FIRST tests need to be run
+    is-deeply $deparsed, Q:to/CODE/.chomp, 'deparse';
+while $guard {
+    $result = FIRST {
+        is-deeply($run, 0, "inside FIRST");
+        $guard = False
+    }
+    ++$run
+}
+CODE
+
+    for 'AST', $ast, 'Str', $deparsed, 'Raku', EVAL($raku) -> $type, $it {
+        $run = 0;
+        $guard = True;
+        $result = Nil;
+
+        is-deeply EVAL($it), Nil, "$type: while loop evaluates to Nil";
+        is-deeply $result, False, "$type: FIRST returns a value";
+        is-deeply $run, 1, "$type: loop block ran";
     }
 }
 


### PR DESCRIPTION
Undo the `RakuAST::Blorst`-ing of `Raku::Expression` thinko while also making `FIRST` a replication of `once` but at a better-defined time by giving `FIRST` return value semantics (like some other famous phasers).