### PR TITLE
Provide some fixups to experimental :cached

### DIFF
--- a/src/core.c/Baggy.rakumod
+++ b/src/core.c/Baggy.rakumod
@@ -318,7 +318,8 @@ my role Baggy does QuantHash {
           $!elems && nqp::elems($!elems),
           nqp::stmts(
             (my \pairs := nqp::join(',',
-              Rakudo::QuantHash.RAW-VALUES-MAP(self, {
+              Rakudo::Sorting.MERGESORT-str(
+                Rakudo::QuantHash.RAW-VALUES-MAP(self, {
                   nqp::concat(
                     nqp::concat(
                       nqp::getattr($_,Pair,'$!key').raku,
@@ -326,7 +327,7 @@ my role Baggy does QuantHash {
                     ),
                     nqp::getattr($_,Pair,'$!value').raku
                   )
-              })
+              }))
             )),
             nqp::if(
               nqp::eqaddr(self.keyof,Mu),

--- a/src/core.c/Setty.rakumod
+++ b/src/core.c/Setty.rakumod
@@ -174,9 +174,10 @@ my role Setty does QuantHash {
           nqp::concat(
             nqp::concat(
               nqp::concat(self.^name,'.new('),
-              nqp::join(",",Rakudo::QuantHash.RAW-VALUES-MAP(self, *.raku))
-            ),
-            ')'
+              nqp::join(",", Rakudo::Sorting.MERGESORT-str(
+                Rakudo::QuantHash.RAW-VALUES-MAP(self, *.raku)
+              ))
+            ), ')'
           )
         )
     }


### PR DESCRIPTION
Addresses R#4666 (#4666), the discussion of which
raised several issues with the previous `is cached` implementation:

- `.gist` is not appropriate as details may be truncated, leading to potential invalid cache matches

- `is cached` is not thread-safe

This patch moves to address both issues by using `.raku` instead and wrapping it in a `lock`/`unlock` cycle. (`Lock.protect` is not an option as it hijacks the `callsame`).

Additionally, `Setty.raku` and `Baggy.raku` have been adjusted to produce sorted contents.