### PR TITLE
RakuAST: evaluate non-trivial package colonpair values once, cached

### DIFF
--- a/src/Raku/ast/package.rakumod
+++ b/src/Raku/ast/package.rakumod
@@ -32,6 +32,9 @@ class RakuAST::Package
 
     has RakuAST::CompilerServices $.compiler-services;
 
+    has RakuAST::Resolver $!resolver;
+    has RakuAST::IMPL::QASTContext $!context;
+
     has Mu $!compose-exception;
 
     # Enclosing parametric role captured at BEGIN-time so the package can
@@ -160,6 +163,8 @@ class RakuAST::Package
             }
         }
 
+        nqp::bindattr(self, RakuAST::Package, '$!resolver', $resolver);
+        nqp::bindattr(self, RakuAST::Package, '$!context', $context);
         nqp::bindattr(self, RakuAST::Package, '$!compiler-services', RakuAST::CompilerServices.new(self, $resolver, $context));
     }
 
@@ -367,12 +372,17 @@ class RakuAST::Package
             %options<name> := $!name.canonicalize if $!name;
             %options<repr> := $!repr if $!repr;
             if $!name {
-                for $!name.IMPL-UNWRAP-LIST($!name.colonpairs) {
-                    my $value := $_.simple-compile-time-quote-value;
-                    if $_.key eq 'ver' {
-                        $value := Version.new($value);
+                my @colonpairs := $!name.IMPL-UNWRAP-LIST($!name.colonpairs);
+                if nqp::elems(@colonpairs) {
+                    my $Failure := $!resolver.type-from-setting('Failure');
+                    for @colonpairs {
+                        my $key := $_.key;
+                        my $value := $_.IMPL-EVAL-COLONPAIR-VALUE-OR-RETHROW(
+                            $!resolver, $!context, $Failure);
+                        next if $key eq 'auth' && nqp::eqaddr($value, Nil);
+                        $value := Version.new($value) if $key eq 'ver' || $key eq 'api';
+                        %options{$key} := $value;
                     }
-                    %options{$_.key} := $value;
                 }
             }
             my $meta-object := $!how.new_type(|%options);
@@ -561,54 +571,56 @@ class RakuAST::Role
     method default-how() { Metamodel::ParametricRoleHOW }
     method attach-target-names() { self.IMPL-WRAP-LIST(['package', 'also', 'generics-pad']) }
 
+    # Called twice: once from Package.new with no real body, then again
+    # from package-def with the parsed body. Only wrap the body when we
+    # have one, since the wrapping calls stubbed-meta-object and that
+    # memoizes; running it before parser state is bound caches a wrong
+    # meta-object.
     method replace-body(RakuAST::Code $role-body, RakuAST::Signature $signature) {
         # The body of a role is internally a Sub that has the parameterization
         # of the role as the signature.  This allows a role to be selected
         # using ordinary dispatch semantics.  The statement list gets a return
         # value added, so that the role's meta-object and lexpad are returned.
-        if $role-body {
-            $signature := $role-body.signature unless $signature;
-        }
-        else {
-            $signature := RakuAST::Signature.new unless $signature;
-            $role-body := RakuAST::RoleBody.new(:$signature);
-        }
-
-        for $signature.IMPL-UNWRAP-LIST($signature.parameters) {
-            $_.set-owner($role-body);
-        }
-
         nqp::bindattr(self, RakuAST::Role, '$!fixup', RakuAST::LexicalFixup.new) unless $!fixup;
-        $role-body.set-fixup($!fixup);
-
-        my $body := $role-body.body;
-
-        my $resolve-instantiations;
         unless nqp::defined($!instantiation-lexicals) {
             nqp::bindattr(self, RakuAST::Role, '$!instantiation-lexicals', []);
         }
-        $body.statement-list.unshift-statement(
-            $resolve-instantiations := RakuAST::Role::ResolveInstantiations.new(
-                $!instantiation-lexicals)
-        );
 
-        $body.statement-list.add-statement(
-          RakuAST::Statement::Expression.new(
-            expression => RakuAST::Nqp.new('list',
-              RakuAST::Declaration::ResolvedConstant.new(
-                compile-time-value => self.stubbed-meta-object
-              ),
-              nqp::elems($!instantiation-lexicals)
-                  ?? RakuAST::Role::TypeEnvVar.new($resolve-instantiations.type-env-var)
-                  !! RakuAST::Nqp.new('curlexpad')
-            )
-          )
-        );
+        unless $signature {
+            $signature := $role-body ?? $role-body.signature !! RakuAST::Signature.new;
+        }
+        my $body-node := $role-body // RakuAST::RoleBody.new(:$signature);
+        $body-node.set-fixup($!fixup);
+        $body-node.replace-name(self.name);
+        $body-node.replace-signature($signature);
 
-        $role-body.replace-name(self.name);
-        $role-body.replace-signature($signature);
+        if $role-body {
+            for $signature.IMPL-UNWRAP-LIST($signature.parameters) {
+                $_.set-owner($role-body);
+            }
 
-        nqp::bindattr(self, RakuAST::Package, '$!body', $role-body);
+            my $body := $role-body.body;
+            my $resolve-instantiations;
+            $body.statement-list.unshift-statement(
+                $resolve-instantiations := RakuAST::Role::ResolveInstantiations.new(
+                    $!instantiation-lexicals)
+            );
+
+            $body.statement-list.add-statement(
+              RakuAST::Statement::Expression.new(
+                expression => RakuAST::Nqp.new('list',
+                  RakuAST::Declaration::ResolvedConstant.new(
+                    compile-time-value => self.stubbed-meta-object
+                  ),
+                  nqp::elems($!instantiation-lexicals)
+                      ?? RakuAST::Role::TypeEnvVar.new($resolve-instantiations.type-env-var)
+                      !! RakuAST::Nqp.new('curlexpad')
+                )
+              )
+            );
+        }
+
+        nqp::bindattr(self, RakuAST::Package, '$!body', $body-node);
         Nil
     }
 

--- a/src/Raku/ast/pair.rakumod
+++ b/src/Raku/ast/pair.rakumod
@@ -105,10 +105,29 @@ class RakuAST::ColonPair
 
     method properties() { OperatorProperties.postfix(':') }
 
+    method simple-compile-time-quote-value() { Nil }
+
+    # Failure results are returned, not rethrown; callers decide, see
+    # `IMPL-EVAL-COLONPAIR-VALUE-OR-RETHROW`. Value is memoized on the
+    # node so side effects fire at most once.
+    method IMPL-EVAL-COLONPAIR-VALUE(RakuAST::Resolver $resolver,
+                                     RakuAST::IMPL::QASTContext $context) {
+        self.simple-compile-time-quote-value
+    }
+
+    # `$Failure` is the caller's already-resolved Failure type, or
+    # `nqp::null` during CORE setting bootstrap.
+    method IMPL-EVAL-COLONPAIR-VALUE-OR-RETHROW(RakuAST::Resolver $resolver,
+                                                RakuAST::IMPL::QASTContext $context,
+                                                Mu $Failure) {
+        my $value := self.IMPL-EVAL-COLONPAIR-VALUE($resolver, $context);
+        $value.exception.throw
+            if !nqp::isnull($Failure) && nqp::istype($value, $Failure);
+        $value
+    }
+
     method canonicalize() {
         my $value := self.simple-compile-time-quote-value;
-        $value := self.value.IMPL-INTERPRET(RakuAST::IMPL::InterpContext.new)
-            if !$value && self.value.IMPL-CAN-INTERPRET;
         $!key ~ (
             $value
                 ?? self.IMPL-QUOTE-VALUE($value)
@@ -317,6 +336,8 @@ class RakuAST::ColonPair::Value
   is RakuAST::QuotePair
 {
     has RakuAST::Expression $.value;
+    has Mu  $!cached-value;
+    has int $!has-cached-value;
 
     method new(Str :$key!, RakuAST::Expression :$value!) {
         my $obj := nqp::create(self);
@@ -329,14 +350,71 @@ class RakuAST::ColonPair::Value
         $visitor($!value);
     }
 
+    # Memoise on $!cached-value/$!has-cached-value; treat the flag as the
+    # authoritative "is there a value" indicator so a legitimately falsy
+    # interpret result (`:foo(0)`, `:foo("")`) doesn't get re-evaluated.
+    method IMPL-CACHE-VALUE(Mu $value) {
+        nqp::bindattr(self, RakuAST::ColonPair::Value, '$!cached-value', $value);
+        nqp::bindattr_i(self, RakuAST::ColonPair::Value, '$!has-cached-value', 1);
+        $value
+    }
+
+    # Never calls IMPL-INTERPRET, so callers that just need to introspect
+    # (base canonicalize, adverb scanners) don't fire side effects.
     method simple-compile-time-quote-value() {
-        # TODO various cases we can handle here
-        if nqp::istype(self.value, RakuAST::QuotedString) {
-            self.value.literal-value
+        return $!cached-value if $!has-cached-value;
+        nqp::istype(self.value, RakuAST::QuotedString)
+            ?? self.IMPL-CACHE-VALUE(self.value.literal-value)
+            !! Nil
+    }
+
+    # Single source of truth for "interpret the value expression once and
+    # cache it". Returns the interpreted value, or Nil when the expression
+    # is not IMPL-INTERPRET-able and a BEGIN-time evaluation is needed
+    # (only IMPL-EVAL-COLONPAIR-VALUE has the resolver/context to do that).
+    method IMPL-INTERPRETED-VALUE-OR-NIL() {
+        return $!cached-value if $!has-cached-value;
+        my $v := self.simple-compile-time-quote-value;
+        return $v if $!has-cached-value;
+        $!value.IMPL-CAN-INTERPRET
+            ?? self.IMPL-CACHE-VALUE($!value.IMPL-INTERPRET(RakuAST::IMPL::InterpContext.new))
+            !! Nil
+    }
+
+    # Non-QuotedString values (`:foo['a','b']`, `:foo('a','b')`) need to
+    # be interpreted so IMPL-QUOTE-VALUE can render the same `<a b>`
+    # canonical form as `:foo<a b>`.
+    method canonicalize() {
+        my $value := self.IMPL-INTERPRETED-VALUE-OR-NIL;
+        self.key ~ (
+            $!has-cached-value && nqp::isconcrete($value)
+                ?? self.IMPL-QUOTE-VALUE($value)
+                !! $!value.origin
+                    ?? $!value.origin.Str
+                    !! $!value.DEPARSE)
+    }
+
+    method IMPL-EVAL-COLONPAIR-VALUE(RakuAST::Resolver $resolver,
+                                     RakuAST::IMPL::QASTContext $context) {
+        my $value := self.IMPL-INTERPRETED-VALUE-OR-NIL;
+        return $value if $!has-cached-value;
+        # Not IMPL-INTERPRET-able; fall through to BEGIN-time evaluation.
+        # The CATCH re-attaches the colonpair's source location because
+        # IMPL-BEGIN-TIME-EVALUATE attributes through self.origin, which
+        # is unset on the BeginTime type object we dispatch through.
+        {
+            CATCH {
+                my $ex := $resolver.convert-begin-time-exception($_);
+                if nqp::can($ex, 'SET_FILE_LINE') && my $origin := self.origin {
+                    my $origin-match := $origin.as-match;
+                    $ex.SET_FILE_LINE($origin-match.file, $origin-match.line);
+                }
+                $ex.rethrow;
+            }
+            $value := RakuAST::BeginTime.IMPL-BEGIN-TIME-EVALUATE(
+                $!value, $resolver, $context);
         }
-        else {
-            Nil
-        }
+        self.IMPL-CACHE-VALUE($value)
     }
 
     method has-compile-time-value() {

--- a/src/Raku/ast/statementprefixes.rakumod
+++ b/src/Raku/ast/statementprefixes.rakumod
@@ -578,7 +578,8 @@ class RakuAST::StatementPrefix::Phaser::Begin
   is RakuAST::StatementPrefix::Thunky
   is RakuAST::BeginTime
 {
-    has Mu $!value;
+    has Mu  $!value;
+    has int $!has-value;
 
     method type() { "BEGIN" }
 
@@ -601,6 +602,8 @@ class RakuAST::StatementPrefix::Phaser::Begin
             }
             nqp::bindattr(self, RakuAST::StatementPrefix::Phaser::Begin,
               '$!value', $producer());
+            nqp::bindattr_i(self, RakuAST::StatementPrefix::Phaser::Begin,
+              '$!has-value', 1);
         }
         Nil
     }
@@ -619,6 +622,13 @@ class RakuAST::StatementPrefix::Phaser::Begin
         $context.ensure-sc($value);
         QAST::WVal.new(:$value)
     }
+
+    # `$!has-value` (vs `$!begin-performed`) avoids two false positives:
+    # the recursion-break window where begin-performed is set but `$!value`
+    # is not yet stored, and BEGIN values that are type objects (which
+    # would fail an `nqp::isconcrete` test).
+    method IMPL-CAN-INTERPRET() { $!has-value }
+    method IMPL-INTERPRET(RakuAST::IMPL::InterpContext $ctx) { $!value }
 }
 
 # The CHECK phaser.

--- a/src/Raku/ast/statements.rakumod
+++ b/src/Raku/ast/statements.rakumod
@@ -1709,17 +1709,24 @@ class RakuAST::ModuleLoading {
         $!unchecked-declarators // nqp::hash
     }
 
-    method IMPL-LOAD-MODULE(RakuAST::Resolver $resolver, RakuAST::Name $module-name) {
+    method IMPL-LOAD-MODULE(RakuAST::Resolver $resolver,
+                            RakuAST::IMPL::QASTContext $context,
+                            RakuAST::Name $module-name) {
         # Build dependency specification for the module.
         my $dependency-specification := $resolver.type-from-setting(
           'CompUnit', 'DependencySpecification'
         );
         my $opts := nqp::hash();
-        for $module-name.IMPL-UNWRAP-LIST($module-name.colonpairs) {
-            $opts{$_.key} := $_.simple-compile-time-quote-value;
+        my @colonpairs := $module-name.IMPL-UNWRAP-LIST($module-name.colonpairs);
+        if nqp::elems(@colonpairs) {
+            my $Failure := $resolver.type-from-setting('Failure');
+            for @colonpairs {
+                $opts{$_.key} := $_.IMPL-EVAL-COLONPAIR-VALUE-OR-RETHROW(
+                    $resolver, $context, $Failure);
+            }
         }
         my $spec := $dependency-specification.new(
-            :short-name($module-name.canonicalize(:colonpairs(False))),
+            :short-name($module-name.canonicalize(:colonpairs(0))),
             :from($opts<from> // 'Perl6'),
             :auth-matcher($opts<auth> // True),
             :api-matcher($opts<api> // True),
@@ -1915,7 +1922,7 @@ class RakuAST::Statement::Use
             ?? self.IMPL-BEGIN-TIME-EVALUATE($!argument, $resolver, $context).List.FLATTENABLE_LIST
             !! Nil;
 
-        my $comp-unit := self.IMPL-LOAD-MODULE($resolver, $!module-name);
+        my $comp-unit := self.IMPL-LOAD-MODULE($resolver, $context, $!module-name);
         self.IMPL-IMPORT($resolver, $comp-unit.handle, $arglist, :module($!module-name.canonicalize));
         self.IMPL-IMPORT-EXPORTHOW($resolver, $comp-unit.handle);
     }
@@ -1947,7 +1954,7 @@ class RakuAST::Statement::Need
 
     method PERFORM-BEGIN(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
         for $!module-names {
-            self.IMPL-LOAD-MODULE($resolver, $_);
+            self.IMPL-LOAD-MODULE($resolver, $context, $_);
         }
     }
 


### PR DESCRIPTION
Under `RAKUDO_RAKUAST=1`, expression-valued package adverbs like `module M:ver($expr)` or `module M:ver({...}())` were either dropped (treated as if the version weren't there) or evaluated multiple times, with side effects firing once per consumer. This is what was making `module Zef:ver($?DISTRIBUTION.meta<version> // '*')` produce `Use of Nil in string context` and report `Zef.^ver` as `(Mu)` instead of the real version.

```
RAKUDO_RAKUAST=1 raku -e 'module M:ver({ note "evaluated"; "1.0" }()) { }; say M.^ver'
# evaluated
# evaluated
# evaluated
# (Mu)
```

Expected: one `evaluated` line and `v1.0`.

Legacy resolves this in `Perl6::World.compile_time_evaluate`, called once per colonpair from `colonpairs_hash`, with a thunk-and-call fallback for non-trivial expressions. The fix mirrors that on `RakuAST::ColonPair::Value` by memoising the resolved value on the node and sharing the Failure-rethrow plumbing between the package-decl and use-statement consumers.

Two deliberate divergences from legacy, called out so they're not surprises:

- legacy stringifies a handled `Failure` through `Version.new`, producing garbage like `vHANDLED.<msg>.in.sub...` with backtrace frames as version parts. We rethrow at compile time instead.
- legacy silently drops `:api(Nil)`. We warn and treat it as empty, matching `:ver(Nil)`, since `:api` is a `Version` on the dependency-spec side. `:auth(Nil)` stays silent because `auth` is a string identity.

A subtler thing worth flagging for review: `RakuAST::Role.replace-body` is now called twice. `Package.new` calls it first with a placeholder body before parser state is bound; `package-def` calls it again with the real body. The body-wrapping branch (which calls `self.stubbed-meta-object`) is gated on the caller passing a real body, because `stubbed-meta-object` memoises and calling it with unbound parser state would freeze in a wrong meta-object. Side effect of doing it this way: `role R:ver({...}())` now works at all, where it used to crash with `lang-call cannot invoke object of type 'VMNull'`.