### PR TITLE
Only call ensure-sc if there is a descriptor

### DIFF
--- a/src/Raku/ast/signature.rakumod
+++ b/src/Raku/ast/signature.rakumod
@@ -1253,7 +1253,7 @@ class RakuAST::Parameter
         }
 
         my $container_descriptor := $param-obj.container_descriptor;
-        $context.ensure-sc($container_descriptor) if $container_descriptor;
+        $context.ensure-sc($container_descriptor) unless nqp::isnull($container_descriptor);
 
         # Bind parameter into its target.
         if self.invocant {

--- a/src/Raku/ast/signature.rakumod
+++ b/src/Raku/ast/signature.rakumod
@@ -1252,7 +1252,8 @@ class RakuAST::Parameter
                           QAST::Op.new(:op<iseq_s>, $wval, $temp-qast-var));
         }
 
-        $context.ensure-sc(nqp::getattr($param-obj, Parameter, '$!container_descriptor'));
+        my $container_descriptor := $param-obj.container_descriptor;
+        $context.ensure-sc($container_descriptor) if $container_descriptor;
 
         # Bind parameter into its target.
         if self.invocant {
@@ -1295,7 +1296,6 @@ class RakuAST::Parameter
                         $value := QAST::Var.new( :name($copy-var), :scope<local> );
                     }
                     else {
-                        my $container_descriptor := $param-obj.container_descriptor;
                         if $container_descriptor {
                             $value := QAST::Op.new(
                                 :op<p6scalarwithvalue>,


### PR DESCRIPTION
On the JVM backend this avoids a NullPointerException for the following code:

  Format.new("%5s")

The call to nqp::getattr returns a null object in this case (for both backends). On MoarVM this doesn't lead to an error. But it still feels appropriate to avoid the call if there is no container descriptor.

This would be the first step for fixing
https://github.com/rakudo/rakudo/issues/5729.