### PR TITLE
RakuAST: fix 'is T' on generic role attributes

### DIFF
--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -927,14 +927,30 @@ class RakuAST::VarDeclaration::Simple
                     !! RakuAST::ArgList.new;
                 my $of := $subset ?? $subset.meta-object !! self.IMPL-OF-TYPE;
 
-                my $container-initializer-ast := RakuAST::ApplyPostfix.new(
-                    operand => RakuAST::Declaration::ResolvedConstant.new(
+                my $base-ast := self.IMPL-EXPLICIT-CONTAINER-BASE-TYPE-AST;
+                my $operand;
+                if $!sigil ne '$' && nqp::isconcrete($base-ast)
+                    && nqp::can($base-ast.meta-object.HOW, 'archetypes')
+                    && $base-ast.meta-object.HOW.archetypes.generic
+                {
+                    # Generic base type (e.g. `is T` in a parametric role):
+                    # reuse the already-resolved type AST as the operand. Its
+                    # IMPL-EXPR-QAST emits a lexical lookup that role
+                    # specialization re-resolves to the concrete type before
+                    # `.new` is dispatched.
+                    $operand := $base-ast;
+                }
+                else {
+                    $operand := RakuAST::Declaration::ResolvedConstant.new(
                         :compile-time-value(
                             $!sigil eq '$'
                                 ?? self.meta-object
                                 !! self.IMPL-CONTAINER-TYPE($of)
                         )
-                    ),
+                    );
+                }
+                my $container-initializer-ast := RakuAST::ApplyPostfix.new(
+                    :$operand,
                     postfix => RakuAST::Call::Method.new(
                         name => RakuAST::Name.from-identifier('new'),
                         :$args

--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -119,8 +119,12 @@ class RakuAST::Initializer::CallAssign
 # Consuming class has to implement IMPL-SIGIL-TYPE which returns the resolution
 # for the lookup created by IMPL-SIGIL-LOOKUP.
 class RakuAST::ContainerCreator {
-    has Mu $!explicit-container-base-type;
-    has Mu $!conflicting-base-type;
+    # The RakuAST::Type node for an explicit container base type (e.g. `is T`
+    # or `is Array[Str]`). Stored as AST, not just its meta-object, so
+    # callers that need the resolved lookup node (not just the type object)
+    # can reuse it directly.
+    has RakuAST::Type $!explicit-container-base-type-ast;
+    has RakuAST::Type $!conflicting-base-type-ast;
     has Bool $.forced-dynamic;
     has Bool $!initialized;
     has Mu $.container-base-type;
@@ -128,28 +132,36 @@ class RakuAST::ContainerCreator {
     has ContainerDescriptor $.container-descriptor;
     has Mu $.bind-constraint;
 
-    method IMPL-SET-EXPLICIT-CONTAINER-BASE-TYPE(Mu $type) {
+    method IMPL-SET-EXPLICIT-CONTAINER-BASE-TYPE(RakuAST::Type $ast) {
         if self.IMPL-HAS-EXPLICIT-CONTAINER-BASE-TYPE {
-            nqp::bindattr(self, RakuAST::ContainerCreator, '$!conflicting-base-type', $!explicit-container-base-type);
+            nqp::bindattr(self, RakuAST::ContainerCreator, '$!conflicting-base-type-ast', $!explicit-container-base-type-ast);
         }
-        nqp::bindattr(self, RakuAST::ContainerCreator, '$!explicit-container-base-type', $type);
+        nqp::bindattr(self, RakuAST::ContainerCreator, '$!explicit-container-base-type-ast', $ast);
         nqp::bindattr(self, RakuAST::ContainerCreator, '$!initialized', False);
     }
 
+    method IMPL-EXPLICIT-CONTAINER-BASE-TYPE-AST() {
+        $!explicit-container-base-type-ast
+    }
+
     method IMPL-HAS-EXPLICIT-CONTAINER-BASE-TYPE() {
-        !nqp::eqaddr($!explicit-container-base-type, Mu)
+        nqp::isconcrete($!explicit-container-base-type-ast)
     }
 
     method IMPL-HAS-CONFLICTING-BASE-TYPE() {
-        !nqp::eqaddr($!conflicting-base-type, Mu)
+        nqp::isconcrete($!conflicting-base-type-ast)
     }
 
     method IMPL-EXPLICIT-CONTAINER-BASE-TYPE() {
-        $!explicit-container-base-type
+        self.IMPL-HAS-EXPLICIT-CONTAINER-BASE-TYPE
+            ?? $!explicit-container-base-type-ast.meta-object
+            !! Mu
     }
 
     method IMPL-CONFLICTING-BASE-TYPE() {
-        $!conflicting-base-type
+        self.IMPL-HAS-CONFLICTING-BASE-TYPE
+            ?? $!conflicting-base-type-ast.meta-object
+            !! Mu
     }
 
     method IMPL-SIGIL-LOOKUP() {
@@ -174,7 +186,8 @@ class RakuAST::ContainerCreator {
         my $container-type;
         my $default := Any;
         my $bind-constraint := Mu;
-        if nqp::eqaddr($!explicit-container-base-type, Mu) {
+        my $explicit-base := self.IMPL-EXPLICIT-CONTAINER-BASE-TYPE;
+        if !self.IMPL-HAS-EXPLICIT-CONTAINER-BASE-TYPE {
             if $sigil eq '@' {
                 $bind-constraint := self.IMPL-SIGIL-TYPE;
                 $container-base-type := nqp::objprimspec($of) ?? array !! Array;
@@ -216,9 +229,9 @@ class RakuAST::ContainerCreator {
                     }
                     else {
                         $container-type := Hash.HOW.parameterize(
-                            Hash, $!explicit-container-base-type, $key-type);
+                            Hash, $explicit-base, $key-type);
                         $bind-constraint := $bind-constraint.HOW.parameterize(
-                            $bind-constraint, $!explicit-container-base-type, $key-type);
+                            $bind-constraint, $explicit-base, $key-type);
                     }
                 }
             }
@@ -239,8 +252,8 @@ class RakuAST::ContainerCreator {
         }
         else {
             $container-type := self.type
-                ?? $!explicit-container-base-type.HOW.parameterize($!explicit-container-base-type, $of)
-                !! $!explicit-container-base-type;
+                ?? $explicit-base.HOW.parameterize($explicit-base, $of)
+                !! $explicit-base;
         }
 
         nqp::bindattr(self, RakuAST::ContainerCreator, '$!initialized', True);
@@ -286,7 +299,7 @@ class RakuAST::ContainerCreator {
         my $container-type := self.container-type;
         # Form the container.
         my str $sigil := self.sigil;
-        if nqp::eqaddr($!explicit-container-base-type, Mu) {
+        if !self.IMPL-HAS-EXPLICIT-CONTAINER-BASE-TYPE {
             if $sigil ne '@' && $sigil ne '%' {
                 if nqp::objprimspec($of) {
                     nqp::die("Natively typed state variables not yet implemented") if self.scope eq 'state';
@@ -303,7 +316,7 @@ class RakuAST::ContainerCreator {
             $container
         }
         else {
-            $!explicit-container-base-type
+            self.IMPL-EXPLICIT-CONTAINER-BASE-TYPE
         }
     }
 }
@@ -885,7 +898,7 @@ class RakuAST::VarDeclaration::Simple
                 if nqp::isconcrete($type) && !$_.argument
                     && (!nqp::istype($type, RakuAST::Lookup) || $type.is-resolved)
                 {
-                    self.IMPL-SET-EXPLICIT-CONTAINER-BASE-TYPE($type.meta-object);
+                    self.IMPL-SET-EXPLICIT-CONTAINER-BASE-TYPE($type);
                     next;
                 }
             }


### PR DESCRIPTION
Makes `t/spec/S02-types/is-type.t` pass with `RAKUDO_RAKUAST=1`