### PR TITLE
TODO both problematic nativecall tests for moar+clang+dyncall

### DIFF
--- a/t/04-nativecall/02-simple-args.t
+++ b/t/04-nativecall/02-simple-args.t
@@ -55,21 +55,16 @@ is TakeInt64(0xFFFFFFFFFF), 9, 'passed int64 0xFFFFFFFFFF';
 sub TakeUint8(uint8) returns int32 is native('./02-simple-args') { * }
 sub TakeUint16(uint16) returns int32 is native('./02-simple-args') { * }
 sub TakeUint32(uint32) returns int32 is native('./02-simple-args') { * }
-if $*DISTRO.name.starts-with('macos') {
-    #
-    # For some reason, on MacOS with clang, the following test fails with -O3
-    # specified.  One can only assume this is some weird compiler issue (tested
-    # on Apple LLVM version 6.1.0 (clang-602.0.49) (based on LLVM 3.6.0svn).
-    #
-    skip("Cannot test TakeUint8(0xFE) on MacOS with -O3");
+
+if $*VM.name eq 'moar' && $*VM.config<cc>.contains("clang") && $*VM.config<nativecall_backend> eq "dyncall" {
+    skip("Cannot test TakeUint8(0xFE) with the combination of moarvm, cc == clang and nativecall_backend == dyncall");
+    # R#2124 https://github.com/rakudo/rakudo/issues/2124
+    skip("Cannot test TakeUint16(0xFFFE) with the combination of moarvm, cc == clang and nativecall_backend == dyncall");
 }
 else {
     is TakeUint8(0xFE),        10, 'passed uint8 0xFE';
+    is TakeUint16(0xFFFE),     11, 'passed uint16 0xFFFE';
 }
-# R#2124 https://github.com/rakudo/rakudo/issues/2124
-skip("Cannot test TakeUint16(0xFFFE) with clang without -O0");
-#is TakeUint16(0xFFFE),     11, 'passed uint16 0xFFFE';
-
 
 is TakeUint32(0xFFFFFFFE), 12, 'passed uint32 0xFFFFFFFE';
 


### PR DESCRIPTION
the code clang generates assumes the upper bytes of an unsigned char or unsigned short are zeroed out, but dyncall only has a function for passing signed char and short, where negative numbers end up sign-extended, messing clang's generated assembly for x == 0xFE up, which tries to comare the whole 32bit register against 0xFE.