### PR TITLE
Type second param of proto for Stash::ASSIGN-KEY

### DIFF
--- a/src/core.c/Stash.rakumod
+++ b/src/core.c/Stash.rakumod
@@ -59,7 +59,7 @@ my class Stash { # declared in BOOTSTRAP
     # 1. Hash is not thread-safe whereas Stash claims to be
     # 2. Stash candidates are fully overriding their counterparts from Hash
     # 3. Minor: could result in some minor improvement in multi-dispatch lookups due to lesser number of candidates
-    proto method ASSIGN-KEY(Stash:D: $, $) {*}
+    proto method ASSIGN-KEY(Stash:D: $, Mu $) {*}
     multi method ASSIGN-KEY(Stash:D: Str:D $key, Mu \assignval) is raw {
         my $storage := nqp::getattr(self,Map,'$!storage');
         my \existing-key := nqp::atkey($storage, $key);


### PR DESCRIPTION
As explained in https://github.com/rakudo/rakudo/issues/5703 the current version leads to a spectest failure on the JVM backend. Running https://github.com/Raku/roast/blob/3032bcf423/integration/advent2011-day07.t eventually Stash::ASSIGN-KEY is called with something that derives from Metamodel::GrammarHOW (and doesn't type match with Any) as the second argument.

Typing the second parameter as Mu solves this problem -- and it also matches the types used in the multi variants of Stash::ASSIGN-KEY.