### PR TITLE
RakuAST: give `o` and `∘` concatenation precedence

### DIFF
--- a/src/Raku/ast/operator-properties.rakumod
+++ b/src/Raku/ast/operator-properties.rakumod
@@ -620,6 +620,8 @@ class OperatorProperties {
           'xx', 'replication-xx',
 
           '~', 'concatenation',
+          '∘', 'concatenation',
+          'o', 'concatenation',
 
           '(&)', 'junctive-and',
           '∩',   'junctive-and',

--- a/t/02-rakudo/compose-operator-precedence.t
+++ b/t/02-rakudo/compose-operator-precedence.t
@@ -1,0 +1,14 @@
+use Test;
+
+plan 2;
+
+# `∘` and `o` are concatenation-precedence infixes (looser than `+`),
+# so `&sin ∘ * + 1` must curry as `&sin ∘ (* + 1)` and call sin on x+1.
+
+my &uni = &sin ∘ * + 1;
+is-approx uni(0), sin(1), '∘ binds looser than +';
+
+my &ascii = &sin o * + 1;
+is-approx ascii(0), sin(1), 'o binds looser than +';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
`infix:<o>` has its own proto in the setting and is not declared as an alias of another operator, so it does not pick up `op_props` from the PROPERTIES map via a shared Routine. Without an entry of its own it resolved to `default-infix` (`t=`, additive level) instead of `concatenation` (`r=`), and `&sin ∘ * + 1` parsed as `(&sin ∘ *) + 1`. `∘` is a constant binding to `&infix:<o>` and inherited the same wrong precedence.

Add explicit `'o'` and `'∘'` entries to the infix PROPERTIES map.