### PR TITLE
Don't try to lower signatures with parametric generic types

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -9631,6 +9631,17 @@ Did you mean a call like '"
                 # Type-check, unless it's Mu, in which case skip it.
                 if $is_generic && !$is_coercive {
                     my $genericname := $param_type.HOW.name(%info<attr_package>);
+
+                    # XXX: Parametric types that are generic are currently not
+                    # supported, so bail out.
+                    # This covers cases such as
+                    # - (::T $a, T @b)
+                    # - (::T $a, Positional[T] $b)
+                    # - cases like above when T comes from an enclosing role
+                    if nqp::can($ptype_archetypes, "parametric") && $ptype_archetypes.parametric {
+                        return 0;
+                    }
+
                     $var.push(QAST::ParamTypeCheck.new(QAST::Op.new(
                         :op('istype_nd'),
                         QAST::Var.new( :name(get_decont_name()), :scope('local') ),


### PR DESCRIPTION
Fixes "inconsistent bind result" for signatures with a type capture followed by @ or % sigiled params using the typevar, or when such a param uses a type capture param of a role.

See discussion starting here: https://irclogs.raku.org/raku-dev/2025-03-07.html#13:49-0001

If someone were so inclined to implement this case by generating code in the lowered signature that creates the concretization on the fly, go ahead. Otherwise, comments from further below in the lowerer seem to imply RakuAST will also make the binding lowering code obsolete anyway.