### PR TITLE
Don't open handles when calling Distribution.content

### DIFF
--- a/src/core.c/CompUnit/Repository/Installation.rakumod
+++ b/src/core.c/CompUnit/Repository/Installation.rakumod
@@ -51,7 +51,7 @@ sub MAIN(:$name, :$auth, :$ver, *@, *%) {
                 ?? $.prefix.add('sources').add($entry{$address}<file>)
                 !! $.prefix.add('resources').add($.meta<files>{$address});
 
-            $file.open(:r)
+            IO::Handle.new(:path($file))
         }
     }
 


### PR DESCRIPTION
Other distribution objects do not return an opened handle (see `Distribution::Locally`), which was the original intention since the user may want to open the handle with a different encoding or may not be interested in opening the handle at all.