### PR TITLE
RakuAST: dedupe @declarations at the source in ast-lexical-declarations

### DIFF
--- a/src/Raku/ast/scoping.rakumod
+++ b/src/Raku/ast/scoping.rakumod
@@ -106,13 +106,17 @@ class RakuAST::LexicalScope
     method ast-lexical-declarations() {
         unless nqp::isconcrete($!declarations-cache) {
             my @declarations;
+            my %declarations-seen;
             my @variables;
             my %variables-seen;
             my @not-if-duplicate;
             self.visit-dfs: -> $node {
                 if nqp::istype($node, RakuAST::Declaration) && $node.is-simple-lexical-declaration {
-                    nqp::push(@declarations, $node);
-                    nqp::push(@variables, $node) unless nqp::istype($node, RakuAST::Routine);
+                    unless %declarations-seen{nqp::objectid($node)} {
+                        nqp::push(@declarations, $node);
+                        nqp::push(@variables, $node) unless nqp::istype($node, RakuAST::Routine);
+                        %declarations-seen{nqp::objectid($node)} := 1;
+                    }
                 }
                 elsif nqp::istype($node, RakuAST::Var::Lexical)
                     || nqp::istype($node, RakuAST::Var::Dynamic)
@@ -130,9 +134,10 @@ class RakuAST::LexicalScope
                                 if nqp::istype($decl, RakuAST::VarDeclaration::Implicit::BlockTopic) && $decl.IMPL-NOT-IF-DUPLICATE {
                                     nqp::push(@not-if-duplicate, $decl);
                                 }
-                                else {
+                                elsif !%declarations-seen{nqp::objectid($decl)} {
                                     nqp::push(@declarations, $decl);
                                     nqp::push(@variables, $decl);
+                                    %declarations-seen{nqp::objectid($decl)} := 1;
                                 }
                             }
                         }


### PR DESCRIPTION
Some CompUnit-level implicit declarations ($!pod, $!data, $!finish, $!rakudoc) are reachable from the ast-lexical-declarations DFS walk via two intentional paths: once when visit-children visits them as direct attributes of CompUnit (so IMPL-BEGIN/IMPL-CHECK reach them to drive PERFORM-BEGIN/PERFORM-CHECK), and once when the DFS visits CompUnit itself and folds in its get-implicit-declarations results (so the resolver registers them as live lexicals via create-implicits).

Both paths are required and cannot be collapsed to one. Removing either side silently breaks a real phase. The bug is that ast-lexical-declarations() was pushing the same underlying RakuAST::Declaration object onto @declarations from both arms of its DFS visitor without deduping, producing duplicate entries in the cached @declarations list. Downstream that surfaces in IMPL-QAST-DECLS as two QAST::Var :decl<static> :name<$=pod> declarations in the same block, tripping "Lexical '$=pod' already declared" in the MAST compiler.

Fix it where the duplicate is introduced: track an objectid-keyed %seen-decl set as @declarations is built, and skip subsequent pushes of an already-seen node. Single source of truth, single dedup key, benefits every consumer of @declarations (IMPL-QAST-DECLS, the generated-lexical clone in lexical-declarations(), and the iterations elsewhere in scoping.rakumod) without per-consumer dedup.

This bug was pre-existing but only surfaced once the Stage qast hangs were fixed and compilation actually reached Stage mast.