### PR TITLE
RakuAST: fix sub signature parameter and parametric role compile crashes

### DIFF
--- a/src/Raku/ast/begintime.rakumod
+++ b/src/Raku/ast/begintime.rakumod
@@ -38,7 +38,7 @@ class RakuAST::BeginTime
             }
         }
         if $code.IMPL-CAN-INTERPRET {
-            $code.IMPL-INTERPRET(RakuAST::IMPL::InterpContext.new)
+            $code.IMPL-INTERPRET(RakuAST::IMPL::InterpContext.new(:$resolver, :$context))
         }
         elsif nqp::istype($code, RakuAST::Code) {
             $code.meta-object;
@@ -63,7 +63,7 @@ class RakuAST::BeginTime
         if $callee.is-resolved && nqp::istype($callee.resolution, RakuAST::CompileTimeValue) &&
                 $args.IMPL-CAN-INTERPRET {
             my $resolved := $callee.resolution.compile-time-value;
-            my @args := $args.IMPL-INTERPRET(RakuAST::IMPL::InterpContext.new);
+            my @args := $args.IMPL-INTERPRET(RakuAST::IMPL::InterpContext.new(:$resolver, :$context));
             my @pos := @args[0];
             my %named := @args[1];
             return $resolved(|@pos, |%named);

--- a/src/Raku/ast/impl.rakumod
+++ b/src/Raku/ast/impl.rakumod
@@ -249,8 +249,19 @@ class RakuAST::IMPL::QASTContext {
 # Rakudo-specific class used for holding state used during interpretation of
 # simple code at BEGIN time.
 class RakuAST::IMPL::InterpContext {
-    method new() {
-        nqp::create(self)
+    # Optional compile pipeline state. IMPL-BEGIN-TIME-CALL and
+    # IMPL-BEGIN-TIME-EVALUATE set these when they have them. A node's
+    # IMPL-INTERPRET can read them to forward to meta-object, so
+    # subclasses like RakuAST::Type::Parameterized can evaluate
+    # arguments without compile-time values via IMPL-BEGIN-TIME-EVALUATE.
+    has Mu $.resolver;
+    has Mu $.context;
+
+    method new(:$resolver, :$context) {
+        my $obj := nqp::create(self);
+        nqp::bindattr($obj, RakuAST::IMPL::InterpContext, '$!resolver', $resolver);
+        nqp::bindattr($obj, RakuAST::IMPL::InterpContext, '$!context', $context);
+        $obj
     }
 }
 

--- a/src/Raku/ast/parsetime.rakumod
+++ b/src/Raku/ast/parsetime.rakumod
@@ -26,7 +26,7 @@ class RakuAST::ParseTime
     # interpret simple things to avoid the cost of compilation.
     method IMPL-BEGIN-TIME-EVALUATE(RakuAST::Node $code, RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
         if $code.IMPL-CAN-INTERPRET {
-            $code.IMPL-INTERPRET(RakuAST::IMPL::InterpContext.new)
+            $code.IMPL-INTERPRET(RakuAST::IMPL::InterpContext.new(:$resolver, :$context))
         }
         elsif nqp::istype($code, RakuAST::Code) {
             my $code-obj := $code.meta-object;
@@ -58,7 +58,7 @@ class RakuAST::ParseTime
         if $callee.is-resolved && nqp::istype($callee.resolution, RakuAST::CompileTimeValue) &&
                 $args.IMPL-CAN-INTERPRET {
             my $resolved := $callee.resolution.compile-time-value;
-            my @args := $args.IMPL-INTERPRET(RakuAST::IMPL::InterpContext.new);
+            my @args := $args.IMPL-INTERPRET(RakuAST::IMPL::InterpContext.new(:$resolver, :$context));
             my @pos := @args[0];
             my %named := @args[1];
             return $resolved(|@pos, |%named);

--- a/src/Raku/ast/signature.rakumod
+++ b/src/Raku/ast/signature.rakumod
@@ -710,6 +710,10 @@ class RakuAST::Parameter
 
     method set-sub-signature(RakuAST::Expression $sub-signature) {
         nqp::bindattr(self, RakuAST::Parameter, '$!sub-signature', $sub-signature);
+        # A sub signature parameter routes dispatch through the full
+        # binder. Propagate that to the owner so a mutation after the
+        # parameter's PERFORM-BEGIN keeps the flag in sync.
+        $!owner.set-custom-args if nqp::isconcrete($!owner);
         Nil
     }
 
@@ -725,6 +729,13 @@ class RakuAST::Parameter
 
     method set-owner(RakuAST::Code $owner) {
         nqp::bindattr(self, RakuAST::Parameter, '$!owner', $owner);
+        # Propagate the parse-time conditions that need the full
+        # binder. A role parametric signature parameter gets its
+        # owner attached here, after its own PERFORM-BEGIN ran with
+        # no owner to update.
+        $owner.set-custom-args
+            if nqp::isconcrete($owner)
+            && ($!sub-signature || nqp::elems($!names) > 2);
     }
 
     method add-type-capture(RakuAST::Type::Capture $type-capture) {
@@ -1122,6 +1133,16 @@ class RakuAST::Parameter
             if $meta-object.HOW.is_composed
             && !($meta-object.optional || $meta-object.slurpy || $meta-object.capture);
 
+        # Parameters needing the full binder force custom-args on
+        # their owning routine. Conditions decidable from AST state
+        # set the flag here at BEGIN time. The flag must be True by
+        # the time the owning routine compiles, which can happen
+        # during BEGIN (for example, a trait_mod multi applied to
+        # an attribute).
+        $!owner.set-custom-args
+            if nqp::isconcrete($!owner)
+            && ($!sub-signature || nqp::elems($!names) > 2);
+
         $!target.to-begin-time($resolver, $context) if $!target;
     }
 
@@ -1197,13 +1218,13 @@ class RakuAST::Parameter
         my int $is-generic  := $ptype-archetypes.generic;
         my int $is-coercive := $ptype-archetypes.coercive;
 
-        # Cases where we need the full binder
-        if $!sub-signature
-          || nqp::elems($!names) > 2
-          || ($is-generic
-               && !$is-coercive
-               && nqp::can($ptype-archetypes, "parametric")
-               && $ptype-archetypes.parametric) {
+        # Generic parametric parameter types need the full binder.
+        # This branch depends on archetype data so it runs at CHECK
+        # time. Parameter shape conditions are handled in PERFORM-BEGIN.
+        if $is-generic
+          && !$is-coercive
+          && nqp::can($ptype-archetypes, "parametric")
+          && $ptype-archetypes.parametric {
             $!owner.set-custom-args;
         }
 
@@ -1273,7 +1294,8 @@ class RakuAST::Parameter
     }
 
     method IMPL-TO-QAST(RakuAST::IMPL::QASTContext $context) {
-        nqp::die('shouldnt get here') if $!sub-signature;
+        nqp::die('RakuAST::Parameter::IMPL-TO-QAST reached for a sub-signature parameter. The owning routine must have custom-args True so dispatch routes through Signature::IMPL-QAST-BINDINGS.')
+            if $!sub-signature;
         # Flag constants we need to pay attention to.
         my @iscont-ops := ['iscont', 'iscont_i', 'iscont_n', 'iscont_s', 'iscont_i', 'iscont_i', 'iscont_i', 'iscont_u', 'iscont_u', 'iscont_u', 'iscont_u'];
 

--- a/src/Raku/ast/type.rakumod
+++ b/src/Raku/ast/type.rakumod
@@ -586,6 +586,57 @@ class RakuAST::Type::Parameterized
             my $ptype := self.IMPL-BASE-TYPE.compile-time-value;
             $ptype.HOW.parameterize($ptype, |@pos, |%named)
         }
+        elsif nqp::isconcrete($resolver) && nqp::isconcrete($context)
+          && ($*COMPILING_CORE_SETTING // 0) != 1
+          && nqp::can(self.IMPL-BASE-TYPE.compile-time-value.HOW, 'parameterize') {
+            # Mirror legacy World.compile_time_evaluate. For arguments
+            # without a compile-time value, evaluate the expression via
+            # IMPL-BEGIN-TIME-EVALUATE.
+            my @pos;
+            my %named;
+            my int $usable := 1;
+            my $sorries := nqp::getattr(self, RakuAST::CheckTime, '$!sorries');
+            my int $sorries-before := nqp::isconcrete($sorries) ?? nqp::elems($sorries) !! 0;
+            for $!args.IMPL-UNWRAP-LIST($!args.args) -> $arg {
+                my $expr := nqp::istype($arg, RakuAST::NamedArg) ?? $arg.named-arg-value !! $arg;
+                my $value;
+                if $expr.has-compile-time-value {
+                    $value := $expr.maybe-compile-time-value;
+                }
+                elsif nqp::istype($expr, RakuAST::Expression) {
+                    # IMPL-BEGIN-TIME-EVALUATE attaches a thunk to the
+                    # expression by mutating its `$!thunks` attribute.
+                    # Save and restore so this evaluation does not change
+                    # later runtime emission for the same node.
+                    my $saved := nqp::getattr($expr, RakuAST::Expression, '$!thunks');
+                    $value := self.IMPL-BEGIN-TIME-EVALUATE($expr, $resolver, $context);
+                    nqp::bindattr($expr, RakuAST::Expression, '$!thunks', $saved);
+                }
+                else {
+                    $usable := 0;
+                    last;
+                }
+
+                if nqp::istype($arg, RakuAST::NamedArg) {
+                    %named{$arg.named-arg-name} := $value;
+                }
+                else {
+                    nqp::push(@pos, $value);
+                }
+            }
+
+            # IMPL-BEGIN-TIME-EVALUATE on a CheckTime traps errors as
+            # add-sorry on self. A sorry delta means the loop failed.
+            $sorries := nqp::getattr(self, RakuAST::CheckTime, '$!sorries');
+            my int $sorries-after := nqp::isconcrete($sorries) ?? nqp::elems($sorries) !! 0;
+            if $usable && $sorries-after == $sorries-before {
+                my $ptype := self.IMPL-BASE-TYPE.compile-time-value;
+                $ptype.HOW.parameterize($ptype, |@pos, |%named)
+            }
+            else {
+                nqp::die('Cannot do compile time parameterization with these args');
+            }
+        }
         else {
             my $args := $!args.IMPL-UNWRAP-LIST($!args.args);
             if nqp::istype($args[0], RakuAST::QuotedString) {
@@ -644,7 +695,9 @@ class RakuAST::Type::Parameterized
     }
 
     method IMPL-INTERPRET(RakuAST::IMPL::InterpContext $ctx) {
-        self.meta-object
+        # Forward resolver/context from the interp ctx so PRODUCE-META-OBJECT
+        # can evaluate arguments without compile-time values.
+        self.meta-object(:resolver($ctx.resolver), :context($ctx.context))
     }
 
     method IMPL-VALUE-TYPE() {

--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -104,7 +104,7 @@ class RakuAST::Initializer::CallAssign
     method IMPL-COMPILE-TIME-VALUE(RakuAST::Resolver $resolver,
         RakuAST::IMPL::QASTContext $context, Mu :$invocant-compiler)
     {
-        self.postfixish.IMPL-INTERPRET(RakuAST::IMPL::InterpContext.new, $invocant-compiler)
+        self.postfixish.IMPL-INTERPRET(RakuAST::IMPL::InterpContext.new(:$resolver, :$context), $invocant-compiler)
     }
 
     method IMPL-THUNK-EXPRESSION(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {

--- a/t/02-rakudo/parameter-sub-signature.t
+++ b/t/02-rakudo/parameter-sub-signature.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 9;
+plan 12;
 
 # Parameter sub signature destructure must compile under both
 # frontends, including when the owning routine is compiled at BEGIN.
@@ -73,5 +73,33 @@ is EVAL(q:to/CODE/),
         foo()
         CODE
     '3|4', 'sub signature parameter default thunk runs';
+
+# 10. Parametric role with a sub signature parameter, applied with an
+# inline array literal as the parameterization argument.
+is EVAL(q:to/CODE/),
+        role R[@a ($x, $y)] { method values { "$x|$y" } }
+        my class C does R[[7, 9]] { }
+        C.new.values
+        CODE
+    '7|9', 'parametric role with sub signature param accepts inline array';
+
+# 11. Parametric role with a named sub signature parameter, applied
+# with a named argument whose value is an inline array literal.
+is EVAL(q:to/CODE/),
+        role R[:@a! ($x, $y)] { method values { "$x|$y" } }
+        my class C does R[:a([7, 9])] { }
+        C.new.values
+        CODE
+    '7|9', 'parametric role with named sub signature param accepts inline array via named arg';
+
+# 12. Parameterization with a non-interpretable argument (`self` in a
+# typename context with no enclosing object) must fail at compile
+# time, not crash or silently proceed.
+dies-ok {
+    EVAL q:to/CODE/
+        role R[$x] { method val { $x } }
+        my class C does R[self] { }
+        CODE
+}, 'role parameterization with self outside object dies cleanly';
 
 # vim: expandtab shiftwidth=4

--- a/t/02-rakudo/parameter-sub-signature.t
+++ b/t/02-rakudo/parameter-sub-signature.t
@@ -1,0 +1,77 @@
+use Test;
+
+plan 9;
+
+# Parameter sub signature destructure must compile under both
+# frontends, including when the owning routine is compiled at BEGIN.
+# A trait_mod multi applied to an attribute declaration is one such
+# case.
+
+# 1. trait_mod multi with a named array sub signature on attribute.
+lives-ok {
+    EVAL q:to/CODE/
+        multi sub trait_mod:<is> (Attribute $a, :@spec! (Int $x, Int $y)) { }
+        my class C { has Str $.tags is spec(1, 2) }
+        CODE
+}, 'trait_mod multi with named array sub signature on attribute compiles';
+
+# 2. Regular sub call with a named array sub signature.
+is EVAL(q:to/CODE/),
+        sub foo(Int $x, :@a! ($p, $q)) { "$x|$p|$q" }
+        foo(99, a => [10, 20])
+        CODE
+    '99|10|20', 'named array sub signature destructure binds';
+
+# 3. Positional sub signature.
+is EVAL(q:to/CODE/),
+        sub foo($h ($x, $y)) { "$x|$y" }
+        foo([10, 20])
+        CODE
+    '10|20', 'positional sub signature destructure binds';
+
+# 4. Multi dispatch where one candidate has a sub signature.
+is EVAL(q:to/CODE/),
+        multi foo(Int $x) { "int $x" }
+        multi foo(Int $x, :@a! ($p, $q)) { "$x|$p|$q" }
+        foo(99, a => [10, 20])
+        CODE
+    '99|10|20', 'multi candidate with sub signature dispatches and binds';
+
+# 5. Nested sub signature.
+is EVAL(q:to/CODE/),
+        sub foo(@a ($b, ($c, $d))) { "$b|$c|$d" }
+        foo([1, [2, 3]])
+        CODE
+    '1|2|3', 'nested sub signature destructure binds';
+
+# 6. trait_mod multi applied to a class declaration.
+lives-ok {
+    EVAL q:to/CODE/
+        multi sub trait_mod:<is> (Mu:U $a, :@meta! (Int $x, Int $y)) { }
+        my class C is meta(1, 2) { }
+        CODE
+}, 'trait_mod multi with named array sub signature on class compiles';
+
+# 7. Slurpy positional with a sub signature.
+is EVAL(q:to/CODE/),
+        sub foo(*@a ($p, $q)) { "$p|$q" }
+        foo([10, 20])
+        CODE
+    '10|20', 'slurpy positional with sub signature destructure binds';
+
+# 8. Hash sub signature destructure.
+is EVAL(q:to/CODE/),
+        sub foo(%h (:$x, :$y)) { "$x|$y" }
+        foo({:x(1), :y(2)})
+        CODE
+    '1|2', 'hash sub signature destructure binds';
+
+# 9. Sub signature parameter with a default value. The default runs
+# through the thunk path before custom-args gets propagated.
+is EVAL(q:to/CODE/),
+        sub foo(:@a ($p, $q) = [3, 4]) { "$p|$q" }
+        foo()
+        CODE
+    '3|4', 'sub signature parameter default thunk runs';
+
+# vim: expandtab shiftwidth=4

--- a/t/12-rakuast/signature.rakutest
+++ b/t/12-rakuast/signature.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 13;
+plan 15;
 
 my $ast;
 my $deparsed;
@@ -563,6 +563,87 @@ CODE
         is-deeply $sub("foo", :bar<baz>), \("foo", bar => 'baz'),
           "$type: Passing a mix of positional and named arguments gets correct capture";
     }
+}
+
+subtest 'Parameter with sub-signature destructure' => {
+    # sub ($pair ($k, $v)) { "$k|$v" }
+    ast RakuAST::Sub.new(
+      signature => RakuAST::Signature.new(
+        parameters => (
+          RakuAST::Parameter.new(
+            target => RakuAST::ParameterTarget::Var.new(:name<$pair>),
+            sub-signature => RakuAST::Signature.new(
+              parameters => (
+                RakuAST::Parameter.new(
+                  target => RakuAST::ParameterTarget::Var.new(:name<$k>),
+                ),
+                RakuAST::Parameter.new(
+                  target => RakuAST::ParameterTarget::Var.new(:name<$v>),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+      body => RakuAST::Blockoid.new(
+        RakuAST::StatementList.new(
+          RakuAST::Statement::Expression.new(
+            expression => RakuAST::QuotedString.new(
+              segments => (
+                RakuAST::Var::Lexical.new('$k'),
+                RakuAST::StrLiteral.new('|'),
+                RakuAST::Var::Lexical.new('$v'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    for
+      'AST', EVAL($ast),
+      'Str', EVAL($deparsed),
+      'Raku', EVAL(EVAL $raku)
+    -> $type, $sub {
+        is $sub([10, 20]), '10|20',
+          "$type: positional sub-signature destructure binds";
+    }
+}
+
+subtest 'set-sub-signature mutator on a Parameter' => {
+    # Build the Parameter without sub-signature, then attach one via
+    # the mutator before wrapping it in a Sub. Locks in the mutator
+    # path that propagates custom-args to the owning routine.
+    my $param := RakuAST::Parameter.new(
+      target => RakuAST::ParameterTarget::Var.new(:name<$pair>),
+    );
+    $param.set-sub-signature(RakuAST::Signature.new(
+      parameters => (
+        RakuAST::Parameter.new(
+          target => RakuAST::ParameterTarget::Var.new(:name<$k>),
+        ),
+        RakuAST::Parameter.new(
+          target => RakuAST::ParameterTarget::Var.new(:name<$v>),
+        ),
+      ),
+    ));
+    my $sub := EVAL RakuAST::Sub.new(
+      signature => RakuAST::Signature.new(parameters => ($param,)),
+      body => RakuAST::Blockoid.new(
+        RakuAST::StatementList.new(
+          RakuAST::Statement::Expression.new(
+            expression => RakuAST::QuotedString.new(
+              segments => (
+                RakuAST::Var::Lexical.new('$k'),
+                RakuAST::StrLiteral.new('|'),
+                RakuAST::Var::Lexical.new('$v'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    is $sub([10, 20]), '10|20', 'mutator path: destructure binds';
 }
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
This fixes two related RakuAST frontend crashes that block installing the `META6` distribution under `RAKUDO_RAKUAST=1`:

**Sub signature parameter in a trait_mod multi**. Installing META6 throws 30 copies of `Cannot resolve caller AT-POS(List:U: Int:D)` because the sub signature destructure on the parameter never has its custom args propagated. Minimal repro:

```raku
multi sub trait_mod:<is>(Routine:D \r, :@a! ($x, $y)) { }
sub f() is a(1, 2) { }
```

**Parametric role with a non compile-time argument**. `class C does R[[7, 9]]` and similar shapes crash because the parameterization tries to read compile-time values that aren't there yet:

```raku
role R[@a ($x, $y)] { method m() { @a } }
class C does R[[7, 9]] { }  
```
