### PR TITLE
Add support for %*SUB-MAIN-OPTS<dash-as-STDIN>

### DIFF
--- a/src/core.c/Argfiles.rakumod
+++ b/src/core.c/Argfiles.rakumod
@@ -5,12 +5,15 @@ Rakudo::Internals.REGISTER-DYNAMIC: '@*ARGS', {
     PROCESS::<@ARGS> := @ARGS;
 }
 Rakudo::Internals.REGISTER-DYNAMIC: '$*ARGFILES', {
-    # Here, we use $*IN's attributes to init the arg files because
-    # the $*ARGFILES won't get instantiated until first access and by that
-    # time the user may have already modified $*IN's attributes to their liking
-    PROCESS::<$ARGFILES> = @*ARGS
-      ?? IO::ArgFiles.new(@*ARGS)
-      !! $*IN
+    PROCESS::<$ARGFILES> = do if @*ARGS -> @ARGS {
+        if %*SUB-MAIN-OPTS<dash-as-STDIN> {
+            $_ = $*IN if $_ eq '-' for @ARGS;
+        }
+        IO::ArgFiles.new(@ARGS)
+    }
+    else {
+        $*IN
+    }
 }
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
If set, will *always* assume that a bare "-" on the command line will be interpreted as STDIN, regardless of language version.

This feature to be added in light of the general deprecation of "-" as an indication for STDIN / STDOUT.  However, many command line script may depend on this behaviour, which will change in 6.e (where it will be assumed to indicate the "./-" file).

With this option, command line scripts can be easily adapted to expose the old and trusted behaviour