### PR TITLE
Implement `@a[**]` with hammering flattening behavior

### DIFF
--- a/src/core.c/array_slice.rakumod
+++ b/src/core.c/array_slice.rakumod
@@ -271,10 +271,10 @@ multi sub postcircumfix:<[ ]>(\SELF, Whatever:D, :$BIND!) is raw {
 
 # @a[**]
 multi sub postcircumfix:<[ ]>(\SELF, HyperWhatever:D $, *%adv) is raw {
-    NYI('HyperWhatever in array index').throw;
+    SELF.flat(:hammer)
 }
 multi sub postcircumfix:<[ ]>(\SELF, HyperWhatever:D $, Mu \assignee) is raw {
-    NYI('HyperWhatever in array index').throw;
+    assignee = SELF.flat(:hammer)
 }
 
 # @a[]


### PR DESCRIPTION
As discussed in:
  https://github.com/Raku/problem-solving/issues/431#issuecomment-2248930043