### PR TITLE
RakuAST: Add :{} object hash initialization

### DIFF
--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -1492,7 +1492,7 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
     }
 
     method circumfix:sym<{ }>($/) {
-        self.attach: $/, $<pointy-block>.ast.block-or-hash;
+        self.attach($/, $<pointy-block>.ast.block-or-hash(:object-hash($*OBJECT-HASH || 0)))
     }
 
     method circumfix:sym<ang>($/) { self.attach: $/, $<nibble>.ast }

--- a/src/Raku/Grammar.nqp
+++ b/src/Raku/Grammar.nqp
@@ -3125,6 +3125,7 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
             <.worry: "Pair with <> really means an empty list, not null string; use :$front" ~ "('') to represent the null string,\n  or :$front" ~ "() to represent the empty list more accurately">
 
           | {}
+            :my $*OBJECT-HASH := $front ?? 0 !! 1;
             <circumfix>
         ]
     }

--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -1125,13 +1125,13 @@ class RakuAST::Block
     # parsed things tentatively as a block to obtain the actual node to use.
     # If constructing AST synthetically, just make the correct thing in the
     # first place.
-    method block-or-hash() {
+    method block-or-hash(int :$object-hash) {
         my @statements := self.body.statement-list.code-statements;
         my int $num-statements := nqp::elems(@statements);
 
         # Empty block is always an empty hash composer
         if $num-statements == 0 {
-            return RakuAST::Circumfix::HashComposer.new
+            return RakuAST::Circumfix::HashComposer.new(:$object-hash)
         }
 
         # Multiple statements is always a block
@@ -1214,7 +1214,7 @@ class RakuAST::Block
         }
         $seen-decl-or-topic
             ?? self
-            !! RakuAST::Circumfix::HashComposer.new($expression)
+            !! RakuAST::Circumfix::HashComposer.new($expression, :$object-hash)
     }
 
     method visit-children(Code $visitor) {


### PR DESCRIPTION
This adds the `:{}` hash composing syntax.

+6 spectests!

```
        t/spec/S03-operators/set_symmetric_difference.t ................... ok
        t/spec/S03-operators/set_union.t .................................. ok
        t/spec/S03-operators/set_difference.t ............................. ok
        t/spec/S32-list/pick.t ............................................ ok
        t/spec/S32-list/roll.t ............................................ ok
        t/spec/S03-operators/set_intersection.t ........................... ok
```