### PR TITLE
RakuAST: default object hash value type to Any when no explicit type is given

### DIFF
--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -228,10 +228,13 @@ class RakuAST::ContainerCreator {
                             $bind-constraint, $of, $key-type);
                     }
                     else {
+                        # No explicit value type with a shape: legacy defaults
+                        # the value type to Any so `my %h{K}` parameterises as
+                        # `Hash[Any, K]`, not `Hash[Mu, K]`.
                         $container-type := Hash.HOW.parameterize(
-                            Hash, $explicit-base, $key-type);
+                            Hash, Any, $key-type);
                         $bind-constraint := $bind-constraint.HOW.parameterize(
-                            $bind-constraint, $explicit-base, $key-type);
+                            $bind-constraint, Any, $key-type);
                     }
                 }
             }

--- a/t/02-rakudo/object-hash-default-value-type.t
+++ b/t/02-rakudo/object-hash-default-value-type.t
@@ -1,0 +1,26 @@
+use Test;
+
+plan 4;
+
+# `my %h{K}` without an explicit value type should default the value type
+# to Any, producing `Hash[Any, K]`. Without a shape the variable stays
+# generic Hash. An explicit value type combines with the shape as
+# `Hash[Of, K]`.
+
+my %a{Mu};
+is %a.WHAT.^name, 'Hash[Any,Mu]',
+    'my %h{Mu} defaults value type to Any';
+
+my %b{Str};
+is %b.WHAT.^name, 'Hash[Any,Str]',
+    'my %h{Str} defaults value type to Any';
+
+my Int %c{Str};
+is %c.WHAT.^name, 'Hash[Int,Str]',
+    'my Int %h{Str} keeps the explicit value type';
+
+my %d;
+is %d.WHAT.^name, 'Hash',
+    'my %h without shape stays the generic Hash';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
`my %h{K}` should parameterise as Hash[Any, K]. The shape-with-no-type branch of IMPL-CALCULATE-TYPES was passing the explicit container base type (Mu when none was supplied) as the value type instead of Any, so the variable came out as Hash[Mu, K]. Surfaced by CBOR::Simple's t/lib/CodecMatches.rakumod comparing decoded maps against their expected shape.