### PR TITLE
Allow MAIN args to reference imported names

### DIFF
--- a/src/core.c/Main.rakumod
+++ b/src/core.c/Main.rakumod
@@ -74,7 +74,7 @@ my sub RUN-MAIN(&main, $mainline, :$in-as-argsfiles) {
         sub thevalue(\a) {
             my \core-a   := try CORE::(a);
             my \global-a := try GLOBAL::(a);
-            my \value-a  := try ::(a);
+            my \value-a  := try %caller-my{a} // ::(a);
             my \type := value-a === core-a && !(global-a === core-a) && !(global-a === Nil)
               ?? global-a
               !! value-a;


### PR DESCRIPTION
Previously the following was not possible:

    module M { enum E is export <F G> }
    import M;
    sub MAIN (E $f, E :$g) { ... }

This was discovered relative to enums but
in reality it affected any imported names.

Fixes R#5875 (#5875)