### PR TITLE
RakuAST: Remove a lot of uses of IMPL-UNWRAP-LIST

### DIFF
--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -2126,9 +2126,7 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
         $<capvar>
           ?? self.attach($/, Nodify('Var', 'NamedCapture').new(
                Nodify('QuotedString').new(
-                 :segments(Nodify('QuotedString').IMPL-WRAP-LIST([
-                   Nodify('StrLiteral').new(~$<desigilname>)
-                 ]))
+                 :segments([Nodify('StrLiteral').new(~$<desigilname>)])
                )
              ))
           !! self.simple-variable($/);
@@ -2152,9 +2150,7 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
             my $name := Nodify('Name').from-identifier('infix');
             $name.add-colonpair(
                 Nodify('QuotedString').new(
-                    :segments($name.IMPL-WRAP-LIST([
-                        Nodify('StrLiteral').new(~$<infixish>)
-                    ]))
+                    :segments([Nodify('StrLiteral').new(~$<infixish>)])
                 )
             );
             self.compile-variable-access($/, '&', '', $name);

--- a/src/Raku/ast/call.rakumod
+++ b/src/Raku/ast/call.rakumod
@@ -397,11 +397,10 @@ class RakuAST::Call::Name
                         }
 
                         my $protoguilt := @ct_result_multi && $ct_result == -1 ?? True !! False;
-                        my $signature := self.IMPL-WRAP-LIST(
+                        my $signature :=
                             nqp::can($routine, 'is_dispatcher') && $routine.is_dispatcher && !$protoguilt
                                 ?? self.IMPL-MULTI-SIG-LIST($routine)
-                                !! [try $routine.signature.gist]
-                        );
+                                !! [try $routine.signature.gist];
 
                         self.add-sorry(
                             $resolver.build-exception: 'X::TypeCheck::Argument',
@@ -637,7 +636,7 @@ class RakuAST::Call::Method
                     RakuAST::Type::Simple.new: RakuAST::Name.new: |@parts;
             }
         }
-        self.IMPL-WRAP-LIST(@lookups)
+        @lookups
     }
 
     method IMPL-SPECIAL-OP(str $name) {
@@ -1030,9 +1029,9 @@ class RakuAST::Call::PrivateMethod
     }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
-        self.IMPL-WRAP-LIST([
+        [
             RakuAST::Var::Lexical::Constant.new('::?CLASS'),
-        ]);
+        ]
     }
 
     method IMPL-POSTFIX-QAST(RakuAST::IMPL::QASTContext $context, Mu $invocant-qast) {
@@ -1312,11 +1311,11 @@ class RakuAST::Stub
     }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
-        self.IMPL-WRAP-LIST([
+        [
             RakuAST::Type::Simple.new(
               RakuAST::Name.from-identifier-parts('X','StubCode')
             )
-        ])
+        ]
     }
 
     method IMPL-TO-QAST(RakuAST::IMPL::QASTContext $context) {

--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -1371,14 +1371,14 @@ class RakuAST::Block
         if $!fresh-exception {
             nqp::push(@implicit, RakuAST::VarDeclaration::Implicit::Special.new(:name('$!')));
         }
-        self.IMPL-WRAP-LIST(@implicit)
+        @implicit
     }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
-        self.IMPL-WRAP-LIST([
+        [
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('Code')),
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('&FATALIZE')),
-        ])
+        ]
     }
 
     method IMPL-FATALIZE() {
@@ -1713,10 +1713,10 @@ class RakuAST::PointyBlock
     }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
-        self.IMPL-WRAP-LIST([
+        [
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('Callable')),
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('&FATALIZE')),
-        ])
+        ]
     }
 
     method IMPL-FATALIZE() {
@@ -1876,10 +1876,10 @@ class RakuAST::Routine
     }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
-        self.IMPL-WRAP-LIST([
+        [
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('Callable')),
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('&FATALIZE')),
-        ])
+        ]
     }
 
     method IMPL-FATALIZE() {
@@ -2025,11 +2025,11 @@ class RakuAST::Routine
                         :scope<my>,
                         :name(self.name),
                         :signature(RakuAST::Signature.new(
-                            :parameters(self.IMPL-WRAP-LIST([
+                            :parameters([
                                 RakuAST::Parameter.new(
                                     :slurpy(RakuAST::Parameter::Slurpy::Capture),
                                 )
-                            ])),
+                            ]),
                         )),
                         :body(RakuAST::OnlyStar.new),
                         :multiness<proto>,
@@ -2114,7 +2114,7 @@ class RakuAST::Routine
         nqp::push(@declarations, RakuAST::VarDeclaration::Implicit::Special.new(:name('$_'))) if $underscore;
         nqp::push(@declarations, RakuAST::VarDeclaration::Implicit::Routine.new()) if $!need-routine-variable;
         nqp::push(@declarations, RakuAST::VarDeclaration::Implicit::Cursor.new()); #TODO maybe we can rule out cases where we don't need it
-        self.IMPL-WRAP-LIST(@declarations)
+        @declarations
     }
 
     method IMPL-HAS-PARAMETER(Str $name) {
@@ -2852,7 +2852,7 @@ class RakuAST::RegexDeclaration
         ];
         nqp::push(@declarations, RakuAST::VarDeclaration::Implicit::Routine.new())
             if nqp::getattr(self, RakuAST::Routine, '$!need-routine-variable');
-        self.IMPL-WRAP-LIST(@declarations)
+        @declarations
     }
 
     method IMPL-COMPILE-BODY(RakuAST::IMPL::QASTContext $context) {
@@ -2975,7 +2975,7 @@ class RakuAST::QuotedMatchConstruct
             }
         }
         nqp::bindattr(self, RakuAST::QuotedMatchConstruct, '$!adverbs',
-            self.IMPL-WRAP-LIST(@checked-adverbs));
+            @checked-adverbs);
         Nil
     }
 
@@ -3082,13 +3082,13 @@ class RakuAST::QuotedRegex
     }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
-        self.IMPL-WRAP-LIST([
+        [
             RakuAST::Var::Lexical.new('$_'),
             RakuAST::Var::Lexical.new('$/'),
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier-parts(
                 'Rakudo', 'Internals', 'RegexBoolification6cMarker'
             ))
-        ])
+        ]
     }
 
     method IMPL-IS-IMMEDIATE-MATCH-ADVERB(str $norm-adverb) {
@@ -3229,11 +3229,11 @@ class RakuAST::Substitution
     }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
-        self.IMPL-WRAP-LIST([
+        [
             RakuAST::Var::Lexical.new('$_'),
             RakuAST::Var::Lexical.new('$/'),
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('Positional')),
-        ])
+        ]
     }
 
     method IMPL-IS-SUBST-MATCH-ADVERB(str $norm-adverb) {
@@ -3492,10 +3492,10 @@ class RakuAST::Transliteration
     }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
-        self.IMPL-WRAP-LIST([
+        [
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('Pair')),
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('StrDistance')),
-        ])
+        ]
     }
 
     method IMPL-EXPR-QAST(RakuAST::IMPL::QASTContext $context) {
@@ -3618,9 +3618,9 @@ class RakuAST::CurryThunk
     }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
-        self.IMPL-WRAP-LIST([
+        [
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('WhateverCode'))
-        ])
+        ]
     }
 
     method IMPL-NUM-PARAMS() {
@@ -3657,10 +3657,10 @@ class RakuAST::BlockThunk
     }
 
     method PRODUCE-IMPLICIT-DECLARATIONS() {
-        self.IMPL-WRAP-LIST([
+        [
             RakuAST::VarDeclaration::Implicit::BlockTopic.new:
                 parameter => self.signature ?? False !! True
-        ]);
+        ];
     }
 
     method IMPL-THUNK-OBJECT-TYPE() {

--- a/src/Raku/ast/compunit.rakumod
+++ b/src/Raku/ast/compunit.rakumod
@@ -369,7 +369,7 @@ class RakuAST::CompUnit
     }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
-        self.IMPL-WRAP-LIST([
+        [
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier-parts(
                 'CompUnit', 'RepositoryRegistry',
             )),
@@ -378,7 +378,7 @@ class RakuAST::CompUnit
                 'X', 'Comp', 'BeginTime'
             )),
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('&COMP_EXCEPTION')),
-        ])
+        ]
     }
 
     method IMPL-FATALIZE {
@@ -433,7 +433,7 @@ class RakuAST::CompUnit
             name => '!EVAL_MARKER', value => 1
         )) if $!is-eval;
 
-        self.IMPL-WRAP-LIST(@decls)
+        @decls
     }
 
     method IMPL-TO-QAST-COMP-UNIT(*%options) {

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -1221,7 +1221,7 @@ class RakuAST::MetaInfix
   is RakuAST::CheckTime
 {
     method IMPL-HOP-INFIX() {
-        self.get-implicit-lookups()[0].resolution.compile-time-value()(
+        self.IMPL-UNWRAP-LIST(self.get-implicit-lookups())[0].resolution.compile-time-value()(
             self.infix.IMPL-HOP-INFIX
         )
     }
@@ -1609,7 +1609,7 @@ class RakuAST::MetaInfix::Cross
     }
 
     method IMPL-HOP-INFIX() {
-        my $lookups := self.get-implicit-lookups;
+        my $lookups := self.IMPL-UNWRAP-LIST(self.get-implicit-lookups);
         $lookups[0].resolution.compile-time-value()(
             self.infix.IMPL-OPERATOR,
             $lookups[1].resolution.compile-time-value,
@@ -1701,7 +1701,7 @@ class RakuAST::MetaInfix::Zip
     }
 
     method IMPL-HOP-INFIX() {
-        my $lookups := self.get-implicit-lookups;
+        my $lookups := self.IMPL-UNWRAP-LIST(self.get-implicit-lookups);
         $lookups[0].resolution.compile-time-value()(
             self.infix.IMPL-OPERATOR,
             $lookups[1].resolution.compile-time-value,
@@ -1808,7 +1808,7 @@ class RakuAST::MetaInfix::Hyper
     }
 
     method IMPL-HOP-INFIX() {
-        self.get-implicit-lookups()[0].resolution.compile-time-value()(
+        self.IMPL-UNWRAP-LIST(self.get-implicit-lookups())[0].resolution.compile-time-value()(
             self.infix.resolution.compile-time-value,
             :dwim-left($!dwim-left),
             :dwim-right($!dwim-right)
@@ -2522,7 +2522,7 @@ class RakuAST::MetaPrefix::Hyper
     }
 
     method IMPL-HOP-INFIX() {
-        self.get-implicit-lookups()[0].resolution.compile-time-value()(
+        self.IMPL-UNWRAP-LIST(self.get-implicit-lookups())[0].resolution.compile-time-value()(
             self.prefix.IMPL-HOP-PREFIX
         )
     }
@@ -3223,7 +3223,7 @@ class RakuAST::MetaPostfix::Hyper
     }
 
     method IMPL-HOP-INFIX() {
-        self.get-implicit-lookups()[0].resolution.compile-time-value()(
+        self.IMPL-UNWRAP-LIST(self.get-implicit-lookups())[0].resolution.compile-time-value()(
             self.postfix.IMPL-HOP-POSTFIX
         )
     }

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -289,7 +289,7 @@ class RakuAST::Infix
         nqp::push(@lookups,
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('Nil')))
             if $!operator eq '^^' || $!operator eq 'xor';
-        self.IMPL-WRAP-LIST(@lookups)
+        @lookups
     }
 
     method PERFORM-PARSE(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
@@ -935,13 +935,13 @@ class RakuAST::FlipFlop
     }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
-        self.IMPL-WRAP-LIST([
+        [
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('Nil')),
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('True')),
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('False')),
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('Int')),
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('Whatever'))
-        ])
+        ]
     }
 
     method PERFORM-BEGIN(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
@@ -1221,7 +1221,7 @@ class RakuAST::MetaInfix
   is RakuAST::CheckTime
 {
     method IMPL-HOP-INFIX() {
-        self.get-implicit-lookups().AT-POS(0).resolution.compile-time-value()(
+        self.get-implicit-lookups()[0].resolution.compile-time-value()(
             self.infix.IMPL-HOP-INFIX
         )
     }
@@ -1309,9 +1309,9 @@ class RakuAST::MetaInfix::Assign
     }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
-        self.IMPL-WRAP-LIST([
+        [
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier(self.IMPL-OPERATOR-NAME(1))),
-        ])
+        ]
     }
 
     method IMPL-OPERATOR() {
@@ -1407,9 +1407,9 @@ class RakuAST::MetaInfix::Negate
     method reducer-name() { $!infix.reducer-name }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
-        self.IMPL-WRAP-LIST([
+        [
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('&METAOP_NEGATE')),
-        ])
+        ]
     }
 
     method IMPL-OPERATOR() {
@@ -1468,9 +1468,9 @@ class RakuAST::MetaInfix::Reverse
     }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
-        self.IMPL-WRAP-LIST([
+        [
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('&METAOP_REVERSE')),
-        ])
+        ]
     }
 
     method IMPL-OPERATOR() {
@@ -1529,8 +1529,7 @@ class RakuAST::MetaInfix::Sequence
     }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
-        self.IMPL-WRAP-LIST([
-        ])
+        []
     }
 
     method IMPL-OPERATOR() {
@@ -1584,10 +1583,10 @@ class RakuAST::MetaInfix::Cross
     }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
-        self.IMPL-WRAP-LIST([
+        [
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('&METAOP_CROSS')),
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier($!infix.reducer-name)),
-        ])
+        ]
     }
 
     method IMPL-OPERATOR() {
@@ -1611,9 +1610,9 @@ class RakuAST::MetaInfix::Cross
 
     method IMPL-HOP-INFIX() {
         my $lookups := self.get-implicit-lookups;
-        $lookups.AT-POS(0).resolution.compile-time-value()(
+        $lookups[0].resolution.compile-time-value()(
             self.infix.IMPL-OPERATOR,
-            $lookups.AT-POS(1).resolution.compile-time-value,
+            $lookups[1].resolution.compile-time-value,
         )
     }
 
@@ -1676,10 +1675,10 @@ class RakuAST::MetaInfix::Zip
     }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
-        self.IMPL-WRAP-LIST([
+        [
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('&METAOP_ZIP')),
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier($!infix.reducer-name)),
-        ])
+        ]
     }
 
     method IMPL-OPERATOR() {
@@ -1703,9 +1702,9 @@ class RakuAST::MetaInfix::Zip
 
     method IMPL-HOP-INFIX() {
         my $lookups := self.get-implicit-lookups;
-        $lookups.AT-POS(0).resolution.compile-time-value()(
+        $lookups[0].resolution.compile-time-value()(
             self.infix.IMPL-OPERATOR,
-            $lookups.AT-POS(1).resolution.compile-time-value,
+            $lookups[1].resolution.compile-time-value,
         )
     }
 
@@ -1770,9 +1769,9 @@ class RakuAST::MetaInfix::Hyper
     method reducer-name() { $!infix.reducer-name }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
-        self.IMPL-WRAP-LIST([
+        [
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('&METAOP_HYPER')),
-        ])
+        ]
     }
 
     method IMPL-OPERATOR() {
@@ -1809,7 +1808,7 @@ class RakuAST::MetaInfix::Hyper
     }
 
     method IMPL-HOP-INFIX() {
-        self.get-implicit-lookups().AT-POS(0).resolution.compile-time-value()(
+        self.get-implicit-lookups()[0].resolution.compile-time-value()(
             self.infix.resolution.compile-time-value,
             :dwim-left($!dwim-left),
             :dwim-right($!dwim-right)
@@ -1993,7 +1992,7 @@ class RakuAST::ApplyInfix
         while nqp::isconcrete($!args.arg-at-pos($i)) {
             @colonpairs.push($!args.arg-at-pos($i++));
         }
-        self.IMPL-WRAP-LIST(@colonpairs)
+        @colonpairs
     }
 
     method operands() { $!args.IMPL-UNWRAP-LIST($!args.args) }
@@ -2517,13 +2516,13 @@ class RakuAST::MetaPrefix::Hyper
     }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
-        self.IMPL-WRAP-LIST([
+        [
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('&METAOP_HYPER_PREFIX')),
-        ])
+        ]
     }
 
     method IMPL-HOP-INFIX() {
-        self.get-implicit-lookups().AT-POS(0).resolution.compile-time-value()(
+        self.get-implicit-lookups()[0].resolution.compile-time-value()(
             self.prefix.IMPL-HOP-PREFIX
         )
     }
@@ -3218,13 +3217,13 @@ class RakuAST::MetaPostfix::Hyper
     }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
-        self.IMPL-WRAP-LIST([
+        [
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('&METAOP_HYPER_POSTFIX')),
-        ])
+        ]
     }
 
     method IMPL-HOP-INFIX() {
-        self.get-implicit-lookups().AT-POS(0).resolution.compile-time-value()(
+        self.get-implicit-lookups()[0].resolution.compile-time-value()(
             self.postfix.IMPL-HOP-POSTFIX
         )
     }

--- a/src/Raku/ast/literals.rakumod
+++ b/src/Raku/ast/literals.rakumod
@@ -216,7 +216,7 @@ class RakuAST::QuotedString
                 }
             }
         }
-        self.IMPL-WRAP-LIST(@needed)
+        @needed
     }
 
     method type-name() { 'string' }

--- a/src/Raku/ast/name.rakumod
+++ b/src/Raku/ast/name.rakumod
@@ -298,10 +298,10 @@ class RakuAST::Name
     }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
-        self.IMPL-WRAP-LIST([
+        [
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('&INDIRECT_NAME_LOOKUP')),
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('PseudoStash')),
-        ])
+        ]
     }
 
     method IMPL-LOOKUP-PARTS() {

--- a/src/Raku/ast/package.rakumod
+++ b/src/Raku/ast/package.rakumod
@@ -158,7 +158,7 @@ class RakuAST::Package
         nqp::bindattr(self, RakuAST::Package, '$!compiler-services', RakuAST::CompilerServices.new(self, $resolver, $context));
     }
 
-    method attach-target-names() { self.IMPL-WRAP-LIST(['package', 'also']) }
+    method attach-target-names() { ['package', 'also'] }
 
     method IMPL-GENERATE-LEXICAL-DECLARATION(RakuAST::Name $name, Mu $type-object) {
         $type-object := self.stubbed-meta-object if nqp::eqaddr($type-object, Mu);
@@ -250,7 +250,7 @@ class RakuAST::Package
         { # Should be replaced by now
             self.add-sorry:
                 $resolver.build-exception: 'X::Package::Stubbed',
-                    packages => self.IMPL-WRAP-LIST([$!name.canonicalize]);
+                    packages => [$!name.canonicalize];
         }
 
         if self.is-resolved && $!repr {

--- a/src/Raku/ast/pair.rakumod
+++ b/src/Raku/ast/pair.rakumod
@@ -31,9 +31,9 @@ class RakuAST::FatArrow
     method named-arg-value() { $!value }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
-        self.IMPL-WRAP-LIST([
+        [
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('Pair')),
-        ])
+        ]
     }
 
     method IMPL-EXPR-QAST(RakuAST::IMPL::QASTContext $context) {
@@ -118,9 +118,9 @@ class RakuAST::ColonPair
     }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
-        self.IMPL-WRAP-LIST([
+        [
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('Pair')),
-        ])
+        ]
     }
 
     method IMPL-CREATE-PAIR(Str $key, Mu $value) {
@@ -203,9 +203,9 @@ class RakuAST::ColonPair::True
     }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
-        self.IMPL-WRAP-LIST([
+        [
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('Pair'))
-        ])
+        ]
     }
 
     method value() {
@@ -249,9 +249,9 @@ class RakuAST::ColonPair::False
     }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
-        self.IMPL-WRAP-LIST([
+        [
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('Pair'))
-        ])
+        ]
     }
 
     method value() {

--- a/src/Raku/ast/regex.rakumod
+++ b/src/Raku/ast/regex.rakumod
@@ -430,7 +430,7 @@ class RakuAST::Regex::CapturingGroup
         self.IMPL-LINK-META-OBJECT($context, $block);
         QAST::Stmts.new(
             $block,
-            self.get-implicit-declarations()[0].IMPL-BIND-QAST($context,
+            self.IMPL-UNWRAP-LIST(self.get-implicit-declarations())[0].IMPL-BIND-QAST($context,
                 self.IMPL-CLOSURE-QAST($context) ),
         )
     }
@@ -440,7 +440,7 @@ class RakuAST::Regex::CapturingGroup
         nqp::bindattr(self, RakuAST::Regex::CapturingGroup, '$!body-qast', $body-qast);
         QAST::Regex.new(
             :rxtype('subrule'), :subtype('capture'),
-            QAST::NodeList.new(self.get-implicit-declarations()[0].IMPL-LOOKUP-QAST($context)),
+            QAST::NodeList.new(self.IMPL-UNWRAP-LIST(self.get-implicit-declarations())[0].IMPL-LOOKUP-QAST($context)),
             $body-qast
         )
     }
@@ -1058,7 +1058,7 @@ class RakuAST::Regex::Interpolation
                 QAST::IVal.new( :value(0) ),
                 QAST::Op.new(
                     :op<callmethod>, :name<new>,
-                   self.get-implicit-lookups[0].IMPL-TO-QAST($context)
+                   self.IMPL-UNWRAP-LIST(self.get-implicit-lookups)[0].IMPL-TO-QAST($context)
                 )
     }
 
@@ -1177,7 +1177,7 @@ class RakuAST::Regex::Assertion::Named
                 nqp::die('Can only use <sym> token in a proto regex');
             }
             else {
-                my $lookups := self.get-implicit-lookups;
+                my $lookups := self.IMPL-UNWRAP-LIST(self.get-implicit-lookups);
                 my $qast;
                 if nqp::elems($lookups) && (my $lookup := $lookups[0]).is-resolved
                     && nqp::istype((my $resolution := $lookup.resolution), RakuAST::CompileTimeValue)
@@ -1212,7 +1212,7 @@ class RakuAST::Regex::Assertion::Named
             my $sub-name := RakuAST::Name.new($sub);
             $sub-name.set-colonpairs(@pairs);
 
-            my $lookups := self.get-implicit-lookups;
+            my $lookups := self.IMPL-UNWRAP-LIST(self.get-implicit-lookups);
             my $package := $lookups[0].meta-object;
             $context.ensure-sc($package);
             my $qast := QAST::Regex.new: :rxtype<subrule>,:subtype<method>,
@@ -1456,7 +1456,7 @@ class RakuAST::Regex::Assertion::InterpolatedBlock
           %mods,
           self.IMPL-REGEX-BLOCK-CALL($context, $!block),
           $!sequential,
-          self.get-implicit-lookups[0]
+          self.IMPL-UNWRAP-LIST(self.get-implicit-lookups)[0]
         )
     }
 
@@ -1503,7 +1503,7 @@ class RakuAST::Regex::Assertion::InterpolatedVar
           %mods,
           $!var.IMPL-TO-QAST($context),
           $!sequential,
-          self.get-implicit-lookups[0]
+          self.IMPL-UNWRAP-LIST(self.get-implicit-lookups)[0]
         )
     }
 

--- a/src/Raku/ast/regex.rakumod
+++ b/src/Raku/ast/regex.rakumod
@@ -410,9 +410,9 @@ class RakuAST::Regex::CapturingGroup
     }
 
     method PRODUCE-IMPLICIT-DECLARATIONS() {
-        self.IMPL-WRAP-LIST([
+        [
             RakuAST::VarDeclaration::Implicit::RegexCapture.new,
-        ])
+        ]
     }
 
     method IMPL-THUNKED-REGEX-QAST(RakuAST::IMPL::QASTContext $context) {
@@ -430,7 +430,7 @@ class RakuAST::Regex::CapturingGroup
         self.IMPL-LINK-META-OBJECT($context, $block);
         QAST::Stmts.new(
             $block,
-            self.get-implicit-declarations().AT-POS(0).IMPL-BIND-QAST($context,
+            self.get-implicit-declarations()[0].IMPL-BIND-QAST($context,
                 self.IMPL-CLOSURE-QAST($context) ),
         )
     }
@@ -440,7 +440,7 @@ class RakuAST::Regex::CapturingGroup
         nqp::bindattr(self, RakuAST::Regex::CapturingGroup, '$!body-qast', $body-qast);
         QAST::Regex.new(
             :rxtype('subrule'), :subtype('capture'),
-            QAST::NodeList.new(self.get-implicit-declarations().AT-POS(0).IMPL-LOOKUP-QAST($context)),
+            QAST::NodeList.new(self.get-implicit-declarations()[0].IMPL-LOOKUP-QAST($context)),
             $body-qast
         )
     }
@@ -1010,9 +1010,9 @@ class RakuAST::Regex::Interpolation
     }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
-        self.IMPL-WRAP-LIST([
+        [
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('PseudoStash')),
-        ])
+        ]
     }
 
     method PERFORM-CHECK(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
@@ -1058,7 +1058,7 @@ class RakuAST::Regex::Interpolation
                 QAST::IVal.new( :value(0) ),
                 QAST::Op.new(
                     :op<callmethod>, :name<new>,
-                   self.get-implicit-lookups.AT-POS(0).IMPL-TO-QAST($context)
+                   self.get-implicit-lookups[0].IMPL-TO-QAST($context)
                 )
     }
 
@@ -1150,17 +1150,17 @@ class RakuAST::Regex::Assertion::Named
         # A call like <foo> will look for <&foo> and only then do <.foo>
         # (but in both cases it captures).
         if $!capturing && $!name.is-identifier {
-            self.IMPL-WRAP-LIST: [RakuAST::Var::Lexical.new('&' ~ $!name.canonicalize)]
+            [RakuAST::Var::Lexical.new('&' ~ $!name.canonicalize)]
         }
         else {
             if $!name.is-identifier || $!name.is-indirect-lookup && !$!name.is-multi-part {
-                self.IMPL-WRAP-LIST: []
+                []
             }
             else {
                 my @parts := $!name.IMPL-UNWRAP-LIST($!name.parts);
                 my @package-parts := nqp::slice(@parts, 0, nqp::elems(@parts) - 2);
                 my $package-name := RakuAST::Name.new(|@package-parts);
-                self.IMPL-WRAP-LIST: [RakuAST::Type::Simple.new($package-name)]
+                [RakuAST::Type::Simple.new($package-name)]
             }
         }
     }
@@ -1179,11 +1179,11 @@ class RakuAST::Regex::Assertion::Named
             else {
                 my $lookups := self.get-implicit-lookups;
                 my $qast;
-                if $lookups.elems && (my $lookup := $lookups.AT-POS(0)).is-resolved
+                if nqp::elems($lookups) && (my $lookup := $lookups[0]).is-resolved
                     && nqp::istype((my $resolution := $lookup.resolution), RakuAST::CompileTimeValue)
                     && nqp::istype($resolution.compile-time-value, Regex)
                 {
-                    my $var-qast := $lookups.AT-POS(0).IMPL-TO-QAST($context);
+                    my $var-qast := $lookups[0].IMPL-TO-QAST($context);
                     $var-qast.annotate('coderef', $resolution.compile-time-value);
                     $qast := QAST::Regex.new: :rxtype<subrule>,:subtype<method>,
                         QAST::NodeList.new: $var-qast;
@@ -1213,7 +1213,7 @@ class RakuAST::Regex::Assertion::Named
             $sub-name.set-colonpairs(@pairs);
 
             my $lookups := self.get-implicit-lookups;
-            my $package := $lookups.AT-POS(0).meta-object;
+            my $package := $lookups[0].meta-object;
             $context.ensure-sc($package);
             my $qast := QAST::Regex.new: :rxtype<subrule>,:subtype<method>,
                 QAST::NodeList.new:
@@ -1445,9 +1445,9 @@ class RakuAST::Regex::Assertion::InterpolatedBlock
     }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
-        self.IMPL-WRAP-LIST([
+        [
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('PseudoStash')),
-        ])
+        ]
     }
 
     method IMPL-REGEX-QAST(RakuAST::IMPL::QASTContext $context, %mods) {
@@ -1456,7 +1456,7 @@ class RakuAST::Regex::Assertion::InterpolatedBlock
           %mods,
           self.IMPL-REGEX-BLOCK-CALL($context, $!block),
           $!sequential,
-          self.get-implicit-lookups.AT-POS(0)
+          self.get-implicit-lookups[0]
         )
     }
 
@@ -1485,9 +1485,9 @@ class RakuAST::Regex::Assertion::InterpolatedVar
     }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
-        self.IMPL-WRAP-LIST([
+        [
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('PseudoStash')),
-        ])
+        ]
     }
 
     method PERFORM-CHECK(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
@@ -1503,7 +1503,7 @@ class RakuAST::Regex::Assertion::InterpolatedVar
           %mods,
           $!var.IMPL-TO-QAST($context),
           $!sequential,
-          self.get-implicit-lookups.AT-POS(0)
+          self.get-implicit-lookups[0]
         )
     }
 

--- a/src/Raku/ast/scoping.rakumod
+++ b/src/Raku/ast/scoping.rakumod
@@ -569,7 +569,7 @@ class RakuAST::ImplicitDeclarations
     # remains constant. Nodes that may be mutated must instead implement
     # get-implicit-declarations and handle the caching themselves.
     method PRODUCE-IMPLICIT-DECLARATIONS() {
-        self.IMPL-WRAP-LIST(nqp::list())
+        []
     }
 
     # Get a list of the implicit declarations.
@@ -955,16 +955,16 @@ class RakuAST::ImplicitLookups
     # remains constant. Nodes that may be mutated must instead implement
     # get-implicit-lookups and handle the caching themselves.
     method PRODUCE-IMPLICIT-LOOKUPS() {
-        self.IMPL-WRAP-LIST(nqp::list())
+        []
     }
 
     # Get a list of the implicit lookups.
     method get-implicit-lookups() {
-        nqp::isconcrete(self)
+        self.IMPL-WRAP-LIST(nqp::isconcrete(self)
             ?? $!implicit-lookups-cache //
                 nqp::bindattr(self, RakuAST::ImplicitLookups, '$!implicit-lookups-cache',
                     self.PRODUCE-IMPLICIT-LOOKUPS())
-            !! self.IMPL-WRAP-LIST([])
+            !! [])
     }
 
     # Drive the implicit lookups to their begin time.

--- a/src/Raku/ast/signature.rakumod
+++ b/src/Raku/ast/signature.rakumod
@@ -169,9 +169,9 @@ class RakuAST::Signature
     }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
-        self.IMPL-WRAP-LIST([
+        [
             RakuAST::Var::Compiler::Lookup.new('$?CLASS')
-        ])
+        ]
     }
 
     method IMPL-HAS-PARAMETER(Str $name) {
@@ -827,7 +827,7 @@ class RakuAST::Parameter
         for @lookups {
             nqp::push(@types, RakuAST::Type::Setting.new(RakuAST::Name.from-identifier($_)));
         }
-        self.IMPL-WRAP-LIST(@types)
+        @types
     }
 
     method IMPL-DEFAULT-RW() {

--- a/src/Raku/ast/statement-mods.rakumod
+++ b/src/Raku/ast/statement-mods.rakumod
@@ -27,9 +27,9 @@ class RakuAST::StatementModifier::Condition
   is RakuAST::ImplicitLookups
 {
     method PRODUCE-IMPLICIT-LOOKUPS() {
-        self.IMPL-WRAP-LIST([
+        [
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('Empty'))
-        ])
+        ]
     }
 
     method IMPL-EMPTY(RakuAST::IMPL::QASTContext $context) {
@@ -216,10 +216,10 @@ class RakuAST::StatementModifier::WhileUntil
     }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
-        self.IMPL-WRAP-LIST([
+        [
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('Nil')),
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('Seq'))
-        ])
+        ]
     }
 
     method IMPL-WRAP-QAST(RakuAST::IMPL::QASTContext $context, Mu $statement-qast, Bool :$sink, Bool :$block) {

--- a/src/Raku/ast/statementprefixes.rakumod
+++ b/src/Raku/ast/statementprefixes.rakumod
@@ -161,11 +161,11 @@ class RakuAST::StatementPrefix::Try
     }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
-        self.IMPL-WRAP-LIST([
+        [
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('Nil')),
             RakuAST::Var::Lexical.new('$!'),
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('Failure')),
-        ])
+        ]
     }
 
     method IMPL-EXPR-QAST(RakuAST::IMPL::QASTContext $context) {
@@ -420,9 +420,9 @@ class RakuAST::StatementPrefix::Once
         my $state-name := QAST::Node.unique('once_');
         nqp::bindattr_s(self, RakuAST::StatementPrefix::Once, '$!state-name', $state-name);
 
-        self.IMPL-WRAP-LIST([
+        [
             RakuAST::VarDeclaration::Implicit::State.new($state-name)
-        ])
+        ]
     }
 
     method IMPL-EXPR-QAST(RakuAST::IMPL::QASTContext $context) {
@@ -447,10 +447,10 @@ class RakuAST::StatementPrefix::Start
     method type() { "start" }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
-        self.IMPL-WRAP-LIST([
+        [
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('Promise')),
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('True')),
-        ])
+        ]
     }
 
     method IMPL-EXPR-QAST(RakuAST::IMPL::QASTContext $context) {
@@ -562,9 +562,9 @@ class RakuAST::StatementPrefix::Phaser::Sinky
     }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
-        self.IMPL-WRAP-LIST([
+        [
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('Nil')),
-        ])
+        ]
     }
 
     method IMPL-EXPR-QAST(RakuAST::IMPL::QASTContext $context) {

--- a/src/Raku/ast/statements.rakumod
+++ b/src/Raku/ast/statements.rakumod
@@ -34,9 +34,9 @@ class RakuAST::Label
     method lexical-name() { $!name }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
-        self.IMPL-WRAP-LIST([
+        [
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('Label')),
-        ])
+        ]
     }
 
     method PRODUCE-META-OBJECT() {
@@ -319,10 +319,10 @@ class RakuAST::StatementList
     }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
-        self.IMPL-WRAP-LIST([
+        [
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('Blob')),
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('Nil')),
-        ])
+        ]
     }
 
     method IMPL-TO-QAST(RakuAST::IMPL::QASTContext $context, :$immediate) {
@@ -474,9 +474,9 @@ class RakuAST::SemiList
     }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
-        self.IMPL-WRAP-LIST([
+        [
             RakuAST::Var::Lexical.new('&infix:<,>'),
-        ])
+        ]
     }
 
     method IMPL-TO-QAST(RakuAST::IMPL::QASTContext $context) {
@@ -527,9 +527,9 @@ class RakuAST::StatementSequence
   is RakuAST::Contextualizable
 {
     method PRODUCE-IMPLICIT-LOOKUPS() {
-        self.IMPL-WRAP-LIST([
+        [
             RakuAST::Var::Lexical.new('&infix:<,>'),
-        ])
+        ]
     }
 
     method IMPL-TO-QAST(RakuAST::IMPL::QASTContext $context) {
@@ -563,9 +563,9 @@ class RakuAST::ProducesNil
   is RakuAST::ImplicitLookups
 {
     method PRODUCE-IMPLICIT-LOOKUPS() {
-        self.IMPL-WRAP-LIST([
+        [
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('Nil')),
-        ])
+        ]
     }
 
     method IMPL-TO-QAST(RakuAST::IMPL::QASTContext $context) {
@@ -855,7 +855,7 @@ class RakuAST::Statement::IfWith
     }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
-        self.IMPL-WRAP-LIST: $!else
+        $!else
             ?? []
             !! [RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('Empty'))]
     }
@@ -996,9 +996,9 @@ class RakuAST::Statement::Unless
     }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
-        self.IMPL-WRAP-LIST([
+        [
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('Empty')),
-        ])
+        ]
     }
 
     method IMPL-TO-QAST(RakuAST::IMPL::QASTContext $context) {
@@ -1050,9 +1050,9 @@ class RakuAST::Statement::Without
     }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
-        self.IMPL-WRAP-LIST([
+        [
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('Empty')),
-        ])
+        ]
     }
 
     method IMPL-TO-QAST(RakuAST::IMPL::QASTContext $context) {
@@ -1135,10 +1135,10 @@ class RakuAST::Statement::Loop
     }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
-        self.IMPL-WRAP-LIST([
+        [
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('Nil')),
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('Seq'))
-        ])
+        ]
     }
 
     method IMPL-DISCARD-RESULT() {
@@ -1477,9 +1477,9 @@ class RakuAST::Statement::When
     }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
-        self.IMPL-WRAP-LIST([
+        [
             RakuAST::Var::Lexical.new('$_'),
-        ])
+        ]
     }
 
     method IMPL-TO-QAST(RakuAST::IMPL::QASTContext $context) {
@@ -1978,9 +1978,9 @@ class RakuAST::Statement::Import
     }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
-        self.IMPL-WRAP-LIST([
+        [
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier-parts('CompUnit', 'Handle')),
-        ])
+        ]
     }
 
     method PERFORM-PARSE(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
@@ -2037,7 +2037,7 @@ class RakuAST::Statement::Require
         my @lookups;
         nqp::push(@lookups, RakuAST::Type::Setting.new(RakuAST::Name.from-identifier-parts('CompUnit', 'DependencySpecification')));
         nqp::push(@lookups, RakuAST::Type::Setting.new(RakuAST::Name.from-identifier-parts('CompUnit', 'RepositoryRegistry')));
-        self.IMPL-WRAP-LIST(@lookups)
+        @lookups
     }
 
     method PERFORM-BEGIN(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
@@ -2064,7 +2064,7 @@ class RakuAST::Statement::Require
         }
 
         if $!module-name && !$!module-name.is-indirect-lookup() {
-            my $top := $!module-name.parts.AT-POS(0);
+            my $top := self.IMPL-UNWRAP-LIST($!module-name.parts)[0];
             my $resolved := $resolver.resolve-name(RakuAST::Name.new($top));
             nqp::bindattr(self, RakuAST::Statement::Require, '$!existing-lookup', $resolved);
 

--- a/src/Raku/ast/statements.rakumod
+++ b/src/Raku/ast/statements.rakumod
@@ -1997,7 +1997,7 @@ class RakuAST::Statement::Import
             !! Nil;
 
         my $module := self.resolution.compile-time-value;
-        my $CompUnitHandle := self.get-implicit-lookups().AT-POS(0).compile-time-value;
+        my $CompUnitHandle := self.IMPL-UNWRAP-LIST(self.get-implicit-lookups())[0].compile-time-value;
         my $handle := $CompUnitHandle.from-unit($module.WHO);
         self.IMPL-IMPORT($resolver, $handle, $arglist, :module($!module-name.canonicalize));
         self.IMPL-IMPORT-EXPORTHOW($resolver, $handle);
@@ -2103,9 +2103,9 @@ class RakuAST::Statement::Require
     }
 
     method IMPL-TO-QAST(RakuAST::IMPL::QASTContext $context) {
-        my $lookups := self.get-implicit-lookups;
-        my $depspec  := $lookups.AT-POS(0).compile-time-value;
-        my $registry := $lookups.AT-POS(1).compile-time-value;
+        my $lookups  := self.IMPL-UNWRAP-LIST(self.get-implicit-lookups);
+        my $depspec  := $lookups[0].compile-time-value;
+        my $registry := $lookups[1].compile-time-value;
 
         my $compunit-qast;
         my $file;

--- a/src/Raku/ast/term.rakumod
+++ b/src/Raku/ast/term.rakumod
@@ -189,9 +189,9 @@ class RakuAST::Term::TopicCall
     }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
-        self.IMPL-WRAP-LIST([
+        [
             RakuAST::Var::Lexical.new('$_'),
-        ])
+        ]
     }
 
     method PERFORM-CHECK(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
@@ -201,7 +201,7 @@ class RakuAST::Term::TopicCall
     method IMPL-EXPR-QAST(RakuAST::IMPL::QASTContext $context) {
         my $postfix-ast := $!call.IMPL-POSTFIX-QAST(
           $context,
-          self.get-implicit-lookups.AT-POS(0).resolution.IMPL-LOOKUP-QAST($context)
+          self.get-implicit-lookups[0].resolution.IMPL-LOOKUP-QAST($context)
         );
         nqp::istype($!call, RakuAST::Call::Methodish)
             ?? QAST::Op.new(:op<hllize>, $postfix-ast)
@@ -443,10 +443,10 @@ class RakuAST::Term::Reduce
     method properties() { $!infix.properties }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
-        self.IMPL-WRAP-LIST([
+        [
             RakuAST::Var::Lexical.new('&infix:<,>'),
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier($!infix.reducer-name)),
-        ])
+        ]
     }
 
     method PERFORM-BEGIN(Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
@@ -472,7 +472,7 @@ class RakuAST::Term::Reduce
     }
 
     method IMPL-HOP-INFIX() {
-        my &reducer := self.get-implicit-lookups.AT-POS(1).resolution.compile-time-value;
+        my &reducer := self.get-implicit-lookups[1].resolution.compile-time-value;
         $!triangle ?? &reducer($!infix.IMPL-HOP-INFIX, True) !! &reducer($!infix.IMPL-HOP-INFIX)
     }
 
@@ -496,7 +496,7 @@ class RakuAST::Term::Reduce
             # Form a List of the argumnets and pass it to the reducer
             # TODO thunk case
             my $name :=
-              self.get-implicit-lookups.AT-POS(0).resolution.lexical-name;
+              self.get-implicit-lookups[0].resolution.lexical-name;
             my $form-list := QAST::Op.new(:op('call'), :$name);
             $!args.IMPL-ADD-QAST-ARGS($context, $form-list);
             QAST::Op.new( :op<call>, $form-meta, $form-list )

--- a/src/Raku/ast/term.rakumod
+++ b/src/Raku/ast/term.rakumod
@@ -201,7 +201,7 @@ class RakuAST::Term::TopicCall
     method IMPL-EXPR-QAST(RakuAST::IMPL::QASTContext $context) {
         my $postfix-ast := $!call.IMPL-POSTFIX-QAST(
           $context,
-          self.get-implicit-lookups[0].resolution.IMPL-LOOKUP-QAST($context)
+          self.IMPL-UNWRAP-LIST(self.get-implicit-lookups)[0].resolution.IMPL-LOOKUP-QAST($context)
         );
         nqp::istype($!call, RakuAST::Call::Methodish)
             ?? QAST::Op.new(:op<hllize>, $postfix-ast)
@@ -472,7 +472,7 @@ class RakuAST::Term::Reduce
     }
 
     method IMPL-HOP-INFIX() {
-        my &reducer := self.get-implicit-lookups[1].resolution.compile-time-value;
+        my &reducer := self.IMPL-UNWRAP-LIST(self.get-implicit-lookups)[1].resolution.compile-time-value;
         $!triangle ?? &reducer($!infix.IMPL-HOP-INFIX, True) !! &reducer($!infix.IMPL-HOP-INFIX)
     }
 
@@ -496,7 +496,7 @@ class RakuAST::Term::Reduce
             # Form a List of the argumnets and pass it to the reducer
             # TODO thunk case
             my $name :=
-              self.get-implicit-lookups[0].resolution.lexical-name;
+              self.IMPL-UNWRAP-LIST(self.get-implicit-lookups)[0].resolution.lexical-name;
             my $form-list := QAST::Op.new(:op('call'), :$name);
             $!args.IMPL-ADD-QAST-ARGS($context, $form-list);
             QAST::Op.new( :op<call>, $form-meta, $form-list )

--- a/src/Raku/ast/traits.rakumod
+++ b/src/Raku/ast/traits.rakumod
@@ -115,9 +115,9 @@ class RakuAST::Trait
     }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
-        self.IMPL-WRAP-LIST([
+        [
             RakuAST::Var::Lexical::Constant.new('&trait_mod:<' ~ self.IMPL-TRAIT-NAME() ~ '>')
-        ])
+        ]
     }
 
     # Checks if this trait has been applied already.

--- a/src/Raku/ast/type.rakumod
+++ b/src/Raku/ast/type.rakumod
@@ -619,11 +619,11 @@ class RakuAST::Type::Enum
     }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
-        self.IMPL-WRAP-LIST([
+        [
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('Pair')),
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('Stringy')),
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('Numeric'))
-        ])
+        ]
     }
 
     method IMPL-GENERATE-LEXICAL-DECLARATION(RakuAST::Name $name, Mu $type-object) {

--- a/src/Raku/ast/variable-access.rakumod
+++ b/src/Raku/ast/variable-access.rakumod
@@ -294,10 +294,10 @@ class RakuAST::Var::Attribute
     }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
-        self.IMPL-WRAP-LIST([
+        [
             RakuAST::Term::Self.new,
             RakuAST::Var::Compiler::Lookup.new('$?CLASS'),
-        ])
+        ]
     }
 
     method IMPL-QAST-PACKAGE-LOOKUP(RakuAST::Impl::QASTContext $context) {
@@ -400,7 +400,7 @@ class RakuAST::Var::Attribute::Public
     }
 
     method args() {
-        $!expression.operand.postfix.args
+        self.IMPL-WRAP-LIST($!expression.operand.postfix.args)
     }
 
     method creates-block() {
@@ -552,9 +552,9 @@ class RakuAST::Var::Compiler::Resources
     }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
-        self.IMPL-WRAP-LIST([
+        [
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier-parts('Distribution', 'Resources')),
-        ])
+        ]
     }
 
     method IMPL-EXPR-QAST(RakuAST::IMPL::QASTContext $context) {
@@ -587,9 +587,9 @@ class RakuAST::Var::Compiler::Distribution
     }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
-        self.IMPL-WRAP-LIST([
+        [
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier-parts('CompUnit', 'Repository', 'Distribution')),
-        ])
+        ]
     }
 
     method IMPL-EXPR-QAST(RakuAST::IMPL::QASTContext $context) {
@@ -669,10 +669,10 @@ class RakuAST::Var::PositionalCapture
     }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
-        self.IMPL-WRAP-LIST([
+        [
             RakuAST::Var::Lexical.new('&postcircumfix:<[ ]>'),
             RakuAST::Var::Lexical.new('$/'),
-        ])
+        ]
     }
 
     method IMPL-EXPR-QAST(RakuAST::IMPL::QASTContext $context) {
@@ -702,10 +702,10 @@ class RakuAST::Var::NamedCapture
     }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
-        self.IMPL-WRAP-LIST([
+        [
             RakuAST::Var::Lexical.new('&postcircumfix:<{ }>'),
             RakuAST::Var::Lexical.new('$/'),
-        ])
+        ]
     }
 
     method IMPL-EXPR-QAST(RakuAST::IMPL::QASTContext $context) {
@@ -836,9 +836,9 @@ class RakuAST::Var::Slang
     }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
-        self.IMPL-WRAP-LIST([
+        [
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('Slang')),
-        ])
+        ]
     }
 
     method sigil() { '$' }

--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -332,9 +332,9 @@ class RakuAST::TraitTarget::Variable
     }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
-        self.IMPL-WRAP-LIST([
+        [
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('Variable')),
-        ])
+        ]
     }
 
     method PERFORM-BEGIN(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
@@ -403,7 +403,7 @@ class RakuAST::VarDeclaration::Constant
     method needs-sink-call() { False }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
-        self.IMPL-WRAP-LIST([
+        [
             self.sigil eq '@'
                 ?? RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('Positional'))
                 !! self.sigil eq '%'
@@ -414,7 +414,7 @@ class RakuAST::VarDeclaration::Constant
                             ?? $!type
                             !! nqp::null,
 
-        ])
+        ]
     }
 
     method visit-children(Code $visitor) {
@@ -1217,7 +1217,7 @@ class RakuAST::VarDeclaration::Simple
             )
         );
 
-        self.IMPL-WRAP-LIST(@lookups)
+        @lookups
     }
 
     method IMPL-SIGIL-TYPE() {
@@ -1675,7 +1675,7 @@ class RakuAST::VarDeclaration::Signature
         if $scope eq 'has' || $scope eq 'HAS' {
             @lookups.push(RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('Nil')));
         }
-        self.IMPL-WRAP-LIST(@lookups)
+        @lookups
     }
 
     method PERFORM-BEGIN(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
@@ -2429,10 +2429,9 @@ class RakuAST::VarDeclaration::Implicit::State
     }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
-        my @lookups := $!init-to-zero ?? [
+        $!init-to-zero ?? [
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('Int'))
         ] !! [];
-        self.IMPL-WRAP-LIST(@lookups)
     }
 
     method PRODUCE-META-OBJECT() {


### PR DESCRIPTION
Removing these ones doesn't break any spectests.

There are more than can be removed, but not all, and I haven't yet figured out exactly which.