### PR TITLE
Provide native int coercers to `Int`/`Cool`

### DIFF
--- a/src/core.c/Cool.rakumod
+++ b/src/core.c/Cool.rakumod
@@ -467,6 +467,21 @@ my class Cool { # declared in BOOTSTRAP
     }
 
     method Version() { self.Str.Version }
+
+    method  int(-->  int) is raw { my  int $a = self.Int; $a }
+    method uint(--> uint) is raw { my uint $a = self.Int; $a }
+
+    method int64(--> int64) is raw { my int64 $a = self.Int; $a }
+    method int32(--> int32) is raw { my int32 $a = self.Int; $a }
+    method int16(--> int16) is raw { my int16 $a = self.Int; $a }
+    method int8( --> int8 ) is raw { my int8  $a = self.Int; $a }
+
+    method uint64(--> uint64) is raw { my uint64 $a = self.Int; $a }
+    method uint32(--> uint32) is raw { my uint32 $a = self.Int; $a }
+    method uint16(--> uint16) is raw { my uint16 $a = self.Int; $a }
+    method uint8( --> uint8 ) is raw { my uint8  $a = self.Int; $a }
+    method byte(  --> byte  ) is raw { my byte   $a = self.Int; $a }
+
 }
 Metamodel::ClassHOW.exclude_parent(Cool);
 

--- a/src/core.c/Int.rakumod
+++ b/src/core.c/Int.rakumod
@@ -272,6 +272,20 @@ my class Int does Real { # declared in BOOTSTRAP
             }
         }
     }
+
+    method  int(-->  int) is raw { my  int $a = self; $a }
+    method uint(--> uint) is raw { my uint $a = self; $a }
+
+    method int64(--> int64) is raw { my int64 $a = self; $a }
+    method int32(--> int32) is raw { my int32 $a = self; $a }
+    method int16(--> int16) is raw { my int16 $a = self; $a }
+    method int8( --> int8 ) is raw { my int8  $a = self; $a }
+
+    method uint64(--> uint64) is raw { my uint64 $a = self; $a }
+    method uint32(--> uint32) is raw { my uint32 $a = self; $a }
+    method uint16(--> uint16) is raw { my uint16 $a = self; $a }
+    method uint8( --> uint8 ) is raw { my uint8  $a = self; $a }
+    method byte(  --> byte  ) is raw { my byte   $a = self; $a }
 }
 
 multi sub prefix:<++>(Int:D $a is rw --> Int:D) {


### PR DESCRIPTION
Specifically:
- .int, .int64, .int32, .int16, .int8
- .uint, .uint64, .uint32, .uint16, .uint8, .byte

Note that this is just to provide the API.  The implementation is definitely hacky: this should probably be handled in the grammar and in RakuAST it probably will.

This makes the following code work:

    say 256.uint8;  # 0
    say 255.int8;   # -1

And:

    multi a(uint8 $) { dd }
    multi a(Int:D $) { dd }
    a 42.uint8;  # sub a(uint8)

Note however that does **not** make multiple dispatch on different native sizes work:

    multi a(uint8  $) { dd }
    multi a(uint16 $) { dd }
    a 42.uint8;
    # Ambiguous call to 'a(Int)'; these signatures all match:
    #   (uint8 $)
    #   (uint16 $)

This will need additional work in the dispatcher logic.