### PR TITLE
Reimagine Azure CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,230 +19,670 @@ pr:
 - main
 
 variables:
+  system.debug: 'true'
   # Turn this Powershell console into a developer powershell console.
   # https://intellitect.com/enter-vsdevshell-powershell/
   PWSH_DEV: |
     $installPath = &"C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationpath
-    $devShell    = &"C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -latest -find **\Microsoft.VisualStudio.DevShell.dll
-    Import-Module $devShell
+    $devShellLoadedSuccess = $false
+    if (Test-Path -Path ../where_is_devshell/here.txt -PathType leaf) {
+      $tryDevShell = Get-Item -Path ../where_is_devshell/here.txt | Get-Content -Head 1
+      if (Test-Path -Path $tryDevShell) {
+        try {
+          Import-Module $tryDevShell
+          $devShell = $tryDevShell
+          $devShellLoadedSuccess = $true
+          Write-Output "Successfully loaded DevShell.dll from $tryDevShell"
+        }
+        catch {
+          Write-Output "##[warning]While trying to load the devShell module from $tryDevShell"
+          Write-Output $_
+        }
+      }
+    }
+    if (-not $devShellLoadedSuccess) {
+      Write-Output "Locating DevShell.dll in visual studio installation, please hold on ..."
+      $devShell = &"C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -latest -find **\Microsoft.VisualStudio.DevShell.dll
+      Write-Output "Found DevShell.dll at $devShell"
+      try {
+        mkdir ../where_is_devshell/
+        $devShell | out-file -filepath ../where_is_devshell/here.txt
+      }
+      catch {
+        Write-Output "##[warning]Couldn't cache $devShell in ../where_is_devshell/here.txt :("
+        Write-Output $_
+      }
+      Import-Module $devShell
+    }
     Enter-VsDevShell -VsInstallPath $installPath -SkipAutomaticLocation -DevCmdArguments "-arch=amd64"
   RAKUDO_CHECKOUT_TYPE: "rev-$(Build.SourceVersion)-selfrepo"
   NQP_CHECKOUT_TYPE: downstream
   MOAR_CHECKOUT_TYPE: downstream
 
+parameters:
+- name: build_backends
+  type: object
+  default: ['JVM', 'MVM']
+- name: test_backends
+  type: object
+  default: ['MVM']
+- name: oses
+  type: object
+  default: ['Win', 'Lin', 'Mac']
+- name: variants
+  type: object
+  default:
+    JVM:
+      Win: ['']
+      Lin: ['']
+      Mac: ['']
+    MVM:
+      Win: ['relocatable', '']
+      Lin: ['relocatable', '']
+      Mac: ['']
+- name: test_variants
+  type: object
+  default:
+    MVM:
+      Win: ['']
+      Lin: ['']
+      Mac: ['']
+
+
 stages:
-- stage: Test
-  condition: ne( variables['BUILD_PRECOMP_RELEASE'], 'yes' )
+- ${{ each os in parameters.oses }}:
+  - stage: Builds_${{ os }}
+    dependsOn: []
+    condition: ne( variables['BUILD_PRECOMP_RELEASE'], 'yes' )
+
+    jobs:
+    - ${{ each backend in parameters.build_backends }}:
+      - ${{ each variant in parameters['variants'][backend][os] }}:
+        - job: ${{ os }}_${{ backend }}_${{ coalesce(variant, 'normal') }}
+          variables:
+          - name: BACKEND
+            value: ${{ backend }}
+          - name: os
+            value: ${{ os }}
+          - name: VARIANT
+            value: ${{ variant }}
+          - name: RELOCATABLE
+            ${{ if or( eq(variant, 'relocatable'), eq(variant, 'fullspectest') ) }}:
+              value: "yes"
+            ${{ if and( ne(variant, 'relocatable'), ne(variant, 'fullspectest') ) }}:
+              value: ""
+          - name: SPECTEST_ONLY
+            ${{ if eq(variant, 'fullspectest') }}:
+              value: "yes"
+            ${{ if ne(variant, 'fullspectest') }}:
+              value: ""
+          - ${{ if eq(backend, 'JVM') }}:
+            - name: NQP_OPTIONS
+              value: '--backends=jvm'
+            - name: RAKUDO_OPTIONS
+              value: '--backends=jvm'
+            - name: MOAR_OPTIONS
+              value: '--no-moar'
+            - name: MOAR_CHECKOUT_TYPE
+              value: 'none'
+          - ${{ if and( eq(backend, 'MVM'), eq(variant, 'relocatable') ) }}:
+            - name: NQP_OPTIONS
+              value: '--backends=moar --relocatable'
+            - name: RAKUDO_OPTIONS
+              value: '--backends=moar --relocatable'
+            - name: MOAR_OPTIONS
+              value: '--relocatable'
+          - ${{ if and( eq(backend, 'MVM'), ne(variant, 'relocatable') ) }}:
+            - name: NQP_OPTIONS
+              value: '--backends=moar'
+            - name: RAKUDO_OPTIONS
+              value: '--backends=moar'
+            - name: MOAR_OPTIONS
+              value: ''
+          - ${{ if eq(os, 'Win') }}:
+            - name: IMAGE_NAME
+              value: 'windows-2022'
+            - name: IS_WIN
+              value: true
+          - ${{ if eq(os, 'Lin') }}:
+            - name: IMAGE_NAME
+              value: 'ubuntu-24.04'
+            - name: IS_WIN
+              value: false
+          - ${{ if eq(os, 'Mac') }}:
+            - name: IMAGE_NAME
+              value: 'macOS-15'
+            - name: IS_WIN
+              value: false
+
+          pool:
+            vmImage: $(IMAGE_NAME)
+          workspace:
+            clean: all
+          timeoutInMinutes: 180
+          steps:
+          - ${{ if eq(os, 'Win') }}:
+            - pwsh: |
+                # Windows has a maximum PATH variable length of 2048 (depending on
+                # how it's accessed). The length of PATH in AzureCI is already
+                # really tight. We'll run into the limit when we add Java and the
+                # MS BuildTools to the path.
+                # To work around this, we remove a bunch of stuff we won't need
+                # from PATH here.
+                $shortened_path = "$(PATH)" -replace ';[^;]*(SeleniumWebDrivers|SQL Server|Mercurial|Amazon|mysql|\\sbt\\|NSIS|Windows Performance Toolkit|php|Subversion)[^;]*(?=(;|$))', ''
+                echo "##vso[task.setvariable variable=PATH]$shortened_path"
+              displayName: "Shorten PATH on Windows"
+            - pwsh: |
+                echo "##vso[task.setvariable variable=JAVA_HOME]$(JAVA_HOME_11_X64)"
+                echo "##vso[task.setvariable variable=PATH]$(JAVA_HOME_11_X64)\bin;$(PATH)"
+              displayName: "Set java version (Windows)"
+              enabled: ${{ eq(backend, 'JVM') }}
+
+          - ${{ if and(ne(os, 'Win'), eq(backend, 'JVM')) }}:
+            - script: |
+                echo "##vso[task.setvariable variable=JAVA_HOME]$(JAVA_HOME_11_X64)"
+                echo "##vso[task.setvariable variable=PATH]$(JAVA_HOME_11_X64)/bin:$(PATH)"
+              displayName: "Set java version (non-Windows)"
+
+          - checkout: self
+            path: selfrepo
+            displayName: Checkout script repo
+            fetchDepth: 200
+
+          - bash: |
+              export IS_AZURE_PIPELINES_BUILD=1
+              echo "##[task.setvariable variable=IS_AZURE_PIPELINES_BUILD]1"
+            displayName: "set IS_AZURE_PIPELINES_BUILD to 1"
+
+          - script: perl selfrepo/tools/build/checkout-repos-for-test.pl $(RAKUDO_CHECKOUT_TYPE) $(NQP_CHECKOUT_TYPE) $(MOAR_CHECKOUT_TYPE)
+            workingDirectory: $(Pipeline.Workspace)
+            displayName: Checkout repositories
+
+          - ${{ if eq(os, 'Win') }}:
+            - task: Cache@2
+              displayName: "load cached location of devshell dll"
+              inputs:
+                key: '"where is devshell on" | "$(IMAGE_NAME)"'
+                path: ../where_is_devshell/
+
+          - ${{ if ne(backend, 'JVM') }}:
+            - bash: |
+                MOAR_REV=$(cd MoarVM; git describe --always)
+                echo "##vso[task.setvariable variable=moar_git_rev]"$MOAR_REV
+                echo moarvm repository has $MOAR_REV checked out
+                NQP_REV=$(cd nqp; git describe --always)
+                echo "##vso[task.setvariable variable=nqp_git_rev]"$NQP_REV
+                echo nqp repository has $NQP_REV checked out
+                echo "##vso[build.addbuildtag]moar-rev-"$MOAR_REV
+                echo "##vso[build.addbuildtag]nqp-rev-"$NQP_REV
+              displayName: "Get moar & nqp revision"
+              workingDirectory: '$(Pipeline.Workspace)/'
+
+          - ${{ if eq(backend, 'JVM') }}:
+            - bash: |
+                NQP_REV=$(cd nqp; git describe --always)
+                echo "##vso[task.setvariable variable=nqp_git_rev]"$NQP_REV
+                echo nqp repository has $NQP_REV checked out
+                echo "##vso[build.addbuildtag]nqp-rev-"$NQP_REV
+              displayName: "Get nqp revision (jvm)"
+              workingDirectory: '$(Pipeline.Workspace)/'
+
+          - task: Cache@2
+            displayName: "load cached NQP-m & moar"
+            inputs:
+              key: 'v3 | "$(BACKEND)" | "$(MOAR_CHECKOUT_TYPE)" | "$(MOAR_OPTIONS)" | "$(IMAGE_NAME)" | "$(moar_git_rev) + $(nqp_git_rev)" | "$(NQP_CHECKOUT_TYPE)" | "$(NQP_OPTIONS)"'
+              path: ../install-nqp-and-moar
+              cacheHitVar: NQP_CACHE_RESTORED
+
+          - bash: |
+              mkdir ../install
+              cp -r ../install-nqp-and-moar/* ../install/
+            displayName: "extract nqp-and-moar cache"
+            condition: eq( variables['NQP_CACHE_RESTORED'], 'true' )
+
+          - ${{ if ne(backend, 'JVM') }}:
+            - task: Cache@2
+              displayName: "load cached moarvm"
+              inputs:
+                key: 'v4 | "$(MOAR_CHECKOUT_TYPE)" | "$(MOAR_OPTIONS)" | "$(IMAGE_NAME)" | "$(moar_git_rev)"'
+                path: ../install-moar
+                cacheHitVar: MOARVM_CACHE_RESTORED
+              condition: ne( variables['NQP_CACHE_RESTORED'], 'true' )
+
+          - bash: |
+              mkdir ../install
+              cp -r ../install-moar/* ../install/
+            displayName: "extract moar cache"
+            condition: eq( variables['MOARVM_CACHE_RESTORED'], 'true' )
+
+          - ${{ if ne(backend, 'JVM') }}:
+            # Build MoarVM
+            - ${{ if ne(os, 'Win') }}:
+              - script: |
+                  perl Configure.pl --prefix=$(Pipeline.Workspace)/install $(MOAR_OPTIONS)
+                  make install -j3 && \
+                  echo "##vso[build.addbuildtag]moar-${{ os }}-${{ coalesce(variant, 'normal') }}-compiled" && \
+                  cp -r ../install ../install-moar
+                workingDirectory: '$(Pipeline.Workspace)/MoarVM'
+                condition: and(succeeded(), ne( variables['MOARVM_CACHE_RESTORED'], 'true' ), ne( variables['NQP_CACHE_RESTORED'], 'true' ) )
+                displayName: Build MoarVM
+            - ${{ if eq(os, 'Win') }}:
+              - pwsh: |
+                  ${{ variables.PWSH_DEV }}
+                  perl Configure.pl --prefix=$(Pipeline.Workspace)\install $(MOAR_OPTIONS)
+                  nmake install && echo "##vso[build.addbuildtag]moar-${{ os }}-${{ coalesce(variant, 'normal') }}-compiled" && cp -r ../install ../install-moar
+                failOnStderr: false
+                workingDirectory: '$(Pipeline.Workspace)/MoarVM'
+                condition: and(succeeded(), ne( variables['MOARVM_CACHE_RESTORED'], 'true' ), ne( variables['NQP_CACHE_RESTORED'], 'true' ) )
+                displayName: Build MoarVM (Windows)
+
+          # Build NQP
+          - ${{ if ne(os, 'Win') }}:
+            - script: |
+                perl Configure.pl --no-silent-build --prefix=$(Pipeline.Workspace)/install $(NQP_OPTIONS)
+                make install -j3 && \
+                echo "##vso[build.addbuildtag]nqp-${{ os }}-${{ coalesce(variant, 'normal') }}-${{ backend }}-compiled" && \
+                cp -r ../install ../install-nqp-and-moar
+              workingDirectory: '$(Pipeline.Workspace)/nqp'
+              condition: and(succeeded(), ne( variables['NQP_CACHE_RESTORED'], 'true') )
+              displayName: Build NQP
+          - ${{ if eq(os, 'Win') }}:
+            - pwsh: |
+                ${{ variables.PWSH_DEV }}
+                perl Configure.pl --no-silent-build --prefix=$(Pipeline.Workspace)\install $(NQP_OPTIONS)
+                nmake install && echo "##vso[build.addbuildtag]nqp-${{ os }}-${{ coalesce(variant, 'normal') }}-${{ backend }}-compiled" && cp -r ../install ../install-nqp-and-moar
+              failOnStderr: false
+              workingDirectory: '$(Pipeline.Workspace)/nqp'
+              condition: and(succeeded(), ne( variables['NQP_CACHE_RESTORED'], 'true'))
+              displayName: Build NQP (Windows)
+
+          - ${{ if ne( backend, 'JVM' ) }}:
+            # Build Rakudo
+            - ${{ if ne(os, 'Win') }}:
+              - script: |
+                  perl Configure.pl --no-silent-build --prefix=$(Pipeline.Workspace)/install $(RAKUDO_OPTIONS)
+                  make install -j3
+                workingDirectory: '$(Pipeline.Workspace)/rakudo'
+                displayName: Build Rakudo
+
+            - ${{ if eq(os, 'Win') }}:
+              - pwsh: |
+                  ${{ variables.PWSH_DEV }}
+                  perl Configure.pl --no-silent-build --prefix=$(Pipeline.Workspace)\install $(RAKUDO_OPTIONS)
+                  nmake install
+                failOnStderr: false
+                workingDirectory: '$(Pipeline.Workspace)/rakudo'
+                displayName: Build Rakudo (Windows)
+
+            - ${{ if eq(variant, 'relocatable') }}:
+              # TODO: Should use "install moved" instead of "install-moved". But `prove` currently fails with an executable path that contains a space.
+              - script: mv install install-moved
+                workingDirectory: $(Pipeline.Workspace)
+                displayName: Move installation
+
+            - task: PublishPipelineArtifact@1
+              displayName: publish artifact
+              inputs:
+                ${{ if eq(variant, 'relocatable') }}:
+                  targetPath: $(Pipeline.Workspace)/install-moved
+                ${{ if ne(variant, 'relocatable') }}:
+                  targetPath: $(Pipeline.Workspace)/install
+                artifact: ${{ backend }}_${{ coalesce(variant, 'normal') }}_${{ os }}
+                publishLocation: 'pipeline'
+
+            #- ${{ if ne(os, 'Win') }}:
+            #  - script: |
+            #      make clean
+            #    workingDirectory: '$(Pipeline.Workspace)/rakudo'
+            #    displayName: Clean build dir
+            #- ${{ if eq(os, 'Win') }}:
+            #  - pwsh: |
+            #      ${{ variables.PWSH_DEV }}
+            #      nmake clean
+            #    failOnStderr: false
+            #    workingDirectory: '$(Pipeline.Workspace)/rakudo'
+            #    displayName: Build Rakudo (Windows)
+
+            - task: PublishPipelineArtifact@1
+              displayName: publish build folder
+              inputs:
+                targetPath: $(Pipeline.Workspace)/rakudo
+                artifact: ${{ backend }}_sourcecode_built_${{ coalesce(variant, 'normal') }}_${{ os }}
+                publishLocation: 'pipeline'
+  
+- ${{ each os in parameters.oses }}:
+  - stage: Tests_${{ os }}
+    dependsOn: Builds_${{ os }}
+    condition: and( ne( variables['BUILD_PRECOMP_RELEASE'], 'yes' ), succeeded('Builds_${{ os }}') )
+    jobs:
+    - ${{ each backend in parameters.test_backends }}:
+      - ${{ each variant in parameters['test_variants'][backend][os] }}:
+        - job: ${{ os }}_${{ backend }}_${{ coalesce(variant, 'normal') }}
+          variables:
+          - name: BACKEND
+            value: ${{ backend }}
+          - name: os
+            value: ${{ os }}
+          - name: VARIANT
+            value: ${{ variant }}
+          - name: RELOCATABLE
+            ${{ if or( eq(variant, 'relocatable'), eq(variant, 'fullspectest') ) }}:
+              value: "yes"
+            ${{ if and( ne(variant, 'relocatable'), ne(variant, 'fullspectest') ) }}:
+              value: ""
+          - name: SPECTEST_ONLY
+            ${{ if eq(variant, 'fullspectest') }}:
+              value: "yes"
+            ${{ if ne(variant, 'fullspectest') }}:
+              value: ""
+          - ${{ if eq(os, 'Win') }}:
+            - name: IMAGE_NAME
+              value: 'windows-2022'
+            - name: IS_WIN
+              value: true
+          - ${{ if eq(os, 'Lin') }}:
+            - name: IMAGE_NAME
+              value: 'ubuntu-24.04'
+            - name: IS_WIN
+              value: false
+          - ${{ if eq(os, 'Mac') }}:
+            - name: IMAGE_NAME
+              value: 'macOS-15'
+            - name: IS_WIN
+              value: false
+
+          pool:
+            vmImage: $(IMAGE_NAME)
+          workspace:
+            clean: all
+          timeoutInMinutes: 180
+
+          steps:
+          - ${{ if eq(os, 'Win') }}:
+            - pwsh: |
+                # Windows has a maximum PATH variable length of 2048 (depending on
+                # how it's accessed). The length of PATH in AzureCI is already
+                # really tight. We'll run into the limit when we add Java and the
+                # MS BuildTools to the path.
+                # To work around this, we remove a bunch of stuff we won't need
+                # from PATH here.
+                $shortened_path = "$(PATH)" -replace ';[^;]*(SeleniumWebDrivers|SQL Server|Mercurial|Amazon|mysql|\\sbt\\|NSIS|Windows Performance Toolkit|php|Subversion)[^;]*(?=(;|$))', ''
+                echo "##vso[task.setvariable variable=PATH]$shortened_path"
+              displayName: "Shorten PATH on Windows"
+
+          - ${{ if eq(os, 'Win') }}:
+            - task: Cache@2
+              displayName: "load cached location of devshell dll"
+              inputs:
+                key: '"where is devshell on" | "$(IMAGE_NAME)"'
+                path: ../where_is_devshell/
+
+          - task: DownloadPipelineArtifact@2
+            inputs:
+              buildType: 'current'
+              targetPath: '$(Pipeline.Workspace)/rakudo'
+              artifact: ${{ backend }}_sourcecode_built_${{ coalesce(variant, 'normal') }}_${{ os }}
+            displayName: Download artifact
+          - task: DownloadPipelineArtifact@2
+            inputs:
+              buildType: 'current'
+              ${{ if ne(variant, 'relocatable') }}:
+                targetPath: '$(Pipeline.Workspace)/install'
+              ${{ if eq(variant, 'relocatable') }}:
+                targetPath: '$(Pipeline.Workspace)/install-moved'
+              artifact: ${{ backend }}_${{ coalesce(variant, 'normal') }}_${{ os }}
+            displayName: Download artifact
+
+          - bash: |
+              export IS_AZURE_PIPELINES_BUILD=1
+              echo "##[task.setvariable variable=IS_AZURE_PIPELINES_BUILD]1"
+            displayName: "set IS_AZURE_PIPELINES_BUILD to 1"
+
+          - ${{ if eq(os, 'Lin') }}:
+            - bash: |
+                curl -L https://cpanmin.us | sudo perl - App::cpanminus --verbose --no-interactive
+                sudo /usr/local/bin/cpanm --notest TAP::Formatter::JUnit
+              displayName: install cpanm, TAP::Formatter::JUnit
+          - ${{ if eq(os, 'Mac') }}:
+            - bash: |
+                curl -L https://cpanmin.us | sudo perl - App::cpanminus --verbose --no-interactive
+                sudo /usr/local/Cellar/perl/5.40.0/bin/cpanm --notest TAP::Formatter::JUnit
+              displayName: install cpanm, TAP::Formatter::JUnit
+          - ${{ if eq(os, 'Win') }}:
+            - pwsh: |
+                cpanm TAP::Formatter::JUnit
+                cpanm App::Prove
+              displayName: install TAP::Formatter::JUnit and App::Prove
+
+          - bash: |
+              echo is azure pipelines build? $IS_AZURE_PIPELINES_BUILD
+              export TIME_STYLE=full-iso
+              echo "chmodding the things"
+              chmod +x install/bin/*
+              chmod +x install-moved/bin/*
+
+              chmod +x install/lib/*
+              chmod +x install-moved/lib/*
+
+              true
+            workingDirectory: $(Pipeline.Workspace) 
+            displayName: "Fix up permissions so we can execute"
+
+          # Test Rakudo
+          - ${{ if eq(os, 'Win') }}:
+            - pwsh: |
+                ${{ variables.PWSH_DEV }}
+                pwd
+                ls -l .
+                $Env:PERL_TEST_HARNESS_DUMP_TAP = "test_results"
+                # TODO: prove fails on this setup when more than a single --ext option is given.
+                # Thus we only run .t tests, not .rakutest. We'll need to fix this some time.
+                prove --timer --formatter TAP::Formatter::JUnit -e ..\install\bin\raku --ext .t -vlr t
+
+              workingDirectory: '$(Pipeline.Workspace)/rakudo'
+              enabled: ${{ ne( variant, 'relocatable' ) }}
+              displayName: Test Rakudo (Windows)
+            - pwsh: |
+                ${{ variables.PWSH_DEV }}
+                pwd
+                ls -l .
+                $Env:PERL_TEST_HARNESS_DUMP_TAP = "test_results"
+                # TODO: prove fails on this setup when more than a single --ext option is given.
+                # Thus we only run .t tests, not .rakutest. We'll need to fix this some time.
+                prove --timer --formatter TAP::Formatter::JUnit -e ..\install-moved\bin\raku --ext .t -vlr t
+              workingDirectory: '$(Pipeline.Workspace)/rakudo'
+              enabled: ${{ eq( variant, 'relocatable' ) }}
+              displayName: Test Rakudo (relocated, Windows)
+
+          - ${{ if ne(os, 'Win') }}:
+            - script: |
+                pwd
+                ls -l .
+                env PERL_TEST_HARNESS_DUMP_TAP=test_results prove --merge --timer --formatter TAP::Formatter::JUnit  -j3 -e ../install/bin/raku --ext .t --ext .rakutest -vlr t && echo "##vso[build.addbuildtag]moar-${{ os }}-${{ coalesce(variant, 'normal') }}-tests-clean"
+              workingDirectory: '$(Pipeline.Workspace)/rakudo'
+              enabled: ${{ eq( variant, '' ) }}
+              displayName: Test Rakudo
+            - script: |
+                pwd
+                ls -l .
+                env PERL_TEST_HARNESS_DUMP_TAP=test_results prove --merge --timer --formatter TAP::Formatter::JUnit -j3 -e ../install-moved/bin/raku --ext .t --ext .rakutest -vlr t && echo "##vso[build.addbuildtag]moar-${{ os }}-${{ coalesce(variant, 'normal') }}-tests-clean"
+              workingDirectory: '$(Pipeline.Workspace)/rakudo'
+              enabled: ${{ eq( variant, 'relocatable' ) }}
+              displayName: Test Rakudo (relocated)
+
+          # Run spectest
+          - ${{ if eq( variant, 'fullspectest' ) }}:
+            - script: |
+                pwd
+                ls -l .
+                export PERL_TEST_HARNESS_DUMP_TAP=test_results
+                make PERL_TEST_HARNESS_DUMP_TAP=test_results TEST_JOBS=3 m-spectest && echo "##vso[build.addbuildtag]moar-${{ os }}-${{ coalesce(variant, 'normal') }}-spectests-clean"
+              workingDirectory: '$(Pipeline.Workspace)/rakudo'
+              displayName: Run spectest
+
+          - bash: |
+              echo "making up classnames from filenames"
+              cat > do_classname_rename.sh <<"EOF"
+              #!/bin/bash
+              path=$1
+              classname=$(echo $path | sed -e 's,^./,,' | tr '/-' '._' | sed -E 's/.rakudo.moar.junit.xml|t.junit.xml|.t.xml|.rakudo.moar.xml//')
+              sed -i -e 's/testcase /testcase classname="'$classname'" /' $path
+              EOF
+              chmod +x do_classname_rename.sh
+              echo "running the script a bunch"
+              find . -type f -iname '*.xml' -exec ./do_classname_rename.sh "{}" ";"
+            workingDirectory: '$(Pipeline.Workspace)/rakudo/test_results/t'
+            displayName: edit test results files
+            condition: succeededOrFailed()
+
+          - task: PublishPipelineArtifact@1
+            displayName: publish test results files
+            condition: always()
+            inputs:
+              targetPath: $(Pipeline.Workspace)/rakudo/test_results
+              artifact: "${{ backend }} ${{ coalesce(variant, 'normal') }}_test_results_${{ os }}_$(System.JobAttempt)"
+              publishLocation: 'pipeline'
+
+          - task: PublishTestResults@2
+            inputs:
+              testResultsFormat: JUnit
+              testResultsFiles: '**/*.xml'
+              searchFolder: '$(Pipeline.Workspace)/rakudo/test_results'
+              testRunTitle: "${{ os }} ${{ backend }} ${{ variant }} rakudo tests"
+              buildPlatform: ${{ os }} ${{ backend }} ${{ variant }}
+            condition: succeededOrFailed()
+
+- stage: Extra_Moar_Stability_Tests
+  dependsOn: Builds_Lin
+  condition: and( ne( variables['BUILD_PRECOMP_RELEASE'], 'yes' ), succeeded('Builds_Lin') )
+
   jobs:
-    # Keep the job and matrix entry names as short as possible as the webinterface
-    # leaves little space for the name.
-    - job: T
-      strategy:
-       matrix:
-         Win_MVM:
-           IMAGE_NAME: 'windows-2019'
-           RAKUDO_OPTIONS: ''
-           NQP_OPTIONS: '--backends=moar'
-           MOAR_OPTIONS: ''
-         Win_JVM:
-           IMAGE_NAME: 'windows-2019'
-           BACKEND: 'JVM'
-           MOAR_CHECKOUT_TYPE: 'none'
-           RAKUDO_OPTIONS: ''
-           NQP_OPTIONS: '--backends=jvm'
-           MOAR_OPTIONS: ''
-         Win_MVM_relocatable:
-           IMAGE_NAME: 'windows-2019'
-           RELOCATABLE: 'yes'
-           RAKUDO_OPTIONS: '--relocatable'
-           NQP_OPTIONS: '--backends=moar --relocatable'
-           MOAR_OPTIONS: '--relocatable'
+  - job: Lin_Spesh_Nodelay
 
-         Mac_MVM:
-           IMAGE_NAME: 'macOS-12'
-           RAKUDO_OPTIONS: ''
-           NQP_OPTIONS: '--backends=moar'
-           MOAR_OPTIONS: ''
-         Mac_JVM:
-           IMAGE_NAME: 'macOS-12'
-           BACKEND: 'JVM'
-           MOAR_CHECKOUT_TYPE: 'none'
-           RAKUDO_OPTIONS: ''
-           NQP_OPTIONS: '--backends=jvm'
-           MOAR_OPTIONS: ''
-         Mac_MVM_reloc:
-           IMAGE_NAME: 'macOS-12'
-           RELOCATABLE: 'yes'
-           RAKUDO_OPTIONS: '--relocatable'
-           NQP_OPTIONS: '--backends=moar --relocatable'
-           MOAR_OPTIONS: '--relocatable'
+    pool:
+      vmImage: 'ubuntu-24.04'
+    workspace:
+      clean: all
+    timeoutInMinutes: 180
 
-         Lin_MVM:
-           IMAGE_NAME: 'ubuntu-20.04'
-           RAKUDO_OPTIONS: ''
-           NQP_OPTIONS: '--backends=moar'
-           MOAR_OPTIONS: ''
-         Lin_JVM:
-           IMAGE_NAME: 'ubuntu-20.04'
-           BACKEND: 'JVM'
-           MOAR_CHECKOUT_TYPE: 'none'
-           RAKUDO_OPTIONS: ''
-           NQP_OPTIONS: '--backends=jvm'
-           MOAR_OPTIONS: ''
-         Lin_MVM_reloc:
-           IMAGE_NAME: 'ubuntu-20.04'
-           RELOCATABLE: 'yes'
-           RAKUDO_OPTIONS: '--relocatable'
-           NQP_OPTIONS: '--backends=moar --relocatable'
-           MOAR_OPTIONS: '--relocatable'
+    steps:
+    - task: DownloadPipelineArtifact@2
+      inputs:
+        buildType: 'current'
+        targetPath: '$(Pipeline.Workspace)/install'
+        artifactName: MVM_relocatable_Lin
+      displayName: Download artifact
+    - task: DownloadPipelineArtifact@2
+      inputs:
+        buildType: 'current'
+        targetPath: '$(Pipeline.Workspace)/rakudo'
+        artifactName: MVM_sourcecode_built_relocatable_Lin
+      displayName: Download artifact
+    - bash: |
+        export IS_AZURE_PIPELINES_BUILD=1
+        echo "##[task.setvariable variable=IS_AZURE_PIPELINES_BUILD]1"
+      displayName: "set IS_AZURE_PIPELINES_BUILD to 1"
+    - bash: |
+        export TIME_STYLE=full-iso
+        chmod +x install/bin/*
+        chmod +x install/lib/*
+        true
+      displayName: "Fix up permissions so we can execute"
+      workingDirectory: '$(Pipeline.Workspace)'
+    - script: |
+        make --version
+        export TIME_STYLE=full-iso
 
-         Lin_MVM_spec:
-           IMAGE_NAME: 'ubuntu-20.04'
-           SPECTEST_ONLY: 'yes'
-           RAKUDO_OPTIONS: ''
-           NQP_OPTIONS: '--backends=moar'
-           MOAR_OPTIONS: ''
+        echo "ls -lisah gen/moar/nqp-version ../install/bin/nqp-m gen/moar/main-version.nqp"
+        ls -lisah gen/moar/nqp-version ../install/bin/nqp-m gen/moar/main-version.nqp
 
-      pool:
-        vmImage: $(IMAGE_NAME)
-      workspace:
-        clean: all
-      timeoutInMinutes: 180
-      steps:
+        echo "ls -lisah gen/ gen/*"
+        ls -lisah gen/ gen/*
 
-        - pwsh: |
-            # Windows has a maximum PATH variable length of 2048 (depending on
-            # how it's accessed). The length of PATH in AzureCI is already
-            # really tight. We'll run into the limit when we add Java and the
-            # MS BuildTools to the path.
-            # To work around this, we remove a bunch of stuff we won't need
-            # from PATH here.
-            $shortened_path = "$(PATH)" -replace ';[^;]*(SeleniumWebDrivers|SQL Server|Mercurial|Amazon|mysql|\\sbt\\|NSIS|Windows Performance Toolkit|php|Subversion)[^;]*(?=(;|$))', ''
-            echo "##vso[task.setvariable variable=PATH]$shortened_path"
-          displayName: "Shorten PATH on Windows"
-          condition: eq( variables['Agent.OS'], 'Windows_NT' )
+        echo "make --trace --just-print m-spectest"
+        make --trace --just-print m-spectest
+      workingDirectory: '$(Pipeline.Workspace)/rakudo'
+      displayName: tell us why you would rebuild everything
 
-        - script: |
-            echo "##vso[task.setvariable variable=JAVA_HOME]$(JAVA_HOME_11_X64)"
-            echo "##vso[task.setvariable variable=PATH]$(JAVA_HOME_11_X64)/bin:$(PATH)"
-          displayName: "Set java version (non-Windows)"
-          condition: and(succeeded(), eq( variables['BACKEND'], 'JVM'), ne( variables['Agent.OS'], 'Windows_NT' ) )
-        - pwsh: |
-            echo "##vso[task.setvariable variable=JAVA_HOME]$(JAVA_HOME_11_X64)"
-            echo "##vso[task.setvariable variable=PATH]$(JAVA_HOME_11_X64)\bin;$(PATH)"
-          displayName: "Set java version (Windows)"
-          condition: and(succeeded(), eq( variables['BACKEND'], 'JVM'), eq( variables['Agent.OS'], 'Windows_NT' ) )
+    - bash: |
+        curl -L https://cpanmin.us | sudo perl - App::cpanminus
+        sudo cpanm --notest TAP::Formatter::JUnit
+      displayName: install cpanm, TAP::Formatter::JUnit
 
-        - checkout: self
-          path: selfrepo
-          displayName: Checkout script repo
+    # turn this line:
+    # spectest_update: $(SPECTEST_DATA) all
+    # into this line:
+    # spectest_update: $(SPECTEST_DATA)
+    - script: |
+        echo "removing 'all' dependency from spectest_update target"
+        sed --in-place=.bak -E 's/^(spectest_update.*) all$/\1/' Makefile
 
-        - script: perl selfrepo/tools/build/checkout-repos-for-test.pl $(RAKUDO_CHECKOUT_TYPE) $(NQP_CHECKOUT_TYPE) $(MOAR_CHECKOUT_TYPE)
-          workingDirectory: $(Pipeline.Workspace)
-          condition: and(succeeded(), ne(variables['BACKEND'], 'JVM'))
-          displayName: Checkout repositories (MoarVM)
-        - script: perl selfrepo/tools/build/checkout-repos-for-test.pl $(RAKUDO_CHECKOUT_TYPE) $(NQP_CHECKOUT_TYPE) none
-          workingDirectory: $(Pipeline.Workspace)
-          condition: and(succeeded(), eq(variables['BACKEND'], 'JVM'))
-          displayName: Checkout repositories (JVM)
+        echo "chmod +x the rakudo-m that t/harness5 uses to run tests"
+        chmod +x rakudo-m
 
-        # Build MoarVM
-        - script: |
-            perl Configure.pl --prefix=../install $(MOAR_OPTIONS)
-            make install
-          workingDirectory: '$(Pipeline.Workspace)/MoarVM'
-          condition: and(succeeded(), ne( variables['Agent.OS'], 'Windows_NT' ), ne( variables['BACKEND'], 'JVM') )
-          displayName: Build MoarVM
-        - pwsh: |
-            ${{ variables.PWSH_DEV }}
-            perl Configure.pl --prefix=..\install $(MOAR_OPTIONS)
-            nmake install
-          failOnStderr: false
-          workingDirectory: '$(Pipeline.Workspace)/MoarVM'
-          condition: and(succeeded(), eq( variables['Agent.OS'], 'Windows_NT' ), ne( variables['BACKEND'], 'JVM') )
-          displayName: Build MoarVM (Windows)
+        echo "creating test_results folder"
+        mkdir test_results
 
-        # Build NQP
-        - script: |
-            perl Configure.pl --prefix=../install $(NQP_OPTIONS)
-            make install
-          workingDirectory: '$(Pipeline.Workspace)/nqp'
-          condition: and(succeeded(), ne( variables['Agent.OS'], 'Windows_NT' ))
-          displayName: Build NQP
-        - pwsh: |
-            ${{ variables.PWSH_DEV }}
-            perl Configure.pl --prefix=..\install $(NQP_OPTIONS)
-            nmake install
-          failOnStderr: false
-          workingDirectory: '$(Pipeline.Workspace)/nqp'
-          condition: and(succeeded(), eq( variables['Agent.OS'], 'Windows_NT' ))
-          displayName: Build NQP (Windows)
+        echo "making spectest checkout"
+        make --trace m-testable
 
-        # Build Rakudo
-        - script: |
-            perl Configure.pl --prefix=../install $(RAKUDO_OPTIONS)
-            make install
-          workingDirectory: '$(Pipeline.Workspace)/rakudo'
-          condition: and(succeeded(), ne( variables['Agent.OS'], 'Windows_NT' ))
-          displayName: Build Rakudo
-        - pwsh: |
-            ${{ variables.PWSH_DEV }}
-            perl Configure.pl --prefix=..\install $(RAKUDO_OPTIONS)
-            nmake install
-          failOnStderr: false
-          workingDirectory: '$(Pipeline.Workspace)/rakudo'
-          condition: and(succeeded(), eq( variables['Agent.OS'], 'Windows_NT' ))
-          displayName: Build Rakudo (Windows)
+        echo "making spectest.data smaller"
+        cp t/spec/spectest.data t/spec/spectest.data.backup
+        head -n 150 t/spec/spectest.data.backup > t/spec/spectest.data
 
-        # TODO: Should use "install moved" instead of "install-moved". But `prove` currently fails with an executable path that contains a space.
-        - script: mv install install-moved
-          workingDirectory: $(Pipeline.Workspace)
-          condition: and(succeeded(), eq( variables['RELOCATABLE'], 'yes' ), ne( variables['Agent.OS'], 'Windows_NT' ) )
-          displayName: Move installation
-        - pwsh: mv install install-moved
-          workingDirectory: $(Pipeline.Workspace)
-          condition: and(succeeded(), eq( variables['RELOCATABLE'], 'yes' ), eq( variables['Agent.OS'], 'Windows_NT' ) )
-          displayName: Move installation (Windows)
+        export PERL_TEST_HARNESS_DUMP_TAP=test_results
+        make --trace  TEST_JOBS=3 m-spectest
+      workingDirectory: '$(Pipeline.Workspace)/rakudo'
+      displayName: spectest with nodelay & blocking
 
-        # Test Rakudo
-        - script: make test
-          workingDirectory: '$(Pipeline.Workspace)/rakudo'
-          condition: and(succeeded(), ne( variables['RELOCATABLE'], 'yes' ), ne( variables['BACKEND'], 'JVM'), ne( variables['Agent.OS'], 'Windows_NT' ), ne( variables['SPECTEST_ONLY'], 'yes' ) )
-          displayName: Test Rakudo
-        - pwsh: |
-            ${{ variables.PWSH_DEV }}
-            nmake test
-          workingDirectory: '$(Pipeline.Workspace)/rakudo'
-          condition: and(succeeded(), ne( variables['RELOCATABLE'], 'yes' ), ne( variables['BACKEND'], 'JVM'), eq( variables['Agent.OS'], 'Windows_NT' ) )
-          displayName: Test Rakudo (Windows)
-        - script: prove -e ../install-moved/bin/raku --ext .t --ext .rakutest -vlr t
-          workingDirectory: '$(Pipeline.Workspace)/rakudo'
-          condition: and(succeeded(), eq( variables['RELOCATABLE'], 'yes' ), ne( variables['BACKEND'], 'JVM'), ne( variables['Agent.OS'], 'Windows_NT' ) )
-          displayName: Test Rakudo (relocated)
-        - pwsh: |
-            ${{ variables.PWSH_DEV }}
-            prove -e ..\install-moved\bin\raku --ext .t --ext .rakutest -vlr t
-          workingDirectory: '$(Pipeline.Workspace)/rakudo'
-          condition: and(succeeded(), eq( variables['RELOCATABLE'], 'yes' ), ne( variables['BACKEND'], 'JVM'), eq( variables['Agent.OS'], 'Windows_NT' ) )
-          displayName: Test Rakudo (relocated, Windows)
+    - script: |
+        echo "listing test results subfolders"
+        ls -lisah *
+        echo "listing all inputs"
+        ls -lisah $(find . -type f -iname '*.t' -o -type f -iname '*.rakudo.moar')
+        echo "running tap2junit"
+        echo "converting..."
+        tap2junit --verbose $(find . -type f -iname '*.t' -o -type f -iname '*.rakudo.moar') || echo "oh no, failed to convert!"
+        echo "making up classnames from filenames"
+        cat > do_classname_rename.sh <<"EOF"
+        #!/bin/bash
+        path=$1
+        classname=$(echo $path | sed -e 's,^./,,' | tr '/-' '._' | sed -E 's/.rakudo.moar.junit.xml|t.junit.xml|.t.xml|.rakudo.moar.xml//')
+        sed -i -e 's/testcase /testcase classname="'$classname'" /' $path
+        EOF
+        chmod +x do_classname_rename.sh
+        echo "running the script a bunch"
+        find . -type f -iname '*.xml' -exec ./do_classname_rename.sh "{}" ";"
+      workingDirectory: '$(Pipeline.Workspace)/rakudo/test_results/t/'
+      displayName: convert tap to junit
+      condition: succeededOrFailed()
+      # make --trace TEST_JOBS=3 MVM_SPESH_NODELAY=1 MVM_SPESH_BLOCKING=1 m-spectest
 
-        # Run spectest
-        - script: make TEST_JOBS=2 m-spectest
-          workingDirectory: '$(Pipeline.Workspace)/rakudo'
-          condition: and(succeeded(), ne( variables['RELOCATABLE'], 'yes' ), ne( variables['BACKEND'], 'JVM'), ne( variables['Agent.OS'], 'Windows_NT' ), eq( variables['SPECTEST_ONLY'], 'yes' ) )
-          displayName: Run spectest
+    - task: PublishTestResults@2
+      inputs:
+        testResultsFormat: JUnit
+        testResultsFiles: '**/*.xml'
+        searchFolder: '$(Pipeline.Workspace)/rakudo/test_results'
+        testRunTitle: "lin mvm relocatable (not) full spectest with(out) spesh NoDelay"
+      condition: succeededOrFailed()
 
-        - publish: $(Pipeline.Workspace)/install-moved
-          condition: and(succeeded(), eq( variables['RELOCATABLE'], 'yes' ), ne( variables['BACKEND'], 'JVM') )
-          displayName: Publish build artifact
+    - task: PublishPipelineArtifact@1
+      displayName: publish test results files
+      condition: always()
+      inputs:
+        targetPath: $(Pipeline.Workspace)/rakudo/test_results
+        artifact: "MVM_extra_moar_spesh_relocatable_test_results_Lin_$(System.JobAttempt)"
+        publishLocation: 'pipeline'
+
 
 - stage: Build_Precomp_Release
+  dependsOn: []
   condition: eq( variables['BUILD_PRECOMP_RELEASE'], 'yes' )
   jobs:
     - job: linux
       displayName: Linux x86_64 build
       pool:
-        vmImage: 'ubuntu-20.04'
+        vmImage: 'ubuntu-24.04'
       container:
         image: centos:7
         options: "--name raku-build-container -v /usr/bin/docker:/tmp/docker:ro"
@@ -272,7 +712,7 @@ stages:
     - job: macos
       displayName: MacOS x86_64 build
       pool:
-        vmImage: 'macOS-12'
+        vmImage: 'macOS-15'
       workspace:
         clean: all
       steps:
@@ -289,7 +729,7 @@ stages:
     - job: windows
       displayName: Windows x86_64 build
       pool:
-        vmImage: 'windows-2019'
+        vmImage: 'windows-2022'
       workspace:
         clean: all
       steps:
@@ -320,7 +760,7 @@ stages:
       - macos
       - windows
       pool:
-        vmImage: 'ubuntu-20.04'
+        vmImage: 'ubuntu-24.04'
       workspace:
         clean: all
       steps:

--- a/tools/build/checkout-repos-for-test.pl
+++ b/tools/build/checkout-repos-for-test.pl
@@ -28,9 +28,16 @@ my %repos = (
 # 'rev-DEADBEEF-https://github.com/url-to/repo' means checkout the given rev.
 my ($rakudo, $nqp, $moar) = @ARGV;
 
+# if we're in azure pipelines, we can make prettier output
+my $is_azure_pipelines = exists $ENV{IS_AZURE_PIPELINES_BUILD};
+
 sub exec_and_check {
     my $msg = pop;
     my @command = @_;
+
+    if ($is_azure_pipelines) {
+        print("##[command]", join " ", map { $_ =~ s/"/\\"/; m/^[a-zA-Z_-]+$/ ? $_ : '"' . $_ . '"' } @command);
+    }
 
     open(my $handle, '-|', @command);
     my $out = '';


### PR DESCRIPTION
- Prettier output (using the JUnit test result formatter)
- Restructure making better use of parameters
- Disable OOMing Win_JMV
- Speed up CI on Windows by working around the compiler search
- More granular output using `echo` commands
- add a nodelay & blocking spec test run
- persist build artifacts
- Speed up testing by running tests in parallel