### PR TITLE
Fix .assuming causing serialization error during precomp

### DIFF
--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -194,6 +194,13 @@ class RakuAST::Code
         $block.code_object($code-obj);
 
         my @compstuff := nqp::getattr($code-obj, Code, '@!compstuff');
+        # @!compstuff is null on a re-compile of a shared AST: the
+        # previous compile's cleanup nulled it and $!begin-performed
+        # keeps IMPL-STUB-CODE from re-running.
+        if nqp::isnull(@compstuff) {
+            @compstuff := nqp::list();
+            nqp::bindattr($code-obj, Code, '@!compstuff', @compstuff);
+        }
         my $cuid := $!cuid;
         $block.set-cuid($!cuid);
 

--- a/src/core.c/ForeignCode.rakumod
+++ b/src/core.c/ForeignCode.rakumod
@@ -103,28 +103,11 @@ $lang = 'Raku' if $lang eq 'perl6';
         my $from := $compiler.exists_stage('optimize') ?? 'optimize' !! 'qast';
         my $qast-cu := $comp-unit.IMPL-TO-QAST-COMP-UNIT;
         my $context := $comp-unit.context;
-        if $context.is-nested {
-            # Nested QAST::CompUnits skip deserialization_code emission, so
-            # their static code refs never get scsetcode'd into the shared
-            # SC. If EVAL returns a Sub the outer compile references,
-            # outer's precomp serialization fails with "missing static
-            # code ref" because the inner code ref's static_code isn't in
-            # any SC. Keep the compunit around via :compunit_ok and run
-            # the shared fixup loop to register each code ref in the
-            # shared SC at the index stashed when the stub was added.
-            my $precomp := $compiler.compile($qast-cu, :$from, :compunit_ok(1));
-            $context.IMPL-FIXUP-COMPILED-CODEREFS(nqp::compunitcodes($precomp));
-            # Run cleanup-tasks registered during begin/compile (mainly to
-            # null @!compstuff on each Code object, which still holds the
-            # IMPL-STUB-CODE closure). The normal compile pipeline does
-            # this from the qast stage in Perl6::Compiler, but this EVAL
-            # path bypasses the stage system.
-            $comp-unit.cleanup;
-            $compiled := $compiler.backend.compunit_mainline($precomp);
-        }
-        else {
-            $compiled := $compiler.compile(:$from, $qast-cu);
-        }
+        # Run the qast-stage SC bookkeeping that AST EVAL otherwise skips.
+        my $precomp := $compiler.compile($qast-cu, :$from, :compunit_ok(1));
+        $context.IMPL-FIXUP-COMPILED-CODEREFS(nqp::compunitcodes($precomp));
+        $comp-unit.cleanup;
+        $compiled := $compiler.backend.compunit_mainline($precomp);
     }
     else {
         $code = nqp::istype($code,Blob) ?? $code.decode('utf8') !! $code.Str;

--- a/t/12-rakuast/xx-fixed-in-rakuast.rakutest
+++ b/t/12-rakuast/xx-fixed-in-rakuast.rakutest
@@ -2,7 +2,7 @@ use Test;
 use lib <t/packages/Test-Helpers>;
 use Test::Helpers;
 
-plan 113;
+plan 114;
 
 # t/spec/S03-sequence/misc.t
 # https://github.com/rakudo/rakudo/issues/5520
@@ -794,6 +794,17 @@ subtest 'use of &?ROUTINE and &?BLOCK' => {
       :out("from-precomped-6137\n"),
       :err(""),
       'precompiling a module returning a synthetic RakuAST Sub from BEGIN works';
+}
+
+# https://github.com/rakudo/rakudo/issues/6169
+# Precompiling a module that loads another module whose mainline calls
+# .assuming. .assuming uses RakuAST::Sub.new(...).EVAL, which previously
+# failed in the non-nested branch.
+{
+    is-run 'use lib <t/packages/12-rakuast/lib>; use UsesAssumingInPrecomp; say "ok"',
+      :out("ok\n"),
+      :err(""),
+      '.assuming in a precompiled module loaded via another module works';
 }
 
 # A Sub returned from BEGIN-time string EVAL used to infinite-loop on invoke

--- a/t/packages/12-rakuast/lib/AssumingInPrecomp.rakumod
+++ b/t/packages/12-rakuast/lib/AssumingInPrecomp.rakumod
@@ -1,0 +1,6 @@
+# Regression fixture for https://github.com/rakudo/rakudo/issues/6169
+# .assuming uses RakuAST::Sub.new(...).EVAL internally. When this module
+# was loaded as a dependency of a precompiling module, the synthetic Sub's
+# static_code never got registered in any SC, so the outer precomp's
+# serializer died with "missing static code ref for closure 'assumed.max'".
+my &max42 = &max.assuming(42);

--- a/t/packages/12-rakuast/lib/UsesAssumingInPrecomp.rakumod
+++ b/t/packages/12-rakuast/lib/UsesAssumingInPrecomp.rakumod
@@ -1,0 +1,4 @@
+# Regression fixture for https://github.com/rakudo/rakudo/issues/6169
+# Loading this module triggers precomp of itself plus AssumingInPrecomp,
+# which is the precise topology that surfaced the bug.
+use AssumingInPrecomp;


### PR DESCRIPTION
`.assuming` constructs a RakuAST::Sub via `RakuAST::Sub.new(...).EVAL`. When that synthetic Sub gets bound somewhere a later precomp's serializer can reach (most directly: `my &x = &foo.assuming(...)` in a module that's `use`d by another module being precompiled), the precomp serializer dies with "missing static code ref for closure 'assumed.X'".

The nested branch of ForeignCode.rakumod's EVAL proto already handled this for the BEGIN-time AST EVAL case (#6137, fix in commit 46ce0e3f8). The non-nested branch had identical bookkeeping needs but was never updated, which is what kept `.assuming` tripping the same class of serialization error.

Resolves #6169.
