### PR TITLE
Some random attribute access consistency changes

### DIFF
--- a/src/Raku/ast/call.rakumod
+++ b/src/Raku/ast/call.rakumod
@@ -405,7 +405,7 @@ class RakuAST::Call::Name
 
                         self.add-sorry(
                             $resolver.build-exception: 'X::TypeCheck::Argument',
-                                :objname($!name.canonicalize),
+                                :objname($name),
                                 :$signature,
                                 :arguments(@arg_names),
                                 :$protoguilt,
@@ -817,7 +817,6 @@ class RakuAST::Call::Method
     }
 
     method PERFORM-BEGIN(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
-        my $name := $!name.canonicalize;
         my %returnish := nqp::hash(
             'return', 1,
             'return-rw', 1,
@@ -826,7 +825,7 @@ class RakuAST::Call::Method
             'nextwith', 1,
             'EVAL', 1,
             'EVALFILE', 1);
-        if nqp::existskey(%returnish, $name) {
+        if nqp::existskey(%returnish, $!name.canonicalize) {
             my $routine := $resolver.find-attach-target('routine');
             if $routine {
                 $routine.set-may-use-return(True);
@@ -1099,6 +1098,8 @@ class RakuAST::Call::PrivateMethod
 class RakuAST::Call::MetaMethod
   is RakuAST::Call::Methodish
 {
+    # Not a RakuAST::Name like the other RakuAST::Call::* classes, because metamethod
+    # names can only be simple identifiers. Not multiple parts and no colonpairs.
     has str $.name;
 
     method new(str :$name!, RakuAST::ArgList :$args) {
@@ -1159,7 +1160,6 @@ class RakuAST::Call::VarMethod
             self.set-resolution($resolved);
         }
 
-        my $name := $!name.canonicalize;
         my %returnish := nqp::hash(
             'return', 1,
             'return-rw', 1,
@@ -1168,7 +1168,7 @@ class RakuAST::Call::VarMethod
             'nextwith', 1,
             'EVAL', 1,
             'EVALFILE', 1);
-        if nqp::existskey(%returnish, $name) {
+        if nqp::existskey(%returnish, $!name.canonicalize) {
             my $routine := $resolver.find-attach-target('routine');
             if $routine {
                 $routine.set-may-use-return(True);
@@ -1207,7 +1207,6 @@ class RakuAST::Call::VarMethod
     }
 
     method IMPL-POSTFIX-HYPER-QAST(RakuAST::IMPL::QASTContext $context, Mu $operand-qast) {
-        my $name       := $!name.canonicalize;
         my $dispatcher := self.dispatcher;
 
         my $call := $dispatcher

--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -998,7 +998,7 @@ class RakuAST::VarDeclaration::Simple
             my $meta := self.meta-object;
             my $target := RakuAST::TraitTarget::Variable.new(
                 self.name,
-                nqp::getattr(self, RakuAST::Declaration, '$!scope'),
+                nqp::getattr_s(self, RakuAST::Declaration, '$!scope'),
                 $meta,
                 $!block.stubbed-meta-object,
                 Mu

--- a/src/core.c/Parameter.rakumod
+++ b/src/core.c/Parameter.rakumod
@@ -657,8 +657,8 @@ multi sub infix:<eqv>(Parameter:D $a, Parameter:D $b) {
     # different flags
     return False
       if nqp::isne_i(
-        nqp::getattr($a,Parameter,'$!flags'),
-        nqp::getattr($b,Parameter,'$!flags')
+        nqp::getattr_i($a,Parameter,'$!flags'),
+        nqp::getattr_i($b,Parameter,'$!flags')
       );
 
     # only pass if both subsignatures are defined and equivalent

--- a/src/core.c/Rakudo/Iterator.rakumod
+++ b/src/core.c/Rakudo/Iterator.rakumod
@@ -6063,7 +6063,7 @@ my class Rakudo::IterateMoreWithoutPhasers does Rakudo::SlippyIterator {
 my class Rakudo::IterateMoreWithPhasers does Rakudo::SlippyIterator {
     has     &!block;
     has     $!source;
-    has     $!count;
+    has int $!count;
     has     $!label;
     has     $!value-buffer;
     has int $!did-init;
@@ -6076,7 +6076,7 @@ my class Rakudo::IterateMoreWithPhasers does Rakudo::SlippyIterator {
         nqp::bindattr($iter, self, '$!slipper', nqp::null);
         nqp::bindattr($iter, self, '&!block', &block);
         nqp::bindattr($iter, self, '$!source', $source);
-        nqp::bindattr($iter, self, '$!count', $count);
+        nqp::bindattr_i($iter, self, '$!count', $count);
         nqp::bindattr($iter, self, '$!label', nqp::decont($label));
         $iter
     }
@@ -6166,7 +6166,7 @@ my class Rakudo::IterateMoreWithPhasers does Rakudo::SlippyIterator {
                                IterationEnd
                              )
                           && nqp::not_i(nqp::eqaddr(  # an empty Slip
-                               $source.push-exactly($!value-buffer, $!count),
+                               $source.push-exactly($!value-buffer, $count),
                                IterationEnd
                              )),
                         ($redo = 1)                   # process these values

--- a/src/core.e/PseudoStash.rakumod
+++ b/src/core.e/PseudoStash.rakumod
@@ -342,7 +342,7 @@ my class PseudoStash is CORE::v6c::PseudoStash {
         nqp::unless(nqp::isconcrete($!walker), ($!walker := CtxWalker.new(self)));
         return 0 if $!walker.exhausted;
 
-        my Mu $mode := nqp::getattr(self, PseudoStash6c, '$!mode');
+        my int $mode = nqp::getattr_i(self, PseudoStash6c, '$!mode');
         my Mu $found := 0;
         nqp::while(
             ((my $ctx-info := $!walker.next-ctx) && !$found),


### PR DESCRIPTION
Fix a couple cases of native attributes not using the typed accessor, and make some other attributes consistent with similar ones.