### PR TITLE
Pod::To::Text: Sort enum pairs by value

### DIFF
--- a/lib/Pod/To/Text.rakumod
+++ b/lib/Pod/To/Text.rakumod
@@ -97,7 +97,9 @@ sub declarator2text($pod) {
             'attribute ' ~ $_.gist
         }
         when .HOW ~~ Metamodel::EnumHOW {
-            "enum $_.raku() { signature2text $_.enums.pairs } \n"
+            "enum $_.raku() " ~
+                signature2text($_.enums.pairs.sort: { .value }) ~
+                " \n"
         }
         when .HOW ~~ Metamodel::ClassHOW {
             'class ' ~ $_.raku


### PR DESCRIPTION
Currently, Pod::To::Text renders enum pod declarators by passing the pair list returned by .pairs to signature2text. The issue with this is that the pairs will not be in any fixed order, meaning rendered output of enum pod declarators could be inconsistent between different renders, which I find to be undesirable behavior. This PR fixes that by sorting the pair list by value. I chose to sort by value because, in my personal experience, writing enums ordered by enum value seems to be fairly common in code.