### PR TITLE
RakuAST: apply :D/:U smiley outside the parameterization wrapper

### DIFF
--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -3446,15 +3446,15 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
             $/.typed-sorry('X::InvalidTypeSmiley', :name($_.key));
         }
 
+        $type := Nodify('Type','Parameterized').new(
+          :base-type($type), :args($<arglist>.ast)
+        ).to-begin-time($*R, $*CU.context) if $<arglist>;
+
         $type := $name.has-colonpair('D')
           ?? Nodify('Type','Definedness').new(:base-type($type), :definite).to-begin-time($*R, $*CU.context)
           !! $name.has-colonpair('U')
             ?? Nodify('Type','Definedness').new(:base-type($type), :!definite).to-begin-time($*R, $*CU.context)
             !! $type;
-
-        $type := Nodify('Type','Parameterized').new(
-          :base-type($type), :args($<arglist>.ast)
-        ).to-begin-time($*R, $*CU.context) if $<arglist>;
 
         $<accept>
           ?? Nodify('Type','Coercion').new(

--- a/t/12-rakuast/xx-fixed-in-rakuast.rakutest
+++ b/t/12-rakuast/xx-fixed-in-rakuast.rakutest
@@ -125,7 +125,8 @@ plan 114;
     is-deeply Q| my Positional:D[Int] $x := Array[Int].new(1, 2) |.AST.EVAL, Array[Int].new(1, 2),
         "Parametarization with DefiniteHOWs works where it should";
 
-    ok Q| my Positional:D[Int] $x; $x.WHAT === Positional:D[Int] |.AST.EVAL,
+    is Q| my Positional:D[Int] $x = Array[Int].new(1, 2); $x.VAR.of.^name |.AST.EVAL,
+        'Positional[Int]:D',
         "Parameterization with DefiniteHOWs is propagated to scalar container";
 }
 


### PR DESCRIPTION
For `Foo:D[Int]` the actions built `Parameterized(Definedness(Foo), [Int])`, which lost the Definedness wrapper at PRODUCE-META-OBJECT time because `Type::Parameterized` uses `IMPL-BASE-TYPE` to fetch the type to parameterize, and that recursively unwraps Derived wrappers down to the underlying `Type::Simple`.  The result was that `my Positional:D[Int] $x` silently compiled to an uninitialized declaration of `Positional[Int]` with no `:D` constraint, and the `MissingInitializer` check never fired.

Swap the wrap order to `Definedness(Parameterized(Foo, [Int]))`, which matches the semantic of `Foo:D[Int]` ("a defined `Foo[Int]`").  Now the outer Definedness's `PRODUCE-META-OBJECT` consumes the Parameterized type's compile-time value as its base, producing a proper `DefiniteHOW`-wrapped `Foo[Int]`.

Reproducer:

    raku -e 'my Positional:D[Int] $x; dd :$x'

Previously: `:x(Positional[Int])` (smiley silently dropped).  Now: SORRY! "Variable definition of type Positional[Int]:D needs to be given an initializer", matching legacy.

The `xx-fixed-in-rakuast.rakutest` regression test for this issue declared an uninitialized `my Positional:D[Int] $x` and asserted `$x.WHAT === Positional:D[Int]`.  Both sides silently dropped `:D` so the comparison spuriously passed.  Replace it with an initialized declaration and a string compare against the literal `'Positional[Int]:D'` for `$x.VAR.of.^name`, which doesn't go through the parser path under test and so actually discriminates the fix.