### PR TITLE
[JVM] Unbreak module loading

### DIFF
--- a/src/Perl6/Metamodel/RolePunning.nqp
+++ b/src/Perl6/Metamodel/RolePunning.nqp
@@ -44,6 +44,10 @@ role Perl6::Metamodel::RolePunning {
 
     # Returns the pun (only creating it if it wasn't already created)
     method pun($target) {
+#?if jvm
+        ## Bandaid for missing nqp::null on first call.
+        $!pun := nqp::null if $!pun =:= NQPMu;
+#?endif
         nqp::ifnull(
           $!pun,
           self.protect({


### PR DESCRIPTION
For some reason the check for nqp::null doesn't work and the method returns NQPMu. Maybe TWEAK didn't run correctly?

I didn't want to undo all (or more changes) of efeb9d7742. Hopefully the bandaid can be removed at one point.