### PR TITLE
RakuAST: don't set Mu refinement on where-free subsets

### DIFF
--- a/src/Raku/ast/type.rakumod
+++ b/src/Raku/ast/type.rakumod
@@ -1127,12 +1127,10 @@ class RakuAST::Type::Subset
         my $block := $!block;
 
         $type.HOW.set_of($type, $!of.meta-object) if $!of;
-        $type.HOW.set_where($type, $block
-          ?? $block.IMPL-CURRIED
+        $type.HOW.set_where($type, $block.IMPL-CURRIED
             ?? $block.IMPL-CURRIED.meta-object
             !! $block.compile-time-value
-          !! Mu
-        );
+        ) if $block;
 
         $type
     }


### PR DESCRIPTION
This increases the number of tests passed for `RAKUDO_RAKUAST=1 ./install/bin/raku t/spec/S02-types/nominalizables.t`