### PR TITLE
RakuAST: parens around postfix operand always border currying

### DIFF
--- a/src/Raku/ast/call.rakumod
+++ b/src/Raku/ast/call.rakumod
@@ -652,6 +652,17 @@ class RakuAST::Call::Method
         SPECIAL-OPS{$name}
     }
 
+    # Special-op postfixes (.WHAT, .HOW, .VAR, .DEFINITE, etc.) compile to
+    # primitive nqp:: ops, not real method calls, so they sit outside the
+    # currying machinery. `(5 ~~ *).WHAT` must therefore evaluate `(5 ~~ *)`
+    # to a WhateverCode and then take its WHAT, rather than being absorbed
+    # into a curried `{ (5 ~~ $_).WHAT }`.
+    method IMPL-CURRIES() {
+        $!name.is-identifier && nqp::istrue(self.IMPL-SPECIAL-OP($!name.canonicalize))
+            ?? 0
+            !! 3
+    }
+
     method IMPL-POSTFIX-QAST(RakuAST::IMPL::QASTContext $context, Mu $invocant-qast) {
         my $name := $!name.canonicalize;
         my $call;

--- a/t/02-rakudo/rakuast-whatever-paren-postfix.t
+++ b/t/02-rakudo/rakuast-whatever-paren-postfix.t
@@ -1,0 +1,53 @@
+use Test;
+
+plan 9;
+
+# `(5 ~~ *).WHAT` returned a curried WhateverCode whose deparsed string
+# was `.WHAT` (and similarly for `.HOW`/`.WHO`/`.VAR`/etc.). Those
+# special-op postfixes compile to primitive nqp:: ops, not real method
+# calls, so they sit outside the currying machinery: `(curried).WHAT`
+# must evaluate the parens to a WhateverCode and then take its WHAT.
+
+# The discriminating check is type-object identity, not isa-ok: in the
+# bug state `(5 ~~ *).WHAT` was a WhateverCode *instance*, not the
+# WhateverCode *type object*. Bind to a variable first so the
+# surrounding test machinery does not itself get absorbed into currying.
+
+{
+    my $r = (5 ~~ *).WHAT;
+    ok $r === WhateverCode,
+        '(5 ~~ *).WHAT returns the WhateverCode type object';
+}
+
+{
+    my $r = (*+1).WHAT;
+    ok $r === WhateverCode,
+        '(*+1).WHAT returns the WhateverCode type object';
+}
+
+# Non-special-op postfixes (regular method calls) MUST still curry
+# through the parens, since that is how legacy and the wider ecosystem
+# build expressions like `("- " ~ *).chars` and use them with `.map`.
+
+{
+    my $c = ("- " ~ *).chars;
+    isa-ok $c, WhateverCode, '("- " ~ *).chars produces a WhateverCode';
+    ok $c.defined, '... a concrete curried instance';
+    is $c("hi"), 4, '... that runs ("- " ~ $_).chars';
+}
+
+# A bare `*` directly under a postfix (no parens) still curries.
+
+{
+    my $r = *.Str;
+    isa-ok $r, WhateverCode, '*.Str (no parens) curries to WhateverCode';
+    ok $r.defined, '*.Str produces a concrete curried instance';
+    is $r(42), '42', '*.Str curried thunk runs with arg';
+}
+
+{
+    my $r = *+1;
+    is $r(10), 11, '*+1 (no parens) still curries and runs';
+}
+
+# vim: ft=raku


### PR DESCRIPTION
`(5 ~~ *).WHAT` returned a curried WhateverCode whose deparsed string was `.WHAT` (and `(*+1).Str`, `(*).foo`, etc. behaved similarly): single parens around a curryable expression were stripped, leaving the inner expression as the bare operand, and the surrounding ApplyPostfix then absorbed the inner currying into a single WhateverCode covering `(expr).postfix`.

Only the double-parens case set IMPL-MUST-NOT-CURRY.  Drop the double-parens gate; any time we unwrap single-expression parens from an ApplyPostfix operand, mark the postfix as a currying border.  The parenthesized operand evaluates to its value first, the postfix then applies to that value, matching the legacy frontend.

Reproducer:

    raku -e 'say (5 ~~ *).WHAT'

Legacy   : (WhateverCode)
RakuAST  : .WHAT  (before)
           (WhateverCode)  (after)