### PR TITLE
Make Map|Hash.new( a => 42, b => 666) more DWIM

### DIFF
--- a/src/core.c/Map.rakumod
+++ b/src/core.c/Map.rakumod
@@ -6,8 +6,10 @@ my class Map does Iterable does Associative { # declared in BOOTSTRAP
 
     # Calling self.new for the arguments case ensures that the right
     # descriptor will be added for typed hashes.
-    multi method new(Map:        --> Map:D) {
-        nqp::create(self)
+    multi method new(Map: --> Map:D) {
+        %_
+          ?? self.new(%_.pairs)
+          !! nqp::create(self)
     }
     multi method new(Map: *@args --> Map:D) {
         self.new.STORE(@args, :INITIALIZE)


### PR DESCRIPTION
Inspired by https://github.com/rakudo/rakudo/issues/3211 and the fact that I've run into this several times myself, and have had to explain why that didn't work.

I think it's fine to make an exception for Map.new / Hash.new and all of its subclasses