### PR TITLE
Add :without-backtrace named argument to die()

### DIFF
--- a/src/core.c/Exception.rakumod
+++ b/src/core.c/Exception.rakumod
@@ -156,11 +156,11 @@ my class X::AdHoc is Exception {
     has $.payload is default(Nil) = "Unexplained error";
 
     my role SlurpySentry { }
-    method TWEAK(:$no-backtrace) {
-        if $no-backtrace {
-            self does my role no-backtrace {
-                method backtrace()    { Nil  }
-                method no-backtrace() { True }
+    method TWEAK(:$without-backtrace) {
+        if $without-backtrace {
+            self does my role without-backtrace {
+                method backtrace()         { Nil  }
+                method without-backtrace() { True }
             }
         }
     }
@@ -612,7 +612,7 @@ do {
             elsif Rakudo::Internals.VERBATIM-EXCEPTION(0) {
                 $err.print($e.Str);
             }
-            elsif $e.?no-backtrace {
+            elsif $e.?without-backtrace {
                 $err.say($e.Str);
             }
             else {

--- a/src/core.c/Exception.rakumod
+++ b/src/core.c/Exception.rakumod
@@ -156,6 +156,14 @@ my class X::AdHoc is Exception {
     has $.payload is default(Nil) = "Unexplained error";
 
     my role SlurpySentry { }
+    method TWEAK(:$no-backtrace) {
+        if $no-backtrace {
+            self does my role no-backtrace {
+                method backtrace()    { Nil  }
+                method no-backtrace() { True }
+            }
+        }
+    }
 
     method message() {
         # Remove spaces for die(*@msg)/fail(*@msg) forms
@@ -603,6 +611,9 @@ do {
             }
             elsif Rakudo::Internals.VERBATIM-EXCEPTION(0) {
                 $err.print($e.Str);
+            }
+            elsif $e.?no-backtrace {
+                $err.say($e.Str);
             }
             else {
                 $err.say("===SORRY!===");

--- a/src/core.c/control.rakumod
+++ b/src/core.c/control.rakumod
@@ -249,10 +249,10 @@ multi sub die(--> Nil) {
 multi sub die(Exception:U $e --> Nil) {
     X::AdHoc.new(:payload("Died with undefined " ~ $e.^name)).throw;
 }
-multi sub die($payload --> Nil) {
+multi sub die($payload, :$no-backtrace --> Nil) {
     $payload ~~ Exception
       ?? $payload.throw
-      !! X::AdHoc.new(:$payload).throw
+      !! X::AdHoc.new(:$payload, :$no-backtrace).throw
 }
 multi sub die(|cap ( *@msg ) --> Nil) {
     X::AdHoc.from-slurpy(|cap).throw

--- a/src/core.c/control.rakumod
+++ b/src/core.c/control.rakumod
@@ -249,10 +249,10 @@ multi sub die(--> Nil) {
 multi sub die(Exception:U $e --> Nil) {
     X::AdHoc.new(:payload("Died with undefined " ~ $e.^name)).throw;
 }
-multi sub die($payload, :$no-backtrace --> Nil) {
+multi sub die($payload, :$without-backtrace --> Nil) {
     $payload ~~ Exception
       ?? $payload.throw
-      !! X::AdHoc.new(:$payload, :$no-backtrace).throw
+      !! X::AdHoc.new(:$payload, :$without-backtrace).throw
 }
 multi sub die(|cap ( *@msg ) --> Nil) {
     X::AdHoc.from-slurpy(|cap).throw


### PR DESCRIPTION
Following up on:
  https://github.com/Raku/problem-solving/issues/59
that was discussed in the resolutions meeting of 21 Feb 2026.
```
  $ raku -e 'die "foo"'
  foo
    in block <unit> at -e line 1

  $ raku -e 'die "foo", :without-backtrace'
  foo
```