### PR TITLE
RakuAST: skip the lexical &name lookup for non-capturing <.name>

### DIFF
--- a/src/Raku/ast/regex.rakumod
+++ b/src/Raku/ast/regex.rakumod
@@ -1181,7 +1181,8 @@ class RakuAST::Regex::Assertion::Named
             else {
                 my $lookups := self.IMPL-UNWRAP-LIST(self.get-implicit-lookups);
                 my $qast;
-                if nqp::elems($lookups) && (my $lookup := $lookups[0]).is-resolved
+                if $!capturing
+                    && nqp::elems($lookups) && (my $lookup := $lookups[0]).is-resolved
                     && nqp::istype((my $resolution := $lookup.resolution), RakuAST::CompileTimeValue)
                     && nqp::istype($resolution.compile-time-value, Regex)
                 {


### PR DESCRIPTION
Mirror the legacy frontend, which gates the same lookup on whether the preceding source character is a `.` (see assertion:sym<name> in Perl6/Actions.nqp).  RakuAST has the same information available structurally via $!capturing, so use that instead of a source-character lookbehind.

Without the gate, `<.name>` with a lexical `&name` Regex in scope (e.g. `my token a { "A" }; "foo" ~~ /<.a>/`) failed to compile with "Cannot stringify object of type QAST::Var".  Now it matches the legacy behavior: parses, dispatches to a cursor method, errors at runtime if no such method exists.

Fixes rakudo/rakudo#5893.