### PR TITLE
Check for literal value in signature with `.return`/ `return-rw`

### DIFF
--- a/src/core.c/Mu.rakumod
+++ b/src/core.c/Mu.rakumod
@@ -70,14 +70,33 @@ my class Mu { # declared in BOOTSTRAP
     method take {
         take self;
     }
+
+    # Check signature of caller Routine for definite value being returned
+    my sub check-signature(Mu $value, str $method) {
+        my int $index = 2;
+        nqp::until(
+          nqp::isnull(my $cf := callframe($index))
+            || nqp::istype((my $callable := $cf.code),Routine),
+          ++$index
+        );
+
+        die "Cannot return $value.raku() with $method when return value $_.raku() is already specified in the signature of $callable.raku.subst(/ "(" .* /)".naive-word-wrapper
+          with $callable.signature.returns;
+    }
     method return-rw(Mu \SELF: |) {  # same code as control.rakumod's return-rw
+        check-signature(SELF, '.return-rw');
+
         my $list := RETURN-LIST(nqp::p6argvmarray());
         nqp::throwpayloadlexcaller(nqp::const::CONTROL_RETURN, $list);
         $list;
     }
-    method return(|) {  # same code as control.rakumod's return
+    method return(Mu $SELF: |) {  # same code as control.rakumod's return
+        check-signature($SELF, '.return');
+
         my $list := RETURN-LIST(nqp::p6argvmarray());
-        nqp::throwpayloadlexcaller(nqp::const::CONTROL_RETURN, nqp::p6recont_ro($list));
+        nqp::throwpayloadlexcaller(
+          nqp::const::CONTROL_RETURN, nqp::p6recont_ro($list)
+        );
         $list;
     }
 


### PR DESCRIPTION
https://github.com/rakudo/rakudo/issues/6003 pointed out that all return typechecks were bypassed if a literal return value was specified in the signature **and** .return or .return-rw were used.
```
$ raku -e 'sub a(--> 42) { "foo".return }; dd a'
foo
```
This problem does not occur when using the return(-rw) sub, because that causes a compilation error:
```
$ raku -e 'sub a(--> 42) { return "foo" }; dd a'
===SORRY!=== Error while compiling -e
No return arguments allowed when return value 42 is already
specified in the signature
```
But since methods are late bound, there is no way to reliably spot this during compilation.

This PR adds a helper subroutine that introspects the call chain for the first Routine, then checks its "returns" signature, and if that indicates something defined, throws an execution error with as much information as possible.

From a performance point of view, this puts a *large* overhead on the value.return idiom.  So maybe we should consider deprecating that idiom if this gets merged.

The error message is now:
```
$ raku -e 'sub a(--> 42) { "foo".return }; dd a'    
Cannot return "foo" with .return when return value 42 is already
specified in the signature of sub a
  in sub a at -e line 1
```