### PR TITLE
Add :invocant option to Parameter.new

### DIFF
--- a/src/core.c/Parameter.rakumod
+++ b/src/core.c/Parameter.rakumod
@@ -63,6 +63,7 @@ my class Parameter { # declared in BOOTSTRAP
         Bool:D :$is-raw         = False,
         Bool:D :$is-rw          = False,
         Bool:D :$is-item        = False,
+        Bool:D :$invocant       = False,
         Bool:D :$multi-invocant = True,
                *%args  # type / default / where / sub_signature captured through %_
         --> Nil
@@ -194,6 +195,7 @@ my class Parameter { # declared in BOOTSTRAP
             $flags +|= nqp::const::SIG_ELEM_IS_OPTIONAL if $optional;
         }
 
+        $flags +|= nqp::const::SIG_ELEM_INVOCANT       if $invocant;
         $flags +|= nqp::const::SIG_ELEM_MULTI_INVOCANT if $multi-invocant;
         $flags +|= nqp::const::SIG_ELEM_IS_COPY        if $is-copy;
         $flags +|= nqp::const::SIG_ELEM_IS_RAW         if $is-raw;
@@ -602,6 +604,7 @@ my class Parameter { # declared in BOOTSTRAP
 
         $name = "$prefix$name$.suffix";
         $raku ~= ($raku ?? ' ' !! '') ~ $name if $name;
+        $raku ~= ':' if $!flags +& nqp::const::SIG_ELEM_INVOCANT;
         $raku ~= $rest if $rest;
         $raku
     }


### PR DESCRIPTION
Previously a user would be required to `use nqp` in order to get access to the `nqp::const::SIG_ELEM_INVOCANT` constant and manually twiddle that flags being provided to the `Parameter` constructor.

This seemed like a simple oversight to me, so I've created this PR to garner the right feedback if I'm mistaken.

Open questions: 

1. Why is "invocant-ness" not considered in `ACCEPTS`?
2. Why is `multi-invocant` set to `True` by default?