### PR TITLE
Fix SETTING:: prefix having literal single quotes on Windows

### DIFF
--- a/tools/templates/Makefile-backend-common.in
+++ b/tools/templates/Makefile-backend-common.in
@@ -230,7 +230,7 @@
 	$(NOECHO)$(CONFIGURE) --expand @shquot(@ctx_template(core_sources)@)@ \
 			 --out @nfpq(@bpm(BUILD_DIR)@/core_sources.@lcspec@)@ \
 			 --set-var=backend=@backend@
-	$(NOECHO@nop())@@bpm(NQP)@ @bpm(GEN_CAT)@ -p 'SETTING::' -f @nfpq(@bpm(BUILD_DIR)@/core_sources.@lcspec@)@ > @nfpq(@bpm(BUILD_DIR)@/CORE.@lcspec@.setting)@
+	$(NOECHO@nop())@@bpm(NQP)@ @bpm(GEN_CAT)@ -p SETTING:: -f @nfpq(@bpm(BUILD_DIR)@/core_sources.@lcspec@)@ > @nfpq(@bpm(BUILD_DIR)@/CORE.@lcspec@.setting)@
 	@echo(The following step can take a long time, please be patient.)@
 	$(NOECHO@nop())@@bpm(RUN_RAKUDO)@ --setting=NULL.@lcspec@ --ll-exception --optimize=3 --target=@btarget@ --stagestats --output=@bsm(SETTING_@ucspec@)@ @nfpq(@bpm(BUILD_DIR)@/CORE.@lcspec@.setting)@
 


### PR DESCRIPTION
The Makefile template used shell-style single quotes around the SETTING:: prefix passed to gen-cat.nqp. On Unix the shell strips these, but on Windows cmd.exe passes them literally, causing .file to return 'SETTING::'src/core.c/Mu.rakumod instead of SETTING::src/core.c/Mu.rakumod.

See: https://irclogs.raku.org/raku/2026-04-11.html#06:20

Resolves #6109