### PR TITLE
Fix some aspects of using `is default`

### DIFF
--- a/src/core.c/Exception.rakumod
+++ b/src/core.c/Exception.rakumod
@@ -1461,7 +1461,7 @@ my class X::Parameter::Default::TypeCheck does X::Comp {
     has $.got is default(Nil);
     has $.expected is default(Nil);
     method message() {
-        "Default value '{Rakudo::Internals.MAYBE-STRING: $!got}' will never bind to a parameter of type {$!expected.^name}"
+        "Default value '{Rakudo::Internals.MAYBE-STRING: $!got}' will never bind to a {$!what} of type {$!expected.^name}"
     }
 }
 

--- a/src/core.c/Exception.rakumod
+++ b/src/core.c/Exception.rakumod
@@ -2892,7 +2892,6 @@ my class X::TypeCheck::Argument is X::TypeCheck {
 
 my class X::TypeCheck::Attribute::Default is X::TypeCheck does X::Comp {
     has str $.name;
-    has $.operation;
     method message {
         self.priors() ~
         (nqp::istype($.expected.HOW, Metamodel::Explaining)

--- a/src/core.c/Hash/Object.rakumod
+++ b/src/core.c/Hash/Object.rakumod
@@ -88,7 +88,7 @@ my role Hash::Object[::TValue, ::TKey] does Associative[TValue] {
             nqp::getattr(self,Map,'$!storage'),
             (my str $WHICH = key.WHICH)
           )),
-          TValue,
+          nqp::getattr(self, Hash, '$!descriptor').default,
           nqp::stmts(
             nqp::deletekey(nqp::getattr(self,Map,'$!storage'),$WHICH),
             nqp::getattr(value,Pair,'$!value')

--- a/t/02-rakudo/13-exceptions.t
+++ b/t/02-rakudo/13-exceptions.t
@@ -7,7 +7,7 @@ plan 14;
 throws-like q<sub foo ( ::T $val ) { my T $a is default($val); }; foo(42)>,
         X::Parameter::Default::TypeCheck,
         "exception isn't lost",
-        message => q<Default value '(Mu)' will never bind to a parameter of type T>;
+        message => q<Default value '(Mu)' will never bind to a variable of type T>;
 
 # https://github.com/Raku/old-issue-tracker/issues/5728
 throws-like q[multi sub f(int $foo is rw) { }; f(42)],


### PR DESCRIPTION
Here is what is taken care of in this PR:

- `(my Int:D %{Str:D} is default(42))<foo>:delete` used to return `Int:D` despite the default. It would now return 42 which puts it in the same league as untyped hashes and arrays, both typed and untyped.
- change the exception thrown when `is default` value type doesn't match attribute's constraint. It used to be `X::TypeCheck::Assignment`, as the default for containers. It is now `X::TypeCheck::Attribute::Default`.
- fix a couple of minor issues with related exceptions
