### PR TITLE
Make mult-arg grep slip its arguments

### DIFF
--- a/src/core.c/Any-iterable-methods.rakumod
+++ b/src/core.c/Any-iterable-methods.rakumod
@@ -334,7 +334,7 @@ Consider using a block if any of these are necessary for your mapping code."
           !! $count == 2
             ?? Rakudo::IterateTwoWithoutPhasers.new(
                  -> \a, \b {
-                     my \params := (a, b);
+                     my \params := Slip.new(a, b);
                      nqp::handle(
                        (my $result := $test(a, b)),
                        'NEXT', nqp::if(
@@ -361,7 +361,7 @@ Consider using a block if any of these are necessary for your mapping code."
                )
             !! Rakudo::IterateMoreWithPhasers.new(
                  -> |c {
-                     my \params := c.list;
+                     my \params := c.list.Slip;
                      nqp::handle(
                        (my $result := $test(|c)),
                        'NEXT', nqp::if(


### PR DESCRIPTION
In response to the discussion at:
  https://www.reddit.com/r/rakulang/comments/1havdtd/why_does_grepping_a_list_in_chunks_group_the/

This breaks 3 tests in roast:
- t/spec/S03-operators/composition.t   Failed tests:  11-12
- t/spec/S32-list/grep.rakudo.moar     Failed test:  50