### PR TITLE
Add `item` to error message stating allowed parameter traits

### DIFF
--- a/src/core.c/traits.rakumod
+++ b/src/core.c/traits.rakumod
@@ -223,7 +223,7 @@ multi sub trait_mod:<is>(Parameter:D $param, |c ) {
       type       => 'is',
       subtype    => c.hash.keys[0],
       declaring  => 'a parameter',
-      highexpect => <rw readonly copy required raw leading_docs trailing_docs>,
+      highexpect => <rw readonly copy raw required item leading_docs trailing_docs>,
     ).throw;
 }
 multi sub trait_mod:<is>(Parameter:D $param, :readonly($)!) {


### PR DESCRIPTION
Also a slight re-ordering: move `raw` one to the left, the idea being: 
First list the parameters that affect how the parameter behaves inside the function body (rw, readonly, copy, raw). Then list the parameters that affect dispatch but not parameter behavior in the body (required, item).