### PR TITLE
Proc::Async PTY support

### DIFF
--- a/src/core.c/Proc/Async.rakumod
+++ b/src/core.c/Proc/Async.rakumod
@@ -102,6 +102,7 @@ my class Proc::Async {
     has $.arg0;
     has $.win-verbatim-args = False;
     has Bool $.started = False;
+    has Bool $.pty = False;
     has $!stdout_supply;
     has CharsOrBytes $!stdout_type;
     has $!stderr_supply;
@@ -196,78 +197,93 @@ my class Proc::Async {
 
     proto method stderr(|) {*}
     multi method stderr(Proc::Async:D: :$bin!) {
-        $!merge_supply
-          ?? X::Proc::Async::SupplyOrStd.new.throw
-          !! $!stderr-fd
-            ?? X::Proc::Async::BindOrUse.new(:handle<stderr>, :use('get the stderr Supply')).throw
-            !! $bin
-              ?? self!pipe('stderr', $!stderr_supply, $!stderr_type, Bytes, $!stderr_descriptor_vow, 2)
-              !! self.stderr(|%_)
+        $!pty
+          ?? X::Proc::Async::PtyOnlyStdOut.new.throw
+          !! $!merge_supply
+            ?? X::Proc::Async::SupplyOrStd.new.throw
+            !! $!stderr-fd
+              ?? X::Proc::Async::BindOrUse.new(:handle<stderr>, :use('get the stderr Supply')).throw
+              !! $bin
+                ?? self!pipe('stderr', $!stderr_supply, $!stderr_type, Bytes, $!stderr_descriptor_vow, 2)
+                !! self.stderr(|%_)
     }
     multi method stderr(Proc::Async:D: :$enc, :$translate-nl) {
-        $!merge_supply
-          ?? X::Proc::Async::SupplyOrStd.new.throw
-          !! $!stderr-fd
-            ?? X::Proc::Async::BindOrUse.new(:handle<stderr>, :use('get the stderr Supply')).throw
-            !! self!wrap-decoder:
-              self!pipe('stderr',$!stderr_supply,$!stderr_type,Chars,Nil,2),
-              $enc, $!stderr_descriptor_vow, 2, :$translate-nl
+        $!pty
+          ?? X::Proc::Async::PtyOrStdErr.new.throw
+          !! $!merge_supply
+            ?? X::Proc::Async::SupplyOrStd.new.throw
+            !! $!stderr-fd
+              ?? X::Proc::Async::BindOrUse.new(:handle<stderr>, :use('get the stderr Supply')).throw
+              !! self!wrap-decoder:
+                self!pipe('stderr',$!stderr_supply,$!stderr_type,Chars,Nil,2),
+                $enc, $!stderr_descriptor_vow, 2, :$translate-nl
     }
 
     proto method Supply(|) {*}
     multi method Supply(Proc::Async:D: :$bin!) {
-        $!stdout_supply || $!stderr_supply
-          ?? X::Proc::Async::SupplyOrStd.new.throw
-          !! $!stdout-fd
-            ?? X::Proc::Async::BindOrUse.new(:handle<stdout>, :use('get the output Supply')).throw
-            !! $!stderr-fd
-              ?? X::Proc::Async::BindOrUse.new(:handle<stderr>, :use('get the output Supply')).throw
-              !! $bin
-                ?? self!pipe('merge',$!merge_supply,$!merge_type,Bytes,Nil,0)
-                !! self.Supply(|%_)
+        $!pty
+          ?? X::Proc::Async::PtyOnlyStdOut.new.throw
+          !! $!stdout_supply || $!stderr_supply
+            ?? X::Proc::Async::SupplyOrStd.new.throw
+            !! $!stdout-fd
+              ?? X::Proc::Async::BindOrUse.new(:handle<stdout>, :use('get the output Supply')).throw
+              !! $!stderr-fd
+                ?? X::Proc::Async::BindOrUse.new(:handle<stderr>, :use('get the output Supply')).throw
+                !! $bin
+                  ?? self!pipe('merge',$!merge_supply,$!merge_type,Bytes,Nil,0)
+                  !! self.Supply(|%_)
     }
     multi method Supply(Proc::Async:D: :$enc, :$translate-nl) {
-        $!stdout_supply || $!stderr_supply
-          ?? X::Proc::Async::SupplyOrStd.new.throw
-          !! $!stdout-fd
-            ?? X::Proc::Async::BindOrUse.new(:handle<stdout>, :use('get the output Supply')).throw
-            !! $!stderr-fd
-              ?? X::Proc::Async::BindOrUse.new(:handle<stderr>, :use('get the output Supply')).throw
-              !! self!wrap-decoder:
-                self!pipe('merge',$!merge_supply,$!merge_type,Chars,Nil,0),
-                $enc, Nil, 0, :$translate-nl
+        $!pty
+          ?? X::Proc::Async::PtyOnlyStdOut.new.throw
+          !! $!stdout_supply || $!stderr_supply
+            ?? X::Proc::Async::SupplyOrStd.new.throw
+            !! $!stdout-fd
+              ?? X::Proc::Async::BindOrUse.new(:handle<stdout>, :use('get the output Supply')).throw
+              !! $!stderr-fd
+                ?? X::Proc::Async::BindOrUse.new(:handle<stderr>, :use('get the output Supply')).throw
+                !! self!wrap-decoder:
+                  self!pipe('merge',$!merge_supply,$!merge_type,Chars,Nil,0),
+                  $enc, Nil, 0, :$translate-nl
     }
 
     proto method bind-stdin($) {*}
     multi method bind-stdin(IO::Handle:D $handle --> Nil) {
         X::Proc::Async::BindOrUse.new(:handle<stdin>, :use('use :w')).throw
           if $!w;
+        X::Proc::Async::BindOrUse.new(:handle<stdin>, :use('use :pty')).throw
+          if $!pty;
         $!stdin-fd := $handle.native-descriptor;
         @!close-after-exit.push($handle)
           if nqp::istype($handle,IO::Pipe);
     }
     multi method bind-stdin(Proc::Async::Pipe:D $pipe --> Nil) {
-        if $!w {
-            X::Proc::Async::BindOrUse.new(:handle<stdin>, :use('use :w')).throw
-        }
+        X::Proc::Async::BindOrUse.new(:handle<stdin>, :use('use :w')).throw
+          if $!w;
+        X::Proc::Async::BindOrUse.new(:handle<stdin>, :use('use :pty')).throw
+          if $!pty;
         $!stdin-fd := $pipe.native-descriptor;
         $!stdin-fd-close := True;
     }
 
     method bind-stdout(IO::Handle:D $handle --> Nil) {
-        $!stdout_supply
-          ?? X::Proc::Async::BindOrUse.new(:handle<stdout>, :use('get the stdout Supply')).throw
-          !! $!merge_supply
-            ?? X::Proc::Async::BindOrUse.new(:handle<stdout>, :use('get the output Supply')).throw
-            !! ($!stdout-fd := $handle.native-descriptor);
+        $!pty
+          ?? X::Proc::Async::BindOrUse.new(:handle<stdout>, :use('use :pty')).throw
+          !! $!stdout_supply
+            ?? X::Proc::Async::BindOrUse.new(:handle<stdout>, :use('get the stdout Supply')).throw
+            !! $!merge_supply
+              ?? X::Proc::Async::BindOrUse.new(:handle<stdout>, :use('get the output Supply')).throw
+              !! ($!stdout-fd := $handle.native-descriptor);
     }
 
     method bind-stderr(IO::Handle:D $handle --> Nil) {
-        $!stderr_supply
-          ?? X::Proc::Async::BindOrUse.new(:handle<stderr>, :use('get the stderr Supply')).throw
-          !! $!merge_supply
-            ?? X::Proc::Async::BindOrUse.new(:handle<stderr>, :use('get the output Supply')).throw
-            !! ($!stderr-fd := $handle.native-descriptor);
+        $!pty
+          ?? X::Proc::Async::BindOrUse.new(:handle<stderr>, :use('use :pty')).throw
+          !! $!stderr_supply
+            ?? X::Proc::Async::BindOrUse.new(:handle<stderr>, :use('get the stderr Supply')).throw
+            !! $!merge_supply
+              ?? X::Proc::Async::BindOrUse.new(:handle<stderr>, :use('get the output Supply')).throw
+              !! ($!stderr-fd := $handle.native-descriptor);
     }
 
     method ready(--> Promise) {
@@ -415,6 +431,7 @@ my class Proc::Async {
         nqp::bindkey($callbacks, 'stdin_fd_close', True) if $!stdin-fd-close;
         nqp::bindkey($callbacks, 'stdout_fd', $!stdout-fd) if $!stdout-fd.DEFINITE;
         nqp::bindkey($callbacks, 'stderr_fd', $!stderr-fd) if $!stderr-fd.DEFINITE;
+        nqp::bindkey($callbacks, 'pty', True) if $!pty;
 
         $!process_handle := nqp::spawnprocasync($scheduler.queue(:hint-affinity),
             $!path.Str,

--- a/src/vm/moar/runner/main.c
+++ b/src/vm/moar/runner/main.c
@@ -35,7 +35,9 @@ enum {
 
     OPT_DEBUGPORT,
 
-    OPT_RAKUDO_HOME
+    OPT_RAKUDO_HOME,
+
+    OPT_PTY_SPAWN_HELPER
 };
 
 static const char *const FLAGS[] = {
@@ -71,6 +73,8 @@ static int parse_flag(const char *arg)
         return OPT_DEBUGPORT;
     else if (starts_with(arg, "--rakudo-home="))
         return OPT_RAKUDO_HOME;
+    else if (starts_with(arg, "--pty-spawn-helper="))
+        return OPT_PTY_SPAWN_HELPER;
     else
         return UNKNOWN_FLAG;
 }
@@ -334,6 +338,18 @@ int main(int argc, char *argv[]) {
             case OPT_RAKUDO_HOME:
                 option_rakudo_home = argv[argi] + strlen("--rakudo-home=");
                 break;
+
+            case OPT_PTY_SPAWN_HELPER: {
+                char *prog = argv[argi] + strlen("--pty-spawn-helper=");
+                char **args = calloc(argc - argi + 1, sizeof(char *));
+                args[0] = prog;
+                args[argc - argi] = 0;
+                for (int argj = 1; argi + argj < argc; argj++)
+                    args[argj] = argv[argi + argj];
+                // Will not return if all goes well.
+                MVM_proc_pty_spawn(prog, args);
+                return EXIT_FAILURE;
+            }
 
             default:
             argv[new_argc++] = argv[argi];


### PR DESCRIPTION
Depends on MoarVM/MoarVM#1840

Has a long way to go. Currently the meat is implemented in Moar core. Maybe - just maybe I can manage to lift it out into a module entirely, but we'll see about that.

Works on Linux. Not tried on MacOS and OpenBSD yet. Definitely not working on Windows yet.