### PR TITLE
MoarVM::Profiler: use unit class to silence deprecation worry

### DIFF
--- a/lib/MoarVM/Profiler.rakumod
+++ b/lib/MoarVM/Profiler.rakumod
@@ -18,7 +18,7 @@
 
 # Make all class references a lot shorter
 
-unit module MoarVM::Profiler;
+unit class MoarVM::Profiler;
 
 # We need NQP here, duh!
 use nqp;
@@ -499,13 +499,12 @@ class Thread does OnHash[<
 }
 
 # Main object returned by profile() and friends.
-class MoarVM::Profiler {
-    has %.types_by_id;
-    has %.types_by_name;
-    has %.threads_by_id;
-    has @.callees_by_id;
-    has @.allocations_by_id;
-    has @.deallocations_by_id;
+has %.types_by_id;
+has %.types_by_name;
+has %.threads_by_id;
+has @.callees_by_id;
+has @.allocations_by_id;
+has @.deallocations_by_id;
 
     method !SET-SELF(@raw) {
         my $*PROFILE = self;
@@ -655,7 +654,6 @@ class MoarVM::Profiler {
     method average_profile(&code, :$times = 5 --> MoarVM::Profiler:D) {
         self.average( self.profile(&code, :$times) )
     }
-}
 
 # Raw subs, for cases where starting an extra scope would be troublesome
 sub profile_start(--> Nil) is export {


### PR DESCRIPTION
`MoarVM::Profiler.rakumod` was declared as `unit module MoarVM::Profiler` with a nested `class MoarVM::Profiler { ... }` of the same name, which triggers a deprecation worry on 6.d. Collapse the wrapper into `unit class MoarVM::Profiler;` with the attribute declarations at file scope. The nested helper classes and the exported subs keep their public addresses and behavior, so external consumers are unaffected, and the file now works the same way under 6.e where the old pattern would install the class as a nested package.