### PR TITLE
Avoid clashes with user-provided type captures

### DIFF
--- a/lib/NativeCall/Types.rakumod
+++ b/lib/NativeCall/Types.rakumod
@@ -125,20 +125,20 @@ our class Pointer is repr<CPointer> {
     multi method raku(::?CLASS:U:) { self.^name                            }
     multi method raku(::?CLASS:D:) { self.^name ~ '.new(' ~ self.Int ~ ')' }
 
-    my role TypedPointer[::TValue] {
-        method of() { TValue }
+    my role TypedPointer[::CORE'NativeCall'TypedPointer'TValue] {
+        method of() { CORE'NativeCall'TypedPointer'TValue }
 
         method deref(::?CLASS:D \ptr:) {
             self
-              ?? nativecast(TValue, ptr)
+              ?? nativecast(CORE'NativeCall'TypedPointer'TValue, ptr)
               !! "Can't dereference a Null Pointer".Failure
         }
 
         method add(::?CLASS:D: Int:D $off --> Pointer:D) {
-            TValue.isa(void)
+            CORE'NativeCall'TypedPointer'TValue.isa(void)
               ?? die("Can't do arithmetic with a void pointer")
               !! nqp::box_i(
-                   self.Int + nqp::nativecallsizeof(TValue) * $off,
+                   self.Int + nqp::nativecallsizeof(CORE'NativeCall'TypedPointer'TValue) * $off,
                    self.WHAT
                  )
         }
@@ -147,10 +147,10 @@ our class Pointer is repr<CPointer> {
 
         method AT-POS(::?CLASS:D: Int:D $pos) {
             nqp::nativecallcast(
-              TValue,
-              nqp::decont(map_return_type(TValue)),
+              CORE'NativeCall'TypedPointer'TValue,
+              nqp::decont(map_return_type(CORE'NativeCall'TypedPointer'TValue)),
               nqp::box_i(
-                nqp::unbox_i(self) + nqp::nativecallsizeof(TValue) * $pos,
+                nqp::unbox_i(self) + nqp::nativecallsizeof(CORE'NativeCall'TypedPointer'TValue) * $pos,
                 Pointer
               )
             )
@@ -185,9 +185,9 @@ our class CArray is repr('CArray') is array_type(Pointer) {
     }
 
     # For parameterization to ints
-    my role IntTypedCArray[::TValue]
-      does Positional[TValue]
-      is   array_type(TValue)
+    my role IntTypedCArray[::CORE'NativeCall'IntTypedCArray'TValue]
+      does Positional[CORE'NativeCall'IntTypedCArray'TValue]
+      is   array_type(CORE'NativeCall'IntTypedCArray'TValue)
     {
         multi method AT-POS(::?CLASS:D: int $pos) is raw {
             nqp::atposref_i(self, $pos)
@@ -233,9 +233,9 @@ our class CArray is repr('CArray') is array_type(Pointer) {
     }
 
     # For parameterization to unsigned ints
-    my role UIntTypedCArray[::TValue]
-      does Positional[TValue]
-      is   array_type(TValue)
+    my role UIntTypedCArray[::CORE'NativeCall'UIntTypedCArray'TValue]
+      does Positional[CORE'NativeCall'UIntTypedCArray'TValue]
+      is   array_type(CORE'NativeCall'UIntTypedCArray'TValue)
     {
         multi method AT-POS(::?CLASS:D: int $pos) is raw {
             nqp::atposref_u(self, $pos);
@@ -287,9 +287,9 @@ our class CArray is repr('CArray') is array_type(Pointer) {
     }
 
     # For parameterization to nums
-    my role NumTypedCArray[::TValue]
-      does Positional[TValue]
-      is   array_type(TValue)
+    my role NumTypedCArray[::CORE'NumTypedCArray'TValue]
+      does Positional[CORE'NumTypedCArray'TValue]
+      is   array_type(CORE'NumTypedCArray'TValue)
     {
         multi method AT-POS(::?CLASS:D: int $pos) is raw {
             nqp::atposref_n(self, $pos);
@@ -332,9 +332,9 @@ our class CArray is repr('CArray') is array_type(Pointer) {
     }
 
     # For parameterization to all other allowed REPRs
-    my role TypedCArray[::TValue]
-      does Positional[TValue]
-      is   array_type(TValue)
+    my role TypedCArray[::CORE'NativeCall'TypedCArray'TValue]
+      does Positional[CORE'NativeCall'TypedCArray'TValue]
+      is   array_type(CORE'NativeCall'TypedCArray'TValue)
     {
         multi method AT-POS(::?CLASS:D: int $pos) is rw {
             Proxy.new:

--- a/src/core.c/Array/Typed.rakumod
+++ b/src/core.c/Array/Typed.rakumod
@@ -1,4 +1,4 @@
-my role Array::Typed[::TValue] does Positional[TValue] {
+my role Array::Typed[::CORE'Array'Typed'TValue] does Positional[CORE'Array'Typed'TValue] {
 
     proto method new(|) {*}
     multi method new(:$shape!) {
@@ -40,7 +40,7 @@ my role Array::Typed[::TValue] does Positional[TValue] {
 
     sub set-descriptor(\list) is raw {
         nqp::bindattr(list,Array,'$!descriptor',
-          ContainerDescriptor.new(:of(TValue), :default(TValue))
+          ContainerDescriptor.new(:of(CORE'Array'Typed'TValue), :default(CORE'Array'Typed'TValue))
         );
         list
     }
@@ -54,7 +54,7 @@ my role Array::Typed[::TValue] does Positional[TValue] {
     proto method BIND-POS(|) {*}
 
     # these BIND-POSses are identical to Array's, except for bindval
-    multi method BIND-POS(Array:D: uint $pos, TValue \bindval) is raw {
+    multi method BIND-POS(Array:D: uint $pos, CORE'Array'Typed'TValue \bindval) is raw {
         nqp::if(
           nqp::isconcrete(
             my $reified := nqp::getattr(self,List,'$!reified')
@@ -72,7 +72,7 @@ my role Array::Typed[::TValue] does Positional[TValue] {
         nqp::bindpos($reified,$pos,bindval)
     }
     # because this is a very hot path, we copied the code from the int candidate
-    multi method BIND-POS(Array:D: Int:D $pos, TValue \bindval) is raw {
+    multi method BIND-POS(Array:D: Int:D $pos, CORE'Array'Typed'TValue \bindval) is raw {
         nqp::if(
           nqp::islt_i($pos,0),
           self!out-of-range($pos),
@@ -97,10 +97,10 @@ my role Array::Typed[::TValue] does Positional[TValue] {
         )
     }
 
-    method is-generic { nqp::hllbool(callsame() || nqp::istrue(TValue.^archetypes.generic)) }
+    method is-generic { nqp::hllbool(callsame() || nqp::istrue(CORE'Array'Typed'TValue.^archetypes.generic)) }
 
     multi method INSTANTIATE-GENERIC(::?CLASS:U: TypeEnv:D \type-environment) is raw {
-        self.^mro.first({ !(.^is_mixin && .is-generic) }).^parameterize: type-environment.instantiate(TValue)
+        self.^mro.first({ !(.^is_mixin && .is-generic) }).^parameterize: type-environment.instantiate(CORE'Array'Typed'TValue)
     }
     multi method INSTANTIATE-GENERIC(::?CLASS:D: TypeEnv:D \type-environment) is raw {
         my \ins-arr = self.WHAT.INSTANTIATE-GENERIC(type-environment);
@@ -109,7 +109,7 @@ my role Array::Typed[::TValue] does Positional[TValue] {
     }
 
     multi method raku(::?CLASS:D:) {
-        my $type := (try TValue.raku) // nqp::getattr(self,Array,'$!descriptor').of.^name;
+        my $type := (try CORE'Array'Typed'TValue.raku) // nqp::getattr(self,Array,'$!descriptor').of.^name;
         my $raku := self.map({
             nqp::isconcrete($_) ?? .raku(:arglist) !! $type
         }).join(', ');

--- a/src/core.c/Associative.rakumod
+++ b/src/core.c/Associative.rakumod
@@ -1,6 +1,6 @@
-my role Associative[::TValue = Mu, ::TKey = Str(Any)] {
-    method of() { TValue }
-    method keyof() { TKey }
+my role Associative[::CORE'Associative'TValue = Mu, ::CORE'Associative'TKey = Str(Any)] {
+    method of() { CORE'Associative'TValue }
+    method keyof() { CORE'Associative'TKey }
 
 # These methods must be implemented by any object performing the Associative
 # role.  The reason this is not actually activated, is that there are some

--- a/src/core.c/Hash/Object.rakumod
+++ b/src/core.c/Hash/Object.rakumod
@@ -1,15 +1,15 @@
-my role Hash::Object[::TValue, ::TKey, ::TDefault = TValue]
-  does Associative[TValue] {
+my role Hash::Object[::CORE'Hash'Object'TValue, ::CORE'Hash'Object'TKey, ::CORE'Hash'Object'TDefault = CORE'Hash'Object'TValue]
+  does Associative[CORE'Hash'Object'TValue] {
 
     # make sure we get the right descriptor
     multi method new(::?CLASS:) {
         nqp::p6bindattrinvres(
           nqp::create(self),Hash,'$!descriptor',
-          ContainerDescriptor.new(:of(TValue), :default(TDefault))
+          ContainerDescriptor.new(:of(CORE'Hash'Object'TValue), :default(CORE'Hash'Object'TDefault))
         )
     }
-    method keyof () { TKey }
-    method AT-KEY(::?CLASS:D: TKey \key) is raw {
+    method keyof () { CORE'Hash'Object'TKey }
+    method AT-KEY(::?CLASS:D: CORE'Hash'Object'TKey \key) is raw {
         my \storage := nqp::getattr(self, Map, '$!storage');
         my str $which = nqp::unbox_s(key.WHICH);
         nqp::existskey(storage,$which)
@@ -22,7 +22,7 @@ my role Hash::Object[::TValue, ::TKey, ::TDefault = TValue]
              )
     }
 
-    method STORE_AT_KEY(::?CLASS:D: TKey \key, Mu \value --> Nil) {
+    method STORE_AT_KEY(::?CLASS:D: CORE'Hash'Object'TKey \key, Mu \value --> Nil) {
         nqp::istype(key,Failure)
           ?? key.throw
           !! nqp::bindkey(
@@ -50,7 +50,7 @@ my role Hash::Object[::TValue, ::TKey, ::TDefault = TValue]
         );
     }
 
-    method ASSIGN-KEY(::?CLASS:D: TKey \key, Mu \assignval) is raw {
+    method ASSIGN-KEY(::?CLASS:D: CORE'Hash'Object'TKey \key, Mu \assignval) is raw {
         key.throw if nqp::istype(key,Failure);
 
         my \storage  := nqp::getattr(self, Map, '$!storage');
@@ -69,7 +69,7 @@ my role Hash::Object[::TValue, ::TKey, ::TDefault = TValue]
         )
     }
 
-    method BIND-KEY(TKey \key, TValue \value) is raw {
+    method BIND-KEY(CORE'Hash'Object'TKey \key, CORE'Hash'Object'TValue \value) is raw {
         nqp::istype(key,Failure)
           ?? key.throw
           !! nqp::getattr(
@@ -83,7 +83,7 @@ my role Hash::Object[::TValue, ::TKey, ::TDefault = TValue]
              )
     }
 
-    method EXISTS-KEY(TKey \key) {
+    method EXISTS-KEY(CORE'Hash'Object'TKey \key) {
         nqp::istype(key,Failure)
           ?? key.throw
           !! nqp::hllbool(
@@ -91,7 +91,7 @@ my role Hash::Object[::TValue, ::TKey, ::TDefault = TValue]
              )
     }
 
-    method DELETE-KEY(TKey \key) {
+    method DELETE-KEY(CORE'Hash'Object'TKey \key) {
         key.throw if nqp::istype(key,Failure);
 
         nqp::if(
@@ -302,14 +302,14 @@ my role Hash::Object[::TValue, ::TKey, ::TDefault = TValue]
     method is-generic {
         nqp::hllbool(
             callsame()
-            || TValue.^archetypes.generic
-            || TKey.^archetypes.generic )
+            || CORE'Hash'Object'TValue.^archetypes.generic
+            || CORE'Hash'Object'TKey.^archetypes.generic )
     }
 
     multi method INSTANTIATE-GENERIC(::?CLASS:U: TypeEnv:D \type-environment --> Associative) is raw {
         self.^mro.first({ !(.^is_mixin && .is-generic) }).^parameterize:
-            type-environment.instantiate(TValue),
-            type-environment.instantiate(TKey)
+            type-environment.instantiate(CORE'Hash'Object'TValue),
+            type-environment.instantiate(CORE'Hash'Object'TKey)
     }
 
     multi method INSTANTIATE-GENERIC(::?CLASS:D: TypeEnv:D \type-environment --> Associative) is raw {
@@ -320,8 +320,8 @@ my role Hash::Object[::TValue, ::TKey, ::TDefault = TValue]
 
     multi method raku(::?CLASS:D \SELF:) {
         SELF.rakuseen('Hash', {
-            my $TKey-raku   := TKey.raku;
-            my $TValue-raku := TValue.raku;
+            my $TKey-raku   := CORE'Hash'Object'TKey.raku;
+            my $TValue-raku := CORE'Hash'Object'TValue.raku;
             $TKey-raku eq 'Any' && $TValue-raku eq 'Mu'
               ?? ( '$(' x nqp::iscont(SELF)
                     ~ ':{' ~ SELF.sort.map({.raku}).join(', ') ~ '}'

--- a/src/core.c/Hash/Typed.rakumod
+++ b/src/core.c/Hash/Typed.rakumod
@@ -1,10 +1,12 @@
-my role Hash::Typed[::TValue, ::TKey, ::TDefault = TValue] does Associative[TValue] {
+my role Hash::Typed[::CORE'Hash'Typed'TValue, ::CORE'Hash'Typed'TKey, ::CORE'Hash'Typed'TDefault = CORE'Hash'Typed'TValue]
+    does Associative[CORE'Hash'Typed'TValue, CORE'Hash'Typed'TKey]
+{
 
     # make sure we get the right descriptor
     multi method new(::?CLASS:) {
         nqp::p6bindattrinvres(
           nqp::create(self),Hash,'$!descriptor',
-          ContainerDescriptor.new(:of(TValue), :default(TDefault))
+          ContainerDescriptor.new(:of(CORE'Hash'Typed'TValue), :default(CORE'Hash'Typed'TDefault))
         )
     }
 
@@ -24,7 +26,7 @@ my role Hash::Typed[::TValue, ::TKey, ::TDefault = TValue] does Associative[TVal
         )
     }
 
-    method BIND-KEY(Mu \key, TValue \value) is raw {
+    method BIND-KEY(Mu \key, CORE'Hash'Typed'TValue \value) is raw {
         nqp::bindkey(
           nqp::getattr(self,Map,'$!storage'),
           key.Str,
@@ -33,11 +35,11 @@ my role Hash::Typed[::TValue, ::TKey, ::TDefault = TValue] does Associative[TVal
     }
 
     method is-generic {
-        nqp::hllbool(callsame() || nqp::istrue(TValue.^archetypes.generic))
+        nqp::hllbool(callsame() || nqp::istrue(CORE'Hash'Typed'TValue.^archetypes.generic))
     }
 
     multi method INSTANTIATE-GENERIC(::?CLASS:U: TypeEnv:D \type-environment --> Associative) is raw {
-        self.^mro.first({ !(.^is_mixin && .is-generic) }).^parameterize: type-environment.instantiate(TValue)
+        self.^mro.first({ !(.^is_mixin && .is-generic) }).^parameterize: type-environment.instantiate(CORE'Hash'Typed'TValue)
     }
     multi method INSTANTIATE-GENERIC(::?CLASS:D: TypeEnv:D \type-environment --> Associative) is raw {
         my \ins-hash = self.INSTANTIATE-GENERIC(type-environment);
@@ -49,10 +51,10 @@ my role Hash::Typed[::TValue, ::TKey, ::TDefault = TValue] does Associative[TVal
         SELF.rakuseen('Hash', {
             '$' x nqp::iscont(SELF)  # self is always deconted
             ~ (self.elems
-               ?? "(my {TValue.raku} % = {
+               ?? "(my {CORE'Hash'Typed'TValue.raku} % = {
                     self.sort.map({.raku}).join(', ')
                    })"
-               !! "(my {TValue.raku} %)"
+               !! "(my {CORE'Hash'Typed'TValue.raku} %)"
               )
         })
     }

--- a/src/core.c/Positional.rakumod
+++ b/src/core.c/Positional.rakumod
@@ -1,5 +1,5 @@
-my role Positional[::T = Mu] {
-    method of() { T }
+my role Positional[::CORE'Positional'TValue = Mu] {
+    method of() { CORE'Positional'TValue }
 
 # These methods must be implemented by any object performing the Positional
 # role.  The reason this is not actually activated, is that there are some


### PR DESCRIPTION
The use of `TValue` would cause an infinite loop, as in:

    role R[::TValue] { has TValue @.a }
    R[Int].new
    # (infinity)

This is apparently the result of unforeseen clashing between the user-provided `::TValue` and the `::TValue` captures that we use in core.

Now, the *correct* fix will be to eventually figure out the nature of this should-not-be-happening collision and address it at the root cause.

However, this fix should be "good enough" until such time as the same collision can be demonstrated as occuring entirely in user code, excluding core entirely. Once that happens, there will be a compelling reason to spend the tuits on this.

It's also probably worth noting that I would rather spend efforts on a complete overhaul of roles and generics rather than surgically addressing this problem.

R#6065 (#6065)