### PR TITLE
Add ValueList as a 6.e feature in core

### DIFF
--- a/src/core.e/ValueList.rakumod
+++ b/src/core.e/ValueList.rakumod
@@ -1,0 +1,91 @@
+my class ValueList
+  is IterationBuffer   # get some low level functionality for free
+  does Positional      # so we can bind into arrays
+  does Iterable        # so it iterates automagically
+  is repr('VMArray')   # needed to get nqp:: ops to work on self
+{
+
+    multi method WHICH(ValueList:D:) {
+        nqp::box_s(
+          nqp::concat(
+            nqp::if(
+              nqp::eqaddr(self.WHAT,ValueList),
+              'ValueList|',
+              nqp::concat(self.^name,'|')
+            ),
+            nqp::sha1(
+              nqp::join(
+                '|',
+                nqp::stmts(  # cannot use native str arrays early in setting
+                  (my $strings  := nqp::list_s),
+                  (my int $i     = -1),
+                  (my int $elems = nqp::elems(self)),
+                  nqp::while(
+                    nqp::islt_i(($i = nqp::add_i($i,1)),$elems),
+                    nqp::push_s($strings,nqp::atpos(self,$i).Str)
+                  ),
+                  $strings
+                )
+              )
+            )
+          ),
+          ValueObjAt
+        )
+    }
+
+    proto method new(|) {*}
+    multi method new(ValueList: @args) {
+        nqp::create(self)!SET-SELF: @args.iterator
+    }
+    multi method new(ValueList: +@args) {
+        nqp::create(self)!SET-SELF: @args.iterator
+    }
+    method STORE(ValueList:D: \to_store, :$INITIALIZE) {
+        $INITIALIZE
+          ?? self!SET-SELF(to_store.iterator)
+          !! X::Assignment::RO.new(value => self).throw
+    }
+
+    method !SET-SELF(\iterator) is raw {
+        nqp::until(
+          nqp::eqaddr((my \pulled := iterator.pull-one),IterationEnd),
+          nqp::push(self, nqp::decont(pulled))
+        );
+
+        # make sure we containerize it to prevent it from being slipped
+        # into a QuantHash
+        my $valuelist = self
+    }
+
+    # set up stringification forms
+    multi method raku(ValueList:D:) {
+        (nqp::eqaddr(self.WHAT,ValueList) ?? 'ValueList' !! self.^name)
+          ~ '.new('
+          ~ self.List.map(*.raku).join(',')
+          ~ ')'
+    }
+    multi method gist(ValueList:D:) { self.List.gist }
+    multi method Str(ValueList:D:)  { self.raku }
+
+    method list() { self.List }
+    method FLATTENABLE_LIST() is implementation-detail { self }
+
+    multi method roll(ValueList:D: |c) { self.List.roll: |c }
+    multi method pick(ValueList:D: |c) { self.List.pick: |c }
+
+    # coercions
+    multi method Capture(ValueList:D:) {
+        nqp::p6bindattrinvres(nqp::create(Capture),Capture,'@!list',self)
+    }
+
+    # methods that are not allowed on immutable things
+    BEGIN for <
+      ASSIGN-POS BIND-POS push append pop shift unshift prepend
+    > -> $method {
+        ValueList.^add_method: $method, method (ValueList:D: |) {
+            X::Immutable.new(:$method, typename => self.^name).throw
+        }
+    }
+}
+
+# vim: expandtab shiftwidth=4

--- a/t/02-rakudo/03-corekeys-6e.t
+++ b/t/02-rakudo/03-corekeys-6e.t
@@ -749,6 +749,7 @@ my @expected = (
     Q{Unicode},
     Q{UnsignedBlob},
     Q{VM},
+    Q{ValueList},
     Q{ValueObjAt},
     Q{Variable},
     Q{Version},

--- a/t/02-rakudo/03-corekeys.t
+++ b/t/02-rakudo/03-corekeys.t
@@ -825,6 +825,7 @@ my @allowed =
         Q{Formatter},
         Q{Grammar},
         Q{PseudoStash},
+        Q{ValueList},
     );
 
 my %nyi-for-backend = (

--- a/t/02-rakudo/04-settingkeys-6e.t
+++ b/t/02-rakudo/04-settingkeys-6e.t
@@ -747,6 +747,7 @@ my %allowed = (
     Q{Unicode},
     Q{UnsignedBlob},
     Q{VM},
+    Q{ValueList},
     Q{ValueObjAt},
     Q{Variable},
     Q{Version},

--- a/tools/templates/6.e/core_sources
+++ b/tools/templates/6.e/core_sources
@@ -9,4 +9,5 @@ src/core.e/Formatter.rakumod
 src/core.e/Format.rakumod
 src/core.e/Rakudo/Iterator.rakumod
 src/core.e/Fixups.rakumod
+src/core.e/ValueList.rakumod
 src/core.e/additions.rakumod


### PR DESCRIPTION
Raku needs a value-type object for lists.  This copies the ValueList ecosystem module https://raku.land/zef:lizmat/ValueList verbatim and makes it part of 6.e.  It does *NOT* provide any additional syntactic sugar to easily create ValueLists, so ValueList.new(...) is the way to go now.