### PR TITLE
Address long-standing discrepancy for != and METAOP_NEGATE

### DIFF
--- a/src/Perl6/Compiler.nqp
+++ b/src/Perl6/Compiler.nqp
@@ -256,8 +256,10 @@ class Perl6::Compiler is HLL::Compiler {
     }
 
     method ast($match, *%adverbs) {
+        self.panic("Unable to obtain AST from parse result (no match object)")
+            unless nqp::isconcrete($match);
         my $ast := $match.ast;
-        self.panic("Unable to obtain AST from parse result")
+        self.panic("Unable to obtain AST from parse result (no AST on match object)")
             unless nqp::isconcrete($ast);
         $ast
     }

--- a/src/Perl6/Optimizer.nqp
+++ b/src/Perl6/Optimizer.nqp
@@ -3685,17 +3685,30 @@ class Perl6::Optimizer {
       }
       elsif self.op_eq_core($metaop, '&METAOP_NEGATE') {
         return NQPMu unless nqp::istype($metaop[0], QAST::Var);
-        if 2 < nqp::getcomp('Raku').language_revision {
-          return QAST::Op.new(:op<call>, :name($metaop[0].name),
-                   QAST::WVal.new(value => $!symbols.find_in_setting("False")),
-                   QAST::Op.new: :op<call>, :name($metaop[0].name),
-                      $op[1], $op[2]);
-        } else {
-          return QAST::Op.new(:op<call>, :name('&prefix:<!>'),
-                    QAST::Op.new: :op<call>, :name($metaop[0].name),
-                      $op[1], $op[2])
-        }
-			}
+
+        my %lookup := nqp::hash(
+          '&infix:<==>', 1,
+          '&infix:<eq>', 1,
+          # ('ne' ne 'troublesome') eq False
+          #'&infix:<ne>', 1,
+          '&infix:<===>', 1,
+          '&infix:<eqv>', 1,
+        );
+
+        return nqp::not_i(nqp::isnull($metaop[0]))
+            && nqp::not_i(nqp::isnull(my $raku-comp := nqp::getcomp('Raku')))
+            && nqp::not_i(nqp::isnull(my $revision := nqp::findmethod($raku-comp, 'language_revision')))
+            && nqp::islt_i(2, $revision($raku-comp))
+            && nqp::not_i(nqp::isnull(my $op-name := $metaop[0].name))
+            && nqp::existskey(%lookup, $op-name)
+          ??
+            QAST::Op.new(:op<call>, :name($metaop[0].name),
+              QAST::WVal.new(value => $!symbols.find_in_setting("False")),
+              QAST::Op.new(:op<call>, :name($metaop[0].name), $op[1], $op[2]))
+          !!
+            QAST::Op.new(:op<call>, :name('&prefix:<!>'),
+              QAST::Op.new(:op<call>, :name($metaop[0].name), $op[1], $op[2]));
+      }
       elsif self.op_eq_core($metaop, '&METAOP_REVERSE') {
         return NQPMu unless nqp::istype($metaop[0], QAST::Var)
           && nqp::elems($op) == 3;

--- a/src/Perl6/Optimizer.nqp
+++ b/src/Perl6/Optimizer.nqp
@@ -3685,10 +3685,17 @@ class Perl6::Optimizer {
       }
       elsif self.op_eq_core($metaop, '&METAOP_NEGATE') {
         return NQPMu unless nqp::istype($metaop[0], QAST::Var);
-        return QAST::Op.new: :op<call>, :name('&prefix:<!>'),
-                QAST::Op.new: :op<call>, :name($metaop[0].name),
-                    $op[1], $op[2];
-      }
+        if 2 < nqp::getcomp('Raku').language_revision {
+          return QAST::Op.new(:op<call>, :name($metaop[0].name),
+                   QAST::WVal.new(value => $!symbols.find_in_setting("False")),
+                   QAST::Op.new: :op<call>, :name($metaop[0].name),
+                      $op[1], $op[2]);
+        } else {
+          return QAST::Op.new(:op<call>, :name('&prefix:<!>'),
+                    QAST::Op.new: :op<call>, :name($metaop[0].name),
+                      $op[1], $op[2])
+        }
+			}
       elsif self.op_eq_core($metaop, '&METAOP_REVERSE') {
         return NQPMu unless nqp::istype($metaop[0], QAST::Var)
           && nqp::elems($op) == 3;

--- a/src/Raku/ast/operator-properties.rakumod
+++ b/src/Raku/ast/operator-properties.rakumod
@@ -685,7 +685,7 @@ class OperatorProperties {
           '≅',      'chaining-commutative',
           '!=',     'chaining-commutative',
           'eq',     'chaining-commutative',
-          'ne',     'chaining',
+          'ne',     'chaining-commutative',
           'le',     'chaining',
           'ge',     'chaining',
           'lt',     'chaining',

--- a/src/Raku/ast/operator-properties.rakumod
+++ b/src/Raku/ast/operator-properties.rakumod
@@ -26,6 +26,7 @@ class OperatorProperties {
     has int $.fiddly;
     has int $.adverb;
     has int $.ternary;
+    has int $.commutative;
 
     # Basic interface
     method new(
@@ -39,7 +40,8 @@ class OperatorProperties {
       int :$diffy,
       int :$fiddly,
       int :$adverb,
-      int :$ternary
+      int :$ternary,
+      int :$commutative
     ) {
         my $obj := nqp::create(self);
         nqp::bindattr_s($obj,OperatorProperties,'$!precedence',
@@ -65,6 +67,8 @@ class OperatorProperties {
           $adverb // (nqp::isconcrete(self) ?? $!adverb !! 0));
         nqp::bindattr_i($obj,OperatorProperties,'$!ternary',
           $ternary // (nqp::isconcrete(self) ?? $!ternary !! 0));
+        nqp::bindattr_i($obj,OperatorProperties,'$!commutative',
+          $commutative // (nqp::isconcrete(self) ?? $!commutative !! 0));
 
         $obj
     }
@@ -82,6 +86,7 @@ class OperatorProperties {
       int :$fiddly,
       int :$adverb,
       int :$ternary,
+      int :$commutative,
       *%_
     ) {
         self.new(
@@ -95,7 +100,8 @@ class OperatorProperties {
           :$diffy,
           :$fiddly,
           :$adverb,
-          :$ternary
+          :$ternary,
+          :$commutative
         )
     }
 
@@ -135,6 +141,7 @@ class OperatorProperties {
         nqp::push_s($parts,':fiddly')  if $!fiddly;
         nqp::push_s($parts,':adverb')  if $!adverb;
         nqp::push_s($parts,':ternary') if $!ternary;
+        nqp::push_s($parts,':commutative') if $!commutative;
 
         $name ~ '.new: ' ~ nqp::join(', ',$parts)
     }
@@ -254,6 +261,7 @@ class OperatorProperties {
     method fiddly()  { nqp::isconcrete(self) ?? $!fiddly  !! 0 }
     method adverb()  { nqp::isconcrete(self) ?? $!adverb  !! 0 }
     method ternary() { nqp::isconcrete(self) ?? $!ternary !! 0 }
+    method commutative() { nqp::isconcrete(self) ?? $!commutative !! 0 }
 
     # Convenience methods
     method chain() {
@@ -321,6 +329,7 @@ class OperatorProperties {
                 nqp::bindkey($hash,'fiddly',$!fiddly)      if $!fiddly;
                 nqp::bindkey($hash,'adverb',$!adverb)      if $!adverb;
                 nqp::bindkey($hash,'ternary',$!ternary)    if $!ternary;
+                nqp::bindkey($hash,'commutative',$!commutative) if $!commutative;
                 $hash
             }
         }
@@ -469,6 +478,9 @@ class OperatorProperties {
           ),
           'chaining', nqp::hash(
             'precedence','m=', 'associative','chain', 'iffy',1, 'diffy',1
+          ),
+          'chaining-commutative', nqp::hash(
+            'precedence','m=', 'associative','chain', 'iffy',1, 'diffy',1, 'commutative',1
           ),
           'tight-and', nqp::hash(
             'precedence','l=', 'associative','left', 'thunky','.t', 'iffy',1
@@ -668,19 +680,19 @@ class OperatorProperties {
           '≼',      'chaining',
           '(>+)',   'chaining',
           '≽',      'chaining',
-          '==',     'chaining',
-          '=~=',    'chaining',
-          '≅',      'chaining',
-          '!=',     'chaining',
-          'eq',     'chaining',
+          '==',     'chaining-commutative',
+          '=~=',    'chaining-commutative',
+          '≅',      'chaining-commutative',
+          '!=',     'chaining-commutative',
+          'eq',     'chaining-commutative',
           'ne',     'chaining',
           'le',     'chaining',
           'ge',     'chaining',
           'lt',     'chaining',
           'gt',     'chaining',
           '=:=',    'chaining',
-          '===',    'chaining',
-          'eqv',    'chaining',
+          '===',    'chaining-commutative',
+          'eqv',    'chaining-commutative',
           'before', 'chaining',
           'after',  'chaining',
           '~~',     'chaining',

--- a/src/core.c/Buf.rakumod
+++ b/src/core.c/Buf.rakumod
@@ -1745,11 +1745,8 @@ multi sub infix:<cmp>(Blob:D $a, Blob:D $b) { ORDER($a.COMPARE($b)) }
 multi sub infix:<eq> (Blob:D $a, Blob:D $b --> Bool:D) {
     nqp::hllbool(nqp::eqaddr($a,$b) || $a.SAME($b))
 }
-multi sub infix:<ne> (Blob:D $a, Blob:D $b --> Bool:D) {
-    nqp::hllbool(
-      nqp::not_i(nqp::eqaddr($a,$b) || $a.SAME($b))
-    )
-}
+#multi sub infix:<ne> (Blob:D $a, Blob:D $b --> Bool:D) {
+#   ---> moved to core_epilogue.rakumod
 multi sub infix:<lt> (Blob:D $a, Blob:D $b) {
     nqp::hllbool(nqp::iseq_i($a.COMPARE($b),-1))
 }

--- a/src/core.c/Numeric.rakumod
+++ b/src/core.c/Numeric.rakumod
@@ -312,10 +312,11 @@ multi sub infix:<=~=>(\a, \b, :$tolerance = $*TOLERANCE)    {
 # U+2245 APPROXIMATELY EQUAL TO
 my constant &infix:<≅> := &infix:<=~=>;
 
-proto sub infix:<!=>(Mu $?, Mu $?, *%) is pure  {*}
+proto sub infix:<!=>(Mu $?, Mu $?, *%) is pure is revision-gated("6.c") {*}
 multi sub infix:<!=>(  --> True) { }
 multi sub infix:<!=>($ --> True) { }
-multi sub infix:<!=>(Mu \a, Mu \b) { not a == b }
+multi sub infix:<!=>(Mu \a, Mu \b) is revision-gated("6.c") { not a == b }
+multi sub infix:<!=>(Mu \a, Mu \b) is revision-gated("6.e") { (a == b) == False }
 # U+2260 NOT EQUAL TO
 my constant &infix:<≠> := &infix:<!=>;
 

--- a/src/core.c/OperatorProperties.rakumod
+++ b/src/core.c/OperatorProperties.rakumod
@@ -156,7 +156,8 @@ BEGIN {
       &infix:«minmax»,
       &infix:«min»,
       &infix:«mod»,
-      &infix:«ne»,
+#      &infix:«ne»,
+       # Properties added in core_epilogue.rakumod
       &infix:«notandthen»,
       &infix:«orelse»,
       &infix:«or»,

--- a/src/core.c/OperatorProperties.rakumod
+++ b/src/core.c/OperatorProperties.rakumod
@@ -11,6 +11,7 @@ class OperatorProperties {
 #    has int $.fiddly;
 #    has int $.adverb;
 #    has int $.ternary;
+#    has int $.commutative;
 
     multi method WHICH(OperatorProperties:D: --> ValueObjAt:D) {
         my $parts := nqp::list_s('OperatorProperties');
@@ -32,6 +33,7 @@ class OperatorProperties {
         nqp::push_s($parts,'fiddly')  if $.fiddly;
         nqp::push_s($parts,'adverb')  if $.adverb;
         nqp::push_s($parts,'ternary') if $.ternary;
+        nqp::push_s($parts,'commutative') if $.commutative;
 
         nqp::box_s(nqp::join('|',$parts),ValueObjAt)
     }
@@ -116,6 +118,8 @@ BEGIN {
       &infix:«=:=»,
       &infix:«==»,
       &infix:«===»,
+      &infix:«=~=»,
+      &infix:«≅»,
       &infix:«=»,
       &infix:«>»,
       &infix:«>=»,

--- a/src/core.c/Str.rakumod
+++ b/src/core.c/Str.rakumod
@@ -4041,13 +4041,6 @@ multi sub infix:<eq>(str $a, str $b --> Bool:D) {
     nqp::hllbool(nqp::iseq_s($a, $b)) #?js: NFG
 }
 
-multi sub infix:<ne>(Str:D $a, Str:D $b --> Bool:D) {
-    nqp::hllbool(nqp::isne_s(nqp::unbox_s($a),nqp::unbox_s($b)))
-}
-multi sub infix:<ne>(str $a, str $b --> Bool:D) {
-    nqp::hllbool(nqp::isne_s($a, $b))
-}
-
 multi sub infix:<lt>(Str:D $a, Str:D $b --> Bool:D) {
     nqp::hllbool(nqp::islt_s(nqp::unbox_s($a),nqp::unbox_s($b)))
 }

--- a/src/core.c/Stringy.rakumod
+++ b/src/core.c/Stringy.rakumod
@@ -32,12 +32,6 @@ multi sub infix:<eq>(    --> Bool::True) { }
 multi sub infix:<eq>(Any --> Bool::True) { }
 multi sub infix:<eq>(\a, \b) { a.Stringy eq b.Stringy }
 
-proto sub infix:<ne>(Mu $?, Mu $?, *%) is pure {*}
-multi sub infix:<ne>(    --> Bool::True) { }
-multi sub infix:<ne>(Any --> Bool::True) { }
-multi sub infix:<ne>(Mu \a, Mu \b)   { not a eq b }
-multi sub infix:<ne>(\a, \b) { a.Stringy ne b.Stringy }
-
 proto sub infix:<lt>($?, $?, *%) is pure {*}
 multi sub infix:<lt>(    --> Bool::True) { }
 multi sub infix:<lt>(Any --> Bool::True) { }

--- a/src/core.c/Unicode.rakumod
+++ b/src/core.c/Unicode.rakumod
@@ -41,7 +41,7 @@ my class Unicode {
       '15.1' => 0x2EE5F.chr,
     # PLEASE ADD NEWER UNICODE VERSIONS HERE, AS SOON AS THE UNICODE
     # CONSORTIUM HAS RELEASED A NEW VERSION
-    ).first(*.value.uniprop('Age') ne 'Unassigned', :end).key.Version;
+    ).first(!(*.value.uniprop('Age') eq 'Unassigned'), :end).key.Version;
 #?endif
 
     has Version $.version = VERSION;

--- a/src/core.c/core_epilogue.rakumod
+++ b/src/core.c/core_epilogue.rakumod
@@ -94,6 +94,32 @@ BEGIN {
     }
 }
 
+## From Stringy.rakumod
+proto sub infix:<ne>(Mu $?, Mu $?, *%) is pure {*}
+multi sub infix:<ne>(    --> Bool::True) { }
+multi sub infix:<ne>(Any --> Bool::True) { }
+#multi sub infix:<ne>(Mu \a, Mu \b) is revision-gated("6.c") { not a eq b }
+#multi sub infix:<ne>(Mu \a, Mu \b) is revision-gated("6.e") { (a eq b) eq False }
+multi sub infix:<ne>(Mu \a, Mu \b) { (a eq b) eq False }
+#multi sub infix:<ne>(\a, \b) is revision-gated("6.c") { a.Stringy ne b.Stringy }
+#multi sub infix:<ne>(\a, \b) is revision-gated("6.e") { (a.Stringy eq b.Stringy) eq False }
+multi sub infix:<ne>(\a, \b) { (a.Stringy eq b.Stringy) eq False }
+
+## From Str.rakumod
+multi sub infix:<ne>(Str:D $a, Str:D $b --> Bool:D) {
+  nqp::hllbool(nqp::isne_s(nqp::unbox_s($a),nqp::unbox_s($b)))
+}
+multi sub infix:<ne>(str $a, str $b --> Bool:D) {
+  nqp::hllbool(nqp::isne_s($a, $b))
+}
+## From Buf.rakumod
+multi sub infix:<ne> (Blob:D $a, Blob:D $b --> Bool:D) {
+  nqp::hllbool(
+          nqp::not_i(nqp::eqaddr($a,$b) || $a.SAME($b))
+  )
+}
+&infix:<ne>.set_op_props();
+
 # Required for use in the optimizer
 nqp::bindhllsym('Raku', 'Mu:U', Mu:U);
 

--- a/src/core.c/metaops.rakumod
+++ b/src/core.c/metaops.rakumod
@@ -53,8 +53,12 @@ sub METAOP_TEST_ASSIGN_VALUE:<orelse>(\lhs, $rhs) is raw is implementation-detai
     lhs orelse (lhs = $rhs)
 }
 
-sub METAOP_NEGATE(\op) is implementation-detail {
-    -> |c { c.elems > 1 ?? !op.(|c) !! True }
+proto sub METAOP_NEGATE(|) is implementation-detail is revision-gated("6.c") {*}
+multi sub METAOP_NEGATE(\op) is implementation-detail is revision-gated("6.c") {
+    -> |c { c.elems > 1 ?? not op.(|c) !! True }
+}
+multi sub METAOP_NEGATE(\op) is implementation-detail is revision-gated("6.e") {
+    -> |c { c.elems > 1 ?? op.(op.(|c), False) !! True }
 }
 
 sub METAOP_REVERSE(\op) is implementation-detail {

--- a/src/core.c/traits.rakumod
+++ b/src/core.c/traits.rakumod
@@ -377,7 +377,7 @@ multi sub trait_mod:<of>(Routine:D $target, Mu:U $type) {
 
 multi sub trait_mod:<is>(Routine:D $r, Str :$revision-gated!) {
     my $chars := nqp::chars($revision-gated);
-    my $internal-revision := 1 + nqp::ord($revision-gated, $chars - 1) - nqp::ord("c");
+    my $internal-revision := nqp::add_i(1, nqp::sub_i(nqp::ord($revision-gated, nqp::sub_i($chars,1)), nqp::ord("c")));
     $r.set-revision-gated;
     $r.^mixin(
         role is-revision-gated[$revision] { method REQUIRED-REVISION(--> Int) { $revision } }.^parameterize($internal-revision)


### PR DESCRIPTION
**Note: This represents a significant but (AFAICT) logically equivalent adjustment to the definition of METAOP_NEGATE**

This patch uses revision-gate to migrate v6e to a version of negation that preserves junctions while accomplishing the same underlying functionality as planting `not` in front of `$expr`.

Previously:

    one(0,1) != 0 # False

Now:

    one(0,1) != 0 # one(Bool::False, Bool::True)

Also fixed in this patch is the ability to add a revision-gated method with the same signature as an already existing method. In such cases, the existing method is also revision-gated, but to the revision that it was introduced (in practice this will usually be the same revision as the proto is gated to).

Addresses R#5686 (#5686) / R#3748 (#3748) / R#3874 (#3874)

See also discussion at:
    https://github.com/Raku/problem-solving/issues/319

Note: Adopting this change will require adjustments to roast.