### PR TITLE
Fix two compiler hangs composing parametric roles with typed attrs

### DIFF
--- a/src/Perl6/Metamodel/GenericHOW.nqp
+++ b/src/Perl6/Metamodel/GenericHOW.nqp
@@ -39,7 +39,14 @@ class Perl6::Metamodel::GenericHOW
               ?? nqp::decont($type_environment.AT-KEY($name))
               !! nqp::null;
 
-        nqp::isnull($found)
+        # A name-collision between a user role's type capture and a core
+        # role's same-named capture (e.g. user `role R[::TValue]` versus
+        # `Array::Typed[::TValue]`) can resolve the lookup to the very
+        # same generic object we just started from.  Without this guard
+        # the recursive call below spins forever.  Treat self-resolution
+        # as "no further resolution available in this env" and return
+        # $target unchanged, mirroring the not-found branch.
+        nqp::isnull($found) || nqp::eqaddr($found, $target)
           ?? $target
           !! $found.HOW.archetypes($found).generic
             ?? $found.HOW.instantiate_generic($found, $type_environment)

--- a/src/core.c/Hash/Object.rakumod
+++ b/src/core.c/Hash/Object.rakumod
@@ -313,7 +313,10 @@ my role Hash::Object[::TValue, ::TKey, ::TDefault = TValue]
     }
 
     multi method INSTANTIATE-GENERIC(::?CLASS:D: TypeEnv:D \type-environment --> Associative) is raw {
-        my \ins-hash = self.INSTANTIATE-GENERIC(type-environment);
+        # Dispatch to the :U candidate via .WHAT - calling
+        # `self.INSTANTIATE-GENERIC` from a :D invocant would re-enter this
+        # same :D candidate and spin forever.
+        my \ins-hash = self.WHAT.INSTANTIATE-GENERIC(type-environment);
         my Mu $descr := type-environment.instantiate( nqp::getattr(self, Hash, '$!descriptor') );
         nqp::p6bindattrinvres((self.elems ?? ins-hash.new(self) !! ins-hash.new), Hash, '$!descriptor', $descr )
     }

--- a/src/core.c/Hash/Typed.rakumod
+++ b/src/core.c/Hash/Typed.rakumod
@@ -40,7 +40,10 @@ my role Hash::Typed[::TValue, ::TKey, ::TDefault = TValue] does Associative[TVal
         self.^mro.first({ !(.^is_mixin && .is-generic) }).^parameterize: type-environment.instantiate(TValue)
     }
     multi method INSTANTIATE-GENERIC(::?CLASS:D: TypeEnv:D \type-environment --> Associative) is raw {
-        my \ins-hash = self.INSTANTIATE-GENERIC(type-environment);
+        # Dispatch to the :U candidate via .WHAT - calling
+        # `self.INSTANTIATE-GENERIC` from a :D invocant would re-enter this
+        # same :D candidate and spin forever.
+        my \ins-hash = self.WHAT.INSTANTIATE-GENERIC(type-environment);
         my Mu $descr := type-environment.instantiate( nqp::getattr(self, Hash, '$!descriptor') );
         nqp::p6bindattrinvres((self.elems ?? ins-hash.new(self) !! ins-hash.new), Hash, '$!descriptor', $descr )
     }

--- a/t/02-rakudo/role-typed-hash-attr-hang.t
+++ b/t/02-rakudo/role-typed-hash-attr-hang.t
@@ -1,0 +1,34 @@
+use Test;
+
+plan 4;
+
+# Issue 6071: composing a parametric role whose body declared a typed-hash
+# attribute (`has T %h` or `has %!instances{Int} of T`) with a generic
+# type-capture as the value type would spin forever in
+# Hash::Typed.INSTANTIATE-GENERIC (and Hash::Object.INSTANTIATE-GENERIC).
+#
+# Root cause: the :D variant called `self.INSTANTIATE-GENERIC(...)`,
+# which with a :D invocant re-entered the same :D multi candidate
+# instead of dispatching to the :U candidate.  Array::Typed used the
+# correct `self.WHAT.INSTANTIATE-GENERIC(...)` and so worked.
+#
+# A regression here will hang at compile time of the EVAL body, which a
+# per-test-file timeout in CI will catch.
+
+lives-ok
+    { EVAL 'role R6071A[::T = Int] { has T %h }; class C6071A does R6071A {}; True' },
+    'Issue 6071 golf: role with generic hash value, composed into class';
+
+lives-ok
+    { EVAL 'role R6071B[::T] { has T %h }; R6071B[Int].new; True' },
+    'role with generic hash value, parameterized and instantiated';
+
+lives-ok
+    { EVAL 'role R6071C[::T] { has %h{Int} of T }; class C6071C does R6071C[Str] {}; True' },
+    'role with `has %h{Int} of T` (the issue 6071 attribute shape)';
+
+lives-ok
+    { EVAL 'role R6071D[::T] { has T @.a }; R6071D[Int].new; True' },
+    'control: role with generic array value still works';
+
+# vim: ft=raku

--- a/t/02-rakudo/role-typed-hash-attr-hang.t
+++ b/t/02-rakudo/role-typed-hash-attr-hang.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 4;
+plan 8;
 
 # Issue 6071: composing a parametric role whose body declared a typed-hash
 # attribute (`has T %h` or `has %!instances{Int} of T`) with a generic
@@ -12,8 +12,18 @@ plan 4;
 # instead of dispatching to the :U candidate.  Array::Typed used the
 # correct `self.WHAT.INSTANTIATE-GENERIC(...)` and so worked.
 #
+# Issue R#6065 / PR R#6073: a *different* hang triggered when the user
+# role's type capture name happened to collide with a core role's
+# capture name (e.g. user `role R[::TValue]` versus
+# `Array::Typed[::TValue]`).  Root cause: TypeEnv keys generic captures
+# by name string, so the lookup of "TValue" returned the very same
+# generic object we asked about, and GenericHOW.instantiate_generic
+# recursed forever on that self-resolution.
+#
 # A regression here will hang at compile time of the EVAL body, which a
 # per-test-file timeout in CI will catch.
+
+# --- Issue 6071: self-recursive :D INSTANTIATE-GENERIC -----------------
 
 lives-ok
     { EVAL 'role R6071A[::T = Int] { has T %h }; class C6071A does R6071A {}; True' },
@@ -27,8 +37,30 @@ lives-ok
     { EVAL 'role R6071C[::T] { has %h{Int} of T }; class C6071C does R6071C[Str] {}; True' },
     'role with `has %h{Int} of T` (the issue 6071 attribute shape)';
 
+# --- Name-collision self-resolution in GenericHOW ---------------------
+
 lives-ok
-    { EVAL 'role R6071D[::T] { has T @.a }; R6071D[Int].new; True' },
-    'control: role with generic array value still works';
+    { EVAL 'role R6073A[::TValue] { has TValue @.a }; R6073A[Int].new; True' },
+    'PR 6073 golf: user `::TValue` colliding with Array::Typed `::TValue`';
+
+lives-ok
+    { EVAL 'role R6073B[::TValue] { has TValue %h }; R6073B[Int].new; True' },
+    'user `::TValue` colliding with Hash::Typed `::TValue`';
+
+lives-ok
+    { EVAL 'role R6073C[::TDefault] { has TDefault %h }; R6073C[Int].new; True' },
+    'user `::TDefault` colliding with Hash::Typed `::TDefault`';
+
+# Types must actually resolve, not just silently leave the attribute generic.
+
+is do {
+    EVAL 'role R6073D[::TValue] { has TValue @.a }; R6073D[Int].new.a.^name'
+}, 'Array[Int]',
+    'collision-named capture still resolves the array element type';
+
+is do {
+    EVAL 'role R6073E[::TValue] { has TValue %.h }; R6073E[Int].new.h.of.^name'
+}, 'Int',
+    'collision-named capture still resolves the hash value type';
 
 # vim: ft=raku


### PR DESCRIPTION
Two independent infinite loops in role specialization that combine to hang the compiler whenever a parametric role's body declares a typed-hash or typed-array attribute against a type capture. Both reproduce in legacy and rakuast since the bugs live in core/metamodel.

First hang (rakudo/rakudo#6071): `role A[::T = Int] { has T %h }; class B does A {}` spins forever during composition.  The `:D` candidate of `INSTANTIATE-GENERIC` in `Hash::Typed` and `Hash::Object` called `self.INSTANTIATE-GENERIC($env)`.  Multi dispatch from a `:D` invocant routes back into the same `:D` candidate instead of the `:U` one, so the call recurses on itself.  `Array::Typed` already had the correct shape (`self.WHAT.INSTANTIATE-GENERIC(...)`), which is why generic-array attributes worked but generic-hash attributes didn't.  Fixed by going through `.WHAT` to reach `:U`, matching Array::Typed.

Second hang (the case rakudo/rakudo#6073 works around by renaming every internal core capture): `role R[::TValue] { has TValue @.a }; R[Int].new` spins forever even after the first fix.  `TypeEnv` keys generic captures by name string.  When the user's capture name collides with a core role's capture (`Array::Typed[::TValue]`, `Hash::Typed[..., ::TValue, ...]`, `::TDefault`), the env's `"TValue"` slot resolves back to the same generic object the resolver was asked to instantiate.  `GenericHOW.instantiate_generic` then recursed on that self-resolution forever.  Instrumented counters confirmed `eqaddr($found, $target)` on every iteration.  Treat that case the same as "lookup found nothing" and return `$target` unchanged.  This is the underlying-cause fix, so the rename workaround in #6073 is no longer needed.

Reproducer:

    raku -e 'role A[::T = Int] { has T %h }; class B does A {}; say "ok"'
    raku -e 'role R[::TValue] { has TValue @.a }; R[Int].new; say "ok"'

Before: both spin forever, CPU pegged, GC thrashing.  After: both print `ok`.

Types still resolve concretely (`R[Int].new.a.^name eq 'Array[Int]'`, `.of` is `Int`), and type-check failures still fire correctly.

Fixes rakudo/rakudo#6071.
