### PR TITLE
RakuAST: silence some spurious `Useless use` sink worries

### DIFF
--- a/src/Raku/ast/call.rakumod
+++ b/src/Raku/ast/call.rakumod
@@ -1329,6 +1329,10 @@ class RakuAST::Stub
         $obj
     }
 
+    method PERFORM-CHECK(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
+        True
+    }
+
     method PRODUCE-IMPLICIT-LOOKUPS() {
         [
             RakuAST::Type::Simple.new(

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -2357,7 +2357,10 @@ class RakuAST::ApplyListInfix
         }
 
         self.add-sunk-worry($resolver, self.origin ?? self.origin.Str !! self.DEPARSE)
-            if self.infix.is-pure && self.sunk && !self.infix.short-circuit;
+            if self.infix.is-pure
+            && self.sunk
+            && !self.infix.short-circuit
+            && !self.IMPL-IS-LIST-LITERAL;
     }
 
     method IMPL-IS-VALID-FEED-STAGE($stage) {

--- a/src/Raku/ast/term.rakumod
+++ b/src/Raku/ast/term.rakumod
@@ -286,6 +286,10 @@ class RakuAST::Term::Rand
     method IMPL-EXPR-QAST(RakuAST::IMPL::QASTContext $context) {
         QAST::Op.new( :op('call'), :name(self.resolution.lexical-name) )
     }
+
+    method PERFORM-CHECK(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
+        True
+    }
 }
 
 # The whatever (*) term.
@@ -313,6 +317,10 @@ class RakuAST::Term::Whatever
     method IMPL-EXPR-QAST(RakuAST::IMPL::QASTContext $context) {
         $context.ensure-sc($!whatever);
         QAST::WVal.new( :value($!whatever), :returns($!whatever) )
+    }
+
+    method PERFORM-CHECK(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
+        True
     }
 }
 
@@ -379,6 +387,10 @@ class RakuAST::Term::HyperWhatever
     method IMPL-EXPR-QAST(RakuAST::IMPL::QASTContext $context) {
         $context.ensure-sc($!whatever);
         QAST::WVal.new( :value($!whatever) )
+    }
+
+    method PERFORM-CHECK(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
+        True
     }
 }
 

--- a/t/02-rakudo/sink-warnings-legacy-parity.t
+++ b/t/02-rakudo/sink-warnings-legacy-parity.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 5;
+plan 8;
 
 sub stderr-of(Str $code) {
     run($*EXECUTABLE.absolute, '-e', $code, :err).err.slurp(:close)
@@ -35,6 +35,18 @@ for <... ??? !!!> -> $yada {
     my $err = stderr-of qq[role R \{ method foo(--> Nil) \{ $yada \} \}];
     nok useless-of($err, $yada),
         "`$yada` is not a useless-use subject for a stubbed method body";
+}
+
+# `rand` is an impure call, `*` is the Whatever singleton, and `**`
+# is the HyperWhatever singleton. None of them are useless values in
+# sink context: `rand` has side effects and the two singletons carry
+# meaning even when their result is discarded. Legacy stays silent on
+# all three at statement level.
+
+for 'rand', '*', '**' -> $term {
+    my $err = stderr-of "sub f \{ $term; 42 \}; f()";
+    nok useless-of($err, $term),
+        "`$term` is not a useless-use subject at statement level";
 }
 
 # vim: expandtab shiftwidth=4

--- a/t/02-rakudo/sink-warnings-legacy-parity.t
+++ b/t/02-rakudo/sink-warnings-legacy-parity.t
@@ -1,0 +1,28 @@
+use Test;
+
+plan 2;
+
+sub stderr-of(Str $code) {
+    run($*EXECUTABLE.absolute, '-e', $code, :err).err.slurp(:close)
+}
+
+sub useless-lines(Str $err) {
+    $err.lines.map(*.trim).grep(*.starts-with('Useless use of '))
+}
+
+sub useless-of(Str $err, Str $subject) {
+    useless-lines($err).any.starts-with("Useless use of $subject ")
+}
+
+# `1, 2, 3;` at statement level produces a worry for each constant
+# operand. Legacy stops there; RakuAST used to add a fourth worry
+# whose subject was the bare `,` operator. Both compilers must keep
+# warning about the operands themselves.
+
+my $comma-err = stderr-of 'sub f { 1, 2, 3; 42 }; f()';
+nok useless-of($comma-err, ','),
+    '`,` is not a useless-use subject for `1, 2, 3;`';
+ok  useless-of($comma-err, 'constant integer 2'),
+    'the constant integer operand of `1, 2, 3;` is still a useless-use subject';
+
+# vim: expandtab shiftwidth=4

--- a/t/02-rakudo/sink-warnings-legacy-parity.t
+++ b/t/02-rakudo/sink-warnings-legacy-parity.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 2;
+plan 5;
 
 sub stderr-of(Str $code) {
     run($*EXECUTABLE.absolute, '-e', $code, :err).err.slurp(:close)
@@ -24,5 +24,17 @@ nok useless-of($comma-err, ','),
     '`,` is not a useless-use subject for `1, 2, 3;`';
 ok  useless-of($comma-err, 'constant integer 2'),
     'the constant integer operand of `1, 2, 3;` is still a useless-use subject';
+
+# The yada-yada stubs `...`, `???` and `!!!` compile to `&fail`,
+# `&warn` and `&die` and have visible side effects when reached, so a
+# stubbed method body like `method foo(--> Nil) { ... }` is not a
+# useless expression in sink context. None of the three stubs should
+# show up as a useless-use subject.
+
+for <... ??? !!!> -> $yada {
+    my $err = stderr-of qq[role R \{ method foo(--> Nil) \{ $yada \} \}];
+    nok useless-of($err, $yada),
+        "`$yada` is not a useless-use subject for a stubbed method body";
+}
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
`Useless use of X in sink context` worries from the RakuAST frontend cover a slightly wider set than legacy, and the extras leak into ecosystem installs as noise.

`ApplyListInfix::PERFORM-CHECK` calls `add-sunk-worry` whenever the infix is pure, which fires for `,` because `infix:<,>` is pure. `1, 2, 3;` at statement level got a fourth `Useless use of , in sink context` on top of the three constant-integer operand worries. Legacy explicitly skips `,` (and `xx`) for the list-literal case. Add `!IMPL-IS-LIST-LITERAL` to the guard.

`RakuAST::Stub` is a `RakuAST::Term`, so it inherits the unconditional sunk worry from `RakuAST::Expression::PERFORM-CHECK`. Legacy treats `...`, `???`, `!!!` as `&fail` / `&warn` / `&die` calls and the impure-call check keeps them quiet. A stubbed method body like `method foo(--> Nil) { ... }` ended up sunk by `--> Nil` and the inherited worry surfaced. Override `PERFORM-CHECK` on `RakuAST::Stub` (the three concrete stubs inherit it).

`Term::Rand`, `Term::Whatever` and `Term::HyperWhatever` have the same inheritance shape. `rand;`, `*;`, `**;` at statement level got the inherited worry, but `rand` is impure and the two singletons carry meaning even when sunk, so legacy stays silent on all three. Override `PERFORM-CHECK` on each.

Surfaced by `zef install URI` (the comma case at `t/01.rakutest:114`), `zef install Log::Timeline` (the stub case at `Log::Timeline::Output:6`), and any role with a `method ... (--> Nil) { ... }` body.
