### PR TITLE
Work around repo.lock unlocking on windows

### DIFF
--- a/src/core.c/CompUnit/Repository/Installation.rakumod
+++ b/src/core.c/CompUnit/Repository/Installation.rakumod
@@ -233,6 +233,9 @@ sub MAIN(*@, *%) {
         my $lock = $.prefix.add('repo.lock').open(:create, :w);
         LEAVE .unlock, .close with $lock;
 
+        # Workaround buggy LEAVE + IO::Handle::DESTROY interaction on windows
+        $lock.do-not-close-automatically;
+
         my $version = self!repository-version;
         self.upgrade-repository unless $version == 2;
 


### PR DESCRIPTION
Commit 7ca96bbd90 started showing a `Failed to unlock filehandle: 158` error on Windows. This attempts to work around a presumed issue in how `IO::Handle::DESTROY` and e.g. `LEAVE $handle.unlock` interact by disabling the auto closing behavior of the lock file being used.