### PR TITLE
Don't use Match::chomp on string

### DIFF
--- a/src/core.c/Match.rakumod
+++ b/src/core.c/Match.rakumod
@@ -394,7 +394,7 @@ my class Match is Capture is Cool does NQPMatchRole {
         for self.Match::caps {
             $r ~= $s ~ (.key // '?') ~ ' ' ~ &?ROUTINE(.value, $d + 1);
         }
-        $d == 0 ?? $r.Match::chomp !! $r;
+        $d == 0 ?? $r.chomp !! $r;
     }
 
     method replace-with(Match:D: Str() $replacement --> Str:D) {


### PR DESCRIPTION
This avoids the following error on the JVM backend when calling .gist on Match objects:

  Cannot dispatch to method chomp on Match because it is not inherited
  or done by Str

I don't understand how this works on MoarVM, but using an unqualified method call looks reasonable to me.