### PR TITLE
Add Mu.Callable($method) "coercer"

### DIFF
--- a/src/core.c/Mu.rakumod
+++ b/src/core.c/Mu.rakumod
@@ -118,8 +118,13 @@ my class Mu { # declared in BOOTSTRAP
         self.HOW.set_why($why);
     }
 
-    method Callable(str $method) is pure { 
-        nqp::ifnull(nqp::tryfindmethod(self,$method),Nil)
+    method Callable(str $method) { 
+        nqp::ifnull(
+          nqp::tryfindmethod(self,$method),
+          X::Method::NotFound.new(
+            :invocant(self), :typename(self.^name), :$method
+          ).Failure
+        )
     }
 
     proto method Bool() {*}

--- a/src/core.c/Mu.rakumod
+++ b/src/core.c/Mu.rakumod
@@ -118,7 +118,7 @@ my class Mu { # declared in BOOTSTRAP
         self.HOW.set_why($why);
     }
 
-    method Sub(str $method) is pure { 
+    method Callable(str $method) is pure { 
         nqp::ifnull(nqp::tryfindmethod(self,$method),Nil)
     }
 

--- a/src/core.c/Mu.rakumod
+++ b/src/core.c/Mu.rakumod
@@ -118,6 +118,8 @@ my class Mu { # declared in BOOTSTRAP
         self.HOW.set_why($why);
     }
 
+    method Sub(str $method) { nqp::findmethod(self, $method) }
+
     proto method Bool() {*}
     multi method Bool(Mu:U: --> False) { }
     multi method Bool(Mu:D:) { self.defined }

--- a/src/core.c/Mu.rakumod
+++ b/src/core.c/Mu.rakumod
@@ -118,15 +118,6 @@ my class Mu { # declared in BOOTSTRAP
         self.HOW.set_why($why);
     }
 
-    method Callable(str $method) { 
-        nqp::ifnull(
-          nqp::tryfindmethod(self,$method),
-          X::Method::NotFound.new(
-            :invocant(self), :typename(self.^name), :$method
-          ).Failure
-        )
-    }
-
     proto method Bool() {*}
     multi method Bool(Mu:U: --> False) { }
     multi method Bool(Mu:D:) { self.defined }

--- a/src/core.c/Mu.rakumod
+++ b/src/core.c/Mu.rakumod
@@ -118,7 +118,7 @@ my class Mu { # declared in BOOTSTRAP
         self.HOW.set_why($why);
     }
 
-    method Sub(str $method) { nqp::findmethod(self, $method) }
+    method Sub(str $method) is pure { nqp::findmethod(self, $method) }
 
     proto method Bool() {*}
     multi method Bool(Mu:U: --> False) { }

--- a/src/core.c/Mu.rakumod
+++ b/src/core.c/Mu.rakumod
@@ -118,7 +118,9 @@ my class Mu { # declared in BOOTSTRAP
         self.HOW.set_why($why);
     }
 
-    method Sub(str $method) is pure { nqp::findmethod(self, $method) }
+    method Sub(str $method) is pure { 
+        nqp::ifnull(nqp::tryfindmethod(self,$method),Nil)
+    }
 
     proto method Bool() {*}
     multi method Bool(Mu:U: --> False) { }

--- a/src/core.e/Fixups.rakumod
+++ b/src/core.e/Fixups.rakumod
@@ -1,6 +1,19 @@
 # This file contains fixups to existing core classes by means of augmentation
 # for language level 6.e.
 
+augment class Mu {
+
+    # introducing .Callable($method)
+    method Callable(str $method) {
+        nqp::ifnull(
+          nqp::tryfindmethod(self,$method),
+          X::Method::NotFound.new(
+            :invocant(self), :typename(self.^name), :$method
+          ).Failure
+        )
+    }
+}
+
 augment class Any {
 
     # introducing snip


### PR DESCRIPTION
The idea being that *Raku* should provide a HLL interface to obtain a Callable object for the given method name on the invocant.

    $ raku -e 'say Int.Callable("Str")(687, :subscript)'
    ₆₈₇

In place of the .^find_method logic, which is *not* Raku specific according to the documentation:

  https://docs.raku.org/type/Metamodel/DefiniteHOW#method_find_method

EDIT: change `Sub` to `Callable`