### PR TITLE
Make DateTime a value type

### DIFF
--- a/src/core.c/DateTime.rakumod
+++ b/src/core.c/DateTime.rakumod
@@ -719,6 +719,20 @@ my class DateTime does Dateish {
           ~ ')'
     }
 
+    multi method WHICH(DateTime:D:) {
+        nqp::box_s(
+          nqp::concat(
+            nqp::if(
+              nqp::eqaddr(self.WHAT,DateTime),
+              'DateTime|',
+              nqp::concat(nqp::unbox_s(self.^name), '|')
+            ),
+            nqp::unbox_s(self.Str)
+          ),
+          ValueObjAt
+        )
+    }
+
     multi method ACCEPTS(DateTime:D: DateTime:D \topic) { self == topic }
 }
 


### PR DESCRIPTION
I don't see a reason why it shouldn't be.  Because the formatter is also part of the object, it uses the formatter's output as string in .WHICH.