### PR TITLE
RakuAST: two Code.assuming bugs in synthesised closures

### DIFF
--- a/src/core.c/core_epilogue.rakumod
+++ b/src/core.c/core_epilogue.rakumod
@@ -384,11 +384,18 @@ augment class Code {
         if $parameter.constraint_list -> @constraints {
             my $head := @constraints.head;
             if @constraints.elems == 1
-              && nqp::not_i(nqp::istype($head,Code)) {
-                %args<value> = $head;  # literalize($head)) ??
+              && nqp::not_i(nqp::istype($head,Code))
+              && nqp::isconcrete($head) {
+                # Concrete value constraint, e.g. `sub f(42) { }`:
+                # match by value, parameter is anonymous.
+                %args<value> = $head;
                 %args<target>:delete;
             }
             else {
+                # Type-object constraint (subset type, etc.) or a
+                # `where`-clause Code: keep the parameter's target so
+                # the synthesised body can reference it by name; turn
+                # the constraint into a where-clause on the binding.
                 %args<where> = literalize($head);
             }
         }

--- a/src/core.c/core_epilogue.rakumod
+++ b/src/core.c/core_epilogue.rakumod
@@ -412,14 +412,24 @@ augment class Code {
         # Current index into positionals
         my int $index;
 
-        # Curry the positional at the given index
+        # For containerised values (or Positional/Associative) we want
+        # `is raw` semantics to survive across the call: the closure
+        # must see the original container at invocation time so
+        # mutations between `.assuming(...)` and the call propagate.
+        # Index into the `@positionals` slurpy itself, embedded as a
+        # literal so the closure does not need that variable to
+        # resolve in any outer scope.  Built once and reused across
+        # every containerised index so we don't emit a fresh Literal
+        # node and WVal per positional.  Other values are literalised
+        # by value.
+        my $positionals-literal := RakuAST::Literal.from-value(@positionals);
         my sub curry-positional($i --> Nil) {
             $args.push(
               nqp::iscont(my $value := @positionals[$i])
                 || nqp::istype($value,Positional)
                 || nqp::istype($value,Associative)
                 ?? RakuAST::ApplyPostfix.new(
-                     operand => RakuAST::Var::Lexical.new("\@positionals"),
+                     operand => $positionals-literal,
                      postfix => RakuAST::Postcircumfix::ArrayIndex.new(
                        index => RakuAST::SemiList.new(
                          RakuAST::Statement::Expression.new(
@@ -705,7 +715,12 @@ augment class Code {
             die "Unexpected @nogo[]";
         }
 
-        # Create the Callable wrapper and return it
+        # Embed the Code being curried as a literal compile-time value
+        # rather than via `self`, so the synthesized closure can be
+        # EVAL'd in the caller's lexical scope (needed for type names
+        # in the curried Code's signature to resolve against the
+        # caller's `use`-imports) without depending on a `self`
+        # binding in that scope.
         my %args =
           signature => RakuAST::Signature.new(
             parameters => @new.List,
@@ -714,22 +729,23 @@ augment class Code {
             RakuAST::StatementList.new(
               RakuAST::Statement::Expression.new(
                 expression => RakuAST::ApplyPostfix.new(
-                  operand => RakuAST::Term::Self.new,
+                  operand => RakuAST::Literal.from-value(self),
                   postfix => RakuAST::Call::Term.new(:$args),
                 )
               )
             )
           )
         ;
+        my $context := CALLER::LEXICAL::;
         if nqp::istype(self,Routine) {
             %args<multiness> = "proto" if self.is_dispatcher;
             %args<traits>.push(trait-is("rw")) if self.rw;
             %args<name> =
               RakuAST::Name.from-identifier("assumed." ~ self.name);
-            RakuAST::Sub.new(|%args).EVAL
+            RakuAST::Sub.new(|%args).EVAL(:$context)
         }
         else {
-            RakuAST::PointyBlock.new(|%args).EVAL
+            RakuAST::PointyBlock.new(|%args).EVAL(:$context)
         }
     }
 }

--- a/t/02-rakudo/rakuast-code-assuming.t
+++ b/t/02-rakudo/rakuast-code-assuming.t
@@ -2,7 +2,7 @@ use lib <t/02-rakudo/test-packages>;
 use Test;
 use AssumingExternalType;
 
-plan 7;
+plan 9;
 
 # External (use-imported) typed named arg curried.
 {
@@ -68,6 +68,19 @@ plan 7;
     is c(), 42, 'is raw curried call sees initial container value';
     $b = 666;
     is c(), 666, 'is raw curried call sees mutated container value';
+}
+
+# Subset-typed pass-through param: the param has to keep its name
+# in the synthesised signature so the body's reference to it
+# resolves.  Triggered by a Whatever placeholder leaving the
+# typed param in the curried signature.
+{
+    subset Simple where Int | Str;
+    sub check (Simple $a, $type) { so $a ~~ $type }
+    is (1, 2, "foo", "bar").first(&check.assuming(*, Int)), 1,
+       'subset-typed Whatever-passthrough, currying Int';
+    is (1, 2, "foo", "bar").first(&check.assuming(*, Str)), "foo",
+       'subset-typed Whatever-passthrough, currying Str';
 }
 
 # vim: expandtab shiftwidth=4

--- a/t/02-rakudo/rakuast-code-assuming.t
+++ b/t/02-rakudo/rakuast-code-assuming.t
@@ -1,0 +1,73 @@
+use lib <t/02-rakudo/test-packages>;
+use Test;
+use AssumingExternalType;
+
+plan 7;
+
+# External (use-imported) typed named arg curried.
+{
+    sub transport(AssumingExternalType :$thing!, Str :$payload) {
+        "thing.value=" ~ $thing.value ~ " payload=" ~ $payload
+    }
+    is &transport.assuming(thing => AssumingExternalType.new(42))(payload => "hi"),
+       "thing.value=42 payload=hi",
+       'assuming over a sub with an externally-defined typed parameter';
+}
+
+# Externally-typed named arg curried inside a class's BUILD.
+{
+    class C {
+        has Code $!transport;
+        submethod BUILD(AssumingExternalType :$thing!) {
+            $!transport = &transport.assuming(thing => $thing);
+        }
+        sub transport(AssumingExternalType :$thing!, Str :$msg!) {
+            "$thing.value()/$msg"
+        }
+        method call(Str $msg) { $!transport(:$msg) }
+    }
+    is C.new(thing => AssumingExternalType.new(99)).call("hello"),
+       "99/hello",
+       'assuming from a BUILD submethod, currying a typed named arg';
+}
+
+# Exercises the `RakuAST::PointyBlock` branch of `Code.assuming`,
+# distinct from the `RakuAST::Sub` branch used by the named-sub
+# tests above.
+{
+    my $b = -> AssumingExternalType $t, Str $msg { "$t.value()/$msg" };
+    is $b.assuming(AssumingExternalType.new(7))("hi"),
+       "7/hi",
+       'assuming over a pointy block with an externally-defined typed parameter';
+}
+
+{
+    sub f($x, $y, $z) { $x + $y + $z }
+    is &f.assuming(1, 2)(10), 13, 'plain positional assuming still works';
+}
+
+# Containerised positional declared inline at the call site: the
+# synthesised closure must not depend on `@positionals` resolving
+# in the caller's lexical scope, since the caller has no such
+# binding.
+{
+    class A { our method f(:$x) { "A.f($x)" } };
+    my &g = &A::f.assuming(my $a = A.new);
+    is g(x => 1), 'A.f(1)',
+       'assuming a containerized positional declared at the call site';
+}
+
+# `is raw` propagation: a Scalar passed positionally must still
+# resolve to the live container at invocation time, so assigning
+# to the source variable between `.assuming(...)` and a call
+# propagates.
+{
+    sub a($a is raw) { $a }
+    my $b = 42;
+    my &c = &a.assuming($b);
+    is c(), 42, 'is raw curried call sees initial container value';
+    $b = 666;
+    is c(), 666, 'is raw curried call sees mutated container value';
+}
+
+# vim: expandtab shiftwidth=4

--- a/t/02-rakudo/test-packages/AssumingExternalType.rakumod
+++ b/t/02-rakudo/test-packages/AssumingExternalType.rakumod
@@ -1,0 +1,5 @@
+unit class AssumingExternalType;
+
+has Int $.value;
+
+method new(Int $value) { self.bless(:$value) }


### PR DESCRIPTION
`Code.assuming` synthesises a `RakuAST::Sub` (or `PointyBlock`) at runtime and `.EVAL`s it. Two bugs in that synthesis showed up trying to install `JSON::RPC` and `Pod::Contents`.

`JSON::RPC`'s `BUILD` does `&transport.assuming(uri => $uri)` where `transport` has `URI :$uri`, and died with `'URI' has not been resolved. Type: RakuAST::Type::Simple`: the synthesised `Sub` ran `.EVAL` with `assuming`'s own setting scope as its lexical context, not the caller's, so types defined via `use` never got found. Route `.EVAL` through the caller's scope and replace `RakuAST::Term::Self` / `RakuAST::Var::Lexical("@positionals")` in the synthesised body with literal-embedded values, so nothing else has to be borrowed from the old scope. Embedding the slurpy itself as a literal keeps `is raw` working: indexed slots of an `is raw` slurpy stay the original containers.

`Pod::Contents`'s `&check_pod.assuming: *, $pod_type` hits a separate bug: `check_pod`'s first param is subset-typed (`POD $pod`), and `ParameterAST` was treating any single non-Code constraint as a literal-value match and deleting the parameter's target. Fine for `sub f(42) { }`, wrong for `sub f(Simple $a) { }` where the constraint is the subset type object. Invisible when currying consumes the param, breaks when a Whatever placeholder lets it survive into the synthesised signature with no name. Gate the value-match path on `nqp::isconcrete($head)`; type objects fall through to the where-clause path which keeps the name.
