### PR TITLE
Remove $?FILE and $?LINE where they don't make much sense

### DIFF
--- a/lib/experimental.rakumod
+++ b/lib/experimental.rakumod
@@ -200,8 +200,6 @@ package EXPORT::will-complain {
     multi sub trait_mod:<will>(Mu:U \type, &complainee, :complain($)!) {
         if type.HOW.archetypes.composable {
             X::Comp::Trait::Invalid.new(
-                file       => $?FILE,
-                line       => $?LINE,
                 type       => 'will',
                 subtype    => 'complain',
                 declaring  => 'role',
@@ -221,8 +219,6 @@ package EXPORT::will-complain {
         my $desc = try $attr.container_descriptor;
         unless $desc && nqp::istype($desc, Metamodel::Explaining) {
             X::Comp::Trait::Invalid.new(
-                file       => $?FILE,
-                line       => $?LINE,
                 type       => 'will',
                 subtype    => 'complain',
                 declaring  => 'attribute',
@@ -236,8 +232,6 @@ package EXPORT::will-complain {
     }
     multi sub trait_mod:<will>(Mu \obj, &complainee, :complain($)!) {
         X::Comp::Trait::Invalid.new(
-            file       => $?FILE,
-            line       => $?LINE,
             type       => 'will',
             subtype    => 'complain',
             declaring  => 'a ' ~ obj.^shortname.lc,
@@ -249,8 +243,6 @@ package EXPORT::will-complain {
         my $desc := try nqp::getattr($var, $var.VAR.^mixin_base, '$!descriptor');
         unless nqp::defined($desc) && nqp::istype($desc, Metamodel::Explaining) {
             X::Comp::Trait::Invalid.new(
-                file       => $?FILE,
-                line       => $?LINE,
                 type       => 'will',
                 subtype    => 'complain',
                 declaring  => 'variable',

--- a/src/core.c/traits.rakumod
+++ b/src/core.c/traits.rakumod
@@ -106,8 +106,6 @@ multi sub trait_mod:<is>(Mu:U $type, *%fail) {
 
 multi sub trait_mod:<is>(Attribute:D $attr, |c ) {
     X::Comp::Trait::Unknown.new(
-      file       => $?FILE,
-      line       => $?LINE,
       type       => 'is',
       subtype    => c.hash.keys[0],
       declaring  => 'an attribute',
@@ -178,7 +176,7 @@ multi sub trait_mod:<is>(Routine:D $r, |c) {
 
     sub trait-name(&t) { &t.signature.params[1].named_names[0] }
 
-    my %info = :file($?FILE), :line($?LINE), :type<is>, :$subtype,
+    my %info = :type<is>, :$subtype,
                :declaring($r.^name.split('+').head.lc);
 
     with @traits.first({.&trait-name eq $subtype}) -> &t {
@@ -222,8 +220,6 @@ BEGIN &trait_mod:<is>.set_onlystar();
 
 multi sub trait_mod:<is>(Parameter:D $param, |c ) {
     X::Comp::Trait::Unknown.new(
-      file       => $?FILE,
-      line       => $?LINE,
       type       => 'is',
       subtype    => c.hash.keys[0],
       declaring  => 'a parameter',
@@ -596,8 +592,6 @@ multi sub trait_mod:<handles>(Method:D $m, &thunk) {
 proto sub trait_mod:<will>(Mu $, |) {*}
 multi sub trait_mod:<will>(Attribute:D $attr, |c ) {
     X::Comp::Trait::Unknown.new(
-      file       => $?FILE,
-      line       => $?LINE,
       type       => 'will',
       subtype    => c.hash.keys[0],
       declaring  => 'an attribute',


### PR DESCRIPTION
The filename and line will get set by World if the exception is thrown at BEGIN time, "file" is not a named argument the X::Comp constructor takes ("filename" would be), so this is not a regression. And the filename and line from the core setting is not very helpful, since you also get a stack trace in that case.

This has the added benefit that the absolute path to the core setting source file (including the path that rakudo source was checked out into) is no longer part of the precompilation result of the core.c setting file :)