### PR TITLE
Add dispatch disambiguation via 'is item' parameter trait

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -5641,6 +5641,23 @@ class Perl6::Actions is HLL::Actions does STDActions {
 
         # Stash any traits.
         %param_info<traits> := $<trait>;
+        if my int $num_traits := nqp::elems(%param_info<traits>) {
+            my int $z;
+            while !%param_info<is_item> && $z < $num_traits {
+                %param_info<is_item> := 1
+                    if nqp::index(%param_info<traits>[$z], 'item') > 0;
+                ++$z;
+            }
+            if %param_info<is_item> && (%param_info<sigil> eq '$' || %param_info<sigil> eq '&') {
+                $/.typed_sorry('X::Comp::Trait::Invalid',
+                    name        => %param_info<variable_name>,
+                    reason      => "only '\@' or '\%' sigiled parameters can be constrained to itemized arguments",
+                    declaring   => 'parameter',
+                    type        => 'is',
+                    subtype     => 'item'
+                );
+            }
+        }
 
         if $<type_constraint> {
             if %param_info<pos_slurpy> || %param_info<pos_lol> || %param_info<pos_onearg> {

--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -2317,6 +2317,9 @@ class Perl6::World is HLL::World {
         if %param_info<default_is_literal> {
             $flags := $flags + nqp::const::SIG_ELEM_DEFAULT_IS_LITERAL;
         }
+        if %param_info<is_item> {
+            $flags := $flags + nqp::const::SIG_ELEM_IS_ITEM;
+        }
         my $primspec := nqp::objprimspec(%param_info<type>);
         if $primspec == nqp::const::BIND_VAL_INT {
             $flags := $flags + nqp::const::SIG_ELEM_NATIVE_INT_VALUE;
@@ -4366,7 +4369,8 @@ class Perl6::World is HLL::World {
     # Applies a list of traits, by calling the apply method on each.
     my %is-traits-to-warn-on-duplicate := nqp::hash(
         'tighter',  1,  'looser', 1,  'equiv', 1,  'rw',   1,  'default', 1,
-        'readonly', 1,  'raw',    1,  'assoc', 1,  'pure', 1,  'export',  1
+        'readonly', 1,  'raw',    1,  'assoc', 1,  'pure', 1,  'export',  1,
+        'item', 1
     );
     method apply_traits($traits, $declarand) {
         my %seen;

--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -2877,6 +2877,18 @@ BEGIN {
         $self
     }));
 
+    Parameter.HOW.add_method(Parameter, 'set_item',
+      nqp::getstaticcode(sub ($self) {
+        $self := nqp::decont($self);
+
+        nqp::bindattr_i($self, Parameter, '$!flags',
+          nqp::getattr_i($self, Parameter, '$!flags')
+            +| nqp::const::SIG_ELEM_IS_ITEM
+        );
+
+        $self
+    }));
+
     Parameter.HOW.add_method(Parameter, 'set_onearg',
       nqp::getstaticcode(sub ($self) {
         $self := nqp::decont($self);

--- a/src/Raku/ast/signature.rakumod
+++ b/src/Raku/ast/signature.rakumod
@@ -839,6 +839,17 @@ class RakuAST::Parameter
         if $is-generic && $is-coercive && !$was-slurpy && !($param-type =:= Mu) && !self.invocant {
             $!owner.set-custom-args;
         }
+
+        my $sigil := $!target.sigil;
+        if self.meta-object.is-item && ($sigil eq '$' || $sigil eq '&') {
+            self.add-sorry:
+                $resolver.build-exception:  'X::Comp::Trait::Invalid',
+                                            name        => $!target.name,
+                                            reason      => "only '\@' or '\%' sigiled parameters can be constrained to itemized arguments",
+                                            declaring   => 'parameter',
+                                            type        => 'is',
+                                            subtype     => 'item';
+        }
     }
 
     method IMPL-TO-QAST(RakuAST::IMPL::QASTContext $context) {

--- a/src/core.c/Associative.rakumod
+++ b/src/core.c/Associative.rakumod
@@ -9,4 +9,6 @@ my role Associative[::TValue = Mu, ::TKey = Str(Any)] {
 #    method EXISTS-KEY($) { ... }
 }
 
+nqp::bindhllsym('Raku', 'Associative', Associative);
+
 # vim: expandtab shiftwidth=4

--- a/src/core.c/traits.rakumod
+++ b/src/core.c/traits.rakumod
@@ -248,6 +248,9 @@ multi sub trait_mod:<is>(Parameter:D $param, :raw($)!) {
 multi sub trait_mod:<is>(Parameter:D $param, :onearg($)!) {
     $param.set_onearg();
 }
+multi sub trait_mod:<is>(Parameter:D $param, :item($)!) {
+    $param.set_item();
+}
 multi sub trait_mod:<is>(Parameter:D $param, :$leading_docs!) {
     Rakudo::Internals.SET_LEADING_DOCS($param, $leading_docs);
 }


### PR DESCRIPTION
This allows for multi routines to distinguish between itemized arguments
via a new `is item` parameter trait.

For the sake of simplicity, the parameter trait does not add any new
ParamTypeChecks[^1] to the parameter. Instead it is only used as a marker
for disambiguation in multiple dispatch:

```
    multi sub a(@a is item) { "itemized!" }
    multi sub a(@a) { "array" }

    a [1,2];  # "array"
    a $[1,2]; # "itemized!"
```

Note that this only makes sense for `@` (positional) and `%` (associative) 
sigilled parameters. Raw, unsigilled parameters are also currently included,
but only if the parameter type is specified to something that does `Positional`
or `Associative`.

[^1]:Taking this approach is complicated by the fact that there appears to be
some decontainerization of arguments via the `callstatic` and `callmethod`
ops: a `ParamTypeCheck` which calls `iscont` on the lowered param always
fails for `$[]` and `${}` arguments. Further research is required.