### PR TITLE
RakuAST: propagate $*COMPILING_CORE_SETTING into QAST stage

### DIFF
--- a/src/Perl6/Compiler.nqp
+++ b/src/Perl6/Compiler.nqp
@@ -263,6 +263,9 @@ class Perl6::Compiler is HLL::Compiler {
     }
 
     method qast($rakuast, *%adverbs) {
+        my str $setting-name := nqp::can($rakuast, 'setting-name') ?? ($rakuast.setting-name // '') !! '';
+        my int $compiling-core := $setting-name eq 'NULL.c' || $setting-name eq 'NULL.d' || $setting-name eq 'NULL.e' ?? 1 !! 0;
+        my $*COMPILING_CORE_SETTING := $compiling-core;
         my $comp_unit := $rakuast.IMPL-TO-QAST-COMP-UNIT;
         $rakuast.cleanup();
         $comp_unit;


### PR DESCRIPTION
`$*COMPILING_CORE_SETTING` is declared and set during parse stage, but the dynvar is not in scope during QAST generation. Several places check it to branch on CORE-compilation behavior, and at least one of those branches matters during CORE setting compilation:

The is-simple-args-proto helper in the MoarVM dispatchers short-circuits to 1 when `$*COMPILING_CORE_SETTING` is true, specifically to avoid "a bunch of throwaway compilations" from the raku-multi dispatcher invoking proto candidates. Without the shortcut, multi dispatches that happen during QAST generation (e.g. from `Call::PrivateMethod`'s IMPL-POSTFIX-QAST looking up a private method via $package.HOW) end up invoking stubbed method code-objects. Those stubs then run the `$compiler-thunk` inside IMPL-STUB-CODE, which recursively compiles the method body on demand. This was observed as `Int::Num` and `Nil::FALLBACK` being compiled mid-way through the compilation of `Rakudo::IterateOneWithPhasers::pull-one`.

Set `$*COMPILING_CORE_SETTING` from the Compiler's qast method based on the `RakuAST::CompUnit`'s setting-name being NULL.c / NULL.d / NULL.e (the three CORE.*.setting bootstrap passes).