### PR TITLE
Sort input file list

### DIFF
--- a/tools/lib/NQP/Config/Rakudo.pm
+++ b/tools/lib/NQP/Config/Rakudo.pm
@@ -803,7 +803,7 @@ sub _revs_iterate {
                 File::Spec->catdir( $base_dir, "src" )
             );
         }
-        return @all_sources;
+        return sort(@all_sources);
     }
 }
 


### PR DESCRIPTION
Sort input file list so that `Makefile` builds in a reproducible way
in spite of non-deterministic filesystem readdir order.

See https://reproducible-builds.org/ for why this is good.

This patch was done while working on reproducible builds for openSUSE.