### PR TITLE
Only look at .pm for code in 6.c/d with -I

### DIFF
--- a/src/core.c/CompUnit/Repository/FileSystem.rakumod
+++ b/src/core.c/CompUnit/Repository/FileSystem.rakumod
@@ -25,7 +25,9 @@ class CompUnit::Repository::FileSystem
             @!extensions := @!extensions.words.List;
         }
         else {
-            @!extensions := <rakumod pm6 pm>;
+            @!extensions := nqp::getcomp('Raku').language_revision < 3
+              ?? <rakumod pm6 pm>
+              !! <rakumod pm6>
         }
     }
 


### PR DESCRIPTION
Exclude the .pm extension if running in v6.e or higher in CURFS