### PR TITLE
RakuAST: emit empty concat for modifier-only alternation branch

### DIFF
--- a/src/Raku/ast/regex.rakumod
+++ b/src/Raku/ast/regex.rakumod
@@ -98,6 +98,10 @@ class RakuAST::Regex::Branching
         my $qast := QAST::Regex.new(:rxtype(self.IMPL-QAST-REGEX-TYPE));
         for $!branches {
             my $branch-qast := $_.IMPL-REGEX-QAST($context, %mods);
+            # An internal modifier (e.g. :i) as a sole branch compiles to
+            # Nil. Emit an empty concat so the alternation has a real QAST
+            # child for the NFA and capnames helpers.
+            $branch-qast := QAST::Regex.new(:rxtype<concat>) unless $branch-qast;
             $branch-qast.backtrack('r') if %mods<r> && !$branch-qast.backtrack;
             $qast.push($branch-qast);
         }

--- a/t/02-rakudo/regex-modifier-alt-branch.t
+++ b/t/02-rakudo/regex-modifier-alt-branch.t
@@ -1,0 +1,70 @@
+use lib <t/packages/Test-Helpers>;
+use Test;
+use Test::Helpers;
+
+plan 5;
+
+# An internal regex modifier (`:i`, `:m`, `:r`, `:s`) alone as a top-level
+# branch of an alternation or conjunction applies to the surrounding
+# construct and compiles to an empty branch.
+
+is-run q:to/CODE/,
+    grammar G {
+        token irregular {
+            :i
+            | 'en-GB-oed'
+            | 'i-ami'
+        }
+    }
+    say G.parse('EN-GB-OED', :rule<irregular>) // 'no';
+    say G.parse('i-ami',     :rule<irregular>) // 'no';
+    say G.parse('zzz',       :rule<irregular>) // 'no';
+    CODE
+    :out("｢EN-GB-OED｣\n｢i-ami｣\nno\n"),
+    ':i as the first branch of `|` alternation matches with the modifier applied';
+
+is-run q:to/CODE/,
+    grammar G {
+        token middle { 'a' | :i | 'B' }
+    }
+    say G.parse('a', :rule<middle>) // 'no';
+    say G.parse('b', :rule<middle>) // 'no';
+    CODE
+    :out("｢a｣\n｢b｣\n"),
+    ':i in a non-first branch position applies to subsequent branches';
+
+is-run q:to/CODE/,
+    grammar G {
+        token nego { :!i | 'foo' | 'bar' }
+    }
+    say G.parse('foo', :rule<nego>) // 'no';
+    say G.parse('FOO', :rule<nego>) // 'no';
+    CODE
+    :out("｢foo｣\nno\n"),
+    ':!i as the first branch of `|` alternation keeps case-sensitive matching';
+
+is-run q:to/CODE/,
+    grammar G {
+        token seqalt {
+            :i
+            || 'foo'
+            || 'bar'
+        }
+    }
+    G.parse('FOO', :rule<seqalt>);
+    say 'compiled';
+    CODE
+    :out("compiled\n"),
+    ':i as the first branch of `||` alternation compiles';
+
+is-run q:to/CODE/,
+    grammar G {
+        token conjAtom { :i & <[ a..z A..Z ]> & 'A' }
+    }
+    G.parse('A', :rule<conjAtom>);
+    say 'compiled';
+    CODE
+    :out("compiled\n"),
+    ':i as the first branch of `&` conjunction compiles';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
When an internal regex modifier (`:i`, `:m`, `:r`, `:s`) appears alone as a top-level branch of a `|` or `||` alternation, its IMPL-REGEX-QAST returns Nil. `RakuAST::Regex::Branching` was pushing that Nil into the QAST::Regex alt, and the NFA builder then died with `elems requires a concrete object` while inspecting the branch.

Legacy emits an empty `QAST::Regex(concat)` for the same shape, which the NFA and capnames helpers handle. Do the same in RakuAST.

Surfaced by `zef install Grammar::HTTP`, whose Grammar::IETF::IOL::RFC5646 contains `token irregular { :i\n| 'en-GB-oed'\n| 'i-ami'\n... }`.

Covers `:i` and `:!i` as the first branch of `|`, a modifier in non-first branch position, `:i` as the first branch of `||` (`SequentialAlternation`), and `:i` as the first branch of `&` (`Conjunction`). Each `Branching` subclass that inherits the patched method has direct coverage.