### PR TITLE
Make positional parameters anonymous in candidate list

### DIFF
--- a/src/core.c/Exception.rakumod
+++ b/src/core.c/Exception.rakumod
@@ -3340,7 +3340,9 @@ my class X::Multi::NoMatch is Exception {
     has $.dispatcher;
     has $.capture;
     method message {
-        my @cand = $.dispatcher.dispatchees.map(*.signature.gist);
+        my @cand = $.dispatcher.dispatchees.map(
+          *.signature.gist.subst(/ <!after \:> <[$@%&+]> <( <[\w-]>+ /, :g)
+        );
         my @un-rw-cand;
         if first / 'is rw' /, @cand {
             my $rw-capture = Capture.new(
@@ -3349,7 +3351,7 @@ my class X::Multi::NoMatch is Exception {
             );
             @un-rw-cand = $.dispatcher.dispatchees».signature.grep({
                 $rw-capture ~~ $^cand
-            })».gist;
+            })».gist».subst(/ <!after \:> <[$@%&+]> <( <[\w-]>+ /, :g);
         }
 
         my $where = so first / where /, @cand;


### PR DESCRIPTION
when throwing an dispatch exception.  Because the actual names ofi positional parameters is not important and can be distracting.

Inspired by https://github.com/rakudo/rakudo/issues/4273