### PR TITLE
Address a small but significant corner case in the optimizer

### DIFF
--- a/src/Perl6/Optimizer.nqp
+++ b/src/Perl6/Optimizer.nqp
@@ -28,6 +28,7 @@ my class Symbols {
 
     # Some interesting symbols.
     has $!Mu;
+    has $!Mu'U;
     has $!Junction;
     has $!Any;
     has $!Block;
@@ -66,6 +67,7 @@ my class Symbols {
         }
         nqp::push(@!block_stack, $!UNIT);
         $!Mu          := self.find_in_setting('Mu');
+        $!Mu'U        := nqp::gethllsym('Raku', 'Mu:U');
         $!Junction    := self.find_in_setting('Junction');
         $!Any         := self.find_in_setting('Any');
         $!Block       := self.find_in_setting('Block');
@@ -119,6 +121,7 @@ my class Symbols {
     method GLOBALish()   { $!GLOBALish }
     method UNIT()        { $!UNIT }
     method Mu()          { $!Mu }
+    method Mu'U()        { $!Mu'U }
     method Junction()    { $!Junction }
     method Any()         { $!Any }
     method Block()       { $!Block }
@@ -1566,6 +1569,8 @@ my class SmartmatchOptimizer {
         self.respect_junctions( $optimized_ast, $fallback_ast, $lhs )
     }
 
+    my $Mu'U := nqp::null;
+
     method maybe_typematch($lhs, $rhs, :$in-when = 0, :$negated = 0) {
         my $sm_type;
         # Don't try if RHS is not a compile-time known type object or it has user-defined ACCEPTS method. In the latter
@@ -1585,6 +1590,13 @@ my class SmartmatchOptimizer {
         return nqp::null()
             if !nqp::can($sm_type_how, 'archetypes')
                 || $sm_type_how.archetypes($sm_type).generic;
+
+        # This edge case muddies up the visual waters quite a bit in hopes of keeping the optimizer speedy
+        return QAST::Op.new( :op<callmethod>, :name<Bool>,
+                QAST::Op.new( :op<istype>, $lhs.ast, $rhs.value )
+        )   if $lhs.value-kind == $OPERAND_VALUE_VAR
+            && nqp::eqaddr($sm_type, nqp::ifnull($Mu'U, $Mu'U := $!symbols.Mu'U))
+            && ! ($sm_type.HOW.archetypes($sm_type).definite && $sm_type.HOW.definite($sm_type));
 
         my $sm_is_subset :=
             $sm_type_how.archetypes($sm_type).nominalizable

--- a/src/core.c/core_epilogue.rakumod
+++ b/src/core.c/core_epilogue.rakumod
@@ -94,6 +94,9 @@ BEGIN {
     }
 }
 
+# Required for use in the optimizer
+nqp::bindhllsym('Raku', 'Mu:U', Mu:U);
+
 #?if moar
 # Cannot be added in the Uni class, as we don't have native arrays
 # then yet, so it must be done here as an augment.


### PR DESCRIPTION
(Fixes R#5644 [#5644])

> with 42 { say $_ ~~ Mu:U }
\# True
> my $m = Mu:U; say $m ~~ Mu:U }
\# True

The above was what the optmized QAST was returning, prmpting this patch.

It makes sense, because in almost all cases the LHS of a smart match will return `True` when smartmatched against `Mu`.

The optimizer wisely took this into consideration. There's only one problem, however, and that's that the moment when you are genuinely checking for `Mu:U` is the one moment where the optimization fails.

This commit utilizes `nqp::ifnull` where possible to reduce the overhead, but it's also a bit of a shame that that I couldn't think of a way to accomplish this without adding a conditional statement to every `maybe_typematch` call in the optimizer.