### PR TITLE
Fix removal of file locking during installation

### DIFF
--- a/src/core.c/CompUnit/Repository/Installation.rakumod
+++ b/src/core.c/CompUnit/Repository/Installation.rakumod
@@ -231,6 +231,7 @@ sub MAIN(*@, *%) {
         my @*MODULES;
         my $path   = self!writeable-path or die "No writeable path found, $.prefix not writeable";
         my $lock = $.prefix.add('repo.lock').open(:create, :w);
+        $lock.lock;
         LEAVE .unlock, .close with $lock;
 
         my $version = self!repository-version;


### PR DESCRIPTION
7ca96bb accidentally removed the logic to lock the file. This reintroduces the necessary locking.