### PR TITLE
Draft: Use positional scalar disambiguation for Array.splice dispatch

### DIFF
--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -4245,7 +4245,7 @@ BEGIN {
                     my $value := nqp::captureposarg($capture, $i);
                     nqp::push_i($capture-scalar-pos-args, $i)
                         if nqp::istype_nd($value, Scalar) # could also be nqp::iscont($value)
-                        && nqp::istype($value, Array);
+                        && (nqp::istype($value, Array) || nqp::istype($value, List));
                 }
                 ++$i;
             }

--- a/src/core.c/Array.rakumod
+++ b/src/core.c/Array.rakumod
@@ -1093,6 +1093,57 @@ my class Array { # declared in BOOTSTRAP
                :range("0..^{self.elems - $offset}")
              ).throw
     }
+    #------ splice(offset,size,positional scalar) candidates
+
+    # these candidates allow the user of splice to indicate that they
+    # want to treat an array as a single item to splice by itemizing
+    # that array a la (*, *, $[1])
+    multi method splice(Array:D:
+                        Whatever $offset, Whatever $size, Positional $new
+        --> Array:D) {
+        self.splice($offset, $size, [$new,])
+    }
+    multi method splice(Array:D:
+                        Whatever $offset, Callable:D $size, Positional $new
+        --> Array:D) {
+        self.splice($offset, $size, [$new,])
+    }
+    multi method splice(Array:D:
+                        Whatever $offset, Int:D $size, Positional $new
+        --> Array:D) {
+        self.splice($offset, $size, [$new,])
+    }
+    multi method splice(Array:D:
+                        Callable:D $offset, Whatever $size, Positional $new
+        --> Array:D) {
+        self.splice($offset, $size, [$new,])
+    }
+    multi method splice(Array:D:
+                        Callable:D $offset, Callable:D $size, Positional $new
+        --> Array:D) {
+        self.splice($offset, $size, [$new,])
+    }
+    multi method splice(Array:D:
+                        Callable:D $offset, Int:D $size, Positional $new
+        --> Array:D) {
+        self.splice($offset, $size, [$new,])
+    }
+    multi method splice(Array:D:
+                        Int:D $offset, Whatever $size, Positional $new
+        --> Array:D) {
+        self.splice($offset, $size, [$new,])
+    }
+    multi method splice(Array:D:
+                        Int:D $offset, Callable:D $size, Positional $new
+        --> Array:D) {
+        self.splice($offset, $size, [$new,])
+    }
+    multi method splice(Array:D:
+                        Int:D $offset, Int:D $size, Positional $new
+        --> Array:D) {
+        self.splice($offset, $size, [$new,])
+    }
+
     #------ splice(offset,size,array) candidates
 
     # we have these 9 multies to avoid infiniloop when incorrect types are

--- a/src/vm/moar/dispatchers.nqp
+++ b/src/vm/moar/dispatchers.nqp
@@ -2622,7 +2622,7 @@ sub disambiguate-positional-arg-candidates($candidates, $capture) {
             my $value := nqp::captureposarg($capture, $i);
             nqp::push_i($capture-scalar-pos-args, $i)
                 if nqp::istype_nd($value, Scalar) # could also be nqp::iscont($value)
-                && nqp::istype($value, Array);
+                && (nqp::istype($value, Array) || nqp::istype($value, List));
         }
         ++$i;
     }


### PR DESCRIPTION
This is a followup to #5543 that utilizes the new disambiguation to resolve #5500.

Essentially this allows `Array.splice` to DWIM for the following syntax:

```
# applies to all candidate combos for Array.splice, just using '*, *,' as an example   
my @array = <a b c>;
@array.splice(*, *, $[<q e d>]); dd @array
# Mu @array = ["a", "b", "c", ["q", "e", "d"]]
### or 
@array.splice(*, *, $(<e r g o>)); dd @array
# Mu @array = ["a", "b", "c", ("e", "r", "g", "o")]
```

This syntax is, in my opinion, much more discoverable (and pleasant) than the other means of dealing with "single argument collapse" (`[[<h m m>],]`.

(Note: This PR includes a commit to enable the disambiguation for `$()`)