### PR TITLE
Add infix + - / * candidates for mixed int / num

### DIFF
--- a/src/core.c/Num.rakumod
+++ b/src/core.c/Num.rakumod
@@ -384,7 +384,7 @@ multi sub infix:</>(num $a, int $b) {
     nqp::iseq_i($b,0) ?? $a.divzero !! nqp::div_n($a, $b)
 }
 multi sub infix:</>(int $a, num $b) {
-    nqp::iseq_n($b,0) ?? $a.divzero !! nqp::div_n($a, $b)
+    nqp::iseq_n($b,0e0) ?? nqp::coerce_in($a).divzero !! nqp::div_n($a, $b)
 }
 
 multi sub infix:<%>(Num:D $a, Num:D $b) {
@@ -394,10 +394,10 @@ multi sub infix:<%>(num $a, num $b) {
     nqp::iseq_n($b,0e0) ?? $a.divzero !! nqp::mod_n($a,$b)
 }
 multi sub infix:<%>(num $a, int $b) {
-    nqp::iseq_i($b,0e0) ?? $a.divzero !! nqp::mod_n($a,$b)
+    nqp::iseq_i($b,0) ?? $a.divzero !! nqp::mod_n($a,$b)
 }
 multi sub infix:<%>(int $a, num $b) {
-    nqp::iseq_n($b,0e0) ?? $a.divzero !! nqp::mod_n($a,$b)
+    nqp::iseq_n($b,0e0) ?? nqp::coerce_in($a).divzero !! nqp::mod_n($a,$b)
 }
 
 # (If we get 0 here, must be underflow, since floating overflow provides Inf.)


### PR DESCRIPTION
Inspired by the benchmark mentioned at
  https://irclogs.raku.org/raku/2025-12-11.html#22:53

When using native int and num in an expression with these infixes, both the natives where being upgraded, which makes it a *lot* slower.

Since the underlying nqp::xxx_n() ops accept native ints (these probably get a nqp::coerce_in inserted at MAST time, I guess), the only thing needed was to add candidates for the mixed cases (assuming the fact that a native "num" was used being enough infectuous to have a native num returned, instead of a Rat).

Makes these infix operations, such as:

  my int $b = 42;
  my num $a = 1e0;
  my num $c = $a * $b for ^10000000;
  say now - INIT now;

between 4x and 7x as fast.