### PR TITLE
Avoid leaking repo.lock handle 

### DIFF
--- a/src/core.c/CompUnit/Repository/Installation.rakumod
+++ b/src/core.c/CompUnit/Repository/Installation.rakumod
@@ -231,6 +231,7 @@ sub MAIN(*@, *%) {
         my @*MODULES;
         my $path   = self!writeable-path or die "No writeable path found, $.prefix not writeable";
         my $lock = $.prefix.add('repo.lock').open(:create, :w);
+        LEAVE $lock.close;
         $lock.lock;
 
         my $version = self!repository-version;

--- a/src/core.c/CompUnit/Repository/Installation.rakumod
+++ b/src/core.c/CompUnit/Repository/Installation.rakumod
@@ -233,6 +233,7 @@ sub MAIN(*@, *%) {
         my $lock = $.prefix.add('repo.lock').open(:create, :w);
         LEAVE $lock.close;
         $lock.lock;
+        LEAVE $lock.unlock;
 
         my $version = self!repository-version;
         self.upgrade-repository unless $version == 2;
@@ -240,7 +241,6 @@ sub MAIN(*@, *%) {
         my $dist-id = $dist.id;
         my $dist-dir = self!dist-dir;
         if not $force and $dist-dir.add($dist-id) ~~ :e {
-            $lock.unlock;
             fail "$dist already installed";
         }
 
@@ -365,8 +365,6 @@ sub MAIN(*@, *%) {
             }
             PROCESS::<$REPO> := $head;
         }
-
-        $lock.unlock;
     } ) }
 
     my sub unlink-if-exists(IO::Path:D $io) { $io.unlink if $io.e }


### PR DESCRIPTION
The repo.lock file would be opened when installing a distribution, but would never get closed. On windows this could manifest as an error saying it can't delete repo.lock because the resource is busy. This updates CURI.install to close the repo.lock file when leaving the function.