### PR TITLE
RakuAST: Guard $!block in TraitTarget::Variable for NULL setting compilation

### DIFF
--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -1000,7 +1000,7 @@ class RakuAST::VarDeclaration::Simple
                 self.name,
                 nqp::getattr_s(self, RakuAST::Declaration, '$!scope'),
                 $meta,
-                $!block.stubbed-meta-object,
+                $!block ?? $!block.stubbed-meta-object !! Mu,
                 Mu
             );
             # Get around RakuAST compiler deconting all arguments:


### PR DESCRIPTION
During CORE setting compilation (--setting=NULL.c), there is no block attach target at the top level because CompUnit only registers as 'compunit', not 'block'. This causes $!block to be Nil when TraitTarget::Variable tries to call stubbed-meta-object on it.

Guard $!block with a Nil check, passing Mu as the code-object. Only phaser traits like will-enter use the block, and those are meaningless without an enclosing block anyway.

Can be reproduced with `RAKUDO_RAKUAST=1 raku --setting=NULL.c -e 'my $x := 1'`. That being said no normal user code should ever hit this unless it you'd have to explicitly passes --setting=NULL.c (which the Makefile does when building the CORE setting).