### PR TITLE
Supply an Any.match method candidate for Any:D

### DIFF
--- a/src/core.c/Any.rakumod
+++ b/src/core.c/Any.rakumod
@@ -145,7 +145,9 @@ my class Any { # declared in BOOTSTRAP
 
     multi method iterator(Any:) { self.list.iterator }
 
-    method match(Any:U: |) { self.Str; nqp::getlexcaller('$/') = Nil }
+    proto method match(|)         {*}
+    multi method match(Any:U: |)  { self.Str; nqp::getlexcaller('$/') = Nil }
+    multi method match(Any:D: |c) { self.Str.match(|c) }
 
     proto method classify(|) is nodal {*}
     multi method classify() {


### PR DESCRIPTION
This addresses the use of non-`Str` candidates arriving
in `where` constraints that attempt to match against
a regex. (R#5464 / https://github.com/rakudo/rakudo/issues/5464).

```
subset S where { m/"aaa"/ }
class C { method Str { "aaa" } }
my S $s = C.new
|=> Invocant of method 'match' must be a type object of
|=> type 'Any', not an object instance of type 'C'.
|=> Did you forget a 'multi'?
```

That same error would occur with where clauses on
signature parameters.

Now it works as expected, calling `Str` on the clause
subject and running the match.

This can still fail if you are trying to match against
an instance of an Any class that does not supply a Str
method. However, this seems like a reasonable site for
such a concern to be raised.

The Any:U candidate (formerly the only candidate) is
useful for issuing the standard warning for trying to
stringify a type object. It is worth noting that
removing it causes issues with running a test case
in `t/spec/S05-substitution/subst.t`:

```
$_ = Any;
s[ea] = "rea";
is $_, "", 'can use s[]="" when $_ is not set';
```

This test case is marked as TODO.