### PR TITLE
Move close to complete generic instantiation, iteration 2

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -3854,6 +3854,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
 
         my $of_type := nqp::null;
         my $is_type := nqp::null;
+        my $*IS-TYPE-TRAIT := nqp::null;
 
         $world.handle_OFTYPE_for_pragma($/, $*SCOPE eq 'has' ?? 'attributes' !! 'variables');
         if $*OFTYPE {
@@ -3912,6 +3913,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
                                       $type.HOW.parameterize(
                                         $type, |$params.FLATTENABLE_LIST)
                                     );
+                                    $*IS-TYPE-TRAIT := $trait;
                                     next;  # handled the trait now
                                 }
                             }
@@ -6048,6 +6050,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
                 |%!named_args, |%additional);
         }
 
+        method match() { $!match }
         method mod() { $!trait_mod }
         method args() { @!pos_args }
     }

--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -3960,6 +3960,8 @@ class Perl6::Actions is HLL::Actions does STDActions {
                 my $build-ast := %cont_info<build_ast>;
                 my $build-thunk;
                 if $build-ast.ann('is-generic') {
+                    # If the initializer is a generic type it would need to be resolved into its final value. To do
+                    # so the codeobject must keep the closure to have access to role's arguments.
                     my $bblock := $world.push_lexpad($/);
                     $bblock.blocktype('declaration_static');
                     $bblock.push($build-ast);

--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -3966,7 +3966,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
                     # so the codeobject must keep the closure to have access to role's arguments.
                     my $bblock := $world.push_lexpad($/);
                     $bblock.blocktype('declaration_static');
-                    $bblock.push($build-ast);
+                    $bblock[0].push(QAST::Stmt.new($build-ast));
                     $world.pop_lexpad();
                     $build-thunk := $world.create_code_obj_and_add_child($bblock, 'Code');
                     $world.cur_lexpad()[0].push(

--- a/src/Perl6/Metamodel/ClassHOW.nqp
+++ b/src/Perl6/Metamodel/ClassHOW.nqp
@@ -296,9 +296,6 @@ class Perl6::Metamodel::ClassHOW
 
     # Handles the various dispatch fallback cases we have.
     method find_method_fallback($obj, $name, :$local = 0) {
-        if nqp::getenvhash<RAKUDO_DEBUG> {
-            note("<<< finding method fallback for '", $name, "' on ", $obj.HOW.name($obj), " of ", $obj.HOW.HOW.name($obj.HOW));
-        }
         # If the object is a junction, need to do a junction dispatch.
         if nqp::istype($obj.WHAT, $junction_type) && $junction_autothreader {
             my $p6name := nqp::hllizefor($name, 'Raku');
@@ -361,18 +358,8 @@ class Perl6::Metamodel::ClassHOW
     }
 
     method instantiate_generic($obj, $type_environment) {
-        if nqp::getenvhash<RAKUDO_DEBUG> {
-            note("+++ class instantiation for ", $obj.HOW.name($obj));
-        }
         return $obj if nqp::isnull(my $type-env-type := Perl6::Metamodel::Configuration.type_env_type);
-        if nqp::getenvhash<RAKUDO_DEBUG> {
-            note("+++ class instantiates ", $obj.HOW.name($obj));
-        }
-        my $c := $obj.INSTANTIATE-GENERIC($type-env-type.new-from-ctx($type_environment));
-        if nqp::getenvhash<RAKUDO_DEBUG> {
-            note("+++ class instantiated into ", $c.HOW.name($c));
-        }
-        $c
+        $obj.INSTANTIATE-GENERIC($type-env-type.new-from-ctx($type_environment))
     }
 }
 

--- a/src/Perl6/Metamodel/ClassHOW.nqp
+++ b/src/Perl6/Metamodel/ClassHOW.nqp
@@ -32,14 +32,20 @@ class Perl6::Metamodel::ClassHOW
     has $!composed;
     has $!is_pun;
     has $!pun_source; # If class is coming from a pun then this is the source role
+    has $!archetypes;
 
     my $archetypes := Perl6::Metamodel::Archetypes.new( :nominal, :inheritable, :augmentable );
     my $archetypes-g := Perl6::Metamodel::Archetypes.new( :nominal, :inheritable, :augmentable, :generic );
     method archetypes($obj?) {
+        $!archetypes // $archetypes
+    }
+
+    method refresh_archetypes($obj) {
         my $dcobj := nqp::decont($obj);
-        nqp::can($dcobj, 'is-generic') && $dcobj.is-generic
-            ?? $archetypes-g
-            !! $archetypes
+        $!archetypes :=
+            (nqp::can($dcobj, 'is-generic') && $dcobj.is-generic)
+                ?? $archetypes-g
+                !! $archetypes;
     }
 
     method new(*%named) {
@@ -254,6 +260,8 @@ class Perl6::Metamodel::ClassHOW
         # Compose invocation protocol.
         self.compose_invocation($obj);
 #?endif
+
+        self.refresh_archetypes($obj);
 
         $obj
     }

--- a/src/Perl6/Metamodel/ClassHOW.nqp
+++ b/src/Perl6/Metamodel/ClassHOW.nqp
@@ -33,23 +33,34 @@ class Perl6::Metamodel::ClassHOW
     has $!is_pun;
     has $!pun_source; # If class is coming from a pun then this is the source role
     has $!archetypes;
+    has $!archt-lock;
 
-    my $archetypes := Perl6::Metamodel::Archetypes.new( :nominal, :inheritable, :augmentable );
-    my $archetypes-g := Perl6::Metamodel::Archetypes.new( :nominal, :inheritable, :augmentable, :generic );
-    method archetypes($obj?) {
-        $!archetypes // $archetypes
-    }
+    my $archetypes-ng := Perl6::Metamodel::Archetypes.new( :nominal, :inheritable, :augmentable );
+    my $archetypes-g  := Perl6::Metamodel::Archetypes.new( :nominal, :inheritable, :augmentable, :generic );
 
-    method refresh_archetypes($obj) {
-        my $dcobj := nqp::decont($obj);
-        $!archetypes :=
-            (nqp::can($dcobj, 'is-generic') && $dcobj.is-generic)
-                ?? $archetypes-g
-                !! $archetypes;
+    method archetypes($obj = nqp::null()) {
+#?if moar
+        # The dispatcher itself is declared at the end of this file. We can't have it in the BOOTSTRAP because the
+        # bootstrap process is using archetypes long before dispatchers from dispatchers.nqp gets registered.
+        nqp::dispatch('raku-class-archetypes', self, $obj)
+#?endif
+#?if !moar
+        if nqp::isconcrete(my $dcobj := nqp::decont($obj)) && nqp::can($dcobj, 'is-generic') {
+            return $dcobj.is-generic ?? $archetypes-g !! $archetypes-ng;
+        }
+        $!archetypes // $archetypes-ng
+#?endif
     }
 
     method new(*%named) {
         nqp::findmethod(NQPMu, 'BUILDALL')(nqp::create(self), %named)
+    }
+
+    method !refresh_archetypes($obj) {
+        $!archetypes :=
+            nqp::can($obj, 'is-generic') && $obj.is-generic
+                ?? $archetypes-g
+                !! $archetypes-ng
     }
 
     my $id_lock := NQPLock.new;
@@ -72,6 +83,7 @@ class Perl6::Metamodel::ClassHOW
         $metaclass.set_auth($obj, $auth) if $auth;
         $metaclass.set_api($obj, $api) if $api;
         $metaclass.setup_mixin_cache($obj);
+        nqp::bindattr($metaclass, Perl6::Metamodel::ClassHOW, '$!archt-lock', NQPLock.new);
         nqp::setboolspec($obj, 5, nqp::null());
         $obj
     }
@@ -261,7 +273,7 @@ class Perl6::Metamodel::ClassHOW
         self.compose_invocation($obj);
 #?endif
 
-        self.refresh_archetypes($obj);
+        self.'!refresh_archetypes'($obj);
 
         $obj
     }
@@ -369,6 +381,69 @@ class Perl6::Metamodel::ClassHOW
         return $obj if nqp::isnull(my $type-env-type := Perl6::Metamodel::Configuration.type_env_type);
         $obj.INSTANTIATE-GENERIC($type-env-type.new-from-ctx($type_environment))
     }
+
+#?if moar
+    nqp::dispatch('boot-syscall', 'dispatcher-register', 'raku-class-archetypes', -> $capture {
+        # Returns archetypes of a class or a class instance
+        # Dispatcher arguments:
+        # ClassHOW object
+        # invocator
+        my $how := nqp::captureposarg($capture, 0);
+
+        my $track-how := nqp::dispatch('boot-syscall', 'dispatcher-track-arg', $capture, 0);
+        nqp::dispatch('boot-syscall', 'dispatcher-guard-concreteness', $track-how);
+
+        unless nqp::isconcrete($how) {
+            nqp::dispatch('boot-syscall', 'dispatcher-delegate', 'boot-code-constant', $archetypes-ng);
+        }
+
+        my $obj := nqp::captureposarg($capture, 1);
+        my $track-obj := nqp::dispatch('boot-syscall', 'dispatcher-track-arg', $capture, 1);
+        nqp::dispatch('boot-syscall', 'dispatcher-guard-concreteness', $track-obj);
+        nqp::dispatch('boot-syscall', 'dispatcher-guard-type', $track-obj);
+
+        if nqp::isconcrete_nd($obj) && nqp::iscont($obj) {
+            my $Scalar := nqp::gethllsym('Raku', 'Scalar');
+            my $track-value := nqp::dispatch('boot-syscall', 'dispatcher-track-attr', $track-obj, $Scalar, '$!value');
+            nqp::dispatch('boot-syscall', 'dispatcher-guard-concreteness', $track-value);
+            nqp::dispatch('boot-syscall', 'dispatcher-guard-type', $track-value);
+            $obj := nqp::getattr($obj, $Scalar, '$!value');
+        }
+
+        my $can-is-generic := !nqp::isnull($obj) && nqp::can($obj, 'is-generic');
+        my $atype;
+
+        if nqp::isconcrete($obj) && $can-is-generic {
+            # If invocant of .HOW.archetypes is a concrete object implementing 'is-generic' method then method outcome
+            # is the ultimate result. But we won't cache it in type's HOW $!archetypes.
+            $atype := $obj.is-generic ?? $archetypes-g !! $archetypes-ng;
+        }
+        else {
+            my $track-archetypes-attr :=
+                nqp::dispatch('boot-syscall', 'dispatcher-track-attr',
+                            $track-how, Perl6::Metamodel::ClassHOW, '$!archetypes');
+            nqp::dispatch('boot-syscall', 'dispatcher-guard-concreteness', $track-archetypes-attr);
+
+            $atype := nqp::getattr($how, Perl6::Metamodel::ClassHOW, '$!archetypes');
+        }
+
+        unless nqp::isconcrete($atype) {
+            # * If we still don't have an archetypes object then it means HOW doesn't know its archetypes yet. Therefore
+            #   whatever we determine here is type's ultimate archetypes.
+            # * Also, since we've taken care of a concrete object case then here 'is-generic' is invoked on the type
+            #   itself, not an instance of it.
+            $atype := $can-is-generic && $obj.is-generic ?? $archetypes-g !! $archetypes-ng;
+            nqp::scwbdisable();
+            nqp::getattr($how, Perl6::Metamodel::ClassHOW, '$!archt-lock').protect({
+                nqp::bindattr($how, Perl6::Metamodel::ClassHOW, '$!archetypes', $atype);
+            });
+            nqp::scwbenable();
+        }
+
+        nqp::dispatch('boot-syscall', 'dispatcher-delegate', 'boot-constant',
+            nqp::dispatch('boot-syscall', 'dispatcher-insert-arg-literal-obj', $capture, 0, $atype));
+    });
+#?endif
 }
 
 # vim: expandtab sw=4

--- a/src/Perl6/Metamodel/Configuration.nqp
+++ b/src/Perl6/Metamodel/Configuration.nqp
@@ -87,6 +87,10 @@ class Perl6::Metamodel::Configuration {
     # Register HLL symbol for code which doesn't have direct access to this class. For example, moar/Perl6/Ops.nqp
     # relies on this symbol.
     nqp::bindhllsym('Raku', 'METAMODEL_CONFIGURATION', Perl6::Metamodel::Configuration);
+
+    my $type-env-type := nqp::null();
+    method set_type_env_type($type) { $type-env-type := $type }
+    method type_env_type()          { $type-env-type }
 }
 
 # vim: expandtab sw=4

--- a/src/Perl6/Metamodel/CurriedRoleHOW.nqp
+++ b/src/Perl6/Metamodel/CurriedRoleHOW.nqp
@@ -41,7 +41,7 @@ class Perl6::Metamodel::CurriedRoleHOW
             }
         }
         for %!named_args {
-            if $_.value.HOW.archetypes($_.value).generic {
+            if (my $value := $_.value).HOW.archetypes($value).generic {
                 return $archetypes_g;
             }
         }

--- a/src/Perl6/Metamodel/GenericHOW.nqp
+++ b/src/Perl6/Metamodel/GenericHOW.nqp
@@ -28,11 +28,16 @@ class Perl6::Metamodel::GenericHOW
     method instantiate_generic($obj, $type_environment) {
         my $found := nqp::null();
         my $name := self.name($obj);
-        my $repr := nqp::reprname($type_environment);
-        if $repr eq 'MVMContext' {
+        my $te-kind := $type_environment.HOW.name($type_environment);
+#?if !jvm
+        if $te-kind eq 'BOOTContext' {
+#?endif
+#?if jvm
+        if $te-kind eq 'ContextRef' {
+#?endif
             $found := nqp::getlexrel($type_environment, $name);
         }
-        elsif $repr eq 'VMHash' {
+        elsif $te-kind eq 'BOOTHash' {
             $found := nqp::atkey($type_environment, $name);
         }
         elsif nqp::isconcrete($type_environment) && $type_environment.EXISTS-KEY($name) {

--- a/src/Perl6/Metamodel/GenericHOW.nqp
+++ b/src/Perl6/Metamodel/GenericHOW.nqp
@@ -26,8 +26,18 @@ class Perl6::Metamodel::GenericHOW
     }
 
     method instantiate_generic($obj, $type_environment) {
+        my $found := nqp::null();
         my $name := self.name($obj);
-        my $found := nqp::getlexrel($type_environment, $name);
+        my $repr := nqp::reprname($type_environment);
+        if $repr eq 'MVMContext' {
+            $found := nqp::getlexrel($type_environment, $name);
+        }
+        elsif $repr eq 'VMHash' {
+            $found := nqp::atkey($type_environment, $name);
+        }
+        elsif nqp::isconcrete($type_environment) && $type_environment.EXISTS-KEY($name) {
+            $found := nqp::decont($type_environment.AT-KEY($name));
+        }
         nqp::isnull($found) ?? $obj !! $found
     }
 

--- a/src/Perl6/Metamodel/MultipleInheritance.nqp
+++ b/src/Perl6/Metamodel/MultipleInheritance.nqp
@@ -49,6 +49,10 @@ role Perl6::Metamodel::MultipleInheritance {
                     $parent.HOW.name($parent) ~ "'");
             }
         }
+        # With a new parent full method list would have to be refreshed.
+        if nqp::istype(self, Perl6::Metamodel::MROBasedMethodDispatch) {
+            self.invalidate_method_caches($obj);
+        }
         if $hides {
             @!hides[+@!hides] := $parent;
         }

--- a/src/Perl6/Metamodel/ParametricRoleHOW.nqp
+++ b/src/Perl6/Metamodel/ParametricRoleHOW.nqp
@@ -198,14 +198,8 @@ class Perl6::Metamodel::ParametricRoleHOW
         # Go through attributes, reifying as needed and adding to
         # the concrete role.
         for self.attributes($obj, :local(1)) {
-            if nqp::getenvhash<RAKUDO_DEBUG> {
-                nqp::say("+++ ATTR " ~ $_.HOW.name($_) ~ " " ~ $_.name() ~ " of " ~ $obj.HOW.name($obj) ~ " is generic? " ~ $_.is_generic);
-            }
             $conc.HOW.add_attribute($conc,
                 (my $ins := $_.is_generic ?? $_.instantiate_generic($type_env) !! nqp::clone($_)));
-            if nqp::getenvhash<RAKUDO_DEBUG> {
-                nqp::say("+++ done with " ~ $_.name() ~ ": " ~ nqp::objectid($_) ~ " -> " ~ nqp::objectid($ins));
-            }
         }
 
         # Go through methods and instantiate them; we always do this

--- a/src/Perl6/Metamodel/ParametricRoleHOW.nqp
+++ b/src/Perl6/Metamodel/ParametricRoleHOW.nqp
@@ -198,8 +198,14 @@ class Perl6::Metamodel::ParametricRoleHOW
         # Go through attributes, reifying as needed and adding to
         # the concrete role.
         for self.attributes($obj, :local(1)) {
+            if nqp::getenvhash<RAKUDO_DEBUG> {
+                nqp::say("+++ ATTR " ~ $_.HOW.name($_) ~ " " ~ $_.name() ~ " of " ~ $obj.HOW.name($obj) ~ " is generic? " ~ $_.is_generic);
+            }
             $conc.HOW.add_attribute($conc,
-                $_.is_generic ?? $_.instantiate_generic($type_env) !! nqp::clone($_));
+                (my $ins := $_.is_generic ?? $_.instantiate_generic($type_env) !! nqp::clone($_)));
+            if nqp::getenvhash<RAKUDO_DEBUG> {
+                nqp::say("+++ done with " ~ $_.name() ~ ": " ~ nqp::objectid($_) ~ " -> " ~ nqp::objectid($ins));
+            }
         }
 
         # Go through methods and instantiate them; we always do this

--- a/src/Perl6/Metamodel/ParametricRoleHOW.nqp
+++ b/src/Perl6/Metamodel/ParametricRoleHOW.nqp
@@ -199,7 +199,7 @@ class Perl6::Metamodel::ParametricRoleHOW
         # the concrete role.
         for self.attributes($obj, :local(1)) {
             $conc.HOW.add_attribute($conc,
-                (my $ins := $_.is_generic ?? $_.instantiate_generic($type_env) !! nqp::clone($_)));
+                $_.is_generic ?? $_.instantiate_generic($type_env) !! nqp::clone($_));
         }
 
         # Go through methods and instantiate them; we always do this

--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -1935,9 +1935,6 @@ class Perl6::World is HLL::World {
                 %info<default_value>  := self.find_single_symbol_in_setting('Any');
             }
             if $shape || @cont_type {
-                if nqp::getenvhash<RAKUDO_DEBUG> {
-                    note("+++ container type: ", %info<container_type>.HOW.name(%info<container_type>));
-                }
                 my $cont_type := %info<container_type>;
                 my $ast := QAST::Op.new(
                     :op('callmethod'), :name('new'),

--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -1905,6 +1905,45 @@ class Perl6::World is HLL::World {
         @value_type[0] := nqp::decont(@value_type[0]) if @value_type;
         @cont_type[0] := nqp::decont(@cont_type[0]) if @cont_type;
 
+        my sub containter-init-ast($cont_type) {
+            my $new-ast;
+            my $is-generic := 0;
+            if $cont_type.HOW.archetypes.generic {
+                $is-generic := 1;
+                if (my $trait := $*IS-TYPE-TRAIT) && $trait.match()<circumfix> -> $circumfix {
+                    # When it is `is Type[Param1, ...]` then the parameterization of a generic is better be done
+                    # once when body block is being ran. For this we install a lexical to which the result of
+                    # parameterization is bound.
+                    my $BLOCK := $*CURPAD // $*W.cur_lexpad();
+                    my $ins_lexical := QAST::Node.unique('__type_ins_');
+                    my $params-ast := QAST::Op.new( :op<callmethod>, :name<FLATTENABLE_LIST>,
+                                                    $circumfix[0].ast.shallow_clone );
+                    $params-ast.flat(1);
+                    my $type-ast := QAST::WVal.new( :value($trait.args[0]) );
+                    $BLOCK[0].push(
+                        QAST::Op.new(
+                            :op<bind>,
+                            QAST::Var.new( :name($ins_lexical), :scope<lexical>, :decl<var> ),
+                            QAST::Op.new(
+                                :op<callmethod>, :name<parameterize>,
+                                QAST::Op.new( :op<how>, $type-ast ),
+                                $type-ast, $params-ast )
+                        )
+                    );
+                    $new-ast := QAST::Var.new( :name($ins_lexical), :scope<lexical> );
+                }
+                else {
+                    $new-ast := QAST::Var.new( :name($cont_type.HOW.name($cont_type)), :scope<lexical> );
+                }
+            }
+            else {
+                $new-ast := QAST::WVal.new( :value($cont_type) );
+            }
+            my $ast := QAST::Op.new( :op('callmethod'), :name('new'), $new-ast );
+            $ast.annotate('is-generic', $is-generic);
+            $ast
+        }
+
         for @post -> $con {
             @value_type[0] := self.create_subset(self.resolve_mo($/, 'subset'),
                 @value_type ?? @value_type[0] !! self.find_single_symbol_in_setting('Mu'),
@@ -1935,14 +1974,7 @@ class Perl6::World is HLL::World {
                 %info<default_value>  := self.find_single_symbol_in_setting('Any');
             }
             if $shape || @cont_type {
-                my $cont_type := %info<container_type>;
-                my $ast := QAST::Op.new(
-                    :op('callmethod'), :name('new'),
-                    ((my $is-generic := $cont_type.HOW.archetypes.generic)
-                        ?? QAST::Var.new( :name($cont_type.HOW.name($cont_type)), :scope<lexical> )
-                        !! QAST::WVal.new( :value(%info<container_type>) ))
-                );
-                $ast.annotate('is-generic', $is-generic);
+                my $ast := containter-init-ast(%info<container_type>);
                 if $shape {
                     my $shape_ast := $shape[0].ast;
                     $shape_ast.named('shape');
@@ -2007,15 +2039,7 @@ class Perl6::World is HLL::World {
                 %info<default_value>  := self.find_single_symbol_in_setting('Any');
             }
             if @cont_type {
-                my $cont_type := %info<container_type>;
-                my $ast := QAST::Op.new(
-                    :op('callmethod'), :name('new'),
-                    ((my $is-generic := $cont_type.HOW.archetypes.generic)
-                        ?? QAST::Var.new( :name($cont_type.HOW.name($cont_type)), :scope<lexical> )
-                        !! QAST::WVal.new( :value(%info<container_type>) ))
-                );
-                $ast.annotate('is-generic', $is-generic);
-                %info<build_ast> := $ast;
+                %info<build_ast> := containter-init-ast(%info<container_type>);
             }
         }
         elsif $sigil eq '&' {

--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -1935,10 +1935,17 @@ class Perl6::World is HLL::World {
                 %info<default_value>  := self.find_single_symbol_in_setting('Any');
             }
             if $shape || @cont_type {
+                if nqp::getenvhash<RAKUDO_DEBUG> {
+                    note("+++ container type: ", %info<container_type>.HOW.name(%info<container_type>));
+                }
+                my $cont_type := %info<container_type>;
                 my $ast := QAST::Op.new(
                     :op('callmethod'), :name('new'),
-                    QAST::WVal.new( :value(%info<container_type>) )
+                    ((my $is-generic := $cont_type.HOW.archetypes.generic)
+                        ?? QAST::Var.new( :name($cont_type.HOW.name($cont_type)), :scope<lexical> )
+                        !! QAST::WVal.new( :value(%info<container_type>) ))
                 );
+                $ast.annotate('is-generic', $is-generic);
                 if $shape {
                     my $shape_ast := $shape[0].ast;
                     $shape_ast.named('shape');

--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -2007,10 +2007,15 @@ class Perl6::World is HLL::World {
                 %info<default_value>  := self.find_single_symbol_in_setting('Any');
             }
             if @cont_type {
-                %info<build_ast> := QAST::Op.new(
+                my $cont_type := %info<container_type>;
+                my $ast := QAST::Op.new(
                     :op('callmethod'), :name('new'),
-                    QAST::WVal.new( :value(%info<container_type>) )
+                    ((my $is-generic := $cont_type.HOW.archetypes.generic)
+                        ?? QAST::Var.new( :name($cont_type.HOW.name($cont_type)), :scope<lexical> )
+                        !! QAST::WVal.new( :value(%info<container_type>) ))
                 );
+                $ast.annotate('is-generic', $is-generic);
+                %info<build_ast> := $ast;
             }
         }
         elsif $sigil eq '&' {

--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -1908,7 +1908,7 @@ class Perl6::World is HLL::World {
         my sub containter-init-ast($cont_type) {
             my $new-ast;
             my $is-generic := 0;
-            if $cont_type.HOW.archetypes.generic {
+            if $*SCOPE eq 'has' && $cont_type.HOW.archetypes.generic {
                 $is-generic := 1;
                 if (my $trait := $*IS-TYPE-TRAIT) && $trait.match()<circumfix> -> $circumfix {
                     # When it is `is Type[Param1, ...]` then the parameterization of a generic is better be done

--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -1921,14 +1921,14 @@ class Perl6::World is HLL::World {
                     $params-ast.flat(1);
                     my $type-ast := QAST::WVal.new( :value($trait.args[0]) );
                     $BLOCK[0].push(
-                        QAST::Op.new(
-                            :op<bind>,
-                            QAST::Var.new( :name($ins_lexical), :scope<lexical>, :decl<var> ),
+                        QAST::Stmt.new(
                             QAST::Op.new(
-                                :op<callmethod>, :name<parameterize>,
-                                QAST::Op.new( :op<how>, $type-ast ),
-                                $type-ast, $params-ast )
-                        )
+                                :op<bind>,
+                                QAST::Var.new( :name($ins_lexical), :scope<lexical>, :decl<var> ),
+                                QAST::Op.new(
+                                    :op<callmethod>, :name<parameterize>,
+                                    QAST::Op.new( :op<how>, $type-ast ),
+                                    $type-ast, $params-ast )))
                     );
                     $new-ast := QAST::Var.new( :name($ins_lexical), :scope<lexical> );
                 }

--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -1730,9 +1730,6 @@ BEGIN {
                 || nqp::defined($build), "Raku");
         }));
     Attribute.HOW.add_method(Attribute, 'instantiate_generic', nqp::getstaticcode(sub ($self, $type_environment) {
-        if nqp::getenvhash<RAKUDO_DEBUG> {
-            nqp::say("^^^ instantiating attribute " ~ $self.name());
-        }
             my $dcself   := nqp::decont($self);
             my $type     := nqp::getattr($dcself, Attribute, '$!type');
             my $cd       := nqp::getattr($dcself, Attribute, '$!container_descriptor');
@@ -1755,17 +1752,6 @@ BEGIN {
                 $avcv := nqp::create(ScalarVAR);
                 nqp::bindattr($avcv, Scalar, '$!value', $avc);
             }
-            if nqp::getenvhash<RAKUDO_DEBUG> && nqp::iscont($avc) {
-                nqp::say("TRY avcv instantiate_generic on " ~ nqp::how_nd($avcv).name($avcv) ~ " for " ~ $self.name());
-                nqp::say(". is generic avcv? " ~ $avcv.is_generic());
-                $avcv.instantiate_generic($type_environment);
-            }
-            if nqp::getenvhash<RAKUDO_DEBUG> {
-                nqp::say("===  AVC: " ~ $avc.HOW.name($avc) ~ " of " ~ $avc.HOW.HOW.name($avc.HOW) ~ "\n"
-                       ~ "=== TYPE: " ~ $type.HOW.name($type) ~ " of " ~ $type.HOW.HOW.name($type.HOW)
-                       ~ " --> " ~ $ins.type.HOW.name($ins.type)
-                );
-            }
             my $avc_copy := nqp::iscont($avc)
                                 ?? ($avcv.is_generic()
                                     ?? $avcv.instantiate_generic($type_environment)
@@ -1774,14 +1760,6 @@ BEGIN {
                                     ?? $avc.HOW.instantiate_generic($avc, $type_environment)
                                     !! $avc);
             unless nqp::eqaddr($avc_copy, $avc) {
-                if nqp::getenvhash<RAKUDO_DEBUG> {
-                    nqp::say(
-                        nqp::join("",
-                            ("AVC for ", $self.name, ": ", $avc.HOW.name($avc), " --> ", nqp::how_nd($avc_copy).name($avc_copy), " of ", $avc_copy.HOW.name($avc_copy), "\n",
-                            "    is container? ", ~nqp::iscont($avc), " --> ", ~nqp::iscont($avc_copy),
-                            (nqp::iscont($avc) ?? " // " ~ $avcv.name() !! "")
-                        )));
-                }
                 if nqp::isconcrete_nd($avc_copy) {
                     my @avc_mro  := nqp::how_nd($avc_copy).mro($avc_copy);
                     my int $i := 0;
@@ -1817,9 +1795,6 @@ BEGIN {
     }));
     Scalar.HOW.add_method(Scalar, 'instantiate_generic', nqp::getstaticcode(sub ($self, $type_environment) {
         my $dcself := nqp::decont($self);
-        if nqp::getenvhash<RAKUDO_DEBUG> {
-            nqp::say("INSTANTIATING Scalar of " ~ nqp::how_nd($dcself).name($dcself));
-        }
         nqp::bindattr($dcself, Scalar, '$!descriptor',
             nqp::getattr($dcself, Scalar, '$!descriptor').instantiate_generic(
                 $type_environment));

--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -77,6 +77,7 @@ my stub array metaclass Perl6::Metamodel::ClassHOW is repr('VMArray') { ... };
 my stub IterationBuffer metaclass Perl6::Metamodel::ClassHOW is repr('VMArray') { ... };
 my stub Map metaclass Perl6::Metamodel::ClassHOW { ... };
 my stub Hash metaclass Perl6::Metamodel::ClassHOW { ... };
+my stub TypeEnv metaclass Perl6::Metamodel::ClassHOW { ... };
 my stub Capture metaclass Perl6::Metamodel::ClassHOW { ... };
 my stub Bool metaclass Perl6::Metamodel::EnumHOW { ... };
 my stub ObjAt metaclass Perl6::Metamodel::ClassHOW { ... };
@@ -1196,7 +1197,7 @@ class ContainerDescriptor does Perl6::Metamodel::Explaining {
     method set_dynamic($dynamic) { $!dynamic := $dynamic; self }
 
     method is_generic() {
-        $!of.HOW.archetypes($!of).generic
+        $!of.HOW.archetypes($!of).generic || $!default.HOW.archetypes($!default).generic
     }
 
     method is_default_generic() {
@@ -1204,7 +1205,10 @@ class ContainerDescriptor does Perl6::Metamodel::Explaining {
     }
 
     method instantiate_generic($type_environment) {
-        my $ins_of := $!of.HOW.instantiate_generic($!of, $type_environment);
+        my $ins_of :=
+            $!of.HOW.archetypes.generic
+                ?? $!of.HOW.instantiate_generic($!of, $type_environment)
+                !! $!of;
         my $ins_default := self.is_default_generic ?? $!default.HOW.instantiate_generic($!default, $type_environment) !! $!default;
         my $ins := nqp::clone(self);
         nqp::bindattr($ins, $?CLASS, '$!of', $ins_of);
@@ -1726,6 +1730,9 @@ BEGIN {
                 || nqp::defined($build), "Raku");
         }));
     Attribute.HOW.add_method(Attribute, 'instantiate_generic', nqp::getstaticcode(sub ($self, $type_environment) {
+        if nqp::getenvhash<RAKUDO_DEBUG> {
+            nqp::say("^^^ instantiating attribute " ~ $self.name());
+        }
             my $dcself   := nqp::decont($self);
             my $type     := nqp::getattr($dcself, Attribute, '$!type');
             my $cd       := nqp::getattr($dcself, Attribute, '$!container_descriptor');
@@ -1736,13 +1743,54 @@ BEGIN {
             if $type.HOW.archetypes($type).generic {
                 nqp::bindattr($ins, Attribute, '$!type',
                     $type.HOW.instantiate_generic($type, $type_environment));
-                my $cd_ins := $cd.instantiate_generic($type_environment);
+            }
+            my $cd_ins := $cd;
+            if $cd.is_generic {
+                $cd_ins := $cd.instantiate_generic($type_environment);
                 nqp::bindattr($ins, Attribute, '$!container_descriptor', $cd_ins);
-                my $avc_copy := nqp::clone_nd($avc);
-                my @avc_mro  := nqp::how_nd($avc).mro($avc);
-                my int $i := 0;
-                $i := $i + 1 while @avc_mro[$i].HOW.is_mixin(@avc_mro[$i]);
-                nqp::bindattr($avc_copy, @avc_mro[$i], '$!descriptor', $cd_ins);
+            }
+            my $avcv := $avc;
+            if nqp::iscont($avc) {
+                # If $avc is a container then simulate nqp::p6var (.VAR) behavior
+                $avcv := nqp::create(ScalarVAR);
+                nqp::bindattr($avcv, Scalar, '$!value', $avc);
+            }
+            if nqp::getenvhash<RAKUDO_DEBUG> && nqp::iscont($avc) {
+                nqp::say("TRY avcv instantiate_generic on " ~ nqp::how_nd($avcv).name($avcv) ~ " for " ~ $self.name());
+                nqp::say(". is generic avcv? " ~ $avcv.is_generic());
+                $avcv.instantiate_generic($type_environment);
+            }
+            if nqp::getenvhash<RAKUDO_DEBUG> {
+                nqp::say("===  AVC: " ~ $avc.HOW.name($avc) ~ " of " ~ $avc.HOW.HOW.name($avc.HOW) ~ "\n"
+                       ~ "=== TYPE: " ~ $type.HOW.name($type) ~ " of " ~ $type.HOW.HOW.name($type.HOW)
+                       ~ " --> " ~ $ins.type.HOW.name($ins.type)
+                );
+            }
+            my $avc_copy := nqp::iscont($avc)
+                                ?? ($avcv.is_generic()
+                                    ?? $avcv.instantiate_generic($type_environment)
+                                    !! nqp::clone_nd($avc))
+                                !! ($avc.HOW.archetypes.generic || $type.HOW.archetypes.generic
+                                    ?? $avc.HOW.instantiate_generic($avc, $type_environment)
+                                    !! $avc);
+            unless nqp::eqaddr($avc_copy, $avc) {
+                if nqp::getenvhash<RAKUDO_DEBUG> {
+                    nqp::say(
+                        nqp::join("",
+                            ("AVC for ", $self.name, ": ", $avc.HOW.name($avc), " --> ", nqp::how_nd($avc_copy).name($avc_copy), " of ", $avc_copy.HOW.name($avc_copy), "\n",
+                            "    is container? ", ~nqp::iscont($avc), " --> ", ~nqp::iscont($avc_copy),
+                            (nqp::iscont($avc) ?? " // " ~ $avcv.name() !! "")
+                        )));
+                }
+                if nqp::isconcrete_nd($avc_copy) {
+                    my @avc_mro  := nqp::how_nd($avc_copy).mro($avc_copy);
+                    my int $i := 0;
+                    my $avc_mro;
+                    $i := $i + 1 while ($avc_mro := @avc_mro[$i]).HOW.is_mixin($avc_mro);
+                    if $avc_mro.HOW.has_attribute($avc_mro, '$!descriptor') {
+                        nqp::bindattr($avc_copy, $avc_mro, '$!descriptor', $cd_ins);
+                    }
+                }
                 nqp::bindattr($ins, Attribute, '$!auto_viv_container', $avc_copy);
             }
             if $pkg.HOW.archetypes($pkg).generic {
@@ -1764,10 +1812,14 @@ BEGIN {
     Scalar.HOW.add_attribute(Scalar, BOOTSTRAPATTR.new(:name<$!value>, :type(Mu), :package(Scalar)));
     Scalar.HOW.add_method(Scalar, 'is_generic', nqp::getstaticcode(sub ($self) {
         my $dcself := nqp::decont($self);
-        nqp::getattr($dcself, Scalar, '$!descriptor').is_generic()
+        my $descr := nqp::getattr($dcself, Scalar, '$!descriptor');
+        $descr.is_generic() || $descr.is_default_generic()
     }));
     Scalar.HOW.add_method(Scalar, 'instantiate_generic', nqp::getstaticcode(sub ($self, $type_environment) {
         my $dcself := nqp::decont($self);
+        if nqp::getenvhash<RAKUDO_DEBUG> {
+            nqp::say("INSTANTIATING Scalar of " ~ nqp::how_nd($dcself).name($dcself));
+        }
         nqp::bindattr($dcself, Scalar, '$!descriptor',
             nqp::getattr($dcself, Scalar, '$!descriptor').instantiate_generic(
                 $type_environment));
@@ -3760,6 +3812,11 @@ BEGIN {
     Hash.HOW.compose_repr(Hash);
     nqp::settypehllrole(Hash, 5);
 
+    # my class TypeEnv is Map {
+    TypeEnv.HOW.add_parent(TypeEnv, Map);
+    TypeEnv.HOW.compose_repr(TypeEnv);
+    nqp::settypehllrole(TypeEnv, 5);
+
     # class Capture is Any {
     #     has @!list;
     #     has %!hash;
@@ -3888,6 +3945,7 @@ BEGIN {
     Perl6::Metamodel::ClassHOW.add_stash(IterationBuffer);
     Perl6::Metamodel::ClassHOW.add_stash(Map);
     Perl6::Metamodel::ClassHOW.add_stash(Hash);
+    Perl6::Metamodel::ClassHOW.add_stash(TypeEnv);
     Perl6::Metamodel::ClassHOW.add_stash(Capture);
     Perl6::Metamodel::EnumHOW.add_stash(Bool);
     Perl6::Metamodel::ClassHOW.add_stash(ObjAt);
@@ -4003,6 +4061,7 @@ BEGIN {
     EXPORT::DEFAULT.WHO<IterationBuffer> := IterationBuffer;
     EXPORT::DEFAULT.WHO<Map>        := Map;
     EXPORT::DEFAULT.WHO<Hash>       := Hash;
+    EXPORT::DEFAULT.WHO<TypeEnv>    := TypeEnv;
     EXPORT::DEFAULT.WHO<Capture>    := Capture;
     EXPORT::DEFAULT.WHO<ObjAt>      := ObjAt;
     EXPORT::DEFAULT.WHO<ValueObjAt> := ValueObjAt;

--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -1206,7 +1206,7 @@ class ContainerDescriptor does Perl6::Metamodel::Explaining {
 
     method instantiate_generic($type_environment) {
         my $ins_of :=
-            $!of.HOW.archetypes.generic
+            $!of.HOW.archetypes($!of).generic
                 ?? $!of.HOW.instantiate_generic($!of, $type_environment)
                 !! $!of;
         my $ins_default := self.is_default_generic ?? $!default.HOW.instantiate_generic($!default, $type_environment) !! $!default;

--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -1756,7 +1756,7 @@ BEGIN {
                                 ?? ($avcv.is_generic()
                                     ?? $avcv.instantiate_generic($type_environment)
                                     !! nqp::clone_nd($avc))
-                                !! ($avc.HOW.archetypes.generic || $type.HOW.archetypes.generic
+                                !! (($avc.HOW.archetypes.generic || $avc.is-generic || $type.HOW.archetypes.generic)
                                     ?? $avc.HOW.instantiate_generic($avc, $type_environment)
                                     !! $avc);
             unless nqp::eqaddr($avc_copy, $avc) {

--- a/src/core.c/Array.rakumod
+++ b/src/core.c/Array.rakumod
@@ -1450,6 +1450,17 @@ my class Array { # declared in BOOTSTRAP
         nqp::bindattr(self, Array, '$!descriptor', nqp::getattr(handle, LTHandle, '$!descriptor'));
     }
 
+    proto method is-generic {*}
+    multi method is-generic(::?CLASS:U:) { False }
+    multi method is-generic(::?CLASS:D:) { nqp::hllbool($!descriptor.is_generic) }
+
+    multi method INSTANTIATE-GENERIC(::?CLASS:D: TypeEnv:D \type-environment) is raw {
+        $!descriptor.is_generic
+            ??  nqp::p6bindattrinvres(
+                    self.clone, Array, '$!descriptor', type-environment.instantiate($!descriptor) )
+            !! self.clone
+    }
+
     method ^parameterize(Mu:U \arr, Mu \of) {
         if nqp::isconcrete(of) {
             die "Can not parameterize {arr.^name} with {of.raku}"

--- a/src/core.c/Array/Typed.rakumod
+++ b/src/core.c/Array/Typed.rakumod
@@ -100,17 +100,9 @@ my role Array::Typed[::TValue] does Positional[TValue] {
     method is-generic { nqp::hllbool(nqp::istrue(TValue.^archetypes.generic)) }
 
     multi method INSTANTIATE-GENERIC(::?CLASS:U: TypeEnv:D \type-environment) is raw {
-        if nqp::getenvhash<RAKUDO_DEBUG> {
-            note "INSTANTIATING type ", self.^name, " with ", type-environment.WHICH,
-                " where TValue is ", type-environment<TValue>.^name;
-        }
         Array.^parameterize: type-environment.instantiate(TValue)
     }
     multi method INSTANTIATE-GENERIC(::?CLASS:D: TypeEnv:D \type-environment) is raw {
-        if nqp::getenvhash<RAKUDO_DEBUG> {
-            note "INSTANTIATING object ", self.^name, " with ", type-environment.WHICH,
-                " where TValue is ", type-environment<TValue>.^name;
-        }
         Array.^parameterize(type-environment.instantiate(TValue)).new: |(self.elems ?? self !! Empty)
     }
 

--- a/src/core.c/Array/Typed.rakumod
+++ b/src/core.c/Array/Typed.rakumod
@@ -97,13 +97,16 @@ my role Array::Typed[::TValue] does Positional[TValue] {
         )
     }
 
-    method is-generic { nqp::hllbool(nqp::istrue(TValue.^archetypes.generic)) }
+    method is-generic { nqp::hllbool(callsame() || nqp::istrue(TValue.^archetypes.generic)) }
 
     multi method INSTANTIATE-GENERIC(::?CLASS:U: TypeEnv:D \type-environment) is raw {
         Array.^parameterize: type-environment.instantiate(TValue)
     }
     multi method INSTANTIATE-GENERIC(::?CLASS:D: TypeEnv:D \type-environment) is raw {
-        Array.^parameterize(type-environment.instantiate(TValue)).new: |(self.elems ?? self !! Empty)
+        my Mu $descr := type-environment.instantiate(nqp::getattr(self, Array, '$!descriptor'));
+        nqp::p6bindattrinvres(
+            Array.^parameterize(type-environment.instantiate(TValue)).new( |(self.elems ?? self !! Empty) ),
+            Array, '$!descriptor', $descr )
     }
 
     multi method raku(::?CLASS:D:) {

--- a/src/core.c/Bag.rakumod
+++ b/src/core.c/Bag.rakumod
@@ -2,11 +2,8 @@ my class Bag does Baggy {
     has ValueObjAt $!WHICH;
     has Int        $!total;
 
-    my role KeyOf[::CONSTRAINT] {
-        method keyof() { CONSTRAINT }
-    }
     method ^parameterize(Mu \base, Mu \type) {
-        my \what := base.^mixin(KeyOf[type]);
+        my \what := base.^mixin(QuantHash::KeyOf[type]);
         what.^set_name(base.^name ~ '[' ~ type.^name ~ ']');
         what
     }

--- a/src/core.c/BagHash.rakumod
+++ b/src/core.c/BagHash.rakumod
@@ -1,10 +1,7 @@
 my class BagHash does Baggy {
 
-    my role KeyOf[::CONSTRAINT] {
-        method keyof() { CONSTRAINT }
-    }
     method ^parameterize(Mu \base, Mu \type) {
-        my \what := base.^mixin(KeyOf[type]);
+        my \what := base.^mixin(QuantHash::KeyOf[type]);
         what.^set_name(base.^name ~ '[' ~ type.^name ~ ']');
         what
     }

--- a/src/core.c/CompUnit/PrecompilationRepository.rakumod
+++ b/src/core.c/CompUnit/PrecompilationRepository.rakumod
@@ -59,8 +59,9 @@ class CompUnit::PrecompilationRepository::Default
 
         my ($handle, $checksum) = (
             self.may-precomp and (
-                my $precomped := self.load($id, :source($source), :checksum($dependency.checksum), :@precomp-stores) # already precompiled?
-                or self.precompile($source, $id, :source-name($dependency.source-name), :force(nqp::hllbool(nqp::istype($precomped,Failure))), :@precomp-stores)
+                my $precomped :=
+                    self.load($id, :source($source), :checksum($dependency.checksum), :@precomp-stores) # already precompiled?
+                    or self.precompile($source, $id, :source-name($dependency.source-name), :force(nqp::hllbool(nqp::istype($precomped,Failure))), :@precomp-stores)
                     and self.load($id, :@precomp-stores) # if not do it now
             )
         );

--- a/src/core.c/Exception.rakumod
+++ b/src/core.c/Exception.rakumod
@@ -2698,7 +2698,7 @@ my class X::Cannot::Empty is Exception {
     }
 }
 my class X::Cannot::New is Exception {
-    has $.class;
+    has Mu $.class is built(:bind);
     method message() {
         "Cannot make a {$.class.^name} object using .new";
     }

--- a/src/core.c/Hash.rakumod
+++ b/src/core.c/Hash.rakumod
@@ -433,6 +433,17 @@ my class Hash { # declared in BOOTSTRAP
         nqp::bindattr(self, Map, '$!storage', nqp::getattr(handle, LTHandle, '$!storage'));
     }
 
+    proto method is-generic {*}
+    multi method is-generic(::?CLASS:U:) { False }
+    multi method is-generic(::?CLASS:D:) { nqp::hllbool($!descriptor.is_generic) }
+
+    multi method INSTANTIATE-GENERIC(::?CLASS:D: TypeEnv:D \type-environment) is raw {
+        $!descriptor.is_generic
+            ??  nqp::p6bindattrinvres(
+                    self.clone, Hash, '$!descriptor', type-environment.instantiate($!descriptor) )
+            !! self.clone
+    }
+
     method ^parameterize(Mu:U \hash, Mu \of, Mu \keyof = Str(Any)) {
 
         # fast path

--- a/src/core.c/Hash/Object.rakumod
+++ b/src/core.c/Hash/Object.rakumod
@@ -259,6 +259,18 @@ my role Hash::Object[::TValue, ::TKey] does Associative[TValue] {
         )
     }
 
+    method is-generic {
+        nqp::hllbool(
+            nqp::istrue(TValue.^archetypes.generic)
+            || nqp::istrue(TKey.^archetypes.generic))
+    }
+
+    multi method INSTANTIATE-GENERIC(::?CLASS:U: TypeEnv:D \type-environment --> Associative) is raw {
+        Hash.^parameterize:
+            type-environment.instantiate(TValue),
+            type-environment.instantiate(TKey)
+    }
+
     multi method raku(::?CLASS:D \SELF:) {
         SELF.rakuseen('Hash', {
             my $TKey-perl   := TKey.raku;

--- a/src/core.c/Hash/Object.rakumod
+++ b/src/core.c/Hash/Object.rakumod
@@ -259,15 +259,22 @@ my role Hash::Object[::TValue, ::TKey] does Associative[TValue] {
         )
     }
 
-    method is-generic { nqp::hllbool(TValue.^archetypes.generic || TKey.^archetypes.generic) }
+    method is-generic {
+        nqp::hllbool(
+            callsame()
+            || TValue.^archetypes.generic
+            || TKey.^archetypes.generic )
+    }
 
     multi method INSTANTIATE-GENERIC(::?CLASS:U: TypeEnv:D \type-environment --> Associative) is raw {
         Hash.^parameterize: type-environment.instantiate(TValue), type-environment.instantiate(TKey)
     }
 
     multi method INSTANTIATE-GENERIC(::?CLASS:D: TypeEnv:D \type-environment --> Associative) is raw {
-        Hash.^parameterize( type-environment.instantiate(TValue),
-                            type-environment.instantiate(TKey) ).new(self)
+        my Mu $descr := type-environment.instantiate( nqp::getattr(self, Hash, '$!descriptor') );
+        nqp::p6bindattrinvres(
+            Hash.^parameterize( type-environment.instantiate(TValue), type-environment.instantiate(TKey) ).new(self),
+            Hash, '$!descriptor', $descr )
     }
 
     multi method raku(::?CLASS:D \SELF:) {

--- a/src/core.c/Hash/Object.rakumod
+++ b/src/core.c/Hash/Object.rakumod
@@ -259,16 +259,15 @@ my role Hash::Object[::TValue, ::TKey] does Associative[TValue] {
         )
     }
 
-    method is-generic {
-        nqp::hllbool(
-            nqp::istrue(TValue.^archetypes.generic)
-            || nqp::istrue(TKey.^archetypes.generic))
-    }
+    method is-generic { nqp::hllbool(TValue.^archetypes.generic || TKey.^archetypes.generic) }
 
     multi method INSTANTIATE-GENERIC(::?CLASS:U: TypeEnv:D \type-environment --> Associative) is raw {
-        Hash.^parameterize:
-            type-environment.instantiate(TValue),
-            type-environment.instantiate(TKey)
+        Hash.^parameterize: type-environment.instantiate(TValue), type-environment.instantiate(TKey)
+    }
+
+    multi method INSTANTIATE-GENERIC(::?CLASS:D: TypeEnv:D \type-environment --> Associative) is raw {
+        Hash.^parameterize( type-environment.instantiate(TValue),
+                            type-environment.instantiate(TKey) ).new(self)
     }
 
     multi method raku(::?CLASS:D \SELF:) {

--- a/src/core.c/Hash/Typed.rakumod
+++ b/src/core.c/Hash/Typed.rakumod
@@ -37,6 +37,9 @@ my role Hash::Typed[::TValue] does Associative[TValue] {
     multi method INSTANTIATE-GENERIC(::?CLASS:U: TypeEnv:D \type-environment --> Associative) is raw {
         Hash.^parameterize: type-environment.instantiate(TValue)
     }
+    multi method INSTANTIATE-GENERIC(::?CLASS:D: TypeEnv:D \type-environment --> Associative) is raw {
+        Hash.^parameterize( type-environment.instantiate(TValue) ).new(self)
+    }
 
     multi method raku(::?CLASS:D \SELF:) {
         SELF.rakuseen('Hash', {

--- a/src/core.c/Hash/Typed.rakumod
+++ b/src/core.c/Hash/Typed.rakumod
@@ -23,6 +23,7 @@ my role Hash::Typed[::TValue] does Associative[TValue] {
           (existing = assignval)
         )
     }
+
     method BIND-KEY(Mu \key, TValue \value) is raw {
         nqp::bindkey(
           nqp::getattr(self,Map,'$!storage'),
@@ -30,6 +31,13 @@ my role Hash::Typed[::TValue] does Associative[TValue] {
           value
         )
     }
+
+    method is-generic { nqp::hllbool(nqp::istrue(TValue.^archetypes.generic)) }
+
+    multi method INSTANTIATE-GENERIC(::?CLASS:U: TypeEnv:D \type-environment --> Associative) is raw {
+        Hash.^parameterize: type-environment.instantiate(TValue)
+    }
+
     multi method raku(::?CLASS:D \SELF:) {
         SELF.rakuseen('Hash', {
             '$' x nqp::iscont(SELF)  # self is always deconted

--- a/src/core.c/Hash/Typed.rakumod
+++ b/src/core.c/Hash/Typed.rakumod
@@ -32,13 +32,17 @@ my role Hash::Typed[::TValue] does Associative[TValue] {
         )
     }
 
-    method is-generic { nqp::hllbool(nqp::istrue(TValue.^archetypes.generic)) }
+    method is-generic {
+        nqp::hllbool(callsame() || nqp::istrue(TValue.^archetypes.generic))
+    }
 
     multi method INSTANTIATE-GENERIC(::?CLASS:U: TypeEnv:D \type-environment --> Associative) is raw {
         Hash.^parameterize: type-environment.instantiate(TValue)
     }
     multi method INSTANTIATE-GENERIC(::?CLASS:D: TypeEnv:D \type-environment --> Associative) is raw {
-        Hash.^parameterize( type-environment.instantiate(TValue) ).new(self)
+        my Mu $descr := type-environment.instantiate( nqp::getattr(self, Hash, '$!descriptor') );
+        nqp::p6bindattrinvres(
+            Hash.^parameterize( type-environment.instantiate(TValue) ).new(self), Hash, '$!descriptor', $descr )
     }
 
     multi method raku(::?CLASS:D \SELF:) {

--- a/src/core.c/Mix.rakumod
+++ b/src/core.c/Mix.rakumod
@@ -5,6 +5,10 @@ my class Mix does Mixy {
 
     my role KeyOf[::CONSTRAINT] {
         method keyof() { CONSTRAINT }
+        method is-generic { CONSTRAINT.^archetypes.generic }
+        method INSTANTIATE-GENERIC(::?CLASS:U: TypeEnv:D \type-environment) is raw {
+            Mix.^parameterize: type-environment.instantiate(CONSTRAINT)
+        }
     }
     method ^parameterize(Mu \base, Mu \type) {
         my \what := base.^mixin(KeyOf[type]);

--- a/src/core.c/Mix.rakumod
+++ b/src/core.c/Mix.rakumod
@@ -3,15 +3,8 @@ my class Mix does Mixy {
     has Real       $!total;
     has Real       $!total-positive;
 
-    my role KeyOf[::CONSTRAINT] {
-        method keyof() { CONSTRAINT }
-        method is-generic { CONSTRAINT.^archetypes.generic }
-        method INSTANTIATE-GENERIC(::?CLASS:U: TypeEnv:D \type-environment) is raw {
-            Mix.^parameterize: type-environment.instantiate(CONSTRAINT)
-        }
-    }
     method ^parameterize(Mu \base, Mu \type) {
-        my \what := base.^mixin(KeyOf[type]);
+        my \what := base.^mixin(QuantHash::KeyOf[type]);
         what.^set_name(base.^name ~ '[' ~ type.^name ~ ']');
         what
     }

--- a/src/core.c/MixHash.rakumod
+++ b/src/core.c/MixHash.rakumod
@@ -1,14 +1,7 @@
 my class MixHash does Mixy {
 
-    my role KeyOf[::CONSTRAINT] {
-        method keyof() { CONSTRAINT }
-        method is-generic { CONSTRAINT.^archetypes.generic }
-        method INSTANTIATE-GENERIC(::?CLASS:U: TypeEnv:D \type-environment) is raw {
-            MixHash.^parameterize: type-environment.instantiate(CONSTRAINT)
-        }
-    }
     method ^parameterize(Mu \base, Mu \type) {
-        my \what := base.^mixin(KeyOf[type]);
+        my \what := base.^mixin(QuantHash::KeyOf[type]);
         what.^set_name(base.^name ~ '[' ~ type.^name ~ ']');
         what
     }

--- a/src/core.c/MixHash.rakumod
+++ b/src/core.c/MixHash.rakumod
@@ -2,6 +2,10 @@ my class MixHash does Mixy {
 
     my role KeyOf[::CONSTRAINT] {
         method keyof() { CONSTRAINT }
+        method is-generic { CONSTRAINT.^archetypes.generic }
+        method INSTANTIATE-GENERIC(::?CLASS:U: TypeEnv:D \type-environment) is raw {
+            MixHash.^parameterize: type-environment.instantiate(CONSTRAINT)
+        }
     }
     method ^parameterize(Mu \base, Mu \type) {
         my \what := base.^mixin(KeyOf[type]);

--- a/src/core.c/Mu.rakumod
+++ b/src/core.c/Mu.rakumod
@@ -1047,7 +1047,7 @@ my class Mu { # declared in BOOTSTRAP
     # Use proto to let child classes only have their own candidates for typeobject and instance invocators.
     proto method INSTANTIATE-GENERIC(Mu) {*}
     multi method INSTANTIATE-GENERIC(::?CLASS:U: TypeEnv:D --> Mu) is raw { self }
-    multi method INSTANTIATE-GENERIC(::?CLASS:D: TypeEnv:D --> Mu) is raw { self }
+    multi method INSTANTIATE-GENERIC(::?CLASS:D: TypeEnv:D --> Mu) is raw { self.clone }
 
     proto method isa(|) {*}
     multi method isa(Mu \SELF: Mu $type --> Bool:D) {

--- a/src/core.c/Mu.rakumod
+++ b/src/core.c/Mu.rakumod
@@ -131,16 +131,8 @@ my class Mu { # declared in BOOTSTRAP
 
     proto method new(|) {*}
     multi method new(*%attrinit) {
-            my Mu $obj := self;
-        if nqp::getenvhash<RAKUDO_DEBUG> && self.^name eq 'A' {
-            note("class ", self.WHICH, " of ", self.HOW.^name, " self is ", self.VAR.^name, ", cont? ", nqp::iscont(self));
-            my $bless := nqp::tryfindmethod(self,'bless');
-            note "   -> bless method: ", $bless.^name, " // ", self.^lookup('bless').WHICH;
-        }
-        my $bless := do { nqp::tryfindmethod(self,'bless') };
-        if nqp::getenvhash<RAKUDO_DEBUG> && self.^name eq 'A' {
-            note "   => bless method: ", $bless.^name;
-        }
+        my Mu $obj := self;
+        my $bless := nqp::tryfindmethod(self,'bless');
         nqp::eqaddr($bless, nqp::findmethod(Mu,'bless'))
                 ?? nqp::create(self).BUILDALL(Empty, %attrinit)
                 !! $bless(self,|%attrinit)

--- a/src/core.c/QuantHash.rakumod
+++ b/src/core.c/QuantHash.rakumod
@@ -47,4 +47,12 @@ my role QuantHash does Associative {
     method Map()  { ... }
 }
 
+my role QuantHash::KeyOf[::CONSTRAINT] {
+    method keyof() { CONSTRAINT }
+    method is-generic { CONSTRAINT.^archetypes.generic }
+    method INSTANTIATE-GENERIC(::?CLASS:U: TypeEnv:D \type-environment) is raw {
+        self.^parameterize: type-environment.instantiate(CONSTRAINT)
+    }
+}
+
 # vim: expandtab shiftwidth=4

--- a/src/core.c/Set.rakumod
+++ b/src/core.c/Set.rakumod
@@ -1,11 +1,8 @@
 my class Set does Setty {
     has ValueObjAt $!WHICH;
 
-    my role KeyOf[::CONSTRAINT] {
-        method keyof() { CONSTRAINT }
-    }
     method ^parameterize(Mu \base, Mu \type) {
-        my \what := base.^mixin(KeyOf[type]);
+        my \what := base.^mixin(QuantHash::KeyOf[type]);
         what.^set_name(base.^name ~ '[' ~ type.^name ~ ']');
         what
     }

--- a/src/core.c/SetHash.rakumod
+++ b/src/core.c/SetHash.rakumod
@@ -1,10 +1,7 @@
 my class SetHash does Setty {
 
-    my role KeyOf[::CONSTRAINT] {
-        method keyof() { CONSTRAINT }
-    }
     method ^parameterize(Mu \base, Mu \type) {
-        my \what := base.^mixin(KeyOf[type]);
+        my \what := base.^mixin(QuantHash::KeyOf[type]);
         what.^set_name(base.^name ~ '[' ~ type.^name ~ ']');
         what
     }

--- a/src/core.c/TypeEnv.rakumod
+++ b/src/core.c/TypeEnv.rakumod
@@ -1,0 +1,35 @@
+# Type Environment is an associative mapping generic type names into final types. Only to be provided by MOP.
+
+my class TypeEnv { # declared in BOOTSTRAP
+# my class TypeEnv is Map
+    my role LexPad {
+        multi method AT-KEY(::?CLASS:D: Str:D $key --> Mu) is raw {
+            nqp::ifnull(nqp::getlexrel(nqp::getattr(self, Map, '$!storage'), $key), Nil)
+        }
+        multi method AT-KEY(::?CLASS:D: Mu \key --> Mu) is raw {
+            nqp::ifnull(nqp::getlexrel(nqp::getattr(self, Map, '$!storage'), key.Str), Nil)
+        }
+
+        multi method EXISTS-KEY(::?CLASS:D: Str:D $key --> Mu) is raw {
+            ! nqp::isnull(nqp::getlexrel(nqp::getattr(self, Map, '$!storage'), $key))
+        }
+        multi method EXISTS-KEY(::?CLASS:D: Mu \key --> Mu) is raw {
+            ! nqp::isnull(nqp::getlexrel(nqp::getattr(self, Map, '$!storage'), key.Str))
+        }
+    }
+
+    method new-from-ctx(Mu \ctx) {
+        nqp::p6bindattrinvres(
+            nqp::create(nqp::reprname(ctx) eq 'MVMContext' ?? self.WHAT but LexPad !! self.WHAT),
+            Map, '$!storage', ctx)
+    }
+
+    method instantiate(::?CLASS:D: Mu \obj --> Mu) is raw {
+        my Mu \type_environment = nqp::getattr(self, Map, '$!storage');
+        nqp::can(obj.HOW, 'instantiate_generic')
+            ?? obj.^instantiate_generic(self)
+            !! obj.INSTANTIATE-GENERIC(self)
+    }
+}
+
+Metamodel::Configuration.set_type_env_type(TypeEnv);

--- a/src/core.c/TypeEnv.rakumod
+++ b/src/core.c/TypeEnv.rakumod
@@ -24,8 +24,30 @@ my class TypeEnv { # declared in BOOTSTRAP
             Map, '$!storage', ctx)
     }
 
-    method instantiate(::?CLASS:D: Mu \obj --> Mu) is raw {
-        my Mu \type_environment = nqp::getattr(self, Map, '$!storage');
+    proto method instantiate(::?CLASS:D: Mu --> Mu) is raw {*}
+    multi method instantiate(::?CLASS:D: ContainerDescriptor:D \descriptor) is raw {
+        if nqp::getenvhash<RAKUDO_DEBUG> {
+            note "+++ instantiating container descriptor ", descriptor.name;
+        }
+        descriptor.instantiate_generic(nqp::getattr(self, Map, '$!storage'))
+    }
+    multi method instantiate(::?CLASS:D: Attribute:D \attr) is raw {
+        attr.instantiate_generic(nqp::getattr(self, Map, '$!storage'))
+    }
+    multi method instantiate(::?CLASS:D: Scalar:D \container) is raw {
+        container.VAR.instantiate_generic(nqp::getattr(self, Map, '$!storage'))
+    }
+    multi method instantiate(::?CLASS:D: Signature:D \sign) is raw {
+        sign.instantiate_generic(nqp::getattr(self, Map, '$!storage'))
+    }
+    multi method instantiate(::?CLASS:D: Parameter:D \param) is raw {
+        param.instantiate_generic(nqp::getattr(self, Map, '$!storage'))
+    }
+    multi method instantiate(::?CLASS:D: Code:D \code) is raw {
+        code.instantiate_generic(nqp::getattr(self, Map, '$!storage'))
+    }
+    # This is slow path.
+    multi method instantiate(::?CLASS:D: Mu \obj --> Mu) is raw {
         nqp::can(obj.HOW, 'instantiate_generic')
             ?? obj.^instantiate_generic(self)
             !! obj.INSTANTIATE-GENERIC(self)

--- a/src/vm/moar/dispatchers.nqp
+++ b/src/vm/moar/dispatchers.nqp
@@ -3311,7 +3311,9 @@ nqp::dispatch('boot-syscall', 'dispatcher-register', 'raku-isinvokable', -> $cap
         }
         my $core-rev-sym := 'CORE-SETTING-REV';
         while nqp::isnull(nqp::getlexrel($ctx, $core-rev-sym)) {
-            $ctx := nqp::ctxcaller($ctx);
+            if nqp::isnull($ctx := nqp::ctxcaller($ctx)) {
+                last
+            }
         }
         until nqp::isnull($ctx) {
             my $lexpad := nqp::ctxlexpad($ctx);

--- a/t/02-rakudo/03-corekeys-6c.t
+++ b/t/02-rakudo/03-corekeys-6c.t
@@ -729,6 +729,7 @@ my @expected = (
   Q{Thread},
   Q{ThreadPoolScheduler},
   Q{True},
+  Q{TypeEnv},
   Q{UINT64_UPPER},
   Q{UInt},
   Q{UIntAttrRef},

--- a/t/02-rakudo/03-corekeys-6d.t
+++ b/t/02-rakudo/03-corekeys-6d.t
@@ -728,6 +728,7 @@ my @expected = (
     Q{Tappable},
     Q{Thread},
     Q{ThreadPoolScheduler},
+    Q{TypeEnv},
     Q{True},
     Q{UINT64_UPPER},
     Q{UInt},

--- a/t/02-rakudo/03-corekeys-6e.t
+++ b/t/02-rakudo/03-corekeys-6e.t
@@ -738,6 +738,7 @@ my @expected = (
     Q{Tappable},
     Q{Thread},
     Q{ThreadPoolScheduler},
+    Q{TypeEnv},
     Q{True},
     Q{UINT64_UPPER},
     Q{UInt},

--- a/t/02-rakudo/03-corekeys.t
+++ b/t/02-rakudo/03-corekeys.t
@@ -731,6 +731,7 @@ my @allowed =
       Q{Tappable},
       Q{Thread},
       Q{ThreadPoolScheduler},
+      Q{TypeEnv},
       Q{True},
       Q{UINT64_UPPER},
       Q{UInt},

--- a/t/02-rakudo/04-settingkeys-6c.t
+++ b/t/02-rakudo/04-settingkeys-6c.t
@@ -728,6 +728,7 @@ my %allowed = (
     Q{Tappable},
     Q{Thread},
     Q{ThreadPoolScheduler},
+    Q{TypeEnv},
     Q{True},
     Q{UINT64_UPPER},
     Q{UInt},

--- a/t/02-rakudo/04-settingkeys-6e.t
+++ b/t/02-rakudo/04-settingkeys-6e.t
@@ -736,6 +736,7 @@ my %allowed = (
     Q{Tappable},
     Q{Thread},
     Q{ThreadPoolScheduler},
+    Q{TypeEnv},
     Q{True},
     Q{UINT64_UPPER},
     Q{UInt},

--- a/t/12-rakuast/doc-declarator.rakutest
+++ b/t/12-rakuast/doc-declarator.rakutest
@@ -426,6 +426,12 @@ CODE
         my ($class, $pod) := EVAL($it);
         isa-ok $class.HOW, Metamodel::ClassHOW, "$type: did we get a class";
         is $class.^name, 'A', "$type: did it get the right name";
+        use nqp;
+        note "BLESS METHOD\n  tryfindmethod: ", nqp::tryfindmethod($class, 'bless').^name, "\n",
+            "  Mu: ", nqp::findmethod(Mu, 'bless').WHICH;
+        note "CLASS : ", $class.WHICH, " of ", $class.HOW.WHICH;
+        note "CREATE: ", nqp::create(nqp::decont($class));
+        note "BLESS : ", $class.bless.BUILDALL(Empty, %());
         isa-ok $class.new, $class, "$type: can it instantiate";
 
         my $private-method := $class.^private_methods.head;

--- a/t/12-rakuast/doc-declarator.rakutest
+++ b/t/12-rakuast/doc-declarator.rakutest
@@ -426,12 +426,6 @@ CODE
         my ($class, $pod) := EVAL($it);
         isa-ok $class.HOW, Metamodel::ClassHOW, "$type: did we get a class";
         is $class.^name, 'A', "$type: did it get the right name";
-        use nqp;
-        note "BLESS METHOD\n  tryfindmethod: ", nqp::tryfindmethod($class, 'bless').^name, "\n",
-            "  Mu: ", nqp::findmethod(Mu, 'bless').WHICH;
-        note "CLASS : ", $class.WHICH, " of ", $class.HOW.WHICH;
-        note "CREATE: ", nqp::create(nqp::decont($class));
-        note "BLESS : ", $class.bless.BUILDALL(Empty, %());
         isa-ok $class.new, $class, "$type: can it instantiate";
 
         my $private-method := $class.^private_methods.head;

--- a/tools/templates/6.c/core_sources
+++ b/tools/templates/6.c/core_sources
@@ -95,6 +95,7 @@ src/core.c/Hash/Typed.rakumod
 src/core.c/Hash/Object.rakumod
 src/core.c/Hash.rakumod
 src/core.c/Stash.rakumod
+src/core.c/TypeEnv.rakumod
 src/core.c/Label.rakumod
 src/core.c/PseudoStash.rakumod
 src/core.c/Parameter.rakumod


### PR DESCRIPTION
A followup to the reverted #5477.

Targetting cases where `auto_viv_container` is remaining uninstantiated, resulting in attributes still using a generic even when installed into classes from a fully specialized role. In particular, the following case is resolved:

```raku
role R[::T] { has @.a is T; }
class C does R[Array[Str:D]] {}
```

Also some cases of scalar containers where default is set to the generic are fixed too:

```raku
role R[::T] { has $.a is default(T); }
```

Key changes:

* Instantiation protocol is introduced. 

  Sometimes generics can make their way inside classes or even objects. For example, an Array could be parameterized with a generic. Currently we cannot properly instantiate it unless some magic is introduced. But magic is magic because it'd be specifically targetting a particular case, leaving, say, user classes in limbo.

  The following bullets are parts of the protocol implementation.
* With this PR method `instantiate_generic` becomes a part of `ClassHOW`. It takes a type environment, creates an instance of Raku wrapper class TypeEnv (a map descenadant) for it, and then submits it to `INSTANTIATE-GENERIC` method, expecting the class itself to do the rest.
* A class or an instance of class can now be a generic. This would be reported as a class archetype, i.e. `MyContainer.^archetypes.generic` would be set.
* All parameterizable classes must be now OK with generics.