### PR TITLE
Move close to complete generic instantiation, iteration 3: the non-parametric generic support in expressions

### DIFF
--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -800,6 +800,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         :my $*CAN_LOWER_TOPIC := 1;                # true if we optimize the $_ lexical away
         :my $*MAY_USE_RETURN := 0;                 # true if the current routine may use return
         :my $*WANT_RAKUAST := 0;                   # if `use experimental :rakuast` is in effect
+        :my $*GENERICS;                            # would be set by roles and by routines with type captures
 
         # Various interesting scopes we'd like to keep to hand.
         :my $*GLOBALish;
@@ -1947,6 +1948,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         :my $*DOC := $*DECLARATOR_DOCS;
         :my $*POD_BLOCK;
         :my $*BORG := {};
+        :my $*GENERICS := nqp::getlexreldyn(nqp::ctxcaller(nqp::ctx()), '$*GENERICS'); # shadow away any outer
         { $*DECLARATOR_DOCS := '' }
         <.attach_leading_docs>
 
@@ -2063,6 +2065,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
                     # then install it in that.
                     else {
                         # If the group doesn't exist, create it.
+                        $*GENERICS := nqp::hash();
                         my $group;
                         if $exists {
                             $group := $package;

--- a/src/Perl6/Metamodel/ClassHOW.nqp
+++ b/src/Perl6/Metamodel/ClassHOW.nqp
@@ -422,7 +422,7 @@ class Perl6::Metamodel::ClassHOW
             my $track-archetypes-attr :=
                 nqp::dispatch('boot-syscall', 'dispatcher-track-attr',
                             $track-how, Perl6::Metamodel::ClassHOW, '$!archetypes');
-            nqp::dispatch('boot-syscall', 'dispatcher-guard-concreteness', $track-archetypes-attr);
+            nqp::dispatch('boot-syscall', 'dispatcher-guard-literal', $track-archetypes-attr);
 
             $atype := nqp::getattr($how, Perl6::Metamodel::ClassHOW, '$!archetypes');
         }

--- a/src/Perl6/Metamodel/ClassHOW.nqp
+++ b/src/Perl6/Metamodel/ClassHOW.nqp
@@ -378,8 +378,8 @@ class Perl6::Metamodel::ClassHOW
     }
 
     method instantiate_generic($obj, $type_environment) {
-        return $obj if nqp::isnull(my $type-env-type := Perl6::Metamodel::Configuration.type_env_type);
-        $obj.INSTANTIATE-GENERIC($type-env-type.new-from-ctx($type_environment))
+        return $obj if nqp::isnull(my $type-env-type := Perl6::Metamodel::Configuration.type_env_from($type_environment));
+        $type-env-type.cache($obj, { $obj.INSTANTIATE-GENERIC($type-env-type) });
     }
 
 #?if moar

--- a/src/Perl6/Metamodel/Configuration.nqp
+++ b/src/Perl6/Metamodel/Configuration.nqp
@@ -91,6 +91,11 @@ class Perl6::Metamodel::Configuration {
     my $type-env-type := nqp::null();
     method set_type_env_type($type) { $type-env-type := $type }
     method type_env_type()          { $type-env-type }
+    method type_env_from($ctx) {
+        return nqp::null() if nqp::isnull($type-env-type);
+        return $ctx if nqp::istype($ctx, $type-env-type);
+        $type-env-type.new-from-ctx($ctx)
+    }
 }
 
 # vim: expandtab sw=4

--- a/src/Perl6/Metamodel/CurriedRoleHOW.nqp
+++ b/src/Perl6/Metamodel/CurriedRoleHOW.nqp
@@ -96,7 +96,10 @@ class Perl6::Metamodel::CurriedRoleHOW
             my $type_env;
             try {
                 my @result := $candidate-how.body_block($!candidate)(|@pos_args, |%!named_args);
-                $type_env := @result[1];
+                $type_env :=
+                    self.archetypes.generic
+                     ?? nqp::ifnull(Perl6::Metamodel::Configuration.type_env_from(@result[1]), @result[1])
+                     !! @result[1];
             }
             for $candidate-how.roles($!candidate, :!transitive) -> $role {
                 if $role.HOW.archetypes.generic && $type_env {

--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -3792,6 +3792,11 @@ BEGIN {
 
     # my class TypeEnv is Map {
     TypeEnv.HOW.add_parent(TypeEnv, Map);
+    TypeEnv.HOW.add_attribute(TypeEnv, Attribute.new(:name<$!primary>, :type(Bool), :package(TypeEnv)));
+    TypeEnv.HOW.add_attribute(TypeEnv, Attribute.new(:name<$!WHICH>, :type(ValueObjAt), :package(TypeEnv)));
+    TypeEnv.HOW.add_method(TypeEnv, 'ctx', nqp::getstaticcode(sub ($self) {
+        nqp::getattr($self, Map, '$!storage')
+    }));
     TypeEnv.HOW.compose_repr(TypeEnv);
     nqp::settypehllrole(TypeEnv, 5);
 

--- a/src/core.c/Mu.rakumod
+++ b/src/core.c/Mu.rakumod
@@ -1047,7 +1047,7 @@ my class Mu { # declared in BOOTSTRAP
     # Use proto to let child classes only have their own candidates for typeobject and instance invocators.
     proto method INSTANTIATE-GENERIC(Mu) {*}
     multi method INSTANTIATE-GENERIC(::?CLASS:U: TypeEnv:D --> Mu) is raw { self }
-    multi method INSTANTIATE-GENERIC(::?CLASS:D: TypeEnv:D --> Mu) is raw { self.clone }
+    multi method INSTANTIATE-GENERIC(::?CLASS:D: TypeEnv:D --> Mu) is raw { self }
 
     proto method isa(|) {*}
     multi method isa(Mu \SELF: Mu $type --> Bool:D) {

--- a/src/core.c/TypeEnv.rakumod
+++ b/src/core.c/TypeEnv.rakumod
@@ -1,56 +1,137 @@
 # Type Environment is an associative mapping generic type names into final types. Only to be provided by MOP.
+# TypeEnv implements caching on per-context and per-object basis. The caches only make sense until all required
+# instnatiations are completed. Normally it means the period of time between a role specializer invokes role body code
+# and until the specializer finishes and produces complete concretization. To avoid wasting resources per-context cache
+# slots must be dropped when no more needed. We do it by claiming the instance of TypeEnv, which creates a missing
+# slot, the primary for that slot. The primary is also responsible for removal of the slot when destroyed. If the
+# underlying context is preserved after that and a new TypeEnv gets created it would become a new primary and will start
+# producing new instantiations for the same generics.
 
+my class TypeEnv::LexPad {...}
 my class TypeEnv { # declared in BOOTSTRAP
-# my class TypeEnv is Map
-    my role LexPad {
-        multi method AT-KEY(::?CLASS:D: Str:D $key --> Mu) is raw {
-            nqp::ifnull(nqp::getlexrel(nqp::getattr(self, Map, '$!storage'), $key), Nil)
-        }
-        multi method AT-KEY(::?CLASS:D: Mu \key --> Mu) is raw {
-            nqp::ifnull(nqp::getlexrel(nqp::getattr(self, Map, '$!storage'), key.Str), Nil)
-        }
+# my class TypeEnv is Map {
+#     has $!primary;
+#     has $!WHICH;
 
-        multi method EXISTS-KEY(::?CLASS:D: Str:D $key --> Mu) is raw {
-            ! nqp::isnull(nqp::getlexrel(nqp::getattr(self, Map, '$!storage'), $key))
-        }
-        multi method EXISTS-KEY(::?CLASS:D: Mu \key --> Mu) is raw {
-            ! nqp::isnull(nqp::getlexrel(nqp::getattr(self, Map, '$!storage'), key.Str))
-        }
-    }
+    method new(|) { callsame()!INIT() }
 
     method new-from-ctx(Mu \ctx) {
         nqp::p6bindattrinvres(
-            nqp::create(nqp::reprname(ctx) eq 'MVMContext' ?? self.WHAT but LexPad !! self.WHAT),
-            Map, '$!storage', ctx)
+            nqp::create(nqp::reprname(ctx) eq 'MVMContext' ?? TypeEnv::LexPad !! self.WHAT),
+            Map,
+            '$!storage',
+            (nqp::istype(ctx, Map) ?? nqp::getattr(ctx, Map, '$!storage') !! ctx) )!INIT()
+    }
+
+    method primary { ? $!primary }
+
+    my Mu $ins-cache := nqp::hash();
+    my $cache-lock = Lock.new;
+
+    method !INIT() {
+        $cache-lock.protect: {
+            my $self-key := self.WHICH;
+            unless nqp::existskey($ins-cache, $self-key) {
+                $!primary := True;
+                nqp::bindkey($ins-cache, $self-key, nqp::hash());
+            }
+        }
+        self
+    }
+
+    submethod DESTROY {
+        if $!primary {
+            $cache-lock.protect: {
+                nqp::deletekey($ins-cache, self.WHICH);
+            }
+        }
     }
 
     proto method instantiate(::?CLASS:D: Mu --> Mu) is raw {*}
     multi method instantiate(::?CLASS:D: ContainerDescriptor:D \descriptor) is raw {
-        if nqp::getenvhash<RAKUDO_DEBUG> {
-            note "+++ instantiating container descriptor ", descriptor.name;
-        }
-        descriptor.instantiate_generic(nqp::getattr(self, Map, '$!storage'))
+        descriptor.instantiate_generic(self)
     }
     multi method instantiate(::?CLASS:D: Attribute:D \attr) is raw {
-        attr.instantiate_generic(nqp::getattr(self, Map, '$!storage'))
+        attr.instantiate_generic(self)
     }
     multi method instantiate(::?CLASS:D: Scalar:D \container) is raw {
-        container.VAR.instantiate_generic(nqp::getattr(self, Map, '$!storage'))
+        container.VAR.instantiate_generic(self)
     }
     multi method instantiate(::?CLASS:D: Signature:D \sign) is raw {
-        sign.instantiate_generic(nqp::getattr(self, Map, '$!storage'))
+        sign.instantiate_generic(self)
     }
     multi method instantiate(::?CLASS:D: Parameter:D \param) is raw {
-        param.instantiate_generic(nqp::getattr(self, Map, '$!storage'))
+        param.instantiate_generic(self)
     }
     multi method instantiate(::?CLASS:D: Code:D \code) is raw {
-        code.instantiate_generic(nqp::getattr(self, Map, '$!storage'))
+        code.instantiate_generic(self)
     }
     # This is slow path.
     multi method instantiate(::?CLASS:D: Mu \obj --> Mu) is raw {
         nqp::can(obj.HOW, 'instantiate_generic')
-            ?? obj.^instantiate_generic(self)
-            !! obj.INSTANTIATE-GENERIC(self)
+                        ?? obj.^instantiate_generic(self)
+                        !! obj.INSTANTIATE-GENERIC(self);
+    }
+
+    # Caching is using two different storages at the same time. The first one is the global $ins-cache hash. The second
+    # is our context where we keep resolved instantiatiations of non-parameteric types (classes, mostly). The latter
+    # is using the convention by which symbols that need instantiation are bound to lexicals with names starting with
+    # "!INS_OF_" prefix.
+    method cache(::?CLASS:D: Mu \obj, &instantiator? --> Mu) is raw {
+        my Mu $ins;
+        $cache-lock.protect: {
+            my $ins-lexical = '!INS_OF_' ~ obj.^name;
+            my \ctx = self.ctx;
+            my $has-lexical := nqp::existskey(ctx, $ins-lexical);
+            my $obj-id;
+            my Mu $obj-idx;
+
+            if $has-lexical {
+                $ins := nqp::atkey(ctx, $ins-lexical);
+            }
+            elsif !$has-lexical {
+                my $self-key := self.WHICH;
+                $obj-id := ~nqp::objectid(obj);
+                $obj-idx := nqp::atkey($ins-cache, $self-key);
+                $ins := nqp::atkey($obj-idx, $obj-id);
+            }
+
+            if nqp::eqaddr(obj, $ins) || nqp::isnull($ins) {
+                $ins := nqp::decont(&instantiator ?? &instantiator() !! self.instantiate(obj));
+                if $has-lexical {
+                    nqp::bindkey(ctx, $ins-lexical, $ins);
+                }
+                else {
+                    nqp::bindkey($obj-idx, $obj-id, $ins);
+                }
+            }
+        }
+        $ins
+    }
+
+    # Bind own identity to the underlying context object. This way two independently created instances of TypeEnv
+    # would be considered the same entity if they share the same context.
+    multi method WHICH(::?CLASS:D:) {
+        $!WHICH // ($!WHICH := nqp::box_s(
+            self.^name ~ "|" ~ nqp::objectid(nqp::getattr(self, Map, '$!storage')),
+            ValueObjAt
+        ))
+    }
+}
+
+my class TypeEnv::LexPad is TypeEnv {
+    multi method AT-KEY(::?CLASS:D: Str:D $key --> Mu) is raw {
+        nqp::ifnull(nqp::getlexrel(nqp::getattr(self, Map, '$!storage'), $key), Nil)
+    }
+    multi method AT-KEY(::?CLASS:D: Mu \key --> Mu) is raw {
+        nqp::ifnull(nqp::getlexrel(nqp::getattr(self, Map, '$!storage'), key.Str), Nil)
+    }
+
+    multi method EXISTS-KEY(::?CLASS:D: Str:D $key --> Mu) is raw {
+        ! nqp::isnull(nqp::getlexrel(nqp::getattr(self, Map, '$!storage'), $key))
+    }
+    multi method EXISTS-KEY(::?CLASS:D: Mu \key --> Mu) is raw {
+        ! nqp::isnull(nqp::getlexrel(nqp::getattr(self, Map, '$!storage'), key.Str))
     }
 }
 

--- a/t/02-rakudo/20-generic-class.rakutest
+++ b/t/02-rakudo/20-generic-class.rakutest
@@ -3,6 +3,8 @@ use Test;
 use nqp;
 
 # This test belongs to the Roast but not before there is common MOP API that allows not to use nqp ops.
+#
+plan 8;
 
 role InsHOW {
     has $!ins-orig;
@@ -113,3 +115,5 @@ is $ci.gimme-the-G.^name, 'R::S::G_2', 'method body resolves generic class into 
 cmp-ok $ci.gimme-the-G.^base-type, &[=:=], Int:D, "class instantiated over role's Int:D arguments";
 
 check-role "After Instantiations";
+
+done-testing;

--- a/t/02-rakudo/20-generic-class.rakutest
+++ b/t/02-rakudo/20-generic-class.rakutest
@@ -1,0 +1,115 @@
+use v6.e.PREVIEW;
+use Test;
+use nqp;
+
+# This test belongs to the Roast but not before there is common MOP API that allows not to use nqp ops.
+
+role InsHOW {
+    has $!ins-orig;
+    has $!ins-orig-how;
+    has $!base-type;
+
+    method set-base-type(Mu, Mu \base-type --> Nil) { $!base-type := base-type }
+    method base-type(Mu --> Mu) is raw { $!base-type }
+
+    # nqp::clone() does shallow clone that leaves hash and list attributes content shared between the original HOW
+    # and its copy. This routine takes care of this by cloning all such attributes. Along the lines %!mro gets reset
+    # in order to refresh all MRO-based caches and dispatchers.
+    my sub clone-HOW(Mu \how --> Mu) is raw {
+        my Mu \how-clone := nqp::clone(how);
+        for Metamodel::ClassHOW.^attributes(:local).sort(*.name) -> \attr {
+            my Mu \val = nqp::getattr(how, Metamodel::ClassHOW, attr.name);
+            if nqp::islist(val) || nqp::ishash(val) {
+                if attr.name eq '%!mro' {
+                    # Reset MRO cache because it has to be rebuilt.
+                    nqp::bindattr(how-clone, Metamodel::ClassHOW, attr.name, nqp::hash());
+                }
+                else {
+                    nqp::bindattr(how-clone, Metamodel::ClassHOW, attr.name, nqp::clone(val));
+                }
+            }
+        }
+        how-clone
+    }
+
+    method compose(Mu \obj, | --> Mu) is raw {
+        unless self.is_composed(obj) {
+            $!ins-orig := obj;
+            # Clone early to have a copy of uncomposed HOW.
+            $!ins-orig-how := clone-HOW(obj.HOW);
+        }
+        nextsame;
+    }
+
+    my atomicint $next-id = 0;
+    method ins-new-type(Mu \obj, TypeEnv:D $typeenv --> Mu) is raw {
+        my Mu \new-how = clone-HOW($!ins-orig-how);
+        my Mu \new-type = Metamodel::Primitives.create_type(new-how);
+        new-type.^set_name(obj.^name ~ "_" ~ ++⚛$next-id); # Not necessary, but will help in identifying instantiation
+        new-type.^publish_method_cache; # This will prevent re-use of methods coming from the original class
+        # Concretizations cache has to be wiped out to avoid them be re-used from the original type.
+        new-type.HOW.wipe_conc_cache;
+        # This is a trick that makes the instantiated class match to the original
+        new-type.^add_parent($!ins-orig);
+        new-how.compose(new-type);
+        new-type
+    }
+}
+
+multi sub trait_mod:<is>(Mu \type, Mu :$ins!) {
+    type.HOW does InsHOW;
+    type.^set-base-type($ins.WHAT);
+}
+
+my \r = role R[::BASE] {
+    # A compound name makes things even harder for the resolver. So, let's be tough!
+    my class S::G is ins(BASE) {
+        method is-generic is raw {
+            self.^base-type.^archetypes.generic
+        }
+
+        multi method INSTANTIATE-GENERIC(::?CLASS:U: TypeEnv:D $typeenv) is raw {
+            my \ins = self.^ins-new-type($typeenv);
+            # Use of .cache prevents re-instantiation of a type within same type environment; e.g. within same role
+            # concretization.
+            my \old-base = ins.^base-type;
+            ins.^set-base-type($typeenv.cache(ins.^base-type));
+            ins
+        }
+    }
+
+    has S::G $.attr;
+
+    method gimme-the-G { S::G }
+}
+
+sub check-role(Str:D $msg) is test-assertion {
+    subtest $msg => {
+        my $role-attr := r.^get_attribute_for_usage('$!attr');
+        my $archetypes := $role-attr.type.^archetypes;
+
+        is $role-attr.type.^name, "R::S::G", "role attribute type name before instantiations";
+        ok $archetypes.generic && $archetypes.nominal && $archetypes.augmentable,
+           "role attribute type archetypes are that of a generic class";
+        ok $role-attr.type.is-generic, "role attribute type is-generic method";
+        ok $role-attr.type.new.^archetypes.generic, "role attribute type instance archetypes is generic";
+    }
+}
+
+check-role "Before Instantiations";
+
+class CS does R[Str:D] { }
+class CI does R[Int:D] { }
+
+my $cs = CS.new;
+
+is $cs.attr.^name,        'R::S::G_1', 'attribute type is the first instantiation';
+is $cs.gimme-the-G.^name, 'R::S::G_1', 'method body resolves generic class into the first instatiation';
+cmp-ok $cs.gimme-the-G.^base-type, &[=:=], Str:D, "class instantiated over role's Str:D argument";
+
+my $ci = CI.new;
+is $ci.attr.^name,        'R::S::G_2', 'attribute type is the second instantiation';
+is $ci.gimme-the-G.^name, 'R::S::G_2', 'method body resolves generic class into the second instatiation';
+cmp-ok $ci.gimme-the-G.^base-type, &[=:=], Int:D, "class instantiated over role's Int:D arguments";
+
+check-role "After Instantiations";


### PR DESCRIPTION
In this episode...

Quoting the main commit message:

Say, `method foo { AGenericClass }` would now return an instantiation of
the class.

Changes required for this to fly:

* `TypeEnv` caching.

  Caching resolves two problems. First, it prevents a class from being
  re-instantiated 2+ times for the same role concretization. Second, it
  provides mechanism for resolving generic types in expression.

* `TypeEnv::LexPad` converted from a mixin role into a subclass of
  `TypeEnv`. This resolves chicken-and-egg problem in role composition.

* `TypeEnv` becomes a value object over its underlying context object

The resolution itself works by installing a special lexical symbol into
the current so called "generic scope" lexpad for each type to be
resolved. The symbol is bound to the type itself. Symbol names are
starting with '!INS_OF_' prefix with full type name attached.

_"generic scope" above is the outermost frame which declares a type
capture. For now this is only role bodies, but in the future routines
with type-capturing parameters are to be added._

Later, when we get a type environment for instantiation, we iterate over
the symbols and bind corresponding type instantiations back to the
symbols in the type environment. When the underlying context is a bare
hash this would only affect further instantiations of the same type. But
when it is lexpad of a closure then the closure gets these instantiations
lexically accessible by all nested frames. The actual resolution happens
by replacing `My::Generic::Type` symbol in the code with lexical
resolution of '!INS_OF_My::Generic::Type'.

Instantiation of referenced generics happens as early as possible,
eagerly. To avoid unnecessary instantiations the compiler installs the
lexical only when the resolution is really needed.

* Added a reference test for class instantiation. The test code is fat
  because we currently don't have any sort of standard API for doing
  these tricks. In the future it would make sense to transfer the test
  to the Roast, as soon as the API is crystallized and published.