### PR TITLE
Use list literal instead of array literal for nl-in default value

### DIFF
--- a/src/core.c/IO/Handle.rakumod
+++ b/src/core.c/IO/Handle.rakumod
@@ -3,7 +3,7 @@ my class IO::Handle {
     has $!PIO;
     has $!mode;
     has $.chomp is rw = Bool::True;
-    has $.nl-in = ["\x0A", "\r\n"];
+    has $.nl-in is rw = ("\x0A", "\r\n");
     has Str:D $.nl-out is rw = "\n";
     has Str $.encoding;
     has Encoding::Decoder $!decoder;


### PR DESCRIPTION
It's a bit faster when creating objects. `raku -e 'my $e; $e = IO::Handle.new for ^1_000_000; say now - INIT now; dd $e'` drops from ~2.2s to ~1.5s.

This does break one spectest, but maybe it's worth changing the test. t/spec/S32-io/io-handle.t test 28 now fails:
```
not ok 28 - .nl-in in subclasses has \n and \r\n
# Failed test '.nl-in in subclasses has \n and \r\n'
# at t/spec/S32-io/io-handle.t line 227
# expected: $["\n", "\r\n"]
#      got: $("\n", "\r\n")
```