### PR TITLE
Fix silent no-op for `$.foo = ...` on non-rw attributes

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -3127,13 +3127,17 @@ class Perl6::Actions is HLL::Actions does STDActions {
             }
             $past.name($desigilname);
             $past.unshift(QAST::Var.new( :name('self'), :scope('lexical') ));
-            # Contextualize based on sigil.
+            # Contextualize based on sigil. Mark so assignment can strip
+            # this wrapper (see assign_op); otherwise .item would wrap a
+            # non-rw accessor result in a throwaway Scalar, silently
+            # swallowing `$.foo = ...`. See rakudo/rakudo#5908 and #6113.
             $past := QAST::Op.new(
                 :op('callmethod'),
                 :name($sigil eq '@' ?? 'list' !!
                       $sigil eq '%' ?? 'hash' !!
                       'item'),
                 $past);
+            $past.annotate('public-attr-contextualizer', 1);
         }
         elsif $twigil eq '^' || $twigil eq ':' {
             $past := add_placeholder_parameter($/, $sigil, $desigilname,
@@ -7910,6 +7914,16 @@ Did you mean a call like '"
         my $var_sigil;
         $lhs_ast := WANTED($lhs_ast,'assign_op/lhs');
         $rhs_ast := wanted($rhs_ast,'assign_op/rhs');
+
+        # `$.foo = ...` wraps the accessor call in a sigil contextualizer
+        # (.item/.list/.hash). In rvalue position that's correct; in lvalue
+        # position it produces a throwaway container that silently swallows
+        # the assignment. Strip the wrap so assignment lands on the bare
+        # accessor and properly errors for non-rw attributes.
+        if nqp::istype($lhs_ast, QAST::Op)
+          && $lhs_ast.ann('public-attr-contextualizer') {
+            $lhs_ast := $lhs_ast[0];
+        }
         if nqp::istype($lhs_ast, QAST::Var) {
             $var_sigil := nqp::substr($lhs_ast.name, 0, 1);
             if $var_sigil eq '%' {

--- a/src/Raku/ast/variable-access.rakumod
+++ b/src/Raku/ast/variable-access.rakumod
@@ -419,6 +419,16 @@ class RakuAST::Var::Attribute::Public
     method IMPL-EXPR-QAST(RakuAST::IMPL::QASTContext $context) {
         $!expression.IMPL-EXPR-QAST($context)
     }
+
+    # In lvalue position (e.g. `$.foo = 42`), peel the outer hllize and
+    # the sigil contextualizer off $!expression's compiled QAST so the
+    # assignment lands on the bare `self.<attr>` method call. Without
+    # this, .item wraps a non-rw accessor result in a throwaway Scalar
+    # container, silently swallowing the assignment.
+    # See rakudo/rakudo#5908 and #6113.
+    method IMPL-ADJUST-QAST-FOR-LVALUE(Mu $qast) {
+        $qast[0][0]
+    }
 }
 
 # The base for special compiler variables ($?FOO).


### PR DESCRIPTION
`$.foo` compiles to `self.foo.item` (and `@.foo`/`%.foo` use `.list`/`.hash`). For non-rw accessors, the accessor returns a bare value, and `Mu.item` wraps it in a fresh mutable Scalar via `(my $ = item)`. Assigning to `$.foo` then silently stores into that throwaway container with no effect on the attribute, instead of throwing `X::Assignment::RO` the way `$obj.foo = ...` does.

This regressed in a6608c212 (2025-02), which switched `Mu.item` from `p6bindattrinvres(create(Scalar), ...)` (no rw descriptor, so STORE threw) to `(my $ = item)` (rw descriptor, so STORE silently succeeds) to unbreak a PDF distribution test. A later attempt to make `.item` return a read-only container (f95f85ac3) was reverted in e0d0d960c because it re-broke the same PDF path.

Fix it at the call site instead of in `Mu.item`: strip the sigil contextualizer (`.item`/`.list`/`.hash`) when the `$.foo` / `@.foo` / `%.foo` term is used as an lvalue, so the assignment lands on the bare `self.foo` method call. Non-rw scalar accessors then error via p6store as expected; `@.foo = 1,2,3` still works through `Array.STORE`; `is rw` accessors are unaffected; and explicit `self.foo.item = 5` written by the user is left alone because only the compiler-inserted wrap is stripped.

Fixes #6113. Also fixes #5908 (same root cause), for which t/spec/S12-methods/accessors.t already has a `#?rakudo todo` test; that test now passes but throws `X::Assignment::RO` (matching external `$obj.a = 5`) rather than the `X::AdHoc` the todo assumed, so the roast expectation needs a follow-up update.