### PR TITLE
MSI: Use $(var.VERSION) For Product Version Instead Of Hardcoded "1.0.0"

### DIFF
--- a/tools/build/binary-release/msi/rakudo.wxs
+++ b/tools/build/binary-release/msi/rakudo.wxs
@@ -6,7 +6,7 @@ xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
             Manufacturer="The Raku Community"
             Name="Rakudo $(var.VERSION)"
             UpgradeCode="08B7EB05-7EAC-4B60-9F5B-AF6E367FE0FD"
-            Version="1.0.0">
+            Version="$(var.VERSION)">
 
         <Package Compressed="yes"
                 InstallerVersion="400"


### PR DESCRIPTION
MSI: Use $(var.VERSION) For Product Version Instead Of Hardcoded "1.0.0"

Update tools/build/binary-release/msi/rakudo.wxs to use $(var.VERSION) for the MSI Product Version instead of the hardcoded "1.0.0". This resolves WinGet manifest validation errors (Manifest-AppsAndFeaturesVersion-Error) caused by successive installers reporting the same version. Relates to #6063.

- Replace Version="1.0.0" with Version="$(var.VERSION)"
- Ensure MSI ProductVersion matches Rakudo release
- Prevent WinGet pipeline rejection due to duplicate versions