### PR TITLE
RakuAST: clean up orphan IMPL-STUB-CODE freshcoderefs at end of compile

### DIFF
--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -175,6 +175,8 @@ class RakuAST::Code
             $context.add-clone-for-cuid($clone, $cuid);
         }
 
+        $context.register-stubbed-code-object($code-obj);
+
         $stub
     }
 
@@ -249,6 +251,8 @@ class RakuAST::Code
         $context.add-fixup-task(-> {
             $fixups
         });
+
+        $context.mark-code-object-finalized($code-obj);
     }
 
     method IMPL-FIXUP-DYNAMICALLY-COMPILED-BLOCK(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context, Mu $block) {

--- a/src/Raku/ast/compunit.rakumod
+++ b/src/Raku/ast/compunit.rakumod
@@ -639,6 +639,8 @@ class RakuAST::CompUnit
             $top-level.set_children([$run-main]);
         }
 
+        $context.cleanup-orphan-stubs();
+
         QAST::CompUnit.new:
             $top-level,
             :hll('Raku'),

--- a/src/Raku/ast/impl.rakumod
+++ b/src/Raku/ast/impl.rakumod
@@ -41,6 +41,19 @@ class RakuAST::IMPL::QASTContext {
     has Hash $!cuid-to-parse-time-resolver;
     has Bool $!parse-time-resolver-cleanup-scheduled;
 
+    # Code objects whose IMPL-STUB-CODE bound a freshcoderef to
+    # Code.$!do but whose IMPL-LINK-META-OBJECT has not yet registered
+    # that coderef with the SC. If the owning AST is discarded before
+    # QAST emission (e.g. block-or-hash repurposing a Block as a Hash
+    # composer), the code object is left with a non-SC'd coderef that
+    # breaks serialization if anything else pulls it into the SC.
+    # cleanup-orphan-stubs nulls Code.$!do for whatever still sits here
+    # right before the QAST::CompUnit is handed to the backend.
+    # Keyed by code object identity so AST nodes that share a meta-object
+    # (a phaser StatementPrefix and its blorst Block) produce one entry
+    # that either node's finalize call clears.
+    has Hash $!stubbed-code-objects;
+
     method new(Mu :$sc!, int :$precompilation-mode, :$setting, :$language-revision) {
         my $obj := nqp::create(self);
         nqp::bindattr($obj, RakuAST::IMPL::QASTContext, '$!sc', $sc);
@@ -56,6 +69,7 @@ class RakuAST::IMPL::QASTContext {
         nqp::bindattr($obj, RakuAST::IMPL::QASTContext, '$!language-revision', $language-revision);
         nqp::bindattr($obj, RakuAST::IMPL::QASTContext, '$!world-bridge', Mu);
         nqp::bindattr($obj, RakuAST::IMPL::QASTContext, '$!cuid-to-parse-time-resolver', {});
+        nqp::bindattr($obj, RakuAST::IMPL::QASTContext, '$!stubbed-code-objects', {});
         $obj
     }
 
@@ -76,6 +90,7 @@ class RakuAST::IMPL::QASTContext {
         nqp::bindattr($context, RakuAST::IMPL::QASTContext, '$!post-deserialize', []);
         nqp::bindattr_i($context, RakuAST::IMPL::QASTContext, '$!is-nested', 1);
         nqp::bindattr($context, RakuAST::IMPL::QASTContext, '$!cuid-to-parse-time-resolver', {});
+        nqp::bindattr($context, RakuAST::IMPL::QASTContext, '$!stubbed-code-objects', {});
         $context
     }
 
@@ -112,6 +127,27 @@ class RakuAST::IMPL::QASTContext {
             nqp::scsetobj($sc, $idx, $obj);
         }
         $obj
+    }
+
+    method register-stubbed-code-object(Mu $code-obj) {
+        my str $key := ~nqp::objectid($code-obj);
+        $!stubbed-code-objects{$key} := $code-obj;
+        Nil
+    }
+
+    method mark-code-object-finalized(Mu $code-obj) {
+        my str $key := ~nqp::objectid($code-obj);
+        nqp::deletekey($!stubbed-code-objects, $key);
+        Nil
+    }
+
+    # Null Code.$!do on every still-unfinalized code object so the
+    # serializer cannot follow it to the orphan stub freshcoderef.
+    method cleanup-orphan-stubs() {
+        for $!stubbed-code-objects {
+            nqp::bindattr(nqp::iterval($_), Code, '$!do', nqp::null());
+        }
+        Nil
     }
 
     method add-code-ref(Mu $code-ref, Mu $block) {

--- a/t/02-rakudo/precomp-declarator-block-or-hash.t
+++ b/t/02-rakudo/precomp-declarator-block-or-hash.t
@@ -1,0 +1,26 @@
+use lib <t/packages/Test-Helpers>;
+use Test;
+use Test::Helpers;
+
+plan 1;
+
+# A `{ :pair, :pair }` block-or-hash inside a routine that has a `#|`
+# declarator-doc comment used to crash precomp with
+# "Serialization Error: missing static code ref for closure". The
+# discarded Block AST had run IMPL-STUB-CODE, leaving an orphan
+# freshcoderef on its Code object; the declarator-doc compose at
+# check time pulled that Code object into the SC, breaking
+# serialization.
+
+my $tmp = make-temp-dir;
+$tmp.add('OrphanStubRepro.rakumod').spurt: q:to/EOF/;
+sub helper { 1 }
+#| docs
+sub trigger { my %h := { a => helper() } }
+EOF
+
+is-run 'use OrphanStubRepro; print "ok"',
+    'precomp of `{ :pair }` block-or-hash inside a #|-documented sub does not orphan a stub',
+    :compiler-args['-I', $tmp.absolute], :out<ok>;
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
IMPL-STUB-CODE creates a non-SC'd freshcoderef and binds it to Code.$!do so a code object is callable during BEGIN-time evaluation. When the owning AST is finalized via IMPL-LINK-META-OBJECT the stub is registered with the SC. If the AST is discarded before QAST emission, e.g. when block-or-hash repurposes a Block as a Hash composer, the code object keeps the orphan stub. Any later path that pulls that code object into the SC (compose-time package caches, metamodel introspection) then breaks serialization with "missing static code ref for closure".

QASTContext now tracks each stubbed code object in a map keyed by nqp::objectid. IMPL-STUB-CODE registers, IMPL-LINK-META-OBJECT finalizes. Right before QAST::CompUnit.new in IMPL-TO-QAST-COMP-UNIT, cleanup-orphan-stubs walks anything still in the map and nulls Code.$!do so the orphan freshcoderef cannot reach the serializer.

Keying by code object identity rather than cuid handles the shared-meta-object case naturally: an AST node that delegates its PRODUCE-META-OBJECT to a child (a phaser StatementPrefix whose blorst is a Block) registers the shared code object once, and a single mark-code-object-finalized call from either node clears the entry. LEAVE / KEEP / FIRST phaser bodies stay live.