### PR TITLE
[JVM] Flatten without overflow/underflow issues

### DIFF
--- a/src/core.c/Rakudo/Iterator.rakumod
+++ b/src/core.c/Rakudo/Iterator.rakumod
@@ -1874,7 +1874,12 @@ class Rakudo::Iterator {
     method Flat(\iterator, $levels, $decont) {
         Flat.new(
           iterator,
+#?if !jvm
           nqp::istype($levels,Whatever) || $levels == Inf ?? -1 !! $levels.Int,
+#?endif
+#?if jvm
+          nqp::istype($levels,Whatever) || $levels == Inf ?? int.Range.max !! $levels.Int,
+#?endif
           $decont.Int
         )
     }


### PR DESCRIPTION
If I'm not mistaken, the code relies on a $level parameter of -1 being coerced to a big positive number (due to the usage of uint). This doesn't work for the JVM backend.

Since the commit that introduced the uint parameter, https://github.com/rakudo/rakudo/commit/74cfe8e373, mentioned some confusion for the expression JIT on Intel, I didn't dare to change the code for MoarVM.