### PR TITLE
Remove playful "just yet" in error messages.

### DIFF
--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -1422,7 +1422,7 @@ class Perl6::World is HLL::World {
             }
         }
         else {
-            nqp::die("Don't know how to 'no $name' just yet");
+            nqp::die("Don't know how to 'no $name'");
         }
     }
 

--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -764,7 +764,7 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
             self.attach: $/, $ast;
         }
         else {
-            nqp::die("Don't know how to 'no " ~ $name ~ "'just yet")
+            nqp::die("Don't know how to 'no " ~ $name ~ "'")
         }
     }
 


### PR DESCRIPTION
It's not explicitly checked for in test/spectest