### PR TITLE
Provide conditional exit status for `USAGE`

### DIFF
--- a/src/core.c/Main.rakumod
+++ b/src/core.c/Main.rakumod
@@ -438,6 +438,7 @@ my sub RUN-MAIN(&main, $mainline, :$in-as-argsfiles) {
     elsif !$provided-g-u && !$provided-a-to-c && %caller-my<&USAGE> -> &usage {
         # DEPRECATED message here
         usage;
+        exit $capture<help> ?? 0 !! 2;
     }
 
     # Display the default USAGE message on either STDOUT/STDERR


### PR DESCRIPTION
Even though it's an older approach, it is trivial
to provide `USAGE` the same exit code logic as for `GENERATE-USAGE`:

  If a `--help` is part of the invocation, exit 0.

  Otherwise, exit 2.

Addresses R#5514 (#5514).