### PR TITLE
Don't allow a Range in an array shape specification

### DIFF
--- a/src/core.c/Array.rakumod
+++ b/src/core.c/Array.rakumod
@@ -1497,6 +1497,9 @@ my class Array { # declared in BOOTSTRAP
     multi method set-shape(Whatever) is raw {
         nqp::create(self.WHAT)
     }
+    multi method set-shape(Range:D $range) is raw {
+        die "Setting a shape with a Range not allowed: $range.raku()";
+    }
     multi method set-shape(\shape) is raw {
         self.set-shape(shape.List)
     }

--- a/src/core.c/native_array.rakumod
+++ b/src/core.c/native_array.rakumod
@@ -4815,6 +4815,9 @@ my class array is Cool does Iterable does Positional {
     multi method set-shape(Whatever) is raw {
         nqp::create(self.WHAT)
     }
+    multi method set-shape(Range:D $range) is raw {
+        die "Setting a shape with a Range not allowed: $range.raku()";
+    }
     multi method set-shape(\shape) is raw {
         self.set-shape(shape.List)
     }


### PR DESCRIPTION
Because it probably does *not* do what you think it does.

Before this, my @a[1..4] would create a 4-dimensional array, with dimensions 1,2,3,4.  Instead of defining a 1-dimensional array with indices 1 through 4.