### PR TITLE
RakuAST: stop "Out-of-sync package detected in LANG1" warnings

### DIFF
--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -172,6 +172,26 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
           !! $hash.FLATTENABLE_HASH
     }
 
+    # Set $*PACKAGE at compunit scope and sync the cursor's braid so the
+    # check_PACKAGE_oopsies sanity check used at every slang switch (LANG)
+    # doesn't fire spuriously while parsing file-scope code outside any
+    # package-def. Mirrors the legacy frontend's compunit-time package
+    # initialization (src/Perl6/World.nqp's comp_unit_stage1 sets
+    # $*PACKAGE := $*GLOBALish then calls $/.set_package($package)).
+    method set-compunit-package($/) {
+        my $package := nqp::getlexdyn('$?PACKAGE');
+        # In EVAL mode we expect $?PACKAGE to be inherited from the outer
+        # dyn-context. For a fresh compile there is no outer $?PACKAGE,
+        # so fall back to the compunit's generated GLOBAL.
+        if nqp::isnull($package) && !$*CU.is-eval {
+            $package := $*CU.generated-global;
+        }
+        unless nqp::isnull($package) {
+            $*PACKAGE := $package;
+            $/.set_package($package);
+        }
+    }
+
     # Perform all actions that are needed before any actual parsing can
     # be done by a grammar.
     method comp-unit-prologue($/) {

--- a/src/Raku/Grammar.nqp
+++ b/src/Raku/Grammar.nqp
@@ -257,10 +257,14 @@ role Raku::Common {
             @keybits.push($base) if $base;
             for @tweaks {
                 my str $t := $_[0];
-                @keybits.push($t eq 'to'
-                  ?? 'HEREDOC'         # all heredocs share the same lang
-                  !! $t ~ '=' ~ $_[1]  # cannot use nqp::join as [1] is Bool
-                );
+                # Heredocs (:to) get a fresh quote-lang per invocation so
+                # the herelang cursor's braid is cloned from the current
+                # scope's self.braid (matching $*PACKAGE) rather than
+                # being inherited from a cached cursor that was built in
+                # a different scope. Mirrors legacy's NOCACHE handling
+                # in src/Perl6/Grammar.nqp's quote_lang lang_key sub.
+                return 'NOCACHE' if $t eq 'to';
+                @keybits.push($t ~ '=' ~ $_[1]);
             }
 
             nqp::join("\0", @keybits)
@@ -297,16 +301,17 @@ role Raku::Common {
               !! $lang.unbalanced($stop)
         }
 
-        # get language from cache or derive it.
+        # get language from cache or derive it. The 'NOCACHE' sentinel
+        # (currently used for heredocs, see key-for-quote-lang) skips the
+        # cache and forces a fresh quote-lang per invocation.
         my $key   := key-for-quote-lang();
         my %cache := %*QUOTE-LANGS;
 
         # Read from / Update to cache in a thread-safe manner
         nqp::lock($quote-lang-lock);
-        my $quote-lang := nqp::ifnull(
-          nqp::atkey(%cache,$key),
-          nqp::bindkey(%cache,$key,create-quote-lang-type())
-        );
+        my $quote-lang := nqp::existskey(%cache, $key) && $key ne 'NOCACHE'
+          ?? nqp::atkey(%cache, $key)
+          !! nqp::bindkey(%cache, $key, create-quote-lang-type());
         nqp::unlock($quote-lang-lock);
 
         # Use $*PACKAGE (the authoritative dyn-var) rather than

--- a/src/Raku/Grammar.nqp
+++ b/src/Raku/Grammar.nqp
@@ -309,7 +309,11 @@ role Raku::Common {
         );
         nqp::unlock($quote-lang-lock);
 
-        $quote-lang.set_package(self.package);
+        # Use $*PACKAGE (the authoritative dyn-var) rather than
+        # self.package (which reads from the cursor's braid; that braid
+        # may have been cloned earlier from a different scope and not
+        # been re-synced when $*PACKAGE changed at scope transitions).
+        $quote-lang.set_package($*PACKAGE);
         $quote-lang
     }
 

--- a/src/Raku/Grammar.nqp
+++ b/src/Raku/Grammar.nqp
@@ -1275,6 +1275,7 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
         :my $*NEXT-STATEMENT-ID := 0;  # to give each statement an ID
         :my $*START-OF-COMPUNIT := 1;  # flag: start of a compilation unit?
         <.lang-setup($outer-cu)>  # set the above variables
+        :my $*PACKAGE;
 
         # Further needed initializations
         {
@@ -1282,6 +1283,7 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
              $*R.create-scope-implicits();
              self.actions.load-M-modules($/);
              self.actions.load-bootstrap($/);
+             self.actions.set-compunit-package($/);
         }
 
         # Perform the actual parsing of the code, using origin tracking


### PR DESCRIPTION
`RAKUDO_RAKUAST=1 make install` was emitting `Out-of-sync package detected in LANG1` while compiling files like lib/Telemetry.rakumod that have multiple classes plus heredocs. The legacy frontend doesn't emit this on the same file. The Raku grammar's quote-lang cache was normalizing `:to` to a constant 'HEREDOC' key, so every heredoc in a compunit shared one cached cursor. The first heredoc set that cursor's braid to whatever package was in scope at the time, and subsequent heredocs reused it and inherited the stale package. When the heredoc body parser later hit an embedded `{}` block it called LANG('MAIN','block'), and check_PACKAGE_oopsies compared the stale braid against $*PACKAGE and fired the warning. Legacy avoids this by returning a 'NOCACHE' sentinel when :to is present (see src/Perl6/Grammar.nqp's quote_lang). The third commit mirrors that.

Two related fixes are bundled because they came up while investigating: declaring `:my $*PACKAGE;` at compunit scope and seeding it from the outer `$?PACKAGE` or the compunit's GLOBAL (file scope code was seeing $*PACKAGE = NQPMu), and using `$*PACKAGE` rather than `self.package` when syncing the quote-lang's braid since the dyn-var is the authoritative source.
