### PR TITLE
Remove largely unknown flags from installed raku script shims

### DIFF
--- a/src/core.c/CompUnit/Repository/Installation.rakumod
+++ b/src/core.c/CompUnit/Repository/Installation.rakumod
@@ -31,8 +31,8 @@ __END__
 /;
 
     my constant $raku-wrapper = '#!/usr/bin/env #raku#
-sub MAIN(:$name, :$auth, :$ver, *@, *%) {
-    CompUnit::RepositoryRegistry.run-script("#name#", :$name, :$auth, :$ver);
+sub MAIN(*@, *%) {
+    CompUnit::RepositoryRegistry.run-script("#name#");
 }';
 
 


### PR DESCRIPTION
These were missed in https://github.com/rakudo/rakudo/commit/73888f45ad2e09f791e45f8e54f8c59628617885