### PR TITLE
Implement sub form of &trans, mainly to support feed operators.

### DIFF
--- a/src/core.e/additions.rakumod
+++ b/src/core.e/additions.rakumod
@@ -48,4 +48,11 @@ multi sub snitch(&snitcher, \SNITCHEE) is raw {
     SNITCHEE
 }
 
+# Introducing trans as a sub for use with feed operatos. Making this a multi is
+# useless, as this candidate would always match
+sub trans(**@a, *%_) {
+    # dd @a, @a.head, @a.tail;
+    @a.tail».trans(|@a.head.list, |%_)
+}
+
 # vim: expandtab shiftwidth=4

--- a/src/core.e/additions.rakumod
+++ b/src/core.e/additions.rakumod
@@ -51,8 +51,9 @@ multi sub snitch(&snitcher, \SNITCHEE) is raw {
 # Introducing trans as a sub for use with feed operatos. Making this a multi is
 # useless, as this candidate would always match
 sub trans(**@a, *%_) {
-    # dd @a, @a.head, @a.tail;
-    @a.tail».trans(|@a.head.list, |%_)
+    @a.tail.elems > 1
+        ?? @a.tail.map(*.trans(|@a.head(*-1).list, |%_))
+        !! @a.tail.trans(|@a.head(*-1).list, |%_)
 }
 
 # vim: expandtab shiftwidth=4

--- a/t/02-rakudo/03-corekeys-6e.t
+++ b/t/02-rakudo/03-corekeys-6e.t
@@ -476,6 +476,7 @@ my @expected = (
     Q{&trait_mod:<returns>},
     Q{&trait_mod:<trusts>},
     Q{&trait_mod:<will>},
+    Q{&trans},
     Q{&trim},
     Q{&trim-leading},
     Q{&trim-trailing},

--- a/t/02-rakudo/03-corekeys.t
+++ b/t/02-rakudo/03-corekeys.t
@@ -820,6 +820,7 @@ my @allowed =
         Q{&snitch},
         Q{&sprintf},
         Q{&term:<nano>},
+        Q{&trans},
         Q{CORE-SETTING-REV},
         Q{Format},
         Q{Formatter},

--- a/t/02-rakudo/04-settingkeys-6e.t
+++ b/t/02-rakudo/04-settingkeys-6e.t
@@ -473,6 +473,7 @@ my %allowed = (
     Q{&trait_mod:<returns>},
     Q{&trait_mod:<trusts>},
     Q{&trait_mod:<will>},
+    Q{&trans},
     Q{&trim},
     Q{&trim-leading},
     Q{&trim-trailing},

--- a/t/02-rakudo/07-implementation-detail-6.e.t
+++ b/t/02-rakudo/07-implementation-detail-6.e.t
@@ -32,7 +32,7 @@ my @lower = ("",<<
   run samecase samemark samewith say sec sech set shell shift sign
   signal sin sinh skip sleep sleep-timer sleep-until slip slurp snip snitch
   so sort splice split sprintf spurt sqrt squish srand subbuf-rw substr
-  substr-rw succeed sum symlink tail take take-rw tan tanh tc tclc trim
+  substr-rw succeed sum symlink tail take take-rw tan tanh tc tclc trans trim
   trim-leading trim-trailing truncate uc unimatch uniname
   uninames uniparse uniprop uniprops unique unival univals unlink
   unpolar unshift val values warn wordcase words zprintf


### PR DESCRIPTION
Tests:

```
use v6.*;
use Test;

my @with-pair;
<abc bbc cbc> ==> trans('b' => 'B') ==> @with-pair;
is-deeply @with-pair, <aBc BBc cBc>.Array, 'trans with feed operator and pair';

my @with-positional;
<abc bbc cbc> ==> trans(['a' => 'A', 'c' => 'C']) ==> @with-positional;
is-deeply @with-positional, <AbC bbC CbC>.Array, 'trans with feed operator and Array';
@with-positional = ();
<abc bbc cbc> ==> trans(('a' => 'A', 'c' => 'C')) ==> @with-positional;
is-deeply @with-positional, <AbC bbC CbC>.Array, 'trans with feed operator and List';

my @with-flags;
<a111bc b222bc c333bc> ==> trans('a'..'z' => 'x', :complement, :squash) ==> @with-flags;
is-deeply @with-flags, ["axbc", "bxbc", "cxbc"], 'trans with feed operator and named flags';
```