### PR TITLE
RakuAST: keep curried `|*.foo` arguments out of arglist flattening

### DIFF
--- a/src/Raku/ast/call.rakumod
+++ b/src/Raku/ast/call.rakumod
@@ -155,7 +155,8 @@ class RakuAST::ArgList
     method IMPL-IS-FLATTENING(RakuAST::Node $arg) {
         nqp::istype($arg, RakuAST::ApplyPrefix) &&
             nqp::istype($arg.prefix, RakuAST::Prefix) &&
-            $arg.prefix.operator eq '|'
+            $arg.prefix.operator eq '|' &&
+            !$arg.IMPL-CURRIED
     }
 
     method IMPL-CAN-INTERPRET() {

--- a/t/02-rakudo/whatever-pipe-prefix-as-arg.t
+++ b/t/02-rakudo/whatever-pipe-prefix-as-arg.t
@@ -1,0 +1,25 @@
+use Test;
+
+plan 4;
+
+# `|*.foo` in an argument list is a WhateverCode whose body slips the
+# result of `$_.foo`. ArgList must keep the WhateverCode intact instead
+# of treating it as a regular `|EXPR` slip-flattening argument and
+# unwrapping it to the bare `*.foo` operand.
+
+is-deeply (1, 2, 3).map(|*.list).List, (1, 2, 3),
+    '|*.list as a positional arg curries and passes a WhateverCode';
+
+is-deeply ((1, 2, 3).map: |*.list).List, (1, 2, 3),
+    '|*.list as a colon-form arg curries and passes a WhateverCode';
+
+is-deeply blob8.new(1, 2, 3, 4).map(|*.polymod(256 xx 3).reverse).List,
+    (0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0, 4),
+    '|*.polymod(...).reverse curries and slips the polymod result';
+
+# Plain `|EXPR` without a Whatever must still flatten.
+sub probe(*@a) { @a.elems }
+is probe(0, |(1, 2, 3), 4), 5,
+    '|(...) without a Whatever still flattens in the arglist';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
`RakuAST::ArgList::IMPL-IS-FLATTENING` matched any `ApplyPrefix` whose prefix was `|`, and `IMPL-ADD-QAST-ARGS` then emitted a `FLATTENABLE_LIST` call on `$arg.operand`, bypassing the node itself. For a curried WhateverCode like `|*.foo`, that meant the CurryThunk wrapping the outer `ApplyPrefix` was discarded and only the inner `*.foo` reached the callee, which tried to call `.foo` on an unbound WhateverCode argument and produced `No such method 'foo' for invocant of type 'VMNull'`.

Skip the flattening branch when the `ApplyPrefix` is curried, so the WhateverCode is passed as a single positional argument like every other WhateverCode form.