### PR TITLE
Allow reduce to return containers as generated

### DIFF
--- a/src/core.c/Any-iterable-methods.rakumod
+++ b/src/core.c/Any-iterable-methods.rakumod
@@ -1679,7 +1679,7 @@ Consider using a block if any of these are necessary for your mapping code."
 
     proto method reduce(|) is nodal {*}
     multi method reduce(Any:U: & --> Nil) { }
-    multi method reduce(Any:D: &with) {
+    multi method reduce(Any:D: &with) is raw {
         (&with.reducer)(&with)(self)
     }
 

--- a/src/core.c/metaops.rakumod
+++ b/src/core.c/metaops.rakumod
@@ -178,7 +178,7 @@ multi sub METAOP_REDUCE_LEFT(\op, \triangle) {
 multi sub METAOP_REDUCE_LEFT(\op) {
     if op.count > 2 and op.count < Inf {
         my $count = op.count;
-        sub (+values) {
+        sub (+values) is raw {
             my \iter = values.iterator;
             my \first = iter.pull-one;
             return op.() if nqp::eqaddr(first,IterationEnd);
@@ -198,7 +198,7 @@ multi sub METAOP_REDUCE_LEFT(\op) {
         }
     }
     else {
-        sub (+values) {
+        sub (+values) is raw {
             my $iter := values.iterator;
             nqp::if(
               nqp::eqaddr((my $result := $iter.pull-one),IterationEnd),


### PR DESCRIPTION
As pointed out in R#2000 (#2000), using `reduce` on a list that includes a container was losing all knowledge of this container.

The following would previously fail:

    my $p := (my %a, |('a'..'e')).reduce:
        sub ($a is raw, $b) is raw { $a{$b} };
    $p = 42;
    # assign requires a concrete object
    #   (got a Any type object instead)

But now it succeeds:

    # {:a(${:b(${:c(${:d(${:e(42)})})})})}

Likewise, the following now returns the initial, mutable container as expected:

    my $x = 1;
    my \result := ($x, 2, 3, 4).reduce:
        -> $a is raw, $ { $a };
    dd result += 1;
    # $x = 2