### PR TITLE
Provide better feedback for ambiguous adverb usage

### DIFF
--- a/src/Raku/Grammar.nqp
+++ b/src/Raku/Grammar.nqp
@@ -1928,6 +1928,11 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
     }
 
     method EXPR-reduce(@termstack, @opstack) {
+        # if there is no @opstack, we have nowhere for the contents of @termstack to go...
+        #   (@termstack comes in with size 1 for this edge-case, so we can just pass the first argument)
+        return self.typed-sorry("X::Syntax::AmbiguousAdverb", adverb => ~nqp::atpos(@termstack, 0))
+            unless nqp::elems(@opstack);
+
         my $op := nqp::pop(@opstack);
 
         # Give it a fresh capture list, since we'll have assumed it has

--- a/src/core.c/Exception.rakumod
+++ b/src/core.c/Exception.rakumod
@@ -2134,8 +2134,15 @@ my class X::Syntax::CannotMeta does X::Syntax {
 
 my class X::Syntax::Adverb does X::Syntax {
     has $.what;
-
     method message() { "You can't adverb " ~ $.what }
+}
+
+my class X::Syntax::AmbiguousAdverb does X::Syntax {
+    has Str $.adverb;
+    method message() {
+        "Cannot determine the destination for named argument: $!adverb\n" ~
+            "Try placing parentheses around the desired callsite to disambiguate."
+    }
 }
 
 my class X::Syntax::Regex::Adverb does X::Syntax {


### PR DESCRIPTION
This fixes an LTA situation:

    > my %h = :1k; say 1 ~ %h<k>:exists ~ 1
    ===SORRY!===
    MVMArray: Can't pop from an empty array

Now we throw an `X::Syntax::AmbiguousAdverb` exception:

    > my %h = :1k; say 1 ~ %h<k>:exists ~ 1
    ===SORRY!=== Error while compiling -e
    Cannot determine the destination for named argument: :exists
    Try placing parentheses around the desired callsite to disambiguate.

This addresses R#1378 (#1378), at least for RakuAST. A sister commit will be added to the grammar in NQP.