### PR TITLE
Fix BUILDPLAN walkers losing init values for @/% attributes

### DIFF
--- a/src/core.c/Mu.rakumod
+++ b/src/core.c/Mu.rakumod
@@ -500,8 +500,18 @@ my class Mu { # declared in BOOTSTRAP
 
                   nqp::if(                       # 0
                     nqp::existskey($init,nqp::atpos($task,3)),
-                    (nqp::getattr(self,nqp::atpos($task,1),nqp::atpos($task,2))
-                      = %attrinit.AT-KEY(nqp::atpos($task,3)))
+                    nqp::if(
+                      # `@`/`%` need :INITIALIZE so STORE replaces storage on
+                      # a container built by action 900, instead of silently
+                      # no-opping on the empty List/Array.
+                      (nqp::iseq_i(nqp::ord(nqp::atpos($task,2),0), 64)    # @
+                        || nqp::iseq_i(nqp::ord(nqp::atpos($task,2),0), 37)),  # %
+                      nqp::getattr(self,nqp::atpos($task,1),nqp::atpos($task,2)).STORE(
+                        %attrinit.AT-KEY(nqp::atpos($task,3)), :INITIALIZE
+                      ),
+                      (nqp::getattr(self,nqp::atpos($task,1),nqp::atpos($task,2))
+                        = %attrinit.AT-KEY(nqp::atpos($task,3)))
+                    )
                   )
                 )
               )
@@ -792,8 +802,18 @@ my class Mu { # declared in BOOTSTRAP
 
               nqp::if(                           # 0
                 nqp::existskey($init,nqp::atpos($task,3)),
-                (nqp::getattr(self,nqp::atpos($task,1),nqp::atpos($task,2))
-                  = %attrinit.AT-KEY(nqp::atpos($task,3))),
+                nqp::if(
+                  # `@`/`%` need :INITIALIZE so STORE replaces storage on
+                  # a container built by action 900, instead of silently
+                  # no-opping on the empty List/Array.
+                  (nqp::iseq_i(nqp::ord(nqp::atpos($task,2),0), 64)    # @
+                    || nqp::iseq_i(nqp::ord(nqp::atpos($task,2),0), 37)),  # %
+                  nqp::getattr(self,nqp::atpos($task,1),nqp::atpos($task,2)).STORE(
+                    %attrinit.AT-KEY(nqp::atpos($task,3)), :INITIALIZE
+                  ),
+                  (nqp::getattr(self,nqp::atpos($task,1),nqp::atpos($task,2))
+                    = %attrinit.AT-KEY(nqp::atpos($task,3)))
+                )
               )
             )
           )


### PR DESCRIPTION
On a rakudo built with `RAKUDO_RAKUAST=1 make install`, constructor-passed values for `@`/`%` attributes were silently dropped when the class had a `container_initializer` (e.g. via `is List`). This affected both frontends at runtime, since the bug is in core classes compiled by RakuAST during the rakudo build:

    RAKUDO_RAKUAST=1 raku -e 'class C { has @.x is List }; say C.new(:x(1,2,3)).x'
    # was () now (1 2 3)

The same issue affected `does`/`but` mixin construction whenever the role declared an `@`/`%` attribute with a `container_initializer` and a value was passed in. This one reproduced on legacy-built rakudo too, since the affected walker has no per-class fast-path:

    raku -e 'role R { has @.x is List }; say (&infix:<but>(42, R, :value([1,2,3]))).x'
    # was () now (1 2 3)

For `has @.x is List`, the BUILDPLAN has two entries: action 900 calls the attribute's `container_initializer` and `bindattr`s the result, then action 0 assigns the named-arg value. After 900 the slot holds an empty `List` instance. Action 0's plain `=` resolves to `List.STORE(value)` without `:INITIALIZE`, which iterates `self` looking for scalar containers to assign into; an empty `List` has none, so STORE returns `self` and no storage replacement happens.

`Mu.POPULATE` is the interpreted reference walker over BUILDPLAN, with an autogen per-class fast-path emitted at compose time via `compiler_services.generate_buildplan_executor`. Both paths are supposed to be semantically identical. Commit b537ce2e5 (Sep 2018) added `STORE(value, :INITIALIZE)` for `@`/`%` to the autogen but did not update `Mu.POPULATE`. Every legacy-frontend class gets the autogen installed at compose time, so the divergence went unnoticed.

The bug surfaces now because `RakuAST::CompilerServices` doesn't yet implement `generate_buildplan_executor`, so RakuAST-compiled classes fall back to `Mu.POPULATE`. On a `RAKUDO_RAKUAST=1`-built rakudo, even legacy-frontend user code hitting a RakuAST-compiled core class (notably `Proc::Async`'s `has @.command is List`) sees the symptom; this is what fails `t/spec/S17-procasync/basic.rakudo.moar` in such builds.

`Mu.BUILD_LEAST_DERIVED` is the parallel walker for `does`/`but` mixin construction. It has no autogen override, so the same issue quietly affected legacy too whenever a role with an `@`/`%` `is List` attribute got mixed in with a value, but the trigger is rare enough to have stayed unreported since 2018.

This patch applies the `@`/`%` sigil check and `STORE(value, :INITIALIZE)` dispatch to action 0 in both walkers. Sibling actions 1100/1200 are NQP-only per the comments in `BUILDPLAN.nqp`, and 1300 uses `bindattr` instead of `=`, so neither share this code path. Implementing `generate_buildplan_executor` in `RakuAST::CompilerServices` for perf parity is left as a separate PR.
