### PR TITLE
Fix @_/%_ resolution inside nested blocks under RAKUDO_RAKUAST=1

### DIFF
--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -2335,10 +2335,22 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
 
         if $twigil eq '' {
             if $name eq '@_' {
-                $ast := slurpy-placeholder('SlurpyArray');
+                # If @_ is already in lexical scope (e.g. from an
+                # enclosing routine that declared *@_), resolve to that
+                # lexical rather than installing a fresh placeholder for
+                # the current block. Without this, a reference inside a
+                # nested block (if/while/...) shadows the outer @_ with
+                # an empty placeholder. Mirrors the legacy de-facto
+                # behavior since 2010.
+                $ast := $*R.resolve-lexical($name)
+                  ?? Nodify('Var', 'Lexical').new(:$sigil, :$desigilname)
+                  !! slurpy-placeholder('SlurpyArray');
             }
             elsif $name eq '%_' {
-                $ast := slurpy-placeholder('SlurpyHash');
+                # See @_ comment above.
+                $ast := $*R.resolve-lexical($name)
+                  ?? Nodify('Var', 'Lexical').new(:$sigil, :$desigilname)
+                  !! slurpy-placeholder('SlurpyHash');
             }
 
             # an anonymous state variable.

--- a/src/core.c/core_epilogue.rakumod
+++ b/src/core.c/core_epilogue.rakumod
@@ -291,7 +291,7 @@ augment class Code {
     }
 
     # Create a RakuAST version of a Parameter object
-    my sub ParameterAST(Parameter:D $parameter, *%_) {
+    my sub ParameterAST(Parameter:D $parameter, *%opts) {
         my $slurpytypes := BEGIN nqp::hash(
           '*',   RakuAST::Parameter::Slurpy::Flattened,
           '**',  RakuAST::Parameter::Slurpy::Unflattened,
@@ -328,7 +328,7 @@ augment class Code {
             );
         }
         else {
-            my $type := %_<type>:exists ?? %_<type> !! $parameter.type;
+            my $type := %opts<type>:exists ?? %opts<type> !! $parameter.type;
 
             $sigil eq '@'
               ?? set-role-type($type, Positional)
@@ -340,7 +340,7 @@ augment class Code {
         # Some kind of capture as target
         if $sigil eq '|' {
             %args<target> = RakuAST::ParameterTarget::Term.new(
-              RakuAST::Name.from-identifier(%_<name> // $parameter.name)
+              RakuAST::Name.from-identifier(%opts<name> // $parameter.name)
             );
             %args<slurpy> = RakuAST::Parameter::Slurpy::Capture;
         }
@@ -348,7 +348,7 @@ augment class Code {
         # An ordinary target
         else {
             %args<target> = RakuAST::ParameterTarget::Var.new(
-              name => %_<name> // ($parameter.name || $sigil)
+              name => %opts<name> // ($parameter.name || $sigil)
             );
         }
 
@@ -368,8 +368,8 @@ augment class Code {
         # If a default value was explicitely specified, we're handling
         # a name argument, which by definition has to become optional
         # if it has a default
-        if %_<default>:exists {
-            %args<default> = literalize(%_<default>);
+        if %opts<default>:exists {
+            %args<default> = literalize(%opts<default>);
             %args<optional>:delete;
         }
 


### PR DESCRIPTION
The RakuAST frontend was auto-declaring a fresh `*@_`/`*%_` on every block that referenced the slurpy, including non-routine inner blocks like `if`/`while`/`for` bodies. So inside `sub f(*%_) { if 1 { %_<k> } }` the inner reference resolved to a fresh empty placeholder for the if-body instead of `f`'s `%_`. The legacy frontend has always walked outward via lexical lookup in this case (it has done so since 2010, see [Raku/old-issue-tracker#1488][bug]).

The most visible breakage was `core.c/core_epilogue.rakumod`'s `.assuming` method, which uses `if %_<key>:exists { %_<key> }` patterns to thread named arguments through to a synthetic curried signature. Under the buggy behavior, every priming attempt produced a curried signature with `Any` defaults, which then failed to compile when the original parameter was typed (e.g. `Int :$a` primed with `:a(1)` produced `Int :$a = Any`, which can't bind). This tripped `t/spec/S06-currying/named.rakudo.moar` mid-run with a `===SORRY!===` when rakudo was built with `RAKUDO_RAKUAST=1`. `Range.first` has the same shape and is similarly affected.

This patch makes RakuAST short-circuit to a lexical lookup if `@_`/`%_` already resolves in scope, mirroring what the legacy frontend has done all along. There is no behavior change at any released language version: the lexical-lookup path was always the de-facto behavior; RakuAST just wasn't matching it.

The rename of `*%_` to `*%opts` in `ParameterAST` is defensive groundwork for a follow-up PR that adopts niner's stricter "each block is a real block with its own signature" reading in 6.e. Under those semantics, `ParameterAST`'s nested-block `%_<type>`/`%_<name>`/`%_<default>` accesses would each get a fresh empty `*%_` and break the helper. Renaming the parameter to a non-magical name now means `ParameterAST` keeps working regardless of which language revision the surrounding setting is compiled at, so the follow-up PR can flip the language semantics without having to touch `core_epilogue.rakumod` again.

[bug]: https://github.com/Raku/old-issue-tracker/issues/1488
