### PR TITLE
RakuAST: change rakufication of `Rat`s

### DIFF
--- a/src/core.c/Rat.rakumod
+++ b/src/core.c/Rat.rakumod
@@ -1,3 +1,5 @@
+my class Raku { … }
+
 # XXX: should be Rational[Int, uint]
 my class Rat is Cool does Rational[Int, Int] {
     method Rat(Rat:D: Real $? --> Rat:D) {
@@ -24,8 +26,17 @@ my class Rat is Cool does Rational[Int, Int] {
             if $d == 1 and (my $b := self.base(10,*)).Numeric === self {
                 $b;
             }
-            else {
+            elsif Raku.legacy {
                 '<' ~ $!numerator ~ '/' ~ $!denominator ~ '>'
+            }
+            else {
+                if $!numerator div $!denominator -> $wholes {
+                    my $parts := $!numerator - ($!denominator * $wholes);
+                    "$wholes$parts.Str(:superscript)/$!denominator.Str(:subscript)"
+                }
+                else {
+                    "$!numerator.Str(:superscript)/$!denominator.Str(:subscript)"
+                }
             }
         }
     }

--- a/src/core.c/Rat.rakumod
+++ b/src/core.c/Rat.rakumod
@@ -13,13 +13,6 @@ my class Rat is Cool does Rational[Int, Int] {
           FatRat,'$!denominator',$!denominator
         )
     }
-
-    # These vulgars have a composed version and are *not* caught by the
-    # correctly displayable in decimal format.
-    my $composed := nqp::hash(
-       '¹/₃','⅓', '²/₃','⅔', '¹/₆','⅙', '⁵/₆','⅚', '¹/₇','⅐', '¹/₉','⅑'
-    );
-
     multi method raku(Rat:D: --> Str:D) {
         if $!denominator == 1 {
             $!numerator ~ '.0'
@@ -37,17 +30,13 @@ my class Rat is Cool does Rational[Int, Int] {
                 '<' ~ $!numerator ~ '/' ~ $!denominator ~ '>'
             }
             else {
-                my $wholes := $!numerator div $!denominator;
-                my $parts  := ($wholes
-                  ?? $!numerator - ($!denominator * $wholes)
-                  !! $!numerator
-                ).Str(:superscript);
-
-                $parts :=
-                  "$parts.Str(:superscript)/$!denominator.Str(:subscript)";
-                $parts := nqp::ifnull(nqp::atkey($composed,$parts),$parts);
-
-                $wholes ?? $wholes ~ $parts !! $parts
+                if $!numerator div $!denominator -> $wholes {
+                    my $parts := $!numerator - ($!denominator * $wholes);
+                    "$wholes$parts.Str(:superscript)/$!denominator.Str(:subscript)"
+                }
+                else {
+                    "$!numerator.Str(:superscript)/$!denominator.Str(:subscript)"
+                }
             }
         }
     }

--- a/src/core.c/Rat.rakumod
+++ b/src/core.c/Rat.rakumod
@@ -13,6 +13,13 @@ my class Rat is Cool does Rational[Int, Int] {
           FatRat,'$!denominator',$!denominator
         )
     }
+
+    # These vulgars have a composed version and are *not* caught by the
+    # correctly displayable in decimal format.
+    my $composed := nqp::hash(
+       '¹/₃','⅓', '²/₃','⅔', '¹/₆','⅙', '⁵/₆','⅚', '¹/₇','⅐', '¹/₉','⅑'
+    );
+
     multi method raku(Rat:D: --> Str:D) {
         if $!denominator == 1 {
             $!numerator ~ '.0'
@@ -30,13 +37,17 @@ my class Rat is Cool does Rational[Int, Int] {
                 '<' ~ $!numerator ~ '/' ~ $!denominator ~ '>'
             }
             else {
-                if $!numerator div $!denominator -> $wholes {
-                    my $parts := $!numerator - ($!denominator * $wholes);
-                    "$wholes$parts.Str(:superscript)/$!denominator.Str(:subscript)"
-                }
-                else {
-                    "$!numerator.Str(:superscript)/$!denominator.Str(:subscript)"
-                }
+                my $wholes := $!numerator div $!denominator;
+                my $parts  := ($wholes
+                  ?? $!numerator - ($!denominator * $wholes)
+                  !! $!numerator
+                ).Str(:superscript);
+
+                $parts :=
+                  "$parts.Str(:superscript)/$!denominator.Str(:subscript)";
+                $parts := nqp::ifnull(nqp::atkey($composed,$parts),$parts);
+
+                $wholes ?? $wholes ~ $parts !! $parts
             }
         }
     }


### PR DESCRIPTION
If the Rat cannot be displayed using a decimal notation (such as <22/3>), then rakufy as a vulgar: 7¹/₃ instead of <22/3> if the RakuAST grammar is being used.  The RakuAST grammar allows vulgars such as  7¹/₃ to represent <22/3>, so roundtripping is ensured.