### PR TITLE
RakuAST: Fix module loading with class shadowing a core type

### DIFF
--- a/src/Raku/ast/statements.rakumod
+++ b/src/Raku/ast/statements.rakumod
@@ -1798,7 +1798,7 @@ class RakuAST::ModuleLoading {
 
             my $existing := nqp::isconcrete($declarand.compile-time-value)
                 ?? Nil
-                !! $resolver.resolve-lexical-constant($key);
+                !! $resolver.resolve-lexical-constant($key, :current-scope-only);
             if $existing {
                 $existing.merge($declarand, :$resolver) unless $existing.compile-time-value =:= $declarand.compile-time-value;
             }


### PR DESCRIPTION
When importing a module that defines a class with the same name as a core class (e.g. `class Date { }`), the RakuAST frontend erroneously threw `X::Redeclaration`.

`IMPL-IMPORT-ONE` used `$resolver.resolve-lexical-constant` which searches all scopes including the SETTING. Finding the core `Date` there, it called `merge()` which has no case for a non-stub import replacing a non-stub outer-scope class.

The old frontend only checks `$target.symbol($key)` (the current lexpad), so it never sees the core symbol and just installs the import, correctly shadowing it.

The fix adds `:current-scope-only` to the `resolve-lexical-constant` call in `IMPL-IMPORT-ONE`.

Fixes #6051