### PR TITLE
RakuAST: synthetically build accessors *and* POPULATE

### DIFF
--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -2058,7 +2058,9 @@ class Perl6::World is HLL::World {
                 %info<bind_constraint> := self.find_single_symbol_in_setting('Associative');
             }
             if $shape {
-                @value_type[0] := self.find_single_symbol_in_setting('Any') unless +@value_type;
+                @value_type[0] := self.find_single_symbol_in_setting(
+                    nqp::getcomp('Raku').language_revision >= 3 ?? 'Mu' !! 'Any'
+                ) unless +@value_type;
                 my $shape_ast := $shape[0].ast;
                 if nqp::istype($shape_ast, QAST::Stmts) {
                     if +@($shape_ast) == 1 {

--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -2425,6 +2425,7 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
                 $ast := Nodify('VarDeclaration::Anonymous').new(
                   :$sigil, :scope<state>
                 );
+                $*R.declare-lexical($ast);
             }
 
             # simple variable

--- a/src/Raku/ast/begintime.rakumod
+++ b/src/Raku/ast/begintime.rakumod
@@ -47,6 +47,7 @@ class RakuAST::BeginTime
             my $thunk := RakuAST::ExpressionThunk.new;
             $code.wrap-with-thunk($thunk);
             $thunk.IMPL-STUB-CODE($resolver, $context);
+            $code.apply-sink(False);
             $thunk.IMPL-QAST-BLOCK($context, :expression($code));
             $thunk.meta-object()()
         }

--- a/src/Raku/ast/call.rakumod
+++ b/src/Raku/ast/call.rakumod
@@ -1286,9 +1286,10 @@ class RakuAST::Call::BlockMethod
                 $!block.IMPL-EXPR-QAST($context),
             )
             !! QAST::Op.new(
-                :op<call>,
+                :op('callmethod'),
+                :name('dispatch:<var>'),
+                $invocant-qast,
                 $!block.IMPL-EXPR-QAST($context),
-                $invocant-qast
             );
         self.args.IMPL-ADD-QAST-ARGS($context, $call);
         $call

--- a/src/Raku/ast/call.rakumod
+++ b/src/Raku/ast/call.rakumod
@@ -155,7 +155,8 @@ class RakuAST::ArgList
     method IMPL-IS-FLATTENING(RakuAST::Node $arg) {
         nqp::istype($arg, RakuAST::ApplyPrefix) &&
             nqp::istype($arg.prefix, RakuAST::Prefix) &&
-            $arg.prefix.operator eq '|'
+            $arg.prefix.operator eq '|' &&
+            !$arg.IMPL-CURRIED
     }
 
     method IMPL-CAN-INTERPRET() {

--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -175,6 +175,8 @@ class RakuAST::Code
             $context.add-clone-for-cuid($clone, $cuid);
         }
 
+        $context.register-stubbed-code-object($code-obj);
+
         $stub
     }
 
@@ -249,6 +251,8 @@ class RakuAST::Code
         $context.add-fixup-task(-> {
             $fixups
         });
+
+        $context.mark-code-object-finalized($code-obj);
     }
 
     method IMPL-FIXUP-DYNAMICALLY-COMPILED-BLOCK(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context, Mu $block) {

--- a/src/Raku/ast/compunit.rakumod
+++ b/src/Raku/ast/compunit.rakumod
@@ -639,6 +639,8 @@ class RakuAST::CompUnit
             $top-level.set_children([$run-main]);
         }
 
+        $context.cleanup-orphan-stubs();
+
         QAST::CompUnit.new:
             $top-level,
             :hll('Raku'),

--- a/src/Raku/ast/impl.rakumod
+++ b/src/Raku/ast/impl.rakumod
@@ -41,6 +41,19 @@ class RakuAST::IMPL::QASTContext {
     has Hash $!cuid-to-parse-time-resolver;
     has Bool $!parse-time-resolver-cleanup-scheduled;
 
+    # Code objects whose IMPL-STUB-CODE bound a freshcoderef to
+    # Code.$!do but whose IMPL-LINK-META-OBJECT has not yet registered
+    # that coderef with the SC. If the owning AST is discarded before
+    # QAST emission (e.g. block-or-hash repurposing a Block as a Hash
+    # composer), the code object is left with a non-SC'd coderef that
+    # breaks serialization if anything else pulls it into the SC.
+    # cleanup-orphan-stubs nulls Code.$!do for whatever still sits here
+    # right before the QAST::CompUnit is handed to the backend.
+    # Keyed by code object identity so AST nodes that share a meta-object
+    # (a phaser StatementPrefix and its blorst Block) produce one entry
+    # that either node's finalize call clears.
+    has Hash $!stubbed-code-objects;
+
     method new(Mu :$sc!, int :$precompilation-mode, :$setting, :$language-revision) {
         my $obj := nqp::create(self);
         nqp::bindattr($obj, RakuAST::IMPL::QASTContext, '$!sc', $sc);
@@ -56,6 +69,7 @@ class RakuAST::IMPL::QASTContext {
         nqp::bindattr($obj, RakuAST::IMPL::QASTContext, '$!language-revision', $language-revision);
         nqp::bindattr($obj, RakuAST::IMPL::QASTContext, '$!world-bridge', Mu);
         nqp::bindattr($obj, RakuAST::IMPL::QASTContext, '$!cuid-to-parse-time-resolver', {});
+        nqp::bindattr($obj, RakuAST::IMPL::QASTContext, '$!stubbed-code-objects', {});
         $obj
     }
 
@@ -76,6 +90,7 @@ class RakuAST::IMPL::QASTContext {
         nqp::bindattr($context, RakuAST::IMPL::QASTContext, '$!post-deserialize', []);
         nqp::bindattr_i($context, RakuAST::IMPL::QASTContext, '$!is-nested', 1);
         nqp::bindattr($context, RakuAST::IMPL::QASTContext, '$!cuid-to-parse-time-resolver', {});
+        nqp::bindattr($context, RakuAST::IMPL::QASTContext, '$!stubbed-code-objects', {});
         $context
     }
 
@@ -112,6 +127,27 @@ class RakuAST::IMPL::QASTContext {
             nqp::scsetobj($sc, $idx, $obj);
         }
         $obj
+    }
+
+    method register-stubbed-code-object(Mu $code-obj) {
+        my str $key := ~nqp::objectid($code-obj);
+        $!stubbed-code-objects{$key} := $code-obj;
+        Nil
+    }
+
+    method mark-code-object-finalized(Mu $code-obj) {
+        my str $key := ~nqp::objectid($code-obj);
+        nqp::deletekey($!stubbed-code-objects, $key);
+        Nil
+    }
+
+    # Null Code.$!do on every still-unfinalized code object so the
+    # serializer cannot follow it to the orphan stub freshcoderef.
+    method cleanup-orphan-stubs() {
+        for $!stubbed-code-objects {
+            nqp::bindattr(nqp::iterval($_), Code, '$!do', nqp::null());
+        }
+        Nil
     }
 
     method add-code-ref(Mu $code-ref, Mu $block) {

--- a/src/Raku/ast/operator-properties.rakumod
+++ b/src/Raku/ast/operator-properties.rakumod
@@ -620,6 +620,8 @@ class OperatorProperties {
           'xx', 'replication-xx',
 
           '~', 'concatenation',
+          '∘', 'concatenation',
+          'o', 'concatenation',
 
           '(&)', 'junctive-and',
           '∩',   'junctive-and',

--- a/src/Raku/ast/package.rakumod
+++ b/src/Raku/ast/package.rakumod
@@ -847,7 +847,7 @@ class RakuAST::Class
         RakuAST::IMPL::QASTContext $context
     ) {
 
-        # Make the resolver aware of outselves
+        # Make the resolver aware the invocant class
         $resolver.push-scope(self.body);
         $resolver.push-package(self);
 
@@ -1070,54 +1070,55 @@ class RakuAST::Class
 
         # Mu.POPULATE for now already contains a POPULATE method,
         # and some naughty people may have added their own.
-        return Nil if nqp::existskey($methods,'POPULATE');
+        unless nqp::existskey($methods,'POPULATE') {
 
-        # at least one attribute to be built
-        if $are-built {
-            # Try to do everything as low level as possible, so extract the
-            # NQP hash from the positional argument
-            # my $nameds := nqp::getattr(%nameds,Map,'$!storage')
-            $statements.unshift-statement(
-              RakuAST::Statement::Expression.new(
-                expression => RakuAST::VarDeclaration::Simple.new(
-                  sigil       => '$',
-                  desigilname => makeName("nameds"),
-                  initializer => RakuAST::Initializer::Bind.new(
-                    # my $nameds := nqp::getattr(%nameds,Map,'$!storage')
-                    RakuAST::Nqp.new(
-                      "getattr",
-                      RakuAST::Var::Lexical.new('%nameds'),
-                      makeType("Map"),
-                      RakuAST::StrLiteral.new('$!storage')
+            # at least one attribute to be built
+            if $are-built {
+                # Try to do everything as low level as possible, so extract the
+                # NQP hash from the positional argument
+                # my $nameds := nqp::getattr(%nameds,Map,'$!storage')
+                $statements.unshift-statement(
+                  RakuAST::Statement::Expression.new(
+                    expression => RakuAST::VarDeclaration::Simple.new(
+                      sigil       => '$',
+                      desigilname => makeName("nameds"),
+                      initializer => RakuAST::Initializer::Bind.new(
+                        # my $nameds := nqp::getattr(%nameds,Map,'$!storage')
+                        RakuAST::Nqp.new(
+                          "getattr",
+                          RakuAST::Var::Lexical.new('%nameds'),
+                          makeType("Map"),
+                          RakuAST::StrLiteral.new('$!storage')
+                        )
+                      )
                     )
                   )
+                );
+            }
+
+            # self
+            add-statement($ast-self);
+
+            # method POPULATE(%nameds) { $statements }
+            my $method := RakuAST::Method.new(
+              name      => makeName("POPULATE"),
+              signature => RakuAST::Signature.new(
+                parameters => (
+                  RakuAST::Parameter.new(
+                    target   => RakuAST::ParameterTarget::Var.new(
+                      name => "\%nameds"
+                    ),
+                    optional => False
+                  )
                 )
-              )
+              ),
+              body      => RakuAST::Blockoid.new($statements)
             );
+
+            $method.IMPL-BEGIN($resolver, $context);
         }
 
-        # self
-        add-statement($ast-self);
-
-        # method POPULATE(%nameds) { $statements }
-        my $method := RakuAST::Method.new(
-          name      => makeName("POPULATE"),
-          signature => RakuAST::Signature.new(
-            parameters => (
-              RakuAST::Parameter.new(
-                target   => RakuAST::ParameterTarget::Var.new(
-                  name => "\%nameds"
-                ),
-                optional => False
-              )
-            )
-          ),
-          body      => RakuAST::Blockoid.new($statements)
-        );
-
-        $method.IMPL-BEGIN($resolver, $context);
-
-        # Remove knowledge of ourselves from the resolver
+        # Remove knowledge of invocant class from the resolver
         $resolver.pop-package();
         $resolver.pop-scope();
     }

--- a/src/Raku/ast/package.rakumod
+++ b/src/Raku/ast/package.rakumod
@@ -827,10 +827,6 @@ class RakuAST::Class
 
     method PRODUCE-META-OBJECT(:$resolver, :$context) {
         my $type := self.stubbed-meta-object(:$resolver, :$context);
-        $resolver.push-scope(self.body);
-        $resolver.push-package(self);
-
-        self.PRODUCE-ACCESSORS-POPULATE($resolver, $context);
         self.PRODUCE-META-ATTACHABLES($type, $type.HOW);
 
         {
@@ -840,8 +836,6 @@ class RakuAST::Class
             }
         }
 
-        $resolver.pop-package();
-        $resolver.pop-scope();
         $type
     }
 
@@ -852,6 +846,10 @@ class RakuAST::Class
                  RakuAST::Resolver $resolver,
         RakuAST::IMPL::QASTContext $context
     ) {
+
+        # Make the resolver aware of outselves
+        $resolver.push-scope(self.body);
+        $resolver.push-package(self);
 
 #- initializations -------------------------------------------------------------
 
@@ -1118,6 +1116,22 @@ class RakuAST::Class
         );
 
         $method.IMPL-BEGIN($resolver, $context);
+
+        # Remove knowledge of ourselves from the resolver
+        $resolver.pop-package();
+        $resolver.pop-scope();
+    }
+
+    method PERFORM-CHECK(
+      RakuAST::Resolver          $resolver,
+      RakuAST::IMPL::QASTContext $context
+    ) {
+        nqp::findmethod(RakuAST::Package::Attachable, 'PERFORM-CHECK')(
+          self, $resolver, $context
+        );
+
+        # Create accessors and POPULATE now
+        self.PRODUCE-ACCESSORS-POPULATE($resolver, $context);
     }
 }
 
@@ -1135,7 +1149,9 @@ class RakuAST::Grammar
       RakuAST::Resolver          $resolver,
       RakuAST::IMPL::QASTContext $context
     ) {
-        nqp::findmethod(RakuAST::Class, 'PERFORM-CHECK')(self, $resolver, $context);
+        nqp::findmethod(RakuAST::Class, 'PERFORM-CHECK')(
+          self, $resolver, $context
+        );
         my $sanity-check := self.HOW.find_method(self,"check-sanity");
         $sanity-check(self) if $sanity-check;
         True;

--- a/src/Raku/ast/package.rakumod
+++ b/src/Raku/ast/package.rakumod
@@ -842,10 +842,7 @@ class RakuAST::Class
     # Produce any accessor methods as well as the POPULATE method from
     # the attributes that are known at this time, and add them as methods
     # for later processing
-    method PRODUCE-ACCESSORS-POPULATE(
-                 RakuAST::Resolver $resolver,
-        RakuAST::IMPL::QASTContext $context
-    ) {
+    method PRODUCE-ACCESSORS-POPULATE(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
 
         # Make the resolver aware the invocant class
         $resolver.push-scope(self.body);

--- a/src/Raku/ast/package.rakumod
+++ b/src/Raku/ast/package.rakumod
@@ -404,27 +404,16 @@ class RakuAST::Package
 
     method PRODUCE-META-OBJECT(:$resolver, :$context) {
         my $type := self.stubbed-meta-object(:$resolver, :$context);
-        self.IMPL-COMPOSE-TYPE($type, :$resolver, :$context);
+        self.IMPL-COMPOSE-TYPE($type);
         CATCH {
             nqp::bindattr(self, RakuAST::Package, '$!compose-exception', $_)
         }
         $type
     }
 
-    # Compose $type via its HOW. When $resolver/$context are present,
-    # hand the MOP a transient CompilerServices and capture the
-    # resulting accessor QAST onto $!accessor-qast before the services
-    # go out of scope. Without context the MOP falls back to runtime
-    # closure accessors; functionally equivalent, slower.
-    method IMPL-COMPOSE-TYPE(Mu $type, :$resolver, :$context) {
-        if nqp::isconcrete($resolver) && nqp::isconcrete($context) {
-            my $cs := RakuAST::CompilerServices.new(self, $resolver, $context);
-            $type.HOW.compose($type, :compiler_services($cs));
-            nqp::bindattr(self, RakuAST::Package, '$!accessor-qast', $cs.IMPL-GET-QAST);
-        }
-        else {
-            $type.HOW.compose($type);
-        }
+    # Compose $type via its HOW
+    method IMPL-COMPOSE-TYPE(Mu $type) {
+        $type.HOW.compose($type);
     }
 
     method apply-implicit-block-semantics(:$resolver, :$context) {
@@ -491,7 +480,7 @@ class RakuAST::Package::Attachable
     # Methods and attributes are not directly added, but rather thorugh the
     # attach target mechanism. Attribute usages are also attached for checking
     # after compose time.
-    has Mu $!attached-methods;
+    has Mu $.attached-methods;
     has Mu $.attached-attributes;
     has Mu $!attached-attribute-usages;
     has Mu $!role-group;
@@ -560,7 +549,7 @@ class RakuAST::Package::Attachable
     # Add methods and attributes to meta object
     method PRODUCE-META-ATTACHABLES($type, $how) {
         for $!attached-methods {
-            my $name        := $_.name.canonicalize;
+            my str $name    := $_.name.canonicalize;
             my $meta-object := $_.meta-object;
 
             if nqp::istype($_, RakuAST::Method) && $_.private {
@@ -580,8 +569,6 @@ class RakuAST::Package::Attachable
 
             # attribute defined means we don't need to check it anymore
             nqp::deletekey($!attached-attribute-usages, $_.name);
-
-            # TODO: create method POPULATE here
         }
     }
 }
@@ -761,7 +748,7 @@ class RakuAST::Role
             my $how := $type.HOW;
             self.PRODUCE-META-ATTACHABLES($type, $how);
             $how.set_body_block($type, self.body.meta-object(:$resolver, :$context));
-            self.IMPL-COMPOSE-TYPE($type, :$resolver, :$context);
+            self.IMPL-COMPOSE-TYPE($type);
             CATCH {
                 nqp::bindattr(self, RakuAST::Package, '$!compose-exception', $_)
             }
@@ -851,12 +838,300 @@ class RakuAST::Class
 
     method PRODUCE-META-OBJECT(:$resolver, :$context) {
         my $type := self.stubbed-meta-object(:$resolver, :$context);
+        $resolver.push-package(self);
+
+        self.PRODUCE-ACCESSORS-POPULATE($resolver, $context);
         self.PRODUCE-META-ATTACHABLES($type, $type.HOW);
-        self.IMPL-COMPOSE-TYPE($type, :$resolver, :$context);
-        CATCH {
-            nqp::bindattr(self, RakuAST::Package, '$!compose-exception', $_)
+
+        {
+            self.IMPL-COMPOSE-TYPE($type);
+            CATCH {
+                nqp::bindattr(self, RakuAST::Package, '$!compose-exception', $_)
+            }
         }
+
+        $resolver.pop-package();
         $type
+    }
+
+    # Produce any accessor methods as well as the POPULATE method from
+    # the attributes that are known at this time, and add them as methods
+    # for later processing
+    method PRODUCE-ACCESSORS-POPULATE(
+                 RakuAST::Resolver $resolver,
+        RakuAST::IMPL::QASTContext $context
+    ) {
+
+#- initializations -------------------------------------------------------------
+
+        # Set up lookup for existing methods
+        my $methods := nqp::hash();
+        for self.attached-methods {
+            my str $name := $_.name.canonicalize;
+            nqp::bindkey($methods,$name,1);
+        }
+
+        # Lookups for proper "getattr" usage depending on primspec
+        # and whether a decont is needed
+        my $getattrs := nqp::list_s(
+          'getattr', 'getattr_i', 'getattr_n', 'getattr_s',
+          '', '', '', '', '', '', 'getattr_u'
+        );
+        my $getattrrefs := nqp::list_s(
+          'getattr', 'getattrref_i', 'getattrref_n', 'getattrref_s',
+          '', '', '', '', '', '', 'getattrref_u'
+        );
+
+        # The body of the POPULATE method to be
+        my $statements := RakuAST::StatementList.new;
+        my $ast-self   := RakuAST::Term::Self.new;
+        my $ast-type   := RakuAST::Nqp.new("what",$ast-self);
+        my $ast-is-raw := RakuAST::Trait::Is.new(
+          name => RakuAST::Name.from-identifier("raw")
+        );
+
+#- helper subs -----------------------------------------------------------------
+
+        # Helper sub for adding statements
+        my sub add-statement($expression) {
+            $statements.add-statement(
+              RakuAST::Statement::Expression.new(:$expression)
+            )
+        }
+
+        # Helper sub to create AST representation of a name
+        my sub makeName(str $name) {
+            nqp::index($name,"::") == -1
+              ?? RakuAST::Name.from-identifier($name)
+              !! RakuAST::Name.from-identifier-parts(|$name.split("::"))
+        }
+
+        # Helper sub to create AST representation of a type by name
+        my sub makeType(str $name) {
+            RakuAST::Type::Simple.new(makeName($name))
+        }
+
+        # Helper sub to create a :foo(bar) named argument
+        my sub makeColonPairValue(str $name, $ast) {
+            RakuAST::ColonPair::Value.new(key => $name, value => $ast)
+        }
+
+#- process all attributes ------------------------------------------------------
+        my int $are-built;
+        my @attributes := self.attached-attributes;
+
+        for @attributes -> $attribute {
+            my str $name   := $attribute.name;
+            my str $sigil  := $attribute.sigil;
+            my str $twigil := $attribute.twigil;
+            my str $key    := $attribute.desigilname.canonicalize;
+
+            my int $is-built     := $twigil eq ".";
+            my int $has-accessor := $is-built;
+            my int $is-bound;
+            my int $is-raw;
+
+            my $default  := RakuAST::Type::Simple.new(makeName("Nil"));
+
+            for self.IMPL-UNWRAP-LIST($attribute.traits) -> $trait {
+                my str $trait-name := $trait.IMPL-TRAIT-NAME;
+
+                # Has some default value logic
+                if $trait-name eq 'will' {
+                    my $expr := $trait.expr;
+                    $default := nqp::istype($expr,RakuAST::Method::Initializer)
+                      ?? $expr.body.statement-list.statements[0].expression.args
+                      !! $expr;
+                }
+
+                # Some type of "is" trait
+                elsif $trait-name eq 'is' {
+                    my str $name := $trait.name.canonicalize;
+
+                    # is required
+                    if $name eq 'required' {
+                        my $required := (my $argument := $trait.argument)
+                          ?? $argument.semilist.head
+                          !! RakuAST::IntLiteral.new(1);
+
+                        # X::Attribute::Required.new(:$name, :$why).throw
+                        $default := RakuAST::ApplyPostfix.new(
+                          operand => RakuAST::ApplyPostfix.new(
+                            operand => makeType("X::Attribute::Required"),
+                            postfix => RakuAST::Call::Method.new(
+                              name => makeName("new"),
+                              args => RakuAST::ArgList.new(
+                                makeColonPairValue(
+                                  "name", RakuAST::StrLiteral.new($name)
+                                ),
+                                makeColonPairValue(
+                                  "why", RakuAST::Literal.from-value($required)
+                                )
+                              )
+                            )
+                          ),
+                          postfix => RakuAST::Call::Method.new(
+                            name => makeName("throw")
+                          )
+                        )
+                    }
+
+                    # is built
+                    elsif $name eq 'built' {
+
+                        # is built(foo)
+                        if (my $argument := $trait.argument) {
+                            my $expression :=
+                              $argument.semilist.statements.head.expression;
+                            if nqp::istype($expression,RakuAST::Term::Enum) {
+                                my str $name := $expression.name.canonicalize;
+                                $name eq 'False'
+                                  ?? ($is-built := 0)
+                                  !! $name eq 'True'
+                                    ?? ($is-built := 1)
+                                    !! nqp::die("Unknown value in 'is built' trait: $name");
+                            }
+                            elsif nqp::istype(
+                                    $expression,RakuAST::ColonPair::True
+                                  ) {
+                                my str $key := $expression.key;
+                                $key eq 'bind'
+                                  ?? ($is-bound := 1)
+                                  !! nqp::die("Unknown colonpair in 'is built' trait: :$key");
+                            }
+                            elsif nqp::istype(
+                                    $expression,RakuAST::ColonPair::False
+                                  ) {
+                                my str $key := $expression.key;
+                                $key eq 'bind'
+                                  ?? ($is-bound := 0)
+                                  !! nqp::die("Unknown colonpair in 'is built' trait: :!$key");
+                            }
+                            else {
+                                nqp::die("Unknown value in 'built' trait");
+                            }
+                        }
+
+                        # is built
+                        else {
+                            $is-built := 1;
+                        }
+                    }
+
+                    # is rw | raw
+                    elsif $name eq 'rw' || $name eq 'raw' {
+                        $is-raw := 1;
+                    }
+
+                    # is huh?
+                    else {
+                        nqp::die("unknown trait: 'is $name");
+                    }
+                }
+
+                # huh?
+                else {
+                    nqp::die("unknown trait: $trait-name");
+                }
+            }
+
+            # need to create an accessor
+            if $has-accessor  && nqp::not_i(nqp::existskey($methods,$key)) {
+                my int $primspec := nqp::objprimspec($attribute.type);
+
+                # nqp::getattr(self,$type,$name)
+                my $expression := RakuAST::Nqp.new(
+                  nqp::atpos_s($is-raw ?? $getattrrefs !! $getattrs, $primspec),
+                  $ast-self,
+                  $ast-type,
+                  RakuAST::StrLiteral.new($sigil ~ '!' ~ $key)
+                );
+                $expression := RakuAST::Nqp.new('decont', $expression)
+                  unless $primspec || $is-raw;
+
+                # method $key () { $gettattr }
+                my $method := RakuAST::Method.new(
+                  name   => makeName($key),
+                  traits => ($ast-is-raw,),
+                  body   => RakuAST::Blockoid.new(
+                    RakuAST::StatementList.new(
+                      RakuAST::Statement::Expression.new(:$expression)
+                    )
+                  )
+                );
+                $method.IMPL-BEGIN($resolver, $context);
+            }
+
+            # attribute can be specified as named argument
+            if $is-built {
+                ++$are-built;
+
+                # nqp::atkey($nameds,$key)
+                my $value := RakuAST::Nqp.new(
+                  "atkey",
+                  RakuAST::Var::Lexical.new('$nameds'),
+                  RakuAST::StrLiteral.new($key)
+                );
+
+                # $!a = nqp::ifnull($value,$default)
+                add-statement(RakuAST::ApplyInfix.new(
+                  left  => RakuAST::Var::Attribute.new(
+                             $attribute.sigil ~ '!' ~ $key
+                           ),
+                  infix => $is-bound
+                    ?? RakuAST::Infix.new(":=")
+                    !! RakuAST::Assignment.new,
+                  right => RakuAST::Nqp.new("ifnull", $value, $default)
+                ));
+            }
+        }
+
+#- wrap it up ------------------------------------------------------------------
+
+        # at least one attribute to be built
+        if $are-built {
+            # Try to do everything as low level as possible, so extract the
+            # NQP hash from the positional argument
+            # my $nameds := nqp::getattr(%nameds,Map,'$!storage')
+            $statements.unshift-statement(
+              RakuAST::Statement::Expression.new(
+                expression => RakuAST::VarDeclaration::Simple.new(
+                  sigil       => '$',
+                  desigilname => makeName("nameds"),
+                  initializer => RakuAST::Initializer::Bind.new(
+                    # my $nameds := nqp::getattr(%nameds,Map,'$!storage')
+                    RakuAST::Nqp.new(
+                      "getattr",
+                      RakuAST::Var::Lexical.new('%nameds'),
+                      makeType("Map"),
+                      RakuAST::StrLiteral.new('$!storage')
+                    )
+                  )
+                )
+              )
+            );
+        }
+
+        # self
+        add-statement($ast-self);
+
+        # method POPULATE(%nameds) { $statements }
+        my $method := RakuAST::Method.new(
+          name      => makeName("POPULATE"),
+          signature => RakuAST::Signature.new(
+            parameters => (
+              RakuAST::Parameter.new(
+                target   => RakuAST::ParameterTarget::Var.new(
+                  name => "\%nameds"
+                ),
+                optional => False
+              )
+            )
+          ),
+          body      => RakuAST::Blockoid.new($statements)
+        );
+
+        $method.IMPL-BEGIN($resolver, $context);
     }
 }
 

--- a/src/Raku/ast/package.rakumod
+++ b/src/Raku/ast/package.rakumod
@@ -878,7 +878,7 @@ class RakuAST::Class
         my sub makeName(str $name) {
             nqp::index($name,"::") == -1
               ?? RakuAST::Name.from-identifier($name)
-              !! RakuAST::Name.from-identifier-parts(|$name.split("::"))
+              !! RakuAST::Name.from-identifier-parts(|nqp::split("::",$name))
         }
 
         # Helper sub to create AST representation of a type by name
@@ -923,7 +923,7 @@ class RakuAST::Class
                 if $trait-name eq 'will' {
                     my $expr := $trait.expr;
                     $default := nqp::istype($expr,RakuAST::Method::Initializer)
-                      ?? $expr.body.statement-list.statements[0].expression.args
+                      ?? $expr.body.statement-list.statements.head.expression
                       !! $expr;
                 }
 
@@ -1005,16 +1005,6 @@ class RakuAST::Class
                     elsif $name eq 'rw' {
                         $is-rw := 1;
                     }
-
-                    # is huh?
-                    else {
-                        nqp::die("unknown trait: 'is $name");
-                    }
-                }
-
-                # huh?
-                else {
-                    nqp::die("unknown trait: $trait-name");
                 }
             }
 

--- a/src/Raku/ast/package.rakumod
+++ b/src/Raku/ast/package.rakumod
@@ -909,14 +909,11 @@ class RakuAST::Class
 
         # Helper sub to create the default value for a given type
         my sub makeDefault($attribute) {
-            my int $primspec :=
-              nqp::objprimspec($attribute.type.resolution.compile-time-value);
-
-            $primspec
+            (my int $primspec := nqp::objprimspec($attribute.IMPL-OF-TYPE))
               ?? RakuAST::Literal.from-value(
                    $primspec == 3 ?? "" !! $primspec == 2 ?? 0e0 !! 0
                  )
-              !! RakuAST::Type::Simple.new(makeName("Nil"))
+              !! makeType("Nil")
         }
 
 #- process all attributes ------------------------------------------------------

--- a/src/Raku/ast/package.rakumod
+++ b/src/Raku/ast/package.rakumod
@@ -838,6 +838,7 @@ class RakuAST::Class
 
     method PRODUCE-META-OBJECT(:$resolver, :$context) {
         my $type := self.stubbed-meta-object(:$resolver, :$context);
+        $resolver.push-scope(self.body);
         $resolver.push-package(self);
 
         self.PRODUCE-ACCESSORS-POPULATE($resolver, $context);
@@ -851,6 +852,7 @@ class RakuAST::Class
         }
 
         $resolver.pop-package();
+        $resolver.pop-scope();
         $type
     }
 
@@ -871,21 +873,10 @@ class RakuAST::Class
             nqp::bindkey($methods,$name,1);
         }
 
-        # Lookups for proper "getattr" usage depending on primspec
-        # and whether a decont is needed
-        my $getattrs := nqp::list_s(
-          'getattr', 'getattr_i', 'getattr_n', 'getattr_s',
-          '', '', '', '', '', '', 'getattr_u'
-        );
-        my $getattrrefs := nqp::list_s(
-          'getattr', 'getattrref_i', 'getattrref_n', 'getattrref_s',
-          '', '', '', '', '', '', 'getattrref_u'
-        );
-
         # The body of the POPULATE method to be
         my $statements := RakuAST::StatementList.new;
         my $ast-self   := RakuAST::Term::Self.new;
-        my $ast-type   := RakuAST::Nqp.new("what",$ast-self);
+        my $ast-type   := RakuAST::Var::Compiler::Lookup.new('$?CLASS');
         my $ast-is-raw := RakuAST::Trait::Is.new(
           name => RakuAST::Name.from-identifier("raw")
         );
@@ -916,6 +907,18 @@ class RakuAST::Class
             RakuAST::ColonPair::Value.new(key => $name, value => $ast)
         }
 
+        # Helper sub to create the default value for a given type
+        my sub makeDefault($attribute) {
+            my int $primspec :=
+              nqp::objprimspec($attribute.type.resolution.compile-time-value);
+
+            $primspec
+              ?? RakuAST::Literal.from-value(
+                   $primspec == 3 ?? "" !! $primspec == 2 ?? 0e0 !! 0
+                 )
+              !! RakuAST::Type::Simple.new(makeName("Nil"))
+        }
+
 #- process all attributes ------------------------------------------------------
         my int $are-built;
         my @attributes := self.attached-attributes;
@@ -929,10 +932,9 @@ class RakuAST::Class
             my int $is-built     := $twigil eq ".";
             my int $has-accessor := $is-built;
             my int $is-bound;
-            my int $is-raw;
+            my int $is-rw;
 
-            my $default  := RakuAST::Type::Simple.new(makeName("Nil"));
-
+            my $default;
             for self.IMPL-UNWRAP-LIST($attribute.traits) -> $trait {
                 my str $trait-name := $trait.IMPL-TRAIT-NAME;
 
@@ -1018,9 +1020,9 @@ class RakuAST::Class
                         }
                     }
 
-                    # is rw | raw
-                    elsif $name eq 'rw' || $name eq 'raw' {
-                        $is-raw := 1;
+                    # is rw
+                    elsif $name eq 'rw' {
+                        $is-rw := 1;
                     }
 
                     # is huh?
@@ -1037,25 +1039,18 @@ class RakuAST::Class
 
             # need to create an accessor
             if $has-accessor  && nqp::not_i(nqp::existskey($methods,$key)) {
-                my int $primspec := nqp::objprimspec($attribute.type);
 
-                # nqp::getattr(self,$type,$name)
-                my $expression := RakuAST::Nqp.new(
-                  nqp::atpos_s($is-raw ?? $getattrrefs !! $getattrs, $primspec),
-                  $ast-self,
-                  $ast-type,
-                  RakuAST::StrLiteral.new($sigil ~ '!' ~ $key)
-                );
-                $expression := RakuAST::Nqp.new('decont', $expression)
-                  unless $primspec || $is-raw;
-
-                # method $key () { $gettattr }
+                # method $key () { $!attribute }
                 my $method := RakuAST::Method.new(
                   name   => makeName($key),
-                  traits => ($ast-is-raw,),
+                  traits => $is-rw ?? ($ast-is-raw,) !! (),
                   body   => RakuAST::Blockoid.new(
                     RakuAST::StatementList.new(
-                      RakuAST::Statement::Expression.new(:$expression)
+                      RakuAST::Statement::Expression.new(
+                       expression => RakuAST::Var::Attribute.new(
+                                       $sigil ~ '!' ~ $key
+                                     )
+                      )
                     )
                   )
                 );
@@ -1066,14 +1061,7 @@ class RakuAST::Class
             if $is-built {
                 ++$are-built;
 
-                # nqp::atkey($nameds,$key)
-                my $value := RakuAST::Nqp.new(
-                  "atkey",
-                  RakuAST::Var::Lexical.new('$nameds'),
-                  RakuAST::StrLiteral.new($key)
-                );
-
-                # $!a = nqp::ifnull($value,$default)
+                # $!a = nqp::ifnull(nqp::atkey($nameds,$key),$default)
                 add-statement(RakuAST::ApplyInfix.new(
                   left  => RakuAST::Var::Attribute.new(
                              $attribute.sigil ~ '!' ~ $key
@@ -1081,12 +1069,24 @@ class RakuAST::Class
                   infix => $is-bound
                     ?? RakuAST::Infix.new(":=")
                     !! RakuAST::Assignment.new,
-                  right => RakuAST::Nqp.new("ifnull", $value, $default)
+                  right => RakuAST::Nqp.new(
+                             "ifnull",
+                             RakuAST::Nqp.new(
+                               "atkey",
+                               RakuAST::Var::Lexical.new('$nameds'),
+                               RakuAST::StrLiteral.new($key)
+                             ),
+                             $default // makeDefault($attribute)
+                           )
                 ));
             }
         }
 
 #- wrap it up ------------------------------------------------------------------
+
+        # Mu.POPULATE for now already contains a POPULATE method,
+        # and some naughty people may have added their own.
+        return Nil if nqp::existskey($methods,'POPULATE');
 
         # at least one attribute to be built
         if $are-built {
@@ -1193,47 +1193,4 @@ class RakuAST::Native
 {
     method declarator()  { "native"             }
     method default-how() { Metamodel::NativeHOW }
-}
-
-# For generating accessors
-class RakuAST::CompilerServices
-{
-    has RakuAST::Package $!package;
-    has RakuAST::Resolver $!resolver;
-    has RakuAST::IMPL::QASTContext $!context;
-    has QAST::Stmts $!qast;
-
-    method new(RakuAST::Package $package, RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
-        my $obj := nqp::create(self);
-        nqp::bindattr($obj, RakuAST::CompilerServices, '$!package', $package);
-        nqp::bindattr($obj, RakuAST::CompilerServices, '$!resolver', $resolver);
-        nqp::bindattr($obj, RakuAST::CompilerServices, '$!context', $context);
-        nqp::bindattr($obj, RakuAST::CompilerServices, '$!qast', QAST::Stmts.new);
-        $obj
-    }
-
-    method generate_accessor(str $meth_name, $package_type, str $attr_name, Mu $type, int $rw) {
-        my $accessor := RakuAST::Method::AttributeAccessor.new(
-            :name(RakuAST::Name.from-identifier($meth_name)),
-            :attr-name($attr_name),
-            :type($type),
-            :package-type($package_type),
-            :rw($rw),
-        );
-        $!resolver.push-scope($!package);
-        $!resolver.push-scope($accessor);
-        $accessor.to-begin-time($!resolver, $!context); # TODO maybe also check?
-        $!resolver.pop-scope();
-        $!resolver.pop-scope();
-        $!qast.push: $accessor.IMPL-QAST-BLOCK($!context);
-        $accessor.meta-object
-    }
-
-    method IMPL-ADD-QAST(QAST::Node $target) {
-        $target.push: $!qast if nqp::elems($!qast.list);
-    }
-
-    # Return the accumulated accessor QAST so Package can keep it and
-    # discard the transient CompilerServices.
-    method IMPL-GET-QAST() { $!qast }
 }

--- a/src/Raku/ast/package.rakumod
+++ b/src/Raku/ast/package.rakumod
@@ -550,17 +550,10 @@ class RakuAST::Package::Attachable
             elsif $_.multiness eq 'multi' {
                 $how.add_multi_method($type, $name, $meta-object);
             }
-
-            # TEMPORARY FIX to get the setting building further
-            elsif $name eq 'POPULATE'
-              && nqp::existskey($how.method_table($type),$name) {
-            }
-
             else {
                 $how.add_method($type, $name, $meta-object);
             }
         }
-
         for $!attached-attributes {
 
             # attribute defined means we don't need to check it anymore

--- a/src/Raku/ast/package.rakumod
+++ b/src/Raku/ast/package.rakumod
@@ -550,10 +550,17 @@ class RakuAST::Package::Attachable
             elsif $_.multiness eq 'multi' {
                 $how.add_multi_method($type, $name, $meta-object);
             }
+
+            # TEMPORARY FIX to get the setting building further
+            elsif $name eq 'POPULATE'
+              && nqp::existskey($how.method_table($type),$name) {
+            }
+
             else {
                 $how.add_method($type, $name, $meta-object);
             }
         }
+
         for $!attached-attributes {
 
             # attribute defined means we don't need to check it anymore

--- a/src/Raku/ast/package.rakumod
+++ b/src/Raku/ast/package.rakumod
@@ -32,12 +32,6 @@ class RakuAST::Package
 
     has Mu $!compose-exception;
 
-    # MOP-generated accessor QAST, captured from a transient
-    # CompilerServices in PRODUCE-META-OBJECT and spliced into the
-    # package body by IMPL-EXPR-QAST. Holding the QAST rather than the
-    # CompilerServices keeps Resolver/QASTContext off the AST.
-    has QAST::Stmts $!accessor-qast;
-
     # Enclosing parametric role captured at BEGIN-time so the package can
     # register itself as an instantiation lexical on that role if it ends up
     # archetypally generic after composition.
@@ -435,11 +429,6 @@ class RakuAST::Package
         my $type-object := self.meta-object;
         $context.ensure-sc($type-object);
         my $body := $!body.IMPL-QAST-BLOCK($context, :blocktype<immediate>);
-        # Splice in any accessor QAST captured by PRODUCE-META-OBJECT;
-        # absent on the degraded compose path.
-        if nqp::isconcrete($!accessor-qast) && nqp::elems($!accessor-qast.list) {
-            $body[0].push($!accessor-qast);
-        }
         my $result := QAST::Stmts.new(
             $body,
             QAST::WVal.new( :value($type-object) )

--- a/src/Raku/ast/scoping.rakumod
+++ b/src/Raku/ast/scoping.rakumod
@@ -1135,13 +1135,16 @@ class RakuAST::PackageInstaller {
         # Catch in-source dupes the install-collision check below
         # silent-replaces: multi-part names (lexical-decl merge only
         # sees the leading identifier) and identifier dupes inside
-        # an augment body (augment opens a fresh lexical scope).
+        # an augment body (augment opens a fresh lexical scope). A
+        # prior `package` declarator is itself a silent-replace target,
+        # so do not flag it here either.
         if $orig-scope eq 'our' || $orig-scope eq 'unit' {
             my $existed := $resolver.declare-our-package($target, $final, self);
             $resolver.add-sorry($resolver.build-exception:
                 'X::Redeclaration', :symbol($name.canonicalize(:colonpairs(0))))
               if $existed
-              && (!$name.is-identifier || $resolver.in-augment-scope);
+              && (!$name.is-identifier || $resolver.in-augment-scope)
+              && $existed.declarator ne 'package';
         }
 
         my %stash := $resolver.IMPL-STASH-HASH($target);

--- a/src/Raku/ast/signature.rakumod
+++ b/src/Raku/ast/signature.rakumod
@@ -1028,9 +1028,12 @@ class RakuAST::Parameter
         if $sigil eq '@' || $sigil eq '%' || $sigil eq '&' {
             my $sigil-type :=
               self.IMPL-UNWRAP-LIST(self.get-implicit-lookups)[$sigil eq '@' ?? 0 !! 3].resolution.compile-time-value;
+            # Match legacy: store the bare element type and treat `:D`/`:U`
+            # as a separate definedness flag. Role parameterisation is
+            # invariant, so the wrapped form would reject `my Str @x` defaults.
             $!type
                 ?? $sigil-type.HOW.parameterize($sigil-type,
-                        $!type.meta-object)
+                        RakuAST::Type.IMPL-MAYBE-NOMINALIZE($!type.meta-object))
                 !! $sigil-type
         }
         else {

--- a/src/Raku/ast/statements.rakumod
+++ b/src/Raku/ast/statements.rakumod
@@ -1917,6 +1917,14 @@ class RakuAST::Statement::Use
     }
 
     method PERFORM-BEGIN(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
+        CATCH {
+            my $ex := $resolver.convert-exception($_);
+            if nqp::can($ex, 'SET_FILE_LINE') && self && my $origin := self.origin {
+                my $origin-match := $origin.as-match;
+                $ex.SET_FILE_LINE($origin-match.file, $origin-match.line);
+            }
+            $ex.rethrow;
+        }
         # Evaluate the argument to the module load, if any.
         my $arglist := $!argument
             ?? self.IMPL-BEGIN-TIME-EVALUATE($!argument, $resolver, $context).List.FLATTENABLE_LIST

--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -228,10 +228,11 @@ class RakuAST::ContainerCreator {
                             $bind-constraint, $of, $key-type);
                     }
                     else {
+                        my $value-default := nqp::getcomp('Raku').language_revision >= 3 ?? Mu !! Any;
                         $container-type := Hash.HOW.parameterize(
-                            Hash, $explicit-base, $key-type);
+                            Hash, $value-default, $key-type);
                         $bind-constraint := $bind-constraint.HOW.parameterize(
-                            $bind-constraint, $explicit-base, $key-type);
+                            $bind-constraint, $value-default, $key-type);
                     }
                 }
             }

--- a/src/core.c/RakuAST/Raku.rakumod
+++ b/src/core.c/RakuAST/Raku.rakumod
@@ -41,7 +41,7 @@ augment class RakuAST::Node {
         $_ = .chomp($spaces) given $*INDENT
     }
 
-    our sub rakufy($value) {
+    our sub rakufy(Mu $value) {
         if nqp::istype($value,List) && $value -> @elements {
             if nqp::istype(@elements.are,Int) {
                 "(@elements.join(',')" ~ (@elements == 1 ?? ',)' !! ')')

--- a/t/02-rakudo/begintime-loop-side-effects.t
+++ b/t/02-rakudo/begintime-loop-side-effects.t
@@ -1,0 +1,48 @@
+use Test;
+
+plan 4;
+
+# A `my constant T = do { ... }` evaluates its initializer at BEGIN
+# time. Inside the do-block, non-final statements are sunk and so a
+# `while` / `until` / `loop` / `repeat` should run imperatively for
+# its side effects. Without sink propagation through the BEGIN-time
+# expression, the loop compiles to a lazy Seq that the constant
+# initializer never iterates, and any list the body mutates is
+# observed at its pre-loop state.
+
+my constant WHILE-RESULT = do {
+    my @arr;
+    my $i = 0;
+    while $i < 3 { @arr.push($i); $i = $i + 1 }
+    @arr
+};
+is-deeply WHILE-RESULT.List, (0, 1, 2),
+    'while body runs for side effects in a BEGIN-time do-block';
+
+my constant UNTIL-RESULT = do {
+    my @arr;
+    my $i = 0;
+    until $i >= 3 { @arr.push($i); $i = $i + 1 }
+    @arr
+};
+is-deeply UNTIL-RESULT.List, (0, 1, 2),
+    'until body runs for side effects in a BEGIN-time do-block';
+
+my constant LOOP-RESULT = do {
+    my @arr;
+    loop (my $i = 0; $i < 3; $i++) { @arr.push($i) }
+    @arr
+};
+is-deeply LOOP-RESULT.List, (0, 1, 2),
+    'C-style loop runs for side effects in a BEGIN-time do-block';
+
+my constant REPEAT-RESULT = do {
+    my @arr;
+    my $i = 0;
+    repeat { @arr.push($i); $i = $i + 1 } while $i < 3;
+    @arr
+};
+is-deeply REPEAT-RESULT.List, (0, 1, 2),
+    'repeat-while body runs for side effects in a BEGIN-time do-block';
+
+# vim: expandtab shiftwidth=4

--- a/t/02-rakudo/compose-operator-precedence.t
+++ b/t/02-rakudo/compose-operator-precedence.t
@@ -1,0 +1,14 @@
+use Test;
+
+plan 2;
+
+# `∘` and `o` are concatenation-precedence infixes (looser than `+`),
+# so `&sin ∘ * + 1` must curry as `&sin ∘ (* + 1)` and call sin on x+1.
+
+my &uni = &sin ∘ * + 1;
+is-approx uni(0), sin(1), '∘ binds looser than +';
+
+my &ascii = &sin o * + 1;
+is-approx ascii(0), sin(1), 'o binds looser than +';
+
+# vim: expandtab shiftwidth=4

--- a/t/02-rakudo/constant-assign-metaop.t
+++ b/t/02-rakudo/constant-assign-metaop.t
@@ -1,0 +1,20 @@
+use Test;
+
+plan 2;
+
+# A constant declared with an assign meta-op like `=%=` has no explicit
+# left operand; the parser synthesises an anonymous state variable on
+# its behalf. The constant's value is computed by applying the wrapped
+# infix between that synthesised state var and the right operand at
+# BEGIN time. These cases exercise that the synthesised variable
+# resolves correctly during the BEGIN-time evaluation.
+
+is-deeply EVAL('my constant \X =%= %( a => 1, b => 2 ); X.Map'),
+    Map.new((:a(1), :b(2))),
+    '=%= constant produces a Map from its right operand';
+
+is EVAL('my constant \A =%= %( a => 1 ); my constant \B =%= %( b => 2 ); "{A<a>}-{B<b>}"'),
+    '1-2',
+    'separate =%= constants get separate anonymous state vars';
+
+# vim: expandtab shiftwidth=4

--- a/t/02-rakudo/dot-assign-var-method.t
+++ b/t/02-rakudo/dot-assign-var-method.t
@@ -1,0 +1,35 @@
+use Test;
+
+plan 4;
+
+# `$x .= &f` is the assign-meta form of `.&f`: assign the result of
+# `f($x)` back to `$x`. The right-hand call goes through the variable
+# form of method dispatch and must arrange the invocant as the first
+# argument so the wrapping `dispatch:<.=>` can mutate `$x`.
+
+sub double($n) { $n * 2 }
+
+my $n = 5;
+$n .= &double;
+is $n, 10, '$n .= &double mutates $n with the result of double($n)';
+
+# Blob result distinguishes the bug from generic failures, because a
+# wrong-shape call put the Blob in a slot that triggered .Str.
+sub head1(Blob $b) { $b.subbuf(0, 1) }
+
+my $blob = blob8.new(0x10, 0x20, 0x30, 0x40);
+$blob .= &head1;
+is-deeply $blob, blob8.new(0x10),
+    '$blob .= &head1 mutates $blob to the trimmed Blob result';
+
+# Standalone `.&f` still calls the routine with the invocant.
+is blob8.new(1, 2, 3).&head1, blob8.new(1),
+    '$x.&f standalone calls f($x)';
+
+# Chained `.= &f` works the same with successive routines.
+my $m = 3;
+$m .= &double;
+$m .= &double;
+is $m, 12, 'chained $x .= &f compositions apply each routine in order';
+
+# vim: expandtab shiftwidth=4

--- a/t/02-rakudo/object-hash-default-value-type.t
+++ b/t/02-rakudo/object-hash-default-value-type.t
@@ -1,0 +1,37 @@
+use lib <t/packages/Test-Helpers>;
+use Test;
+use Test::Helpers;
+
+plan 6;
+
+# `my %h{K}` without an explicit value type is revision-gated:
+#   6.c/6.d default the value type to Any
+#   6.e defaults it to Mu, so Junctions and other Mu-typed values fit
+# An explicit value type combines with the shape as `Hash[Of, K]` on
+# either revision. Without a shape the variable stays the generic Hash.
+
+is-run 'my %h{Mu}; print %h.WHAT.^name',
+    '6.d default: my %h{Mu} defaults value type to Any',
+    :out<Hash[Any,Mu]>;
+
+is-run 'use v6.e.PREVIEW; my %h{Mu}; print %h.WHAT.^name',
+    '6.e: my %h{Mu} defaults value type to Mu',
+    :out<Hash[Mu,Mu]>;
+
+is-run 'my %h{Str}; print %h.WHAT.^name',
+    '6.d default: my %h{Str} defaults value type to Any',
+    :out<Hash[Any,Str]>;
+
+is-run 'use v6.e.PREVIEW; my %h{Str}; print %h.WHAT.^name',
+    '6.e: my %h{Str} defaults value type to Mu',
+    :out<Hash[Mu,Str]>;
+
+is-run 'my Int %h{Str}; print %h.WHAT.^name',
+    'my Int %h{Str} keeps the explicit value type on either revision',
+    :out<Hash[Int,Str]>;
+
+is-run 'my %h; print %h.WHAT.^name',
+    'my %h without shape stays the generic Hash on either revision',
+    :out<Hash>;
+
+# vim: expandtab shiftwidth=4

--- a/t/02-rakudo/our-package-redeclaration.t
+++ b/t/02-rakudo/our-package-redeclaration.t
@@ -2,7 +2,7 @@ use lib <t/packages/Test-Helpers>;
 use Test;
 use Test::Helpers;
 
-plan 7;
+plan 9;
 
 is-run q:to/CODE/,
     EVAL q[class A {}];
@@ -56,6 +56,22 @@ is-run q:to/CODE/,
     :err(/'Redeclaration of symbol' .* "'B'"/),
     :exitcode(1), :out(''),
     'augment-body nested class redecl is a Redeclaration';
+
+is-run q:to/CODE/,
+    package A::B { our sub helper() { 42 } };
+    role A::B { has $.x };
+    print "no-error";
+    CODE
+    :out('no-error'), :err(''),
+    'in-source `package A::B` then `role A::B` silent-replaces';
+
+is-run q:to/CODE/,
+    package A::B { our sub helper() { 42 } };
+    role A::B { has $.x };
+    print A::B::helper;
+    CODE
+    :out('42'), :err(''),
+    'silent-replaced role keeps the package WHO (our sub stays reachable)';
 
 is-run q:to/CODE/,
     my $a = $*TMPDIR.add("rakuast-reload-a-{$*PID}.rakumod");

--- a/t/02-rakudo/precomp-declarator-block-or-hash.t
+++ b/t/02-rakudo/precomp-declarator-block-or-hash.t
@@ -1,0 +1,26 @@
+use lib <t/packages/Test-Helpers>;
+use Test;
+use Test::Helpers;
+
+plan 1;
+
+# A `{ :pair, :pair }` block-or-hash inside a routine that has a `#|`
+# declarator-doc comment used to crash precomp with
+# "Serialization Error: missing static code ref for closure". The
+# discarded Block AST had run IMPL-STUB-CODE, leaving an orphan
+# freshcoderef on its Code object; the declarator-doc compose at
+# check time pulled that Code object into the SC, breaking
+# serialization.
+
+my $tmp = make-temp-dir;
+$tmp.add('OrphanStubRepro.rakumod').spurt: q:to/EOF/;
+sub helper { 1 }
+#| docs
+sub trigger { my %h := { a => helper() } }
+EOF
+
+is-run 'use OrphanStubRepro; print "ok"',
+    'precomp of `{ :pair }` block-or-hash inside a #|-documented sub does not orphan a stub',
+    :compiler-args['-I', $tmp.absolute], :out<ok>;
+
+# vim: expandtab shiftwidth=4

--- a/t/02-rakudo/signature-array-elem-definedness.t
+++ b/t/02-rakudo/signature-array-elem-definedness.t
@@ -1,0 +1,21 @@
+use Test;
+
+plan 2;
+
+# `SomeType:D @arr` as a parameter declares the element type as the
+# bare base type for container parameterisation and enforces `:D`
+# separately, matching the long-standing legacy behaviour. A default
+# whose container is `Array[SomeType]` should bind, because role
+# parameterisation is invariant and `Array[Str]` does not `do`
+# `Positional[Str:D]`.
+
+my Str @chars = 'a', 'b';
+
+sub with-default(Str:D :@alpha = @chars) { @alpha }
+is with-default().elems, 2,
+    'Str:D :@alpha = Array[Str] default binds';
+
+is &with-default.signature.params[0].type.^name, 'Positional[Str]',
+    'Str:D @alpha parameter stores Positional[Str], not Positional[Str:D]';
+
+# vim: expandtab shiftwidth=4

--- a/t/02-rakudo/whatever-pipe-prefix-as-arg.t
+++ b/t/02-rakudo/whatever-pipe-prefix-as-arg.t
@@ -1,0 +1,25 @@
+use Test;
+
+plan 4;
+
+# `|*.foo` in an argument list is a WhateverCode whose body slips the
+# result of `$_.foo`. ArgList must keep the WhateverCode intact instead
+# of treating it as a regular `|EXPR` slip-flattening argument and
+# unwrapping it to the bare `*.foo` operand.
+
+is-deeply (1, 2, 3).map(|*.list).List, (1, 2, 3),
+    '|*.list as a positional arg curries and passes a WhateverCode';
+
+is-deeply ((1, 2, 3).map: |*.list).List, (1, 2, 3),
+    '|*.list as a colon-form arg curries and passes a WhateverCode';
+
+is-deeply blob8.new(1, 2, 3, 4).map(|*.polymod(256 xx 3).reverse).List,
+    (0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0, 4),
+    '|*.polymod(...).reverse curries and slips the polymod result';
+
+# Plain `|EXPR` without a Whatever must still flatten.
+sub probe(*@a) { @a.elems }
+is probe(0, |(1, 2, 3), 4), 5,
+    '|(...) without a Whatever still flattens in the arglist';
+
+# vim: expandtab shiftwidth=4

--- a/t/12-rakuast/xx-fixed-in-rakuast.rakutest
+++ b/t/12-rakuast/xx-fixed-in-rakuast.rakutest
@@ -2,7 +2,7 @@ use Test;
 use lib <t/packages/Test-Helpers>;
 use Test::Helpers;
 
-plan 114;
+plan 113;
 
 # t/spec/S03-sequence/misc.t
 # https://github.com/rakudo/rakudo/issues/5520
@@ -31,12 +31,6 @@ plan 114;
 # https://github.com/rakudo/rakudo/issues/5454
 {
     is Q| $_="0X"; m/\d/ ~ m/X/ |.AST.EVAL, "0X", "multiple m// works correctly";
-}
-
-# t/spec/S09-hashes/objecthash.t
-# https://github.com/rakudo/rakudo/issues/5419
-{
-    is Q| my %h{Int}; %h.of |.AST.EVAL, Mu, "creating an object hash without specifying an 'of type' defaults to Mu";
 }
 
 # t/spec/S06-currying/misc.t (?)


### PR DESCRIPTION
This commit removes the use of compiler services to create class accessors, but instead builds synthetic RakuAST trees that are added as methods.

It also builds the POPULATE logic using the same logic iterating over all of the known attributes.

This compiles.  And installs the methods.  However, attempting to instantiate a class results in:
  Could not find a compile-time-value for lexical $?CLASS

So this somehow needs to be fixed before this can be merged.