### PR TITLE
RakuAST: Set mod topic temporarization correctly

### DIFF
--- a/src/Raku/ast/statement-mods.rakumod
+++ b/src/Raku/ast/statement-mods.rakumod
@@ -214,25 +214,21 @@ class RakuAST::StatementModifier::For
         my $expression := self.expression;
         my $expression-qast := $expression.IMPL-TO-QAST($context);
 
-        # We generally want to temporarize the topic, except if our expression
-        # is a call, which is used to *produce* $_ into the loop statement
-        # and thus $_ can't be temporarized
-        (nqp::istype($expression, RakuAST::Call) || nqp::istype($expression, RakuAST::ApplyPostfix))
-                ??
-        self.IMPL-FOR-QAST(
-            $context, 'serial',
-            ($sink ?? 'sink' !! 'eager'),
-            $expression-qast,
-            $statement-qast)
-                !!
-        self.IMPL-TEMPORARIZE-TOPIC(
-            $expression-qast,
-            self.IMPL-FOR-QAST(
+        nqp::istype($expression, RakuAST::QuotedRegex)
+                        ??
+            self.IMPL-TEMPORARIZE-TOPIC(
+                $expression-qast,
+                self.IMPL-FOR-QAST(
+                    $context, 'serial',
+                    ($sink ?? 'sink' !! 'eager'),
+                    $expression-qast,
+                    $statement-qast))
+                        !!
+             self.IMPL-FOR-QAST(
                 $context, 'serial',
                 ($sink ?? 'sink' !! 'eager'),
                 $expression-qast,
                 $statement-qast)
-        )
     }
 
     method expression-thunk() {


### PR DESCRIPTION
We actually only want to do this in the case that we have a `QuotedRegex` for an expression.