### PR TITLE
RakuAST: tighten double-closure check and silence `xx` sink warning

### DIFF
--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -1461,10 +1461,9 @@ class RakuAST::Block
     }
 
     method IMPL-CHECK-DOUBLE-CLOSURE(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
-        if self.find-nodes(
-            RakuAST::Expression,
-            :condition(-> $node { $node.IMPL-CURRIED }),
-            :stopper(RakuAST::LexicalScope))
+        my $stmts := self.body.statement-list;
+        if $stmts.IMPL-IS-SINGLE-EXPRESSION
+            && $stmts.code-statements[0].expression.IMPL-CURRIED
         {
             return $resolver.build-exception: 'X::Syntax::Malformed',
                 :what('double closure; WhateverCode is already a closure without curlies, so either remove the curlies or use valid parameter syntax instead of *');

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -335,6 +335,7 @@ class RakuAST::Infix
           '⚛+=',  False,
           '⚛-=',  False,
           '⚛−=',  False,
+          'xx',   False,
         );
         nqp::atkey(NP,$!operator) // True
     }

--- a/t/02-rakudo/double-closure-and-xx-sink.t
+++ b/t/02-rakudo/double-closure-and-xx-sink.t
@@ -1,0 +1,33 @@
+use lib <t/packages/Test-Helpers>;
+use Test;
+use Test::Helpers;
+
+plan 3;
+
+# A `where { ... }` clause whose body is a single curried expression
+# (e.g. `where { *.foo }`) is a malformed double closure. A nested
+# WhateverCode inside a method-call argument is the call's argument,
+# not the block's return value, and is well-formed.
+
+throws-like
+    { EVAL 'sub f($x where { *.so }) { }' },
+    X::Syntax::Malformed,
+    message => /:i 'double closure' /,
+    '`where { *.so }` is rejected as a double closure';
+
+lives-ok
+    { EVAL 'sub f(@x where @x.map(* ~~ Int)) { }; f([1, 2])' },
+    'WhateverCode inside a method call argument inside a where clause compiles';
+
+# Side effects on the left of `xx` are observable when the resulting
+# Seq is iterated, including by sink. Suppress the sink-context
+# warning, which would be a false positive when the left has side
+# effects. Compile-time worries print to NQP's stderr handle and
+# can't be captured via `$*ERR`, so a subprocess is the cleanest
+# way to assert the warning does not fire.
+
+is-run '5 xx 2',
+    :err(''),
+    '`xx` in sink context emits no compile-time warning';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Two issues surfaced by `zef install HTTP::HPACK`.

`RakuAST::Code.IMPL-CHECK-DOUBLE-CLOSURE` walked the whole subtree of a `where` block looking for any curried expression. A WhateverCode nested inside a method call argument (e.g. `where @x.map(* ~~ Int)`) is the call's argument, not the block's return value, so flagging it is wrong. Check only the body's single top-level expression for curry, matching legacy's hash-vs-block detection in Perl6/Actions.nqp.

`xx` was treated as a pure infix for the sink-context warning. Its left operand is thunked, so side effects there are observable when the resulting Seq is iterated. Mark `xx` non-pure so `.method() xx N` in sink context stays quiet, matching legacy.

Surfaced by `zef install HTTP::HPACK`, whose `HTTP::HPACK` class has `method encode-headers(@headers where [and] @headers.map(* ~~ HTTP::HPACK::Header))` and `@tree.push(0) xx 2`.