### PR TITLE
Add infix:<cmp>(Iterable:D, Iterable:D)

### DIFF
--- a/src/core.c/Order.rakumod
+++ b/src/core.c/Order.rakumod
@@ -68,6 +68,10 @@ multi sub infix:<cmp>(\a, Code:D $b) {
      a.Stringy cmp $b.name
 }
 
+multi sub infix:<cmp>(Iterable:D \a, Iterable:D \b) is default {
+    infix:<cmp>(a.iterator, b.iterator)
+}
+
 multi sub infix:<cmp>(List:D \a, List:D \b) {
     nqp::if(
       a.is-lazy || b.is-lazy,


### PR DESCRIPTION
In response to https://github.com/rakudo/rakudo/issues/6075

This will do a cmp on all the values that their iterators produce, and thus creating the same semantics for Seq cmp Seq or something with a Seq on either side, such as:

  dd (lazy (1,2,3)) cmp (1,2,3)

which would produce `Less` instead of `Same` before this addition