### PR TITLE
Remove undocumented quotelang extenders

### DIFF
--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -3472,13 +3472,13 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
     token quote_mod:sym<w>  { <sym> }
     token quote_mod:sym<ww> { <sym> }
     token quote_mod:sym<x>  { <sym> }
-    token quote_mod:sym<to> { <sym> }
-    token quote_mod:sym<s>  { <sym> }
-    token quote_mod:sym<a>  { <sym> }
-    token quote_mod:sym<h>  { <sym> }
-    token quote_mod:sym<f>  { <sym> }
-    token quote_mod:sym<c>  { <sym> }
-    token quote_mod:sym<b>  { <sym> }
+#    token quote_mod:sym<to> { <sym> }
+#    token quote_mod:sym<s>  { <sym> }
+#    token quote_mod:sym<a>  { <sym> }
+#    token quote_mod:sym<h>  { <sym> }
+#    token quote_mod:sym<f>  { <sym> }
+#    token quote_mod:sym<c>  { <sym> }
+#    token quote_mod:sym<b>  { <sym> }
 
     proto token quote { <...> }
     token quote:sym<apos>  { :dba('single quotes') "'" ~ "'" <nibble(self.quote_lang(self.slang_grammar('Quote'), "'", "'", ['q']))> }


### PR DESCRIPTION
The primary quotelang markers q, qq, and Q allow for a number of extenders according to the documentation: w, ww, and x.  So instead of qw, one could also say q:w, and instead of qqww one could also say qq:ww.

The grammar however **ALSO** allows for: to, s, a, h, f, c, b, o.  Allowing one to say qqto and Qf (to name but two of the possible combinations).

I think this is taking the TIMTOWTDO a little too far.  So this commit removes support for these undocumented quotelang extenders.

This breaks three spectest files:
- t/spec/S02-literals/misc-interpolation.t
- t/spec/S02-literals/quoting.t
- t/spec/integration/advent2014-day16.t

because they check for a, b and to as quotelang extenders respectively. If this change is OKd, then these tests will have to be adapted.  The adaptation is quite simple: add a colon.