### PR TITLE
Make $?SOURCE / $?CHECKSUM available on 6.e and higher

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -1353,11 +1353,13 @@ class Perl6::Actions is HLL::Actions does STDActions {
             statementlist_with_handlers($/)
         );
 
-        $world.install_lexical_symbol($unit, '$?SOURCE', $*OMIT-SOURCE
-            ?? $world.find_single_symbol_in_setting('Nil')
-            !! nqp::hllizefor($/.orig, 'Raku'));
-        $world.install_lexical_symbol($unit, '$?CHECKSUM',
-            nqp::hllizefor(nqp::sha1($/.orig), 'Raku'));
+        if nqp::getcomp('Raku').language_revision > 2 {
+            $world.install_lexical_symbol($unit, '$?SOURCE', $*OMIT-SOURCE
+                ?? $world.find_single_symbol_in_setting('Nil')
+                !! nqp::hllizefor($/.orig, 'Raku'));
+            $world.install_lexical_symbol($unit, '$?CHECKSUM',
+                nqp::hllizefor(nqp::sha1($/.orig), 'Raku'));
+        }
 
         # Errors/warnings in sinking pass should ignore highwater mark.
         $/.'!clear_highwater'();

--- a/src/Raku/ast/compunit.rakumod
+++ b/src/Raku/ast/compunit.rakumod
@@ -433,15 +433,17 @@ class RakuAST::CompUnit
             add($!pod) if $!pod-content;
         }
 
-        add(RakuAST::VarDeclaration::Implicit::Constant.new(
-          name  => '$?SOURCE',
-          value => nqp::hllizefor($!source, 'Raku')
-        ));
+        if $!language-revision gt "d" {
+            add(RakuAST::VarDeclaration::Implicit::Constant.new(
+              name  => '$?SOURCE',
+              value => nqp::hllizefor($!source, 'Raku')
+            ));
 
-        add(RakuAST::VarDeclaration::Implicit::Constant.new(
-          name  => '$?CHECKSUM',
-          value => nqp::hllizefor($!checksum, 'Raku')
-        ));
+            add(RakuAST::VarDeclaration::Implicit::Constant.new(
+              name  => '$?CHECKSUM',
+              value => nqp::hllizefor($!checksum, 'Raku')
+            ));
+        }
 
         my sub relative-source-filename() {
             if $*LITERALS {


### PR DESCRIPTION
Although this is mostly intended to be used by the new interactive debugger that @patrickb is working on, it feels wrong to introduce these compile time variables in 6.c and 6.d as well, this late in the 6.d lifetime cycle.

Hence this commit, making them *unavailable* on 6.c and 6.d