### PR TITLE
Fix memory leaking in infinity-bound ...

### DIFF
--- a/src/core.c/Rakudo/SEQUENCE.rakumod
+++ b/src/core.c/Rakudo/SEQUENCE.rakumod
@@ -360,7 +360,7 @@ sub SEQUENCE(
         }
     });
     $infinite
-        ?? (gathered.Slip, Slip.from-iterator(righti)).lazy.iterator
+        ?? gathered.lazy.iterator
         !! (gathered.Slip, Slip.from-iterator(righti)).iterator
 }
 


### PR DESCRIPTION
It's simple: there's no reason to involve the `righti` iterator at all. Remove that, et voila, no memory leak for inifinite sequences.

There are only two possible `righti` for infinities:

    > [Inf].iterator.pull-one
    Inf
    > [*].iterator.pull-one
    1

Neither provides anything of any use to the lazy iteration of the underlying gather that comprises the real reason for the `...` sequence to exist.

R#1399 (#1399) and RT#131829.