### PR TITLE
Test and fix that Instant.from-posix-nanos and Instant.from-posix  match

### DIFF
--- a/src/core.c/Instant.rakumod
+++ b/src/core.c/Instant.rakumod
@@ -15,7 +15,9 @@ my class Instant is Cool does Real {
     }
 
     method from-posix-nanos(Instant:U: Int:D $nanos --> Instant:D) {
-        nqp::p6bindattrinvres(nqp::create(Instant),Instant,'$!tai',$nanos)
+        my $posix = $nanos / 1000000000;
+        nqp::p6bindattrinvres(nqp::create(Instant),Instant,'$!tai',
+          (Rakudo::Internals.tai-from-posix($posix,0) * 1000000000).Int)
     }
 
     method to-nanos(--> Int:D) {

--- a/t/02-rakudo/99-misc.t
+++ b/t/02-rakudo/99-misc.t
@@ -2,7 +2,7 @@ use lib <t/packages/Test-Helpers>;
 use Test;
 use Test::Helpers;
 
-plan 10;
+plan 11;
 
 subtest 'IO::Handle.raku.EVAL roundtrips' => {
     plan 7;
@@ -149,4 +149,8 @@ is ParameterChild.new(foobar => 'Baz').foobar, 'Baz', 'Subclassing of Parameter 
 
 is Parameter.new(:name('$a'), :type(Int), :optional).perl, 'Int $a?', 'Parameter takes by-name parameters itself';
 
+subtest 'Temporal', {
+    my $posix = 915148800.999_999_999_999_9;
+    is Instant.from-posix-nanos( ($posix * 10**9).Int ), Instant.from-posix( $posix), '.from-posix-nanos vs .from-posix';
+}
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
* Add test that Instant.from-posix and .from-posix-nanos agree

* Fix Instant::from-posix-nanos to include leap-seconds