### PR TITLE
RakuAST - Remove special handling of '$]'

### DIFF
--- a/src/Raku/Grammar.nqp
+++ b/src/Raku/Grammar.nqp
@@ -3690,11 +3690,6 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
         <.obsvar: '$?'>
     }
 
-    token special-variable:sym<$]> {
-        <.sym> {} <!before \w | '('>
-        <.obsvar: '$]'>
-    }
-
     regex special-variable:sym<${ }> {
         <sigil>
         '{'


### PR DESCRIPTION
This commit addresses R#5652 (#5652), which noted the following malfunction: using a state variable inside of a positional lookup, eg. `[++$]` caused a SORRY exception related to informing the user of differences between Perl and Raku.

So this commit is also a bit of an instigation to ask ourselves how badly we want these handrails to stay with us.

I don't necessarily think they should all be removed. But... ... it seems like we can safely eject them where doing so enables otherwise valid Raku to compile and run.