### PR TITLE
Provide deeper context into `run` failures

### DIFF
--- a/src/core.c/Exception.rakumod
+++ b/src/core.c/Exception.rakumod
@@ -682,6 +682,7 @@ do {
 
 my role X::OS is Exception {
     has $.os-error;
+    has $.error-code;
     method message() { $.os-error }
 }
 
@@ -3757,6 +3758,7 @@ my class X::Proc::Unsuccessful is Exception {
     has $.proc;
     method message() {
         "The spawned command '{$.proc.command[0]}' exited unsuccessfully (exit code: $.proc.exitcode(), signal: $.proc.signal())"
+        ~ ($.proc.os-error ?? "\n(OS error = $.proc.os-error())" !! "")
     }
 }
 

--- a/src/core.c/Proc/Async.rakumod
+++ b/src/core.c/Proc/Async.rakumod
@@ -390,9 +390,8 @@ my class Proc::Async {
             $!ready_vow.keep($pid);
         });
 
-        nqp::bindkey($callbacks, 'error', -> Mu \err {
-            my $error := X::OS.new(os-error => err);
-            $!exit_promise.break($error);
+        nqp::bindkey($callbacks, 'error', -> Mu \err, $code = 0 {
+            $!exit_promise.break(my $error := X::OS.new(:os-error(err), :error-code($code)));
             $!ready_vow.break($error);
         });
 


### PR DESCRIPTION
After 92bd7e4, we stopped returning an exit code of `-1` for cases when attempting to `run` a nonexistent command.

This patch returns the previous behavior while also surfacing the underlying error from `libuv`, which makes it much more clear to the user what the underlying cause of the `run` failure is:

    > r 'run "e-not-a-command"'
    The spawned command 'e-not-a-command' exited
        unsuccessfully (exit code: -1, signal: 254)
    (OS error = Failed to spawn process e-not-a-command:
        no such file or directory (error code -2))

R#1590 (#1590)