### PR TITLE
Improve `.flat` logic

### DIFF
--- a/src/core.c/Array.rakumod
+++ b/src/core.c/Array.rakumod
@@ -410,7 +410,11 @@ my class Array { # declared in BOOTSTRAP
     }
 
     multi method flat(Array:U:) { self }
-    multi method flat(Array:D:) { Seq.new(self.iterator) }
+    multi method flat(Array:D: $levels = Whatever, :$hammer) {
+        $hammer
+          ?? self.Iterable::flat($levels, :hammer)
+          !! Seq.new(self.iterator)  # not hammering, always conted, so no-op
+    }
 
     method reverse(Array:D: --> Seq:D) is nodal {
         self.is-lazy    # reifies

--- a/src/core.c/Iterable.rakumod
+++ b/src/core.c/Iterable.rakumod
@@ -18,7 +18,9 @@ my role Iterable {
         nqp::p6bindattrinvres(nqp::create(Scalar), Scalar, '$!value', self)
     }
 
-    method flat(Iterable:D:) { Seq.new(Rakudo::Iterator.Flat(self.iterator)) }
+    method flat(Iterable:D: $levels = Whatever, :$hammer = False) {
+        Seq.new: Rakudo::Iterator.Flat: self.iterator, $levels, $hammer
+    }
 
     method lazy-if($flag) { $flag ?? self.lazy !! self }
 

--- a/src/core.c/Rakudo/Iterator.rakumod
+++ b/src/core.c/Rakudo/Iterator.rakumod
@@ -1830,70 +1830,64 @@ class Rakudo::Iterator {
     }
 
     # Return an iterator that flattens all embedded Iterables into a single
-    # iterator, producing a single sequence of non-Iterable values..
+    # iterator, producing a single sequence of non-Iterable values
     my class Flat does Iterator {
-        has Iterator $!source;
-        has Iterator $!nested;
+        has      $!iterator;
+        has      $!next;
+        has uint $!levels;
+        has uint $!decont;
 
-        method new(\source) {
-            nqp::p6bindattrinvres(nqp::create(self),self,'$!source',source)
+        method new($iterator, uint $levels, uint $decont) {
+            my $self := nqp::create(self);
+            nqp::bindattr(  $self,Flat,'$!next',nqp::list);
+            nqp::bindattr_i($self,Flat,'$!levels',$levels);
+            nqp::bindattr_i($self,Flat,'$!decont',$decont);
+            nqp::p6bindattrinvres($self,Flat,'$!iterator',$iterator)
         }
 
         method pull-one() is raw {
-            nqp::if(
-              $!nested,
+            nqp::while(
+              nqp::eqaddr((my $pulled := $!iterator.pull-one),IterationEnd),
               nqp::if(
-                nqp::eqaddr((my \nested := $!nested.pull-one),IterationEnd),
+                nqp::elems($!next),
+                ($!iterator := nqp::pop($!next)),
+                (return IterationEnd)
+              )
+            );
+
+            nqp::if(
+              nqp::istype($pulled,Iterable),
+              nqp::if(
+                nqp::elems($!next) < $!levels
+                  && $!decont >= nqp::iscont($pulled),
                 nqp::stmts(
-                  ($!nested := Iterator),
+                  nqp::push($!next,$!iterator),
+                  ($!iterator := $pulled.iterator),
                   self.pull-one
                 ),
-                nested
+                $pulled
               ),
-              nqp::if(
-                nqp::iscont(my \got := $!source.pull-one),
-                got,
-                nqp::if(
-                  nqp::istype(got,Iterable),
-                  nqp::stmts(
-                    ($!nested := Flat.new(got.iterator)),
-                    self.pull-one
-                  ),
-                  got
-                )
-              )
+              $pulled
             )
         }
 
-        method push-all(\target --> IterationEnd) {
-            nqp::if(
-              $!nested,
-              nqp::stmts(
-                $!nested.push-all(target),
-                ($!nested := Iterator)
-              )
-            );
-
-            nqp::until(
-              nqp::eqaddr((my \got := $!source.pull-one), IterationEnd),
-              nqp::if(
-                nqp::iscont(got),
-                target.push(got),
-                nqp::if(
-                  nqp::istype(got,Iterable),
-                  Flat.new(got.iterator).push-all(target),
-                  target.push(got)
-                )
-              )
-            );
+        method is-lazy(--> Bool:D) {
+            $!iterator.is-lazy
         }
-        method is-lazy() { $!source.is-lazy }
-        method is-deterministic(--> Bool:D) { $!source.is-deterministic }
+        method is-deterministic(--> Bool:D) {
+            $!iterator.is-deterministic
+        }
         method is-monotonically-increasing(--> Bool:D) {
-            $!source.is-monotonically-increasing
+            $!iterator.is-monotonically-increasing
         }
     }
-    method Flat(\iterator) { Flat.new(iterator) }
+    method Flat(\iterator, $levels, $decont) {
+        Flat.new(
+          iterator,
+          nqp::istype($levels,Whatever) || $levels == Inf ?? -1 !! $levels.Int,
+          $decont.Int
+        )
+    }
 
     # Return an iterator that will cache a source iterator for the index
     # values that the index iterator provides, from a given offest in the


### PR DESCRIPTION
- add positional to indicate number of levels to flatten.  Defaults to Inf / Whatever
- add boolean named arg :hammer.  If specified with a true value, will disregard any containerization on Iterables, and flatten those iterables.  Defaults to False

Inspired by https://github.com/Raku/problem-solving/issues/431