### PR TITLE
Make Int.uniname return a Failure on unassigned codepoints

### DIFF
--- a/src/core.c/unicodey.rakumod
+++ b/src/core.c/unicodey.rakumod
@@ -460,8 +460,11 @@ augment class Int {
     multi method uniname(Int:D: --> Str:D) {
         nqp::islt_I(self,0)       # (bigint) negative number?
           ?? '<illegal>'
-          !! nqp::isbig_I(self)   # bigint positive number?
-            ?? '<unassigned>'
+          !! nqp::isbig_I(self) || nqp::iseq_s(
+               (my str $name = nqp::getuniname(self)),
+               '<unassigned>'
+             )
+            ?? Failure.new("Unassigned codepoint: 0x" ~ self.base(16))
             !! nqp::getuniname(self)
     }
 


### PR DESCRIPTION
As discussed in https://github.com/rakudo/rakudo/issues/3636

This however breaks tests in t/spec/S15-unicode-information/uniname.t so a decision needs to be made.