### PR TITLE
RakuAST: Make multi subs check for re-declaration of signatures

### DIFF
--- a/src/core.c/Exception.rakumod
+++ b/src/core.c/Exception.rakumod
@@ -1375,6 +1375,15 @@ my class X::Redeclaration::Outer does X::Comp {
     }
 }
 
+my class X::Redeclaration::Multi does X::Comp {
+    has $.symbol;
+    has @.ambiguous;
+    method message() {
+        ("Redeclaration of multi sub '$.symbol' with equivalent signatures would lead to ambiguous dispatch: "
+        ).naive-word-wrapper ~ "\n\t" ~ @!ambiguous.map({ .raku }).join("\n\t")
+    }
+}
+
 my class X::Dynamic::Postdeclaration does X::Comp {
     has $.symbol;
     method message() {


### PR DESCRIPTION
This addresses the oldest existing unsolved ticket in the old issue tracker:

Catch duplicate signatures in a multi sub at compile time, as they will inevitably fail at run-time.

Fixes #5455 