### PR TITLE
RakuAST: avoid pathologically slow Raku dispatch in add-phasers-handling-code

### DIFF
--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -1051,7 +1051,7 @@ class RakuAST::ScopePhaser {
 
     method add-phasers-handling-code(RakuAST::IMPL::Context $context, Mu $qast) {
         my $block := nqp::istype(self, RakuAST::Code) ?? self.meta-object !! NQPMu;
-        my $phasers := $block ?? nqp::getattr($block, Block, '$!phasers') !! NQPMu;
+        my $phasers := nqp::isconcrete($block) ?? nqp::getattr($block, Block, '$!phasers') !! NQPMu;
 
         if $!has-exit-handler || self.needs-result > 1 || $phasers && (nqp::istype($phasers, Code) || nqp::existskey($phasers, 'LEAVE') || nqp::existskey($phasers, 'POST')) {
             $qast.has_exit_handler(1);
@@ -1142,14 +1142,18 @@ class RakuAST::ScopePhaser {
                     %seen{nqp::objectid($_.meta-object)} := 1;
                 }
             }
-            if $block {
-                my $enter-phasers := $block.phasers('ENTER');
+            if nqp::isconcrete($block) && nqp::ishash($phasers) && nqp::existskey($phasers, 'ENTER') {
+                my $enter-phasers := nqp::atkey($phasers, 'ENTER');
                 if nqp::isconcrete($enter-phasers) {
-                    for $enter-phasers.FLATTENABLE_LIST {
-                        unless %seen{nqp::objectid($_)} {
-                            $context.ensure-sc($_);
-                            $enter-setup.push(QAST::Op.new(:op<call>, QAST::WVal.new(:value($_))));
+                    my int $i := 0;
+                    my int $n := nqp::elems($enter-phasers);
+                    while $i < $n {
+                        my $p := nqp::atpos($enter-phasers, $i);
+                        unless %seen{nqp::objectid($p)} {
+                            $context.ensure-sc($p);
+                            $enter-setup.push(QAST::Op.new(:op<call>, QAST::WVal.new(:value($p))));
                         }
+                        $i := $i + 1;
                     }
                 }
             }


### PR DESCRIPTION
During CORE setting compilation, `add-phasers-handling-code` runs once per Code object being compiled. Two call sites hit Raku level dispatch on Sub meta-objects that carry a trait mixin (e.g. `Sub+{is-implementation-detail}`, `Sub+{is-DEPRECATED}`). Dispatching `.Bool` or a regular method on such a mixed-in type is hundreds of times slower than on a plain Sub, and multiplied over the tens of thousands of `add-phasers-handling-code` invocations in CORE it causes Stage qast to effectively hang.

Replace the two slow sites with nqp primitives:

  1. The entry booleanization `$block ?? ... !! NQPMu` becomes `nqp::isconcrete($block) ?? ... !! NQPMu`.

  2. The ENTER-branch `$block.phasers('ENTER')` method call (and the `.FLATTENABLE_LIST` iteration) becomes a direct `nqp::atkey` lookup plus `nqp::elems`/`nqp::atpos` loop, guarded by an `nqp::ishash` + `nqp::existskey pre-check`.

Both changes must be present together. The ENTER-branch rewrite carries the majority of the benefit by unblocking the first hang point (sub with ENTER phaser, typically installed via the DEPRECATED trait). The entry rewrite by itself has no measurable effect, but once the ENTER hang is unblocked, the entry rewrite is what allows the remaining calls to finish. Removing either causes Stage qast to fail to complete.

Other similar Raku-level boolean checks in this method (`$!PRE`, `$!FIRST`, `$!let`, `$!temp`, etc.) were investigated and shown not to be a bottleneck during CORE compilation and are left alone.