### PR TITLE
RakuAST: nominalize coercive types for descriptor default in pre-6.e

### DIFF
--- a/src/Raku/ast/type.rakumod
+++ b/src/Raku/ast/type.rakumod
@@ -62,6 +62,20 @@ class RakuAST::Type
             !! $v-how.archetypes($v).nominalizable ?? $v-how.nominalize($v) !! $v
     }
 
+    # Like IMPL-MAYBE-NOMINALIZE, but always nominalizes coercive types so the
+    # value used for a Scalar's default is the coercion's nominal target rather
+    # than the coercion type itself. Mirrors legacy's `maybe-nominalize` in
+    # src/Perl6/World.nqp, which the descriptor-build path uses for default_value.
+    method IMPL-NOMINALIZE-FOR-DEFAULT($v) {
+        my $v-how := $v.HOW;
+        !$v-how.archetypes($v).coercive
+            && (nqp::can($v-how, 'language_revision')
+                    ?? $v-how.language_revision($v) < 3
+                    !! nqp::getcomp('Raku').language_revision < 3)
+            ?? self.IMPL-MAYBE-DEFINITE-HOW-BASE($v)
+            !! $v-how.archetypes($v).nominalizable ?? $v-how.nominalize($v) !! $v
+    }
+
     method is-native() { False }
     method is-coercive() { False }
 }

--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -264,8 +264,11 @@ class RakuAST::ContainerCreator {
         # Form container descriptor.
 
         # A definite-constrained variable (e.g. `my Int:U $a`) should default
-        # to the nominalized base type, not the wrapped type itself.
-        $default := RakuAST::Type.IMPL-MAYBE-NOMINALIZE($of) if self.type;
+        # to the nominalized base type, not the wrapped type itself. For a
+        # coercive type, the default is the coercion's nominal target so that
+        # an uninitialized `my Coerced(Source) $v` does not store the coercion
+        # type itself as a value.
+        $default := RakuAST::Type.IMPL-NOMINALIZE-FOR-DEFAULT($of) if self.type;
         my int $dynamic := self.twigil eq '*' ?? 1 !! self.forced-dynamic ?? 1 !! 0;
         nqp::bindattr(self, RakuAST::ContainerCreator, '$!container-descriptor',
             RakuAST::IMPL::Containers.create-descriptor(


### PR DESCRIPTION
This increases the number of tests passed for `RAKUDO_RAKUAST=1 ./install/bin/raku t/spec/S02-types/nominalizables.t`