### PR TITLE
Use binding for all sub aliases

### DIFF
--- a/src/core.c/Any.rakumod
+++ b/src/core.c/Any.rakumod
@@ -490,7 +490,7 @@ multi sub infix:<===>(\a, \b --> Bool:D) {
     )
 }
 # U+2A76 THREE CONSECUTIVE EQUALS SIGNS
-my constant &infix:<⩶> = &infix:<===>;
+my constant &infix:<⩶> := &infix:<===>;
 
 proto sub prefix:<++>(Mu, *%)        {*}
 multi sub prefix:<++>(Mu:D $a is rw) { $a = $a.succ }

--- a/src/core.c/Numeric.rakumod
+++ b/src/core.c/Numeric.rakumod
@@ -220,14 +220,14 @@ proto sub infix:<*>($?, $?, *%) is pure   {*}
 multi sub infix:<*>($x = 1)      { $x.Numeric }
 multi sub infix:<*>(\a, \b)    { a.Numeric * b.Numeric }
 # U+00D7 MULTIPLICATION SIGN
-my constant &infix:<×> = &infix:<*>;
+my constant &infix:<×> := &infix:<*>;
 
 proto sub infix:</>($?, $?, *%) is pure {*}
 multi sub infix:</>() { "infix:</>".no-zero-arg }
 multi sub infix:</>($x)          { $x.Numeric }
 multi sub infix:</>(\a, \b)    { a.Numeric / b.Numeric }
 # U+00F7 DIVISION SIGN
-my constant &infix:<÷> = &infix:</>;
+my constant &infix:<÷> := &infix:</>;
 
 proto sub infix:<div>($, $, *%) is pure  {*}
 # rest of infix:<div> is in Int.rakumod
@@ -269,7 +269,7 @@ multi sub infix:<==>($?)        { Bool::True }
 multi sub infix:<==>(\a, \b)   { a.Numeric == b.Numeric }
 
 # U+2A75 TWO CONSECUTIVE EQUALS SIGNS
-my constant &infix:<⩵> = &infix:<==>;
+my constant &infix:<⩵> := &infix:<==>;
 
 proto sub infix:<=~=>($?, $?, *%) {*}  # note, can't be pure due to dynvar
 multi sub infix:<=~=>($?) { Bool::True }
@@ -284,7 +284,7 @@ multi sub infix:<=~=>(\a, \b, :$tolerance = $*TOLERANCE)    {
     }
 }
 # U+2245 APPROXIMATELY EQUAL TO
-my constant &infix:<≅> = &infix:<=~=>;
+my constant &infix:<≅> := &infix:<=~=>;
 
 proto sub infix:<!=>(Mu $?, Mu $?, *%) is pure  {*}
 multi sub infix:<!=>($?)                    { Bool::True }

--- a/src/core.c/set_elem.rakumod
+++ b/src/core.c/set_elem.rakumod
@@ -113,9 +113,9 @@ proto sub infix:<(cont)>($, $, *%) is pure {*}
 multi sub infix:<(cont)>(\a, \b --> Bool:D) { b (elem) a }
 
 # U+220B CONTAINS AS MEMBER
-my constant &infix:<∋> = &infix:<(cont)>;
+my constant &infix:<∋> := &infix:<(cont)>;
 # U+220D SMALL CONTAINS AS MEMBER
-my constant &infix:<∍> = &infix:<(cont)>;
+my constant &infix:<∍> := &infix:<(cont)>;
 
 # U+220C DOES NOT CONTAIN AS MEMBER
 proto sub infix:<∌>($, $, *%) is pure {*}


### PR DESCRIPTION
Using assignment doesn't cause a segfault if you multi the alias name anymore (what 998a1ef fixed in the past), but might as well make them all consistent.