### PR TITLE
Remove type specification by name in Parameter constructor

### DIFF
--- a/src/core.c/Parameter.rakumod
+++ b/src/core.c/Parameter.rakumod
@@ -35,23 +35,6 @@ my class Parameter { # declared in BOOTSTRAP
         Metamodel::DefiniteHOW.new_type(:base_type(::($type)), :$definite)
     }
 
-    sub str-to-type(Str:D $type, Int:D $flags is rw --> Mu) {
-        if $type.ends-with(Q/:D/) {
-            $flags +|= nqp::const::SIG_ELEM_DEFINED_ONLY;
-            definitize-type($type.chop(2), True)
-        }
-        elsif $type.ends-with(Q/:U/) {
-            $flags +|= nqp::const::SIG_ELEM_UNDEFINED_ONLY;
-            definitize-type($type.chop(2), False)
-        }
-        elsif $type.ends-with(Q/:_/) {
-            ::($type.chop(2))
-        }
-        else {
-            ::($type)
-        }
-    }
-
     submethod BUILD(
         Parameter:D:
         Str:D  :$name           is copy = "",
@@ -140,27 +123,7 @@ my class Parameter { # declared in BOOTSTRAP
 
         if %args.EXISTS-KEY('type') {
             my $type := %args.AT-KEY('type');
-            if $type.DEFINITE {
-                if nqp::istype($type,Str) {
-                    if $type.ends-with(Q/)/) {
-                        my $start = $type.index(Q/(/);
-                        my $constraint-type :=
-                          str-to-type($type.substr($start + 1, *-1), my $);
-                        my $target-type :=
-                          str-to-type($type.substr(0, $start), $flags);
-                        $!type := Metamodel::CoercionHOW.new_type($target-type, $constraint-type);
-                    }
-                    else {
-                        $!type := str-to-type($type, $flags)
-                    }
-                }
-                else {
-                    $!type := $type.WHAT;
-                }
-            }
-            else {
-                $!type := $type;
-            }
+            $!type := $type.DEFINITE ?? $type.WHAT !! $type;
         }
         else {
             $!type := Any;


### PR DESCRIPTION
The Parameter constructor has a "type" argument that besides type objects also accepts concrete values. In moste cases it used that value's type but if the value was a string, it instead checked whether that string might be a type name and looked up that type instead.

By special casing strings ending in ')' this feature violates the principle of least surprise. If the string ends in ')' but does not contain a type name, it throws an internal error.

This feature is untested, undocumented, broken and unwise, so let's remove it. Nowhere else do we allow for specifying types by their name and for good reason. Type names are not unique and they can become quite complex containing even arbitrary code in the case of parameterized roles.