### PR TITLE
drastically speed up raku-ast-compiler.nqp

### DIFF
--- a/tools/build/raku-ast-compiler.nqp
+++ b/tools/build/raku-ast-compiler.nqp
@@ -78,9 +78,9 @@ grammar RakuASTParser {
         | <string>
         | ['/' <-[/]>+ '/' || '//' || '/' <?before \s* [\d | '$']>] # regex or // operator
         | $<numeric>=[ \d+ ['.' \d*]? [<[eE]> \d+]? ]
-        | $<paren>='(' <nqp-code> [ ')' || {} <.panic('Missing ) for opening ( at line ' ~ self.line-of($<paren>))> ]
-        | $<brace>='{' <nqp-code> [ '}' || {} <.panic('Missing } for opening { at line ' ~ self.line-of($<brace>))> ]
-        | $<brckt>='[' <nqp-code> [ ']' || {} <.panic('Missing ] for opening [ at line ' ~ self.line-of($<brckt>))> ]
+        | $<paren>='(' {} <nqp-code> [ ')' || {} <.panic('Missing ) for opening ( at line ' ~ self.line-of($<paren>))> ]
+        | $<brace>='{' {} <nqp-code> [ '}' || {} <.panic('Missing } for opening { at line ' ~ self.line-of($<brace>))> ]
+        | $<brckt>='[' {} <nqp-code> [ ']' || {} <.panic('Missing ] for opening [ at line ' ~ self.line-of($<brckt>))> ]
         | <?[\s#]> <ws>
         || $<other>=[<-[{}()\[\]'"\s\w$/]>+] # don't include in LTM as it'd win too much
         )*


### PR DESCRIPTION
Terminating the LTM immediately after opening paren, bracket, or brace prevents the NFA from running all the way to the end of the file whenever it encounters an nqp-code token. This makes nqp-m finish the raku-ast-compiler in 4 seconds instead of 1600, and moar is a bit faster, too (but already plenty fast)