### PR TITLE
Complete generic instantiation 4

### DIFF
--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -2029,7 +2029,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
 
                     # Setup generic context.
                     if $*PKGDECL eq 'role' {
-                        ($*GENERICS-PAD := $curpad).annotate('generic-attributes', []);
+                        ($*GENERICS-PAD := $curpad).annotate('instantiation-lexicals', []);
                     }
 
                     # If it exists already, then it's either uncomposed (in which

--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -2027,6 +2027,11 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
                         $fullname := $longname.fully_qualified_with($target_package);
                     }
 
+                    # Setup generic context.
+                    if $*PKGDECL eq 'role' {
+                        ($*GENERICS-PAD := $curpad).annotate('generic-attributes', []);
+                    }
+
                     # If it exists already, then it's either uncomposed (in which
                     # case we just stubbed it), a role (in which case multiple
                     # variants are OK) or else an illegal redecl.
@@ -2068,7 +2073,6 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
                     # a parametric role group for it (unless we got one), and
                     # then install it in that.
                     else {
-                        $*GENERICS-PAD := $curpad;
                         # If the group doesn't exist, create it.
                         my $group;
                         if $exists {

--- a/src/Perl6/Metamodel/ClassHOW.nqp
+++ b/src/Perl6/Metamodel/ClassHOW.nqp
@@ -378,8 +378,9 @@ class Perl6::Metamodel::ClassHOW
     }
 
     method instantiate_generic($obj, $type_environment) {
-        return $obj if nqp::isnull(my $type-env-type := Perl6::Metamodel::Configuration.type_env_from($type_environment));
-        $type-env-type.cache($obj, { $obj.INSTANTIATE-GENERIC($type-env-type) });
+        my $type-env := Perl6::Metamodel::Configuration.type_env_from($type_environment);
+        return $obj if nqp::isnull($type-env);
+        $type-env.cache($obj, { $obj.INSTANTIATE-GENERIC($type-env) });
     }
 
 #?if moar

--- a/src/Perl6/Metamodel/ClassHOW.nqp
+++ b/src/Perl6/Metamodel/ClassHOW.nqp
@@ -416,7 +416,12 @@ class Perl6::Metamodel::ClassHOW
         if nqp::isconcrete($obj) && $can-is-generic {
             # If invocant of .HOW.archetypes is a concrete object implementing 'is-generic' method then method outcome
             # is the ultimate result. But we won't cache it in type's HOW $!archetypes.
-            $atype := $obj.is-generic ?? $archetypes-g !! $archetypes-ng;
+            nqp::dispatch('boot-syscall', 'dispatcher-delegate', 'boot-code-constant',
+                nqp::dispatch('boot-syscall', 'dispatcher-insert-arg-literal-obj',
+                    nqp::dispatch('boot-syscall', 'dispatcher-drop-arg',
+                        nqp::dispatch('boot-syscall', 'dispatcher-drop-arg', $capture, 1),
+                        0),
+                    0, { $obj.is-generic ?? $archetypes-g !! $archetypes-ng }));
         }
         else {
             my $track-archetypes-attr :=
@@ -425,23 +430,23 @@ class Perl6::Metamodel::ClassHOW
             nqp::dispatch('boot-syscall', 'dispatcher-guard-literal', $track-archetypes-attr);
 
             $atype := nqp::getattr($how, Perl6::Metamodel::ClassHOW, '$!archetypes');
-        }
 
-        unless nqp::isconcrete($atype) {
-            # * If we still don't have an archetypes object then it means HOW doesn't know its archetypes yet. Therefore
-            #   whatever we determine here is type's ultimate archetypes.
-            # * Also, since we've taken care of a concrete object case then here 'is-generic' is invoked on the type
-            #   itself, not an instance of it.
-            $atype := $can-is-generic && $obj.is-generic ?? $archetypes-g !! $archetypes-ng;
-            nqp::scwbdisable();
-            nqp::getattr($how, Perl6::Metamodel::ClassHOW, '$!archt-lock').protect({
-                nqp::bindattr($how, Perl6::Metamodel::ClassHOW, '$!archetypes', $atype);
-            });
-            nqp::scwbenable();
-        }
+            unless nqp::isconcrete($atype) {
+                # * If we still don't have an archetypes object then it means HOW doesn't know its archetypes yet. Therefore
+                #   whatever we determine here is type's ultimate archetypes.
+                # * Also, since we've taken care of a concrete object case then here 'is-generic' is invoked on the type
+                #   itself, not an instance of it.
+                $atype := $can-is-generic && $obj.is-generic ?? $archetypes-g !! $archetypes-ng;
+                nqp::scwbdisable();
+                nqp::getattr($how, Perl6::Metamodel::ClassHOW, '$!archt-lock').protect({
+                    nqp::bindattr($how, Perl6::Metamodel::ClassHOW, '$!archetypes', $atype);
+                });
+                nqp::scwbenable();
+            }
 
-        nqp::dispatch('boot-syscall', 'dispatcher-delegate', 'boot-constant',
-            nqp::dispatch('boot-syscall', 'dispatcher-insert-arg-literal-obj', $capture, 0, $atype));
+            nqp::dispatch('boot-syscall', 'dispatcher-delegate', 'boot-constant',
+                nqp::dispatch('boot-syscall', 'dispatcher-insert-arg-literal-obj', $capture, 0, $atype));
+        }
     });
 #?endif
 }

--- a/src/Perl6/Metamodel/CoercionHOW.nqp
+++ b/src/Perl6/Metamodel/CoercionHOW.nqp
@@ -15,13 +15,12 @@ class Perl6::Metamodel::CoercionHOW
 
     method archetypes($obj?) {
         unless nqp::isconcrete($!archetypes) {
-            my $generic := 
-                $!target_type.HOW.archetypes($!target_type).generic 
+            my $generic :=
+                $!target_type.HOW.archetypes($!target_type).generic
                 || $!constraint_type.HOW.archetypes($!constraint_type).generic;
             $!archetypes := Perl6::Metamodel::Archetypes.new(
                 :coercive, :nominalizable, :$generic,
-                definite => $!target_type.HOW.archetypes($!target_type).definite,
-            );
+                definite => $!target_type.HOW.archetypes($!target_type).definite );
         }
         $!archetypes
     }
@@ -75,7 +74,7 @@ class Perl6::Metamodel::CoercionHOW
     }
 
     method instantiate_generic($coercion_type, $type_env) {
-        return $coercion_type unless $!archetypes.generic;
+        return $coercion_type unless self.archetypes.generic;
         my $ins_target :=
             $!target_type.HOW.archetypes($!target_type).generic
                 ?? $!target_type.HOW.instantiate_generic($!target_type, $type_env)
@@ -136,9 +135,7 @@ class Perl6::Metamodel::CoercionHOW
           ?? nqp::defined(
                my $method := nqp::tryfindmethod(
                  nqp::what($value),
-                 $nominal_target.HOW.name($nominal_target)
-               )
-             ) 
+                 $nominal_target.HOW.name($nominal_target)))
             ?? (nqp::istype((my $coerced := $method($value)),$!target_type)
                 || nqp::istype($coerced, nqp::gethllsym('Raku', 'Failure')))
               ?? $coerced
@@ -166,9 +163,8 @@ class Perl6::Metamodel::CoercionHOW
     # Handle invalid type on accepting
     method !invalid_type($value) {
         self."!invalid"(
-          $value, 
-          "value is of unacceptable type " ~ $value.HOW.name($value)
-        )
+          $value,
+          "value is of unacceptable type " ~ $value.HOW.name($value) )
     }
 
     # Attempt coercion with TargetType.COERCE($value).
@@ -203,8 +199,7 @@ class Perl6::Metamodel::CoercionHOW
           "method $method_name returned "
              ~ (nqp::defined($coerced_value)
                  ?? "an instance of "
-                 !! "a type object "
-               )
+                 !! "a type object ")
              ~ $coerced_value.HOW.name($coerced_value)
         )
     }
@@ -238,11 +233,10 @@ class Perl6::Metamodel::CoercionHOW
                   if nqp::istype($coerced_value, $!target_type)
                     || nqp::istype(
                          $coerced_value,
-                         nqp::gethllsym('Raku', 'Failure')
-                       )
+                         nqp::gethllsym('Raku', 'Failure') )
             }
-            if nqp::defined($exception) { 
-                nqp::rethrow($exception); 
+            if nqp::defined($exception) {
+                nqp::rethrow($exception);
             }
             elsif !nqp::isnull($coerced_value) {
                 self."!invalid_coercion"($value, 'new', $coerced_value)

--- a/src/Perl6/Metamodel/Configuration.nqp
+++ b/src/Perl6/Metamodel/Configuration.nqp
@@ -91,10 +91,10 @@ class Perl6::Metamodel::Configuration {
     my $type-env-type := nqp::null();
     method set_type_env_type($type) { $type-env-type := $type }
     method type_env_type()          { $type-env-type }
-    method type_env_from($ctx) {
+    method type_env_from($ctx, *%params) {
         return nqp::null() if nqp::isnull($type-env-type);
         return $ctx if nqp::istype($ctx, $type-env-type);
-        $type-env-type.new-from-ctx($ctx)
+        $type-env-type.new-from-ctx($ctx, |%params)
     }
 }
 

--- a/src/Perl6/Metamodel/GenericHOW.nqp
+++ b/src/Perl6/Metamodel/GenericHOW.nqp
@@ -43,7 +43,11 @@ class Perl6::Metamodel::GenericHOW
         elsif nqp::isconcrete($type_environment) && $type_environment.EXISTS-KEY($name) {
             $found := nqp::decont($type_environment.AT-KEY($name));
         }
-        nqp::isnull($found) ?? $obj !! $found
+        nqp::isnull($found)
+            ?? $obj
+            !! $found.HOW.archetypes($found).generic
+                ?? $found.HOW.instantiate_generic($found, $type_environment)
+                !! $found
     }
 
     method compose($obj) {

--- a/src/Perl6/Metamodel/ParametricRoleHOW.nqp
+++ b/src/Perl6/Metamodel/ParametricRoleHOW.nqp
@@ -167,7 +167,9 @@ class Perl6::Metamodel::ParametricRoleHOW
                 my $error;
                 try {
                     my @result := $!body_block(|@pos_args, |%named_args);
+                    nqp::scwbdisable();
                     $type_env := nqp::ifnull(Perl6::Metamodel::Configuration.type_env_from(@result[1]), @result[1]);
+                    nqp::scwbenable();
                     CATCH {
                         $error := $!;
                     }
@@ -195,6 +197,8 @@ class Perl6::Metamodel::ParametricRoleHOW
     }
 
     method specialize_with($obj, $conc, $type_env, @pos_args) {
+        # Here we instantiate generics bound to implementation detail lexicals !INS_OF_*. Perhaps, it'd make more
+        # sense to move this semantics into role body, where a TypeEnv instance would eventaully be created.
         my $hll-typeenv := nqp::can($type_env, 'instantiate');
         my $ctx := $hll-typeenv ?? $type_env.ctx !! $type_env;
         my $ctx-iter := nqp::iterator($ctx);

--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -1935,8 +1935,9 @@ class Perl6::World is HLL::World {
                 }
                 elsif !($archetypes.nominal || $archetypes.nominalizable
                         || $archetypes.composable || $archetypes.composalizable) {
-                    # Pure generic types, resolve via lexival lookup
-                    $new-ast := QAST::Var.new( :name($cont_type.HOW.name($cont_type)), :scope<lexical> );
+                    # Pure generic types, resolve via lexical lookup
+                    $new-ast := QAST::Var.new( :name(my $name := $cont_type.HOW.name($cont_type)), :scope<lexical> );
+                    $new-ast.annotate('pure-generic-lexical', 1);
                 }
                 else {
                     # Other generics must be resolved by the instantiation protocol.

--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -1900,7 +1900,10 @@ class Perl6::World is HLL::World {
     method install_instantiation_lexical($type) {
         my $ins_lexical := self.instantiation_lexical($type);
         if nqp::isconcrete(my $generics-pad := $*GENERICS-PAD) {
-            self.install_lexical_symbol($generics-pad, $ins_lexical, $type);
+            unless $generics-pad.symbol($ins_lexical) {
+                $generics-pad.ann('instantiation-lexicals').push($ins_lexical);
+                self.install_lexical_symbol($generics-pad, $ins_lexical, $type);
+            }
         }
         else {
             $/.worry("Generic type '" ~ $type.HOW.name($type) ~ "' is used out of a generic context");

--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -3808,9 +3808,6 @@ BEGIN {
     TypeEnv.HOW.add_parent(TypeEnv, Map);
     TypeEnv.HOW.add_attribute(TypeEnv, Attribute.new(:name<$!primary>, :type(Bool), :package(TypeEnv)));
     TypeEnv.HOW.add_attribute(TypeEnv, Attribute.new(:name<$!WHICH>, :type(ValueObjAt), :package(TypeEnv)));
-    TypeEnv.HOW.add_method(TypeEnv, 'ctx', nqp::getstaticcode(sub ($self) {
-        nqp::getattr($self, Map, '$!storage')
-    }));
     TypeEnv.HOW.compose_repr(TypeEnv);
     nqp::settypehllrole(TypeEnv, 5);
 

--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -1743,7 +1743,12 @@ BEGIN {
                     $type.HOW.instantiate_generic($type, $type_environment));
             }
             if nqp::isconcrete($ci) {
+#?if !jvm
                 nqp::bindattr($ins, Attribute, '$!container_initializer', nqp::p6capturelexwhere($ci.clone()));
+#?endif
+#?if jvm
+                nqp::bindattr($ins, Attribute, '$!container_initializer', $ci.clone());
+#?endif
             }
             my $cd_ins := $cd;
             if $cd.is_generic {
@@ -1783,7 +1788,12 @@ BEGIN {
                     $pkg.HOW.instantiate_generic($pkg, $type_environment));
             }
             if nqp::defined($bc) {
+#?if !jvm
                 nqp::bindattr($ins, Attribute, '$!build_closure', nqp::p6capturelexwhere($bc.clone()));
+#?endif
+#?if jvm
+                nqp::bindattr($ins, Attribute, '$!build_closure', $bc.clone());
+#?endif
             }
             $ins
         }));

--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -1736,10 +1736,14 @@ BEGIN {
             my $pkg      := nqp::getattr($dcself, Attribute, '$!package');
             my $avc      := nqp::getattr($dcself, Attribute, '$!auto_viv_container');
             my $bc       := nqp::getattr($dcself, Attribute, '$!build_closure');
+            my $ci       := nqp::getattr($dcself, Attribute, '$!container_initializer');
             my $ins      := nqp::clone($dcself);
             if $type.HOW.archetypes($type).generic {
                 nqp::bindattr($ins, Attribute, '$!type',
                     $type.HOW.instantiate_generic($type, $type_environment));
+            }
+            if nqp::isconcrete($ci) {
+                nqp::bindattr($ins, Attribute, '$!container_initializer', nqp::p6capturelexwhere($ci.clone()));
             }
             my $cd_ins := $cd;
             if $cd.is_generic {
@@ -1779,7 +1783,7 @@ BEGIN {
                     $pkg.HOW.instantiate_generic($pkg, $type_environment));
             }
             if nqp::defined($bc) {
-                nqp::bindattr($ins, Attribute, '$!build_closure', $bc.clone());
+                nqp::bindattr($ins, Attribute, '$!build_closure', nqp::p6capturelexwhere($bc.clone()));
             }
             $ins
         }));

--- a/src/core.c/Array.rakumod
+++ b/src/core.c/Array.rakumod
@@ -1461,11 +1461,12 @@ my class Array { # declared in BOOTSTRAP
             !! self.clone
     }
 
-    method ^parameterize(Mu:U \arr, Mu \of) {
+    method ^parameterize(Mu:U \type, Mu \of) {
         if nqp::isconcrete(of) {
-            die "Can not parameterize {arr.^name} with {of.raku}"
+            die "Can not parameterize {type.^name} with {of.raku}"
         }
         else {
+            my \arr = type.^mro.first(!*.^is_mixin);
             my $what := arr.^mixin(Array::Typed[of]);
             # needs to be done in COMPOSE phaser when that works
             $what.^set_name("{arr.^name}[{of.^name}]");

--- a/src/core.c/Array/Typed.rakumod
+++ b/src/core.c/Array/Typed.rakumod
@@ -100,12 +100,12 @@ my role Array::Typed[::TValue] does Positional[TValue] {
     method is-generic { nqp::hllbool(callsame() || nqp::istrue(TValue.^archetypes.generic)) }
 
     multi method INSTANTIATE-GENERIC(::?CLASS:U: TypeEnv:D \type-environment) is raw {
-        Array.^parameterize: type-environment.instantiate(TValue)
+        self.WHAT.^parameterize: type-environment.instantiate(TValue)
     }
     multi method INSTANTIATE-GENERIC(::?CLASS:D: TypeEnv:D \type-environment) is raw {
         my Mu $descr := type-environment.instantiate(nqp::getattr(self, Array, '$!descriptor'));
         nqp::p6bindattrinvres(
-            Array.^parameterize(type-environment.instantiate(TValue)).new( |(self.elems ?? self !! Empty) ),
+            self.WHAT.^parameterize(type-environment.instantiate(TValue)).new( |(self.elems ?? self !! Empty) ),
             Array, '$!descriptor', $descr )
     }
 

--- a/src/core.c/Hash.rakumod
+++ b/src/core.c/Hash.rakumod
@@ -444,16 +444,18 @@ my class Hash { # declared in BOOTSTRAP
             !! self.clone
     }
 
-    method ^parameterize(Mu:U \hash, Mu \of, Mu \keyof = Str(Any)) {
+    method ^parameterize(Mu:U \type, Mu \of, Mu \keyof = Str(Any)) {
+
+        my \hash = type.^mro.first(!*.^is_mixin);
 
         # fast path
         if nqp::eqaddr(of,Mu) && nqp::eqaddr(keyof,Str(Any)) {
-            hash
+            type
         }
 
         # error checking
         elsif nqp::isconcrete(of) {
-            "Can not parameterize {hash.^name} with {of.raku}"
+            "Can not parameterize {type.^name} with {of.raku}"
         }
 
         # only constraint on type
@@ -467,7 +469,7 @@ my class Hash { # declared in BOOTSTRAP
 
         # error checking
         elsif nqp::isconcrete(keyof) {
-            "Can not parameterize {hash.^name} with {keyof.raku}"
+            "Can not parameterize {type.^name} with {keyof.raku}"
         }
 
         # no support for native types yet

--- a/src/core.c/Hash/Object.rakumod
+++ b/src/core.c/Hash/Object.rakumod
@@ -267,13 +267,15 @@ my role Hash::Object[::TValue, ::TKey] does Associative[TValue] {
     }
 
     multi method INSTANTIATE-GENERIC(::?CLASS:U: TypeEnv:D \type-environment --> Associative) is raw {
-        Hash.^parameterize: type-environment.instantiate(TValue), type-environment.instantiate(TKey)
+        self.WHAT.^parameterize: type-environment.instantiate(TValue), type-environment.instantiate(TKey)
     }
 
     multi method INSTANTIATE-GENERIC(::?CLASS:D: TypeEnv:D \type-environment --> Associative) is raw {
         my Mu $descr := type-environment.instantiate( nqp::getattr(self, Hash, '$!descriptor') );
         nqp::p6bindattrinvres(
-            Hash.^parameterize( type-environment.instantiate(TValue), type-environment.instantiate(TKey) ).new(self),
+            self.WHAT.^parameterize(
+                type-environment.instantiate(TValue),
+                type-environment.instantiate(TKey) ).new(self),
             Hash, '$!descriptor', $descr )
     }
 

--- a/src/core.c/Hash/Typed.rakumod
+++ b/src/core.c/Hash/Typed.rakumod
@@ -37,12 +37,12 @@ my role Hash::Typed[::TValue] does Associative[TValue] {
     }
 
     multi method INSTANTIATE-GENERIC(::?CLASS:U: TypeEnv:D \type-environment --> Associative) is raw {
-        Hash.^parameterize: type-environment.instantiate(TValue)
+        self.WHAT.^parameterize: type-environment.instantiate(TValue)
     }
     multi method INSTANTIATE-GENERIC(::?CLASS:D: TypeEnv:D \type-environment --> Associative) is raw {
         my Mu $descr := type-environment.instantiate( nqp::getattr(self, Hash, '$!descriptor') );
         nqp::p6bindattrinvres(
-            Hash.^parameterize( type-environment.instantiate(TValue) ).new(self), Hash, '$!descriptor', $descr )
+            self.WHAT.^parameterize( type-environment.instantiate(TValue) ).new(self), Hash, '$!descriptor', $descr )
     }
 
     multi method raku(::?CLASS:D \SELF:) {


### PR DESCRIPTION
The epic saga continues with the fourth episode, in which we are:

- adding support for nominalizables of non-parameteric generics in expressions
- fixing a bug in archetypes dispatcher of ClassHOW where generic status of instances of a class would be cached by the new-disp
- and fixing a bug in CoercionHOW where it might use uninitialized `$!archetypes`