### PR TITLE
RakuAST: Use stubby meta for Routine

### DIFF
--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -1365,7 +1365,7 @@ class RakuAST::Routine
   is RakuAST::LexicalScope
   is RakuAST::Term
   is RakuAST::Code
-  is RakuAST::Meta
+  is RakuAST::StubbyMeta
   is RakuAST::Declaration
   is RakuAST::Attaching
   is RakuAST::ImplicitDeclarations
@@ -1390,13 +1390,11 @@ class RakuAST::Routine
 
     method replace-name(RakuAST::Name $new-name) {
         nqp::bindattr(self, RakuAST::Routine, '$!name', $new-name);
-        self.IMPL-RESET-CACHED-META-OBJECT;
         Nil
     }
 
     method replace-signature(RakuAST::Signature $new-signature) {
         nqp::bindattr(self, RakuAST::Routine, '$!signature', $new-signature);
-        self.IMPL-RESET-CACHED-META-OBJECT;
         Nil
     }
 
@@ -1427,8 +1425,12 @@ class RakuAST::Routine
         ])
     }
 
+    method PRODUCE-STUBBED-META-OBJECT() {
+        nqp::create(self.IMPL-META-OBJECT-TYPE)
+    }
+
     method PRODUCE-META-OBJECT() {
-        my $routine := nqp::create(self.IMPL-META-OBJECT-TYPE);
+        my $routine := self.stubbed-meta-object;
         my $signature := self.placeholder-signature || self.signature;
         nqp::bindattr($routine, Code, '$!signature', $signature.meta-object);
         nqp::bindattr($signature.meta-object, Signature, '$!code', $routine);

--- a/src/Raku/ast/meta.rakumod
+++ b/src/Raku/ast/meta.rakumod
@@ -24,10 +24,6 @@ class RakuAST::Meta
     method compile-time-value() {
         self.meta-object
     }
-
-    method IMPL-RESET-CACHED-META-OBJECT() {
-        nqp::bindattr(self, RakuAST::Meta, '$!meta-object-produced', False);
-    }
 }
 
 # Anything doing RakuAST::StubbyMeta is not only capable of producing a


### PR DESCRIPTION
This is much cleaner approach, as it means that anything that has a reference to the stubbed meta object will still have a reference to it after names/types are reset.

Additionally, using this approach resolves two additional spec tests:

```
	t/spec/S32-list/produce.t ......................................... ok
	t/spec/S32-list/reduce.t .......................................... ok
```