### PR TITLE
Fix type smiley enforcement on anonymous params in list assignment

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -3664,8 +3664,19 @@ class Perl6::Actions is HLL::Actions does STDActions {
                 else {
                     my $world := $*W;
                     $world.handle_OFTYPE_for_pragma($/,'parameters');
+                    my @value_type := $*OFTYPE ?? [$*OFTYPE.ast] !! [];
+                    if @value_type && $_<defined_only> {
+                        @value_type[0] := $world.create_definite_type(
+                            $world.resolve_mo($/, 'definite'),
+                            @value_type[0], 1);
+                    }
+                    elsif @value_type && $_<undefined_only> {
+                        @value_type[0] := $world.create_definite_type(
+                            $world.resolve_mo($/, 'definite'),
+                            @value_type[0], 0);
+                    }
                     my %cont_info := $world.container_type_info($/, :$post,
-                      $_<sigil> || '$', $*OFTYPE ?? [$*OFTYPE.ast] !! [], []);
+                      $_<sigil> || '$', @value_type, []);
                     $list.push($world.build_container_past(
                       %cont_info,
                       $world.create_container_descriptor(

--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -1774,10 +1774,14 @@ class RakuAST::VarDeclaration::Signature
                 }
                 elsif $_.type {
                     # Anonymous typed parameter (e.g. Int or Any:D) in a
-                    # list declaration. Create a placeholder container so
-                    # it consumes the RHS value at this position.
+                    # list declaration. Create a typed placeholder container
+                    # so it consumes and type-checks the RHS value at this
+                    # position.
+                    my $of := $_.type.meta-object;
+                    my $desc := ContainerDescriptor.new(:$of, :default($of), :name('anon'));
+                    $context.ensure-sc($desc);
                     $value-list.push: QAST::Op.new(
-                        :op('p6scalarfromdesc'), QAST::Op.new(:op('null'))
+                        :op('p6scalarfromdesc'), QAST::WVal.new(:value($desc))
                     );
                 }
             }

--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -1769,7 +1769,17 @@ class RakuAST::VarDeclaration::Signature
 
             for @params {
                 nqp::push(@terms, $_.target) if nqp::istype($_.target, RakuAST::ParameterTarget::Term);
-                $value-list.push: $_.target.IMPL-LOOKUP-QAST($context) if $_.target;
+                if $_.target {
+                    $value-list.push: $_.target.IMPL-LOOKUP-QAST($context);
+                }
+                elsif $_.type {
+                    # Anonymous typed parameter (e.g. Int or Any:D) in a
+                    # list declaration. Create a placeholder container so
+                    # it consumes the RHS value at this position.
+                    $value-list.push: QAST::Op.new(
+                        :op('p6scalarfromdesc'), QAST::Op.new(:op('null'))
+                    );
+                }
             }
             if nqp::istype($!initializer, RakuAST::Initializer::Assign) {
                 my $init-qast := $!initializer.IMPL-TO-QAST($context);


### PR DESCRIPTION
`my ($foo, Any:D, $buzz) = (42, Any, 'lightyear')` should fail because `Any` is undefined, but the `:D` constraint was silently ignored on both frontends. The RakuAST frontend had an additional bug where `$buzz` received `(Any)` instead of 'lightyear'.

The RakuAST issue was that anonymous typed parameters (those with no target variable) were skipped entirely when building the LHS of the assignment, so all subsequent values shifted by one position. The fix creates a placeholder container for these parameters. On the old frontend, `dissect_type_into_parameter` nominalizes `Any:D` to `Any` and stores the definedness constraint in a `defined_only` flag, but the anonymous container path never read that flag. The fix reconstructs the definite type before creating the container descriptor.

After this change, both frontends correctly reject type smiley violations in list assignment:

`Type check failed in assignment to anon; expected Any:D but got Any (Any)`

The RakuAST frontend now also assigns the correct value to `$buzz`:

```
RAKUDO_RAKUAST=1 raku -e 'my ($foo, Int:D, $buzz) = (42, 99, "lightyear"); say "$foo $buzz"'

42 lightyear
```

Resolves #6111
