### PR TITLE
Fix RakuAST .EVAL at BEGIN time losing access to setting symbols

### DIFF
--- a/src/Raku/ast/compunit.rakumod
+++ b/src/Raku/ast/compunit.rakumod
@@ -256,6 +256,13 @@ class RakuAST::CompUnit
     # does not declare its own GLOBAL and so forth.
     method is-eval() { $!is-eval ?? True !! False }
 
+    # The setting context the CompUnit's resolver knows about, if any.
+    method setting() {
+        nqp::isconcrete($!resolver)
+          ?? nqp::getattr($!resolver, RakuAST::Resolver, '$!setting')
+          !! Mu
+    }
+
     method attach-target-names() {
         self.IMPL-WRAP-LIST(['compunit'])
     }

--- a/src/Raku/ast/resolver.rakumod
+++ b/src/Raku/ast/resolver.rakumod
@@ -819,11 +819,13 @@ class RakuAST::Resolver::EVAL
     # The stack of scopes we are in (an array of RakuAST::LexicalScope).
     has Mu $!scopes;
 
-    method new(Mu :$global!, Mu :$context!) {
+    method new(Mu :$global!, Mu :$context!, Mu :$setting) {
         my $obj := nqp::create(self);
         nqp::bindattr($obj, RakuAST::Resolver, '$!outer', $context);
         nqp::bindattr($obj, RakuAST::Resolver, '$!setting',
-            self.IMPL-SETTING-FROM-CONTEXT($context));
+            nqp::defined($setting)
+              ?? $setting
+              !! self.IMPL-SETTING-FROM-CONTEXT($context));
         nqp::bindattr($obj, RakuAST::Resolver, '$!global', $global);
         nqp::bindattr($obj, RakuAST::Resolver, '$!attach-targets', nqp::hash());
         my $cur-package := $obj.resolve-lexical-constant-in-outer('$?PACKAGE');
@@ -907,9 +909,34 @@ class RakuAST::Resolver::EVAL
                 return $found if nqp::isconcrete($found);
             }
 
-            # Fallback handling
-            self.resolve-lexical-in-outer($name)
+            # Fallback: try the captured outer context, and if that doesn't
+            # reach the setting (e.g. EVAL from inside a BEGIN block whose
+            # outer chain isn't yet linked to CORE), walk $!setting directly.
+            my $found := self.resolve-lexical-in-outer($name);
+            return $found if nqp::isconcrete($found);
+            my $setting := nqp::getattr(self, RakuAST::Resolver, '$!setting');
+            nqp::isnull($setting) || !$setting
+              ?? Nil
+              !! self.IMPL-RESOLVE-LEXICAL-IN-SETTING($setting, $name)
         }
+    }
+
+    # Walk a given setting context for $name, returning an External::Setting
+    # on a hit. Setting-only walk: no native/primspec handling, since callers
+    # pass a real setting context. Mirrors the setting branch of
+    # resolve-lexical-in-outer on the base class.
+    method IMPL-RESOLVE-LEXICAL-IN-SETTING(Mu $setting, Str $name) {
+        my $context := $setting;
+        until nqp::isnull($context) {
+            if nqp::existskey($context, $name) {
+                return RakuAST::Declaration::External::Setting.new(
+                  :lexical-name($name),
+                  :compile-time-value(nqp::atkey($context, $name))
+                );
+            }
+            $context := nqp::ctxouter($context);
+        }
+        Nil
     }
 
     # Resolves a lexical to its declaration. The declaration must have a
@@ -953,8 +980,18 @@ class RakuAST::Resolver::EVAL
                 }
             }
 
-            # Fallback handling
-            self.resolve-lexical-constant-in-outer($name)
+            # Fallback: same shape as resolve-lexical above. Try the captured
+            # outer context; if that doesn't reach the setting (BEGIN-time
+            # EVAL cases), walk $!setting directly. Needed here because
+            # IMPL-FIXUP-DYNAMICALLY-COMPILED-BLOCK asks for constants via
+            # this method when baking &routine / Nil / Mu etc. into
+            # dynamically-compiled Code bodies.
+            my $found := self.resolve-lexical-constant-in-outer($name);
+            return $found if nqp::isconcrete($found);
+            my $setting := nqp::getattr(self, RakuAST::Resolver, '$!setting');
+            nqp::isnull($setting) || !$setting
+              ?? Nil
+              !! self.IMPL-RESOLVE-LEXICAL-IN-SETTING($setting, $name)
         }
     }
 }

--- a/src/core.c/ForeignCode.rakumod
+++ b/src/core.c/ForeignCode.rakumod
@@ -87,7 +87,14 @@ $lang = 'Raku' if $lang eq 'perl6';
         }
 
         # Perform symbol resolution, then compile to QAST and in turn bytecode.
-        my $resolver := RakuAST::Resolver::EVAL.new(:context($eval_ctx), :global(GLOBAL));
+        # When called from a BEGIN block the captured outer-context chain may
+        # not yet be linked to the setting; in that case thread the setting
+        # through from the currently-compiling CompUnit so lexicals like &say
+        # can still be resolved at compile time.
+        my $outer-setting := $*CU && nqp::istype($*CU, RakuAST::CompUnit)
+            ?? $*CU.setting !! Mu;
+        my $resolver := RakuAST::Resolver::EVAL.new(
+            :context($eval_ctx), :global(GLOBAL), :setting($outer-setting));
         $comp-unit.begin($resolver);
         $comp-unit.check($resolver);
         if $resolver.has-compilation-errors {

--- a/t/12-rakuast/xx-fixed-in-rakuast.rakutest
+++ b/t/12-rakuast/xx-fixed-in-rakuast.rakutest
@@ -2,7 +2,7 @@ use Test;
 use lib <t/packages/Test-Helpers>;
 use Test::Helpers;
 
-plan 106;
+plan 110;
 
 # t/spec/S03-sequence/misc.t
 # https://github.com/rakudo/rakudo/issues/5520
@@ -737,6 +737,51 @@ subtest 'use of &?ROUTINE and &?BLOCK' => {
     todo q|ensure that hyper operators prime as expected|
         unless %*ENV<RAKUDO_RAKUAST>;
     ok *>>.fmt("%02x")(42) eq "2a", "postfix hyper primes properly";
+}
+
+# https://github.com/rakudo/rakudo/issues/6134
+# RakuAST node .EVAL used to fail at BEGIN time because the EVAL resolver's
+# captured outer context chain doesn't reach the CORE setting mid-compile.
+{
+    my $sub = BEGIN Q|sub foo { }|.AST.EVAL;
+    isa-ok $sub, Sub, 'BEGIN-time EVAL of a parsed RakuAST sub produces a Sub';
+}
+
+{
+    lives-ok {
+        BEGIN Q||.AST.EVAL;
+    }, 'BEGIN-time EVAL of an empty RakuAST statement list lives';
+}
+
+{
+    my $greeter = BEGIN Q|sub { "hi " ~ "there" }|.AST.EVAL;
+    is $greeter(), "hi there",
+      'BEGIN-time EVAL of a RakuAST sub can resolve setting routines and run';
+}
+
+{
+    (temp %*ENV)<RAKUDO_RAKUAST> = 1;
+    is-run q:to/PROG/, :out("foo\n"),
+        my &foo = BEGIN {
+            RakuAST::Sub.new(
+              name => RakuAST::Name.from-identifier("foo"),
+              body => RakuAST::Blockoid.new(
+                RakuAST::StatementList.new(
+                  RakuAST::Statement::Expression.new(
+                    expression => RakuAST::Call::Name::WithoutParentheses.new(
+                      name => RakuAST::Name.from-identifier("say"),
+                      args => RakuAST::ArgList.new(
+                        RakuAST::StrLiteral.new("foo")
+                      )
+                    )
+                  )
+                )
+              )
+            ).EVAL
+        }
+        foo();
+        PROG
+      'synthetic RakuAST::Sub calling a setting routine runs at runtime';
 }
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
Calling .EVAL on a synthetic RakuAST node inside a BEGIN block failed
with "Could not find a compile-time-value for lexical Nil" because the
EVAL resolver couldn't reach CORE. At BEGIN time the caller's lexical
context chain terminates at the partially-built CompUnit mainline and
never links to the setting, so IMPL-SETTING-FROM-CONTEXT returns Nil
and the outer-context walk in the resolver never finds built-ins like
Nil, Mu, or &say. Two symptom shapes surface depending on where the
lookup happens:

  * PERFORM-BEGIN on RakuAST::Call::Name calls resolve-lexical('&say')
    and gets Nil, leading to X::Undeclared::Symbols at check time.

  * IMPL-FIXUP-DYNAMICALLY-COMPILED-BLOCK (which statically bakes
    outer-lexical references into dynamically-compiled Code bodies)
    calls resolve-lexical-constant('&say') / ('Nil') and gets Nil,
    throwing "Could not find a compile-time-value for lexical X" or
    "Undeclared routine: &X used at line -1" for synthetic nodes.

Thread the currently-compiling CompUnit's setting through to the EVAL
resolver and give the resolver a setting-aware fallback on both lookup
paths:

1. New narrow CompUnit.setting accessor exposing $!resolver.$!setting
   (the BOOTContext of the outer compile's setting). Guards with
   nqp::isconcrete and uses nqp::getattr directly because the Raku $.
   accessor silently masks VMNull (which $!setting can be while
   compiling CORE.setting itself).

2. RakuAST::Resolver::EVAL.new accepts :$setting and stores it as
   `$!setting`, overriding IMPL-SETTING-FROM-CONTEXT's walk-the-$!outer
   result.

3. ForeignCode's RakuAST EVAL path threads $*CU.setting into the new
   resolver when $*CU is a RakuAST::CompUnit; otherwise (runtime EVAL,
   $*CU undefined) it passes Mu and the resolver falls back to the
   existing IMPL-SETTING-FROM-CONTEXT path, preserving prior behavior.

4. resolve-lexical and resolve-lexical-constant on Resolver::EVAL both
   get a setting fallback: after $!outer fails to find the name, walk
   $!setting directly and return an External::Setting declaration
   (shared helper, matching the External::Setting already returned by
   resolve-lexical-in-outer on setting hits). Both methods need it
   because PERFORM-BEGIN uses resolve-lexical while
   IMPL-FIXUP-DYNAMICALLY-COMPILED-BLOCK (called per-Code-node by
   IMPL-COMPILE-DYNAMICALLY, and per-compunit by IMPL-TO-QAST-COMP-UNIT)
   uses resolve-lexical-constant.

Runtime .EVAL is unchanged: $*CU is undefined at runtime, so the new
setting-threading branch is skipped.

Fixes https://github.com/rakudo/rakudo/issues/6134