### PR TITLE
don't call nqp::rebless on every statement

### DIFF
--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -962,7 +962,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         <!!{ $/.set_actions($actions); 1 }>
         <!before <.[\])}]> | $ >
         <!stopper>
-        <!!{ nqp::rebless($/, self.slang_grammar('MAIN')); 1 }>
+        <!!{ if !nqp::eqaddr($/.WHAT, (my $sgm := self.slang_grammar('MAIN'))) { nqp::rebless($/, $sgm); }; 1 }>
         [
         | <label> <statement($*LABEL)> { $*LABEL := '' if $*LABEL }
         | <statement_control>


### PR DESCRIPTION
it causes a full deoptimization up the entire stack, even when it has no effect otherwise.

This effect is especially drastic for extremely deeply nested parse trees, but deoptimizing unnecessarily should be avoided regardless, IMO.