### PR TITLE
Stop RakuAST AST nodes from holding compile pipeline state

### DIFF
--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -2568,7 +2568,7 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
             my $context := $*CU.context;
             $ast.body.IMPL-BEGIN($R, $context);
             $ast.to-begin-time($R, $context);
-            $ast.IMPL-COMPOSE($context);
+            $ast.IMPL-COMPOSE($R, $context);
         }
 
         self.attach: $/, $ast;

--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -102,7 +102,7 @@ class RakuAST::Node {
         }
         # Apply implicit block semantics.
         if nqp::istype(self, RakuAST::ImplicitBlockSemanticsProvider) {
-            self.apply-implicit-block-semantics();
+            self.apply-implicit-block-semantics(:$resolver, :$context);
         }
         if nqp::istype(self, RakuAST::BeginTime) {
             self.ensure-begin-performed($resolver, $context);
@@ -121,7 +121,7 @@ class RakuAST::Node {
         }
         # Apply implicit block semantics.
         if nqp::istype(self, RakuAST::ImplicitBlockSemanticsProvider) {
-            self.apply-implicit-block-semantics();
+            self.apply-implicit-block-semantics(:$resolver, :$context);
         }
 
         # Ensure parse time was performed already before visiting children, when it is a

--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -86,11 +86,9 @@ class RakuAST::Code
     has Bool $.custom-args;
     has Mu $!qast-block;
     has str $!cuid;
-    # Only for use by the fallback resolver in dynamically compiled code!
-    has RakuAST::Resolver $!resolver;
 
     method PERFORM-PARSE(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
-        nqp::bindattr(self, RakuAST::Code, '$!resolver', $resolver.clone);
+        Nil
     }
 
     method IMPL-EXTRA-BEGIN-TIME-DECLS(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
@@ -129,17 +127,14 @@ class RakuAST::Code
     }
 
     method IMPL-STUB-CODE(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
-        # Not all objects of certain subclasses will be attached properly,
-        # so get that resolver here
-        nqp::bindattr(self, RakuAST::Code, '$!resolver', $resolver.clone)
-            unless $!resolver;
-
         my $code-obj := self.meta-object;
         nqp::bindattr_s(self, RakuAST::Code, '$!cuid', QAST::Block.next-cuid());
 
         # Stash it under the QAST block unique ID.
         my str $cuid := $!cuid;
         $context.sub-id-to-code-object(){$cuid} := $code-obj;
+
+        $context.record-parse-time-resolver($cuid, $resolver.clone);
 
         my $precomp;
         my $compiler-thunk := {
@@ -168,7 +163,6 @@ class RakuAST::Code
         nqp::bindattr($code-obj, Code, '@!compstuff', @compstuff);
         $context.add-cleanup-task(sub () {
             nqp::bindattr($code-obj, Code, '@!compstuff', nqp::null());
-            nqp::bindattr(self, RakuAST::Code, '$!resolver', RakuAST::Resolver) if $context.is-precompilation-mode;
         });
 
         @compstuff[1] := $compiler-thunk; # Used by multi-dispatcher to force compilation
@@ -258,6 +252,8 @@ class RakuAST::Code
     }
 
     method IMPL-FIXUP-DYNAMICALLY-COMPILED-BLOCK(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context, Mu $block) {
+        # Parse-time resolver if still cached; else call-site resolver.
+        my $parse-time-resolver := $context.parse-time-resolver($!cuid) || $resolver;
         my $visit-block;
         my $visit-children;
 
@@ -308,7 +304,7 @@ class RakuAST::Code
                         );
                     }
                     elsif $name ne '$_' { #TODO figure out why we specifially don't declare $_ in ExpressionThunks
-                        my $decl := $!resolver.resolve-lexical-constant($name);
+                        my $decl := $parse-time-resolver.resolve-lexical-constant($name);
                         if $decl {
                             $decl.to-begin-time($resolver, $context); # Ensure any required lookups are resolved
                             my $value := $decl.compile-time-value;
@@ -338,7 +334,7 @@ class RakuAST::Code
                     my $op := $visit.op;
                     if ($op eq 'call' || $op eq 'callstatic' || $op eq 'chain') && $visit.name {
                         if ! $declared-in-cu($visit.name) {
-                            my $routine := $!resolver.resolve-lexical-constant($visit.name);
+                            my $routine := $parse-time-resolver.resolve-lexical-constant($visit.name);
                             if $routine {
                                 my $value := $routine.compile-time-value;
                                 $context.ensure-sc($value);
@@ -379,7 +375,9 @@ class RakuAST::Code
         my $wrapper := QAST::Block.new(QAST::Stmts.new(), nqp::clone($block));
         $wrapper.annotate('DYN_COMP_WRAPPER', 1);
 
-        my $package := $!resolver.current-package;
+        # Parse-time resolver if still cached; else call-site resolver.
+        my $parse-time-resolver := $context.parse-time-resolver($!cuid) || $resolver;
+        my $package := $parse-time-resolver.current-package;
         $context.ensure-sc($package);
 
         my $comp-unit := $resolver.find-attach-target("compunit");
@@ -484,7 +482,10 @@ class RakuAST::Code
         }
         return 0 unless $has_nested_blocks;
 
-        my $resolver := $!resolver;
+        # Parse-time resolver from the QASTContext side table; this path
+        # runs at compile time and the caller doesn't have its own
+        # resolver to fall back to.
+        my $resolver := $context.parse-time-resolver($!cuid);
         my $throwaway_block_ast := RakuAST::Block.new(:!implicit-topic);
         $throwaway_block_ast.set-implicit-topic(0);
         $throwaway_block_ast.to-begin-time($resolver, $context);
@@ -1759,7 +1760,6 @@ class RakuAST::Routine
         nqp::bindattr(self, RakuAST::Routine, '$!package', $package // $resolver.global-package);
         my $block := $resolver.find-attach-target('block', :skip-first);
         nqp::bindattr(self, RakuAST::Routine, '$!outer', $block);
-        nqp::bindattr(self, RakuAST::Code, '$!resolver', $resolver.clone);
     }
 
     method set-need-routine-variable() {
@@ -2413,7 +2413,6 @@ class RakuAST::Methodish
                 nqp::bindattr(self, RakuAST::Routine, '$!package', $package);
             }
         }
-        nqp::bindattr(self, RakuAST::Code, '$!resolver', $resolver.clone);
     }
 
     method PERFORM-BEGIN(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {

--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -729,7 +729,7 @@ class RakuAST::ExpressionThunk
             self.IMPL-THUNK-SIGNATURE)
     }
 
-    method PRODUCE-META-OBJECT() {
+    method PRODUCE-META-OBJECT(:$resolver, :$context) {
         my $code := nqp::create(self.IMPL-THUNK-OBJECT-TYPE);
         my $signature := self.IMPL-GET-OR-PRODUCE-SIGNATURE;
         nqp::bindattr($code, Code, '$!signature', $signature.meta-object);
@@ -1414,11 +1414,11 @@ class RakuAST::Block
         Nil
     }
 
-    method PRODUCE-STUBBED-META-OBJECT() {
+    method PRODUCE-STUBBED-META-OBJECT(:$resolver, :$context) {
         nqp::create(Block);
     }
 
-    method PRODUCE-META-OBJECT() {
+    method PRODUCE-META-OBJECT(:$resolver, :$context) {
         self.IMPL-PRODUCE-META-OBJECT
     }
 
@@ -1620,7 +1620,7 @@ class RakuAST::PointyBlock
         self.IMPL-UNWRAP-LIST(self.get-implicit-lookups)[1].resolution.compile-time-value;
     }
 
-    method PRODUCE-META-OBJECT() {
+    method PRODUCE-META-OBJECT(:$resolver, :$context) {
         my $block := self.IMPL-PRODUCE-META-OBJECT();
         my $signature := self.signature || self.placeholder-signature;
 
@@ -1782,11 +1782,11 @@ class RakuAST::Routine
         self.IMPL-UNWRAP-LIST(self.get-implicit-lookups)[1].resolution.compile-time-value;
     }
 
-    method PRODUCE-STUBBED-META-OBJECT() {
+    method PRODUCE-STUBBED-META-OBJECT(:$resolver, :$context) {
         nqp::create(self.IMPL-META-OBJECT-TYPE)
     }
 
-    method PRODUCE-META-OBJECT() {
+    method PRODUCE-META-OBJECT(:$resolver, :$context) {
         my $routine := self.stubbed-meta-object;
         my $signature := self.placeholder-signature || self.signature;
         nqp::bindattr($routine, Code, '$!signature', $signature.meta-object);
@@ -2676,7 +2676,7 @@ class RakuAST::Method::AttributeAccessor
 
     method declarator() { 'submethod' }
 
-    method PRODUCE-META-OBJECT() {
+    method PRODUCE-META-OBJECT(:$resolver, :$context) {
         my $meta := nqp::findmethod(RakuAST::Routine, 'PRODUCE-META-OBJECT')(self);
         $meta.set_rw if $!rw;
         $meta
@@ -2758,7 +2758,7 @@ class RakuAST::RegexDeclaration
         Nil
     }
 
-    method PRODUCE-META-OBJECT() {
+    method PRODUCE-META-OBJECT(:$resolver, :$context) {
         my $meta := nqp::findmethod(RakuAST::Routine, 'PRODUCE-META-OBJECT')(self);
         nqp::bindattr_s($meta, $meta.WHAT, '$!source',
           self.declarator ~ ' ' ~ $!source
@@ -2830,7 +2830,7 @@ class RakuAST::RegexThunk
   is RakuAST::BeginTime
 {
 
-    method PRODUCE-META-OBJECT() {
+    method PRODUCE-META-OBJECT(:$resolver, :$context) {
         # Create default signature, receiving invocant only.
         my $signature := nqp::create(Signature);
         my $parameter := nqp::create(Parameter);
@@ -3612,7 +3612,7 @@ class RakuAST::BlockThunk
         self.IMPL-QAST-BLOCK($context, :blocktype('declaration_static'), :expression($!expression));
     }
 
-    method PRODUCE-META-OBJECT() {
+    method PRODUCE-META-OBJECT(:$resolver, :$context) {
         my $code := nqp::create(self.IMPL-THUNK-OBJECT-TYPE);
         my $param := nqp::create(Parameter);
         nqp::bindattr_s($param, Parameter, '$!variable_name', '$_');

--- a/src/Raku/ast/compunit.rakumod
+++ b/src/Raku/ast/compunit.rakumod
@@ -37,6 +37,12 @@ class RakuAST::CompUnit
     has Mu $!export-package;
     has Mu $.herestub-queue;
     has int $!explicit-ctxsave;
+    # Compile pipeline state. CompUnit itself is never reachable from the
+    # SC graph, so it can hold these. Other AST nodes must NOT capture
+    # $.context or $!resolver as attributes: QASTContext transitively
+    # references non-serializable MVMContext frames via Resolver, and a
+    # serializable AST node holding them drags MVMContext into the SC
+    # and crashes serialize.
     has RakuAST::IMPL::QASTContext $.context;
     has RakuAST::Resolver $!resolver;
 

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -3583,7 +3583,7 @@ class RakuAST::Statement::For
         $!body.apply-sink(self.IMPL-DISCARD-RESULT ?? True !! False);
     }
 
-    method apply-implicit-block-semantics() {
+    method apply-implicit-block-semantics(:$resolver, :$context) {
         $!body.set-implicit-topic(True, :required);
     }
 

--- a/src/Raku/ast/impl.rakumod
+++ b/src/Raku/ast/impl.rakumod
@@ -31,6 +31,16 @@ class RakuAST::IMPL::QASTContext {
     # to it so the shared $!num_code_refs counter advances.
     has Mu $.world-bridge;
 
+    # Per-cuid parse-time resolver snapshot, used by dynamic-EVAL fallback
+    # and role-body lexical fixup. Held here rather than on the AST so
+    # nodes don't retain Resolver instances (and drag MVMContext into the
+    # SC). Drained at CompUnit cleanup time in precompilation mode so the
+    # serialized bytecode does not pin Resolver state; post-precomp load
+    # of that bytecode then degrades to the call-site scope. Outside
+    # precomp the map lives for the QASTContext's lifetime.
+    has Hash $!cuid-to-parse-time-resolver;
+    has Bool $!parse-time-resolver-cleanup-scheduled;
+
     method new(Mu :$sc!, int :$precompilation-mode, :$setting, :$language-revision) {
         my $obj := nqp::create(self);
         nqp::bindattr($obj, RakuAST::IMPL::QASTContext, '$!sc', $sc);
@@ -45,6 +55,7 @@ class RakuAST::IMPL::QASTContext {
         nqp::bindattr($obj, RakuAST::IMPL::QASTContext, '$!setting', $setting);
         nqp::bindattr($obj, RakuAST::IMPL::QASTContext, '$!language-revision', $language-revision);
         nqp::bindattr($obj, RakuAST::IMPL::QASTContext, '$!world-bridge', Mu);
+        nqp::bindattr($obj, RakuAST::IMPL::QASTContext, '$!cuid-to-parse-time-resolver', {});
         $obj
     }
 
@@ -64,6 +75,7 @@ class RakuAST::IMPL::QASTContext {
         # case.
         nqp::bindattr($context, RakuAST::IMPL::QASTContext, '$!post-deserialize', []);
         nqp::bindattr_i($context, RakuAST::IMPL::QASTContext, '$!is-nested', 1);
+        nqp::bindattr($context, RakuAST::IMPL::QASTContext, '$!cuid-to-parse-time-resolver', {});
         $context
     }
 
@@ -156,6 +168,26 @@ class RakuAST::IMPL::QASTContext {
 
     method add-cleanup-task($task) {
         nqp::push($!cleanup-tasks, $task)
+    }
+
+    method record-parse-time-resolver(str $cuid, $resolver) {
+        $!cuid-to-parse-time-resolver{$cuid} := $resolver;
+        if !$!parse-time-resolver-cleanup-scheduled && self.is-precompilation-mode {
+            nqp::bindattr(self, RakuAST::IMPL::QASTContext,
+              '$!parse-time-resolver-cleanup-scheduled', True);
+            my $ctx := self;
+            self.add-cleanup-task({
+                nqp::bindattr($ctx, RakuAST::IMPL::QASTContext,
+                  '$!cuid-to-parse-time-resolver', {})
+            });
+        }
+        Nil
+    }
+
+    method parse-time-resolver(str $cuid) {
+        nqp::existskey($!cuid-to-parse-time-resolver, $cuid)
+          ?? $!cuid-to-parse-time-resolver{$cuid}
+          !! Mu
     }
 
     # Reconnect freshly-compiled code refs to the Code objects and SC slots

--- a/src/Raku/ast/meta.rakumod
+++ b/src/Raku/ast/meta.rakumod
@@ -2,16 +2,23 @@
 # that meta-object is used in a very general sense: it's any object that
 # models a program element that still exists until runtime. The meta-object
 # of a class is actually its type object, not its HOW.
+# meta-object accepts optional :$resolver and :$context. Subclasses whose
+# PRODUCE-META-OBJECT needs them (Package, Class, Role) get full compile
+# time composition when both are passed; the bare call falls back to a
+# degraded compose where accessors are generated at runtime. The cache is
+# shared between both paths, so the first call wins.
 class RakuAST::Meta
   is RakuAST::CompileTimeValue
 {
     has Mu $!cached-meta-object;
     has Bool $!meta-object-produced;
 
-    method meta-object() {
+    method meta-object(:$resolver, :$context) {
         unless $!meta-object-produced {
-            nqp::bindattr(self, RakuAST::Meta, '$!cached-meta-object',
-                self.PRODUCE-META-OBJECT());
+            my $obj := nqp::isconcrete($resolver) && nqp::isconcrete($context)
+                ?? self.PRODUCE-META-OBJECT(:$resolver, :$context)
+                !! self.PRODUCE-META-OBJECT();
+            nqp::bindattr(self, RakuAST::Meta, '$!cached-meta-object', $obj);
             nqp::bindattr(self, RakuAST::Meta, '$!meta-object-produced', True);
         }
         $!cached-meta-object
@@ -20,8 +27,8 @@ class RakuAST::Meta
     # For when the user would be fine with a stubbed meta-object but may also
     # deal with objects that don't stub and instead just have a fully initialized
     # meta-object available.
-    method stubbed-meta-object() {
-        self.meta-object
+    method stubbed-meta-object(:$resolver, :$context) {
+        self.meta-object(:$resolver, :$context)
     }
 
     method has-meta-object() {
@@ -45,10 +52,12 @@ class RakuAST::StubbyMeta
     has Mu $!cached-stubbed-meta-object;
     has Bool $!stubbed-meta-object-produced;
 
-    method stubbed-meta-object() {
+    method stubbed-meta-object(:$resolver, :$context) {
         unless $!stubbed-meta-object-produced {
-            nqp::bindattr(self, RakuAST::StubbyMeta, '$!cached-stubbed-meta-object',
-                self.PRODUCE-STUBBED-META-OBJECT());
+            my $obj := nqp::isconcrete($resolver) && nqp::isconcrete($context)
+                ?? self.PRODUCE-STUBBED-META-OBJECT(:$resolver, :$context)
+                !! self.PRODUCE-STUBBED-META-OBJECT();
+            nqp::bindattr(self, RakuAST::StubbyMeta, '$!cached-stubbed-meta-object', $obj);
             nqp::bindattr(self, RakuAST::StubbyMeta, '$!stubbed-meta-object-produced', True);
         }
         $!cached-stubbed-meta-object
@@ -58,11 +67,11 @@ class RakuAST::StubbyMeta
         $!cached-stubbed-meta-object || False
     }
 
-    method meta-object() {
+    method meta-object(:$resolver, :$context) {
         # Ensure we have the stubbed meta-object first, then delegate to our
         # parent to produce the full meta-object.
-        self.stubbed-meta-object();
-        nqp::findmethod(RakuAST::Meta, 'meta-object')(self)
+        self.stubbed-meta-object(:$resolver, :$context);
+        nqp::findmethod(RakuAST::Meta, 'meta-object')(self, :$resolver, :$context)
     }
 
     method compile-time-value() {

--- a/src/Raku/ast/package.rakumod
+++ b/src/Raku/ast/package.rakumod
@@ -30,12 +30,13 @@ class RakuAST::Package
     has Bool $.is-require-stub;
     has Bool $!installed;
 
-    has RakuAST::CompilerServices $.compiler-services;
-
-    has RakuAST::Resolver $!resolver;
-    has RakuAST::IMPL::QASTContext $!context;
-
     has Mu $!compose-exception;
+
+    # MOP-generated accessor QAST, captured from a transient
+    # CompilerServices in PRODUCE-META-OBJECT and spliced into the
+    # package body by IMPL-EXPR-QAST. Holding the QAST rather than the
+    # CompilerServices keeps Resolver/QASTContext off the AST.
+    has QAST::Stmts $!accessor-qast;
 
     # Enclosing parametric role captured at BEGIN-time so the package can
     # register itself as an instantiation lexical on that role if it ends up
@@ -163,9 +164,6 @@ class RakuAST::Package
             }
         }
 
-        nqp::bindattr(self, RakuAST::Package, '$!resolver', $resolver);
-        nqp::bindattr(self, RakuAST::Package, '$!context', $context);
-        nqp::bindattr(self, RakuAST::Package, '$!compiler-services', RakuAST::CompilerServices.new(self, $resolver, $context));
     }
 
     method attach-target-names() { ['package', 'also'] }
@@ -200,7 +198,7 @@ class RakuAST::Package
             $scope := 'our' if $scope eq 'unit';
             my $name := $!name;
             if $name && !$name.is-empty && !$name.is-anonymous {
-                my $type-object := self.stubbed-meta-object;
+                my $type-object := self.stubbed-meta-object(:$resolver, :$context);
                 my $full-name := self.IMPL-FULL-NAME($resolver);
                 $type-object.HOW.set_name(
                     $type-object,
@@ -330,36 +328,36 @@ class RakuAST::Package
 
     # Declare the lexicals for this type of package
     method declare-lexicals(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
-        self.meta-object-as-lexicals($resolver, 'PACKAGE');
-        self.meta-object-as-lexicals($resolver, 'CLASS')
+        self.meta-object-as-lexicals($resolver, 'PACKAGE', :$context);
+        self.meta-object-as-lexicals($resolver, 'CLASS', :$context)
           unless self.declarator eq 'package';
     }
 
     # Helper method to create $?CLASS ::?CLASS and similar
-    method meta-object-as-lexicals(RakuAST::Resolver $resolver, str $root) {
+    method meta-object-as-lexicals(RakuAST::Resolver $resolver, str $root, :$context) {
         for '$?', '::?' {
-            $resolver.declare-lexical(self.implicit-constant($_ ~ $root));
+            $resolver.declare-lexical(self.implicit-constant($_ ~ $root, :$resolver, :$context));
         }
     }
 
     # Helper method to create $?CLASS ::?CLASS and similar
-    method meta-object-as-body-lexicals(str $root) {
+    method meta-object-as-body-lexicals(str $root, :$resolver, :$context) {
         my $body := self.body;
         for '$?', '::?' {
             $body.add-generated-lexical-declaration(
-              self.implicit-constant($_ ~ $root)
+              self.implicit-constant($_ ~ $root, :$resolver, :$context)
             )
         }
     }
 
     # Helper method to define an implicit constant for the meta object
-    method implicit-constant(str $name) {
+    method implicit-constant(str $name, :$resolver, :$context) {
         RakuAST::VarDeclaration::Implicit::Constant.new(
-          :$name, :value(self.stubbed-meta-object)
+          :$name, :value(self.stubbed-meta-object(:$resolver, :$context))
         )
     }
 
-    method PRODUCE-STUBBED-META-OBJECT() {
+    method PRODUCE-STUBBED-META-OBJECT(:$resolver, :$context) {
         if self.is-resolved {
             self.resolution.compile-time-value;
         }
@@ -368,17 +366,24 @@ class RakuAST::Package
         }
         else {
             # Create the type object and return it; this stubs the type.
+            # Colonpair values evaluate against $resolver/$context when
+            # present, so callers in the compile pipeline must pass both.
+            # Packages without colonpairs work fine without context.
             my %options;
             %options<name> := $!name.canonicalize if $!name;
             %options<repr> := $!repr if $!repr;
             if $!name {
                 my @colonpairs := $!name.IMPL-UNWRAP-LIST($!name.colonpairs);
                 if nqp::elems(@colonpairs) {
-                    my $Failure := $!resolver.type-from-setting('Failure');
+                    nqp::die("RakuAST::Package.stubbed-meta-object: package with colonpairs `"
+                      ~ $!name.canonicalize
+                      ~ "' requires resolver and context, but caller did not pass them")
+                        unless nqp::isconcrete($resolver) && nqp::isconcrete($context);
+                    my $Failure := $resolver.type-from-setting('Failure');
                     for @colonpairs {
                         my $key := $_.key;
                         my $value := $_.IMPL-EVAL-COLONPAIR-VALUE-OR-RETHROW(
-                            $!resolver, $!context, $Failure);
+                            $resolver, $context, $Failure);
                         next if $key eq 'auth' && nqp::eqaddr($value, Nil);
                         $value := Version.new($value) if $key eq 'ver' || $key eq 'api';
                         %options{$key} := $value;
@@ -397,27 +402,45 @@ class RakuAST::Package
         }
     }
 
-    method PRODUCE-META-OBJECT() {
-        my $type := self.stubbed-meta-object;
-        $type.HOW.compose($type, :compiler_services($!compiler-services));
+    method PRODUCE-META-OBJECT(:$resolver, :$context) {
+        my $type := self.stubbed-meta-object(:$resolver, :$context);
+        # Construct a transient CompilerServices for the MOP if the
+        # caller threaded $resolver/$context through. The CompilerServices
+        # lives only for this method call - it never gets stored on the
+        # AST, so the Resolver and QASTContext it holds (with their
+        # MVMContext frames) cannot reach the SC. We capture the
+        # generated accessor QAST onto $!accessor-qast (serializable
+        # QAST::Stmts) before the CompilerServices goes out of scope, so
+        # IMPL-EXPR-QAST can splice it into the body. Without context we
+        # compose without compiler_services; the MOP then generates
+        # accessors via runtime closures rather than capturing
+        # compile-time QAST - functionally equivalent, slower.
+        if nqp::isconcrete($resolver) && nqp::isconcrete($context) {
+            my $cs := RakuAST::CompilerServices.new(self, $resolver, $context);
+            $type.HOW.compose($type, :compiler_services($cs));
+            nqp::bindattr(self, RakuAST::Package, '$!accessor-qast', $cs.IMPL-GET-QAST);
+        }
+        else {
+            $type.HOW.compose($type);
+        }
         CATCH {
             nqp::bindattr(self, RakuAST::Package, '$!compose-exception', $_)
         }
         $type
     }
 
-    method apply-implicit-block-semantics() {
+    method apply-implicit-block-semantics(:$resolver, :$context) {
         unless $!block-semantics-applied {
-            self.meta-object-as-body-lexicals('PACKAGE');
-            self.additional-body-lexicals;
+            self.meta-object-as-body-lexicals('PACKAGE', :$resolver, :$context);
+            self.additional-body-lexicals(:$resolver, :$context);
 
             nqp::bindattr(self,RakuAST::Package,'$!block-semantics-applied',1);
         }
     }
 
     # Add any additional lexicals to the body
-    method additional-body-lexicals() {
-        self.meta-object-as-body-lexicals('CLASS')
+    method additional-body-lexicals(:$resolver, :$context) {
+        self.meta-object-as-body-lexicals('CLASS', :$resolver, :$context)
           unless self.declarator eq 'package';
     }
 
@@ -425,7 +448,11 @@ class RakuAST::Package
         my $type-object := self.meta-object;
         $context.ensure-sc($type-object);
         my $body := $!body.IMPL-QAST-BLOCK($context, :blocktype<immediate>);
-        $!compiler-services.IMPL-ADD-QAST($body[0]);
+        # Splice in any accessor QAST captured by PRODUCE-META-OBJECT;
+        # absent on the degraded compose path.
+        if nqp::isconcrete($!accessor-qast) && nqp::elems($!accessor-qast.list) {
+            $body[0].push($!accessor-qast);
+        }
         my $result := QAST::Stmts.new(
             $body,
             QAST::WVal.new( :value($type-object) )
@@ -437,8 +464,12 @@ class RakuAST::Package
         self.compile-time-value
     }
 
-    method IMPL-COMPOSE(RakuAST::IMPL::QASTContext $context) {
-        self.meta-object; # Ensure it's composed
+    method IMPL-COMPOSE(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
+        # $resolver/$context are mandatory here: this is the first
+        # meta-object access for the package and fills the cache. A bare
+        # call would cache the degraded compose and starve later callers
+        # of accessor QAST.
+        self.meta-object(:$resolver, :$context);
         self.IMPL-MAYBE-REGISTER-INSTANTIATION-LEXICAL;
     }
 
@@ -627,8 +658,8 @@ class RakuAST::Role
     method parameterization() { self.body.signature }
 
     method declare-lexicals(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
-        self.meta-object-as-lexicals($resolver, 'PACKAGE');
-        self.meta-object-as-lexicals($resolver, 'ROLE');
+        self.meta-object-as-lexicals($resolver, 'PACKAGE', :$context);
+        self.meta-object-as-lexicals($resolver, 'ROLE', :$context);
 
         for '$?CLASS', '::?CLASS' {
             $resolver.declare-lexical(
@@ -674,8 +705,8 @@ class RakuAST::Role
         $resolver.current-scope.add-generated-lexical-declaration(self.body.fixup) if self.body.fixup;
     }
 
-    method additional-body-lexicals() {
-        self.meta-object-as-body-lexicals('ROLE');
+    method additional-body-lexicals(:$resolver, :$context) {
+        self.meta-object-as-body-lexicals('ROLE', :$resolver, :$context);
 
         self.body.add-generated-lexical-declaration(
             # $?CONCRETIZATION is actually a run-time symbol because it's being initialized when role is
@@ -725,25 +756,24 @@ class RakuAST::Role
         Nil
     }
 
-    method PRODUCE-META-OBJECT() {
-        # Obtain the stubbed meta-object, which is the type object.
-        my $type := self.stubbed-meta-object;
+    method PRODUCE-META-OBJECT(:$resolver, :$context) {
+        my $type := self.stubbed-meta-object(:$resolver, :$context);
 
         unless self.is-stub {
-            my $how  := $type.HOW;
+            my $how := $type.HOW;
             self.PRODUCE-META-ATTACHABLES($type, $how);
-
-            $how.set_body_block($type, self.body.meta-object);
-
-            # The role needs to be composed before we add the possibility
-            # to the group
-            {
-                $how.compose($type, :compiler_services(self.compiler-services));
-                CATCH {
-                    nqp::bindattr(self, RakuAST::Package, '$!compose-exception', $_)
-                }
+            $how.set_body_block($type, self.body.meta-object(:$resolver, :$context));
+            if nqp::isconcrete($resolver) && nqp::isconcrete($context) {
+                my $cs := RakuAST::CompilerServices.new(self, $resolver, $context);
+                $how.compose($type, :compiler_services($cs));
+                nqp::bindattr(self, RakuAST::Package, '$!accessor-qast', $cs.IMPL-GET-QAST);
             }
-
+            else {
+                $how.compose($type);
+            }
+            CATCH {
+                nqp::bindattr(self, RakuAST::Package, '$!compose-exception', $_)
+            }
             my $group :=
               nqp::getattr(self, RakuAST::Package::Attachable, '$!role-group');
             $group.HOW.add_possibility($group, $type) unless $group =:= Mu;
@@ -759,8 +789,10 @@ class RakuAST::Role
         nqp::push($!instantiation-lexicals, $lexical);
     }
 
-    method IMPL-COMPOSE(RakuAST::IMPL::QASTContext $context) {
-        self.meta-object;
+    method IMPL-COMPOSE(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
+        # See Package.IMPL-COMPOSE; $resolver/$context are mandatory and
+        # the first meta-object access fills the cache.
+        self.meta-object(:$resolver, :$context);
         self.body.IMPL-FINISH-ROLE-BODY($context);
     }
 }
@@ -826,17 +858,20 @@ class RakuAST::Class
     method declarator()  { "class"             }
     method default-how() { Metamodel::ClassHOW }
 
-    method PRODUCE-META-OBJECT() {
-        # Obtain the stubbed meta-object, which is the type object.
-        my $type := self.stubbed-meta-object();
+    method PRODUCE-META-OBJECT(:$resolver, :$context) {
+        my $type := self.stubbed-meta-object(:$resolver, :$context);
         my $how  := $type.HOW;
-
         self.PRODUCE-META-ATTACHABLES($type, $how);
-        {
-        $how.compose($type, :compiler_services(self.compiler-services));
-            CATCH {
-                nqp::bindattr(self, RakuAST::Package, '$!compose-exception', $_)
-            }
+        if nqp::isconcrete($resolver) && nqp::isconcrete($context) {
+            my $cs := RakuAST::CompilerServices.new(self, $resolver, $context);
+            $how.compose($type, :compiler_services($cs));
+            nqp::bindattr(self, RakuAST::Package, '$!accessor-qast', $cs.IMPL-GET-QAST);
+        }
+        else {
+            $how.compose($type);
+        }
+        CATCH {
+            nqp::bindattr(self, RakuAST::Package, '$!compose-exception', $_)
         }
         $type
     }
@@ -873,12 +908,12 @@ class RakuAST::Module
     method default-how() { Metamodel::ModuleHOW  }
 
     method declare-lexicals(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
-        self.meta-object-as-lexicals($resolver, 'PACKAGE');
-        self.meta-object-as-lexicals($resolver, 'MODULE');
+        self.meta-object-as-lexicals($resolver, 'PACKAGE', :$context);
+        self.meta-object-as-lexicals($resolver, 'MODULE', :$context);
     }
 
-    method additional-body-lexicals() {
-        self.meta-object-as-body-lexicals('MODULE');
+    method additional-body-lexicals(:$resolver, :$context) {
+        self.meta-object-as-body-lexicals('MODULE', :$resolver, :$context);
     }
 }
 
@@ -939,4 +974,8 @@ class RakuAST::CompilerServices
     method IMPL-ADD-QAST(QAST::Node $target) {
         $target.push: $!qast if nqp::elems($!qast.list);
     }
+
+    # Return the accumulated accessor QAST so Package can keep it and
+    # discard the transient CompilerServices.
+    method IMPL-GET-QAST() { $!qast }
 }

--- a/src/Raku/ast/package.rakumod
+++ b/src/Raku/ast/package.rakumod
@@ -404,17 +404,19 @@ class RakuAST::Package
 
     method PRODUCE-META-OBJECT(:$resolver, :$context) {
         my $type := self.stubbed-meta-object(:$resolver, :$context);
-        # Construct a transient CompilerServices for the MOP if the
-        # caller threaded $resolver/$context through. The CompilerServices
-        # lives only for this method call - it never gets stored on the
-        # AST, so the Resolver and QASTContext it holds (with their
-        # MVMContext frames) cannot reach the SC. We capture the
-        # generated accessor QAST onto $!accessor-qast (serializable
-        # QAST::Stmts) before the CompilerServices goes out of scope, so
-        # IMPL-EXPR-QAST can splice it into the body. Without context we
-        # compose without compiler_services; the MOP then generates
-        # accessors via runtime closures rather than capturing
-        # compile-time QAST - functionally equivalent, slower.
+        self.IMPL-COMPOSE-TYPE($type, :$resolver, :$context);
+        CATCH {
+            nqp::bindattr(self, RakuAST::Package, '$!compose-exception', $_)
+        }
+        $type
+    }
+
+    # Compose $type via its HOW. When $resolver/$context are present,
+    # hand the MOP a transient CompilerServices and capture the
+    # resulting accessor QAST onto $!accessor-qast before the services
+    # go out of scope. Without context the MOP falls back to runtime
+    # closure accessors; functionally equivalent, slower.
+    method IMPL-COMPOSE-TYPE(Mu $type, :$resolver, :$context) {
         if nqp::isconcrete($resolver) && nqp::isconcrete($context) {
             my $cs := RakuAST::CompilerServices.new(self, $resolver, $context);
             $type.HOW.compose($type, :compiler_services($cs));
@@ -423,10 +425,6 @@ class RakuAST::Package
         else {
             $type.HOW.compose($type);
         }
-        CATCH {
-            nqp::bindattr(self, RakuAST::Package, '$!compose-exception', $_)
-        }
-        $type
     }
 
     method apply-implicit-block-semantics(:$resolver, :$context) {
@@ -763,14 +761,7 @@ class RakuAST::Role
             my $how := $type.HOW;
             self.PRODUCE-META-ATTACHABLES($type, $how);
             $how.set_body_block($type, self.body.meta-object(:$resolver, :$context));
-            if nqp::isconcrete($resolver) && nqp::isconcrete($context) {
-                my $cs := RakuAST::CompilerServices.new(self, $resolver, $context);
-                $how.compose($type, :compiler_services($cs));
-                nqp::bindattr(self, RakuAST::Package, '$!accessor-qast', $cs.IMPL-GET-QAST);
-            }
-            else {
-                $how.compose($type);
-            }
+            self.IMPL-COMPOSE-TYPE($type, :$resolver, :$context);
             CATCH {
                 nqp::bindattr(self, RakuAST::Package, '$!compose-exception', $_)
             }
@@ -860,16 +851,8 @@ class RakuAST::Class
 
     method PRODUCE-META-OBJECT(:$resolver, :$context) {
         my $type := self.stubbed-meta-object(:$resolver, :$context);
-        my $how  := $type.HOW;
-        self.PRODUCE-META-ATTACHABLES($type, $how);
-        if nqp::isconcrete($resolver) && nqp::isconcrete($context) {
-            my $cs := RakuAST::CompilerServices.new(self, $resolver, $context);
-            $how.compose($type, :compiler_services($cs));
-            nqp::bindattr(self, RakuAST::Package, '$!accessor-qast', $cs.IMPL-GET-QAST);
-        }
-        else {
-            $how.compose($type);
-        }
+        self.PRODUCE-META-ATTACHABLES($type, $type.HOW);
+        self.IMPL-COMPOSE-TYPE($type, :$resolver, :$context);
         CATCH {
             nqp::bindattr(self, RakuAST::Package, '$!compose-exception', $_)
         }

--- a/src/Raku/ast/signature.rakumod
+++ b/src/Raku/ast/signature.rakumod
@@ -264,7 +264,7 @@ class RakuAST::Signature
         @generated
     }
 
-    method PRODUCE-META-OBJECT() {
+    method PRODUCE-META-OBJECT(:$resolver, :$context) {
         # Produce meta-objects for each parameter.
         my @parameters;
         if $!implicit-invocant {
@@ -473,7 +473,7 @@ class RakuAST::FakeSignature
         True
     }
 
-    method PRODUCE-META-OBJECT() {
+    method PRODUCE-META-OBJECT(:$resolver, :$context) {
         $!block.meta-object; # To bind block to signature
         $!signature.meta-object
     }
@@ -842,7 +842,7 @@ class RakuAST::Parameter
         False
     }
 
-    method PRODUCE-META-OBJECT() {
+    method PRODUCE-META-OBJECT(:$resolver, :$context) {
         my $parameter := nqp::create(Parameter);
         if $!target {
             nqp::bindattr_s($parameter, Parameter, '$!variable_name',
@@ -1995,7 +1995,7 @@ class RakuAST::ParameterTarget::Var
         $!declaration.set-where($where) if $!declaration;
     }
 
-    method PRODUCE-META-OBJECT() {
+    method PRODUCE-META-OBJECT(:$resolver, :$context) {
         unless $!declaration {
             nqp::die('Cannot produce meta object for attribute parameter target');
         }
@@ -2177,7 +2177,7 @@ class RakuAST::ParameterTarget::Term
         }
     }
 
-    method PRODUCE-META-OBJECT() {
+    method PRODUCE-META-OBJECT(:$resolver, :$context) {
         my $of := self.IMPL-OF-TYPE;
         my $default := $of;
         my $descriptor := self.IMPL-CONTAINER-DESCRIPTOR($default);

--- a/src/Raku/ast/statement-mods.rakumod
+++ b/src/Raku/ast/statement-mods.rakumod
@@ -370,7 +370,7 @@ class RakuAST::StatementModifier::Condition::Thunk
         Nil
     }
 
-    method PRODUCE-META-OBJECT() {
+    method PRODUCE-META-OBJECT(:$resolver, :$context) {
         Nil
     }
 

--- a/src/Raku/ast/statementprefixes.rakumod
+++ b/src/Raku/ast/statementprefixes.rakumod
@@ -722,7 +722,6 @@ class RakuAST::StatementPrefix::Phaser::Enter
               // $resolver.find-attach-target('compunit')
             ).add-enter-phaser(self)
         );
-        nqp::bindattr(self, RakuAST::Code, '$!resolver', $resolver.clone);
         self.IMPL-STUB-CODE($resolver, $context);
     }
 
@@ -746,7 +745,6 @@ class RakuAST::StatementPrefix::Phaser::End
 
     method PERFORM-BEGIN(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
         $resolver.find-attach-target('compunit').add-end-phaser(self.meta-object);
-        nqp::bindattr(self, RakuAST::Code, '$!resolver', $resolver.clone);
         self.IMPL-STUB-CODE($resolver, $context);
     }
 }
@@ -789,7 +787,6 @@ class RakuAST::StatementPrefix::Phaser::Block
               // $resolver.find-attach-target('compunit')
             ).add-phaser(
           self.type, self, :has-exit-handler(self.exit-handler));
-        nqp::bindattr(self, RakuAST::Code, '$!resolver', $resolver.clone);
         self.IMPL-STUB-CODE($resolver, $context);
     }
 
@@ -889,7 +886,6 @@ class RakuAST::StatementPrefix::Phaser::Leave
         ($resolver.find-attach-target('block')
               // $resolver.find-attach-target('compunit')
             ).add-leave-phaser(self);
-        nqp::bindattr(self, RakuAST::Code, '$!resolver', $resolver.clone);
         self.IMPL-STUB-CODE($resolver, $context);
     }
 }
@@ -904,7 +900,6 @@ class RakuAST::StatementPrefix::Phaser::Keep
         ($resolver.find-attach-target('block')
               // $resolver.find-attach-target('compunit')
             ).add-keep-phaser(self);
-        nqp::bindattr(self, RakuAST::Code, '$!resolver', $resolver.clone);
         self.IMPL-STUB-CODE($resolver, $context);
     }
 }
@@ -1066,7 +1061,6 @@ class RakuAST::StatementPrefix::Phaser::Undo
         ($resolver.find-attach-target('block')
               // $resolver.find-attach-target('compunit')
             ).add-undo-phaser(self);
-        nqp::bindattr(self, RakuAST::Code, '$!resolver', $resolver.clone);
         self.IMPL-STUB-CODE($resolver, $context);
     }
 }

--- a/src/Raku/ast/statementprefixes.rakumod
+++ b/src/Raku/ast/statementprefixes.rakumod
@@ -251,7 +251,7 @@ class RakuAST::StatementPrefix::Thunky
         # Avoid worries about sink context
     }
 
-    method PRODUCE-META-OBJECT() {
+    method PRODUCE-META-OBJECT(:$resolver, :$context) {
         if nqp::istype(self.blorst, RakuAST::Block) {
             # Block, already has a meta-object.
             self.blorst.meta-object
@@ -366,7 +366,7 @@ class RakuAST::StatementPrefix::Blorst
         self.blorst.apply-sink(False);
     }
 
-    method apply-implicit-block-semantics() {
+    method apply-implicit-block-semantics(:$resolver, :$context) {
         self.blorst.set-fresh-variables(:match, :exception)
           if nqp::istype(self.blorst, RakuAST::Block);
     }

--- a/src/Raku/ast/statements.rakumod
+++ b/src/Raku/ast/statements.rakumod
@@ -39,7 +39,7 @@ class RakuAST::Label
         ]
     }
 
-    method PRODUCE-META-OBJECT() {
+    method PRODUCE-META-OBJECT(:$resolver, :$context) {
         my $label-type :=
           self.IMPL-UNWRAP-LIST(self.get-implicit-lookups)[0].resolution.compile-time-value;
         # TODO line, prematch, postmatch
@@ -149,7 +149,7 @@ class RakuAST::Statement
 class RakuAST::ImplicitBlockSemanticsProvider
   is RakuAST::Node
 {
-    method apply-implicit-block-semantics() {
+    method apply-implicit-block-semantics(:$resolver, :$context) {
         nqp::die('apply-implicit-block-semantics not implemented by ' ~ self.HOW.name(self));
     }
 }
@@ -831,7 +831,7 @@ class RakuAST::Statement::IfWith
           $else // RakuAST::Block);
     }
 
-    method apply-implicit-block-semantics() {
+    method apply-implicit-block-semantics(:$resolver, :$context) {
         my int $last-was-with;
         if self.IMPL-QAST-TYPE eq 'with' {
             $last-was-with := 1;
@@ -953,7 +953,7 @@ class RakuAST::Statement::Elsif {
         $obj
     }
 
-    method apply-implicit-block-semantics() {
+    method apply-implicit-block-semantics(:$resolver, :$context) {
         $!then.set-implicit-topic(False, :local);
     }
 
@@ -967,7 +967,7 @@ class RakuAST::Statement::Orwith
 {
     method IMPL-QAST-TYPE() { 'with' }
 
-    method apply-implicit-block-semantics() {
+    method apply-implicit-block-semantics(:$resolver, :$context) {
         self.then.set-implicit-topic(True, :required);
     }
 }
@@ -991,7 +991,7 @@ class RakuAST::Statement::Unless
         $obj
     }
 
-    method apply-implicit-block-semantics() {
+    method apply-implicit-block-semantics(:$resolver, :$context) {
         $!body.set-implicit-topic(False, :local);
     }
 
@@ -1045,7 +1045,7 @@ class RakuAST::Statement::Without
         $obj
     }
 
-    method apply-implicit-block-semantics() {
+    method apply-implicit-block-semantics(:$resolver, :$context) {
         $!body.set-implicit-topic(True, :required);
     }
 
@@ -1125,7 +1125,7 @@ class RakuAST::Statement::Loop
     # Is the loop always executed once?
     method repeat() { False }
 
-    method apply-implicit-block-semantics() {
+    method apply-implicit-block-semantics(:$resolver, :$context) {
         $!body.set-implicit-topic(False, :local);
     }
 
@@ -1415,7 +1415,7 @@ class RakuAST::Statement::Given
         $!body.apply-sink($is-sunk);
     }
 
-    method apply-implicit-block-semantics() {
+    method apply-implicit-block-semantics(:$resolver, :$context) {
         $!body.set-implicit-topic(True, :required);
     }
 
@@ -1454,7 +1454,7 @@ class RakuAST::Statement::When
         $obj
     }
 
-    method apply-implicit-block-semantics() {
+    method apply-implicit-block-semantics(:$resolver, :$context) {
         $!body.set-implicit-topic(False);
     }
 
@@ -1528,7 +1528,7 @@ class RakuAST::Statement::Whenever
         $!body.apply-sink($is-sunk);
     }
 
-    method apply-implicit-block-semantics() {
+    method apply-implicit-block-semantics(:$resolver, :$context) {
         $!body.set-implicit-topic(True, :required);
     }
 
@@ -1571,7 +1571,7 @@ class RakuAST::Statement::Default
         $obj
     }
 
-    method apply-implicit-block-semantics() {
+    method apply-implicit-block-semantics(:$resolver, :$context) {
         $!body.set-implicit-topic(1);
     }
 
@@ -1618,7 +1618,7 @@ class RakuAST::Statement::ExceptionHandler
         $obj
     }
 
-    method apply-implicit-block-semantics() {
+    method apply-implicit-block-semantics(:$resolver, :$context) {
         $!body.set-implicit-topic(True, :exception);
         $!body.set-fresh-variables(:match, :exception);
     }

--- a/src/Raku/ast/term.rakumod
+++ b/src/Raku/ast/term.rakumod
@@ -293,7 +293,11 @@ class RakuAST::Term::Whatever
   is RakuAST::Term
   is RakuAST::BeginTime
 {
-    has RakuAST::CompUnit $!enclosing-comp-unit;
+    # The Whatever singleton itself, captured at PERFORM-BEGIN. Storing
+    # the singleton rather than the enclosing CompUnit keeps a non
+    # serializable back-reference (CompUnit -> QASTContext -> MVMContext)
+    # off this AST node.
+    has Mu $!whatever;
 
     method new() {
         nqp::create(self)
@@ -302,13 +306,13 @@ class RakuAST::Term::Whatever
     method PERFORM-BEGIN(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
         my $compunit := $resolver.find-attach-target('compunit');
         $compunit.ensure-singleton-whatever($resolver);
-        nqp::bindattr(self, RakuAST::Term::Whatever, '$!enclosing-comp-unit', $compunit);
+        nqp::bindattr(self, RakuAST::Term::Whatever, '$!whatever',
+            $compunit.singleton-whatever());
     }
 
     method IMPL-EXPR-QAST(RakuAST::IMPL::QASTContext $context) {
-        my $whatever := $!enclosing-comp-unit.singleton-whatever();
-        $context.ensure-sc($whatever);
-        QAST::WVal.new( :value($whatever), :returns($whatever) )
+        $context.ensure-sc($!whatever);
+        QAST::WVal.new( :value($!whatever), :returns($!whatever) )
     }
 }
 
@@ -357,7 +361,9 @@ class RakuAST::Term::HyperWhatever
   is RakuAST::Term
   is RakuAST::BeginTime
 {
-    has RakuAST::CompUnit $!enclosing-comp-unit;
+    # See comment on RakuAST::Term::Whatever for why we store the
+    # singleton rather than the enclosing CompUnit.
+    has Mu $!whatever;
 
     method new() {
         nqp::create(self)
@@ -366,13 +372,13 @@ class RakuAST::Term::HyperWhatever
     method PERFORM-BEGIN(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
         my $compunit := $resolver.find-attach-target('compunit');
         $compunit.ensure-singleton-hyper-whatever($resolver);
-        nqp::bindattr(self, RakuAST::Term::HyperWhatever, '$!enclosing-comp-unit', $compunit);
+        nqp::bindattr(self, RakuAST::Term::HyperWhatever, '$!whatever',
+            $compunit.singleton-hyper-whatever());
     }
 
     method IMPL-EXPR-QAST(RakuAST::IMPL::QASTContext $context) {
-        my $whatever := $!enclosing-comp-unit.singleton-hyper-whatever();
-        $context.ensure-sc($whatever);
-        QAST::WVal.new( :value($whatever) )
+        $context.ensure-sc($!whatever);
+        QAST::WVal.new( :value($!whatever) )
     }
 }
 

--- a/src/Raku/ast/type.rakumod
+++ b/src/Raku/ast/type.rakumod
@@ -152,7 +152,7 @@ class RakuAST::Type::Simple
         }
     }
 
-    method PRODUCE-META-OBJECT() {
+    method PRODUCE-META-OBJECT(:$resolver, :$context) {
         self.resolution.compile-time-value
     }
 
@@ -305,7 +305,7 @@ class RakuAST::Type::Coercion
 
     method is-coercive() { True }
 
-    method PRODUCE-META-OBJECT() {
+    method PRODUCE-META-OBJECT(:$resolver, :$context) {
         Perl6::Metamodel::CoercionHOW.new_type(
             self.base-type.compile-time-value,
             $!constraint.meta-object,
@@ -400,7 +400,7 @@ class RakuAST::Type::Definedness
         $!through-pragma ?? ($!definite ?? ':D' !! ':U') ~ ' by pragma' !! ''
     }
 
-    method PRODUCE-META-OBJECT() {
+    method PRODUCE-META-OBJECT(:$resolver, :$context) {
         Perl6::Metamodel::DefiniteHOW.new_type(
             :base_type(self.base-type.compile-time-value),
             :definite($!definite),
@@ -488,7 +488,7 @@ class RakuAST::Type::Capture
 
     method allowed-scopes() { self.IMPL-WRAP-LIST(['my']) }
 
-    method PRODUCE-META-OBJECT() {
+    method PRODUCE-META-OBJECT(:$resolver, :$context) {
         Perl6::Metamodel::GenericHOW.new_type(
             :name($!name.canonicalize),
         );
@@ -575,7 +575,7 @@ class RakuAST::Type::Parameterized
         }
     }
 
-    method PRODUCE-META-OBJECT() {
+    method PRODUCE-META-OBJECT(:$resolver, :$context) {
         if !$!args.args {
             self.base-type.compile-time-value
         }
@@ -949,7 +949,7 @@ class RakuAST::Type::Enum
         }
     }
 
-    method PRODUCE-META-OBJECT() {
+    method PRODUCE-META-OBJECT(:$resolver, :$context) {
         Perl6::Metamodel::EnumHOW.new_type(
             :name($!name.canonicalize(:colonpairs(0))),
             :base_type($!base-type)
@@ -1128,7 +1128,7 @@ class RakuAST::Type::Subset
         self.check-scope($resolver, 'subset');
     }
 
-    method PRODUCE-STUBBED-META-OBJECT() {
+    method PRODUCE-STUBBED-META-OBJECT(:$resolver, :$context) {
         Perl6::Metamodel::SubsetHOW.new_type(
             :name($!name.canonicalize(:colonpairs(0))),
             :refinee(Any),
@@ -1136,7 +1136,7 @@ class RakuAST::Type::Subset
         )
     }
 
-    method PRODUCE-META-OBJECT() {
+    method PRODUCE-META-OBJECT(:$resolver, :$context) {
         my $type  := self.stubbed-meta-object;
         my $block := $!block;
 

--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -359,7 +359,7 @@ class RakuAST::TraitTarget::Variable
         self.add-trait-sorries;
     }
 
-    method PRODUCE-META-OBJECT() {
+    method PRODUCE-META-OBJECT(:$resolver, :$context) {
         my $Variable  := self.IMPL-UNWRAP-LIST(self.get-implicit-lookups)[0].compile-time-value;
         my $varvar := nqp::create($Variable);
         nqp::bindattr_s($varvar, $Variable, '$!name', $!name);
@@ -1255,7 +1255,7 @@ class RakuAST::VarDeclaration::Simple
         self.IMPL-UNWRAP-LIST(self.get-implicit-lookups)[2].resolution.compile-time-value
     }
 
-    method PRODUCE-META-OBJECT() {
+    method PRODUCE-META-OBJECT(:$resolver, :$context) {
         # If it's our-scoped, then container is vivified via. package access.
         my str $scope := self.scope;
 
@@ -2157,7 +2157,7 @@ class RakuAST::VarDeclaration::Implicit::Special
   is RakuAST::VarDeclaration::Implicit
   is RakuAST::Meta
 {
-    method PRODUCE-META-OBJECT() {
+    method PRODUCE-META-OBJECT(:$resolver, :$context) {
         # Reuse the container descriptor for the common cases that we expect
         # to have.
         # Mu nominals use Untyped so Scalar STORE skips the type check that
@@ -2314,7 +2314,7 @@ class RakuAST::VarDeclaration::Implicit::Constant
         QAST::Var.new( :decl('static'), :scope('lexical'), :name(self.name), :value($!value) )
     }
 
-    method PRODUCE-META-OBJECT() {
+    method PRODUCE-META-OBJECT(:$resolver, :$context) {
         self.compile-time-value
     }
 
@@ -2390,7 +2390,7 @@ class RakuAST::VarDeclaration::Implicit::Cursor
         $obj
     }
 
-    method PRODUCE-META-OBJECT() {
+    method PRODUCE-META-OBJECT(:$resolver, :$context) {
         my $cont-desc := RakuAST::IMPL::Containers.create-descriptor(
             :of(Mu), :default(Nil), :dynamic(0), :name('$¢'));
         my $container := nqp::create(Scalar);
@@ -2504,7 +2504,7 @@ class RakuAST::VarDeclaration::Implicit::State
         ] !! [];
     }
 
-    method PRODUCE-META-OBJECT() {
+    method PRODUCE-META-OBJECT(:$resolver, :$context) {
         my str $name := nqp::getattr_s(self, RakuAST::VarDeclaration::Implicit, '$!name');
 
         # Create a container descriptor and attach it to a Scalar container, then set it to Int.new(0)

--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -2532,11 +2532,9 @@ class RakuAST::VarDeclaration::Implicit::State
 # commonalities for doc variables
 class RakuAST::VarDeclaration::Implicit::Doc
   is RakuAST::VarDeclaration::Implicit
-  is RakuAST::BeginTime
   is RakuAST::CheckTime
 {
     has Mu $.value;
-    has Mu $!cu;
 
     method new() {
         my $obj := nqp::create(self);
@@ -2544,11 +2542,6 @@ class RakuAST::VarDeclaration::Implicit::Doc
           self.name);
         nqp::bindattr_s($obj, RakuAST::Declaration, '$!scope', 'my');
         $obj
-    }
-
-    method PERFORM-BEGIN(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
-        nqp::bindattr(self, RakuAST::VarDeclaration::Implicit::Doc, '$!cu',
-          $resolver.find-attach-target('compunit'));
     }
 
     method IMPL-QAST-DECL(RakuAST::IMPL::QASTContext $context) {
@@ -2574,9 +2567,7 @@ class RakuAST::VarDeclaration::Implicit::Doc::Pod
       RakuAST::IMPL::QASTContext $context
     ) {
         nqp::bindattr(self, RakuAST::VarDeclaration::Implicit::Doc, '$!value',
-          nqp::getattr(
-            self,RakuAST::VarDeclaration::Implicit::Doc,'$!cu'
-          ).pod-content
+          $resolver.find-attach-target('compunit').pod-content
         );
     }
 }
@@ -2593,9 +2584,7 @@ class RakuAST::VarDeclaration::Implicit::Doc::Data
     ) {
         nqp::bindattr(self, RakuAST::VarDeclaration::Implicit::Doc, '$!value',
           nqp::ifnull(
-            nqp::getattr(
-              self,RakuAST::VarDeclaration::Implicit::Doc,'$!cu'
-            ).data-content,
+            $resolver.find-attach-target('compunit').data-content,
             Mu
           )
         );
@@ -2613,9 +2602,7 @@ class RakuAST::VarDeclaration::Implicit::Doc::Finish
       RakuAST::IMPL::QASTContext $context
     ) {
         nqp::bindattr(self, RakuAST::VarDeclaration::Implicit::Doc, '$!value',
-          nqp::getattr(
-            self,RakuAST::VarDeclaration::Implicit::Doc,'$!cu'
-          ).finish-content,
+          $resolver.find-attach-target('compunit').finish-content,
         );
     }
 }
@@ -2654,9 +2641,7 @@ class RakuAST::VarDeclaration::Implicit::Doc::Rakudoc
     ) {
         my $*RAKUDOC := [];
         self.fetch-blocks(
-          nqp::getattr(
-            self,RakuAST::VarDeclaration::Implicit::Doc,'$!cu'
-          ).statement-list
+          $resolver.find-attach-target('compunit').statement-list
         );
 
         nqp::bindattr(self, RakuAST::VarDeclaration::Implicit::Doc, '$!value',

--- a/src/core.c/Rakudo/Internals.rakumod
+++ b/src/core.c/Rakudo/Internals.rakumod
@@ -217,7 +217,11 @@ my class Rakudo::Internals {
     method EXPORT_SYMBOL(Str:D $name, @tags, Mu \sym) {
         $export-symbol-lock.protect: {
             my @export_packages = $*EXPORT;
-            for $*R ?? $*R.packages.map({$_.meta-object}) !! nqp::hllize(@*PACKAGES).list {
+            for $*R ?? $*R.packages.map({$_.stubbed-meta-object}) !! nqp::hllize(@*PACKAGES).list {
+                # PRODUCE-STUBBED-META-OBJECT returns Nil for augmented
+                # roles (the real X::Augment::Illegal sorry fires later);
+                # skip them so we don't blow up on Nil.WHO first.
+                next if nqp::eqaddr($_, Nil);
                 my $who := .WHO;
                 @export_packages.append: $who.EXISTS-KEY('EXPORT')
                   ?? $who.AT-KEY('EXPORT')

--- a/t/02-rakudo/unit-class-export-compose.t
+++ b/t/02-rakudo/unit-class-export-compose.t
@@ -1,0 +1,52 @@
+use lib <t/packages/Test-Helpers>;
+use Test;
+use Test::Helpers;
+
+plan 2;
+
+# Regression test for the `unit class` compose path under the RakuAST
+# frontend. During body parsing of a `unit class`, the class sits on the
+# resolver's open-packages stack. When the body declares any `is export`
+# symbol, `Rakudo::Internals.EXPORT_SYMBOL` walks the open packages and
+# previously called bare `.meta-object` on each to reach `.WHO`. That
+# bare call ran `PRODUCE-META-OBJECT()` without `CompilerServices`,
+# filling the cache via the degraded path. The package-def `IMPL-COMPOSE`
+# that runs at end-of-file then returned the cached degraded value, and
+# the MOP generated attribute accessors as runtime closures instead of
+# capturing them as compile time QAST. Functionally correct, measurably
+# slower. The structural assertion in `RakuAST::Package.meta-object`
+# trips loudly if anyone re-introduces a bare reader before IMPL-COMPOSE.
+
+my $tmp       = make-temp-dir;
+my $mod-store = $tmp.add('module-store');
+$mod-store.mkdir;
+
+$mod-store.add('UnitClassExportCompose.rakumod').spurt: q:to/EOF/;
+unit class UnitClassExportCompose is export;
+
+has $.x = 42;
+has Int $.n is rw = 7;
+
+sub helper() is export { 'hi' }
+EOF
+
+my $proc = run :out, :err,
+    $*EXECUTABLE.absolute,
+    '-I', $mod-store.absolute,
+    '-e', 'use UnitClassExportCompose;
+           my $o = UnitClassExportCompose.new;
+           say $o.x;
+           say $o.n;
+           $o.n = 99;
+           say $o.n;
+           say helper();';
+
+my $err = $proc.err.slurp(:close);
+my $out = $proc.out.slurp(:close);
+
+is  $proc.exitcode, 0,
+    'unit class with attributes plus `is export` precompiles and loads cleanly';
+nok $err,
+    'no errors or warnings in stderr';
+
+# vim: expandtab shiftwidth=4

--- a/t/02-rakudo/whatever-default-precomp.t
+++ b/t/02-rakudo/whatever-default-precomp.t
@@ -1,0 +1,50 @@
+use lib <t/packages/Test-Helpers>;
+use Test;
+use Test::Helpers;
+
+plan 4;
+
+# Regression test for a precomp crash originally observed under the
+# RakuAST frontend:
+#   Missing serialize REPR function for REPR MVMContext (BOOTContext)
+# A `*` or `**` in an attribute default produced an AST node that
+# held a reference to the enclosing CompUnit, which transitively
+# reaches MVMContext frames with no serialize REPR. The plain `class`
+# form below is what crashed in the wild (`zef install
+# IO::Socket::Async::SSL`); a leading `unit module` shifted the AST
+# layout enough to keep the node out of the SC.
+
+sub precomp-and-load($name, $source, $desc) {
+    my $tmp       = make-temp-dir;
+    my $mod-store = $tmp.add('module-store');
+    $mod-store.mkdir;
+    $mod-store.add("$name.rakumod").spurt: $source;
+
+    my $proc = run :out, :err,
+        $*EXECUTABLE.absolute,
+        '-I', $mod-store.absolute,
+        '-e', "use $name; say Foo.new";
+
+    my $err = $proc.err.slurp(:close);
+    $proc.out.close;
+
+    is  $proc.exitcode, 0, "$desc: exits cleanly";
+    nok $err.contains('MVMContext'),
+        "$desc: no MVMContext serialize REPR error";
+}
+
+precomp-and-load 'WhateverDefault', q:to/EOF/, 'Whatever attribute default';
+#| docs for class Foo
+class Foo is export {
+    has $.x = *;
+}
+EOF
+
+precomp-and-load 'HyperWhateverDefault', q:to/EOF/, 'HyperWhatever attribute default';
+#| docs for class Foo
+class Foo is export {
+    has $.x = **;
+}
+EOF
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Currently `zef install IO::Socket::Async::SSL` (and other modules) crashes during precompilation under `RAKUDO_RAKUAST=1` with `Missing serialize REPR function for REPR MVMContext (BOOTContext)`. Several RakuAST AST nodes were holding back-references to compile pipeline state (`Resolver`, `QASTContext`, `CompilerServices`); those types transitively reference `MVMContext` frames which have no serialize REPR, so any AST node that landed in the SC dragged the whole chain in.

Three reference paths fixed:

`Code` stored `$!resolver` as an attribute. Moved to a cuid-keyed map on `QASTContext` so the AST holds no Resolver reference.

`Package` (and `Class`, `Role`) stored `$!resolver`, `$!context`, and `$!compiler-services` attributes that fed accessor generation via `HOW.compose`. Replaced with parameter passing on `meta-object` / `stubbed-meta-object` / `PRODUCE-META-OBJECT`. A transient `CompilerServices` gets built locally during compose, its accumulated accessor QAST gets captured onto the serializable `$!accessor-qast`, then the transient gets discarded.

`Whatever` and `HyperWhatever` stored the enclosing `CompUnit` only to fetch the singleton at QAST emit time; now store the singleton directly. `VarDeclaration::Implicit::Doc` subclasses (`$=pod`, `$=data`, `$=finish`, `$=rakudoc`) similarly stored `$!cu` only to pull content out at `PERFORM-CHECK`; now look the `CompUnit` up via `find-attach-target` at check time.

Also caught a related silent perf regression: `Rakudo::Internals.EXPORT_SYMBOL` called bare `.meta-object` on every open package to reach `.WHO`, which for `unit class` packages triggered compose without `CompilerServices` and silently degraded every attribute accessor to a runtime closure. Switched to `stubbed-meta-object` (which has the `.WHO` we need without triggering full compose).

Two regression tests added under `t/02-rakudo/`: `whatever-default-precomp.t` for the SC-reachability crash (`class Foo is export { has $.x = * }`); `unit-class-export-compose.t` for the silent compose degradation (`unit class Foo is export; has $.x`).
