### PR TITLE
RakuAST: allow `= Nil` as initializer on a typed attribute

### DIFF
--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -1166,7 +1166,8 @@ class RakuAST::VarDeclaration::Simple
                 {
                     my $expression := $initializer.expression;
                     my $expression-type := $expression.return-type;
-                    unless $expression-type =:= Mu || nqp::objprimspec($of) || $of.HOW.archetypes.generic {
+                    unless $expression-type =:= Mu || $expression-type =:= Nil
+                        || nqp::objprimspec($of) || $of.HOW.archetypes.generic {
                         unless $expression.has-compile-time-value
                             ?? nqp::istype($expression.maybe-compile-time-value, $of) # can check actual value
                             !! nqp::istype($expression-type, $of.IMPL-BASE-TYPE) # bare type can't match definedness

--- a/t/02-rakudo/attr-default-nil-typed.t
+++ b/t/02-rakudo/attr-default-nil-typed.t
@@ -1,0 +1,22 @@
+use Test;
+
+plan 3;
+
+# `Nil` is a valid initializer for a typed attribute. The assignment
+# resets the Scalar to its container default (set by `is default(...)`
+# or the type-object default otherwise), regardless of the declared
+# type's definedness.
+
+lives-ok
+    { EVAL 'class AttrNilTyped1 { has IO::Handle $.x = Nil }; AttrNilTyped1.new' },
+    '`has TypedClass $.x = Nil` compiles and constructs';
+
+is EVAL('class AttrNilTyped2 { has IO::Handle $.x = Nil }; AttrNilTyped2.new.x.^name'),
+    'IO::Handle',
+    '`= Nil` default yields the type object';
+
+is EVAL('class AttrNilTyped3 { has Int $.x is default(42) is rw = Nil }; my $a = AttrNilTyped3.new; $a.x = Nil; ~$a.x'),
+    '42',
+    '`= Nil` honors `is default(...)`';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
`RakuAST::VarDeclaration::Simple.PERFORM-CHECK` runs a compile-time type check on attribute defaults to catch declarations like `has Int $.x = "oops"`. It also rejected `has IO::Handle $.x = Nil`, which legacy accepts because assigning `Nil` to a Scalar resets it to the container's default value rather than storing `Nil` itself.

Skip the type check when the initializer expression statically evaluates to `Nil`. The runtime container-assign path handles the reset, honoring `is default(...)` when set and falling back to the type-object default otherwise.

Surfaced by `zef install CSV::Parser`, whose `CSV::Parser` class has `has IO::Handle $.file_handle = Nil`.