### PR TITLE
RakuAST: accept trailing #= declarator doc on routines

### DIFF
--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -3897,6 +3897,23 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
     method add-trailing-declarator-doc($/) {
         my $from := $/.from;
 
+        # `enter-block-scope` set-declarands the Routine stub first;
+        # the signature's parameters then overwrite `$*DECLARAND`.  By
+        # the time the .ws-consumed trailing `#=` after a routine body
+        # fires its action, `$*DECLARAND` is the last Parameter and
+        # the doc lands on the wrong target.  Promote back to the
+        # Routine when we're past the signature (the grammar clears
+        # `$*IN-DECL` before parsing the body), leaving mid-signature
+        # `#=` attached to the Parameter.
+        if $*IN-DECL eq ''
+            && $*BLOCK
+            && nqp::istype($*BLOCK, Nodify('Routine'))
+            && nqp::istype($*DECLARAND, Nodify('Parameter'))
+        {
+            $*DECLARAND          := $*BLOCK;
+            $*LAST-TRAILING-LINE := +$*ORIGIN-SOURCE.original-line($from);
+        }
+
         sub accept($/) {
             $*DECLARAND.add-trailing(~$/);
             ++$*FROM-SEEN{$from};

--- a/src/Raku/Grammar.nqp
+++ b/src/Raku/Grammar.nqp
@@ -5720,14 +5720,16 @@ Rakudo significantly on *every* run."
         <.typed-panic: 'X::Syntax::Comment::Embedded'>
     }
 
-    # single / multi-line leading declarator block
-    token comment:sym<#|> { '#|' \h $<attachment>=[\N* \n?] }
+    # Attachment stops before the trailing `\n`; the enclosing
+    # whitespace rule eats it.  Lets `$$` in `end-statement` anchor on
+    # the same line as a block close, matching legacy's ENDSTMT leg in
+    # `Perl6/Grammar.nqp`.
+    token comment:sym<#|> { '#|' \h $<attachment>=[\N*] }
     token comment:sym<#|(...)> {
        '#|' <?opener> <attachment=.quibble(self.Quote)>
     }
 
-    # single / multi-line trailing declarator block
-    token comment:sym<#=> { '#=' \h $<attachment>=[\N* \n?] }
+    token comment:sym<#=> { '#=' \h $<attachment>=[\N*] }
     token comment:sym<#=(...)> {
         '#=' <?opener> <attachment=.quibble(self.Quote)> \n?
     }

--- a/t/02-rakudo/rakuast-trailing-declarator-doc.t
+++ b/t/02-rakudo/rakuast-trailing-declarator-doc.t
@@ -1,0 +1,72 @@
+use Test;
+
+plan 7;
+
+# RakuAST used to refuse `sub f { 7 } #= trailing` at parse time with
+# "Strange text after block (missing semicolon or comma?)".  Two
+# entangled issues:
+#
+#   1. `comment:sym<#=>` (and `#|`) captured the trailing `\n`, so
+#      `end-statement`'s `<.horizontal-whitespace>? $$ <.ws>` leg
+#      couldn't anchor `$$` before the newline once the comment had
+#      consumed it.  Legacy's `comment:sym<#=>` deliberately stops
+#      before the newline.
+#
+#   2. When the .ws-consumed comment did finally run its action, the
+#      most-recently-set `$*DECLARAND` was the last signature
+#      parameter, not the enclosing routine.  `Parameter`'s
+#      set-declarand happens after `enter-block-scope`'s set-declarand
+#      on the routine stub, so the trailing #= attached to the wrong
+#      AST node.
+
+is EVAL(q:to/CODE/), 'trailing',
+sub TDD-A { 7 } #= trailing
+&TDD-A.WHY.contents.head
+CODE
+    'trailing #= attaches to a parameterless sub';
+
+is EVAL(q:to/CODE/), 'bdoc',
+sub TDD-B($x) { $x } #= bdoc
+&TDD-B.WHY.contents.head
+CODE
+    'trailing #= attaches to a sub past its signature';
+
+is EVAL(q:to/CODE/), 'one two',
+sub TDD-C { 7 } #= one
+sub TDD-D($x) { $x } #= two
+&TDD-C.WHY.contents.head ~ ' ' ~ &TDD-D.WHY.contents.head
+CODE
+    'trailing #= attaches correctly to a chain of subs';
+
+is EVAL(q:to/CODE/), 'sigdoc',
+sub TDD-E($x) #= sigdoc
+  { $x }
+&TDD-E.WHY.contents.head
+CODE
+    'trailing #= between signature and body still works';
+
+ok EVAL(q:to/CODE/),
+sub TDD-F { 7 } # not a declarator doc
+!(try &TDD-F.WHY.contents.defined)
+CODE
+    'plain trailing `#` comment does not produce a declarator doc';
+
+is EVAL(q:to/CODE/), 'leading',
+#| leading
+sub TDD-G { 7 }
+&TDD-G.WHY.contents.head
+CODE
+    'leading #| declarator doc still works';
+
+# Guard against the easy over-promotion: a *mid-signature* trailing
+# `#=` should stay attached to the Parameter, not get promoted up to
+# the enclosing Routine.
+is EVAL(q:to/CODE/), 'xdoc:nosubdoc',
+sub TDD-H($x #= xdoc
+         ) { $x }
+(&TDD-H.signature.params[0].WHY ?? &TDD-H.signature.params[0].WHY.contents.head !! 'NIL')
+  ~ ':' ~ (&TDD-H.WHY.contents.defined ?? 'subdoc' !! 'nosubdoc')
+CODE
+    'mid-signature trailing #= stays on the parameter, not on the routine';
+
+# vim: ft=raku


### PR DESCRIPTION
`sub f { 7 } #= trailing` SORRYed at parse time with "Strange text after block (missing semicolon or comma?)".  Two interacting causes:

  1. `comment:sym<#=>` and `comment:sym<#|>` captured the trailing `\n` as part of their attachment, so end-statement's `$$` leg couldn't anchor before the newline once the comment had eaten it.  Legacy's `comment:sym<#=>` (Perl6/Grammar.nqp) deliberately stops before the `\n` for exactly this reason.

  2. After (1), the `.ws`-consumed comment fired its action while `$*DECLARAND` still pointed at the last signature Parameter, not the enclosing Routine.  `set-declarand` on a Parameter runs after `enter-block-scope`'s set-declarand on the Routine stub, so the trailing #= attached to a Parameter and dropped on the floor for the routine.

Fix (1) by ending the attachment match at end-of-line in both `#|` and `#=`.  Fix (2) in `add-trailing-declarator-doc` by promoting `$*DECLARAND` back to `$*BLOCK` when `$*DECLARAND` is a Parameter, `$*BLOCK` is a Routine, and `$*IN-DECL eq ''`.  The `$*IN-DECL` gate keeps mid-signature `#=` (`sub h($x #= xdoc) {...}`) on the Parameter, since the grammar only clears `$*IN-DECL` after the signature and before the body.

Reproducer (legacy returns `trailing`/`bdoc`; rakuast SORRYed before, both pass now):

    raku -e 'sub f { 7 } #= trailing
    say &f.WHY.contents.head'

    raku -e 'sub g($x) { $x } #= bdoc
    say &g.WHY.contents.head'

Incidentally also fixes `sub f($x) #= sigdoc\n{ $x }` (was Nil).