### PR TITLE
Deprecates Distribution::Resource.Str

### DIFF
--- a/src/core.c/Distribution/Resource.rakumod
+++ b/src/core.c/Distribution/Resource.rakumod
@@ -22,7 +22,9 @@ class Distribution::Resource {
     }
 
     # delegate appropriate IO::Path methods to the resource IO::Path object
-    multi method Str(::?CLASS:D: |c) {
+    multi method Str(::?CLASS:D: |c)
+      is DEPRECATED('%?RESOURCES<key> directly instead')
+    {
         self.IO.Str(|c)
     }
     multi method gist(::?CLASS:D: |c) {


### PR DESCRIPTION
The concern with this method is described in #5504. It may unexpectedly return inconsistent values depending on the compilation stage.