### PR TITLE
RakuAST: fix compound metaop assignment Z+=, X+=, <<+=>>

### DIFF
--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -1841,11 +1841,13 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
     }
 
     method infix-prefix-meta-operator:sym<X>($/) {
-        self.attach: $/, Nodify('MetaInfix', 'Cross').new($<infixish>.ast);
+        self.attach: $/, self.wrap-meta-assign:
+          $<infixish>.ast, -> $base { Nodify('MetaInfix', 'Cross').new($base) };
     }
 
     method infix-prefix-meta-operator:sym<Z>($/) {
-        self.attach: $/, Nodify('MetaInfix', 'Zip').new($<infixish>.ast);
+        self.attach: $/, self.wrap-meta-assign:
+          $<infixish>.ast, -> $base { Nodify('MetaInfix', 'Zip').new($base) };
     }
 
     method infix-postfix-meta-operator:sym<=>($/) {
@@ -1853,16 +1855,34 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
     }
 
     method infix-circumfix-meta-operator:sym<« »>($/) {
-        self.attach: $/, Nodify('MetaInfix', 'Hyper').new:
-          infix      => $<infixish>.ast,
-          dwim-left  => $<opening> eq '«',
-          dwim-right => $<closing> eq '»'
+        self.attach: $/, self.wrap-meta-assign:
+          $<infixish>.ast, -> $base {
+              Nodify('MetaInfix', 'Hyper').new:
+                infix      => $base,
+                dwim-left  => $<opening> eq '«',
+                dwim-right => $<closing> eq '»'
+          };
     }
     method infix-circumfix-meta-operator:sym«<< >>»($/) {
-        self.attach: $/, Nodify('MetaInfix', 'Hyper').new:
-          infix      => $<infixish>.ast,
-          dwim-left  => $<opening> eq '<<',
-          dwim-right => $<closing> eq '>>'
+        self.attach: $/, self.wrap-meta-assign:
+          $<infixish>.ast, -> $base {
+              Nodify('MetaInfix', 'Hyper').new:
+                infix      => $base,
+                dwim-left  => $<opening> eq '<<',
+                dwim-right => $<closing> eq '>>'
+          };
+    }
+
+    # Lift the Assign outside any Z/X/Hyper wrap so codegen sees compound
+    # assignment at the outermost position.  R/S keep the inner shape:
+    # reversed operand order makes the RHS the target, not the LHS.
+    method wrap-meta-assign($inner, $wrap) {
+        if nqp::istype($inner, Nodify('MetaInfix', 'Assign')) {
+            Nodify('MetaInfix', 'Assign').new($wrap($inner.infix))
+        }
+        else {
+            $wrap($inner)
+        }
     }
 
 #-------------------------------------------------------------------------------

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -197,6 +197,9 @@ class RakuAST::Infixish
         nqp::die('Cannot compile ' ~ self.HOW.name(self) ~ ' as a list infix');
     }
 
+    # Override on infixes whose call returns a lazy producer (needs p6sink).
+    method IMPL-RESULT-NEEDS-ITERATION() { False }
+
     # A node can implement this if it wishes to have full control of the
     # compilation of nodes. Most implement IMPL-INFIX-QAST, which gets the
     # QAST of the operands.
@@ -1304,7 +1307,13 @@ class RakuAST::MetaInfix::Assign
 
     method is-pure() { False }
 
+    method IMPL-RESULT-NEEDS-ITERATION() {
+        nqp::istype($!infix, RakuAST::MetaInfix::Zip)
+          || nqp::istype($!infix, RakuAST::MetaInfix::Cross)
+    }
+
     method IMPL-IS-TEST() {
+        return False unless nqp::istype(self.infix, RakuAST::Infix);
         my $basesym := self.infix.operator;
         $basesym eq '||' || $basesym eq '&&'  || $basesym eq '//'
         || $basesym eq 'or' || $basesym eq 'and' || $basesym eq 'orelse'
@@ -1359,6 +1368,10 @@ class RakuAST::MetaInfix::Assign
                 )
             )
         }
+        elsif self.IMPL-WRAPS-LIST-META {
+            QAST::Op.new: :op<call>,
+              self.IMPL-NESTED-META-HOP-QAST($context), $left-qast, $right-qast
+        }
         else {
             QAST::Op.new(:op<call>,
               self.IMPL-HOP-INFIX-QAST($context) , $left-qast, $right-qast
@@ -1377,6 +1390,45 @@ class RakuAST::MetaInfix::Assign
         while $i < nqp::elems($operands) {
             $operands[$i].apply-sink(False);
             $i++;
+        }
+    }
+
+    method IMPL-LIST-INFIX-QAST(RakuAST::IMPL::QASTContext $context, Mu $operands) {
+        if self.IMPL-WRAPS-LIST-META {
+            my $op := QAST::Op.new: :op<call>, self.IMPL-NESTED-META-HOP-QAST($context);
+            for $operands { $op.push($_) }
+            $op
+        }
+        else {
+            self.IMPL-INFIX-QAST($context, $operands[0], $operands[1])
+        }
+    }
+
+    method IMPL-WRAPS-LIST-META() {
+        self.IMPL-RESULT-NEEDS-ITERATION
+          || nqp::istype($!infix, RakuAST::MetaInfix::Hyper)
+    }
+
+    # Emits METAOP_<TYPE>(METAOP_ASSIGN(base)).  The flipped
+    # METAOP_ASSIGN(METAOP_<TYPE>(base)) returns a Seq that breaks native arrays.
+    method IMPL-NESTED-META-HOP-QAST(RakuAST::IMPL::QASTContext $context) {
+        my $base       := $!infix.infix;
+        my $assign-hop := QAST::Op.new: :op('call'), :name('&METAOP_ASSIGN'),
+                            $base.IMPL-HOP-INFIX-QAST($context);
+        if nqp::istype($!infix, RakuAST::MetaInfix::Hyper) {
+            my $hyper := $!infix;
+            my $hop   := QAST::Op.new: :op('call'), :name('&METAOP_HYPER'),
+                            $assign-hop;
+            $hop.push(QAST::WVal.new(:value(True), :named('dwim-left')))  if $hyper.dwim-left;
+            $hop.push(QAST::WVal.new(:value(True), :named('dwim-right'))) if $hyper.dwim-right;
+            $hop
+        }
+        else {
+            my str $name := nqp::istype($!infix, RakuAST::MetaInfix::Zip)
+                              ?? '&METAOP_ZIP' !! '&METAOP_CROSS';
+            QAST::Op.new: :op('call'), :name($name),
+                $assign-hop,
+                QAST::Var.new(:name('&METAOP_REDUCE_RIGHT'), :scope('lexical'))
         }
     }
 }
@@ -2049,7 +2101,8 @@ class RakuAST::ApplyInfix
         );
 
         # handle op=
-        if nqp::istype($infix, RakuAST::MetaInfix::Assign) {
+        if nqp::istype($infix, RakuAST::MetaInfix::Assign)
+          && nqp::istype($infix.infix, RakuAST::Infix) {
             my str $operator := $infix.infix.operator;
             if $operator eq ',' || $operator eq 'xx' {
                 my $sigil := (try $left.sigil) // '';
@@ -2181,7 +2234,7 @@ class RakuAST::ApplyInfix
         $!infix.IMPL-APPLY-SINK-TO-OPERANDS($operands, $is-sunk);
     }
 
-    method needs-sink-call() { $!infix.is-pure }
+    method needs-sink-call() { $!infix.is-pure || $!infix.IMPL-RESULT-NEEDS-ITERATION }
 
     method IMPL-CAN-INTERPRET() {
         $!infix.IMPL-CAN-INTERPRET && $!args.IMPL-CAN-INTERPRET

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -1161,9 +1161,7 @@ CODE
 #- M ---------------------------------------------------------------------------
 
     multi method deparse(RakuAST::MetaInfix::Assign:D $ast --> Str:D) {
-        my str $operator = $ast.infix.operator;
-        self.hsyn("infix-$operator", self.xsyn("infix",$operator))
-          ~ self.hsyn("meta-=", '=')
+        self.deparse($ast.infix) ~ self.hsyn("meta-=", '=')
     }
 
     multi method deparse(RakuAST::MetaInfix::Cross:D $ast --> Str:D) {

--- a/t/12-rakuast/meta-operators.rakutest
+++ b/t/12-rakuast/meta-operators.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 11;
+plan 14;
 
 my $ast;
 my $deparsed;
@@ -284,6 +284,123 @@ subtest 'Triangle reduce meta-op on left associative operator' => {
     is-deeply $deparsed, '[\+] 1, 2, 3', 'deparse';
     is-deeply $_, (1,3,6), @type[$++]
       for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+{
+    my @a = 1, 2, 3;
+    subtest 'Zip+Assign meta-op assigns elementwise to LHS' => {
+        # @a Z+= (10, 20, 30)
+        ast RakuAST::ApplyListInfix.new(
+          infix    => RakuAST::MetaInfix::Assign.new(
+            RakuAST::MetaInfix::Zip.new(
+              RakuAST::Infix.new("+")
+            )
+          ),
+          operands => (
+            RakuAST::Var::Lexical.new('@a'),
+            RakuAST::Circumfix::Parentheses.new(
+              RakuAST::SemiList.new(
+                RakuAST::Statement::Expression.new(
+                  expression => RakuAST::ApplyListInfix.new(
+                    infix    => RakuAST::Infix.new(","),
+                    operands => (
+                      RakuAST::IntLiteral.new(10),
+                      RakuAST::IntLiteral.new(20),
+                      RakuAST::IntLiteral.new(30),
+                    )
+                  )
+                )
+              )
+            ),
+          )
+        );
+
+        is-deeply $deparsed, '@a Z+= (10, 20, 30)', 'deparse';
+
+        my @expected = 11, 22, 33;
+        for 'AST', $ast, 'Str', $deparsed, 'Raku', EVAL($raku) -> $type, $it {
+            EVAL($it);
+            is-deeply @a, @expected, "$type: did mutate the array";
+            @expected = @expected Z+ (10, 20, 30);
+        }
+    }
+}
+
+{
+    my @a = 1, 2, 3;
+    subtest 'Cross+Assign meta-op assigns the cross to LHS' => {
+        # @a X+= (10, 20)
+        ast RakuAST::ApplyListInfix.new(
+          infix    => RakuAST::MetaInfix::Assign.new(
+            RakuAST::MetaInfix::Cross.new(
+              RakuAST::Infix.new("+")
+            )
+          ),
+          operands => (
+            RakuAST::Var::Lexical.new('@a'),
+            RakuAST::Circumfix::Parentheses.new(
+              RakuAST::SemiList.new(
+                RakuAST::Statement::Expression.new(
+                  expression => RakuAST::ApplyListInfix.new(
+                    infix    => RakuAST::Infix.new(","),
+                    operands => (
+                      RakuAST::IntLiteral.new(10),
+                      RakuAST::IntLiteral.new(20),
+                    )
+                  )
+                )
+              )
+            ),
+          )
+        );
+
+        is-deeply $deparsed, '@a X+= (10, 20)', 'deparse';
+
+        # Element-wise X+= accumulates each RHS element into the LHS slot
+        my @expected = [31, 32, 33];
+        EVAL($ast);
+        is-deeply @a, @expected, 'AST: did mutate the array';
+    }
+}
+
+{
+    my @a = 1, 2, 3;
+    subtest 'Hyper+Assign meta-op assigns elementwise to LHS' => {
+        # @a <<+=>> (10, 20, 30)
+        ast RakuAST::ApplyInfix.new(
+          left => RakuAST::Var::Lexical.new('@a'),
+          infix => RakuAST::MetaInfix::Assign.new(
+            RakuAST::MetaInfix::Hyper.new(
+              infix      => RakuAST::Infix.new("+"),
+              dwim-left  => True,
+              dwim-right => True,
+            )
+          ),
+          right => RakuAST::Circumfix::Parentheses.new(
+            RakuAST::SemiList.new(
+              RakuAST::Statement::Expression.new(
+                expression => RakuAST::ApplyListInfix.new(
+                  infix    => RakuAST::Infix.new(","),
+                  operands => (
+                    RakuAST::IntLiteral.new(10),
+                    RakuAST::IntLiteral.new(20),
+                    RakuAST::IntLiteral.new(30),
+                  )
+                )
+              )
+            )
+          ),
+        );
+
+        is-deeply $deparsed, '@a <<+>>= (10, 20, 30)', 'deparse';
+
+        my @expected = 11, 22, 33;
+        for 'AST', $ast, 'Str', $deparsed, 'Raku', EVAL($raku) -> $type, $it {
+            EVAL($it);
+            is-deeply @a, @expected, "$type: did mutate the array";
+            @expected = @expected Z+ (10, 20, 30);
+        }
+    }
 }
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
These silently no-opped because codegen produced a lazy Seq that never got iterated in sink context. Emit the legacy element-wise METAOP_ZIP(METAOP_ASSIGN(+)) shape so per-element mutation fires during the call and native typed arrays survive.