### PR TITLE
Add `:by` to `.min` / `.max` / `.minmax`

### DIFF
--- a/src/core.c/Order.rakumod
+++ b/src/core.c/Order.rakumod
@@ -246,6 +246,7 @@ augment class Any {
 
         nqp::defined($min) ?? $min !! Inf
     }
+    multi method min(Any:D: :&by!) { self.min(&by, |%_) }
     multi method min(Any:D: &by) {
         my &comparator := aritize22(&by);
 
@@ -302,6 +303,7 @@ augment class Any {
 
         nqp::defined($max) ??  $max !! -Inf
     }
+    multi method max(Any:D: :&by!) { self.max(&by, |%_) }
     multi method max(Any:D: &by) {
         my &comparator := aritize22(&by);
 
@@ -426,7 +428,7 @@ augment class Any {
           ?? Range.new($min,$max,:$excludes-min,:$excludes-max)
           !! Range.Inf-Inf
     }
-
+    multi method minmax(Any:D: :&by!) { self.minmax(&by, |%_) }
     multi method minmax(Any:D: &by) {
         nqp::if(
           (my $iter := self.iterator-and-first(".minmax",my $pulled)),


### PR DESCRIPTION
The sub versions of min/max/minmax take a :by named argument to indicate the comperator.  However, the method versions take an optional positional argument and ignore any :by specification (because of the implicit *%_ in the method signature.

This can cause silent breakage when refactoring code from subs to methods as spotted by vendethiel++
  https://irclogs.raku.org/raku/2024-07-18.html#14:27

This adds 3 candidates taking the :by named argument, so that this type of breakage will not happen when refactoring code.