### PR TITLE
Add lower-bounding for the revision-gated trait

### DIFF
--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -3889,10 +3889,13 @@ BEGIN {
             nqp::scwbenable;
         }
 
+
+#?if !moar
         my $caller-revision := nqp::getcomp('Raku').language_revision;
         if nqp::can($self, 'REQUIRED-REVISION') && $self.REQUIRED-REVISION <= $caller-revision {
           $dispatch_order := $self.'!filter-revision-gated-candidates'($caller-revision, $dispatch_order)
         }
+#?endif
 
         $dispatch_order
     }));

--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -3827,6 +3827,55 @@ BEGIN {
         }
     }));
 
+#?if !moar
+    Routine.HOW.add_method(Routine, '!filter-revision-gated-candidates',
+      nqp::getstaticcode(sub ($self, $caller-revision, @candidates) {
+        $self := nqp::decont($self);
+
+        my int $idx := 0;
+        my int $allowed-idx := 0;
+        my @allowed-candidates;
+        my %gated-candidates;
+        while $idx < nqp::elems(@candidates) {
+          my $candidate := nqp::atpos(@candidates, $idx++);
+
+          unless nqp::isconcrete($candidate) {
+            nqp::push(@allowed-candidates, $candidate);
+            $allowed-idx++;
+            next;
+          }
+
+          my $required-revision := nqp::atkey($candidate, 'required_revision');
+          my $is-revision-specified := nqp::isconcrete($required-revision);
+          if !$is-revision-specified || $required-revision <= $caller-revision  {
+            if (nqp::existskey($candidate, 'signature')) && $is-revision-specified {
+              my $signature := nqp::atkey($candidate, 'signature').raku;
+              if nqp::existskey(%gated-candidates, $signature) {
+                my $candidate-idx := nqp::atkey(%gated-candidates, $signature);
+                my $last-seen-revision := nqp::atkey(
+                        nqp::atpos(@allowed-candidates, $candidate-idx),
+                        'required_revision'
+                                                                                      );
+
+                if $last-seen-revision < $required-revision {
+                  nqp::bindkey(%gated-candidates, $signature, $candidate-idx);
+                  nqp::bindpos(@allowed-candidates, $candidate-idx, $candidate);
+                  # Do *not* bump $allowed-idx here
+                }
+              } else {
+                nqp::push(@allowed-candidates, $candidate);
+                nqp::bindkey(%gated-candidates, $signature, $allowed-idx++);
+              }
+            } else {
+              nqp::push(@allowed-candidates, $candidate);
+              $allowed-idx++;
+            }
+          }
+        }
+        @allowed-candidates
+    }));
+#?endif
+
     Routine.HOW.add_method(Routine, 'dispatch_order',
       nqp::getstaticcode(sub ($self) {
         $self := nqp::decont($self);
@@ -3839,6 +3888,12 @@ BEGIN {
             );
             nqp::scwbenable;
         }
+
+        my $caller-revision := nqp::getcomp('Raku').language_revision;
+        if nqp::can($self, 'REQUIRED-REVISION') && $self.REQUIRED-REVISION <= $caller-revision {
+          $dispatch_order := $self.'!filter-revision-gated-candidates'($caller-revision, $dispatch_order)
+        }
+
         $dispatch_order
     }));
 
@@ -3848,6 +3903,9 @@ BEGIN {
 
         # Count arguments.
         my int $num_args := nqp::captureposelems($capture);
+
+        # Get the compiler revision for handling the revision-gated trait
+        my $caller-revision := nqp::getcomp('Raku').language_revision;
 
         # Get list and number of candidates, triggering a sort if there are none.
         my @candidates := $self.dispatch_order;
@@ -3868,8 +3926,6 @@ BEGIN {
         my $Positional             := nqp::null;
         my $PositionalBindFailover := nqp::null;
         my $Associative            := nqp::null;
-
-        my $caller-revision := nqp::getlexcaller('$?LANGUAGE-REVISION');
 
         my int $done;
         until $done {

--- a/t/02-rakudo/12-multi-revision-gated.t
+++ b/t/02-rakudo/12-multi-revision-gated.t
@@ -1,0 +1,23 @@
+use lib <t/packages/Test-Helpers>;
+use Test;
+use Test::Helpers;
+
+plan 3;
+
+my $to-eval = q:to/END/;
+
+proto sub gated(|) is revision-gated("6.c") {*}
+multi sub gated(Int $x) is revision-gated("6.c") { print "6.c ($x)" }
+multi sub gated(Int $x) is revision-gated("6.d") { print "6.d ({$x+1})" }
+multi sub gated(Int $x) is revision-gated("6.e") { print "6.e ({$x+2})" }
+
+gated(6);
+
+END
+
+is-run 'use v6.c;' ~ $to-eval,
+        :out("6.c (6)"), q|is revision-gated("6.c") candidate called for 'use v6.c;'|;
+is-run 'use v6.d;' ~ $to-eval,
+        :out("6.d (7)"), q|is revision-gated("6.d") candidate called for 'use v6.d;'|;
+is-run 'use v6.e.PREVIEW;' ~ $to-eval,
+        :out("6.e (8)"), q|is revision-gated("6.e") candidate called for 'use v6.e;'|;


### PR DESCRIPTION
This adds a finishing touch to revision gating: the ability to use revision gating to evolve methods that otherwise have the exact same signature.

The is done by adding the trait to the candidate that is to be replaced:

    ```
    # protos always require the minimum version, this is how dispatch
    # knows to look for revision gated candidates
    proto sub foo(|) is revision-gated("6.c")
    # multis with the same signature as their replacement also need
    # the trait
    multi sub foo(Int $x) is revision-gated("6.c") { say "old x: $x" }
    # the replacement is revision gated to the version in which it
    # is introduced
    multi sub foo(Int $x) is revision-gated("6.e") { say "new x: {$x+1}" }
    ```

This leads to the following behavior:

    ```
    foo(555)
    #=> old x: 555
    ```

    ```
    use v6.e.PREVIEW;
    foo(555)
    #=> new x: 556
    ```