### PR TITLE
Gate nested-package install on 6.e and deprecate silent replacement of enclosing module

### DIFF
--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -1702,7 +1702,23 @@ class Perl6::World is HLL::World {
         }
         if $create_scope eq 'our' {
             if nqp::existskey($cur_pkg.WHO, $name) {
-                self.steal_WHO($symbol, ($cur_pkg.WHO){$name});
+                my $existing := ($cur_pkg.WHO){$name};
+                # Silently replacing an enclosing module with a class,
+                # role, grammar, etc. is legacy behavior specific to
+                # Raku 6.d and earlier. Under 6.e the same pattern
+                # installs the declaration as a nested package instead,
+                # so warn pre-6.e code to migrate before authors bump
+                # their language version.
+                if nqp::getcomp('Raku').language_revision < 3
+                  && $existing.HOW.HOW.name($existing.HOW) eq 'Perl6::Metamodel::ModuleHOW'
+                  && $symbol.HOW.HOW.name($symbol.HOW) ne 'Perl6::Metamodel::ModuleHOW' {
+                    $/.PRECURSOR.typed_worry(
+                        'X::Package::SameNameAsEnclosingModule',
+                        :kind($pkgdecl),
+                        :name($existing.HOW.name($existing)),
+                    );
+                }
+                self.steal_WHO($symbol, $existing);
             }
             self.install_package_symbol_unchecked($cur_pkg, $name, $symbol);
         }

--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -1649,13 +1649,19 @@ class Perl6::World is HLL::World {
         if +@parts {
             try {
                 my $resolved_pkg := self.find_single_symbol(@parts[0], :upgrade_to_global($create_scope ne 'my'));
-                # Check if resolving would install over the current
-                # package. E.g. module Foo::Bar { class Foo::Bar { } }
-                # the resolver finds outer Foo, whose Bar entry is the
-                # current module. The intent is Foo::Bar::Foo::Bar.
-                unless +@parts == 1
-                  && nqp::existskey($resolved_pkg.WHO, $name)
-                  && ($resolved_pkg.WHO){$name} =:= $package {
+                # In 6.e and later, detect when installing would land on
+                # the enclosing package (e.g. `class Foo::Bar` inside
+                # `module Foo::Bar`) and keep the remaining name parts so
+                # the chase loop nests the declaration as
+                # Foo::Bar::Foo::Bar. In 6.d and earlier, preserve the
+                # legacy silent-replace behavior where the new package
+                # simply overwrites the module in the outer stash via
+                # steal_WHO below.
+                my $use-nested := nqp::getcomp('Raku').language_revision >= 3
+                    && +@parts == 1
+                    && nqp::existskey($resolved_pkg.WHO, $name)
+                    && ($resolved_pkg.WHO){$name} =:= $package;
+                unless $use-nested {
                     $cur_pkg := $resolved_pkg;
                     $cur_lex := 0;
                     $create_scope := 'our';

--- a/src/Raku/ast/scoping.rakumod
+++ b/src/Raku/ast/scoping.rakumod
@@ -1027,12 +1027,15 @@ class RakuAST::PackageInstaller {
             my $first := @parts[0].name;
             my $resolved := $resolver.partially-resolve-name-constant(RakuAST::Name.new(|@parts));
 
-            # Check if the resolution would lead us to install over the
-            # current package. This happens when e.g. class Foo::Bar is
-            # declared inside module Foo::Bar: the resolver finds the
-            # outer Foo package and its Bar stash entry is the current
-            # module, but the intent is Foo::Bar::Foo::Bar.
-            if $resolved {
+            # In 6.e and later, detect when the resolved path would
+            # install over the enclosing package (e.g. class Foo::Bar
+            # declared inside module Foo::Bar) and clear $resolved so
+            # the else branch creates intermediate stubs under the
+            # current package, producing Foo::Bar::Foo::Bar.
+            # In 6.d and earlier, let $resolved stand so the legacy
+            # silent-replace path below does the ModuleHOW steal_WHO
+            # overwrite, matching the traditional grammar.
+            if $resolved && nqp::getcomp('Raku').language_revision >= 3 {
                 my $check := self.IMPL-UNWRAP-LIST($resolved);
                 my $check-target := $check[0];
                 my $check-remaining := self.IMPL-UNWRAP-LIST($check[1]);
@@ -1104,7 +1107,19 @@ class RakuAST::PackageInstaller {
         }
         if $scope eq 'our' {
             if nqp::existskey(%stash, $final) && !(%stash{$final} =:= $type-object) {
-                if nqp::istype(%stash{$final}.HOW, Perl6::Metamodel::PackageHOW) || $name.is-identifier || $orig-scope eq 'my' {
+                # On 6.d and earlier, allow the specific legacy pattern
+                # where a declaration silently replaces its enclosing
+                # module (`module Foo::Bar { class Foo::Bar { } }`),
+                # matching the traditional grammar. Other ModuleHOW
+                # collisions stay strict (pre-PR #6122 RakuAST
+                # behavior). On 6.e the enclosing-package case is
+                # handled by the nested-install path above, so this
+                # branch is only reached for non-enclosing collisions.
+                if nqp::istype(%stash{$final}.HOW, Perl6::Metamodel::PackageHOW)
+                  || (nqp::getcomp('Raku').language_revision < 3
+                      && nqp::istype(%stash{$final}.HOW, Perl6::Metamodel::ModuleHOW)
+                      && %stash{$final} =:= $current-package)
+                  || $name.is-identifier || $orig-scope eq 'my' {
                     nqp::setwho($type-object, %stash{$final}.WHO);
                 }
                 else {

--- a/src/Raku/ast/scoping.rakumod
+++ b/src/Raku/ast/scoping.rakumod
@@ -1107,6 +1107,7 @@ class RakuAST::PackageInstaller {
         }
         if $scope eq 'our' {
             if nqp::existskey(%stash, $final) && !(%stash{$final} =:= $type-object) {
+                my $existing := %stash{$final};
                 # On 6.d and earlier, allow the specific legacy pattern
                 # where a declaration silently replaces its enclosing
                 # module (`module Foo::Bar { class Foo::Bar { } }`),
@@ -1115,12 +1116,32 @@ class RakuAST::PackageInstaller {
                 # behavior). On 6.e the enclosing-package case is
                 # handled by the nested-install path above, so this
                 # branch is only reached for non-enclosing collisions.
-                if nqp::istype(%stash{$final}.HOW, Perl6::Metamodel::PackageHOW)
+                if nqp::istype($existing.HOW, Perl6::Metamodel::PackageHOW)
                   || (nqp::getcomp('Raku').language_revision < 3
-                      && nqp::istype(%stash{$final}.HOW, Perl6::Metamodel::ModuleHOW)
-                      && %stash{$final} =:= $current-package)
+                      && nqp::istype($existing.HOW, Perl6::Metamodel::ModuleHOW)
+                      && $existing =:= $current-package)
                   || $name.is-identifier || $orig-scope eq 'my' {
-                    nqp::setwho($type-object, %stash{$final}.WHO);
+                    # Warn when we're actually using the legacy silent-
+                    # replace path on pre-6.e code, so authors migrate
+                    # before they bump their language version to 6.e,
+                    # which installs this pattern as a nested package
+                    # instead. Mirrors the deprecation emitted from the
+                    # traditional grammar's package installer.
+                    # Restrict to multi-part names: single-identifier
+                    # collisions nest inside the enclosing module's WHO
+                    # without losing the outer module, so behavior is
+                    # identical on 6.d and 6.e and there's nothing to
+                    # warn about.
+                    if !$name.is-identifier
+                      && nqp::istype($existing.HOW, Perl6::Metamodel::ModuleHOW)
+                      && !nqp::istype($type-object.HOW, Perl6::Metamodel::ModuleHOW)
+                      && nqp::getcomp('Raku').language_revision < 3 {
+                        $resolver.add-worry: $resolver.build-exception:
+                            'X::Package::SameNameAsEnclosingModule',
+                            :kind(self.declarator),
+                            :name($existing.HOW.name($existing));
+                    }
+                    nqp::setwho($type-object, $existing.WHO);
                 }
                 else {
                     $resolver.add-sorry: $resolver.build-exception:

--- a/src/core.c/Exception.rakumod
+++ b/src/core.c/Exception.rakumod
@@ -1432,6 +1432,21 @@ my class X::Redeclaration::Multi does X::Comp {
     }
 }
 
+my class X::Package::SameNameAsEnclosingModule does X::Comp {
+    has $.kind;
+    has $.name;
+    method message() {
+        ("Declaring $.kind '$.name' inside an enclosing module of the "
+        ~ "same name silently replaces the module in the outer stash. This "
+        ~ "is legacy behavior specific to Raku 6.d and earlier; in Raku 6.e "
+        ~ "the same pattern installs the $.kind as a nested package "
+        ~ "instead. Rewrite as 'unit $.kind $.name;' in its own file "
+        ~ "(or otherwise avoid the module+same-named-$.kind collision) to "
+        ~ "work the same way on either revision."
+        ).naive-word-wrapper
+    }
+}
+
 my class X::Dynamic::Postdeclaration does X::Comp {
     has $.symbol;
     method message() {

--- a/t/02-rakudo/nested-package-collision-gate.t
+++ b/t/02-rakudo/nested-package-collision-gate.t
@@ -1,0 +1,68 @@
+use lib <t/packages/Test-Helpers>;
+use Test;
+use Test::Helpers;
+
+# Verifies the language-version gate on the nested-package-collision
+# behavior introduced by #6122 (see #5854). The pattern in question is:
+#
+#     module Foo::Bar { class Foo::Bar { method x { 42 } } }
+#
+# Pre-6.e: the class silently replaces the module in the outer stash
+#          (steal_WHO); Foo::Bar resolves to the class.
+# 6.e:     the class installs as Foo::Bar::Foo::Bar; Foo::Bar stays
+#          the module.
+#
+# Both frontends must agree on the behavior selected by the language
+# version. We drive the matrix via is-run, toggling RAKUDO_RAKUAST to
+# exercise the RakuAST frontend.
+
+plan 6;
+
+my $code_6d = q:to/CODE/;
+    use v6.d;
+    module Foo::Bar { class Foo::Bar { method x { 42 } } }
+    print Foo::Bar.HOW.^name ~ ';' ~ Foo::Bar.x;
+    CODE
+
+my $code_6e = q:to/CODE/;
+    use v6.e.PREVIEW;
+    module Foo::Bar { class Foo::Bar { method x { 42 } } }
+    print Foo::Bar.HOW.^name ~ ';' ~ Foo::Bar::Foo::Bar.x;
+    CODE
+
+# Non-enclosing module collision (`module A::B::Mod {}; class A::B::Mod {}`
+# at top level) is a different pattern: not an enclosing-package rewrite,
+# just two declarations at the same address. Both frontends must reject
+# it as a Redeclaration on every revision, rather than silently replacing
+# the module with the class.
+my $code_broader = q:to/CODE/;
+    module Alpha::Beta::Mod { }
+    class Alpha::Beta::Mod { method x { 7 } }
+    print Alpha::Beta::Mod.x;
+    CODE
+
+{
+    temp %*ENV;
+    %*ENV<RAKUDO_RAKUAST>:delete;
+    is-run $code_6d, :out('Perl6::Metamodel::ClassHOW;42'),
+      '6.d traditional: silent-replace';
+    is-run $code_6e, :out('Perl6::Metamodel::ModuleHOW;42'),
+      '6.e traditional: nested Foo::Bar::Foo::Bar';
+    is-run $code_broader, :err(/'Redeclaration of symbol' .* 'Alpha::Beta::Mod'/),
+      :exitcode(1), :out(''),
+      '6.d traditional: non-enclosing collision is a Redeclaration';
+}
+
+{
+    temp %*ENV;
+    %*ENV<RAKUDO_RAKUAST> = '1';
+    is-run $code_6d, :out('Perl6::Metamodel::ClassHOW;42'),
+      '6.d RakuAST: silent-replace (emulates traditional)';
+    is-run $code_6e, :out('Perl6::Metamodel::ModuleHOW;42'),
+      '6.e RakuAST: nested Foo::Bar::Foo::Bar';
+    is-run $code_broader, :err(/'Redeclaration of symbol' .* 'Alpha::Beta::Mod'/),
+      :exitcode(1), :out(''),
+      '6.d RakuAST: non-enclosing collision is a Redeclaration';
+}
+
+# vim: expandtab shiftwidth=4

--- a/t/02-rakudo/nested-package-collision-gate.t
+++ b/t/02-rakudo/nested-package-collision-gate.t
@@ -8,15 +8,16 @@ use Test::Helpers;
 #     module Foo::Bar { class Foo::Bar { method x { 42 } } }
 #
 # Pre-6.e: the class silently replaces the module in the outer stash
-#          (steal_WHO); Foo::Bar resolves to the class.
+#          (steal_WHO); Foo::Bar resolves to the class. A deprecation
+#          worry is emitted pointing authors at the migration target.
 # 6.e:     the class installs as Foo::Bar::Foo::Bar; Foo::Bar stays
-#          the module.
+#          the module. No warning.
 #
 # Both frontends must agree on the behavior selected by the language
 # version. We drive the matrix via is-run, toggling RAKUDO_RAKUAST to
 # exercise the RakuAST frontend.
 
-plan 6;
+plan 10;
 
 my $code_6d = q:to/CODE/;
     use v6.d;
@@ -30,6 +31,21 @@ my $code_6e = q:to/CODE/;
     print Foo::Bar.HOW.^name ~ ';' ~ Foo::Bar::Foo::Bar.x;
     CODE
 
+my $code_6d_no_collision = q:to/CODE/;
+    use v6.d;
+    class Alpha::Beta { method x { 99 } }
+    print Alpha::Beta.x;
+    CODE
+
+# Single-identifier collision (`module Foo { class Foo {} }`) nests the
+# class inside the module's WHO without losing the outer module on
+# either revision, so behavior is already aligned and no worry fires.
+my $code_6d_single = q:to/CODE/;
+    use v6.d;
+    module Foo { class Foo { method x { 7 } } }
+    print Foo.HOW.^name ~ ';' ~ Foo::Foo.x;
+    CODE
+
 # Non-enclosing module collision (`module A::B::Mod {}; class A::B::Mod {}`
 # at top level) is a different pattern: not an enclosing-package rewrite,
 # just two declarations at the same address. Both frontends must reject
@@ -41,13 +57,22 @@ my $code_broader = q:to/CODE/;
     print Alpha::Beta::Mod.x;
     CODE
 
+my $deprecation-rx = rx/
+    'Declaring class' \h "'Foo::Bar'" \h 'inside an enclosing module' .*
+    'silently replaces' .* 'Raku 6.d' .* 'Raku 6.e' .* "'unit class Foo::Bar;'"
+/;
+
 {
     temp %*ENV;
     %*ENV<RAKUDO_RAKUAST>:delete;
-    is-run $code_6d, :out('Perl6::Metamodel::ClassHOW;42'),
-      '6.d traditional: silent-replace';
-    is-run $code_6e, :out('Perl6::Metamodel::ModuleHOW;42'),
-      '6.e traditional: nested Foo::Bar::Foo::Bar';
+    is-run $code_6d, :out('Perl6::Metamodel::ClassHOW;42'), :err($deprecation-rx),
+      '6.d traditional: silent-replace + deprecation worry';
+    is-run $code_6e, :out('Perl6::Metamodel::ModuleHOW;42'), :err(''),
+      '6.e traditional: nested Foo::Bar::Foo::Bar, no warning';
+    is-run $code_6d_no_collision, :out('99'), :err(''),
+      '6.d traditional: stub-package upgrade does not warn';
+    is-run $code_6d_single, :out('Perl6::Metamodel::ModuleHOW;7'), :err(''),
+      '6.d traditional: single-identifier natural nesting, no warning';
     is-run $code_broader, :err(/'Redeclaration of symbol' .* 'Alpha::Beta::Mod'/),
       :exitcode(1), :out(''),
       '6.d traditional: non-enclosing collision is a Redeclaration';
@@ -56,10 +81,14 @@ my $code_broader = q:to/CODE/;
 {
     temp %*ENV;
     %*ENV<RAKUDO_RAKUAST> = '1';
-    is-run $code_6d, :out('Perl6::Metamodel::ClassHOW;42'),
-      '6.d RakuAST: silent-replace (emulates traditional)';
-    is-run $code_6e, :out('Perl6::Metamodel::ModuleHOW;42'),
-      '6.e RakuAST: nested Foo::Bar::Foo::Bar';
+    is-run $code_6d, :out('Perl6::Metamodel::ClassHOW;42'), :err($deprecation-rx),
+      '6.d RakuAST: silent-replace + deprecation worry';
+    is-run $code_6e, :out('Perl6::Metamodel::ModuleHOW;42'), :err(''),
+      '6.e RakuAST: nested Foo::Bar::Foo::Bar, no warning';
+    is-run $code_6d_no_collision, :out('99'), :err(''),
+      '6.d RakuAST: stub-package upgrade does not warn';
+    is-run $code_6d_single, :out('Perl6::Metamodel::ModuleHOW;7'), :err(''),
+      '6.d RakuAST: single-identifier natural nesting, no warning';
     is-run $code_broader, :err(/'Redeclaration of symbol' .* 'Alpha::Beta::Mod'/),
       :exitcode(1), :out(''),
       '6.d RakuAST: non-enclosing collision is a Redeclaration';


### PR DESCRIPTION
PR #6122 (for issue #5854) fixed a longstanding quirk where declaring a class inside a module with the same name, e.g. `module Foo::Bar { class Foo::Bar { } }`, silently replaced the module with the class in the outer stash. The fix was the correct behavior per the language spec, but it regressed ecosystem modules.

This PR keeps #6122's fix but puts it behind a `use v6.e.PREVIEW` gate. On 6.d and 6.c the traditional grammar continues to silently replace as it always has, and RakuAST now emulates the same behavior rather than throwing X::Redeclaration. On 6.e the new nested semantics apply to both frontends. That gives the ecosystem a migration window for fixes.

Pre-6.e code that hits the legacy silent-replace path additionally emits a compile time worry that suggests how the issue can be fixed.

### 6.d (class silently replaces module, worry fires)

```console
$ raku -e 'use v6.d; module Foo::Bar { class Foo::Bar { method x { 42 } } }; say Foo::Bar.HOW.^name; say Foo::Bar.x'
Potential difficulties:
    Declaring class 'Foo::Bar' inside an enclosing module of the same name
    silently replaces the module in the outer stash. This is legacy behavior
    specific to Raku 6.d and earlier; in Raku 6.e the same pattern installs
    the class as a nested package instead. Rewrite as 'unit class Foo::Bar;'
    in its own file (or otherwise avoid the module+same-named-class
    collision) to work the same way on either revision.
    at -e:1
    ------> use v6.d; module Foo::Bar { class <HERE>Foo::Bar { method x { 42 } } }; say Foo:
Perl6::Metamodel::ClassHOW
42

$ RAKUDO_RAKUAST=1 raku -e 'use v6.d; module Foo::Bar { class Foo::Bar { method x { 42 } } }; say Foo::Bar.HOW.^name; say Foo::Bar.x'
Potential difficulties:
    Declaring class 'Foo::Bar' inside an enclosing module of the same name
    silently replaces the module in the outer stash. This is legacy behavior
    specific to Raku 6.d and earlier; in Raku 6.e the same pattern installs
    the class as a nested package instead. Rewrite as 'unit class Foo::Bar;'
    in its own file (or otherwise avoid the module+same-named-class
    collision) to work the same way on either revision.
    at line
Perl6::Metamodel::ClassHOW
42
```

### 6.e (class installs nested, outer module preserved, no warning)

```console
$ raku -e 'use v6.e.PREVIEW; module Foo::Bar { class Foo::Bar { method x { 42 } } }; say Foo::Bar.HOW.^name; say Foo::Bar::Foo::Bar.x'
Perl6::Metamodel::ModuleHOW
42

$ RAKUDO_RAKUAST=1 raku -e 'use v6.e.PREVIEW; module Foo::Bar { class Foo::Bar { method x { 42 } } }; say Foo::Bar.HOW.^name; say Foo::Bar::Foo::Bar.x'
Perl6::Metamodel::ModuleHOW
42
```
