### PR TITLE
Default object hash value type to Mu under 6.e, Any otherwise

### DIFF
--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -2058,7 +2058,9 @@ class Perl6::World is HLL::World {
                 %info<bind_constraint> := self.find_single_symbol_in_setting('Associative');
             }
             if $shape {
-                @value_type[0] := self.find_single_symbol_in_setting('Any') unless +@value_type;
+                @value_type[0] := self.find_single_symbol_in_setting(
+                    nqp::getcomp('Raku').language_revision >= 3 ?? 'Mu' !! 'Any'
+                ) unless +@value_type;
                 my $shape_ast := $shape[0].ast;
                 if nqp::istype($shape_ast, QAST::Stmts) {
                     if +@($shape_ast) == 1 {

--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -228,10 +228,11 @@ class RakuAST::ContainerCreator {
                             $bind-constraint, $of, $key-type);
                     }
                     else {
+                        my $value-default := nqp::getcomp('Raku').language_revision >= 3 ?? Mu !! Any;
                         $container-type := Hash.HOW.parameterize(
-                            Hash, $explicit-base, $key-type);
+                            Hash, $value-default, $key-type);
                         $bind-constraint := $bind-constraint.HOW.parameterize(
-                            $bind-constraint, $explicit-base, $key-type);
+                            $bind-constraint, $value-default, $key-type);
                     }
                 }
             }

--- a/t/02-rakudo/object-hash-default-value-type.t
+++ b/t/02-rakudo/object-hash-default-value-type.t
@@ -1,0 +1,37 @@
+use lib <t/packages/Test-Helpers>;
+use Test;
+use Test::Helpers;
+
+plan 6;
+
+# `my %h{K}` without an explicit value type is revision-gated:
+#   6.c/6.d default the value type to Any
+#   6.e defaults it to Mu, so Junctions and other Mu-typed values fit
+# An explicit value type combines with the shape as `Hash[Of, K]` on
+# either revision. Without a shape the variable stays the generic Hash.
+
+is-run 'my %h{Mu}; print %h.WHAT.^name',
+    '6.d default: my %h{Mu} defaults value type to Any',
+    :out<Hash[Any,Mu]>;
+
+is-run 'use v6.e.PREVIEW; my %h{Mu}; print %h.WHAT.^name',
+    '6.e: my %h{Mu} defaults value type to Mu',
+    :out<Hash[Mu,Mu]>;
+
+is-run 'my %h{Str}; print %h.WHAT.^name',
+    '6.d default: my %h{Str} defaults value type to Any',
+    :out<Hash[Any,Str]>;
+
+is-run 'use v6.e.PREVIEW; my %h{Str}; print %h.WHAT.^name',
+    '6.e: my %h{Str} defaults value type to Mu',
+    :out<Hash[Mu,Str]>;
+
+is-run 'my Int %h{Str}; print %h.WHAT.^name',
+    'my Int %h{Str} keeps the explicit value type on either revision',
+    :out<Hash[Int,Str]>;
+
+is-run 'my %h; print %h.WHAT.^name',
+    'my %h without shape stays the generic Hash on either revision',
+    :out<Hash>;
+
+# vim: expandtab shiftwidth=4

--- a/t/12-rakuast/xx-fixed-in-rakuast.rakutest
+++ b/t/12-rakuast/xx-fixed-in-rakuast.rakutest
@@ -2,7 +2,7 @@ use Test;
 use lib <t/packages/Test-Helpers>;
 use Test::Helpers;
 
-plan 114;
+plan 113;
 
 # t/spec/S03-sequence/misc.t
 # https://github.com/rakudo/rakudo/issues/5520
@@ -31,12 +31,6 @@ plan 114;
 # https://github.com/rakudo/rakudo/issues/5454
 {
     is Q| $_="0X"; m/\d/ ~ m/X/ |.AST.EVAL, "0X", "multiple m// works correctly";
-}
-
-# t/spec/S09-hashes/objecthash.t
-# https://github.com/rakudo/rakudo/issues/5419
-{
-    is Q| my %h{Int}; %h.of |.AST.EVAL, Mu, "creating an object hash without specifying an 'of type' defaults to Mu";
 }
 
 # t/spec/S06-currying/misc.t (?)


### PR DESCRIPTION
`my %h{K}` without an explicit value type defaulted to Any in legacy and to Mu in RakuAST. Issue #5419 reported the legacy Any default as a bug: junctions and other Mu-typed values cannot be stored in an Any-typed slot, so `my %b{Int}; %b{1} = 5|6` fails. ab5tract added the Mu default to RakuAST (test in xx-fixed-in-rakuast.rakutest). lizmat later normalised legacy's `:{ }` syntax to also default to Any (`8f8b95866`) and closed the issue.

Reconcile both frontends behind a 6.e gate: keep the long-standing Any default for 6.c/6.d so ecosystem code that round-trips object hashes against Any-typed expectations (CBOR::Simple's CodecMatches fixtures, for instance) keeps working, and adopt Mu under 6.e where junction storage is permitted.

The xx-fixed-in-rakuast.rakutest assertion is dropped because the behaviour is no longer frontend-specific. A replacement revision-aware test lives at t/02-rakudo/object-hash-default-value-type.t.