### PR TITLE
RakuAST: silent-replace cross-compunit class reload in 'our' scope

### DIFF
--- a/src/Raku/ast/resolver.rakumod
+++ b/src/Raku/ast/resolver.rakumod
@@ -25,6 +25,45 @@ class RakuAST::Resolver {
     # The current comp unit's EXPORT package.
     has Mu $!export-package;
 
+    # In-source `our` package decls seen in this compunit's BEGIN
+    # walk. Keyed by install target's `nqp::objectid` plus the final
+    # name part so the same trailing name under different `my`-scoped
+    # parents in sibling blocks doesn't collide.
+    has Mu $!our-package-decl-map;
+
+    method in-augment-scope() {
+        my int $i := nqp::elems($!packages);
+        while $i-- {
+            return 1 if $!packages[$i].augmented;
+        }
+        0
+    }
+
+    method declare-our-package(Mu $target, str $final, RakuAST::Package $pkg) {
+        # Skip the 6.d `module Foo::Bar { class Foo::Bar { } }`
+        # pattern: silent-replace at install time, no tracker entry.
+        # Canonical name is only needed when we have an enclosing
+        # package to compare against.
+        my int $i := nqp::elems($!packages);
+        if $i {
+            my str $full-name := $pkg.name.canonicalize(:colonpairs(0));
+            while $i-- {
+                my $enclosing := $!packages[$i].compile-time-value;
+                return NQPMu
+                  if nqp::can($enclosing.HOW, 'name')
+                  && $enclosing.HOW.name($enclosing) eq $full-name;
+            }
+        }
+        my str $key := nqp::objectid($target) ~ '::' ~ $final;
+        my $existed := nqp::atkey($!our-package-decl-map, $key);
+        $!our-package-decl-map{$key} := $pkg;
+        # Allow stub-then-real: `class Foo { ... }` followed by the
+        # real body. Flag only when both sides are non-stub.
+        $existed && !$pkg.is-stub && !$existed.is-stub
+            ?? $existed
+            !! NQPMu
+    }
+
     # Create a shallow clone, but deep clone attach targets and packages
     method clone() {
         my $clone := nqp::clone(self);
@@ -32,6 +71,8 @@ class RakuAST::Resolver {
           nqp::clone($!attach-targets));
         nqp::bindattr($clone,RakuAST::Resolver,'$!packages',
           nqp::clone($!packages));
+        nqp::bindattr($clone,RakuAST::Resolver,'$!our-package-decl-map',
+          nqp::clone($!our-package-decl-map));
         $clone
     }
 
@@ -835,6 +876,7 @@ class RakuAST::Resolver::EVAL
               !! self.IMPL-SETTING-FROM-CONTEXT($context));
         nqp::bindattr($obj, RakuAST::Resolver, '$!global', $global);
         nqp::bindattr($obj, RakuAST::Resolver, '$!attach-targets', nqp::hash());
+        nqp::bindattr($obj, RakuAST::Resolver, '$!our-package-decl-map', nqp::hash());
         my $cur-package := $obj.resolve-lexical-constant-in-outer('$?PACKAGE');
         nqp::bindattr($obj, RakuAST::Resolver, '$!packages',
             $cur-package ?? [$cur-package] !! []);
@@ -1027,6 +1069,7 @@ class RakuAST::Resolver::Compile
         nqp::bindattr($obj, RakuAST::Resolver, '$!attach-targets', $attach-targets // nqp::hash());
         nqp::bindattr($obj, RakuAST::Resolver, '$!global', $global);
         nqp::bindattr($obj, RakuAST::Resolver, '$!packages', []);
+        nqp::bindattr($obj, RakuAST::Resolver, '$!our-package-decl-map', nqp::hash());
 
         nqp::bindattr($obj, RakuAST::Resolver::Compile, '$!scopes',
           $scopes // []);

--- a/src/Raku/ast/scoping.rakumod
+++ b/src/Raku/ast/scoping.rakumod
@@ -1002,6 +1002,13 @@ class RakuAST::PackageInstaller {
         my $final;
         my $lexical;
         my $type-object := nqp::eqaddr($meta-object, Mu) ?? self.stubbed-meta-object !! $meta-object;
+        # If the multi-part install resolves its parent through the
+        # setting / outer lexical chain (cross-compunit reload),
+        # capture *which* parent that was and treat the install-
+        # collision as silent only when $target is still that exact
+        # parent at check time (the loop below may reassign $target
+        # to a freshly-created intermediate stub, which is ours).
+        my $setting-resolved-target;
 
         my $illegal-pseudo-package := $name.contains-pseudo-package-illegal-for-declaration;
         $resolver.add-sorry: $resolver.build-exception:
@@ -1058,6 +1065,7 @@ class RakuAST::PackageInstaller {
             if $resolved { # first parts of the name found
                 $resolved := self.IMPL-UNWRAP-LIST($resolved);
                 $target := $resolved[0];
+                $setting-resolved-target := $target if $resolved[2] eq 'lexical';
                 if $scope eq 'our' && nqp::elems(@parts) >= 1 && $resolved[2] eq 'lexical' {
                     # Upgrade lexically imported top level package to global
                     ($resolver.get-global.WHO){$first} := $resolver.resolve-lexical($first).compile-time-value;
@@ -1107,6 +1115,18 @@ class RakuAST::PackageInstaller {
             }
         }
 
+        # Catch in-source dupes the install-collision check below
+        # silent-replaces: multi-part names (lexical-decl merge only
+        # sees the leading identifier) and identifier dupes inside
+        # an augment body (augment opens a fresh lexical scope).
+        if $orig-scope eq 'our' || $orig-scope eq 'unit' {
+            my $existed := $resolver.declare-our-package($target, $final, self);
+            $resolver.add-sorry($resolver.build-exception:
+                'X::Redeclaration', :symbol($name.canonicalize(:colonpairs(0))))
+              if $existed
+              && (!$name.is-identifier || $resolver.in-augment-scope);
+        }
+
         my %stash := $resolver.IMPL-STASH-HASH($target);
         # upgrade a lexically imported package stub to package scope if it exists
         if $lexical {
@@ -1115,19 +1135,10 @@ class RakuAST::PackageInstaller {
         if $scope eq 'our' {
             if nqp::existskey(%stash, $final) && !(%stash{$final} =:= $type-object) {
                 my $existing := %stash{$final};
-                # On 6.d and earlier, allow the specific legacy pattern
-                # where a declaration silently replaces its enclosing
-                # module (`module Foo::Bar { class Foo::Bar { } }`),
-                # matching the traditional grammar. Other ModuleHOW
-                # collisions stay strict (pre-PR #6122 RakuAST
-                # behavior). On 6.e the enclosing-package case is
-                # handled by the nested-install path above, so this
-                # branch is only reached for non-enclosing collisions.
-                if nqp::istype($existing.HOW, Perl6::Metamodel::PackageHOW)
-                  || (nqp::getcomp('Raku').language_revision < 3
-                      && nqp::istype($existing.HOW, Perl6::Metamodel::ModuleHOW)
-                      && $existing =:= $current-package)
-                  || $name.is-identifier || $orig-scope eq 'my' {
+                if self.IMPL-SHOULD-SILENT-REPLACE(
+                    $existing, $current-package, $name, $orig-scope,
+                    nqp::eqaddr($target, $setting-resolved-target)
+                ) {
                     self.IMPL-MAYBE-WORRY-SAME-NAME-AS-ENCLOSING(
                         $resolver, $existing, $type-object, $current-package, $name);
                     nqp::setwho($type-object, $existing.WHO);
@@ -1139,6 +1150,22 @@ class RakuAST::PackageInstaller {
             }
             %stash{$final} := $type-object;
         }
+    }
+
+    # Conditions under which an `our`-scoped install collision is
+    # silently replaced rather than raising X::Redeclaration. Stub
+    # PackageHOW upgrades; 6.d `module Foo::Bar { class Foo::Bar { } }`
+    # enclosing-module replace; identifier and `my`-scope (caught
+    # elsewhere); and cross-compunit reload (target resolved through
+    # the setting / outer chain), matching legacy `install_package`.
+    method IMPL-SHOULD-SILENT-REPLACE(Mu $existing, Mu $current-package, RakuAST::Name $name, str $orig-scope, int $target-from-setting) {
+        nqp::istype($existing.HOW, Perl6::Metamodel::PackageHOW)
+        || (nqp::getcomp('Raku').language_revision < 3
+            && nqp::istype($existing.HOW, Perl6::Metamodel::ModuleHOW)
+            && $existing =:= $current-package)
+        || $name.is-identifier
+        || $orig-scope eq 'my'
+        || $target-from-setting
     }
 
     # Emit a SameNameAsEnclosing worry when a declaration silently

--- a/t/02-rakudo/our-package-redeclaration.t
+++ b/t/02-rakudo/our-package-redeclaration.t
@@ -1,0 +1,73 @@
+use lib <t/packages/Test-Helpers>;
+use Test;
+use Test::Helpers;
+
+plan 7;
+
+is-run q:to/CODE/,
+    EVAL q[class A {}];
+    EVAL q[class A {}];
+    print "no-error";
+    CODE
+    :err(/'Redeclaration of symbol' .* "'A'"/),
+    :exitcode(1), :out(''),
+    'cross-EVAL identifier class is a Redeclaration';
+
+is-run q:to/CODE/,
+    EVAL q[class A::B {}];
+    EVAL q[class A::B {}];
+    print "no-error";
+    CODE
+    :err(/'Redeclaration of symbol' .* "'A::B'"/),
+    :exitcode(1), :out(''),
+    'cross-EVAL multi-part class is a Redeclaration';
+
+is-run q:to/CODE/,
+    class A::B {};
+    class A::B {};
+    print "no-error";
+    CODE
+    :err(/'Redeclaration of symbol' .* "'A::B'"/),
+    :exitcode(1), :out(''),
+    'in-source multi-part dupe is a Redeclaration';
+
+is-run q:to/CODE/,
+    class Foo { ... };
+    class Foo { method bar { 42 } };
+    print Foo.new.bar;
+    CODE
+    :out('42'), :err(''),
+    'stub-then-real composes and runs';
+
+is-run q:to/CODE/,
+    { my grammar G { token TOP { . } }; class G::A {} };
+    { my grammar G { token TOP { . } }; class G::A {} };
+    print "ok";
+    CODE
+    :out('ok'), :err(''),
+    'sibling my-scoped parents do not collide';
+
+is-run q:to/CODE/,
+    class AAAA { class B { } };
+    use MONKEY-TYPING;
+    augment class AAAA { class B { } };
+    print "no-error";
+    CODE
+    :err(/'Redeclaration of symbol' .* "'B'"/),
+    :exitcode(1), :out(''),
+    'augment-body nested class redecl is a Redeclaration';
+
+is-run q:to/CODE/,
+    my $a = $*TMPDIR.add("rakuast-reload-a-{$*PID}.rakumod");
+    my $b = $*TMPDIR.add("rakuast-reload-b-{$*PID}.rakumod");
+    $a.spurt(q[class CompUnit::Repository::Staging { method new(|) { self } }]);
+    $b.spurt(q[class CompUnit::Repository::Staging { method new(|) { self } }]);
+    LEAVE { $a.unlink if $a.e; $b.unlink if $b.e; }
+    $*REPO.load($a);
+    $*REPO.load($b);
+    print "ok";
+    CODE
+    :out('ok'), :err(''),
+    'cross-compunit $*REPO.load reload silent-replaces';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Installed zef couldn't install anything under `RAKUDO_RAKUAST=1`, dying with `Redeclaration of symbol 'CompUnit::Repository::Staging'`: a `CompUnit::DependencySpecification.new(:short-name<...Staging>)` literal in `Zef::Client` gets harvested as a precomp runtime dep, so loading the precompiled module preloads Staging. Client's defensive `$*REPO.load($staging-path)` (handles the case where Staging isn't in CORE) then re-loads it. Legacy `install_package` silent-replaces this; RakuAST's install-collision check fired.

Reproducer (no precomp needed):

    $ RAKUDO_RAKUAST=1 raku -e '
        my $a = $*TMPDIR.add("a-{$*PID}.rakumod");
        my $b = $*TMPDIR.add("b-{$*PID}.rakumod");
        $a.spurt(q[class CompUnit::Repository::Staging {}]);
        $b.spurt(q[class CompUnit::Repository::Staging {}]);
        $*REPO.load($a); $*REPO.load($b); say "ok";
    '
    # ===SORRY!=== Redeclaration of symbol 'CompUnit::Repository::Staging'.

When a multi-part install resolves its parent through the setting / outer / imported lexical chain (`partially-resolve-name-constant` returns `'lexical'`), `IMPL-INSTALL-PACKAGE` captures that parent. At install-collision time, if the current `$target` is still that captured object, `IMPL-SHOULD-SILENT-REPLACE` takes the silent path; that's the cross-compunit reload case. When resolution returns `'global'` (target in our own GLOBAL tree, e.g. cross-EVAL), or when the install path created a fresh intermediate stub, no capture is held and the check stays strict. Identifier and fresh-stub branches similarly never capture.

In-source multi-part dupes resolve through the lexical chain too, so they take the same silent-replace. `RakuAST::Resolver` carries a per-compunit tracker of `our`-scoped package declarations keyed by install target's `nqp::objectid` plus the final name part. Keying by target identity lets the same trailing name install into different `my`-scoped parents in sibling blocks without colliding. The tracker raises X::Redeclaration on a second non-identifier (or augment-body identifier) declaration; stub-then-real and the 6.d nested-in-same-named-enclosing pattern are excluded.