### PR TITLE
Ensure path-spec is a Str

### DIFF
--- a/src/core.c/CompUnit/Repository/Unknown.rakumod
+++ b/src/core.c/CompUnit/Repository/Unknown.rakumod
@@ -1,5 +1,5 @@
 class CompUnit::Repository::Unknown does CompUnit::Repository {
-    has $.path-spec;
+    has Str $.path-spec;
     has $.short-name;
 
     method need(

--- a/src/core.c/CompUnit/RepositoryRegistry.rakumod
+++ b/src/core.c/CompUnit/RepositoryRegistry.rakumod
@@ -53,7 +53,7 @@ class CompUnit::RepositoryRegistry {
         }
         else {
             CompUnit::Repository::Unknown.new(
-              :path-spec($spec),
+              :path-spec($spec.Str),
               :short-name($short-id)
             )
         }


### PR DESCRIPTION
path-specs should always be strings, but previously we could construct a `CompUnit::Repository::Unknown` with a path-spec that is `CompUnit::Repository::Spec`. This adds some typing and stringification to ensure that path-spec will be a string.