### PR TITLE
Fix .assuming dep leak when consumer is precompiled with legacy frontend

### DIFF
--- a/src/Raku/ast/compunit.rakumod
+++ b/src/Raku/ast/compunit.rakumod
@@ -119,11 +119,41 @@ class RakuAST::CompUnit
               $precompilation-mode);
         }
         else {
-            $sc := nqp::createsc($comp-unit-name);
-            nqp::pushcompsc($sc);
-            nqp::bindattr($obj, RakuAST::CompUnit, '$!sc', $sc);
-            nqp::bindattr($obj, RakuAST::CompUnit, '$!context',
-              RakuAST::IMPL::QASTContext.new(:$sc, :$precompilation-mode, :$setting, :$language-revision));
+            # Runtime AST EVAL inside a precompiling legacy-frontend
+            # compile: bridge through Perl6::World, mirroring
+            # Perl6::Grammar TOP's nested-compile setup.
+            my $outer-world := nqp::getlexdyn('$*W');
+            my $is-legacy-nested := $eval
+                && nqp::isconcrete($outer-world)
+                && nqp::can($outer-world, 'is_precompilation_mode')
+                && $outer-world.is_precompilation_mode;
+
+            if $is-legacy-nested {
+                my $nested-world := $outer-world.create_nested();
+                $sc := $nested-world.sc;
+                nqp::bindattr_i($obj, RakuAST::CompUnit, '$!is-eval', 2);
+                nqp::bindattr($obj, RakuAST::CompUnit, '$!sc', $sc);
+                my $context := RakuAST::IMPL::QASTContext.new(
+                  :$sc, :$precompilation-mode,
+                  :$setting, :$language-revision);
+                nqp::bindattr_i($context, RakuAST::IMPL::QASTContext,
+                  '$!is-nested', 1);
+                $context.set-world-bridge($nested-world);
+                nqp::bindattr($obj, RakuAST::CompUnit, '$!context', $context);
+            }
+            else {
+                $sc := nqp::createsc($comp-unit-name);
+                nqp::pushcompsc($sc);
+                nqp::bindattr($obj, RakuAST::CompUnit, '$!sc', $sc);
+                nqp::bindattr($obj, RakuAST::CompUnit, '$!context',
+                  RakuAST::IMPL::QASTContext.new(:$sc, :$precompilation-mode, :$setting, :$language-revision));
+                # Set the SC description to $?FILES only on the
+                # fresh-SC path. The bridged path shares the outer
+                # World's SC, whose description was already set by
+                # the outer's compile and must not be overwritten.
+                my $file := nqp::getlexdyn('$?FILES');
+                nqp::scsetdesc($sc, $file) unless nqp::isnull($file);
+            }
             nqp::bindattr($obj, RakuAST::CompUnit, '$!pod',
               RakuAST::VarDeclaration::Implicit::Doc::Pod.new);
             # $=data / $=finish / $=rakudoc are per-compunit, not setting-level;
@@ -139,9 +169,6 @@ class RakuAST::CompUnit
                   RakuAST::VarDeclaration::Implicit::Doc::Rakudoc.new);
             }
         }
-
-        my $file := nqp::getlexdyn('$?FILES');
-        nqp::scsetdesc($sc, $file) unless nqp::isnull($file);
 
         $obj
     }
@@ -348,6 +375,9 @@ class RakuAST::CompUnit
         for $!context.cleanup-tasks {
             $_()
         }
+        # Propagate any inner @!load_dependency_tasks to the outer World.
+        my $world := $!context.world-bridge;
+        $world.finish if nqp::isconcrete($world);
     }
 
     method record-precompilation-dependencies() {

--- a/src/Raku/ast/impl.rakumod
+++ b/src/Raku/ast/impl.rakumod
@@ -27,6 +27,10 @@ class RakuAST::IMPL::QASTContext {
     has int $.is-nested;
     has Mu $.language-revision; # Same type as in CORE-SETTING-REV
 
+    # Optional nested Perl6::World; when set, add-code-ref delegates
+    # to it so the shared $!num_code_refs counter advances.
+    has Mu $.world-bridge;
+
     method new(Mu :$sc!, int :$precompilation-mode, :$setting, :$language-revision) {
         my $obj := nqp::create(self);
         nqp::bindattr($obj, RakuAST::IMPL::QASTContext, '$!sc', $sc);
@@ -40,7 +44,12 @@ class RakuAST::IMPL::QASTContext {
         nqp::bindattr_i($obj, RakuAST::IMPL::QASTContext, '$!is-nested', 0);
         nqp::bindattr($obj, RakuAST::IMPL::QASTContext, '$!setting', $setting);
         nqp::bindattr($obj, RakuAST::IMPL::QASTContext, '$!language-revision', $language-revision);
+        nqp::bindattr($obj, RakuAST::IMPL::QASTContext, '$!world-bridge', Mu);
         $obj
+    }
+
+    method set-world-bridge(Mu $world) {
+        nqp::bindattr(self, RakuAST::IMPL::QASTContext, '$!world-bridge', $world);
     }
 
     method create-nested() {
@@ -94,9 +103,15 @@ class RakuAST::IMPL::QASTContext {
     }
 
     method add-code-ref(Mu $code-ref, Mu $block) {
-        my int $code-ref-idx := nqp::elems($!code-ref-blocks);
-        nqp::push($!code-ref-blocks, $block);
-        nqp::scsetcode($!sc, $code-ref-idx, $code-ref);
+        my int $code-ref-idx;
+        if nqp::isconcrete($!world-bridge) {
+            $code-ref-idx := $!world-bridge.add_root_code_ref($code-ref, $block);
+        }
+        else {
+            $code-ref-idx := nqp::elems($!code-ref-blocks);
+            nqp::push($!code-ref-blocks, $block);
+            nqp::scsetcode($!sc, $code-ref-idx, $code-ref);
+        }
         $!sub-id-to-sc-idx{$block.cuid} := $code-ref-idx;
     }
 


### PR DESCRIPTION
`zef install Astro::Utils` fails on test with "Missing or wrong version of dependency 'EVAL_<n>'". Same general area as #6170 but a different symptom and a separate code path in the `Code.assuming` -> `RakuAST::Sub.new(...).EVAL` plumbing.

This is a parallel-frontend integration bug. RakuAST and legacy each have their own compile-time bookkeeping (SCs, code-ref counters) and their own outer-discovery dynvar (`$*CU` for RakuAST, `$*W` for legacy) set by their respective grammar/actions during parse. RakuAST's runtime EVAL only knows about `$*CU`. When `RakuAST::Node.EVAL` fires inside a precompiling module whose outer compile is the legacy frontend (the default when `RAKUDO_RAKUAST` is unset), `$*CU` is unbound, the share-SC path is skipped, and the AST EVAL mints a fresh ephemeral SC. The consumer's serializer captures references to the EVAL'd Sub via the producer's stash, records `EVAL_<n>` as a cross-SC dep, and the next load can't resolve it because the SC is process-local.

The legacy frontend already solves the equivalent problem for itself: `Perl6::Grammar`'s TOP rule does `nqp::getlexdyn('$*W')` + `$outer_world.create_nested()` so nested compiles share the outer's `CompilationContext` and its `$!num_code_refs` counter. RakuAST's `:outer-cu($*CU)` arm is the analogous mechanism for RakuAST -> RakuAST nesting; it has no fallback when the outer compile is legacy. This patch adds that fallback: discover the outer Perl6::World via `nqp::getlexdyn('$*W')`, share its SC via `create_nested()`, and bridge RakuAST's `add-code-ref` to the nested World's `add_root_code_ref` so RakuAST and legacy halves coordinate on the shared counter and don't collide at SC indices.

Why a bridge rather than orphaning the ephemeral SC: the EVAL'd Sub's SC affinity has to land somewhere durable. Pre-fix it's claimed by an ephemeral SC the consumer can't resolve; post-fix it's claimed by the consumer's own SC and serialized inline like any other compile-time data. The disclaim alternative -- `nqp::scdisclaim` the ephemeral SC and let the consumer claim by virtue of "no SC" -- was tried on a separate branch and rejected; scdisclaim doesn't reach every transitively-tagged object, so leftover ephemeral affinity reappears as serialization failures of a different shape, including #6137-style "missing static code ref for closure" errors. Sharing through `create_nested` is what `compile_in_context` and `Perl6::Grammar` TOP already do for the same reason.

I tried building a regression fixture but couldn't reduce the `Astro::Utils` failure to a minimal standalone test.