### PR TITLE
[JVM] Add extra check for GLOBAL being null

### DIFF
--- a/src/core.c/stubs.rakumod
+++ b/src/core.c/stubs.rakumod
@@ -48,6 +48,17 @@ sub DYNAMIC(str $name, @deprecation?) is raw {  # is implementation-detail
           value,
           nqp::stmts(
             (my str $pkgname = nqp::replace($name,1,1,'')),
+#?if jvm
+            nqp::if(
+              nqp::isnull(GLOBAL) || nqp::isnull(my \res := nqp::atkey(GLOBAL.WHO,$pkgname)),
+              nqp::ifnull(
+                nqp::atkey(PROCESS.WHO,$pkgname),
+                Rakudo::Internals.INITIALIZE-DYNAMIC($name, @deprecation)
+              ),
+              res
+            )
+#?endif
+#?if !jvm
             nqp::ifnull(
               nqp::atkey(GLOBAL.WHO,$pkgname),
               nqp::ifnull(
@@ -55,6 +66,7 @@ sub DYNAMIC(str $name, @deprecation?) is raw {  # is implementation-detail
                 Rakudo::Internals.INITIALIZE-DYNAMIC($name, @deprecation)
               )
             )
+#?endif
           )
         )
       )


### PR DESCRIPTION
This fixes a NullPointerException on the JVM backend for code like

  use v6.c.UNKNOWN

That code does not blow up on MoarVM, which handles calling "WHO" on a null object gracefully.