### PR TITLE
Introduce Hash::Ordered: hashes that keep the order of the keys

### DIFF
--- a/src/core.c/Hash/Ordered.rakumod
+++ b/src/core.c/Hash/Ordered.rakumod
@@ -1,0 +1,102 @@
+my class Hash::Ordered is Hash {
+    has str @.keys;
+
+    method STORE(Hash::Ordered:D: |c) {
+        my str @*KEYS;
+        self.Hash::STORE(|c);
+        @!keys := @*KEYS;
+        self
+    }
+
+    method STORE_AT_KEY(Hash::Ordered:D: Str() $key, Mu \value --> Nil) {
+        nqp::push_s(@*KEYS,$key);
+        self.Hash::STORE_AT_KEY($key, value);
+    }
+
+    method AT-KEY(Hash::Ordered:D: Str() $key) is raw {
+        nqp::ifnull(
+          nqp::atkey(nqp::getattr(self,Map,'$!storage'),$key),
+          nqp::stmts(
+            nqp::push_s(@!keys,$key),
+            nextsame;
+          )
+        )
+    }
+
+    method ASSIGN-KEY(Hash::Ordered:D: Str() $key, Mu \value) is raw {
+        nqp::ifnull(
+          nqp::atkey(nqp::getattr(self,Map,'$!storage'),$key),
+          nqp::stmts(
+            nqp::push_s(@!keys,$key),
+            self.Hash::AT-KEY($key)
+          )
+        ) = value
+    }
+
+    method BIND-KEY(Hash::Ordered:D: Str() $key, Mu \value) is raw {
+        nqp::push_s(@!keys,$key)
+          unless nqp::existskey(nqp::getattr(self,Map,'$!storage'),$key);
+
+        self.Hash::BIND-KEY($key, value)
+    }
+
+    method keys(Hash::Ordered:D:) {
+        my $storage := nqp::getattr(self,Map,'$!storage');
+        my $old     := @!keys;
+
+        # all ok
+        if nqp::elems(@!keys) == nqp::elems($storage) {
+            $old
+        }
+
+        # Something changed, revisit keys
+        else {
+            my str @new;
+            my $seen    := nqp::hash;
+
+            my int $elems = nqp::elems($old);
+            my int $i     = -1;
+
+            nqp::while(
+              nqp::islt_i(++$i,$elems),
+              nqp::if(
+                nqp::existskey($storage,my str $key = nqp::atpos_s($old,$i))
+                  && nqp::not_i(nqp::existskey($seen,$key)),
+                nqp::stmts(
+                  nqp::push_s(@new,$key),
+                  nqp::bindkey($seen,$key,1)
+                )
+              )
+            );
+
+            @!keys := @new
+        }
+    }
+
+
+    method values(Hash::Ordered:D:) { self{self.keys}    }
+    method pairs( Hash::Ordered:D:) { self{self.keys}:p  }
+    method kv(    Hash::Ordered:D:) { self{self.keys}:kv }
+
+    method iterator(Hash::Ordered:D:) {
+        self.pairs.iterator
+    }
+    method antipairs(Hash::Ordered:D:) {
+        self.pairs.map(*.antipair)
+    }
+
+    method clone(Hash::Ordered:D:) {
+        nqp::p6bindattrinvres(
+          self.Hash::clone,Hash::Ordered,'@!keys',self.keys
+        )
+    }
+
+    method raku(Hash::Ordered:D:) {
+        self.^name
+          ~ '.new(('
+          ~ self.Hash::raku.substr(1, *-1)
+          ~ '))'
+    }
+}
+
+# vim: expandtab shiftwidth=4

--- a/tools/templates/6.c/core_sources
+++ b/tools/templates/6.c/core_sources
@@ -94,6 +94,7 @@ src/core.c/Map.rakumod
 src/core.c/Hash/Typed.rakumod
 src/core.c/Hash/Object.rakumod
 src/core.c/Hash.rakumod
+src/core.c/Hash/Ordered.rakumod
 src/core.c/Stash.rakumod
 src/core.c/TypeEnv.rakumod
 src/core.c/Label.rakumod


### PR DESCRIPTION
This subclass of Hash will keep the order in which keys have been added, with as little overhead as possible.

The theory of operation is that whenever a key is accessed, and the key does **not** exist in the hash, then the key will be added to the list of known keys.  If a key is deleted, that key is **not** removed from the list of known keys (but it *is* deleted from the hash).

Only when some form of iteration is needed over the keys (or values) of the hash, is the list of known keys (which is in order of appearance) checked for existence in the hash, and any double entries or deleted keys are removed, and the list of keys updated.

The current syntax is:
```raku
  my %h is Hash::Ordered = ...;
```
This could probably be improved by either a dedicated trait, such as:
```raku
  my %h is ordered = ...;
```
or maybe some other syntax, such as:
```raku
  my %h{:ordered} = ...;
```
Support for typed ordered hashes is basically automatically available.

Support for object hashes would need to be made separately.  This shouldn't be too hard, but felt only necessary if this change to the Raku Programming Language is approved.

Also, maybe this should become a 6.e feature: but then integration into the legacy, as well as the Raku grammar, would be more troublesome.