### PR TITLE
Complete generic instantiation 5

### DIFF
--- a/src/Perl6/Metamodel/ClassHOW.nqp
+++ b/src/Perl6/Metamodel/ClassHOW.nqp
@@ -437,9 +437,9 @@ class Perl6::Metamodel::ClassHOW
                 #   whatever we determine here is type's ultimate archetypes.
                 # * Also, since we've taken care of a concrete object case then here 'is-generic' is invoked on the type
                 #   itself, not an instance of it.
-                $atype := $can-is-generic && $obj.is-generic ?? $archetypes-g !! $archetypes-ng;
                 nqp::getattr($how, Perl6::Metamodel::ClassHOW, '$!archt-lock').protect({
                     nqp::scwbdisable();
+                    $atype := $can-is-generic && $obj.is-generic ?? $archetypes-g !! $archetypes-ng;
                     nqp::bindattr($how, Perl6::Metamodel::ClassHOW, '$!archetypes', $atype);
                     nqp::scwbenable();
                 });

--- a/src/core.c/Array.rakumod
+++ b/src/core.c/Array.rakumod
@@ -1461,12 +1461,11 @@ my class Array { # declared in BOOTSTRAP
             !! self.clone
     }
 
-    method ^parameterize(Mu:U \type, Mu \of) {
+    method ^parameterize(Mu:U \arr, Mu \of) {
         if nqp::isconcrete(of) {
-            die "Can not parameterize {type.^name} with {of.raku}"
+            die "Can not parameterize {arr.^name} with {of.raku}"
         }
         else {
-            my \arr = type.^mro.first(!*.^is_mixin);
             my $what := arr.^mixin(Array::Typed[of]);
             # needs to be done in COMPOSE phaser when that works
             $what.^set_name("{arr.^name}[{of.^name}]");

--- a/src/core.c/Array/Typed.rakumod
+++ b/src/core.c/Array/Typed.rakumod
@@ -100,13 +100,12 @@ my role Array::Typed[::TValue] does Positional[TValue] {
     method is-generic { nqp::hllbool(callsame() || nqp::istrue(TValue.^archetypes.generic)) }
 
     multi method INSTANTIATE-GENERIC(::?CLASS:U: TypeEnv:D \type-environment) is raw {
-        self.WHAT.^parameterize: type-environment.instantiate(TValue)
+        self.^mro.first({ !(.^is_mixin && .is-generic) }).^parameterize: type-environment.instantiate(TValue)
     }
     multi method INSTANTIATE-GENERIC(::?CLASS:D: TypeEnv:D \type-environment) is raw {
         my Mu $descr := type-environment.instantiate(nqp::getattr(self, Array, '$!descriptor'));
         nqp::p6bindattrinvres(
-            self.WHAT.^parameterize(type-environment.instantiate(TValue)).new( |(self.elems ?? self !! Empty) ),
-            Array, '$!descriptor', $descr )
+            self.WHAT.INSTANTIATE-GENERIC(type-environment).new(self), Array, '$!descriptor', $descr )
     }
 
     multi method raku(::?CLASS:D:) {

--- a/src/core.c/Hash.rakumod
+++ b/src/core.c/Hash.rakumod
@@ -444,18 +444,15 @@ my class Hash { # declared in BOOTSTRAP
             !! self.clone
     }
 
-    method ^parameterize(Mu:U \type, Mu \of, Mu \keyof = Str(Any)) {
-
-        my \hash = type.^mro.first(!*.^is_mixin);
-
+    method ^parameterize(Mu:U \hash, Mu \of, Mu \keyof = Str(Any)) {
         # fast path
         if nqp::eqaddr(of,Mu) && nqp::eqaddr(keyof,Str(Any)) {
-            type
+            hash
         }
 
         # error checking
         elsif nqp::isconcrete(of) {
-            "Can not parameterize {type.^name} with {of.raku}"
+            "Can not parameterize {hash.^name} with {of.raku}"
         }
 
         # only constraint on type
@@ -469,12 +466,12 @@ my class Hash { # declared in BOOTSTRAP
 
         # error checking
         elsif nqp::isconcrete(keyof) {
-            "Can not parameterize {type.^name} with {keyof.raku}"
+            die "Can not parameterize {hash.^name} with {keyof.raku}"
         }
 
         # no support for native types yet
         elsif nqp::objprimspec(keyof) {
-            'Parameterization of hashes with native '
+            die 'Parameterization of hashes with native '
               ~ keyof.raku
               ~ ' not yet implemented. Sorry.'
         }

--- a/src/core.c/Hash/Object.rakumod
+++ b/src/core.c/Hash/Object.rakumod
@@ -267,16 +267,15 @@ my role Hash::Object[::TValue, ::TKey] does Associative[TValue] {
     }
 
     multi method INSTANTIATE-GENERIC(::?CLASS:U: TypeEnv:D \type-environment --> Associative) is raw {
-        self.WHAT.^parameterize: type-environment.instantiate(TValue), type-environment.instantiate(TKey)
+        self.^mro.first({ !(.^is_mixin && .is-generic) }).^parameterize:
+            type-environment.instantiate(TValue),
+            type-environment.instantiate(TKey)
     }
 
     multi method INSTANTIATE-GENERIC(::?CLASS:D: TypeEnv:D \type-environment --> Associative) is raw {
         my Mu $descr := type-environment.instantiate( nqp::getattr(self, Hash, '$!descriptor') );
         nqp::p6bindattrinvres(
-            self.WHAT.^parameterize(
-                type-environment.instantiate(TValue),
-                type-environment.instantiate(TKey) ).new(self),
-            Hash, '$!descriptor', $descr )
+            self.WHAT.INSTANTIATE-GENERIC(type-environment).new(self), Hash, '$!descriptor', $descr )
     }
 
     multi method raku(::?CLASS:D \SELF:) {

--- a/src/core.c/Hash/Typed.rakumod
+++ b/src/core.c/Hash/Typed.rakumod
@@ -37,12 +37,12 @@ my role Hash::Typed[::TValue] does Associative[TValue] {
     }
 
     multi method INSTANTIATE-GENERIC(::?CLASS:U: TypeEnv:D \type-environment --> Associative) is raw {
-        self.WHAT.^parameterize: type-environment.instantiate(TValue)
+        self.^mro.first({ !(.^is_mixin && .is-generic) }).^parameterize: type-environment.instantiate(TValue)
     }
     multi method INSTANTIATE-GENERIC(::?CLASS:D: TypeEnv:D \type-environment --> Associative) is raw {
         my Mu $descr := type-environment.instantiate( nqp::getattr(self, Hash, '$!descriptor') );
         nqp::p6bindattrinvres(
-            self.WHAT.^parameterize( type-environment.instantiate(TValue) ).new(self), Hash, '$!descriptor', $descr )
+            self.INSTANTIATE-GENERIC(type-environment).new(self), Hash, '$!descriptor', $descr )
     }
 
     multi method raku(::?CLASS:D \SELF:) {


### PR DESCRIPTION
In this episode two problems are taken care of:

First, MoarVM was still crashing with `SIGSEGV` on Apple Silicon, despite all the previous attempt to get around the bug; with this PR no crash has been observed so far.

Second, this PR changes the approach to re-parameterization of `Array` and `Hash` classes. Say, we have a generic parameterization of `Array[T]`. Re-parameterizing it an instantiation of `T` would end up with something like `Array[T][Str]`, but the CORE was stripping off any mixins, revealing the original `Array` class and parameterized over it. There is a problem with this approach: if the generic was parameterized over a mixin, giving us something like `Array+{MyRole}[T]` then re-parameterizing resulted in a plain `Array[Str]`. This is barely something user would be happy too see happening.

The new approach is to strip off only _generic_ mixins. This would effectively remove `Array::Typed` (or `Hash` counterparts of it) but preserve user's non-generic mixin. Apparently, those applied to the parameterization (`Array::Typed[Str]+{MyRole}` or alike) would be lost too. `MyRole` must take own care of the instantiation if needs to be there no matter what because there is no single common way to resolve this conflict of interests.