### PR TITLE
RakuAST: Throw right exceptions for declaring numeric and match variables

### DIFF
--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -2494,7 +2494,7 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
 
         my str $scope := $*SCOPE;
         my     $type  := $*OFTYPE.ast if $*OFTYPE;
-        my str $sigil := $<sigil>;
+        my str $sigil := $<variable><sigil>;
         my     $where := $*WHERE;
 
         # No type or type is not a native type
@@ -2529,14 +2529,14 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
 
         my $decl;
         my $shape := $<semilist> ?? $<semilist>[0].ast !! Nodify('SemiList');
-        if $<desigilname> {
-            my $desigilname := $<desigilname>;
+        if $<variable><desigilname> {
+            my $desigilname := $<variable><desigilname>;
             my $ast := $desigilname<longname>
                 ?? $desigilname<longname>.ast
                 !! Nodify('Name').from-identifier(~$desigilname);
             $ast.to-begin-time($*R, $*CU.context);
 
-            my str $twigil := $<twigil> || '';
+            my str $twigil := $<variable><twigil> || '';
             my str $name   := $sigil ~ $twigil ~ $ast.canonicalize;
             my $dynprag := $*LANG.pragma('dynamic-scope');
             my $forced-dynamic := $dynprag ?? $dynprag($name) !! 0;
@@ -2559,7 +2559,7 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
                    "Cannot declare an anonymous '$scope' scoped variable"
                  )
               !! ($decl := Nodify('VarDeclaration', 'Anonymous').new(
-                     :$scope, :$type, :$sigil, :twigil(~$<twigil> || ''),
+                     :$scope, :$type, :$sigil, :twigil(~$<variable><twigil> || ''),
                      :$shape,
                    ));
         }

--- a/src/Raku/Grammar.nqp
+++ b/src/Raku/Grammar.nqp
@@ -3696,10 +3696,10 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
           | $<sigil>=['$'] $<desigilname>=[<[/_!¢]>]
 
           # $0
-          | <sigil> $<index>=[\d+]
+          | <sigil> $<index>=[\d+]                  [<?{ $*IN-DECL }> <.typed-panic('X::Syntax::Variable::Numeric')>]?
 
           # $<foo>
-          | <sigil> <?[<]> <postcircumfix>
+          | <sigil> <?[<]> <postcircumfix>          [<?{ $*IN-DECL }> <.typed-panic('X::Syntax::Variable::Match')>]?
 
           # 👍
           | $<desigilname>=<.sigilless-variable>
@@ -3959,20 +3959,12 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
         :my $*VARIABLE;
         :my $*VARIABLE-NAME;
         :my $sigil;
-        [
-          | <sigil> <twigil>? <desigilname>?
-
-          | $<sigil>=['$'] $<desigilname>=[<[/_!¢]>]
-
-          | $<desigilname>=<.sigilless-variable>
-
-          # TODO cases for when you declare something you're not allowed to
-        ]
+        <variable>
         {
             $*IN-DECL := '';
             $*LEFTSIGIL := self.leading-char unless $*LEFTSIGIL;
-            $sigil := $<sigil> ?? $<sigil>.Str !! "";
-            $*VARIABLE-NAME := $<sigil> ~ $<twigil> ~ $<desigilname>;
+            $sigil := $<variable><sigil> ?? $<variable><sigil>.Str !! "";
+            $*VARIABLE-NAME := $sigil ~ $<variable><twigil> ~ $<variable><desigilname>;
             $/.add-variable($*VARIABLE-NAME);
         }
         [


### PR DESCRIPTION
Gets t/spec/S15-literals/identifiers.t passing and two individual tests in S32-exceptions/misc2.t.