### PR TITLE
RakuAST: throw correct exception for disallowed adverbs when augmenting

### DIFF
--- a/src/Raku/ast/package.rakumod
+++ b/src/Raku/ast/package.rakumod
@@ -191,7 +191,12 @@ class RakuAST::Package
                 my $key := $_.key;
                 if $key ne 'ver' && $key ne 'api' && $key ne 'auth' {
                     self.add-sorry:
-                        $resolver.build-exception: 'X::Syntax::Type::Adverb',
+                        $resolver.build-exception: 'X::Syntax::' ~ ($!augmented ?? 'Augment' !! 'Type') ~ '::Adverb',
+                            adverb => $key
+                }
+                elsif $!augmented && $key eq 'auth' {
+                    self.add-sorry:
+                        $resolver.build-exception: 'X::Syntax::Augment::Adverb',
                             adverb => $key
                 }
             }


### PR DESCRIPTION
Gets t/spec/S12-class/open.t passing with `RAKUDO_RAKUAST=1`.