### PR TITLE
RakuAST: silent-replace prior `package` declarator under multi-part names

### DIFF
--- a/src/Raku/ast/scoping.rakumod
+++ b/src/Raku/ast/scoping.rakumod
@@ -1135,13 +1135,16 @@ class RakuAST::PackageInstaller {
         # Catch in-source dupes the install-collision check below
         # silent-replaces: multi-part names (lexical-decl merge only
         # sees the leading identifier) and identifier dupes inside
-        # an augment body (augment opens a fresh lexical scope).
+        # an augment body (augment opens a fresh lexical scope). A
+        # prior `package` declarator is itself a silent-replace target,
+        # so do not flag it here either.
         if $orig-scope eq 'our' || $orig-scope eq 'unit' {
             my $existed := $resolver.declare-our-package($target, $final, self);
             $resolver.add-sorry($resolver.build-exception:
                 'X::Redeclaration', :symbol($name.canonicalize(:colonpairs(0))))
               if $existed
-              && (!$name.is-identifier || $resolver.in-augment-scope);
+              && (!$name.is-identifier || $resolver.in-augment-scope)
+              && $existed.declarator ne 'package';
         }
 
         my %stash := $resolver.IMPL-STASH-HASH($target);

--- a/t/02-rakudo/our-package-redeclaration.t
+++ b/t/02-rakudo/our-package-redeclaration.t
@@ -2,7 +2,7 @@ use lib <t/packages/Test-Helpers>;
 use Test;
 use Test::Helpers;
 
-plan 7;
+plan 9;
 
 is-run q:to/CODE/,
     EVAL q[class A {}];
@@ -56,6 +56,22 @@ is-run q:to/CODE/,
     :err(/'Redeclaration of symbol' .* "'B'"/),
     :exitcode(1), :out(''),
     'augment-body nested class redecl is a Redeclaration';
+
+is-run q:to/CODE/,
+    package A::B { our sub helper() { 42 } };
+    role A::B { has $.x };
+    print "no-error";
+    CODE
+    :out('no-error'), :err(''),
+    'in-source `package A::B` then `role A::B` silent-replaces';
+
+is-run q:to/CODE/,
+    package A::B { our sub helper() { 42 } };
+    role A::B { has $.x };
+    print A::B::helper;
+    CODE
+    :out('42'), :err(''),
+    'silent-replaced role keeps the package WHO (our sub stays reachable)';
 
 is-run q:to/CODE/,
     my $a = $*TMPDIR.add("rakuast-reload-a-{$*PID}.rakumod");


### PR DESCRIPTION
`RakuAST::Package`'s install path has two redeclaration checks: an early `declare-our-package` tracker that catches in-source dupes for multi-part names and augments, and a later stash-installation check that consults `IMPL-SHOULD-SILENT-REPLACE` (which already lets a prior `PackageHOW` be silently replaced). The early check skipped that silent-replace logic, so `package A::B { ... }` followed by `role A::B { ... }` (or `class A::B { ... }`) at top level fired `X::Redeclaration` even though the stash check would have replaced the package with the role's type. Legacy accepts the pattern.

Skip the early flag when the prior declaration was the `package` declarator. Same-kind redeclarations (e.g. `class A::B + class A::B`) still error.

Surfaced by `zef install Cro::Core`, whose `Cro::ResourceIdentifier` module declares `enum Cro::ResourceIdentifier::Host`, then `package Cro::ResourceIdentifier { our sub decode-percents ... }`, then `role Cro::ResourceIdentifier { ... }`.