### PR TITLE
RakuAST: Avoid re-declaration of `$_` in sub-sig

### DIFF
--- a/src/Raku/ast/signature.rakumod
+++ b/src/Raku/ast/signature.rakumod
@@ -1404,7 +1404,11 @@ class RakuAST::ParameterTarget::Var
     method is-begin-performed-before-children() { True }
 
     method visit-children(Code $visitor) {
-        $visitor($!declaration);
+        # We don't want to visit the declaration if it is a topic variable,
+        # as that will result in multiple declarations because blocks already
+        # automatically declare a `$_`. And if the signature is not on a block
+        # it will still find a lexical `$_` somewhere in scope.
+        $visitor($!declaration) unless $!name eq '$_';
     }
 }
 


### PR DESCRIPTION
This fixes the following code:

    for [1,2],[3,4] -> ($_,$b) { }

which was previously dying with the error that $_ is already declared.

With this change, we avoid this re-declaration without adding too much logic dedicated to this corner case.

Fixes #5402 .