### PR TITLE
Restore old logic in find_best_dispatchee

### DIFF
--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -3934,7 +3934,10 @@ BEGIN {
                                   ) || (
                                     ($flags +& nqp::const::TYPE_NATIVE_UINT)
                                       && nqp::iscont_u($arg)
-                                  ) || nqp::iscont_n($arg);  # NATIVE_NUM
+                                  ) || (
+                                    ($flags +& nqp::const::TYPE_NATIVE_NUM)
+                                      && nqp::iscont_n($arg)
+                                  )
                             }
 
                             # Got a native, does it match?
@@ -3947,7 +3950,10 @@ BEGIN {
                             ) || (
                               ($flags +& nqp::const::TYPE_NATIVE_UINT)
                                 && $got_prim != nqp::const::BIND_VAL_UINT
-                            ) || $got_prim != nqp::const::BIND_VAL_NUM {  # NATIVE_NUM
+                            ) || (
+                              ($flags +& nqp::const::TYPE_NATIVE_NUM)
+                                && $got_prim != nqp::const::BIND_VAL_NUM
+                            ) {
 
                                 # Mismatch.
                                 $no_mismatch := 0;


### PR DESCRIPTION
The refactoring from 70b8b229fa changed the logic to detect a mismatch between the expected type and the passed in value when doing the type check for native parameters. But if I'm not mistaken the new version got some cases wrong:

* In the first chain of conditions a container with a native num passed in would bypass the check for the expected type.

* In the second chain of conditions any native str, int, or uint value that matches the expected type, would be diagnosed as a mismatch due to the last alternative.

This commit restores the old logic in both places.

Fixes https://github.com/rakudo/rakudo/issues/5688.