### PR TITLE
Add VM.ownup to produce backtraces of all threads and exit

### DIFF
--- a/lib/ownup.rakumod
+++ b/lib/ownup.rakumod
@@ -1,0 +1,7 @@
+# Shorthand for loading a control-c handler that will produce
+# a full backtrace of all threads on STDERR when control-c is
+# pressed.
+
+signal(SIGINT).tap: { VM.ownup }
+
+# vim: expandtab shiftwidth=4

--- a/src/core.c/VM.rakumod
+++ b/src/core.c/VM.rakumod
@@ -98,6 +98,17 @@ class VM does Systemic {
           !! $platform-name.IO
     }
 
+    method ownup() {
+#?if moar
+        nqp::syscall("all-thread-bt",1);
+#?endif
+#?if !moar
+        # Attempy to mimic the MoarVM functionality for now
+        CATCH { .note; exit 2 }
+        die;
+#?endif
+    }
+
     proto method osname(|) {*}
     multi method osname(VM:U:) {
 #?if jvm

--- a/tools/build/install-core-dist.raku
+++ b/tools/build/install-core-dist.raku
@@ -31,6 +31,7 @@ if Compiler.backend eq 'moar' {
     %provides<SL>               = "lib/SL.rakumod";
     %provides<MoarVM::SIL>      = "lib/MoarVM/SIL.rakumod";
     %provides<SIL>              = "lib/SIL.rakumod";
+    %provides<ownup>            = "lib/ownup.rakumod";
 }
 
 my $prefix := @*ARGS[0];


### PR DESCRIPTION
This wraps Timo Paulssen's new "all-thread-bt" MoarVM syscall in a method on the VM class, and attempts to do the same on other backends.

That syscall generates a complete backtrace of *all* running threads and then exits.  This can be very useful while debugging infinilooping code.

The "ownup" module wraps this functionality in a control-c wrapper, so that you can create a full backtrace on an infinilooping program by adding "-Mownup" on the command line, and pressing control-c when it becomes clear a program is infinilooping.

The name "own up" was chosen as a non-religious alias for "confess".