### PR TITLE
Change Linux pre-built release pipeline, CentOS 7 -> Ubuntu 16.04

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -673,22 +673,12 @@ stages:
     - job: linux
       displayName: Linux x86_64 build
       pool:
-        vmImage: 'ubuntu-20.04'
+        vmImage: 'ubuntu-22.04'
       container:
-        image: centos:7
-        options: "--name raku-build-container -v /usr/bin/docker:/tmp/docker:ro"
+        image: patrickbkr/ubuntu-with-sudo:16.04
       workspace:
         clean: all
       steps:
-        - script: |
-            /tmp/docker exec -t -u 0 raku-build-container sh -c 'sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo'
-            /tmp/docker exec -t -u 0 raku-build-container sh -c 'sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo'
-            /tmp/docker exec -t -u 0 raku-build-container sh -c 'sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo'
-          displayName: Work around mirrorlist.centos.org being discontinued
-
-        - script: /tmp/docker exec -t -u 0 raku-build-container sh -c "yum -y update && yum -y install sudo"
-          displayName: Set up sudo (see https://github.com/microsoft/azure-pipelines-agent/issues/2043)
-
         - checkout: self
           path: source
           displayName: Checkout repository

--- a/tools/build/binary-release/build-containers/Dockerfile
+++ b/tools/build/binary-release/build-containers/Dockerfile
@@ -1,0 +1,3 @@
+FROM ubuntu:16.04
+RUN apt update
+RUN apt -y install sudo

--- a/tools/build/binary-release/build-linux.sh
+++ b/tools/build/binary-release/build-linux.sh
@@ -1,6 +1,6 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
-# This script should be allowed to run sudo in a CentOS 7 installation (a
+# This script should be allowed to run sudo in a debian based distro (a
 # container will do just fine).
 # For some strange reason the environment variables are lost when running this
 # script with `sudo` in azure pipelines. So we just do sudo ourselves for the
@@ -11,26 +11,11 @@ set -o pipefail
 
 echo "========= Starting build"
 
-echo "========= Updating CentOS 7"
-sudo yum -y update
-sudo yum clean all
-
-echo "========= install a new enough gcc"
-sudo yum -y install centos-release-scl
-
-# Fix up repo specs for out of support CentOS 7 again
-sudo sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
-sudo sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
-sudo sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
-
-sudo yum -y install devtoolset-8
-# Somehow scl_source fails on Azure CI (but works in an identical local container).
-# So just skip scl_source entirely and just source the target file directly.
-#source scl_source enable devtoolset-8
-source /opt/rh/devtoolset-8/enable
+echo "========= Updating distro"
+sudo apt update
 
 echo "========= Downloading dependencies"
-sudo yum -y install curl git perl perl-core
+sudo apt -y install build-essential curl git perl
 
 echo "========= Downloading release"
 curl -o rakudo.tgz $RELEASE_URL


### PR DESCRIPTION
Azure removed support for the Ubuntu 20.04 agent OS. We need to mount the docker binary into the container to work around missing root permissions in the container. That only works when the host's docker binary is glibc compatible with the container glibc. Upgrading Ubuntu from 20.04 to 22.04 made the host's docker binary incompatible with CentOS' 7 glibc. The same problem arose with several other distributions and glibc versions.

So as a fix, I created a derived Ubuntu 16.04 container that already has `sudo` preinstalled. This alleviates us of the need to run the host's docker in the container and resolves the above issue. The upgrade of the container OS to Ubuntu 16.04 was not strictly necessary. But given I was already fuddling with the pre-built release pipeline, this felt like the right time to do so.
An important effect of the OS upgrade is that the minimum required glibc version for Rakudo is now changed from 2.17 to 2.23.