### PR TITLE
Better errors for common array parameter mistakes

### DIFF
--- a/src/core.c/Exception.rakumod
+++ b/src/core.c/Exception.rakumod
@@ -2814,9 +2814,23 @@ my class X::TypeCheck is Exception {
             !! $complainee.Str
     }
     method explain {
-        nqp::istype($!expected.HOW, Metamodel::Explaining)
+        my $msg = nqp::istype($!expected.HOW, Metamodel::Explaining)
             ?? self.complainee-message
-            !! "expected $.expectedn but got $.gotn"
+            !! "expected $.expectedn but got $.gotn";
+
+        # A lot of beginners make mistakes when typing array parameters,
+        # so let's try and catch some of the common ones
+        if $!expected ~~ Positional {
+            # Positionals have an `of` method
+            if $!expected.of ~~ Array {
+                $msg ~= ". Did you mean to expect an array of Arrays?";
+            }
+            # but we don't know what $!got is and it may not have an `of` method
+            elsif $!got.^can('of') && $!got.of =:= Mu {
+                $msg ~= ". You have to pass an explicitly typed array, not one that just might happen to contain elements of the correct type.";
+            }
+        }
+        $msg.naive-word-wrapper
     }
     method message() {
         self.priors() ~


### PR DESCRIPTION
These are mistakes that beginners make a lot, so try to help them out. The two particular cases I'm thinking of are something like: `sub a(Array @b) { dd @b }; my @c = 1, 3; a(@c)`
where they forgot or didn't realize that the `@` sigil on the parameter already implied an array.
and
`sub a(Int @b) { dd @b }; my @c = 1, 3; a(@c)`
where they forgot or didn't realize that Raku's types are nominal, i.e., they need to be be explicitly declared, they aren't just inferred.