### PR TITLE
Add "no-remote-debugging" module

### DIFF
--- a/lib/no-remote-debugging.rakumod
+++ b/lib/no-remote-debugging.rakumod
@@ -1,0 +1,13 @@
+# Loading this module (either directly or through setting
+# the RAKUDO_OPT environment variable) will check whether
+# the process has activated the remote debugger, and will
+# exit with a note if remote debugging is possible.
+
+INIT {
+    if VM.remote-debugging {
+        note "Sorry, no remote debugging allowed";
+        exit 2;
+    }
+}
+
+# vim: expandtab shiftwidth=4

--- a/tools/build/install-core-dist.raku
+++ b/tools/build/install-core-dist.raku
@@ -31,6 +31,7 @@ if Compiler.backend eq 'moar' {
     %provides<SL>               = "lib/SL.rakumod";
     %provides<MoarVM::SIL>      = "lib/MoarVM/SIL.rakumod";
     %provides<SIL>              = "lib/SIL.rakumod";
+    %provides<no-remote-debugging> = "lib/no-remote-debugging.rakumod";
 }
 
 my $prefix := @*ARGS[0];


### PR DESCRIPTION
So that you can disable debugging easily from the command line (with -Mno-remote-debugging) or by adding that to the RAKUDO_OPT environment variable.