### PR TITLE
Handle .extension("foo") on IOs without extension differently

### DIFF
--- a/src/core.c/IO/Path.rakumod
+++ b/src/core.c/IO/Path.rakumod
@@ -150,7 +150,7 @@ my class IO::Path is Cool does IO {
     }
     multi method extension(IO::Path:D:
       Str $subst,
-      Int :$parts = 1,
+      Int :$parts = ?self.extension,
       Str :$joiner = nqp::chars($subst) ?? '.' !! ''
     ) {
       self.new: :dirname(self.dirname), :volume(self.volume),


### PR DESCRIPTION
Before this commit, "foo".IO.extension("bar") would return "foo".IO instead of the probably expected "foo.bar".IO.  To get that behaviour one needs to specify :parts(0) as well.  Which, at least to me, was a bit of a WAT.

This commit changes that to be more DWIM, so that "foo".IO.extension("bar") *will* return "foo.bar".IO.  This is achieved by changing the default of the :parts named argument to 0 if there is no extension yet.

Spectest remains clean.  Ecosystem fallout is expected to be minimal, as any code expecting to add the extension, would have been expected to specify the :parts named argument explicitly anyway.