### PR TITLE
when starting a Thread, also set its thread name

### DIFF
--- a/src/core.c/Thread.rakumod
+++ b/src/core.c/Thread.rakumod
@@ -53,7 +53,9 @@ my class Thread {
 
         my $entry := anon sub THREAD-ENTRY() {
             my $*THREAD = self;
+#?if !jvm
             nqp::setthreadname(nqp::threadid($!vm_thread) ~ ": " ~ $!name);
+#?endif
             CONTROL {
                 default {
 #?if !jvm

--- a/src/core.c/Thread.rakumod
+++ b/src/core.c/Thread.rakumod
@@ -53,6 +53,7 @@ my class Thread {
 
         my $entry := anon sub THREAD-ENTRY() {
             my $*THREAD = self;
+            nqp::setthreadname(nqp::threadid($!vm_thread) ~ ": " ~ $!name);
             CONTROL {
                 default {
 #?if !jvm


### PR DESCRIPTION
uses the thread ID (rakudo internal) + the given name

Before:
![screenshot of gdb's command "info threads" showing 16 threads, most of which are named simply "rakudo-m", one is "spesh optimizer", one is "async io thread"](https://github.com/user-attachments/assets/5d12f2a0-c5cc-4637-8fe5-27c8395b39d5)
![screenshot of perf report, where the "command" column shows mostly "rakudo", or "spesh optimizer" sometimes](https://github.com/user-attachments/assets/7a89999e-c705-42ec-ab32-90066aef6a53)



After:
![screenshot of gdb's command "info threads" where rakudo threads are identified with a number followed by GeneralWorke, TimerWorker, Supervisor, but also threads without numbers, like async io thread, or spesh thread. the very first one is named simply "rakudo-m".](https://github.com/user-attachments/assets/b114005d-53a8-4987-ad39-47ace2b456a5)
![screenshot of "perf report" showing results from different threads with their names in the "command" column](https://github.com/user-attachments/assets/68b298a1-eff7-414e-8479-93de1f5f4999)


(note that the length of thread names is limited by the system. for example, on linux the library we use for this (pthreads) writes to `/proc/thread-self/comm` which the kernel limits to 15 bytes + null terminator (see `man 5 proc_pid_comm`)