### PR TITLE
Introduce Any.are(type --> Bool:D)

### DIFF
--- a/src/core.c/Any-iterable-methods.rakumod
+++ b/src/core.c/Any-iterable-methods.rakumod
@@ -2159,6 +2159,27 @@ Consider using a block if any of these are necessary for your mapping code."
         $type
     }
 
+    multi method are(Any:D: Mu:U $type --> Bool:D) {
+        my int $i;
+        my $iterator := self.iterator;
+
+        nqp::until(
+          nqp::eqaddr((my $pulled := $iterator.pull-one),IterationEnd),
+          nqp::unless(
+            nqp::istype($pulled.WHAT,$type),
+            fail("Expected '"
+              ~ $type.^name
+              ~ "' but got '"
+              ~ $pulled.^name
+              ~ "' in element $i"
+            ),
+            ++$i
+          )
+        );
+
+        True
+    }
+
     proto method nodemap(|) is nodal {*}
     multi method nodemap(Associative:D: &op) {
         self.new.STORE: self.keys, self.values.nodemap(&op), :INITIALIZE


### PR DESCRIPTION
This would allow a shorter way to say:

    sub a(@a where .are ~~ Int) { }

namely:

    sub a(@a where .are(Int)) { }

Further advantages:
- shortcircuiting as soon as an offending type is encountered
- instead of returning False, return a Failure with more error information such as expected / gotten type *and* the element number that offended

After this, we'd only need to make X::TypeCheck::Binding::Parameter actually show the message of the Failure, instead of "anonymous constraint to be met".