### PR TITLE
for app-lifetime threads, show "App-Lifetime Thread" in .gist

### DIFF
--- a/src/core.c/Thread.rakumod
+++ b/src/core.c/Thread.rakumod
@@ -127,7 +127,7 @@ my class Thread {
         "Thread<$.id>($.name)"
     }
     multi method gist(Thread:D:) {
-        "Thread #$.id" ~ ($!name ne '<anon>' ?? " ($!name)" !! '')
+        ($.app_lifetime ?? "App-Lifetime " !! "") ~ "Thread #$.id" ~ ($!name ne '<anon>' ?? " ($!name)" !! '')
     }
 
     method yield(Thread:U: --> Nil) {


### PR DESCRIPTION
Looking for feedback if this is wanted / helpful:

```
⬢ [timo@toolbox rakudo]$ rakudo-m -e 'for ^10 { start { say $*THREAD; say "doing something lol"; sleep (0.5..2).rand } }; start react whenever Supply.interval(0.5) { say "ping"; say $*THREAD; last if $++ > 3 }; await start react whenever Promise.in(5) { say $*THREAD; say "aaand were done" };'
App-Lifetime Thread #4 (GeneralWorker)
doing something lol
App-Lifetime Thread #6 (GeneralWorker)
doing something lol
App-Lifetime Thread #7 (GeneralWorker)
doing something lol
App-Lifetime Thread #8 (GeneralWorker)
doing something lol
App-Lifetime Thread #9 (GeneralWorker)
doing something lol
App-Lifetime Thread #10 (GeneralWorker)
doing something lol
App-Lifetime Thread #11 (GeneralWorker)
doing something lol
App-Lifetime Thread #12 (GeneralWorker)
doing something lol
App-Lifetime Thread #13 (GeneralWorker)
doing something lol
App-Lifetime Thread #14 (GeneralWorker)
doing something lol
ping
App-Lifetime Thread #16 (TimerWorker)
ping
App-Lifetime Thread #16 (TimerWorker)
ping
App-Lifetime Thread #16 (TimerWorker)
ping
App-Lifetime Thread #16 (TimerWorker)
ping
App-Lifetime Thread #16 (TimerWorker)
App-Lifetime Thread #4 (GeneralWorker)
aaand were done
```

These threads are of course all app-lifetime, since they are started by the ThreadPoolScheduler.