### PR TITLE
Add worry for WhateverCode on LHS of smartmatch

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -10719,6 +10719,7 @@ Did you mean a call like '"
                 := $*W.find_symbol: ['HyperWhatever'], :setting-only)
             !! $hyper_whatever_sym
     }
+
     method whatever_curry($/, $qast, $upto_arity) {
         my int $curried :=
             # It must be an op and...
@@ -10760,6 +10761,20 @@ Did you mean a call like '"
         my $Whatever      := self.whatever_sym;
         my $WhateverCode  := self.whatever_code_sym;
         my $HyperWhatever := self.hyper_whatever_sym;
+
+        # Provide some helpful feedback to those using a WhateverCode as LHS of a smartmatch
+        # (For a good cry, just compare this to the RakuAST implementation of the same worry)
+        if $qast.op eq 'chain' && $qast.name eq '&infix:<~~>'
+            && nqp::isconcrete($qast[0])
+            && nqp::istype($qast[0], QAST::Op)
+            && $qast[0].op eq 'p6capturelex'
+            && nqp::isconcrete($qast[0][0])
+            && nqp::istype($qast[0][0], QAST::Op)
+            && $qast[0][0].op eq 'callmethod' && $qast[0][0].name eq 'clone'
+            && nqp::isconcrete($qast[0][0][0])
+            && nqp::istype($qast[0][0][0], QAST::WVal)
+            && nqp::istype($qast[0][0][0].value, $WhateverCode)
+        { $/.typed_worry('X::WhateverCode::SmartMatch::LHS') }
 
         # Find anything we might need to curry and bail out if there's nothing
         while $i < $e {

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -1568,6 +1568,10 @@ class RakuAST::ApplyInfix
                 self.add-sorry: $left.build-bind-exception($resolver);
             }
 
+            if $infix.operator eq '~~' && $left.IMPL-CURRIED {
+                self.add-worry: $resolver.build-exception: 'X::WhateverCode::SmartMatch::LHS';
+            }
+
             my $type := self.left.return-type;
             if nqp::istype($infix, RakuAST::Assignment) && !nqp::eqaddr($type, Mu) {
                 my $right := self.right;

--- a/src/core.c/Exception.rakumod
+++ b/src/core.c/Exception.rakumod
@@ -3528,6 +3528,13 @@ my class X::HyperWhatever::Multiple is Exception {
     }
 }
 
+my class X::WhateverCode::SmartMatch::LHS {
+    method message() {
+        "WhateverCode on LHS of smart-match does not curry the smart-match expression.\n"
+            ~ "Try placing the WhateverCode expression on the RHS instead if results are not as expected."
+    }
+}
+
 my class X::EXPORTHOW::InvalidDirective does X::Comp {
     has $.directive;
     method message() {


### PR DESCRIPTION
Smartmatch only curries `Whatever`, so any user that provides a `WhateverCode` expression as an LHS is likely to encounter a surprising failure (when compared to the behavior of most other infix operaators).

In order to be proactive and helpful to such users, we emit a descriptive worry in this scenario.