### PR TITLE
RakuAST: Fix binding of $_ on smartmatch RHS

### DIFF
--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -279,7 +279,9 @@ class RakuAST::Infix
                 nqp::die('Cannot compile bind to ' ~ $left.HOW.name($left));
             }
         }
-        elsif nqp::existskey(OP-SMARTMATCH, $op) && !nqp::istype($right, RakuAST::Var) {
+        elsif nqp::existskey(OP-SMARTMATCH, $op)
+            && (!nqp::istype($right, RakuAST::Var) || (nqp::istype($right, RakuAST::Var::Lexical) && $right.is-topic))
+        {
             self.IMPL-SMARTMATCH-QAST($context, $left, $right, nqp::atkey(OP-SMARTMATCH, $op));
         }
         else {

--- a/src/Raku/ast/variable-access.rakumod
+++ b/src/Raku/ast/variable-access.rakumod
@@ -54,6 +54,10 @@ class RakuAST::Var::Lexical
             !! Nil
     }
 
+    method is-topic() {
+        self.name eq '$_'
+    }
+
     method IMPL-IS-META-OP() {
         ($!sigil eq '&' || $!sigil eq '')
             && nqp::elems($!desigilname.colonpairs) == 1

--- a/t/12-rakuast/regex-charclass.rakutest
+++ b/t/12-rakuast/regex-charclass.rakutest
@@ -36,8 +36,9 @@ subtest 'All of the simple character classes' => {
       'deparse';
 
     my $target := ".\b\r7\e\f \n\0 \t\nx";
-    is $target ~~ $_, $target, "@type[$++]: pass case"
-      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+    for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku) -> $result {
+        is $target ~~ $result, $target, "@type[$++]: pass case";
+    }
 }
 
 subtest 'All of the simple character classes than can be negated' => {
@@ -59,8 +60,9 @@ subtest 'All of the simple character classes than can be negated' => {
       'deparse';
 
     my $target := "abcdefghi.";
-    is $target ~~ $_, $target, "@type[$++]: pass case"
-      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+    for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku) -> $result {
+        is $target ~~ $result, $target, "@type[$++]: pass case";
+    }
 }
 
 subtest 'A single unicode character specified by name' => {
@@ -71,9 +73,10 @@ subtest 'A single unicode character specified by name' => {
       RakuAST::Regex::CharClass::Specified.new(:$characters)
     );
     is-deeply $deparsed, '/ \c[COMMA]/', 'deparse';
-    
-    is $characters ~~ $_, $characters, "@type[$++]: pass case"
-      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+
+    for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku) -> $result {
+        is $characters ~~ $result, $characters, "@type[$++]: pass case";
+    }
 }
 
 subtest 'Multiple unicode characters specified by name' => {
@@ -86,9 +89,10 @@ subtest 'Multiple unicode characters specified by name' => {
     is-deeply $deparsed,
       '/ \c[REGIONAL INDICATOR SYMBOL LETTER U, REGIONAL INDICATOR SYMBOL LETTER A]/',
       'deparse';
-    
-    is $characters ~~ $_, $characters, "@type[$++]: pass case"
-      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+
+    for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku) -> $result {
+        is $characters ~~ $result, $characters, "@type[$++]: pass case";
+    }
 }
 
 subtest 'Multiple unicode characters specified by name negated' => {
@@ -101,9 +105,10 @@ subtest 'Multiple unicode characters specified by name negated' => {
     is-deeply $deparsed,
       '/ \C[REGIONAL INDICATOR SYMBOL LETTER U, REGIONAL INDICATOR SYMBOL LETTER A]/',
       'deparse';
-    
-    is "ab" ~~ $_, "a", "@type[$++]: pass case"
-      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+
+    for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku) -> $result {
+        is "ab" ~~ $result, "a", "@type[$++]: pass case";
+    }
 }
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
This fixes #5239 without any changes to spectests (might be good to add a test, or unfudge one if one already existed, as this behavior does not work in the base compiler).

Note: It could also be fixed without breaking tests by removing the guard against `RakuAST::Var` entirely, however I'm operating under the assumption that there are variable related optimizations in the dedicated `infix:<~~>` implementation.