### PR TITLE
In methods of `Cool` that call methods of `Str`, coerce `Cool` parameters to the adequate types

### DIFF
--- a/src/core.c/Cool.rakumod
+++ b/src/core.c/Cool.rakumod
@@ -125,17 +125,17 @@ my class Cool { # declared in BOOTSTRAP
 
     proto method samecase($, *%) {*}
     multi method samecase(Cool:D: Cool:D $pattern) {
-        self.Str.samecase($pattern)
+        self.Str.samecase($pattern.Str)
     }
 
     proto method samemark($, *%) {*}
     multi method samemark(Cool:D: Cool:D $pattern) {
-        self.Str.samemark($pattern)
+        self.Str.samemark($pattern.Str)
     }
 
     proto method samespace($, *%) is implementation-detail {*}
     multi method samespace(Cool:D: Cool:D $pattern) {
-        self.Str.samespace($pattern)
+        self.Str.samespace($pattern.Str)
     }
 
     proto method starts-with(|) {*}


### PR DESCRIPTION
(This builds on what got introduced with PR [3524](https://github.com/rakudo/rakudo/pull/3524).)

In [Line 228](https://github.com/rakudo/rakudo/blob/211197cbc824f516c1ab53a7db8b85360b4ca890/src/core.c/Cool.rakumod#L228) of src/core.c/Cool.rakumod , coerce the `Cool $pos` to `Int` when passing it to `Str.contains()`.

This needs to be done because `Str.contains()` [requires](https://github.com/rakudo/rakudo/blob/211197cbc824f516c1ab53a7db8b85360b4ca890/src/core.c/Str.rakumod#L423C1-L423C75) the second positional to be an Int. So one needs to convert the `Cool $pos` to Int, just like it is already being done in the three multis of `Cool.contains()` right above. This should fix the fact that Rakudo freezes when calling `.contains()` with a Regex for `$needle` and a non-Int Cool for `$pos`, e.g.:
```
	12345.contains(/5/, "1")
```
and it probably also fixes the same issue for the case when the invocant is already a String:
```
	"abc".contains(/c/, "1")
```

------

Edit: There are three more methods of `Cool` that accept another `Cool` parameter, and which then pass this parameter—without first casting it to `Str`—to a method of `Str` that only accepts a `Str` parameter in this position. Namely: samecase, samemark and samespace from [src/core.c/Cool.rakumod](https://github.com/rakudo/rakudo/blob/211197cbc824f516c1ab53a7db8b85360b4ca890/src/core.c/Cool.rakumod#L126-L139)

    multi method samecase(Cool:D: Cool:D $pattern) {
        self.Str.samecase($pattern)
    }

    multi method samemark(Cool:D: Cool:D $pattern) {
        self.Str.samemark($pattern)
    }

    multi method samespace(Cool:D: Cool:D $pattern) {
        self.Str.samespace($pattern)
    }

As you can see, they call corresponding multis of Str ([defined in src/core.c/Str.rakumod](https://github.com/rakudo/rakudo/blob/211197cbc824f516c1ab53a7db8b85360b4ca890/src/core.c/Str.rakumod#L2632-L2833)), and these all require `$pattern` to be of type `Str:D`. Thus, I've changed these calls to `self.Str.samecase($pattern.Str)` etc. in the second commit. (Compare how other methods of `Cool` that accept another `Cool` parameter (named $pat, $needle or $suffix) also coerce these parameters to `Str` before passing them on to the corresponding methods on `self.Str`.)

With these changes, the `multi sub samemark`, defined at the [very bottom](https://github.com/rakudo/rakudo/blob/211197cbc824f516c1ab53a7db8b85360b4ca890/src/core.c/Str.rakumod#L4186) of the file src/core.c/Cool, should likewise work correctly with calls like `samemark('aeiou', <ä e i ö ü>)`, which so far lead to freezing.