### PR TITLE
Add Str.spurt method to 6.e

### DIFF
--- a/src/core.e/Fixups.rakumod
+++ b/src/core.e/Fixups.rakumod
@@ -404,6 +404,8 @@ augment class Str {
           $needle, $pos, :ignorecase($smartcase && $needle!lowercase-only), |%_
         )
     }
+
+    method spurt(Str:D: IO() $io) { $io.spurt(self) }
 }
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
To easily spurt the contents of a string to a file, with automatic coercing of the path to an IO::Path.

As suggested in https://www.nntp.perl.org/group/perl.perl6.users/2025/09/msg11499.html