### PR TITLE
Introduce a `Block.WhateverCode` coercer

### DIFF
--- a/src/core.c/Block.rakumod
+++ b/src/core.c/Block.rakumod
@@ -30,6 +30,27 @@ my class Block { # declared in BOOTSTRAP
         )
     }
 
+    proto method WhateverCode(|) {*}
+    multi method WhateverCode(Block:U:) { WhateverCode }
+    multi method WhateverCode(Block:D:) {
+        if nqp::isconcrete($!phasers) {
+            die "Cannot convert to WhateverCode because the Block has phasers";
+        }
+        else {
+            my $wc := nqp::create(WhateverCode);
+            nqp::bindattr(
+              $wc,Code,'$!do',nqp::getattr(self,Code,'$!do')
+            );
+            nqp::bindattr(
+              $wc,Code,'$!signature',nqp::getattr(self,Code,'$!signature')
+            );
+            nqp::bindattr(
+              $wc,Code,'@!compstuff',nqp::getattr(self,Code,'@!compstuff')
+            );
+            $wc
+        }
+    }
+
     method fatalize() is implementation-detail {
         self.add_phaser: 'POST', -> $_ {
             nqp::istype($_,Failure) ?? .throw !! True


### PR DESCRIPTION
This is really just a quick implementation of an idea wrt performance. Since WhateverCodes cannot have phasers, they can be treated differently in .map / for loops taking a simpler path.  However, from the grammar it is impossible to create slightly more complex WhateverCodes, even though they are actually quite simple, e.g.: { $_ ~ $_ } .