### PR TITLE
[JVM] Decont Routine object when looking for attribute

### DIFF
--- a/src/Perl6/Optimizer.nqp
+++ b/src/Perl6/Optimizer.nqp
@@ -4493,7 +4493,10 @@ class Perl6::Optimizer {
                     :op('atpos'),
                     QAST::Var.new(
                         :name('@!dispatchees'), :scope('attribute'),
-                        QAST::Var.new( :name($call.name), :scope('lexical') ),
+                        QAST::Op.new(
+                            :op('decont'),
+                            QAST::Var.new( :name($call.name), :scope('lexical') )
+                        ),
                         QAST::WVal.new( :value($!symbols.find_lexical('Routine')) )
                     ),
                     QAST::IVal.new( :value($idx) )


### PR DESCRIPTION
Without this running running S32-list/skip.t from roast failed with a RuntimeException:

  No such attribute '@!dispatchees' for this object

This is a somewhat golfed version of the failing code, which also blows up on MoarVM.

  use nqp;
  BEGIN my (&plan = do { use Test; (&plan) };
  nqp::getattr(&plan,Routine,'@!dispatchees');