### PR TITLE
RakuAST: drop `:D` from the element type when parameterising a sigil role

### DIFF
--- a/src/Raku/ast/signature.rakumod
+++ b/src/Raku/ast/signature.rakumod
@@ -1028,9 +1028,12 @@ class RakuAST::Parameter
         if $sigil eq '@' || $sigil eq '%' || $sigil eq '&' {
             my $sigil-type :=
               self.IMPL-UNWRAP-LIST(self.get-implicit-lookups)[$sigil eq '@' ?? 0 !! 3].resolution.compile-time-value;
+            # Match legacy: store the bare element type and treat `:D`/`:U`
+            # as a separate definedness flag. Role parameterisation is
+            # invariant, so the wrapped form would reject `my Str @x` defaults.
             $!type
                 ?? $sigil-type.HOW.parameterize($sigil-type,
-                        $!type.meta-object)
+                        RakuAST::Type.IMPL-MAYBE-NOMINALIZE($!type.meta-object))
                 !! $sigil-type
         }
         else {

--- a/t/02-rakudo/signature-array-elem-definedness.t
+++ b/t/02-rakudo/signature-array-elem-definedness.t
@@ -1,0 +1,21 @@
+use Test;
+
+plan 2;
+
+# `SomeType:D @arr` as a parameter declares the element type as the
+# bare base type for container parameterisation and enforces `:D`
+# separately, matching the long-standing legacy behaviour. A default
+# whose container is `Array[SomeType]` should bind, because role
+# parameterisation is invariant and `Array[Str]` does not `do`
+# `Positional[Str:D]`.
+
+my Str @chars = 'a', 'b';
+
+sub with-default(Str:D :@alpha = @chars) { @alpha }
+is with-default().elems, 2,
+    'Str:D :@alpha = Array[Str] default binds';
+
+is &with-default.signature.params[0].type.^name, 'Positional[Str]',
+    'Str:D @alpha parameter stores Positional[Str], not Positional[Str:D]';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
`SomeType:D :@arr` in a parameter list was stored on the parameter as `Positional[SomeType:D]` instead of `Positional[SomeType]`. Role parameterisation is invariant, so an `Array[SomeType]` default like `Str:D :@alpha = @chars64std` (where `@chars64std` is a `my Str @`) failed to bind because `Array[Str]` does not `do Positional[Str:D]`. Legacy stores the bare element type and enforces definedness as a separate per-element constraint. Match it by nominalising the element type before parameterising the sigil role.

Surfaced by `zef install Base64`, where the third `encode-base64` multi has `Str:D :@alpha = @chars64std`.