### PR TITLE
RakuAST: report stub grammars in X::Package::Stubbed alongside other stubs

### DIFF
--- a/src/Raku/ast/package.rakumod
+++ b/src/Raku/ast/package.rakumod
@@ -844,9 +844,10 @@ class RakuAST::Grammar
       RakuAST::Resolver          $resolver,
       RakuAST::IMPL::QASTContext $context
     ) {
+        nqp::findmethod(RakuAST::Class, 'PERFORM-CHECK')(self, $resolver, $context);
         my $sanity-check := self.HOW.find_method(self,"check-sanity");
         $sanity-check(self) if $sanity-check;
-        True
+        True;
     }
 }
 


### PR DESCRIPTION
This allows `t/spec/S32-exceptions/misc2.rakudo.moar` to pass with `RAKUDO_RAKUAST=1`-built rakudo