### PR TITLE
Install improvements

### DIFF
--- a/tools/build/binary-release/assets/Linux/README.md
+++ b/tools/build/binary-release/assets/Linux/README.md
@@ -1,7 +1,7 @@
 Rakudo
 ======
 
-This is a pre-built package of Rakudo, a Raku compiler.
+Rakudo is a compiler and runtime for the Raku programming language.
 
 This package includes the Rakudo compiler and the module installer Zef.
 
@@ -9,12 +9,22 @@ This package includes the Rakudo compiler and the module installer Zef.
 Running Raku
 ============
 
+THERE IS MORE THAN ONE FOLDER YOU NEED TO ADD TO YOUR PATH!
+
+`raku` and it's associated programs are located in the `bin/` subfolder.
+Installed Raku scripts, including `zef`, are located in the
+`share/perl6/site/bin/` subfolder. So both need to be in your PATH.
+
 To run a Raku program, open a command prompt and type
 
-    /path/to/this/folder/bin/raku my_script.raku
+    raku my_script.raku
+
+To start an interactive Raku environment call `raku` without an argument
+
+    raku
 
 To add the relevant paths to your environment so you don't have to type the
-full path run the following script (don't forget the 'eval "$()"'):
+full path, run the following script (don't forget the 'eval "$()"'):
 
     eval "$(/path/to/this/folder/scripts/set-env.sh)"
 
@@ -27,26 +37,22 @@ following to `~/.bash_profile` or your equivalent:
 
     eval "$(/path/to/this/folder/scripts/set-env.sh --quiet)"
 
-To start an interactive Raku environment call `raku` without an argument
 
-    raku
-
-
-Installing modules
+Installing Modules
 ==================
 
 To install Raku modules you can use the Zef module installer.
 
-    raku /path/to/this/folder/share/perl6/site/bin/zef install JSON::Fast
+    zef install JSON::Fast
 
 Modules will be installed into this Raku package and will thus be available
 even when moving this package.
 
 
-Native code modules
+Native Code Modules
 -------------------
 
-To install modules that require a compiler toolchain, you have to have a
+To install modules that require a C compiler toolchain, you have to have a C
 compiler installed.
 
 - On Debian/Ubuntu based systems do `sudo apt-get install gcc make`
@@ -60,7 +66,7 @@ Recent changes and feature additions are documented in the `docs/ChangeLog`
 text file.
 
 
-Where to get help or answers to questions
+Where to Get Help or Answers to Questions
 =========================================
 
 There are several mailing lists, IRC channels, and wikis available with help
@@ -84,13 +90,13 @@ Questions about NQP can also be posted to the #raku IRC channel.
 For questions about MoarVM, you can join #moarvm on Libera.
 
 
-Reporting bugs
+Reporting Bugs
 ==============
 
 See https://rakudo.org/issue-trackers
 
 
-Submitting patches
+Submitting Patches
 ==================
 
 If you have a patch that fixes a bug or adds a new feature, please create a

--- a/tools/build/binary-release/assets/MacOS/README.md
+++ b/tools/build/binary-release/assets/MacOS/README.md
@@ -1,7 +1,7 @@
 Rakudo
 ======
 
-This is a pre-built package of Rakudo, a Raku compiler.
+Rakudo is a compiler and runtime for the Raku programming language.
 
 This package includes the Rakudo compiler and the module installer Zef.
 
@@ -9,12 +9,22 @@ This package includes the Rakudo compiler and the module installer Zef.
 Running Raku
 ============
 
+THERE IS MORE THAN ONE FOLDER YOU NEED TO ADD TO YOUR PATH!
+
+`raku` and it's associated programs are located in the `bin/` subfolder.
+Installed Raku scripts, including `zef`, are located in the
+`share/perl6/site/bin/` subfolder. So both need to be in your PATH.
+
 To run a Raku program, open a command prompt and type
 
-    /path/to/this/folder/bin/raku my_script.raku
+    raku my_script.raku
+
+To start an interactive Raku environment call `raku` without an argument
+
+    raku
 
 To add the relevant paths to your environment so you don't have to type the
-full path run the following script (don't forget the 'eval "$()"'):
+full path, run the following script (don't forget the 'eval "$()"'):
 
     eval "$(/path/to/this/folder/scripts/set-env.sh)"
 
@@ -27,26 +37,22 @@ following to `~/.bash_profile` or your equivalent:
 
     eval "$(/path/to/this/folder/scripts/set-env.sh --quiet)"
 
-To start an interactive Raku environment call `raku` without an argument
 
-    raku
-
-
-Installing modules
+Installing Modules
 ==================
 
 To install Raku modules you can use the Zef module installer.
 
-    raku /path/to/this/folder/share/perl6/site/bin/zef install JSON::Fast
+    zef install JSON::Fast
 
 Modules will be installed into this Raku package and will thus be available
 even when moving this package.
 
 
-Native code modules
+Native Code Modules
 -------------------
 
-To install modules that require a compiler toolchain, you have to have a
+To install modules that require a C compiler toolchain, you have to have a C
 compiler installed. You can do that by installing `XCode` from the App Store.
 
 
@@ -57,7 +63,7 @@ Recent changes and feature additions are documented in the `docs/ChangeLog`
 text file.
 
 
-Where to get help or answers to questions
+Where to Get Help or Answers to Questions
 =========================================
 
 There are several mailing lists, IRC channels, and wikis available with help
@@ -81,13 +87,13 @@ Questions about NQP can also be posted to the #raku IRC channel.
 For questions about MoarVM, you can join #moarvm on Libera.
 
 
-Reporting bugs
+Reporting Bugs
 ==============
 
 See https://rakudo.org/issue-trackers
 
 
-Submitting patches
+Submitting Patches
 ==================
 
 If you have a patch that fixes a bug or adds a new feature, please create a

--- a/tools/build/binary-release/assets/Windows/README.txt
+++ b/tools/build/binary-release/assets/Windows/README.txt
@@ -1,20 +1,43 @@
 Rakudo
 ======
 
-This is a pre-built package of Rakudo, a Raku compiler.
+Rakudo is a compiler and runtime for the Raku programming language.
 
 This package includes the Rakudo compiler and the module installer Zef.
 
+Contents
+========
 
-Running Raku
-============
+- Set-Env
+- Running Raku
+- Installing Modules
+    - Native Code Modules
+- PATH
+- Preventing Garbled Text Output
+- Non-Console Applications
+- Changes
+- Where to Get Help or Answers to Questions
+- Reporting Bugs
+- Submitting Patches
 
-To run a Raku program, open a command prompt and type
 
-    C:\path\to\this\folder\bin\raku.exe my_script.raku
+Set-Env
+=======
 
-To add the relevant paths to your environment so you don't have to type the
-full path execute the following script in CMD:
+This package provides a script to set up a terminal window to work nicely with
+Raku. It
+
+- sets up the PATH variable to contain BOTH paths necessary to directly call
+  `raku` and Raku scripts such as `zef`,
+- searches for a C build toolchain and if found activates it, so installing
+  modules which compile some C code works and
+- changes the codepage to UTF-8 so input and output of unicode characters
+  doesn't break.
+
+See the following sections for a deeper explanation why all of this is
+necessary and how to do it manually.
+
+To run `set-env` execute the following in CMD:
 
     C:\path\to\this\folder\scripts\set-env.bat
 
@@ -22,23 +45,32 @@ or when using Powershell (note the dot at the beginning):
 
     . C:\path\to\this\folder\scripts\set-env.ps1
 
-To start an interactive Raku environment call `raku` without an argument
+
+Running Raku
+============
+
+Once your terminal is set up you can start an interactive Raku environment by
+typing
 
     raku.exe
 
+To run a Raku script type
 
-Installing modules
+    raku.exe my_script.raku
+
+
+Installing Modules
 ==================
 
 To install Raku modules you can use the Zef module installer.
 
-    raku.exe C:\path\to\this\folder\share\perl6\site\bin\zef install JSON::Fast
+    zef install JSON::Fast
 
 Modules will be installed into this Raku package and will thus be available
 even when moving this package.
 
 
-Native code modules
+Native Code Modules
 -------------------
 
 To install modules that require a compiler toolchain, you need to have the
@@ -50,25 +82,91 @@ Microsoft BuildTools contain that compiler. You can use the installer script
 to guide you through the installation.
 
 Alternatively you can install the BuildTools manually. They can be downloaded
-[here](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=BuildTools).
+[here](https://aka.ms/vs/stable/vs_BuildTools.exe).
 You'll need to select the `C++ build tools` and recommended components.
 
 The compiler is only usable in a special Build Tools CMD / PowerShell window.
+Once the BuildTools  are installed you should see new entries in the start
+menu:
 
-To make use of the Build Tools in Rakudo using CMD:
-- start a CMD window using
-    Start Menu -> Visual Studio 2019 ->
-    x86 / x64 Native Tools Command Prompt for VS 2019
-- Execute `C:\path\to\this\folder\scripts\set-env.bat`
+Start Menu -> Visual Studio 20XX -> x64 Native Tools Command Prompt for VS
 
-To make use of the Build Tools in Rakudo using PowerShell:
-- start a PowerShell window using
-    Start Menu -> Visual Studio 2019 -> Developer PowerShell for VS 2019
-- Execute `C:\path\to\this\folder\scripts\set-env.ps1`
+The `set-env` script automatically sets up the terminal for BuildTools as well.
 
 
-Non-console applications
-------------------------
+PATH
+====
+
+THERE IS MORE THAN ONE FOLDER YOU NEED TO ADD TO YOUR PATH!
+
+`raku` and it's associated programs are located in the `bin\` subfolder.
+Installed Raku scripts, including `zef`, are located in the
+`share\perl6\site\bin\` subfolder. So both need to be in your PATH.
+
+
+Preventing Garbled Text Output
+==============================
+
+<boring-but-important>
+
+First a bit of background. Windows supports two types of text encoding that
+applications can choose from.
+
+The ancient `Codepage based` approach - texts are made up of 8-bit bytes. The
+configured codepage determines how to decode those bytes. Different languages
+bring their own codepages with the characters they need.
+
+Later came the newer `Unicode based` approach - texts are made up of 16-bit
+shorts, no codepages are necessary anymore as the characters of most languages
+fit into those 16 bits. The approach is still a bit limited as a lot more, but
+not all unicode characters fit into those 16 bits. For that and many other
+reasons, UTF-8 came to be. That's an 8-bit based encoding where characters can,
+but don't need to use more than one byte. Most modern applications use UTF-8.
+On Windows UTF-8 based applications are once again codepage based, but use a
+special Codepage - 65001 - that represents UTF-8.
+
+The default codepage is sadly not 65001, but some other codepage depending on
+the language of Windows. This is so as to not break compatibility with ancient
+applications using that other codepage.
+
+When using a UTF-8 application with a wrong codepage, the text output you see
+is garbled. Raku is such a UTF-8 application. Thus when using Raku in a console
+window with a non-UTF-8 codepage input and output of Unicode characters will
+break.
+
+</boring-but-important>
+
+So how to solve this?
+
+In a CMD window execute `chcp 65001` to set the codepage. You have to execute
+this every time you open a new CMD window.
+
+In a Powershell window execute
+
+    $OutputEncoding = [console]::InputEncoding = [console]::OutputEncoding = New-Object System.Text.UTF8Encoding
+
+to set the codepage. Once again you have to do this every time you open a new
+window. To do that automatically, add the above line to your Powershell profile.
+
+It's also possible to configure the UTF-8 codepage globally in Windows, but that's
+a beta feature and breaks backward compatibility with a few legacy command line
+applications. In the Windows System Settings navigate here:
+
+Settings
+  --> Time & language
+  --> Language & region
+  --> Administrative language settings
+  --> Change system locale
+
+Then check `Beta: Use Unicode UTF-8 for worldwide language support` and restart
+the computer.
+
+Last but not least, the `set-env.ps1` and `set-env.bat` scripts perform the
+respective commands automatically.
+
+
+Non-Console Applications
+========================
 
 On Windows programs are compiled to either be _console_ applications or
 _non-console_ applications. _Console_ applications always open a console
@@ -103,7 +201,7 @@ Recent changes and feature additions are documented in the `docs/ChangeLog`
 text file.
 
 
-Where to get help or answers to questions
+Where to Get Help or Answers to Questions
 =========================================
 
 There are several mailing lists, IRC channels, and wikis available with help
@@ -127,13 +225,13 @@ Questions about NQP can also be posted to the #raku IRC channel.
 For questions about MoarVM, you can join #moarvm on Libera.
 
 
-Reporting bugs
+Reporting Bugs
 ==============
 
 See https://rakudo.org/issue-trackers
 
 
-Submitting patches
+Submitting Patches
 ==================
 
 If you have a patch that fixes a bug or adds a new feature, please create a

--- a/tools/build/binary-release/assets/Windows/scripts/set-env-cmd-helper.ps1
+++ b/tools/build/binary-release/assets/Windows/scripts/set-env-cmd-helper.ps1
@@ -6,7 +6,7 @@ function activate_buildtools() {
     $cmds += "ECHO                  =========================================`n"
     $cmds += "ECHO.`n"
 
-    $cims = Get-CimInstance MSFT_VSInstance
+    $cims = Get-CimInstance MSFT_VSInstance -Namespace root/cimv2/vs
     $chosen_cim = $null
     foreach ($cim in $cims) {
         $install_location = $cim.InstallLocation
@@ -32,7 +32,7 @@ function activate_buildtools() {
 
     $setup = Get-ChildItem -Path $install_location -Filter VsDevCmd.bat -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1
     if (-Not $setup) {
-        $cmds += "ECHO The PowerShell setup module wasn't found.`n"
+        $cmds += "ECHO The CMD setup module wasn't found.`n"
         return
     }
     $setup = $setup.FullName
@@ -78,11 +78,23 @@ function add_to_path() {
     else {
         $cmds += "ECHO Paths already set. Nothing to do.`n"
     }
+    $cmds += "ECHO.`n"
+    return $cmds
+}
+
+
+function enable_utf8() {
+    $cmds += "ECHO                              Enabling UTF-8`n"
+    $cmds += "ECHO                             ================`n"
+    $cmds += "ECHO.`n"
+    $cmds += "chcp 65001`n"
+    $cmds += "ECHO Done.`n"
     return $cmds
 }
 
 $cmds += activate_buildtools
 $cmds += add_to_path
+$cmds += enable_utf8
 $cmds += @'
 ECHO.
 ECHO ================================================================================

--- a/tools/build/binary-release/assets/Windows/scripts/set-env.ps1
+++ b/tools/build/binary-release/assets/Windows/scripts/set-env.ps1
@@ -5,7 +5,7 @@ function activate_buildtools() {
     Write-Host "                 ========================================="
     Write-Host ""
 
-    $cims = Get-CimInstance MSFT_VSInstance
+    $cims = Get-CimInstance MSFT_VSInstance -Namespace root/cimv2/vs
     $chosen_cim = $null
     foreach ($cim in $cims) {
         $install_location = $cim.InstallLocation
@@ -76,9 +76,18 @@ function add_to_path() {
     }
 }
 
+function enable_utf8() {
+    Write-Host "                              Enabling UTF-8"
+    Write-Host "                             ================"
+    Write-Host ""
+    $OutputEncoding = [console]::InputEncoding = [console]::OutputEncoding = New-Object System.Text.UTF8Encoding
+    Write-Host "Done."
+}
+
 
 activate_buildtools
 add_to_path
+enable_utf8
 
 Write-Host @'
 

--- a/tools/build/binary-release/assets/Windows/scripts/vs_build_tools_install_assistant.ps1
+++ b/tools/build/binary-release/assets/Windows/scripts/vs_build_tools_install_assistant.ps1
@@ -1,4 +1,4 @@
-$url = "https://download.visualstudio.microsoft.com/download/pr/02aebac1-9464-4473-9af5-710a97b8f023/92c237448ec5563948a83f2f9e01d3050755a15eb473c9e7ffefd735bf7474f1/vs_BuildTools.exe"
+$url = "https://aka.ms/vs/stable/vs_BuildTools.exe"
 
 $scriptPath = split-path -parent $MyInvocation.MyCommand.Definition
 
@@ -16,8 +16,7 @@ function download {
 }
 
 function runInstaller($installer) {
-    Start-Process -Wait -FilePath $installer -ArgumentList "--norestart --wait --includeRecommended --add Microsoft.VisualStudio.Workload.VCTools"
-    #--quiet --installPath="C:\raku_vs_buildtools"
+    Start-Process -Wait -FilePath $installer -ArgumentList "--norestart --passive --wait --includeRecommended --add Microsoft.VisualStudio.Workload.VCTools"
 }
 
 function getInput($prompt) {
@@ -27,11 +26,11 @@ function getInput($prompt) {
 
 Write-Host @"
 ================================================================================
-Welcome to Rakudos Visual Studio Build Tools 2019 installation assistant.
+Welcome to Rakudos Visual Studio Build Tools installation assistant.
 The installation
-- needs approximately 4.5 GB of disk space
-- downloads ~1.2 GB of data
-- might take 30 minutes or longer with a 10 MBit/s connection
+- needs approximately 9 GB of disk space
+- downloads ~2.2 GB of data
+- might take 10 minutes or longer with a 50 MBit/s connection
 ================================================================================
 
 "@
@@ -42,7 +41,7 @@ if (($response -ne '') -and ($response -ne 'y') -and ($response -ne 'Y')) {
     exit
 }
 
-Write-Host -NoNewline "Downloading the installer stub (1.3 MB) ... "
+Write-Host -NoNewline "Downloading the installer stub (4.2 MB) ... "
 $installer = download
 
 Write-Host @"
@@ -50,10 +49,8 @@ done
 
 ================================================================================
 We are about to start the graphical installer. After some dialogs, downloading
-the actuall installer and more dialogs you will be presented with a component
-selection interface. The required components will already be selected. Just
-click the "Install" button on the bottom right. You are free to select
-additional components or change the installation location.
+the real installer and more dialogs the actual download and installation will
+start. Just be patient.
 ================================================================================
 
 "@
@@ -68,16 +65,10 @@ Write-Host @"
 
 ================================================================================
 Installation finished.
-To make use of the Build Tools in Rakudo using CMD:
-- start a CMD window using
-    Start Menu -> Visual Studio 2019 ->
-    x86 / x64 Native Tools Command Prompt for VS 2019
-- Execute $scriptPath\set-env.bat
 
-To make use of the Build Tools in Rakudo using PowerShell:
-- start a PowerShell window using
-    Start Menu -> Visual Studio 2019 -> Developer PowerShell for VS 2019
-- Execute $scriptPath\set-env.ps1
+To make use of the Build Tools in Rakudo execute $scriptPath\set-env.bat / ps1
+in a CMD / Powershell window or if you used the MSI installer use the start
+menu entries `Rakudo -> Rakudo CMD` / `Rakudo -> Rakudo Powershell`.
 ================================================================================
 
 "@

--- a/tools/build/binary-release/msi/assets/README.txt
+++ b/tools/build/binary-release/msi/assets/README.txt
@@ -3,8 +3,7 @@ Rakudo
 
 Rakudo is a compiler and runtime for the Raku programming language.
 
-This package includes the Rakudo compiler and runtime itself and the Zef module
-installer.
+This package includes the Rakudo compiler and the module installer Zef.
 
 
 The Start Menu Shortcuts
@@ -13,11 +12,13 @@ The Start Menu Shortcuts
 You'll find the following Shortcuts in the Start Menu `Rakudo` folder
 
 - Rakudo enabled PowerShell and CMD consoles
-    These consoles have the Rakudo executables folders added to the PATH so you
-    can directly use the `raku.exe`, `rakuw.exe` and `zef.bat` commands. If you
-    chose to modify your path during installation, these shortcuts do nothing
-    special, as all PowerShell and CMD consoles will have the respective folders
-    in their PATH already.
+    These consoles
+    - set up the PATH variable to contain BOTH paths necessary to directly call
+      `raku` and Raku scripts such as `zef`,
+    - search for a C build toolchain and if found activate it, so installing
+      modules which compile some C code works and
+    - change the codepage to UTF-8 so input and output of unicode characters
+      doesn't break.
 - Rakudo REPL
     Short for `Read Eval Print Loop`. A Rakudo interactive command interpreter.
     Useful for easily experimenting with Raku.
@@ -34,10 +35,9 @@ You'll find the following Shortcuts in the Start Menu `Rakudo` folder
 Running Raku
 ============
 
-If you chose to set the PATH variable during install or use one of the Rakudo
-enabled PowerShell or CMD shortcuts you can directly use the `raku.exe` and
-`rakuw.exe` commands. Otherwise you need to type the full path of the respective
-executable.
+If you chose to set the PATH variable during install or use the
+`Rakudo Powershell` or `Rakudo CMD` start menu entries you can directly use the
+`raku.exe` and `rakuw.exe` commands.
 
 To run a Raku program, open a command prompt and type
 
@@ -53,7 +53,7 @@ Installing modules
 
 To install Raku modules you can use the Zef module installer.
 
-    raku.exe C:\path\to\this\folder\share\perl6\site\bin\zef install JSON::Fast
+    zef install JSON::Fast
 
 Modules will be installed into this Raku package and will thus be available even
 when moving this package.
@@ -64,28 +64,15 @@ Native code modules
 
 To install modules that require a compiler toolchain, you need to have the
 Microsoft Visual C compiler installed. The freely available
-Microsoft BuildTools contain that compiler. You can use the installer script
-
-    C:\path\to\this\folder\scripts\vs_build_tools_install_assistant.ps1
-
-to guide you through the installation.
+Microsoft BuildTools contain that compiler. There is a start menu entry to
+start a CLI based wizard to guide you through the installation.
 
 Alternatively you can install the BuildTools manually. They can be downloaded
 [here](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=BuildTools).
 You'll need to select the `C++ build tools` and recommended components.
 
 The compiler is only usable in a special Build Tools CMD / PowerShell window.
-
-To make use of the Build Tools in Rakudo using CMD:
-- start a CMD window using
-    Start Menu -> Visual Studio 2019 ->
-    x86 / x64 Native Tools Command Prompt for VS 2019
-- Execute `C:\path\to\this\folder\scripts\set-env.bat`
-
-To make use of the Build Tools in Rakudo using PowerShell:
-- start a PowerShell window using
-    Start Menu -> Visual Studio 2019 -> Developer PowerShell for VS 2019
-- Execute `C:\path\to\this\folder\scripts\set-env.ps1`
+The start menu entries `Rakudo Powershell` and `Rakudo CMD` provide for this.
 
 
 Non-console applications
@@ -179,7 +166,7 @@ for more information.
 License
 =======
 
-Rakudo is Copyright © 2008-2022, The Perl Foundation. Rakudo is distributed
+Rakudo is Copyright © 2008-2025, The Raku Foundation. Rakudo is distributed
 under the terms of the Artistic License 2.0. For more details, see the full
 text of the license in the file LICENSE.
 

--- a/tools/build/binary-release/msi/assets/scripts/rakudo_repl.ps1
+++ b/tools/build/binary-release/msi/assets/scripts/rakudo_repl.ps1
@@ -1,0 +1,4 @@
+$OutputEncoding = [console]::InputEncoding = [console]::OutputEncoding = New-Object System.Text.UTF8Encoding
+$script_path = split-path -parent $MyInvocation.MyCommand.Definition
+$bin_path = (Resolve-Path "$script_path\..\bin").Path
+&"$bin_path\raku.exe"

--- a/tools/build/binary-release/msi/build-msi.ps1
+++ b/tools/build/binary-release/msi/build-msi.ps1
@@ -11,12 +11,13 @@ $work_rakudo_release_dir = "$work_dir\rakudo_release_files"
 Remove-Item -ErrorAction Ignore -Recurse $work_rakudo_release_dir
 Copy-Item -Path $rakudo_release_dir -Destination $work_rakudo_release_dir –Recurse
 Remove-Item "$work_rakudo_release_dir\README.txt"
+Copy-Item -Path "$asset_dir\*" -Exclude "scripts" -Destination $work_rakudo_release_dir
+Copy-Item -Path "$asset_dir\scripts\*" -Destination "$work_rakudo_release_dir\scripts"
 
 &"$wix_dir\heat.exe" dir $work_rakudo_release_dir -dr RAKUDO_BIN_DIR_REFS -cg FileComponents -gg -g1 -sfrag -srd -suid -ke -sw5150 -var "var.RAKUDO_BIN_FILES_DIR" -out "$work_dir\rakudo_bin_files.wxs"
-&"$wix_dir\heat.exe" dir $asset_dir -dr ASSET_DIR_REFS -cg AssetComponents -gg -g1 -sfrag -srd -suid -ke -sw5150 -var "var.ASSET_FILES_DIR" -out "$work_dir\asset_files.wxs"
 &"$wix_dir\candle.exe" "$work_dir\rakudo_bin_files.wxs" -arch x64 -dRAKUDO_BIN_FILES_DIR="$work_rakudo_release_dir" -out "$work_dir\rakudo_bin_files.wxsobj"
 &"$wix_dir\candle.exe" "$work_dir\asset_files.wxs" -arch x64 -dASSET_FILES_DIR="$asset_dir" -out "$work_dir\asset_files.wxsobj"
 
 &"$wix_dir\candle.exe" "$msi_dir\rakudo.wxs" -ext WixUtilExtension -dVERSION="$rakudo_version" -dASSET_FILE_DIR="$asset_dir" -dINSTALLER_ASSET_FILE_DIR="$installer_asset_dir" -out "$work_dir\rakudo.wxsobj"
 
-&"$wix_dir\light.exe" -ext WixUIExtension -ext WixUtilExtension "$work_dir\rakudo_bin_files.wxsobj" "$work_dir\asset_files.wxsobj" "$work_dir\rakudo.wxsobj" -sw1076 -o $out_file
+&"$wix_dir\light.exe" -ext WixUIExtension -ext WixUtilExtension "$work_dir\rakudo_bin_files.wxsobj" "$work_dir\rakudo.wxsobj" -sw1076 -o $out_file

--- a/tools/build/binary-release/msi/installer-assets/License.rtf
+++ b/tools/build/binary-release/msi/installer-assets/License.rtf
@@ -2,7 +2,7 @@
 {\*\generator Riched20 10.0.18362}\viewkind4\uc1 
 \pard\sa200\sl276\slmult1\qc\b\f0\fs22\lang9 Artistic License 2.0\b0\par
 
-\pard\sa200\sl276\slmult1 Copyright (c) 2000-2006, The Perl Foundation.\par
+\pard\sa200\sl276\slmult1 Copyright (c) 2000-2025, The Perl Foundation.\par
 Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.\par
 \b Preamble\b0\par
 This license establishes the terms under which a given free software Package may be copied, modified, distributed, and/or redistributed. The intent is that the Copyright Holder maintains some artistic control over the development of that Package while still keeping the Package available as open source and free software.\par

--- a/tools/build/binary-release/msi/rakudo.wxs
+++ b/tools/build/binary-release/msi/rakudo.wxs
@@ -167,7 +167,8 @@ xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
                 <Shortcut Id="REPLShortcut"
                         Name="Rakudo REPL"
                         Description="The Rakudo REPL"
-                        Target="[INSTALLDIR]bin\raku"
+                        Target="[POWERSHELLEXE]"
+                        Arguments='-File "[INSTALLDIR]scripts\rakudo_repl.ps1"'
                         WorkingDirectory="INSTALLDIR"
                         Icon="RakudoIcon" />
                 <Shortcut Id="READMEShortcut"
@@ -203,7 +204,6 @@ xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
         <!--Features-->
         <Feature Id="ProductFeature" Level="1" Title="Rakudo $(var.VERSION)">
             <ComponentGroupRef Id="FileComponents" />
-            <ComponentGroupRef Id="AssetComponents" />
             
             <ComponentRef Id="RakudoShortcuts" />
             <ComponentRef Id="RakudoPath" />


### PR DESCRIPTION
- Tell users they might need to do a reboot post install
- Reword the READMEs
- Improve the `set-env` scripts to also change the shell to UTF-8
- Explain the Windows unicode mess in the README
- Update the BuildTools installer wizard to the latest BuildTools version
  and make it fully automated