### PR TITLE
Ensure `%!mro` is not modified concurrently

### DIFF
--- a/src/Perl6/Metamodel/ClassHOW.nqp
+++ b/src/Perl6/Metamodel/ClassHOW.nqp
@@ -52,7 +52,9 @@ class Perl6::Metamodel::ClassHOW
     }
 
     method new(*%named) {
-        nqp::findmethod(NQPMu, 'BUILDALL')(nqp::create(self), %named)
+        my $obj := nqp::findmethod(NQPMu, 'BUILDALL')(nqp::create(self), %named);
+        $obj.setup_mro_engine();
+        $obj
     }
 
     method !refresh_archetypes($obj) {

--- a/src/Perl6/Metamodel/ConcreteRoleHOW.nqp
+++ b/src/Perl6/Metamodel/ConcreteRoleHOW.nqp
@@ -30,7 +30,9 @@ class Perl6::Metamodel::ConcreteRoleHOW
     }
 
     method new(*%named) {
-        nqp::findmethod(NQPMu, 'BUILDALL')(nqp::create(self), %named)
+        my $obj := nqp::findmethod(NQPMu, 'BUILDALL')(nqp::create(self), %named);
+        $obj.setup_mro_engine();
+        $obj
     }
 
     my class Collision {

--- a/src/Perl6/Metamodel/NativeHOW.nqp
+++ b/src/Perl6/Metamodel/NativeHOW.nqp
@@ -18,7 +18,9 @@ class Perl6::Metamodel::NativeHOW
     }
 
     method new(*%named) {
-        nqp::findmethod(NQPMu, 'BUILDALL')(nqp::create(self), %named)
+        my $obj := nqp::findmethod(NQPMu, 'BUILDALL')(nqp::create(self), %named);
+        $obj.setup_mro_engine();
+        $obj
     }
 
     method new_type(:$name = '<anon>', :$repr = 'P6opaque', :$ver, :$auth, :$api) {

--- a/src/Perl6/Metamodel/NativeRefHOW.nqp
+++ b/src/Perl6/Metamodel/NativeRefHOW.nqp
@@ -19,7 +19,9 @@ class Perl6::Metamodel::NativeRefHOW
     }
 
     method new(*%named) {
-        nqp::findmethod(NQPMu, 'BUILDALL')(nqp::create(self), %named)
+        my $obj := nqp::findmethod(NQPMu, 'BUILDALL')(nqp::create(self), %named);
+        $obj.setup_mro_engine();
+        $obj
     }
 
     method new_type(:$name = '<anon>', :$ver, :$auth, :$api) {


### PR DESCRIPTION
Introduce lock-protection for the attribute and atomize operations we perform with it.