### PR TITLE
Throw coercion failures on object hashes

### DIFF
--- a/src/core.c/Hash/Object.rakumod
+++ b/src/core.c/Hash/Object.rakumod
@@ -22,15 +22,17 @@ my role Hash::Object[::TValue, ::TKey] does Associative[TValue] {
     }
 
     method STORE_AT_KEY(::?CLASS:D: TKey \key, Mu \value --> Nil) {
-        nqp::bindkey(
-          nqp::getattr(self,Map,'$!storage'),
-          nqp::unbox_s(key.WHICH),
-          Pair.new(
-            key,
-            nqp::p6scalarfromdesc(nqp::getattr(self,Hash,'$!descriptor'))
-            = value
-          )
-        )
+        nqp::istype(key,Failure)
+          ?? key.throw
+          !! nqp::bindkey(
+               nqp::getattr(self,Map,'$!storage'),
+               nqp::unbox_s(key.WHICH),
+               Pair.new(
+                 key,
+                 nqp::p6scalarfromdesc(nqp::getattr(self,Hash,'$!descriptor'))
+                 = value
+               )
+             )
     }
 
     method PUSH_FROM_MAP(\target --> Nil) is implementation-detail {
@@ -48,6 +50,8 @@ my role Hash::Object[::TValue, ::TKey] does Associative[TValue] {
     }
 
     method ASSIGN-KEY(::?CLASS:D: TKey \key, Mu \assignval) is raw {
+        key.throw if nqp::istype(key,Failure);
+
         my \storage  := nqp::getattr(self, Map, '$!storage');
         my \WHICH    := key.WHICH;
         my \existing := nqp::atkey(storage,WHICH);
@@ -65,24 +69,30 @@ my role Hash::Object[::TValue, ::TKey] does Associative[TValue] {
     }
 
     method BIND-KEY(TKey \key, TValue \value) is raw {
-        nqp::getattr(
-          nqp::bindkey(
-            nqp::getattr(self,Map,'$!storage'),
-            key.WHICH,
-            Pair.new(key,value)
-          ),
-          Pair,
-          '$!value'
-        )
+        nqp::istype(key,Failure)
+          ?? key.throw
+          !! nqp::getattr(
+               nqp::bindkey(
+                 nqp::getattr(self,Map,'$!storage'),
+                 key.WHICH,
+                 Pair.new(key,value)
+               ),
+               Pair,
+               '$!value'
+             )
     }
 
     method EXISTS-KEY(TKey \key) {
-        nqp::hllbool(
-          nqp::existskey(nqp::getattr(self,Map,'$!storage'),key.WHICH)
-        )
+        nqp::istype(key,Failure)
+          ?? key.throw
+          !! nqp::hllbool(
+               nqp::existskey(nqp::getattr(self,Map,'$!storage'),key.WHICH)
+             )
     }
 
     method DELETE-KEY(TKey \key) {
+        key.throw if nqp::istype(key,Failure);
+
         nqp::if(
           nqp::isnull(my \value := nqp::atkey(
             nqp::getattr(self,Map,'$!storage'),


### PR DESCRIPTION
If an object hash is defined with a coercion type (e.g. Int(Str)) the Failure of the coercion would be stored as the key.  Only to be thrown whenever that key would be accessed in the hash, e.g. with .keys.

This commit checks for Failure inside the storing methods of object hashes, and throws that immediately instead of just storing the .WHICH of it.

Inspired by #4301

Spectests clean.