### PR TITLE
RakuAST: propagate sink before BEGIN-time QAST emission

### DIFF
--- a/src/Raku/ast/begintime.rakumod
+++ b/src/Raku/ast/begintime.rakumod
@@ -47,6 +47,7 @@ class RakuAST::BeginTime
             my $thunk := RakuAST::ExpressionThunk.new;
             $code.wrap-with-thunk($thunk);
             $thunk.IMPL-STUB-CODE($resolver, $context);
+            $code.apply-sink(False);
             $thunk.IMPL-QAST-BLOCK($context, :expression($code));
             $thunk.meta-object()()
         }

--- a/t/02-rakudo/begintime-loop-side-effects.t
+++ b/t/02-rakudo/begintime-loop-side-effects.t
@@ -1,0 +1,48 @@
+use Test;
+
+plan 4;
+
+# A `my constant T = do { ... }` evaluates its initializer at BEGIN
+# time. Inside the do-block, non-final statements are sunk and so a
+# `while` / `until` / `loop` / `repeat` should run imperatively for
+# its side effects. Without sink propagation through the BEGIN-time
+# expression, the loop compiles to a lazy Seq that the constant
+# initializer never iterates, and any list the body mutates is
+# observed at its pre-loop state.
+
+my constant WHILE-RESULT = do {
+    my @arr;
+    my $i = 0;
+    while $i < 3 { @arr.push($i); $i = $i + 1 }
+    @arr
+};
+is-deeply WHILE-RESULT.List, (0, 1, 2),
+    'while body runs for side effects in a BEGIN-time do-block';
+
+my constant UNTIL-RESULT = do {
+    my @arr;
+    my $i = 0;
+    until $i >= 3 { @arr.push($i); $i = $i + 1 }
+    @arr
+};
+is-deeply UNTIL-RESULT.List, (0, 1, 2),
+    'until body runs for side effects in a BEGIN-time do-block';
+
+my constant LOOP-RESULT = do {
+    my @arr;
+    loop (my $i = 0; $i < 3; $i++) { @arr.push($i) }
+    @arr
+};
+is-deeply LOOP-RESULT.List, (0, 1, 2),
+    'C-style loop runs for side effects in a BEGIN-time do-block';
+
+my constant REPEAT-RESULT = do {
+    my @arr;
+    my $i = 0;
+    repeat { @arr.push($i); $i = $i + 1 } while $i < 3;
+    @arr
+};
+is-deeply REPEAT-RESULT.List, (0, 1, 2),
+    'repeat-while body runs for side effects in a BEGIN-time do-block';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
`IMPL-BEGIN-TIME-EVALUATE` wraps a thunked expression in a fresh `ExpressionThunk` and compiles it without first propagating sink context, because the enclosing `SinkBoundary`'s `calculate-sink` does not run until CHECK time. With nothing marking the inner statements, `Statement::Loop::IMPL-DISCARD-RESULT` returned False for a `while` / `until` / `loop` / `repeat` sitting at statement level inside a `do { ... }` initializer, so the loop compiled to a lazy `Seq.from-loop` that the constant initializer never iterated. The body never ran and any list it was meant to mutate stayed at its pre-loop state, breaking BEGIN-time builders like the `HUFFMAN_TREE` table in `HTTP::HPACK`.

Apply sink on the begin-time expression before compiling its QAST. `Block::propagate-sink` then walks into its `StatementList` with `:has-block-parent(True)`, which marks non-final loops as block-statements so they emit the imperative QAST form. The CHECK-time `calculate-sink` pass still runs later, but `mark-sunk` and `mark-block-statement` are idempotent flag-setters and the second walk produces the same node state.