### PR TITLE
RakuAST: stop using non-method packages as implicit invocant types

### DIFF
--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -2451,7 +2451,7 @@ class RakuAST::Methodish
             if $package.can-have-methods {
                 $package.ATTACH-METHOD(self) unless self.scope eq 'our';
             }
-            else {
+            elsif self.scope ne 'our' {
                 $resolver.add-worry:  # XXX should be self.add-worry
                   $resolver.build-exception: 'X::Useless::Declaration',
                     name  => $name,
@@ -2724,7 +2724,7 @@ class RakuAST::RegexDeclaration
     method IMPL-META-OBJECT-TYPE() { Regex }
 
     method IMPL-INVOCANT-TYPE-CHECK() {
-        self.scope ne 'my'
+        self.scope ne 'my' && self.scope ne 'our'
     }
 
     method PRODUCE-IMPLICIT-DECLARATIONS() {

--- a/src/Raku/ast/signature.rakumod
+++ b/src/Raku/ast/signature.rakumod
@@ -194,7 +194,7 @@ class RakuAST::Signature
                     $type := Mu;
                 }
                 elsif $!is-on-named-method {
-                    if $!invocant-type-check && nqp::isconcrete($!method-package) && !nqp::istype($!method-package, RakuAST::Grammar) {
+                    if $!invocant-type-check && nqp::isconcrete($!method-package) && !nqp::istype($!method-package, RakuAST::Grammar) && $!method-package.can-have-methods {
                         my $Class := self.IMPL-UNWRAP-LIST(self.get-implicit-lookups)[0];
                         if $!is-on-role-method && $Class.is-resolved {
                             $type := RakuAST::Type::Simple.new(RakuAST::Name.from-identifier('$?CLASS'));


### PR DESCRIPTION
The implicit invocant type for a Methodish declaration in a package context came from `$!method-package.stubbed-meta-object`, regardless of whether that package was actually method-capable.  When the enclosing package is a plain `package` or `module` (not class/role/grammar), the resulting type fails `X::Parameter::BadType` ("Package 'P' is insufficiently type-like to qualify a parameter") and the entire declaration fails to compile.

Match legacy by:

  - Skipping the package-typed invocant when the package is not method-capable (signature.rakumod), so `package P { our method m {} }`, `package P { our regex bar {} }`, `package P { has method m {} }`, etc. all compile with a Mu invocant.  Plain methods/submethods in non-method packages now match legacy (compile, with the existing "Useless declaration of a has-scoped method" warning for `has` scope).

  - Treating `my`- and `our`-scoped regex declarations the same way as legacy `regex_coderef` in Perl6/Actions.nqp does (always Mu invocant), even when declared inside a class.  Previously `class C { our regex bar {} }; "abc" ~~ /<&C::bar>/` failed at runtime with "Type check failed in binding to parameter '<anon>'; expected C but got Match".

  - Suppressing the bogus "Useless declaration of a has-scoped method" worry for `our`-scoped declarations.  `our` is the legitimate way to expose a sub in a package, and legacy doesn't warn about it.

Reproducer:

    raku -e 'package P { our regex bar { b } }; say "abc" ~~ /<&P::bar>/'

Previously SORRY'd; now produces `｢b｣`, matching legacy.