### PR TITLE
RakuAST: declare the anonymous state variable for assign meta-operators

### DIFF
--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -2425,6 +2425,7 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
                 $ast := Nodify('VarDeclaration::Anonymous').new(
                   :$sigil, :scope<state>
                 );
+                $*R.declare-lexical($ast);
             }
 
             # simple variable

--- a/src/Raku/ast/statements.rakumod
+++ b/src/Raku/ast/statements.rakumod
@@ -1917,6 +1917,14 @@ class RakuAST::Statement::Use
     }
 
     method PERFORM-BEGIN(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
+        CATCH {
+            my $ex := $resolver.convert-exception($_);
+            if nqp::can($ex, 'SET_FILE_LINE') && self && my $origin := self.origin {
+                my $origin-match := $origin.as-match;
+                $ex.SET_FILE_LINE($origin-match.file, $origin-match.line);
+            }
+            $ex.rethrow;
+        }
         # Evaluate the argument to the module load, if any.
         my $arglist := $!argument
             ?? self.IMPL-BEGIN-TIME-EVALUATE($!argument, $resolver, $context).List.FLATTENABLE_LIST

--- a/t/02-rakudo/constant-assign-metaop.t
+++ b/t/02-rakudo/constant-assign-metaop.t
@@ -1,0 +1,20 @@
+use Test;
+
+plan 2;
+
+# A constant declared with an assign meta-op like `=%=` has no explicit
+# left operand; the parser synthesises an anonymous state variable on
+# its behalf. The constant's value is computed by applying the wrapped
+# infix between that synthesised state var and the right operand at
+# BEGIN time. These cases exercise that the synthesised variable
+# resolves correctly during the BEGIN-time evaluation.
+
+is-deeply EVAL('my constant \X =%= %( a => 1, b => 2 ); X.Map'),
+    Map.new((:a(1), :b(2))),
+    '=%= constant produces a Map from its right operand';
+
+is EVAL('my constant \A =%= %( a => 1 ); my constant \B =%= %( b => 2 ); "{A<a>}-{B<b>}"'),
+    '1-2',
+    'separate =%= constants get separate anonymous state vars';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
The parser synthesises an anonymous state variable for an assign meta-operator without a left operand, like `=%=`. The synthesised declaration was missing a `declare-lexical` call. Evaluation of `my constant \X =%= %( ... )` at BEGIN time then failed with "Could not find a compile-time-value for lexical %ANON_VAR_1".