### PR TITLE
RakuAST: add meta-object to RakuAST::Declaration::Import

### DIFF
--- a/src/Raku/ast/scoping.rakumod
+++ b/src/Raku/ast/scoping.rakumod
@@ -772,6 +772,8 @@ class RakuAST::Declaration::External::Setting
 class RakuAST::Declaration::Import
   is RakuAST::Declaration::External::Constant
 {
+    method meta-object() { self.compile-time-value }
+
     method IMPL-QAST-DECL(RakuAST::IMPL::QASTContext $context) {
         my $value := self.compile-time-value;
         $context.ensure-sc($value);


### PR DESCRIPTION
`compunit.rakumod` calls `.meta-object` on the result of `find-lexical('&MAIN')` to build the `QAST::WVal` for the entry-point invocation. When `&MAIN` is imported from a `use`d module, `find-lexical` returns a `RakuAST::Declaration::Import`, which has `compile-time-value` but no `meta-object`, so the lookup blows up.

```
# lib/MyMod.rakumod
unit module MyMod;
our sub MAIN($x) is export { say "got $x" }

# main.raku
use MyMod;

RAKUDO_RAKUAST=1 raku -Ilib main.raku hi
# No such method 'meta-object' for invocant of type 'RakuAST::Declaration::Import'
```

For an imported symbol the meta-object IS the value it holds, so `meta-object` just delegates to `compile-time-value`. Mirrors the relationship that already exists on `RakuAST::Meta` in the opposite direction.
