### PR TITLE
New andthen/orelse for 6.e

### DIFF
--- a/src/core.c/Promise.rakumod
+++ b/src/core.c/Promise.rakumod
@@ -254,7 +254,7 @@ my class Promise does Awaitable {
         }
     }
 
-    proto method andthen(|) is revision-gated('6c') { * }
+    proto method andthen(|) is revision-gated('6.c') { * }
     multi method andthen(Promise:D: &code, :$synchronous) {
         nqp::lock($!lock);
         if $!status == Broken {
@@ -279,7 +279,7 @@ my class Promise does Awaitable {
                                $synchronous)
         }
     }
-    multi method andthen(Promise:D: &code, :$synchronous) is revision-gated('6e') {
+    multi method andthen(Promise:D: &code, :$synchronous) is revision-gated('6.e') {
         nqp::lock($!lock);
         if $!status == Broken {
             nqp::unlock($!lock);
@@ -304,7 +304,7 @@ my class Promise does Awaitable {
         }
     }
 
-    proto method orelse(|) is revision-gated('6c') { * }
+    proto method orelse(|) is revision-gated('6.c') { * }
     multi method orelse(Promise:D: &code, :$synchronous) {
         nqp::lock($!lock);
         if $!status == Broken {

--- a/src/core.c/Promise.rakumod
+++ b/src/core.c/Promise.rakumod
@@ -333,11 +333,11 @@ my class Promise does Awaitable {
             my $then-p := self.new(:$!scheduler);
             my $vow := $then-p.vow;
             self!PLANNED-THEN( $then-p,
-                    $vow,
-                    { $!status == Kept
-                            ?? $vow.keep($!result)
-                            !! do { my $*PROMISE := $then-p; $vow.keep(code(self)) } },
-                    $synchronous)
+                               $vow,
+                               { $!status == Kept
+                                    ?? $vow.keep($!result)
+                                    !! do { my $*PROMISE := $then-p; $vow.keep(code(self)) } },
+                               $synchronous)
         }
     }
     multi method orelse(Promise:D: &code, :$synchronous) is revision-gated('6.e') {

--- a/src/core.c/Promise.rakumod
+++ b/src/core.c/Promise.rakumod
@@ -321,8 +321,8 @@ my class Promise does Awaitable {
         if $!status == Broken {
             nqp::unlock($!lock);
             $synchronous
-                    ?? code(self)
-                    !! self.WHAT.start( { code(self) }, :$!scheduler);
+                ?? code(self)
+                !! self.WHAT.start( { code(self) }, :$!scheduler);
         }
         elsif $!status == Kept {
             # Already have the result, start immediately.

--- a/src/core.c/Promise.rakumod
+++ b/src/core.c/Promise.rakumod
@@ -335,8 +335,8 @@ my class Promise does Awaitable {
             self!PLANNED-THEN( $then-p,
                                $vow,
                                { $!status == Kept
-                                    ?? $vow.keep($!result)
-                                    !! do { my $*PROMISE := $then-p; $vow.keep(code(self)) } },
+                                   ?? $vow.keep($!result)
+                                   !! do { my $*PROMISE := $then-p; $vow.keep(code(self)) } },
                                $synchronous)
         }
     }

--- a/src/core.c/Promise.rakumod
+++ b/src/core.c/Promise.rakumod
@@ -291,7 +291,7 @@ my class Promise does Awaitable {
             my \final-result := code($!result);
             $synchronous
                     ?? nqp::istype(final-result, Awaitable)
-                        ?? $*AWAITER.await(final-result)
+                        ?? self.then({ final-result }, :synchronous)
                         !! final-result
                     !! nqp::istype(final-result, Awaitable)
                         ?? self.WHAT.start({ $*AWAITER.await(final-result) }, :$!scheduler)
@@ -347,7 +347,7 @@ my class Promise does Awaitable {
             my \final-result := code(self.cause);
             $synchronous
                     ?? nqp::istype(final-result, Awaitable)
-                        ?? $*AWAITER.await(final-result)
+                        ?? self.then({ final-result }, :synchronous)
                         !! final-result
                     !! nqp::istype(final-result, Awaitable)
                         ?? self.WHAT.start({ $*AWAITER.await(final-result) }, :$!scheduler)


### PR DESCRIPTION
These are revision gated and appear to be fully operational with just minor tweaks.

Adding in automatic awaiting on `Promise` results should also be pretty straightforward, should we wish to take that approach.

#5892 