### PR TITLE
Check if requested backtrace is null

### DIFF
--- a/src/core.c/CallFrame.rakumod
+++ b/src/core.c/CallFrame.rakumod
@@ -8,10 +8,8 @@ my class CallFrame {
     ) is implementation-detail {
         nqp::stmts(
           (my int $i = nqp::add_i(level,1)),
-          ($!annotations := nqp::atkey(
-            nqp::atpos(nqp::getattr(bt,List,'$!reified'),$i),
-            'annotations'
-          )),
+          (my $bt := nqp::atpos(nqp::getattr(bt,List,'$!reified'),$i)),
+          ($!annotations := nqp::isnull($bt) ?? $bt !! nqp::atkey($bt,'annotations')),
           (my $ctx := ctx),
           nqp::while(
             nqp::isgt_i(--$i,0),


### PR DESCRIPTION
... before trying to extract a value. This will avoid an internal error on the JVM backend when exploring call frames that don't exist. For details see https://github.com/rakudo/rakudo/issues/3607.

The old code works on MoarVM, because calling  on
a  object doesn't explode there. But adding the extra check shouldn't hurt, either.