### PR TITLE
RakuAST: strip colonpairs from subset/enum meta-object names

### DIFF
--- a/src/Raku/ast/type.rakumod
+++ b/src/Raku/ast/type.rakumod
@@ -951,7 +951,7 @@ class RakuAST::Type::Enum
 
     method PRODUCE-META-OBJECT() {
         Perl6::Metamodel::EnumHOW.new_type(
-            :name($!name.canonicalize),
+            :name($!name.canonicalize(:colonpairs(0))),
             :base_type($!base-type)
         )
     }
@@ -1130,7 +1130,7 @@ class RakuAST::Type::Subset
 
     method PRODUCE-STUBBED-META-OBJECT() {
         Perl6::Metamodel::SubsetHOW.new_type(
-            :name($!name.canonicalize),
+            :name($!name.canonicalize(:colonpairs(0))),
             :refinee(Any),
             :refinement(nqp::null)
         )


### PR DESCRIPTION
Under `RAKUDO_RAKUAST=1`, the version adverb on a subset or enum leaks into `.^name`:

```
RAKUDO_RAKUAST=1 raku -e 'subset S:ver("1.0") of Int; say S.^name'
# S:ver("1.0")    <-- should be: S
```

Same problem for `enum E:ver(...) <a b c>`. Legacy passes just the bare identifier to `new_type(:name(...))` on the HOW. The version adverb lives separately on `.^ver`/`.^auth`/`.^api`, so the runtime-visible `.^name` should be the unqualified declared name.

`RakuAST::Name.canonicalize` defaults to including colonpairs because most callers want the source-roundtrip form. Subset and enum want the bare identity form, which is what the seven other call sites in RakuAST that pass `:colonpairs(0)` are already doing. This adds the same flag in the subset and enum meta-object builders.