### PR TITLE
RakuAST: Default unnamed packages to `anon` scope instead of `our`

### DIFF
--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -2492,13 +2492,15 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
           !! $/.panic("Cannot resolve meta-object for $declarator");
 
         # Stub the package AST node.
-        my str $scope := $*SCOPE // 'our';
+
+        my $name-match := $*PACKAGE-NAME;
+        my $name       := $name-match ?? $name-match.ast !! Nodify('Name');
+
+        my str $scope := $*SCOPE || ($name-match eq '::' ?? 'anon' !! 'our');
         my $augmented := $scope eq 'augment';
         $/.typed-panic('X::Syntax::Augment::WithoutMonkeyTyping')
           if $augmented && !$*LANG.pragma('MONKEY-TYPING');
 
-        my $name-match := $*PACKAGE-NAME;
-        my $name       := $name-match ?? $name-match.ast !! Nodify('Name');
         my %special := nqp::hash(
             'package', 'Package',
             'role', 'Role',

--- a/src/Raku/ast/package.rakumod
+++ b/src/Raku/ast/package.rakumod
@@ -72,7 +72,7 @@ class RakuAST::Package
     method dba()         { "package"             }
     method default-how() { Metamodel::PackageHOW }
 
-    method allowed-scopes() { self.IMPL-WRAP-LIST(['augment', 'my', 'our', 'unit']) }
+    method allowed-scopes() { self.IMPL-WRAP-LIST(['anon', 'augment', 'my', 'our', 'unit']) }
     method default-scope()       { 'our' }
     method can-have-methods()    { False }
     method can-have-attributes() { False }


### PR DESCRIPTION
This fixes the error

    Cannot declare our-scoped role inside of a role
    (the scope inside of a role is generic, so there is no unambiguous
    package to install the symbol in)

that showed up when using anonymous roles.

This is probably the wrong fix, as the scope should be `anon` instead of `my` in such cases. But that gives another error:

    Cannot use 'anon' with role declaration

