### PR TITLE
Add some checking on Grammar.parse

### DIFF
--- a/src/core.c/Grammar.rakumod
+++ b/src/core.c/Grammar.rakumod
@@ -10,6 +10,11 @@ my class Grammar is Match {
           ?? $grammar."$rule"(|$args.Capture)
           !! $grammar."$rule"();
 
+        unless nqp::istype($cursor,Match) {
+            my $type := self.^find_method($rule).^name;
+            die "$type '$rule' returned a $cursor.^name() object ($cursor.gist()) rather than a Match object";
+        }
+
         my int $chars = $orig.chars;  # must be HLL, $orig can be Cool
         nqp::while(
           $cursor


### PR DESCRIPTION
https://irclogs.raku.org/raku/2026-03-14.html#14:22 noted an LTA error message for:
```
$ raku -e 'grammar { method TOP { <.asdfwqef> } }.new.parse("asdf")'
P6opaque: no such attribute '$!pos' on type Match in a Str when
trying to get a value
```
This commit adds some checking to Grammar.parse, resulting in this error message now:
```
Method 'TOP' returned a Str object (.asdfwqef) rather than a Match object
```
Error message might require some more tuning.  Suggestions welcome.