### PR TITLE
Don't link to docs.raku.org for non-CORE types

### DIFF
--- a/src/core.c/Mu.rakumod
+++ b/src/core.c/Mu.rakumod
@@ -96,7 +96,11 @@ my class Mu { # declared in BOOTSTRAP
                     $where := "type/$what";
                 }
 
-                "No documentation available for $what. Perhaps it can be found at https://docs.raku.org/$where.html".naive-word-wrapper
+                (CORE::{$what}:exists
+                    ?? "Sorry, no documentation is attached to $what."
+                       ~ "  Perhaps it can be found at https://docs.raku.org/$where.html"
+                    !! "Sorry, no documentation is attached to $what."
+                ).naive-word-wrapper
             }
         }
 


### PR DESCRIPTION
The default `.WHY` message currently always refers users to <https://docs.raku.org> for documentation on undocumented types. This is confusing for non-CORE types and could create the impression that the docs site has many broken links/missing pages.

This PR removes the docs.raku.org reference for any types that don't pass `CORE::{$what}:exists`