### PR TITLE
RakuAST: detect duplicate `our multi method` declarations

### DIFF
--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -2469,6 +2469,41 @@ class RakuAST::Methodish
             nqp::bindattr(self.meta-object, Routine, '@!dispatchees', []);
             $resolver.outer-scope.add-generated-lexical-declaration(self) if self.scope ne 'has';
         }
+
+        # Install `our` multi/proto methods into the package's OUR stash
+        # with duplicate detection.  Routine.PERFORM-BEGIN's stash install
+        # excludes multi, and Methodish doesn't chain through it; non-multi
+        # `our method` is handled by LexicalScope.PERFORM-CHECK.  Skip
+        # roles and non-method-capable packages: their existing role-scope
+        # / useless-declaration errors already report the issue.
+        if self.lexical-name && self.scope eq 'our'
+                && (self.multiness eq 'multi' || self.multiness eq 'proto') {
+            my $install-pkg := $package;
+            # Mainline (no enclosing package) falls back to GLOBAL.  Skip
+            # during CORE.setting compile: GLOBAL's `.WHO` isn't wired up
+            # that early in bootstrap.
+            if !$install-pkg && !($*COMPILING_CORE_SETTING // 0) {
+                $install-pkg := $resolver.global-package;
+            }
+            # GLOBAL is wrapped in a non-Package Implicit::Constant; only
+            # real RakuAST::Package nodes carry `can-have-methods`.
+            if $install-pkg
+                    && !$package-is-role
+                    && (!nqp::istype($install-pkg, RakuAST::Package)
+                            || $install-pkg.can-have-methods) {
+                my $stash := $install-pkg.stubbed-meta-object.WHO;
+                if nqp::existskey($stash, self.lexical-name) {
+                    self.add-sorry:
+                        $resolver.build-exception: 'X::Redeclaration',
+                            :symbol(self.declaration-name),
+                            :what(self.declaration-kind);
+                }
+                else {
+                    $stash{self.lexical-name} := self.meta-object;
+                }
+            }
+        }
+
         self.IMPL-STUB-PHASERS($resolver, $context);
 
         my $stub := self.IMPL-STUB-CODE($resolver, $context);


### PR DESCRIPTION
`class C { our multi method m(Int) {}; our multi method m(Str) {} }` silently compiled in RakuAST, leaving the second method unreachable. Two existing duplicate-detection paths skip the case:

  - Routine.PERFORM-BEGIN's package-stash install is gated on `multiness ne 'multi'`.
  - LexicalScope.PERFORM-CHECK's duplicate check iterates `ast-lexical-declarations`, which excludes multi/proto routines because `is-simple-lexical-declaration` returns False for them.

Install into the package's OUR stash from Methodish.PERFORM-BEGIN for `our`-scoped multi and proto methods, with duplicate detection.  The first declaration installs; a second declaration with the same name finds the existing entry and SORRYs with "Redeclaration of method 'm'", matching the legacy frontend's `install_method` in Perl6/Actions.nqp.

Cases covered:

  - `class C { our multi method m(Int) {}; our multi method m(Str) {} }`
  - `our multi method m(Int) {}; our multi method m(Str) {}` at mainline (falls back to GLOBAL package; skipped during CORE.setting compile because GLOBAL's `.WHO` stash is not yet wired up that early in bootstrap and reading it faults)
  - `class C { our proto method m(|) {*}; our multi method m(Int) {} }` (proto and multi share the install path, so the second declaration finds the proto's entry and errors)

Cases deliberately skipped:

  - Roles (`role R { our multi method m ... }`) - the pre-existing `Cannot declare our-scoped method inside of a role` error already catches the user's problem; adding the install would only emit a redundant Redeclaration.
  - Non-method-capable packages (package, module) - the existing useless-declaration / package-not-type-like errors already fire.

Reproducer:

    raku -e 'class C { our multi method m(Int) {}; our multi method m(Str) {} }'

Previously: silent accept.  Now: SORRY! "Redeclaration of method 'm'".