### PR TITLE
Fix handling of dynamic containers on 6.e PseudoStash

### DIFF
--- a/src/core.e/PseudoStash.rakumod
+++ b/src/core.e/PseudoStash.rakumod
@@ -354,7 +354,7 @@ my class PseudoStash is CORE::v6c::PseudoStash {
                                         (nqp::bitand_i($mode, REQUIRE_DYNAMIC)
                                          || nqp::iseq_i($ctx-info.mode, DYNAMIC_CHAIN)),
                                         nqp::if(
-                                            ($is-dynamic || nqp::if(nqp::can($val.VAR, "dynamic"), $val.VAR.dynamic)),
+                                            ($is-dynamic || nqp::if(nqp::iscont($val), $val.VAR.dynamic)),
                                             nqp::getattr($ctx-info, CtxWalker::Return, '$!sym-info'),
                                             X::Symbol::NotDynamic),
                                         nqp::if(


### PR DESCRIPTION
Before it was trying to provide support for Array and Hash containers. But since `.VAR` returns the original object when there is no `Scalar` container the code was considering as dynamic symbols any kind of symbol which has a returning true `dynamic` method. Aside of that, attempt to test for the method on roles was causing them to pun unintentionally.