### PR TITLE
RakuAST: fix subset-typed parameter binding under v6.e

### DIFF
--- a/src/Raku/ast/type.rakumod
+++ b/src/Raku/ast/type.rakumod
@@ -153,7 +153,7 @@ class RakuAST::Type::Simple
     }
 
     method PRODUCE-META-OBJECT() {
-        RakuAST::Type.IMPL-MAYBE-NOMINALIZE: self.resolution.compile-time-value
+        self.resolution.compile-time-value
     }
 
     method IMPL-EXPR-QAST(RakuAST::IMPL::QASTContext $context) {


### PR DESCRIPTION
This allows `RAKUDO_RAKUAST=1 ./install/bin/raku t/spec/S02-types/subset-6e.t` to pass on a `RAKUDO_RAKUAST=1`-built rakudo