### PR TITLE
Add :translate-nl named arg to IO::Path.slurp

### DIFF
--- a/src/core.c/IO/Path.rakumod
+++ b/src/core.c/IO/Path.rakumod
@@ -697,7 +697,7 @@ my class IO::Path is Cool does IO {
     }
 
     proto method slurp() {*}
-    multi method slurp(IO::Path:D: :$bin, :$enc) {
+    multi method slurp(IO::Path:D: :$bin, :$enc, :$translate-nl = True) {
         my $blob;
 
         # Treating "-" as an indication of STDIN?
@@ -725,7 +725,7 @@ my class IO::Path is Cool does IO {
                 ?? Rakudo::Internals.NORMALIZE_ENCODING($enc)
                 !! 'utf8'
             );
-            nqp::istype($decoded,Failure)
+            nqp::istype($decoded,Failure) || !$translate-nl
               ?? $decoded
               !! nqp::join("\n",nqp::split("\r\n",$decoded))
         }


### PR DESCRIPTION
Defaults to True.  So specify :!translate-nl if you don't want newline (\r\n -> \n) translation.  Slurping a file without newline translation *can* make it up to 7% faster.

As suggested in:
  https://github.com/rakudo/rakudo/issues/3391#issuecomment-569957370