### PR TITLE
Enhance feedback around named subset parameters

### DIFF
--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -3481,6 +3481,9 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
             }
             $parameter.set-signature-constraint($signature);
         }
+
+        self.SET-NODE-ORIGIN($/, $parameter);
+
         # Leave the exact time of Parameter's BEGIN to the signature
         make $parameter;
     }

--- a/src/core.c/Exception.rakumod
+++ b/src/core.c/Exception.rakumod
@@ -902,8 +902,13 @@ my role X::Comp is Exception {
             self.Exception::gist;
         }
     }
-    method at-line(*@lines, :$filename is copy) {
+
+    method at-line(*@src-lines, :$filename is copy) {
         my $fn = $.directive-filename // $.filename;
+
+        my @lines = @src-lines.grep(Int:D);
+        return "at line <anon>" unless @lines;
+
         # If $filename is specified and is different from $fn then the message is about a "long" location crossing a
         # #line directive. Most typical it would be an unclosed brace or a quote starting before the directive.
         with $filename {
@@ -1533,6 +1538,15 @@ my class X::Parameter::MultipleTypeConstraints does X::Comp {
     method message() {
         ($.parameter ?? "Parameter $.parameter" !! 'A parameter')
         ~ " may only have one prefix type constraint";
+    }
+}
+
+my class X::Parameter::Named::SubsetTypeWithoutDefault does X::Comp {
+    has Str $.parameter;
+    has Mu $.subset;
+    method message() {
+        "Optional named parameter '$.parameter' with subset type {$.subset.^name} needs a valid default value\n"
+        ~ "otherwise it will throw exceptions when a value is absent at the callsite"
     }
 }
 

--- a/src/core.c/Exception.rakumod
+++ b/src/core.c/Exception.rakumod
@@ -903,11 +903,8 @@ my role X::Comp is Exception {
         }
     }
 
-    method at-line(*@src-lines, :$filename is copy) {
+    method at-line(*@lines, :$filename is copy) {
         my $fn = $.directive-filename // $.filename;
-
-        my @lines = @src-lines.grep(Int:D);
-        return "at line <anon>" unless @lines;
 
         # If $filename is specified and is different from $fn then the message is about a "long" location crossing a
         # #line directive. Most typical it would be an unclosed brace or a quote starting before the directive.

--- a/t/12-rakuast/xx-fixed-in-rakuast.rakutest
+++ b/t/12-rakuast/xx-fixed-in-rakuast.rakutest
@@ -2,7 +2,7 @@ use Test;
 use lib <t/packages/Test-Helpers>;
 use Test::Helpers;
 
-plan 106;
+plan 107;
 
 # t/spec/S03-sequence/misc.t
 # https://github.com/rakudo/rakudo/issues/5520
@@ -718,6 +718,27 @@ subtest 'use of &?ROUTINE and &?BLOCK' => {
         };
         my $c = A.new();
     }], "Submethods can access attributes");
+}
+
+{
+    todo q|subsets on named parameters will worry without usable defaults|, 2 unless %*ENV<RAKUDO_RAKUAST>;
+
+    my $failure-to-conform = q:to/FAILURE-TO-CONFORM/;
+        subset X where /"x"/;
+        sub foo(X :$x = "y") { :$x };
+    FAILURE-TO-CONFORM
+    throws-like $failure-to-conform,
+            X::Parameter::Default::TypeCheck,
+            "Non-conformant default value results in useful feedback";
+
+
+    my $default-missing = q:to/DEFAULT-MISSING/;
+        subset X where /"x"/;
+        sub foo(X :$x) { :$x };
+    DEFAULT-MISSING
+    throws-like $default-missing,
+            X::Parameter::Named::TypeIsSubsetWithoutDefault,
+            "Missing default value results in useful feedback";
 }
 
 # vim: expandtab shiftwidth=4

--- a/t/12-rakuast/xx-fixed-in-rakuast.rakutest
+++ b/t/12-rakuast/xx-fixed-in-rakuast.rakutest
@@ -721,23 +721,15 @@ subtest 'use of &?ROUTINE and &?BLOCK' => {
 }
 
 {
-    todo q|subsets on named parameters will worry without usable defaults|, 2 unless %*ENV<RAKUDO_RAKUAST>;
-
-    my $failure-to-conform = q:to/FAILURE-TO-CONFORM/;
-        subset X where /"x"/;
-        sub foo(X :$x = "y") { :$x };
-    FAILURE-TO-CONFORM
-    throws-like $failure-to-conform,
-            X::Parameter::Default::TypeCheck,
-            "Non-conformant default value results in useful feedback";
-
+    todo q|subsets on named parameters will worry without usable defaults|
+        unless %*ENV<RAKUDO_RAKUAST>;
 
     my $default-missing = q:to/DEFAULT-MISSING/;
         subset X where /"x"/;
         sub foo(X :$x) { :$x };
     DEFAULT-MISSING
     throws-like $default-missing,
-            X::Parameter::Named::TypeIsSubsetWithoutDefault,
+            X::Parameter::Named::SubsetTypeWithoutDefault,
             "Missing default value results in useful feedback";
 }
 


### PR DESCRIPTION
Adding a worry here provides users with a bit of
helpful feedback when they define an optional
named parameter with a subset type but fail to
provide a valid default value.

Default values are also checked for conformance
to the provided subset, with the obvious caveat
that an expression without a compile time value
will pass through this protection.