### PR TITLE
RakuAST: Support where blocks on variables

### DIFF
--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -2069,6 +2069,7 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
         my str $scope := $*SCOPE;
         my     $type  := $*OFTYPE ?? $*OFTYPE.ast !! Nodify('Type');
         my str $sigil := $<sigil>;
+        my     $where := $*WHERE;
 
         my $decl;
         if $<desigilname> {
@@ -2085,7 +2086,7 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
             my $forced-dynamic := $dynprag ?? $dynprag($name) !! 0;
             $decl := Nodify('VarDeclaration','Simple').new:
               :$scope, :$type, :$sigil, :$twigil, :desigilname($ast),
-              :$shape, :$forced-dynamic;
+              :$shape, :$forced-dynamic, :$where;
 
             $/.typed-worry('X::Redeclaration', :symbol($name))
               if ($scope eq 'my' || $scope eq 'state' || $scope eq 'our')

--- a/src/Raku/Grammar.nqp
+++ b/src/Raku/Grammar.nqp
@@ -3645,11 +3645,16 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
                    ]+
         ]?
         [ <.ws> <trait>+ ]?
-        <.stub-variable($/)>
+        :my $where;
+        [
+            <.ws> <.constraint-where> <.ws> <EXPR('j')>
+            { $where := $<EXPR>.ast }
+        ]?
+        <.stub-variable($/, $where)>
         [<.ws> <initializer>]?
     }
 
-    token stub-variable($*VARIABLE-MATCH) { <?> }
+    token stub-variable($*VARIABLE-MATCH, $*WHERE) { <?> }
 
     token desigilname {
         [

--- a/src/Raku/ast/type.rakumod
+++ b/src/Raku/ast/type.rakumod
@@ -608,6 +608,7 @@ class RakuAST::Type::Enum
 
 class RakuAST::Type::Subset
   is RakuAST::Type
+  is RakuAST::Lookup
   is RakuAST::Declaration
   is RakuAST::BeginTime
   is RakuAST::TraitTarget
@@ -642,6 +643,7 @@ class RakuAST::Type::Subset
         }
         $obj.set-traits($traits) if $traits;
         $obj.set-WHY($WHY);
+        $obj.set-resolution($obj);
         $obj
     }
 

--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -448,6 +448,7 @@ class RakuAST::VarDeclaration::Simple
     has RakuAST::Package     $!attribute-package;
     has RakuAST::Method      $!accessor;
     has RakuAST::Type        $!conflicting-type;
+    has RakuAST::Expression  $.where;
 
     has Mu $!container-initializer;
     has Mu $!package;
@@ -461,6 +462,7 @@ class RakuAST::VarDeclaration::Simple
         RakuAST::Initializer :$initializer,
            RakuAST::SemiList :$shape,
                         Bool :$forced-dynamic,
+         RakuAST::Expression :$where,
     RakuAST::Doc::Declarator :$WHY
     ) {
         my $obj := nqp::create(self);
@@ -484,6 +486,8 @@ class RakuAST::VarDeclaration::Simple
           RakuAST::Method);
         nqp::bindattr($obj, RakuAST::ContainerCreator, '$!forced-dynamic',
           $forced-dynamic ?? True !! False);
+        nqp::bindattr($obj, RakuAST::VarDeclaration::Simple, '$!where',
+          $where // RakuAST::Expression);
 
         if $WHY {
             $scope && $scope eq 'has'
@@ -507,7 +511,7 @@ class RakuAST::VarDeclaration::Simple
         self.twigil eq '.' ?? self.sigil ~ '!' ~ self.desigilname.canonicalize !! self.name
     }
 
-    method set-type($type) {
+    method set-type(RakuAST::Type $type) {
         nqp::bindattr(self, RakuAST::VarDeclaration::Simple, '$!type', $type);
     }
 
@@ -541,6 +545,7 @@ class RakuAST::VarDeclaration::Simple
         $visitor($!initializer) if nqp::isconcrete($!initializer);
         $visitor($!shape)       if nqp::isconcrete($!shape);
         $visitor($!accessor)    if nqp::isconcrete($!accessor);
+        $visitor($!where)       if nqp::isconcrete($!where);
         self.visit-traits($visitor);
         $visitor(self.WHY) if self.WHY;
     }
@@ -590,10 +595,11 @@ class RakuAST::VarDeclaration::Simple
         my @late-traits;
         my @traits := self.IMPL-UNWRAP-LIST(self.traits);
 
+        my $of-type;
         for @traits {
             if nqp::istype($_, RakuAST::Trait::Of) {
                 nqp::bindattr(self, RakuAST::VarDeclaration::Simple, '$!conflicting-type', $!type) if $!type;
-                nqp::bindattr(self, RakuAST::VarDeclaration::Simple, '$!type', $_.type);
+                nqp::bindattr(self, RakuAST::VarDeclaration::Simple, '$!type', $of-type := $_.type);
                 next;
             }
             elsif nqp::istype($_, RakuAST::Trait::Is) {
@@ -608,25 +614,40 @@ class RakuAST::VarDeclaration::Simple
             nqp::push(@late-traits, $_);
         }
 
+        my $subset;
+        if my $where := $!where {
+            my $type := $of-type // self.get-implicit-lookups.AT-POS(0);
+            my $type-name := $type ?? $type.name.canonicalize !! "Mu";
+            my $subset-name := RakuAST::Name.from-identifier: QAST::Node.unique($type-name ~ '+anon_subset');
+            $subset := RakuAST::Type::Subset.new: :name($subset-name), :of($type ?? RakuAST::Trait::Of.new($type) !! Mu), :$where;
+            $subset.ensure-begin-performed($resolver, $context);
+            self.set-type($subset);
+        }
+
         # Apply any traits.
         self.set-traits(self.IMPL-WRAP-LIST(@late-traits));
 
         if $scope eq 'has' || $scope eq 'HAS' {
-            if $!shape || self.IMPL-HAS-CONTAINER-BASE-TYPE {
+            if $!shape || self.IMPL-HAS-CONTAINER-BASE-TYPE || $subset {
                 my $args := $!shape
                     ?? RakuAST::ArgList.new(
                         RakuAST::ColonPair::Value.new(:key<shape>, :value($!shape))
                     )
                     !! RakuAST::ArgList.new;
-                my $of := $!type
-                  ?? self.get-implicit-lookups.AT-POS(0).resolution.compile-time-value
-                  !! Mu;
+                my $of := $subset
+                        ?? $subset.meta-object
+                        !! $!type
+                            ?? self.get-implicit-lookups.AT-POS(0).resolution.compile-time-value
+                            !! Mu;
+
                 my $container-initializer-ast := RakuAST::ApplyPostfix.new(
                     operand => RakuAST::Declaration::ResolvedConstant.new(
                         :compile-time-value(
-                            $!shape && self.sigil eq '%'
-                                ?? self.IMPL-CONTAINER-TYPE($of, :key-type($!shape.code-statements[0].expression.compile-time-value))
-                                !! self.IMPL-CONTAINER-TYPE($of)
+                            $!sigil eq '$'
+                                ?? self.meta-object
+                                !! $!shape && self.sigil eq '%'
+                                    ?? self.IMPL-CONTAINER-TYPE($of, :key-type($!shape.code-statements[0].expression.compile-time-value))
+                                    !! self.IMPL-CONTAINER-TYPE($of)
                         )
                     ),
                     postfix => RakuAST::Call::Method.new(
@@ -634,6 +655,7 @@ class RakuAST::VarDeclaration::Simple
                         :$args
                     )
                 );
+
                 my $thunk := RakuAST::BlockThunk.new(:expression($container-initializer-ast));
                 $container-initializer-ast.wrap-with-thunk($thunk);
                 $thunk.ensure-begin-performed($resolver, $context);
@@ -831,8 +853,11 @@ class RakuAST::VarDeclaration::Simple
 
     method IMPL-QAST-DECL(RakuAST::IMPL::QASTContext $context) {
         my str $scope := self.scope;
-        my $of :=
-          self.get-implicit-lookups.AT-POS(0).resolution.compile-time-value;
+        my $of := $!where
+                    ?? $!type.meta-object
+                    !! $!type
+                        ?? self.get-implicit-lookups.AT-POS(0).resolution.compile-time-value
+                        !! Mu;
 
         if $scope eq 'my' && !$!desigilname.is-multi-part {
             # Lexically scoped

--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -449,6 +449,7 @@ class RakuAST::VarDeclaration::Simple
     has RakuAST::Method      $!accessor;
     has RakuAST::Type        $!conflicting-type;
     has RakuAST::Expression  $.where;
+    has RakuAST::Type        $.original-type;
 
     has Mu $!container-initializer;
     has Mu $!package;
@@ -488,6 +489,8 @@ class RakuAST::VarDeclaration::Simple
           $forced-dynamic ?? True !! False);
         nqp::bindattr($obj, RakuAST::VarDeclaration::Simple, '$!where',
           $where // RakuAST::Expression);
+        nqp::bindattr($obj, RakuAST::VarDeclaration::Simple, '$!original-type',
+          $type // RakuAST::Type);
 
         if $WHY {
             $scope && $scope eq 'has'
@@ -546,6 +549,7 @@ class RakuAST::VarDeclaration::Simple
         $visitor($!shape)       if nqp::isconcrete($!shape);
         $visitor($!accessor)    if nqp::isconcrete($!accessor);
         $visitor($!where)       if nqp::isconcrete($!where);
+        $visitor($!original-type) if nqp::isconcrete($!original-type);
         self.visit-traits($visitor);
         $visitor(self.WHY) if self.WHY;
     }

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -2588,7 +2588,7 @@ CODE
         @parts.push(self.syn-scope($ast.scope));
         @parts.push(' ');
 
-        if $ast.type -> $type {
+        if $ast.original-type -> $type {
             @parts.push(self.syn-type($type));
             @parts.push(' ');
         }
@@ -2607,6 +2607,11 @@ CODE
                 @parts.push(' ');
                 @parts.push(self.deparse($_));
             }
+        }
+
+        if $ast.where -> $where {
+            @parts.push(' where ');
+            @parts.push(self.deparse($where));
         }
 
         if $ast.initializer -> $initializer {

--- a/src/core.c/RakuAST/Raku.rakumod
+++ b/src/core.c/RakuAST/Raku.rakumod
@@ -255,6 +255,10 @@ augment class RakuAST::Node {
           'twigil', -> {
               my $twigil := self.twigil;
               :$twigil if $twigil
+          },
+          'original-type', -> {
+              my $type := self.original-type;
+              :$type if $type
           }
         );
 
@@ -1265,7 +1269,7 @@ augment class RakuAST::Node {
     multi method raku(RakuAST::VarDeclaration::Simple:D: --> Str:D) {
         self!add-WHY:
           self!nameds:
-            <scope type shape sigil twigil desigilname traits initializer>
+            <scope original-type shape sigil twigil desigilname traits initializer where>
     }
 
     multi method raku(RakuAST::VarDeclaration::Term:D: --> Str:D) {

--- a/t/12-rakuast/var.rakutest
+++ b/t/12-rakuast/var.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 53;
+plan 59;
 
 my $ast;
 my $deparsed;
@@ -1214,4 +1214,145 @@ subtest 'variable with a trait' => {
     }
 }
 
+subtest 'scalar variable with a where guard (passing initializer)' => {
+    ast RakuAST::VarDeclaration::Simple.new(
+      sigil       => "\$",
+      desigilname => RakuAST::Name.from-identifier("f"),
+      initializer => RakuAST::Initializer::Assign.new(
+        RakuAST::IntLiteral.new(5)
+      ),
+      where       => RakuAST::IntLiteral.new(5)
+    );
+
+    is-deeply $deparsed, 'my $f where 5 = 5', 'deparse';
+    for 'AST', $ast, 'Str', $deparsed, 'Raku', EVAL($raku) -> $type, $it {
+        is-deeply EVAL($it), 5, "$type: EVAL";
+    }
+}
+
+subtest 'scalar variable with a where guard (failing initializer)' => {
+    ast RakuAST::VarDeclaration::Simple.new(
+      sigil       => "\$",
+      desigilname => RakuAST::Name.from-identifier("f"),
+      initializer => RakuAST::Initializer::Assign.new(
+       RakuAST::IntLiteral.new(6)
+      ),
+      where       => RakuAST::IntLiteral.new(5)
+    );
+
+    is-deeply $deparsed, 'my $f where 5 = 6', 'deparse';
+    for 'AST', $ast, 'Str', $deparsed, 'Raku', EVAL($raku) -> $type, $it {
+        throws-like { EVAL($it) }, X::TypeCheck::Assignment, "$type: EVAL";
+    }
+}
+
+subtest 'array variable with a where guard (passing initializer)' => {
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::VarDeclaration::Simple.new(
+          sigil       => "\@",
+          desigilname => RakuAST::Name.from-identifier("h"),
+          initializer => RakuAST::Initializer::Assign.new(
+            RakuAST::IntLiteral.new(5)
+          ),
+          where       => RakuAST::IntLiteral.new(5)
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::ApplyPostfix.new(
+          operand => RakuAST::Var::Lexical.new("\@h"),
+          postfix => RakuAST::Postcircumfix::ArrayIndex.new(
+            index => RakuAST::SemiList.new(
+              RakuAST::Statement::Expression.new(
+                expression => RakuAST::IntLiteral.new(0)
+              )
+            )
+          )
+        )
+      )
+    );
+    my $output = Q:to/END/;
+my @h where 5 = 5;
+@h[0]
+END
+    is-deeply $deparsed, $output, 'deparse';
+    for 'AST', $ast, 'Str', $deparsed, 'Raku', EVAL($raku) -> $type, $it {
+        is-deeply EVAL($it), 5, "$type: EVAL";
+    }
+}
+
+subtest 'array variable with a where guard (failing initializer)' => {
+    ast RakuAST::VarDeclaration::Simple.new(
+      sigil       => "\@",
+      desigilname => RakuAST::Name.from-identifier("h"),
+      initializer => RakuAST::Initializer::Assign.new(
+        RakuAST::IntLiteral.new(6)
+      ),
+      where       => RakuAST::IntLiteral.new(5)
+    );
+
+    is-deeply $deparsed, 'my @h where 5 = 6', 'deparse';
+    for 'AST', $ast, 'Str', $deparsed, 'Raku', EVAL($raku) -> $type, $it {
+        throws-like { EVAL($it) }, X::TypeCheck::Assignment, "$type: EVAL";
+    }
+}
+
+subtest 'hash variable with a where guard (passing initializer)' => {
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::VarDeclaration::Simple.new(
+          sigil       => "\%",
+          desigilname => RakuAST::Name.from-identifier("h"),
+          initializer => RakuAST::Initializer::Assign.new(
+            RakuAST::ColonPair::Number.new(
+              key   => "s",
+              value => RakuAST::IntLiteral.new(5)
+            )
+          ),
+          where       => RakuAST::IntLiteral.new(5)
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::ApplyPostfix.new(
+          operand => RakuAST::Var::Lexical.new("\%h"),
+          postfix => RakuAST::Postcircumfix::LiteralHashIndex.new(
+            index => RakuAST::QuotedString.new(
+              processors => <words val>,
+              segments   => (
+                RakuAST::StrLiteral.new("s"),
+              )
+            )
+          )
+        )
+      )
+    );
+
+    my $output = Q:to/END/;
+my %h where 5 = :5s;
+%h<s>
+END
+    is-deeply $deparsed, $output, 'deparse';
+    for 'AST', $ast, 'Str', $deparsed, 'Raku', EVAL($raku) -> $type, $it {
+        is-deeply EVAL($it), 5, "$type: EVAL";
+    }
+}
+
+subtest 'hash variable with a where guard (failing initializer)' => {
+    ast RakuAST::VarDeclaration::Simple.new(
+      sigil       => "\%",
+      desigilname => RakuAST::Name.from-identifier("h"),
+      initializer => RakuAST::Initializer::Assign.new(
+        RakuAST::ColonPair::Number.new(
+          key   => "s",
+          value => RakuAST::IntLiteral.new(6)
+        )
+      ),
+      where       => RakuAST::IntLiteral.new(5)
+    );
+
+    is-deeply $deparsed, 'my %h where 5 = :6s', 'deparse';
+    for 'AST', $ast, 'Str', $deparsed, 'Raku', EVAL($raku) -> $type, $it {
+        throws-like { EVAL($it) }, X::TypeCheck::Assignment, "$type: EVAL";
+    }
+}
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously the grammar was confused by the existence of where blocks in variable declarations.

Now they are fully supported.

This diverges from base behavior in that previously we would output `<anon>` as the name of type that failed in a binding check. Now this is replaced by, for example, `Mu::Int+anon_subset_1`.

This can eventually be cleaned up such that the actual subset definition is displayed in the error message, so leaving it as an implementation detail for now.

[Unfortunately this commit does not introduce any new passing spectests]