### PR TITLE
RakuAST: Re-generate meta-objects on name or signature change

### DIFF
--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -1390,11 +1390,13 @@ class RakuAST::Routine
 
     method replace-name(RakuAST::Name $new-name) {
         nqp::bindattr(self, RakuAST::Routine, '$!name', $new-name);
+        self.IMPL-RESET-CACHED-META-OBJECT;
         Nil
     }
 
     method replace-signature(RakuAST::Signature $new-signature) {
         nqp::bindattr(self, RakuAST::Routine, '$!signature', $new-signature);
+        self.IMPL-RESET-CACHED-META-OBJECT;
         Nil
     }
 

--- a/src/Raku/ast/meta.rakumod
+++ b/src/Raku/ast/meta.rakumod
@@ -24,6 +24,10 @@ class RakuAST::Meta
     method compile-time-value() {
         self.meta-object
     }
+
+    method IMPL-RESET-CACHED-META-OBJECT() {
+        nqp::bindattr(self, RakuAST::Meta, '$!meta-object-produced', False);
+    }
 }
 
 # Anything doing RakuAST::StubbyMeta is not only capable of producing a


### PR DESCRIPTION
The previous behavior was only inheriting a blank signature when defining a custom operator.

This change allows the following code to work:

```
    multi sub infix:<quack>($x, $y) { "$x|$y" }; (* quack 5).(3).say
```

The following spectests pass as a result of this change:

```
	t/spec/integration/advent2009-day22.t ............................. ok
	t/spec/integration/advent2012-day19.t ............................. ok
```
