### PR TITLE
Fix a regression where exception is thrown for a generic type

### DIFF
--- a/src/core.c/Exception.rakumod
+++ b/src/core.c/Exception.rakumod
@@ -2911,7 +2911,7 @@ my class X::TypeCheck::Attribute::Default is X::TypeCheck does X::Comp {
     has str $.name;
     method message {
         self.priors() ~
-        (nqp::istype($.expected.HOW, Metamodel::Explaining)
+        (nqp::istype(self.expected.HOW, Metamodel::Explaining)
             ?? "Can never $.operation default value to attribute '$.name': $.explain"
             !! "Can never $.operation default value $.gotn to attribute '$.name', it expects: $.expectedn")
     }

--- a/src/core.c/traits.rakumod
+++ b/src/core.c/traits.rakumod
@@ -132,7 +132,11 @@ multi sub trait_mod:<is>(Attribute:D $attr, :$required!) {
 multi sub trait_mod:<is>(Attribute:D $attr, Mu :$default!) {
     my Mu $descriptor := $attr.container_descriptor;
     my Mu $of := $descriptor.of;
-    if nqp::istype($default, $of) || nqp::eqaddr($default,Nil) || nqp::eqaddr($of, Mu) {
+    # When either $of or $default are generics we can't actually typecheck the default at compile time. Therefore we'd
+    # have to accept it as is for now.
+    if $of.^archetypes.generic || nqp::istype($default, $of)
+        || nqp::eqaddr($default,Nil) || nqp::eqaddr($of, Mu)
+    {
         $descriptor.set_default(nqp::decont($default));
     }
     else {


### PR DESCRIPTION
Revealed by tests for `OrderedHash:auth<zef:FCO>`.

Two bugs were actually revealed.

First, when the exception generates a message it reads from `$.expected`. But if the type in `expected` doesn't implement method `item` (sometimes it is "doesn't yet" because it could still being composed) then a derived exception gets produced which overshadows the original one.

Second, the trait must not attempt typechecking the default value when either the value, or the constraint type are generics. They could eventually resolve into something valid and passing the typecheck.

Resolves #5472 