### PR TITLE
RakuAST: emit proper SORRY exceptions for invalid feed-operator stages

### DIFF
--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -885,26 +885,9 @@ class RakuAST::Feed
                 $stage := QAST::Op.new( :op('locallifetime'), $stage, $tmp );
             }
             else {
-                my str $error := "Only routine calls or variables that can '.append' may appear on either side
-of feed operators.";
-                if nqp::istype($stage, QAST::Children) && nqp::istype($stage[0], QAST::Var) {
-                    if nqp::istype($stage, QAST::Op) && $stage.op eq 'ifnull'
-                        && nqp::eqat($stage[0].name, '&', 0) {
-                        $error := "A feed may not sink values into a code object.
-Did you mean a call like '"
-                            ~ nqp::substr($stage[0].name, 1)
-                            ~ "()' instead?";
-                    }
-
-                    # Looks like an array, yet we wound up here (which we
-                    # wouldn't if it was an ordinary array.  Assume it's
-                    # a shaped array definition throwing a spanner into the
-                    # works.
-                    elsif nqp::eqat($stage[0].name, '@', 0) {
-                        $error := "Cannot feed into shaped arrays, as one cannot '.append' to them.";
-                    }
-                }
-                $_.PRECURSOR.panic($error);
+                # ApplyListInfix.PERFORM-CHECK should reject this earlier.
+                nqp::die("internal error: feed stage of unsupported QAST kind "
+                  ~ $stage.HOW.name($stage));
             }
             $result := $stage;
         }
@@ -2284,20 +2267,64 @@ class RakuAST::ApplyListInfix
 
     method PERFORM-CHECK(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
         if nqp::istype($!infix, RakuAST::Feed) {
-            for $!operands {
-                if nqp::istype($_, RakuAST::Var::Lexical) && $_.sigil eq '&' {
+            my $op := $!infix.operator;
+            my @stages;
+            if $op eq '==>' || $op eq '==>>' {
+                for $!operands { @stages.push($_) }
+            }
+            else {
+                for $!operands { @stages.unshift($_) }
+            }
+            @stages.shift;  # source operand, not a stage to validate
+            for @stages {
+                my $stage := $_;
+                if nqp::istype($stage, RakuAST::Var) && $stage.sigil eq '&' {
                     self.add-sorry(
                         $resolver.build-exception: 'X::AdHoc', :payload(
                             "A feed may not sink values into a code object.\n"
                                 ~ "Did you mean a call like '"
-                                ~ $_.desigilname.canonicalize
+                                ~ self.IMPL-FEED-CODE-OBJECT-NAME($stage)
                                 ~ "()' instead?"));
+                }
+                elsif !self.IMPL-IS-VALID-FEED-STAGE($stage) {
+                    my str $error := "Only routine calls or variables that can '.append' may appear on either side\nof feed operators.";
+                    # `my @x = ...` / `our @x = ...` gets legacy's
+                    # "shaped arrays" wording even without a declared
+                    # shape; other scopes get the generic message.
+                    if nqp::istype($stage, RakuAST::VarDeclaration::Simple)
+                      && $stage.sigil eq '@'
+                      && ($stage.scope eq 'my' || $stage.scope eq 'our') {
+                        $error := "Cannot feed into shaped arrays, as one cannot '.append' to them.";
+                    }
+                    self.add-sorry(
+                        $resolver.build-exception: 'X::AdHoc', :payload($error));
                 }
             }
         }
 
         self.add-sunk-worry($resolver, self.origin ?? self.origin.Str !! self.DEPARSE)
             if self.infix.is-pure && self.sunk && !self.infix.short-circuit;
+    }
+
+    method IMPL-IS-VALID-FEED-STAGE($stage) {
+        return 1 if nqp::istype($stage, RakuAST::Call);
+        return 1 if nqp::istype($stage, RakuAST::Var);
+        # `my @a <== source`: a bare declaration acts as the Var.
+        # An initializer (`my @a = grep(...)`) or a shape
+        # (`my @a[5]`) makes it a complex expression that legacy
+        # correctly rejects, so we reject too.
+        if nqp::istype($stage, RakuAST::VarDeclaration::Simple) {
+            return 1 unless $stage.initializer || $stage.shape;
+        }
+        0
+    }
+
+    method IMPL-FEED-CODE-OBJECT-NAME($stage) {
+        return $stage.desigilname.canonicalize
+          if nqp::istype($stage, RakuAST::Var::Lexical);
+        return $stage.name.canonicalize
+          if nqp::istype($stage, RakuAST::Var::Package);
+        nqp::can($stage, 'name') ?? ~$stage.name !! ''
     }
 
     method IMPL-CAN-INTERPRET() {

--- a/t/02-rakudo/rakuast-feed-validation.t
+++ b/t/02-rakudo/rakuast-feed-validation.t
@@ -1,0 +1,102 @@
+use lib <t/packages/Test-Helpers>;
+use Test;
+use Test::Helpers;
+
+plan 18;
+
+# Compile-time validation of `==>` / `<==` stages, matching the
+# legacy frontend's `make_feed` in src/Perl6/Actions.nqp.
+
+# --- Invalid shapes that must SORRY ---
+
+is-run q|5 ==> 10; say "ok"|,
+    'literal ==> literal SORRYs',
+    :err(/'Only routine calls or variables'/),
+    :exitcode(1);
+
+is-run q|5 <== 10; say "ok"|,
+    'literal <== literal SORRYs',
+    :err(/'Only routine calls or variables'/),
+    :exitcode(1);
+
+is-run q|my $x = grep(* > 4) <== map(* * 2) <== (1..5); say $x|,
+    'my $x = ... <== ... <== source SORRYs',
+    :err(/'Only routine calls or variables'/),
+    :exitcode(1);
+
+is-run q|my @x = grep(* > 4) <== map(* * 2) <== (1..5); say @x|,
+    'my @x = ... <== ... <== source SORRYs with shaped-array wording',
+    :err(/'Cannot feed into shaped arrays'/),
+    :exitcode(1);
+
+is-run q|our @x = grep(* > 4) <== map(* * 2) <== (1..5); say @x|,
+    'our @x = ... <== ... <== source SORRYs with shaped-array wording',
+    :err(/'Cannot feed into shaped arrays'/),
+    :exitcode(1);
+
+is-run q|sub f { state @x = grep(* > 4) <== map(* * 2) <== 1..3; @x }; say f|,
+    'state @x = ... gets the generic SORRY, NOT shaped-array wording',
+    :err(/'Only routine calls or variables'/),
+    :exitcode(1);
+
+is-run q|sub double($x) { $x * 2 }; my @a = (1..3) ==> &double; say @a|,
+    '&lexical-code-object as stage SORRYs with sink-into-code-object wording',
+    :err(/'A feed may not sink values into a code object'/),
+    :exitcode(1);
+
+# `&Pkg::foo`: rakuast gives the helpful "code object" hint; legacy
+# gives the generic message.  Match either.
+is-run q|class C { our sub foo($x) { $x * 2 } }; (1..3) ==> &C::foo; say "ok"|,
+    '&Pkg::foo (Var::Package with & sigil) SORRYs',
+    :err(/'A feed may not sink values into a code object' | 'Only routine calls or variables'/),
+    :exitcode(1);
+
+is-run q|say ((1..3) ==> [].push)|,
+    'method call ([].push) on RHS of feed SORRYs',
+    :err(/'Only routine calls or variables'/),
+    :exitcode(1);
+
+is-run q|my @a; (1..3) ==> @a.append; say @a|,
+    'method call (@a.append) on RHS of feed SORRYs',
+    :err(/'Only routine calls or variables'/),
+    :exitcode(1);
+
+is-run q|say ((1..5) ==> map(* * 2) ==> .grep(* > 4))|,
+    'bare .method call as feed stage SORRYs',
+    :err(/'Only routine calls or variables'/),
+    :exitcode(1);
+
+# --- Valid feeds (no error) ---
+
+is-run q|say ((1..5) ==> map(* * 2) ==> grep(* > 4))|,
+    'forward feed chain returns expected value',
+    :out("(6 8 10)\n");
+
+is-run q|say (grep(* > 4) <== map(* * 2) <== (1..5))|,
+    'backward feed chain returns expected value',
+    :out("(6 8 10)\n");
+
+is-run q|my @x; (1..5) ==> map(* * 2) ==> @x; say @x|,
+    'forward feed into @-var',
+    :out("[2 4 6 8 10]\n");
+
+is-run q|my @x; @x <== map(* * 2) <== (1..5); say @x|,
+    'backward feed into @-var',
+    :out("[2 4 6 8 10]\n");
+
+is-run q|my $x = (1..5); say ($x ==> map(* * 2))|,
+    'scalar var source feeds to a call',
+    :out("(2..10)\n");
+
+is-run q|say ((1..3) ==> map(* + 10))|,
+    '2-stage forward feed: source ==> call',
+    :out("(11 12 13)\n");
+
+# Bare `my @a` (no initializer) is treated as the destination Var,
+# not as an assignment expression.  Matches legacy and the
+# S03-feeds/basic.t shape `my @a <== gather ...`.
+is-run q|my @a <== gather for 1..3 -> $i { take $i }; say @a|,
+    'bare my @a <== source compiles (declaration acts as Var)',
+    :out("[1 2 3]\n");
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
`RakuAST::Feed.IMPL-LIST-INFIX-QAST` validated each non-source stage against the legal QAST shapes and fell through to an error path that called `$_.PRECURSOR.panic($error)`.  That line was lifted from `make_feed` in `src/Perl6/Actions.nqp` where `$_` is a Match (which has `PRECURSOR`); in RakuAST `$_` is a QAST node, which doesn't, so when an invalid stage actually reached the error path the compiler crashed with `Cannot find method 'PRECURSOR' on object of type QAST::Want`.  For some shapes the validation didn't trigger at all and the program just produced wrong output - e.g.
`my $x = grep(...) <== map(...) <== (1..5)` silently returned `()`.

Validation moves to `RakuAST::ApplyListInfix.PERFORM-CHECK`, which has a `Resolver` in scope and the natural `add-sorry` / `build-exception` reporting path.  Acceptance set narrowed to `RakuAST::Call` and `RakuAST::Var` to match legacy.  `&`-sigil detection broadened from `Var::Lexical` to all `Var` subclasses so package-qualified code refs like `&Pkg::foo` get the `did you mean foo()?` hint.  The shaped-arrays wording is restricted to `my`/`our` scope, matching legacy's QAST-shape-based check.