### PR TITLE
Add exit-ok to Test module

### DIFF
--- a/lib/Test.rakumod
+++ b/lib/Test.rakumod
@@ -544,6 +544,23 @@ multi sub dies-ok(Callable $code, $reason = '') is export {
     $ok or ($die_on_fail and die-on-fail) or $ok;
 }
 
+multi sub exit-ok(
+        &code,
+  Int:D $exit = 0,
+  Str:D $desc = "Checking for exit($exit)"
+) is export {
+    my $got;
+    my $seen;
+    my &*EXIT = { $seen = True; $got = $_ }
+    $time_after = nqp::time;
+    code();
+    my $ok = $seen
+      ?? proclaim($got == $exit, "Was the exit code $exit?")
+      !! proclaim(False, "Code did not exit, no exit value to check");
+    $time_before = nqp::time;
+    $ok or ($die_on_fail and die-on-fail) or $ok;
+}
+
 multi sub lives-ok(Callable $code, $reason = '') is export {
     $time_after = nqp::time;
     try {


### PR DESCRIPTION
As promised in https://github.com/Raku/problem-solving/issues/492#issuecomment-3263735792 the "exit-ok" subroutine takes a Callable (which is expected to call exit() ), an integer value (0 by default), and an optional description.

If the code performs an "exit", then the value will be checked: it will be judged ok if the value matches, else it will be a nok.

If the code does not execute an "exit", then it will also be a nok.