### PR TITLE
RakuAST: allow anonymous declarations across all package kinds

### DIFF
--- a/src/Raku/ast/name.rakumod
+++ b/src/Raku/ast/name.rakumod
@@ -89,6 +89,12 @@ class RakuAST::Name
         nqp::elems($!parts) == 2 && $!parts[0].is-empty && $!parts[1].is-empty # name is just '::'
     }
 
+    # True when this name denotes a symbol that gets installed in a
+    # scope.
+    method is-installable() {
+        !self.is-empty && !self.is-anonymous
+    }
+
     method is-simple() {
         for $!parts {
             return False unless nqp::istype($_, RakuAST::Name::Part::Simple);

--- a/src/Raku/ast/package.rakumod
+++ b/src/Raku/ast/package.rakumod
@@ -197,7 +197,7 @@ class RakuAST::Package
             my str $scope := self.scope;
             $scope := 'our' if $scope eq 'unit';
             my $name := $!name;
-            if $name && !$name.is-empty && !$name.is-anonymous {
+            if $name && $name.is-installable {
                 my $type-object := self.stubbed-meta-object(:$resolver, :$context);
                 my $full-name := self.IMPL-FULL-NAME($resolver);
                 $type-object.HOW.set_name(
@@ -370,7 +370,7 @@ class RakuAST::Package
             # present, so callers in the compile pipeline must pass both.
             # Packages without colonpairs work fine without context.
             my %options;
-            %options<name> := $!name.canonicalize if $!name;
+            %options<name> := $!name.canonicalize if $!name && $!name.is-installable;
             %options<repr> := $!repr if $!repr;
             if $!name {
                 my @colonpairs := $!name.IMPL-UNWRAP-LIST($!name.colonpairs);

--- a/src/Raku/ast/scoping.rakumod
+++ b/src/Raku/ast/scoping.rakumod
@@ -509,9 +509,24 @@ class RakuAST::Declaration
             $resolver.build-exception: 'X::Declaration::Scope', :$scope, :$declaration
             unless $ok;
 
-        if $scope eq 'our' && nqp::istype($resolver.find-attach-target('package'), RakuAST::Role) {
-            self.add-sorry:
-                $resolver.build-exception: 'X::Declaration::OurScopeInRole', :$declaration;
+        if $scope eq 'our'
+                && nqp::istype($resolver.find-attach-target('package'), RakuAST::Role) {
+            # A RakuAST::PackageInstaller (Package, Type::Subset, Type::Enum,
+            # ...) with a non-installable name installs no symbol. For that
+            # case 'our' has no observable effect and the check would be a
+            # false positive. Routines and variables install through other
+            # paths. The strict check applies to them.
+            my $anonymous-package := False;
+            if nqp::istype(self, RakuAST::PackageInstaller) {
+                my $name := self.name;
+                $anonymous-package := nqp::istype($name, RakuAST::Name)
+                    && nqp::isconcrete($name)
+                    && !$name.is-installable;
+            }
+            unless $anonymous-package {
+                self.add-sorry:
+                    $resolver.build-exception: 'X::Declaration::OurScopeInRole', :$declaration;
+            }
         }
     }
 
@@ -997,6 +1012,8 @@ class RakuAST::PackageInstaller {
         RakuAST::Package $current-package,
         Mu :$meta-object
     ) {
+        # Anonymous declarations install no symbol.
+        return Nil unless $name.is-installable;
         my $orig-scope := $scope;
         my $target;
         my $final;

--- a/src/Raku/ast/type.rakumod
+++ b/src/Raku/ast/type.rakumod
@@ -866,9 +866,7 @@ class RakuAST::Type::Enum
         self.apply-traits($resolver, $context, self);
         $meta.HOW.compose($meta);
 
-        # Don't install an anonymous enum
-        my $anonymous := !$!name.canonicalize;
-        if !$anonymous {
+        if $!name.is-installable {
             self.IMPL-INSTALL-PACKAGE(
                 $resolver, self.scope, $!name, $!current-package, :meta-object(Mu)
             );
@@ -1098,17 +1096,18 @@ class RakuAST::Type::Subset
         # set up the meta object
         my $package := $!current-package;
         my $type    := self.stubbed-meta-object;
-        $type.HOW.set_name(
-          $type,
-          $!name.qualified-with(
-            RakuAST::Name.from-identifier-parts(
-              |nqp::split('::', $package.HOW.name($package))
-            )
-          ).canonicalize(:colonpairs(0))
-        ) unless nqp::eqaddr($package, $resolver.get-global);
-        # Update the Stash's name, too.
-        nqp::bindattr_s($type.WHO, Stash, '$!longname', $type.HOW.name($type));
-
+        if $!name.is-installable {
+            $type.HOW.set_name(
+              $type,
+              $!name.qualified-with(
+                RakuAST::Name.from-identifier-parts(
+                  |nqp::split('::', $package.HOW.name($package))
+                )
+              ).canonicalize(:colonpairs(0))
+            ) unless nqp::eqaddr($package, $resolver.get-global);
+            # Update the Stash's name, too.
+            nqp::bindattr_s($type.WHO, Stash, '$!longname', $type.HOW.name($type));
+        }
         self.IMPL-INSTALL-PACKAGE(
           $resolver, self.scope, $!name, $package, :meta-object(Mu)
         );
@@ -1129,11 +1128,12 @@ class RakuAST::Type::Subset
     }
 
     method PRODUCE-STUBBED-META-OBJECT(:$resolver, :$context) {
-        Perl6::Metamodel::SubsetHOW.new_type(
-            :name($!name.canonicalize(:colonpairs(0))),
-            :refinee(Any),
-            :refinement(nqp::null)
-        )
+        my %options;
+        %options<refinee>    := Any;
+        %options<refinement> := nqp::null;
+        %options<name> := $!name.canonicalize(:colonpairs(0))
+          if $!name.is-installable;
+        Perl6::Metamodel::SubsetHOW.new_type(|%options)
     }
 
     method PRODUCE-META-OBJECT(:$resolver, :$context) {

--- a/src/Raku/ast/variable-access.rakumod
+++ b/src/Raku/ast/variable-access.rakumod
@@ -786,7 +786,7 @@ class RakuAST::Var::Package
     }
 
     method PERFORM-CHECK(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
-        if !self.is-resolved && ($!name.is-empty || $!name.is-anonymous) {
+        if !self.is-resolved && !$!name.is-installable {
             my $name := $!name.canonicalize;
             self.add-sorry:
                 $resolver.build-exception: 'X::Undeclared', :symbol($!sigil ~ $name),

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -1249,7 +1249,7 @@ CODE
 #- N ---------------------------------------------------------------------------
 
     multi method deparse(RakuAST::Name:D $ast --> Str:D) {
-        $ast.canonicalize
+        $ast.is-installable ?? $ast.canonicalize !! '::'
     }
 
     multi method deparse(RakuAST::Nqp:D $ast --> Str:D) {

--- a/t/12-rakuast/enum.rakutest
+++ b/t/12-rakuast/enum.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 6;
+plan 7;
 
 my $ast;
 my $deparsed;
@@ -207,6 +207,33 @@ subtest 'CHECK-wrapped enum with <words> term' => {
     my package p-ast  { is-deeply EVAL($ast),       $abc, 'AST'  }
     my package p-str  { is-deeply EVAL($deparsed),  $abc, 'Str'  }
     my package p-raku { is-deeply EVAL(EVAL $raku), $abc, 'Raku' }
+}
+
+subtest 'Anonymous enum (enum ::)' => {
+    # AST two-Empty parts. The enum installs no symbol when the name
+    # is not installable. Evaluating the AST still yields the values
+    # Map, matching named-enum behavior.
+    my $ast := RakuAST::Type::Enum.new(
+      scope => 'my',
+      name  => RakuAST::Name.new(
+        RakuAST::Name::Part::Empty.new,
+        RakuAST::Name::Part::Empty.new,
+      ),
+      term => RakuAST::QuotedString.new(
+        segments   => (RakuAST::StrLiteral.new("a b c"),),
+        processors => <words val>
+      )
+    );
+    is $ast.DEPARSE, 'my enum :: <a b c>',
+        'AST two-Empty: deparse uses :: placeholder';
+    is-deeply EVAL($ast), $abc,
+        'AST two-Empty: enum AST evaluates to expected Map';
+
+    # Source forms outside a role. Grammar emits two Empty parts.
+    lives-ok { EVAL 'enum :: <x y z>' },
+        'Source: anonymous enum compiles outside a role';
+    is-deeply EVAL('enum :: <a b c>'), $abc,
+        'Source: anonymous enum yields expected Map';
 }
 
 # vim: expandtab shiftwidth=4

--- a/t/12-rakuast/subset.rakutest
+++ b/t/12-rakuast/subset.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 7;
+plan 8;
 
 my $ast;
 my $deparsed;
@@ -222,6 +222,69 @@ subtest 'Subset with a where literal' => {
         nok 41    ~~ $subset, "$type: subset does not accept 41";
         nok "foo" ~~ $subset, "$type: subset does not accept foo";
     }
+}
+
+subtest 'Anonymous subset (subset ::)' => {
+    # my subset :: of Str where /42/
+    my $two-ast := RakuAST::Type::Subset.new(
+      scope => 'my',
+      name  => RakuAST::Name.new(
+        RakuAST::Name::Part::Empty.new,
+        RakuAST::Name::Part::Empty.new,
+      ),
+      of    => RakuAST::Type::Simple.new(
+          RakuAST::Name.from-identifier("Str")
+        ),
+      where => RakuAST::QuotedRegex.new(
+        body => RakuAST::Regex::Literal.new('42')
+      )
+    );
+
+    is $two-ast.DEPARSE, 'my subset :: of Str where /42/',
+        'AST two-Empty: deparse uses :: placeholder';
+    my $subset := EVAL $two-ast;
+    is $subset.^name, '<anon>', 'AST two-Empty: anonymous name';
+
+    # Single-Empty-part Name shape. Only constructible via the
+    # RakuAST API. The grammar always emits two empty parts for `::`.
+    my $single := EVAL RakuAST::Type::Subset.new(
+      scope => 'my',
+      name  => RakuAST::Name.new(RakuAST::Name::Part::Empty.new),
+      of    => RakuAST::Type::Simple.new(
+          RakuAST::Name.from-identifier("Int")
+        ),
+    );
+    is $single.^name, '<anon>', 'AST single-Empty: anonymous name';
+
+    lives-ok {
+        EVAL 'class C { has Str %.bla{subset :: of Str where any("ble", "blob")} }';
+    }, 'Source: anonymous subset as hash typed-key constraint compiles';
+
+    # An anonymous subset inside a role installs no symbol, so the
+    # 'our' default scope is harmless.
+    lives-ok {
+        EVAL 'role R { subset :: of Int where * > 0; method m() { 42 } }';
+    }, 'Source: anonymous subset inside role compiles';
+
+    # Anonymous package declarations (class/role/module/grammar ::)
+    # get a default name from their HOW. The SubsetHOW default is the
+    # literal '<anon>' while ClassHOW/RoleHOW/ModuleHOW/GrammarHOW
+    # default to '<anon|N>'. This pins both formats.
+    is (class :: { }).^name.starts-with('<anon|'),   True,
+        'class :: .^name uses HOW anon default';
+    is (role :: { }).^name.starts-with('<anon|'),    True,
+        'role :: .^name uses HOW anon default';
+    is (module :: { }).^name.starts-with('<anon|'),  True,
+        'module :: .^name uses HOW anon default';
+    is (grammar :: { }).^name.starts-with('<anon|'), True,
+        'grammar :: .^name uses HOW anon default';
+
+    # The OurScopeInRole exemption is gated on RakuAST::PackageInstaller.
+    # RakuAST::Sub is not a PackageInstaller, so anonymous 'our sub' in
+    # a role throws regardless of name shape.
+    throws-like { EVAL 'role R { our sub :: () { } }' },
+        X::Declaration::OurScopeInRole,
+        'our sub :: in role throws (exemption is PackageInstaller-only)';
 }
 
 subtest 'Subset with a where regex' => {


### PR DESCRIPTION
Anonymous package declarations under RAKUDO_RAKUAST=1 had three bugs:

`subset :: of Str where /42/` crashed in
RakuAST::Type::Subset.PERFORM-BEGIN's IMPL-INSTALL-PACKAGE call. This broke JSON::Unmarshal whose t/070-parameterised uses `has Str %.bla{subset :: of Str where ...}`.

`class :: { }`, `role :: { }`, `module :: { }`, `grammar :: { }` compiled but `.^name` returned the empty string because RakuAST::Package::PRODUCE-STUBBED-META-OBJECT passed an empty :name to the HOW.

`role R { subset :: of Int where * > 0; ... }` died with X::Declaration::OurScopeInRole because check-scope fired before the install path could short-circuit.

A new RakuAST::Name.is-installable predicate is the single gate at every site that decides whether to write a name, install a symbol, or pass :name to a HOW. It returns False for any Name with no identifiable symbol (empty Name, single empty part, or the two- Empty-part `::` form).

IMPL-INSTALL-PACKAGE early-returns Nil for non-installable names. Subset and Package PRODUCE-STUBBED-META-OBJECT omit :name so the HOW defaults (`<anon>` for SubsetHOW, `<anon|N>` for ClassHOW/ RoleHOW/ModuleHOW/GrammarHOW) apply. Type::Enum passes :name unconditionally because EnumHOW.new_type requires it, matching legacy. Type::Enum::PERFORM-BEGIN switches its gate to is-installable for consistency. Behavior is unchanged.

check-scope skips the OurScopeInRole sorry for RakuAST::PackageInstaller declarations (Package, Type::Subset, Type::Enum) with a non-installable name. Routines and variables install through other paths where the strict check applies.

RakuAST::Name deparses as `::` when not installable so anonymous AST nodes round-trip through deparse without an empty name slot.

Tests in t/12-rakuast/subset.rakutest and t/12-rakuast/enum.rakutest cover AST construction in one-Empty and two-Empty Name shapes, deparse round-trip, .^name parity across all package kinds, the JSON::Unmarshal hash typed-key case, anonymous subset in a role, and that anonymous our-scoped routines in a role throw X::Declaration::OurScopeInRole.