### PR TITLE
Add variable name if possible to warning about use of uninitialized numeric

### DIFF
--- a/src/core.c/Mu.rakumod
+++ b/src/core.c/Mu.rakumod
@@ -789,30 +789,30 @@ my class Mu { # declared in BOOTSTRAP
     proto method Numeric(|) {*}
     multi method Numeric(Mu:U \v:) {
         my $name = (defined($*VAR_NAME) ?? $*VAR_NAME !! try v.VAR.name) // '';
-        $name   ~= ' ' if $name ne '';
-        warn "Use of uninitialized value {$name}of type {self.^name} in numeric context";
+        $name    = " $name" if $name;
+        warn "Use of uninitialized value$name of type {self.^name} in numeric context";
         0
     }
     proto method Real(|) {*}
     multi method Real(Mu:U \v:) {
         my $name = (defined($*VAR_NAME) ?? $*VAR_NAME !! try v.VAR.name) // '';
-        $name   ~= ' ' if $name ne '';
-        warn "Use of uninitialized value {$name}of type {self.^name} in numeric context";
+        $name    = " $name" if $name;
+        warn "Use of uninitialized value$name of type {self.^name} in numeric context";
         0
     }
     proto method Int(|) {*}
     multi method Int(Mu:U \v:) {
         my $name = (defined($*VAR_NAME) ?? $*VAR_NAME !! try v.VAR.name) // '';
-        $name   ~= ' ' if $name ne '';
-        warn "Use of uninitialized value {$name}of type {self.^name} in numeric context";
+        $name    = " $name" if $name;
+        warn "Use of uninitialized value$name of type {self.^name} in numeric context";
         0
     }
 
     proto method Str(|) {*}
     multi method Str(Mu:U \v:) {
         my $name = (defined($*VAR_NAME) ?? $*VAR_NAME !! try v.VAR.name) // '';
-        $name   ~= ' ' if $name ne '';
-        warn "Use of uninitialized value {$name}of type {self.^name} in string"
+        $name    = " $name" if $name;
+        warn "Use of uninitialized value$name of type {self.^name} in string"
                 ~ " context.\nMethods .^name, .raku, .gist, or .say can be"
                 ~ " used to stringify it to something meaningful.";
         ''

--- a/src/core.c/Mu.rakumod
+++ b/src/core.c/Mu.rakumod
@@ -788,17 +788,23 @@ my class Mu { # declared in BOOTSTRAP
 
     proto method Numeric(|) {*}
     multi method Numeric(Mu:U \v:) {
-        warn "Use of uninitialized value of type {self.^name} in numeric context";
+        my $name = (defined($*VAR_NAME) ?? $*VAR_NAME !! try v.VAR.name) // '';
+        $name   ~= ' ' if $name ne '';
+        warn "Use of uninitialized value {$name}of type {self.^name} in numeric context";
         0
     }
     proto method Real(|) {*}
     multi method Real(Mu:U \v:) {
-        warn "Use of uninitialized value of type {self.^name} in numeric context";
+        my $name = (defined($*VAR_NAME) ?? $*VAR_NAME !! try v.VAR.name) // '';
+        $name   ~= ' ' if $name ne '';
+        warn "Use of uninitialized value {$name}of type {self.^name} in numeric context";
         0
     }
     proto method Int(|) {*}
     multi method Int(Mu:U \v:) {
-        warn "Use of uninitialized value of type {self.^name} in numeric context";
+        my $name = (defined($*VAR_NAME) ?? $*VAR_NAME !! try v.VAR.name) // '';
+        $name   ~= ' ' if $name ne '';
+        warn "Use of uninitialized value {$name}of type {self.^name} in numeric context";
         0
     }
 


### PR DESCRIPTION
So `my $f; ++$f while $f < 3; say $f` now says:
```
Use of uninitialized value $f of type Any in numeric context
  in block <unit> at -e line 1
3
```