### PR TITLE
In do_nibbling, don't allow a `starter` without `stopper` to backtrack

### DIFF
--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -5612,7 +5612,8 @@ grammar Perl6::QGrammar is HLL::Grammar does STD {
 
                     $from := $to := $c.pos;
                 }
-            || .
+            || <!starter> .
+            || <.panic("argh")>
             ]
         ]*
         {


### PR DESCRIPTION
Otherwise code like `<3<<<<<<<<<<<<<<<<<<<<<<<<<` will take forever to parse.

To do: raise the correct kind of error for this, and I haven't run spec tests yet, so the PR is for getting CI to do it :)