### PR TITLE
RakuAST: throw for '!' vars in 'my' | 'our' | 'state' scope

### DIFF
--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -986,6 +986,11 @@ class RakuAST::VarDeclaration::Simple
         ) if self.twigil eq '*' && self.desigilname.is-multi-part;
 
         self.add-sorry(
+          $resolver.build-exception: 'X::Syntax::Variable::Twigil',
+            :twigil(self.twigil), :scope(self.scope), :name(self.name)
+        ) if self.twigil eq '!' && (self.scope eq 'my' || self.scope eq 'our' || self.scope eq 'state');
+
+        self.add-sorry(
           $resolver.build-exception: 'X::Syntax::Variable::ConflictingTypes',
             :outer($!conflicting-type.compile-time-value), :inner($!type.compile-time-value)
         ) if $!conflicting-type;


### PR DESCRIPTION
So e.g., `role A { my $!foo }` now throws `X::Syntax::Variable::Twigil`.

No new spectest files pass, but fixes one of the two failing tests in t/spec/6.c/S14-roles/mixin-6c.t.