### PR TITLE
Provide adverbial forms of map

### DIFF
--- a/src/core.c/Any-iterable-methods.rakumod
+++ b/src/core.c/Any-iterable-methods.rakumod
@@ -100,6 +100,20 @@ Consider using a block if any of these are necessary for your mapping code."
               !! Rakudo::IterateMoreWithoutPhasers.new(&code, $source, $count, $label)
     }
 
+    # These candidates provide a more modern approach to specifying the map targets
+    multi method map(&block, :$label, :$flat!) {
+        self.flatmap(&block, :$label)
+    }
+    multi method map(&block, :$duck!) {
+        self.duckmap(&block)
+    }
+    multi method map(&block, :$node!) {
+        self.nodemap(&block)
+    }
+    multi method map(&block, :$deep!) {
+        self.deepmap(&block)
+    }
+
     proto method flatmap (|) is nodal {*}
     multi method flatmap(&block, :$label) {
         self.map(&block, :$label).flat

--- a/src/core.c/Slip.rakumod
+++ b/src/core.c/Slip.rakumod
@@ -48,6 +48,18 @@ my class Slip { # is List
     multi method map(Slip:D: &) {
         nqp::eqaddr(self,Empty) ?? Empty !! nextsame
     }
+    multi method map(Slip:D: &, :$deep!) {
+        nqp::eqaddr(self,Empty) ?? Empty !! nextsame
+    }
+    multi method map(Slip:D: &, :$node!) {
+        nqp::eqaddr(self,Empty) ?? Empty !! nextsame
+    }
+    multi method map(Slip:D: &, :$flat!) {
+        nqp::eqaddr(self,Empty) ?? Empty !! nextsame
+    }
+    multi method map(Slip:D: &, :$duck!) {
+        nqp::eqaddr(self,Empty) ?? Empty !! nextsame
+    }
     multi method first(Slip:D: &) {
         nqp::eqaddr(self,Empty) ?? Nil !! nextsame
     }


### PR DESCRIPTION
This commit opens a different way of specifying map variants. This is mostly for cosmetic reasons and operates under the impression that named argument adverbs, had they been available, would have been used over the smashedcase versions we currently offer.

* [flatmap](https://github.com/Raku/problem-solving/issues/430)