### PR TITLE
Add native int/num method "bits"

### DIFF
--- a/src/core.c/Int.rakumod
+++ b/src/core.c/Int.rakumod
@@ -16,6 +16,8 @@ my class Int does Real { # declared in BOOTSTRAP
     # class Int is Cool
     #     has bigint $!value is box_target;
 
+    method bits(Int:U:) { nqp::objprimbits(self) || Inf }
+
     multi method WHICH(Int:D: --> ValueObjAt:D) {
         nqp::box_s(
           nqp::concat(

--- a/src/core.c/Num.rakumod
+++ b/src/core.c/Num.rakumod
@@ -6,6 +6,8 @@ my class Num does Real { # declared in BOOTSTRAP
     # class Num is Cool
     #     has num $!value is box_target;
 
+    method bits(Num:U:) { nqp::objprimbits(self) || nqp::objprimbits(num) }
+
     multi method WHICH(Num:D: --> ValueObjAt:D) {
         nqp::box_s(
           nqp::concat(

--- a/src/core.c/Rakudo/Internals.rakumod
+++ b/src/core.c/Rakudo/Internals.rakumod
@@ -1793,7 +1793,7 @@ my class Rakudo::Internals {
 }
 
 # expose the number of bits a native int has
-my constant $?BITS = nqp::isgt_i(nqp::add_i(2147483648, 1), 0) ?? 64 !! 32;
+my constant $?BITS = nqp::objprimbits(int);
 
 {   # setting up END phaser handling
     my int $the-end-is-done;


### PR DESCRIPTION
TIL I learned about the existence of nqp::objprimbits.  This is now used to initialize $?BITS with, and to introduce the .bits method to native int and num types.

Because these types do not directly exist as classes, the methods actually live inside the Int and Num classes, and are gated to (native) type objects.

This now allows one to do:

    say int16.bits;  # 16
    say num.bits;    # 64
    say Uint.bits;   # Inf