### PR TITLE
Don't use lexical resolution for out-of-context generic classes

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -10968,8 +10968,10 @@ Did you mean a call like '"
         my $past;
         if nqp::isconcrete($archetypes) && $is_generic && $archetypes.nominal && !$archetypes.parametric {
             my $ins_lexical := $world.install_instantiation_lexical($/, $type);
-            $past := QAST::Var.new( :name($ins_lexical), :scope<lexical> );
-            $past.annotate('generic-lexical', 1);
+            $past :=
+                nqp::isnull($ins_lexical)
+                    ?? QAST::WVal.new( :value($type) )
+                    !! QAST::Var.new( :name($ins_lexical), :scope<lexical> ).annotate_self('generic-lexical', 1);
         }
         elsif $is_generic || nqp::isnull(nqp::getobjsc($type)) || istype($type.HOW,$/.how('package')) {
             $past := $world.symbol_lookup(@name, $/);

--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -1900,7 +1900,7 @@ class Perl6::World is HLL::World {
     method install_instantiation_lexical($/, $type) {
         unless nqp::isconcrete(my $generics-pad := $*GENERICS-PAD) {
             $/.worry("Generic type '" ~ $type.HOW.name($type) ~ "' is used out of a generic context");
-            return $type.HOW.name($type);
+            return nqp::null();
         }
 
         my $ins_lexical := self.instantiation_lexical($type);


### PR DESCRIPTION
There is a chance that this also resolves a SIGSEGV in MoarVM.