### PR TITLE
RakuAST: drop dead compile-time-value read in package-lookup parse

### DIFF
--- a/src/Raku/ast/term.rakumod
+++ b/src/Raku/ast/term.rakumod
@@ -37,7 +37,6 @@ class RakuAST::Term::Name
             if $name.canonicalize {
                 $resolved := $resolver.resolve-name($name);
                 if $resolved {
-                    my $v := $resolved.compile-time-value;
                     self.set-resolution($resolved);
                 }
             }


### PR DESCRIPTION
Makes `t/spec/S12-enums/misc.t`  pass with `RAKUDO_RAKUAST=1`