### PR TITLE
Implement proper %g support in 6.e sprintf

### DIFF
--- a/src/core.e/Formatter.rakumod
+++ b/src/core.e/Formatter.rakumod
@@ -163,26 +163,20 @@ our class Formatter {
     }
 
     # Set up value for scientific notation: at this point it
-    # is guaranteed that the value is *not* 0 and that it is
-    # *not* Inf, -Inf or NaN.  This version will *always*
-    # render with a period, even if precision is 0
-    our sub scientify-period(str $letter, int $positions, $value --> str) {
+    # is guaranteed that the value is *not* Inf, -Inf or NaN.
+    # This version will *always* render with a decimal point,
+    # even if precision is 0
+    our sub scientify-point(str $letter, int $positions, $value --> str) {
         my str $string = scientify($letter, $positions, $value);
-        my int $offset = 1 + nqp::eqat($string,'-',0);
 
-        $positions
+        # Not zero positions or reverted to "e" format
+        $positions || nqp::indexic($string,"e",0) > -1
           ?? $string
-          !! nqp::concat(
-               nqp::substr($string,0,$offset),
-               nqp::concat(
-                 ".",
-                 nqp::substr($string,$offset)
-               )
-             )
+          !! nqp::concat($string,".")
     }
 
     # Set up value for scientific notation: at this point it
-    # is guaranteed that the value *not* Inf, -Inf or NaN.
+    # is guaranteed that the value is *not* Inf, -Inf or NaN.
     # The value 0 can only occur here with dynamic width or
     # precision.
     our sub scientify(str $letter, int $positions, $value --> str) {
@@ -242,67 +236,92 @@ our class Formatter {
         }
     }
 
-    # Set up value for either floating point or scientific
+    # Set up value for either a sort of floating point or scientific
+    # notation: this version will *always* render with a period if it
+    # is *not* reverting to %e format. At this point it is guaranteed
+    # that the value is *not* Inf, -Inf or NaN.  The value 0 can only
+    # occur here with dynamic width or precision.
+    our sub bestfit-point(str $letter, int $positions, $value --> str) {
+        my str $string = bestfit($letter, $positions, $value);
+
+        # Not zero positions or reverted to "e" format
+        $value
+          ?? $positions || nqp::indexic($string,"e",0) > -1
+            ?? $string
+            !! nqp::concat($string,".")
+          !! "0."
+    }
+
+    # Set up value for either a sort of floating point or scientific
     # notation: at this point it is guaranteed that the value is
     # *not* Inf, -Inf or NaN.  The value 0 can only occur here
-    # with dynamic width or
-    # precision.
+    # with dynamic width or precision.
     our sub bestfit(
-      str $letter, int $positions, $value
+      str $letter      is copy,
+      int $significant is copy,
+          $value
     --> str) {
 
         # Something complicated to do
         if $value {
-            my $abs := $value.abs;
-            my constant $divider = 10.log;
+
+            # One would specify a 0 significance to indicate that the
+            # decimal point should be shown for whole values (with the
+            # # also occurring in the format).  Otherwise, we just use
+            ++$significant unless $significant;
 
             # Initial rendering
-            my int $exp     = $abs ?? ($abs.log / $divider).floor !! 0;
-            my int $abs-exp = nqp::abs_i($exp);
-            my     $power  := 10 ** $abs-exp;
-            my str $string  = (($exp < 0
-              ?? $abs * $power
-              !! $abs / $power
-            ) * 10 ** $positions).round.Str;
+            my $abs          := $value.abs;
+            my str $string    = $abs.Str;
+            my int $has-point = nqp::isgt_i(nqp::index($string,".",1),-1);
+            my int $has-zero  = nqp::eqat($string,'0',0);
 
-            # Fix up decimal point
-            $string = $positions
-              ?? nqp::concat(
-                   nqp::substr($string,0,1),
-                   nqp::concat(
-                     ".",
-                     nqp::substr($string,1,$positions)
-                   )
-                 )
-              !! nqp::substr($string,0,1);
+            # Initial rendering has sufficient significant digits
+            if nqp::chars($string) - $has-zero - $has-point <= $significant {
 
-            # Fix up for consumption
-            nqp::concat(
-              ($value < 0 ?? "-" !! ""),
-              nqp::concat(
-                $string,
-                nqp::concat(
-                  $letter,
-                  nqp::concat(
-                    ($exp < 0 ?? "-" !! "+"),
-                    ($abs-exp < 10 ?? "0" ~ $abs-exp !! ~$abs-exp)
-                  )
-                )
-              )
-            )
+                # Make sure the negative values were handled correctly
+                $value < 0
+                  ?? nqp::concat("-",$string)
+                  !! $string
+            }
+
+            # Out of range of significant digits, so, revert to using
+            # exponential notation (which will take care of any rounding
+            # issues).
+            else {
+                $string = scientify(
+                  ($letter = $letter eq 'G' ?? 'E' !! 'e'),
+                  $significant - 1,
+                  $value
+                );
+
+                # See if we can move it back to simple format, now that
+                # all the proper rounding has been done.
+                my int $index = nqp::index($string,nqp::concat($letter,"+"));
+                if $index > -1 {
+
+                    # Number of digits in positive exponent
+                    my int $power = nqp::substr($string,$index+2);
+
+                    # Remove exponential notation if possible
+                    $index         # number of digits with decimal point
+                      - $has-point # subtract any decimal point
+                      + $power <= $significant
+                      ?? nqp::substr($string,0,$index)
+                      !! $string
+                }
+
+                # Nothing possible left to do
+                else {
+                    $string
+                }
+            }
         }
 
-        # Simple 0 handling
+        # 0 returns "0", as it has no number of significant digits
+        # and the "g/G" format only shows significant digits
         else {
-            nqp::concat(
-              $positions
-                ?? nqp::concat('0.',nqp::x('0',$positions))
-                !! '0',
-              nqp::concat(
-                $letter,
-                '+00'
-              )
-            )
+            "0"
         }
     }
 
@@ -824,7 +843,8 @@ our class Formatter {
         # Generic handling of floating point logic, returns a ready
         # to use AST
         sub handle-float-numeric($/,
-          $size, $precision, $parameter, str $zero, $not-zero is copy
+          $size, $precision, $parameter, str $zero, $not-zero is copy,
+          :$NAN-OR-INF
         ) {
             my str $signer = signer($/);
 
@@ -843,7 +863,7 @@ our class Formatter {
 
             # Set up NaN / ±Inf handling
             my $nan-or-inf := ast-call-method(
-              $parameter, $<sym> eq 'F' ?? 'uc' !! 'Str'
+              $parameter, $NAN-OR-INF ?? 'uc' !! 'Str'
             );
 
             # Filling out with zeroes
@@ -928,10 +948,10 @@ our class Formatter {
 
             make handle-float-numeric($/,
               $size, $precision, $parameter,
-              zero-exponential($/, $letter, $size, $precision),
-              ast-call-sub(has-hash($/)
+              zero-exponential($/, $letter, $size, $precision),  # zero
+              ast-call-sub(has-hash($/)                          # not-zero
                   && (!is-literal-int($precision) || $precision.value == 0)
-                  ?? 'scientify-period'
+                  ?? 'scientify-point'
                   !! 'scientify',
                 ast-string($letter),
                 $precision,
@@ -948,8 +968,8 @@ our class Formatter {
 
             make handle-float-numeric($/,
               $size, $precision, $parameter,
-              zero-float($/, $size, $precision),
-              ast-call-sub(
+              zero-float($/, $size, $precision),  # zero
+              ast-call-sub(                       # not-zero
                 has-hash($/)
                   ?? 'stringify-multiplier-digits-point'
                   !! 'stringify-multiplier-digits',
@@ -958,7 +978,8 @@ our class Formatter {
                   ?? ast-integer(10 ** $precision.value)
                   !! ast-infix(ast-integer(10), '**', $precision),
                 $precision
-              )
+              ),
+              :NAN-OR-INF($<sym> eq 'F')
             );
         }
 
@@ -968,18 +989,19 @@ our class Formatter {
             my $precision := precision($/) // ast-integer(6);
             my $parameter := parameter($/, :coerce<Numeric>);
             my $letter    := $<sym>.Str;
+            my int $point  = has-hash($/)
+              && (!is-literal-int($precision) || $precision.value == 0);
 
             make handle-float-numeric($/,
               $size, $precision, $parameter,
-              zero-exponential($/, $letter, $size, $precision),
-              ast-call-sub(has-hash($/)
-                  && (!is-literal-int($precision) || $precision.value == 0)
-                  ?? 'bestfit-period'
-                  !! 'bestfit',
+              $point ?? "0." !! "0",   # zero
+              ast-call-sub(            # not-zero
+                $point ?? 'bestfit-point' !! 'bestfit',
                 ast-string($letter),
                 $precision,
                 $parameter
-              )
+              ),
+              :NAN-OR-INF($letter eq 'G')
             )
         }
 
@@ -1019,14 +1041,6 @@ our class Formatter {
         # an escaped %
         method directive:sym<%>($/ --> Nil) {
             make ast-string('%');
-        }
-
-        # alas, don't know this one
-        method panic($/ --> Nil) {
-            X::Str::Sprintf::Directives::Unsupported.new(
-              directive => ~$/<sym>,
-              sequence  => ~$/
-            ).throw;
         }
     }
 

--- a/src/core.e/Formatter.rakumod
+++ b/src/core.e/Formatter.rakumod
@@ -168,11 +168,17 @@ our class Formatter {
     # even if precision is 0
     our sub scientify-point(str $letter, int $positions, $value --> str) {
         my str $string = scientify($letter, $positions, $value);
+        my int $index  = nqp::index($string,$letter);
 
-        # Not zero positions or reverted to "e" format
-        $positions || nqp::indexic($string,"e",0) > -1
+        # Not zero positions or generated with "e" format
+        $positions
           ?? $string
-          !! nqp::concat($string,".")
+          !! $index > -1
+            ?? nqp::concat(
+                 nqp::substr($string,0,$index),
+                 nqp::concat(".",nqp::substr($string,$index))
+               )
+            !! nqp::concat($string,".")
     }
 
     # Set up value for scientific notation: at this point it
@@ -294,7 +300,7 @@ our class Formatter {
                   $significant - 1,
                   $value
                 );
-
+                
                 # See if we can move it back to simple format, now that
                 # all the proper rounding has been done.
                 my int $index = nqp::index($string,nqp::concat($letter,"+"));


### PR DESCRIPTION
Until now, it would basically do the same as %f.

Hugely simplified from the NQP implementation, it will first try
to just stringify the value (as that already very closely matches
%g/G semantics).  Only if that stringification has more digits
than the required number of digits of accuracy, will it run the
%e/E logic.  Upon return, it checks whether the resulting string
could also be represented without the e/E notation within the
significant digits range.