### PR TITLE
Add an istype check on the role group

### DIFF
--- a/src/Perl6/Metamodel/ParametricRoleHOW.nqp
+++ b/src/Perl6/Metamodel/ParametricRoleHOW.nqp
@@ -119,7 +119,8 @@ class Perl6::Metamodel::ParametricRoleHOW
         $checkee := nqp::decont($checkee);
 
         nqp::eqaddr($checkee, $target.WHAT)
-          || ($!in_group && nqp::eqaddr($checkee, $!group))
+          # checking whether the $!group is of the type $checkee allows for inline definitions of transitive roles
+          || ($!in_group && nqp::istype($!group, $checkee))  # this will do an nqp::eqaddr($!group, $checkee) check
           || self.checkee_eqaddr_list($checkee, self.pretending_to_be)
           || self.checkee_istype_list($checkee, self.roles_to_compose)
           || self.type_check_parents($target, $checkee)


### PR DESCRIPTION
This addresses R#5317, which had the following test case:

    role R {}
    role S does R {}
    my R $v = role V does S {}

This was golfed to:

    role R {}; role S does R {}; nqp::istype(role V does S {}, R)
    # 0
    # ... but
    nqp::istype(U does S {}.HOW.compose(U), R)
    # 1

When looking into it further, this call to `ParametericRoleHOW.compose` produces a `ParametricRoleGroupHOW`.

I started out by messing around with `RakuAST::Role.PRODUCE-META-OBJECT` but that was a dead end because `ParametricRoleHOW.compose` *always* "failed" to produce a `ParametricRoleGroupHOW` (which is what it does when running the code above).

Then I found the `ParametricRoleHOW.type_check` method and gave the most literal translation of what works in user code back into NQP terms, adding `nqp::istype($!group, $checkee)` to the existing group-related check.