### PR TITLE
Add ! twigil to private attribute

### DIFF
--- a/lib/MoarVM/SIL.rakumod
+++ b/lib/MoarVM/SIL.rakumod
@@ -77,7 +77,7 @@ class Not-Inlined {
 class MoarVM::SIL {
     has Bag $.inlineds     is built(:bind);
     has Bag $.not-inlineds is built(:bind);
-    has Int $status        is built(:bind);
+    has Int $!status       is built(:bind);
 
     method sink() { say self.report }
     method report() {


### PR DESCRIPTION
Searching the Rakudo codebase shows that Rakudo consistently uses twigils for all attributes with a single exception (outside of test code).  This PR removes that one exception.

See raku/problem-solving#358 for related discussion of whether non-twigiled attributes should be deprecated 