### PR TITLE
Restore :$source parameter to load(...) multi

### DIFF
--- a/src/core.c/CompUnit/PrecompilationRepository.rakumod
+++ b/src/core.c/CompUnit/PrecompilationRepository.rakumod
@@ -260,11 +260,12 @@ Need to re-check dependencies.")
     multi method load(
       Str:D $id,
       Instant :$since,
+      IO::Path :$source,
       CompUnit::PrecompilationStore :@precomp-stores =
         Array[CompUnit::PrecompilationStore].new($.store),
     ) {
         self.load(
-          CompUnit::PrecompilationId.new($id), :$since, :@precomp-stores)
+          CompUnit::PrecompilationId.new($id), :$since, :$source, :@precomp-stores)
     }
 
     multi method load(


### PR DESCRIPTION
The `:$source` parameter was removed from one of the `load(...)` multi methods because it was presumed to be unused. The problem, however, was that it was not being used and not that the parameter existed. This restores the `:$source` parameter and now correctly passes it along to the next `load(...)` multi method (which does use the parameter).