### PR TITLE
[JVM] Unbreak usage of "hash" with named args

### DIFF
--- a/src/core.c/Hash.rakumod
+++ b/src/core.c/Hash.rakumod
@@ -497,7 +497,9 @@ multi sub circumfix:<{ }>(*@elems) { my % = @elems }
 BEGIN my &circumfix:<:{ }> = sub (*@e) { Hash.^parameterize(Mu,Any).new(@e) }
 
 proto sub hash(|) {*}
+#?if !jvm
 multi sub hash() is default { my %h }
+#?endif
 multi sub hash(*%h) { %h }
 multi sub hash(*@a, *%h) { my % = flat @a, %h }
 


### PR DESCRIPTION
A couple of spectests were failing when "hash" was used with named arguments, like so:

  $ ./rakudo-j -e 'say hash(a => 1)'
  Unexpected named argument 'a' passed
    in block <unit> at -e line 1

Removing the multi sub added with f725f5f4bd for the JVM backend fixes the problem. AFAIU the wrong multi was used, because named arguments weren't taken into account during multi dispatch.