### PR TITLE
Add :end named argument to .split with limit

### DIFF
--- a/src/core.c/Str.rakumod
+++ b/src/core.c/Str.rakumod
@@ -2090,6 +2090,30 @@ my class Str does Stringy { # declared in BOOTSTRAP
 #-------------------------------------------------------------------------------
 # .split and associated logic
 
+    multi method split(Str:D: Regex:D $needle, $limit, :$end! --> Seq:D) {
+        self!split-enz($needle, $limit, $end)
+    }
+
+    multi method split(Str:D: Str() $needle, $limit, :$end! --> Seq:D) {
+        self!split-enz($needle, $limit, $end)
+    }
+
+    method !split-enz($needle, $limit, $end) {
+        if !$end || nqp::istype($limit,Whatever) || $limit == Inf {
+            self.split($needle, |%_)
+        }
+        else {
+            my $steps = $limit - 1;
+            my @parts = self.split($needle, |%_, :v);
+            my @result;
+            while @parts > 1 && $steps-- {
+                @result.unshift(@parts.pop);
+                @parts.pop;
+            }
+            (@parts.join, |@result).Seq
+        }
+    }
+
     multi method split(Str:D: Regex:D $regex, $limit = Whatever;;
       :$v , :$k, :$kv, :$p, :$skip-empty --> Seq:D) {
 

--- a/src/core.c/Str.rakumod
+++ b/src/core.c/Str.rakumod
@@ -2094,7 +2094,7 @@ my class Str does Stringy { # declared in BOOTSTRAP
         self!split-enz($needle, $limit, $end)
     }
 
-    multi method split(Str:D: Str() $needle, $limit, :$end! --> Seq:D) {
+    multi method split(Str:D: Str(Cool) $needle, $limit, :$end! --> Seq:D) {
         self!split-enz($needle, $limit, $end)
     }
 

--- a/src/core.c/Str.rakumod
+++ b/src/core.c/Str.rakumod
@@ -2103,8 +2103,8 @@ my class Str does Stringy { # declared in BOOTSTRAP
             self.split($needle, |%_)
         }
         else {
-            my $steps = $limit - 1;
-            my @parts = self.split($needle, |%_, :v);
+            my int $steps = $limit - 1;
+            my     @parts = self.split($needle, |%_, :v);
             my @result;
             while @parts > 1 && $steps-- {
                 @result.unshift(@parts.pop);


### PR DESCRIPTION
As discussed at
  https://irclogs.raku.org/raku/2026-02-11.html#18:33-0001

The implementation is really just a post-processing wrapper around the basic implementation.  For some reason it also needed two multi candidates, because otherwise the :end! candidates wouldn't get selected.