### PR TITLE
Fix `dir` to give "." and ".." again

### DIFF
--- a/src/core.c/Rakudo/Iterator.rakumod
+++ b/src/core.c/Rakudo/Iterator.rakumod
@@ -1508,8 +1508,8 @@ class Rakudo::Iterator {
         has Mu  $!CWD;       # IO::Path object for $*CWD when testing
         has Mu  $!tester;    # object to call .ACCEPTS on to accept entry
         has Mu  $!dirhandle; # low level directory handle
-#?if jvm
-        has $!dots;  # JVM doesnt produce "." and "..", so we need to fake them
+#?if !js
+        has $!dots;  # Moar & JVM don't produce "." and "..", so we need to fake them
 #?endif
 
         method !SET-SELF(\path, Mu \tester) {
@@ -1518,7 +1518,7 @@ class Rakudo::Iterator {
             $!CWD       := path.CWD.IO;
             $!tester    := tester;
             $!dirhandle := nqp::opendir(path.absolute);
-#?if jvm
+#?if !js
             $!dots   := nqp::list_s(".","..");
 #?endif
 
@@ -1532,14 +1532,14 @@ class Rakudo::Iterator {
             my $*CWD := $!CWD;
 
             nqp::while(
-#?if jvm
+#?if !js
               ($entry = nqp::if(
                 nqp::elems($!dots),
                 nqp::shift_s($!dots),
                 nqp::nextfiledir($!dirhandle)
               )),
 #?endif
-#?if !jvm
+#?if js
               ($entry = nqp::nextfiledir($!dirhandle)),
 #?endif
               nqp::if(
@@ -1555,7 +1555,7 @@ class Rakudo::Iterator {
         }
 
         method push-all(\target --> IterationEnd) {
-#?if jvm
+#?if !js
             my $dots      := $!dots;
 #?endif
             my $path      := $!path;
@@ -1566,14 +1566,14 @@ class Rakudo::Iterator {
 
             my $*CWD := $!CWD;
             nqp::while(
-#?if jvm
+#?if !js
               ($entry = nqp::if(
                 nqp::elems($dots),
                 nqp::shift_s($dots),
                 nqp::nextfiledir($dirhandle)
               )),
 #?endif
-#?if !jvm
+#?if js
               ($entry = nqp::nextfiledir($dirhandle)),
 #?endif
               nqp::if(
@@ -1601,19 +1601,13 @@ class Rakudo::Iterator {
             $!path  := path;
             $!prefix = path.prefix-for-dir;
 
-#?if !jvm
+#?if js
             my $dirhandle := nqp::opendir(path.absolute);
             # skipping . and .. worked, JVM never produces them
             if nqp::iseq_s(nqp::nextfiledir($dirhandle),'.')
               && nqp::iseq_s(nqp::nextfiledir($dirhandle),'..') {
                 $!dirhandle  := $dirhandle;
-#?endif
-#?if jvm
-                $!dirhandle := nqp::opendir(path.absolute);
-#?endif
-
                 self
-#?if !jvm
             }
 
             # strange, no '.' or '..' at start, run with tester
@@ -1623,6 +1617,10 @@ class Rakudo::Iterator {
                   -> str $d { nqp::isne_s($d,'.') && nqp::isne_s($d,'..') },
                 )
             }
+#?endif
+#?if !js
+            $!dirhandle := nqp::opendir(path.absolute);
+            self
 #?endif
         }
 


### PR DESCRIPTION
Now that Moar does not give "." and ".." for dirs anymore, we need to put it in ourselves, just as we do for the JVM.