### PR TITLE
Fix spurious sigspace warning for rx:s// in RakuAST frontend

### DIFF
--- a/src/Raku/Grammar.nqp
+++ b/src/Raku/Grammar.nqp
@@ -4657,6 +4657,7 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
     token quote:sym</ /> {
         :my %*RX;
         :my $*INTERPOLATE := 1;
+        :my $*WHITESPACE-OK := 0;
         '/'
         <nibble(self.quote-lang(self.Regex, '/', '/'))>
         [ '/' || <.panic: "Unable to parse regex; couldn't find final '/'"> ]
@@ -4666,6 +4667,7 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
         <.quote-lang-rx>
         :my %*RX;
         :my $*INTERPOLATE := 1;
+        :my $*WHITESPACE-OK := 0;
         {}  # make sure $/ gets set
         <.qok($/)>
         <rx-adverbs>


### PR DESCRIPTION
The `quote:sym<rx>` and `quote:sym</ />` tokens in the RakuAST grammar were missing the `:my $*WHITESPACE-OK := 0` dynamic variable declaration. When the `:s` adverb was parsed, `adverb-rx2str-control` tried to set `$*WHITESPACE-OK := 1` but the assignment silently failed (wrapped in try) because the variable didn't exist in scope. This caused the `atom` token to always emit the "Space is not significant here" warning, even when `:s` was explicitly specified.

Added the missing declaration to both tokens, matching what all other regex quote forms (`m`, `ms`, `s`, `ss`, `S`, `Ss`) already had.

Fixes #6006