### PR TITLE
6.e: Gate @_/%_ shadowing semantics on language revision

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -3168,7 +3168,19 @@ class Perl6::Actions is HLL::Actions does STDActions {
               'X::Comp::NYI', feature => 'Pod variable ' ~ $name);
         }
         elsif $name eq '@_' {
-            if $world.nearest_signatured_block_declares('@_') {
+            # Pre-6.e: resolve to an enclosing routine's @_ via the
+            # nearest signatured block. 6.e+: each block is a real block
+            # with its own signature, so auto-declare a fresh placeholder
+            # on the current block instead. See:
+            #   https://github.com/Raku/roast/commit/0b8c717e6
+            #
+            # The "current pad already has @_" check is needed even
+            # under 6.e so that an if/while/etc. CONDITION (which is
+            # parsed in the outer pad, before the body's new pad gets
+            # pushed) doesn't try to redeclare an explicit *@_ parameter.
+            if (nqp::getcomp('Raku').language_revision < 3
+                && $world.nearest_signatured_block_declares('@_'))
+              || +$world.cur_lexpad().symbol('@_') {
                 $past.scope('lexical');
             }
             else {
@@ -3177,7 +3189,12 @@ class Perl6::Actions is HLL::Actions does STDActions {
             }
         }
         elsif $name eq '%_' {
-            if $world.nearest_signatured_block_declares('%_') || $*METHODTYPE {
+            # Same 6.e gate as @_ above. The $*METHODTYPE check stays
+            # unconditional: methods auto-have *%_ in every revision.
+            if (nqp::getcomp('Raku').language_revision < 3
+                && $world.nearest_signatured_block_declares('%_'))
+              || +$world.cur_lexpad().symbol('%_')
+              || $*METHODTYPE {
                 $past.scope('lexical');
             }
             else {

--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -2334,23 +2334,31 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
         my $ast;
 
         if $twigil eq '' {
-            if $name eq '@_' {
-                # If @_ is already in lexical scope (e.g. from an
-                # enclosing routine that declared *@_), resolve to that
-                # lexical rather than installing a fresh placeholder for
-                # the current block. Without this, a reference inside a
-                # nested block (if/while/...) shadows the outer @_ with
-                # an empty placeholder. Mirrors the legacy de-facto
-                # behavior since 2010.
-                $ast := $*R.resolve-lexical($name)
-                  ?? Nodify('Var', 'Lexical').new(:$sigil, :$desigilname)
-                  !! slurpy-placeholder('SlurpyArray');
-            }
-            elsif $name eq '%_' {
-                # See @_ comment above.
-                $ast := $*R.resolve-lexical($name)
-                  ?? Nodify('Var', 'Lexical').new(:$sigil, :$desigilname)
-                  !! slurpy-placeholder('SlurpyHash');
+            if $name eq '@_' || $name eq '%_' {
+                # @_/%_ are magical auto-declaring slurpies. Two semantics:
+                #
+                # Pre-6.e (the de-facto behavior since 2010): a reference
+                # to @_/%_ inside a nested block resolves to an enclosing
+                # routine's @_/%_ via lexical lookup, rather than
+                # auto-declaring a fresh placeholder on the inner block.
+                # Lots of existing code is written against this.
+                #
+                # 6.e+: each block is a real block with its own signature,
+                # so @_/%_ inside e.g. an if-body auto-declares on that
+                # block, shadowing the outer one. See:
+                #   https://github.com/Raku/roast/commit/0b8c717e6
+                #   https://github.com/Raku/old-issue-tracker/issues/1488
+                if nqp::getcomp('Raku').language_revision < 3
+                    && $*R.resolve-lexical($name)
+                {
+                    $ast := Nodify('Var', 'Lexical').new(:$sigil, :$desigilname);
+                }
+                elsif $name eq '@_' {
+                    $ast := slurpy-placeholder('SlurpyArray');
+                }
+                else {
+                    $ast := slurpy-placeholder('SlurpyHash');
+                }
             }
 
             # an anonymous state variable.


### PR DESCRIPTION
Under 6.c/6.d both frontends keep doing what the legacy frontend has done since 2010: an @_/%_ reference inside a nested block (if/while/for body etc.) resolves outward to the enclosing routine's slurpy via lexical lookup. Lots of existing code is written against this.

Under 6.e, follow niner's reading from https://github.com/Raku/roast/commit/0b8c717e6 ("Remove dubious test that only incidentally passed anyway"): each block is a real block with its own signature, so @_/%_ inside e.g. an if-body auto-declares a fresh empty *@_/*%_ on that block, shadowing the outer one.

The legacy mirror also adds a `cur_lexpad().symbol(...)` short-circuit. This is needed under 6.e for any @_/%_ reference parsed while `cur_lexpad()` is still the routine's own pad: the routine body itself, signature defaults/traits, and the conditions of nested if/while/for (which are parsed in the outer pad before the body's newpad is pushed). Without it, `add_placeholder_parameter` would re-encounter the existing parameter symbol and throw X::Redeclaration. The RakuAST frontend does not need an analogous guard; its `add-placeholder-parameter` already marks the placeholder as already-declared when the attach-target block has the parameter (or is a method), so the explicit *@_/*%_ is reused at runtime instead of redeclared.