### PR TITLE
RakuAST: route `.&f` and `.= &f` through `dispatch:<var>`

### DIFF
--- a/src/Raku/ast/call.rakumod
+++ b/src/Raku/ast/call.rakumod
@@ -1286,9 +1286,10 @@ class RakuAST::Call::BlockMethod
                 $!block.IMPL-EXPR-QAST($context),
             )
             !! QAST::Op.new(
-                :op<call>,
+                :op('callmethod'),
+                :name('dispatch:<var>'),
+                $invocant-qast,
                 $!block.IMPL-EXPR-QAST($context),
-                $invocant-qast
             );
         self.args.IMPL-ADD-QAST-ARGS($context, $call);
         $call

--- a/t/02-rakudo/dot-assign-var-method.t
+++ b/t/02-rakudo/dot-assign-var-method.t
@@ -1,0 +1,35 @@
+use Test;
+
+plan 4;
+
+# `$x .= &f` is the assign-meta form of `.&f`: assign the result of
+# `f($x)` back to `$x`. The right-hand call goes through the variable
+# form of method dispatch and must arrange the invocant as the first
+# argument so the wrapping `dispatch:<.=>` can mutate `$x`.
+
+sub double($n) { $n * 2 }
+
+my $n = 5;
+$n .= &double;
+is $n, 10, '$n .= &double mutates $n with the result of double($n)';
+
+# Blob result distinguishes the bug from generic failures, because a
+# wrong-shape call put the Blob in a slot that triggered .Str.
+sub head1(Blob $b) { $b.subbuf(0, 1) }
+
+my $blob = blob8.new(0x10, 0x20, 0x30, 0x40);
+$blob .= &head1;
+is-deeply $blob, blob8.new(0x10),
+    '$blob .= &head1 mutates $blob to the trimmed Blob result';
+
+# Standalone `.&f` still calls the routine with the invocant.
+is blob8.new(1, 2, 3).&head1, blob8.new(1),
+    '$x.&f standalone calls f($x)';
+
+# Chained `.= &f` works the same with successive routines.
+my $m = 3;
+$m .= &double;
+$m .= &double;
+is $m, 12, 'chained $x .= &f compositions apply each routine in order';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
`Call::BlockMethod.IMPL-POSTFIX-QAST` emitted a bare `op<call>` with the block as callee and the invocant as the only argument when the node carried no dispatcher (the standalone `$x.&f` case and the `.= &f` case where `DottyInfix::CallAssign` resets the dispatcher).

`DottyInfix::CallAssign.IMPL-DOTTY-INFIX-QAST` then shifted the first child off and prepended the LHS, expecting the legacy `callmethod dispatch:<var>` shape, which produced `callmethod dispatch:<.=> &f $x`: a method call on the routine instead of the invocant. The routine ended up coercing the Blob LHS to Str when the dispatch resolved a method by name, surfacing as `Stringification of a Blob[uint8] is not done with 'Str'` on a `Blob $b .= &h` line.

Emit `callmethod dispatch:<var> $invocant $block` in the no-dispatcher branch so the standalone call still resolves to `$block($invocant)` and the `.= &f` rewrite produces the correct shape.