### PR TITLE
RakuAST: Improve WhateverCode's .raku

### DIFF
--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -2669,10 +2669,12 @@ class RakuAST::CurryThunk
   is RakuAST::ImplicitLookups
 {
     has Mu $!parameters;
+    has Str $!original-expression;
 
-    method new() {
+    method new(Str $original-expression) {
         my $obj := nqp::create(self);
-        nqp::bindattr($obj, RakuAST::CurryThunk,, '$!parameters', []);
+        nqp::bindattr($obj, RakuAST::CurryThunk, '$!parameters', []);
+        nqp::bindattr($obj, RakuAST::CurryThunk, '$!original-expression', $original-expression);
         $obj
     }
 
@@ -2719,6 +2721,10 @@ class RakuAST::CurryThunk
 
     method IMPL-THUNK-SIGNATURE() {
         RakuAST::Signature.new(parameters => self.IMPL-WRAP-LIST($!parameters))
+    }
+
+    method IMPL-THUNK-META-OBJECT-PRODUCED(Mu $code) {
+        nqp::bindattr($code, self.get-implicit-lookups.AT-POS(0).compile-time-value, '$!original-expression', $!original-expression)
     }
 }
 

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -62,7 +62,7 @@ class RakuAST::Expression
 
     # This creates the curry. Parameters are always added via CurryThunk.IMPL-ADD-PARAM
     method IMPL-CURRY() {
-        my $thunk := RakuAST::CurryThunk.new;
+        my $thunk := RakuAST::CurryThunk.new(self.DEPARSE);
         self.wrap-with-thunk($thunk);
         $thunk
     }

--- a/src/core.c/WhateverCode.rakumod
+++ b/src/core.c/WhateverCode.rakumod
@@ -1,4 +1,5 @@
 my class WhateverCode is Code {
+    has Str $!original-expression;
 
     # helper method for array slicing
     multi method POSITIONS(WhateverCode:D: Failure:D \failure) { failure }
@@ -23,6 +24,10 @@ my class WhateverCode is Code {
 
     method has-phasers(--> False) { }
     method has-loop-phasers(--> False) { }
+
+    multi method raku(WhateverCode:D:) {
+        $!original-expression // "WhateverCode.new"
+    }
 }
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
This change allows `(* * *).raku` to return `* * *`, providing round-tripping through `raku` for WhateverCodes.