### PR TITLE
RakuAST: retry .& resolution at check time to handle forward references

### DIFF
--- a/src/Raku/ast/call.rakumod
+++ b/src/Raku/ast/call.rakumod
@@ -1126,6 +1126,7 @@ class RakuAST::Call::VarMethod
   is RakuAST::Call::Methodish
   is RakuAST::Lookup
   is RakuAST::BeginTime
+  is RakuAST::CheckTime
 {
     has RakuAST::Name $.name;
 
@@ -1176,6 +1177,12 @@ class RakuAST::Call::VarMethod
         }
 
         Nil
+    }
+
+    method PERFORM-CHECK(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
+        unless self.is-resolved {
+            self.PERFORM-BEGIN($resolver, $context);
+        }
     }
 
     method undeclared-symbol-details() {


### PR DESCRIPTION
Under `RAKUDO_RAKUAST=1`, `.&foo` against a `my sub` declared later in the same scope is reported as undeclared, even though plain `foo()` works fine.

```
RAKUDO_RAKUAST=1 raku -e 'sub MAIN { say 42.&inc }; my sub inc($n) { $n + 1 }'
# ===SORRY!=== Undeclared routine:
#     inc used at line 1
```

`RakuAST::Call::Name` already handles this: it has a `PERFORM-CHECK` that retries `PERFORM-BEGIN` if resolution failed at BEGIN time, which is how forward references to `my sub` work in general. `RakuAST::Call::VarMethod` was missing the same retry. This adds it.