### PR TITLE
Make Rationals remember where they divided by 0

### DIFF
--- a/src/core.c/Rat.rakumod
+++ b/src/core.c/Rat.rakumod
@@ -108,38 +108,46 @@ PROCESS::<$RAT-OVERFLOW> = Num;
 # which would be useless.  Also used when normalization *was* needed.
 proto sub CREATE_RATIONAL_FROM_INTS(|) is implementation-detail {*}
 multi sub CREATE_RATIONAL_FROM_INTS(Int:D $nu, Int:D $de, Any, Any) is raw {
-    nqp::islt_I($de,UINT64_UPPER)            # do we need to downgrade to float?
-      ?? nqp::p6bindattrinvres(              # no, we need to keep a Rat
-           nqp::p6bindattrinvres(nqp::create(Rat),Rat,'$!numerator',$nu),
-           Rat,'$!denominator',$de
-         )
-      !! $*RAT-OVERFLOW.UPGRADE-RAT($nu, $de)
+    $de
+      ?? nqp::islt_I($de,UINT64_UPPER)       # do we need to upgrade?
+        ?? nqp::p6bindattrinvres(            # no, we need to keep a Rat
+             nqp::p6bindattrinvres(nqp::create(Rat),Rat,'$!numerator',$nu),
+             Rat,'$!denominator',$de
+           )
+        !! $*RAT-OVERFLOW.UPGRADE-RAT($nu, $de)
+      !! Rat.zero-denominator($nu, $de)
 }
 
 # already a FatRat, so keep that
 multi sub CREATE_RATIONAL_FROM_INTS(
   Int:D $nu, Int:D $de, FatRat, Any
 --> FatRat:D) is raw {
-    nqp::p6bindattrinvres(
-      nqp::p6bindattrinvres(nqp::create(FatRat),FatRat,'$!numerator',$nu),
-      FatRat,'$!denominator',$de
-    )
+    $de
+      ?? nqp::p6bindattrinvres(
+           nqp::p6bindattrinvres(nqp::create(FatRat),FatRat,'$!numerator',$nu),
+           FatRat,'$!denominator',$de
+         )
+      !! FatRat.zero-denominator($nu, $de)
 }
 multi sub CREATE_RATIONAL_FROM_INTS(
   Int:D $nu, Int:D $de, Any, FatRat
 --> FatRat:D) is raw {
-    nqp::p6bindattrinvres(
-      nqp::p6bindattrinvres(nqp::create(FatRat),FatRat,'$!numerator',$nu),
-      FatRat,'$!denominator',$de
-    )
+    $de
+      ?? nqp::p6bindattrinvres(
+           nqp::p6bindattrinvres(nqp::create(FatRat),FatRat,'$!numerator',$nu),
+           FatRat,'$!denominator',$de
+         )
+      !! FatRat.zero-denominator($nu, $de)
 }
 multi sub CREATE_RATIONAL_FROM_INTS(
   Int:D $nu, Int:D $de, FatRat, FatRat
 --> FatRat:D) is raw {
-    nqp::p6bindattrinvres(
-      nqp::p6bindattrinvres(nqp::create(FatRat),FatRat,'$!numerator',$nu),
-      FatRat,'$!denominator',$de
-    )
+    $de
+      ?? nqp::p6bindattrinvres(
+           nqp::p6bindattrinvres(nqp::create(FatRat),FatRat,'$!numerator',$nu),
+           FatRat,'$!denominator',$de
+         )
+      !! FatRat.zero-denominator($nu, $de)
 }
 
 multi sub prefix:<->(Rat:D $a --> Rat:D) {


### PR DESCRIPTION
Inspired by https://github.com/rakudo/rakudo/issues/3738

This stores a handled Failure with the location where the Rational was created, and throws that whenever it is being stringified.

    my $a = 0;
    my $b = 1 / $a;
    say "inbetween"
    say $b;

results in:

    Attempt to divide 1 by zero
      in "foo" at $file line 2

    Actually thrown at:
      in "foo" at $file line 4

Passes all tests, but makes handling of Rationals up to 30% slower.