### PR TITLE
Revert "Assorted grammar tests"

### DIFF
--- a/t/12-rakuast/xx-fixed-in-rakuast.rakutest
+++ b/t/12-rakuast/xx-fixed-in-rakuast.rakutest
@@ -2,7 +2,7 @@ use Test;
 use lib <t/packages/Test-Helpers>;
 use Test::Helpers;
 
-plan 39;
+plan 37;
 
 # t/spec/S03-sequence/misc.t
 # https://github.com/rakudo/rakudo/issues/5520
@@ -228,28 +228,4 @@ plan 39;
     is-deeply @a, [<b c d>], 'did the code do the right thing';
 }
 
-# https://irclogs.raku.org/raku/2024-08-20.html#12:13
-{
-    my $keyword = "use";
-    grammar G {
-        token TOP { [<keyword> | <text> ]* };
-        token keyword { $keyword };
-        token text { . }
-    };
-    is G.parse("use my stuff;")<keyword>, "use", "Interpolating variables into grammars works";
-}
-
-{
-    grammar H {
-        token TOP {
-            [
-                | <kw>
-                | <text>
-            ]*
-        }
-        token kw { <!ww>use }
-        token text { . }
-    }
-    is H.parse("use my stuff;")<kw>, "use", "<!ww> at start of token doesn't prevent matching the token";
-}
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
This reverts commit f6b5422b44e77daf56b96db134773018a0cd713c.

I'm pretty sure I was wrong. LTM explains well, why a leading `<!ww> prevents a branch from taking precedence.
Whether a variable interpolation should terminate the LTM chain can be discussed, but is definitely not clear-cut wrong.