### PR TITLE
RakuAST: align nested-EVAL fixup with legacy frontend so `$!do` gets unstubbed

### DIFF
--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -198,7 +198,7 @@ class RakuAST::Code
         $block.set-cuid($!cuid);
 
         my $fixups := QAST::Stmts.new();
-        unless $context.is-precompilation-mode || $context.is-nested {
+        unless $context.is-precompilation-mode {
             # We need to do a fixup of the code block for the non-precompiled case.
             $fixups.push(
                 QAST::Op.new(

--- a/src/Raku/ast/compunit.rakumod
+++ b/src/Raku/ast/compunit.rakumod
@@ -555,7 +555,7 @@ class RakuAST::CompUnit
             :code_ref_blocks($context.code-ref-blocks),
             :compilation_mode($!precompilation-mode),
             :pre_deserialize(@pre-deserialize),
-            :post_deserialize($context.is-nested ?? [] !! $context.post-deserialize()),
+            :post_deserialize($context.post-deserialize()),
             :repo_conflict_resolver(QAST::Op.new(
                 :op('callmethod'), :name('resolve_repossession_conflicts'),
                 self.IMPL-UNWRAP-LIST(self.get-implicit-lookups)[0].IMPL-TO-QAST($context) )),

--- a/src/Raku/ast/impl.rakumod
+++ b/src/Raku/ast/impl.rakumod
@@ -46,6 +46,14 @@ class RakuAST::IMPL::QASTContext {
     method create-nested() {
         my $context := nqp::clone(self);
         nqp::bindattr($context, RakuAST::IMPL::QASTContext, '$!cleanup-tasks', []);
+        # Give the nested context its own post-deserialize bucket so
+        # add-fixup-task pushes only land on the inner compunit, not the
+        # shared outer one. Without this, compunit.rakumod has to force the
+        # nested compunit's :post_deserialize to [] to avoid polluting the
+        # outer's serialized fixups, which silently throws away the runtime
+        # $!do bind that IMPL-LINK-META-OBJECT emits for the non-precomp
+        # case.
+        nqp::bindattr($context, RakuAST::IMPL::QASTContext, '$!post-deserialize', []);
         nqp::bindattr_i($context, RakuAST::IMPL::QASTContext, '$!is-nested', 1);
         $context
     }

--- a/t/12-rakuast/xx-fixed-in-rakuast.rakutest
+++ b/t/12-rakuast/xx-fixed-in-rakuast.rakutest
@@ -2,7 +2,7 @@ use Test;
 use lib <t/packages/Test-Helpers>;
 use Test::Helpers;
 
-plan 111;
+plan 113;
 
 # t/spec/S03-sequence/misc.t
 # https://github.com/rakudo/rakudo/issues/5520
@@ -794,6 +794,21 @@ subtest 'use of &?ROUTINE and &?BLOCK' => {
       :out("from-precomped-6137\n"),
       :err(""),
       'precompiling a module returning a synthetic RakuAST Sub from BEGIN works';
+}
+
+# A Sub returned from BEGIN-time string EVAL used to infinite-loop on invoke
+# because nested IMPL-LINK-META-OBJECT skipped the runtime $!do fixup, so
+# the cloned IMPL-STUB-CODE stub never got replaced with the compiled
+# coderef.
+{
+    use MONKEY-SEE-NO-EVAL;
+    my $s1 = BEGIN EVAL 'sub { 42 }';
+    is $s1(), 42,
+      'invoking a Sub returned from BEGIN-time string EVAL works';
+
+    my $s2 = BEGIN EVAL 'sub { 1 + 2 }';
+    is $s2(), 3,
+      'BEGIN-time string-EVAL Sub with setting operator runs';
 }
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
A Sub returned from a BEGIN-time string EVAL (such as `my $s = BEGIN EVAL 'sub { 42 }'; say $s()`) infinite-looped on invoke under RAKUDO_RAKUAST=1 because RakuAST silently routes runtime EVAL into a code path the legacy frontend never enters.

In the legacy frontend, runtime EVAL (outer compile not in precompilation mode) emits a runtime QAST::BVal fixup for the inner sub literal's `$!do`. When the inner mainline runs and the cloned Sub gets its `$!do` bound, re-dispatch through the Sub lands on the compiled coderef. The stub never wins.

In RakuAST the same scenario produced no such fixup. Three separate shortcuts in three different files conspired to drop it. Removing all three is one alignment with legacy, just spread across files:

- IMPL-LINK-META-OBJECT in src/Raku/ast/code.rakumod gated the runtime `$!do` fixup on `unless is-precompilation-mode || is-nested`. Legacy's equivalent gates only on precomp because legacy's `$is_nested` is itself defined as `$outer_world && $outer_world.is_precompilation_mode()` (Perl6/Grammar.nqp). RakuAST sets `$!is-nested` = 1 whenever there is an outer compunit, regardless of precomp, so the extra clause caused every runtime EVAL to skip the fixup.

- create-nested in src/Raku/ast/impl.rakumod cloned the parent QASTContext but only reset `$!cleanup-tasks`. `$!post-deserialize` stayed aliased to the outer's array, so any fixup that did get pushed by the inner compile leaked into the outer compunit's serialized fixups.

- IMPL-TO-QAST-COMP-UNIT in src/Raku/ast/compunit.rakumod compensated for the aliasing by forcing the inner QAST::CompUnit's `:post_deserialize` to [] for any nested context. That dropped the legitimate inner fixup that IMPL-LINK-META-OBJECT was supposed to emit. Even if the gate above had let the fixup through, this wipe would have erased it.

Drop the `is-nested` clause from the IMPL-LINK-META-OBJECT gate, give create-nested its own `$!post-deserialize` bucket the way it already gives `$!cleanup-tasks` one, and drop the now-redundant nested branch in compunit.rakumod's `:post_deserialize`. The inner compunit emits the fixup, the fixup lands in the inner bucket, the inner compunit serializes it as its own `:post_deserialize`. Same shape as legacy.

`$!is-nested` itself is not changed at the setter; create-nested still sets it = 1 unconditionally. Other readers of `$!is-nested` are left alone, including the `:is_nested` attribute on the inner QAST::CompUnit that gates deserialization_code emission and the add-fixup-task `is-precompilation-mode` check that was already correct.

Archeology for why the aliasing existed in the first place:

- e8bd1b3fd (2022-12-07) introduced create-nested to replace start-nested/stop-nested. It reset `$!cleanup-tasks` for the inner context but not `$!post-deserialize`. The commit message names cleanup-tasks specifically as the thing that must not be shared. The post-deserialize sharing appears to be an oversight: the context was cloned but only the one attribute the commit was about got reset.

- 639f20a22 (2023-11-11) added the `:post_deserialize $context.is-nested ?? [] !! ...` defensive branch as part of an unrelated refactor (replace fallback resolver with compile-time lookups). The hunk is not mentioned in the commit message. It worked around the `$!post-deserialize` aliasing the larger refactor was newly exposing, rather than fixing the aliasing itself.