### PR TITLE
First attempt to use a dispatcher instead of nqp::p6definite

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -6294,7 +6294,15 @@ class Perl6::Actions is HLL::Actions does STDActions {
             }
             elsif $name eq 'DEFINITE' {
                 whine_if_args($/, $past, $name);
+#?if moar
+                $past := QAST::Op.new(
+                    :op<dispatch>,
+                    QAST::SVal.new(:value<raku-definite>),
+                );
+#?endif
+#?if !moar
                 $past.op('p6definite');
+#?endif
             }
             else {
                 $past.name( $name );
@@ -6391,7 +6399,14 @@ class Perl6::Actions is HLL::Actions does STDActions {
 
     method term:sym<dotty>($/) {
         my $past := $<dotty>.ast;
-        $past.unshift(WANTED(QAST::Var.new( :name('$_'), :scope('lexical') ),'dotty') );
+        if $past.op eq 'dispatch' {
+            my $syscall := $past.shift;
+            $past.unshift(WANTED(QAST::Var.new( :name('$_'), :scope('lexical') ),'dotty') );
+            $past.unshift($syscall);
+        }
+        else {
+            $past.unshift(WANTED(QAST::Var.new( :name('$_'), :scope('lexical') ),'dotty') );
+        }
         make QAST::Op.new( :op('hllize'), $past);
     }
 
@@ -7386,7 +7401,14 @@ class Perl6::Actions is HLL::Actions does STDActions {
 
             # Method calls may be to a foreign language, and thus return
             # values may need type mapping into Raku land.
-            $past.unshift(WANTED($/[0].ast,'EXPR/POSTFIX'));
+            if $past.op eq 'dispatch' {
+                my $syscall := $past.shift;
+                $past.unshift(WANTED($/[0].ast,'EXPR/POSTFIX'));
+                $past.unshift($syscall);
+            }
+            else {
+                $past.unshift(WANTED($/[0].ast,'EXPR/POSTFIX'));
+            }
             if nqp::istype($past, QAST::Op) && $past.op eq 'callmethod' {
                 unless $<OPER> && (
                   (my $sym := $<OPER><sym>) eq '.=' ||

--- a/src/Perl6/Optimizer.nqp
+++ b/src/Perl6/Optimizer.nqp
@@ -3633,7 +3633,12 @@ class Perl6::Optimizer {
               QAST::Op.new: :op<call>, :name($metaop[0][0].name),
                 $operand,
                 QAST::Op.new(:op<if>,
+#?if moar
+                  QAST::Op.new(:op<dispatch>, QAST::SVal.new(:value<raku-definite>), $assignee_var),
+#?endif
+#?if !moar
                   QAST::Op.new(:op<p6definite>, $assignee_var),
+#?endif
                   $assignee_var,
                   QAST::Op.new(:op<call>, :name($metaop[0][0].name)));
             }
@@ -3644,7 +3649,12 @@ class Perl6::Optimizer {
               $op.push:
               QAST::Op.new: :op<call>, :name($metaop[0].name),
                 QAST::Op.new(:op<if>,
+#?if moar
+                  QAST::Op.new(:op<dispatch>, QAST::SVal.new(:value<raku-definite>), $assignee_var),
+#?endif
+#?if !moar
                   QAST::Op.new(:op<p6definite>, $assignee_var),
+#?endif
                   $assignee_var,
                   QAST::Op.new(:op<call>, :name($metaop[0].name))),
                 $operand;

--- a/src/vm/moar/dispatchers.nqp
+++ b/src/vm/moar/dispatchers.nqp
@@ -3210,6 +3210,21 @@ nqp::dispatch('boot-syscall', 'dispatcher-register', 'raku-isinvokable', -> $cap
     nqp::dispatch('boot-syscall', 'dispatcher-delegate', 'boot-constant', $delegate);
 });
 
+nqp::dispatch('boot-syscall', 'dispatcher-register', 'raku-definite', -> $capture {
+    my $track-arg := nqp::dispatch('boot-syscall', 'dispatcher-track-arg', $capture, 0);
+    nqp::dispatch('boot-syscall', 'dispatcher-guard-type', $track-arg);
+    nqp::dispatch('boot-syscall', 'dispatcher-guard-concreteness', $track-arg);
+    my $value := nqp::captureposarg($capture, 0);
+    if nqp::isconcrete_nd($value) && nqp::istype_nd($value, Scalar) {
+        nqp::dispatch('boot-syscall', 'dispatcher-guard-concreteness',
+             nqp::dispatch('boot-syscall', 'dispatcher-track-attr', $track-arg, Scalar, '$!value'));
+        $value := nqp::getattr($value, Scalar, '$!value');
+    }
+    nqp::dispatch('boot-syscall', 'dispatcher-delegate', 'boot-constant',
+         nqp::dispatch('boot-syscall', 'dispatcher-insert-arg-literal-obj', $capture, 0,
+            nqp::hllboolfor(nqp::isconcrete($value), 'Raku')));
+});
+
 # Smartmatch support
 {
     my $hllbool     := nqp::getstaticcode(-> $prim { nqp::hllboolfor(nqp::istrue($prim), 'Raku') });


### PR DESCRIPTION
Although this PR patches the legacy parser, but it was inspired by @MasterDuke17 notice about getting rid of `nqp::p6` family altogether for the better optimizations of new-disp approach. So, would make better sense with RakuAST.

Currently needs taking care about `$v.VAR.DEFINITE` case where it erroneously reports `False`. From the point of view of a dispatcher there is no difference if it is `$v.DEFINITE` or `$v.VAR.DEFINITE`. Therefore the most likely solution would be to somehow know that the invocant is a `.VAR` call and signal this fact via an extra argument of the dispatcher.
