### PR TITLE
RakuAST: handle custom package declarators like legacy does

### DIFF
--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -2601,7 +2601,20 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
             'knowhow', 'Knowhow',
             'native', 'Native',
         );
-        my $package := Nodify(nqp::existskey(%special, $declarator) ?? %special{$declarator} !! 'Package').new(
+        my str $ast-class;
+        if nqp::existskey(%special, $declarator) {
+            $ast-class := %special{$declarator};
+        }
+        else {
+            # A custom declarator registered via EXPORTHOW::DECLARE. Route to
+            # RakuAST::Class when the HOW can take attributes so the body's
+            # `has` declarations have an attach target; otherwise to bare
+            # RakuAST::Package so attribute usage emits the typed
+            # `cannot have attributes` error rather than a method-missing
+            # crash. The HOW handles compose either way.
+            $ast-class := nqp::can($how, 'add_attribute') ?? 'Class' !! 'Package';
+        }
+        my $package := Nodify($ast-class).new(
           :$how, :$name, :$scope, :$augmented
         );
 

--- a/src/Raku/ast/variable-access.rakumod
+++ b/src/Raku/ast/variable-access.rakumod
@@ -267,14 +267,22 @@ class RakuAST::Var::Attribute
     method PERFORM-BEGIN(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
         my $package := $resolver.find-attach-target('package');
         if $package {
-            # We can't check attributes exist until we compose the
-            # package, since they may come from roles. Thus we need to
-            # attach them to the package.
-            $package.ATTACH-ATTRIBUTE-USAGE(self);
-            nqp::bindattr(self, RakuAST::Var::Attribute, '$!package', $package);
-        }
-        else {
-            # TODO check-time error
+            if nqp::istype($package, RakuAST::Package::Attachable) {
+                # We can't check attributes exist until we compose the
+                # package, since they may come from roles. Thus we need to
+                # attach them to the package.
+                $package.ATTACH-ATTRIBUTE-USAGE(self);
+                nqp::bindattr(self, RakuAST::Var::Attribute, '$!package', $package);
+            }
+            else {
+                my $pkgdecl := nqp::getlexdyn('$*PKGDECL');
+                self.add-sorry:
+                    $resolver.build-exception: 'X::Attribute::Package',
+                        package-kind => nqp::isconcrete($pkgdecl)
+                            ?? ~$pkgdecl
+                            !! $package.declarator,
+                        name         => $!name;
+            }
         }
     }
 

--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -849,9 +849,12 @@ class RakuAST::VarDeclaration::Simple
                 nqp::bindattr(self, RakuAST::VarDeclaration::Simple, '$!attribute-package',
                     $attribute-package);
                 if self.is-attribute && !$!attribute-package.can-have-attributes {
+                    my $pkgdecl := nqp::getlexdyn('$*PKGDECL');
                     my $ex := $resolver.build-exception: 'X::Attribute::Package',
                         name         => self.name,
-                        package-kind => $!attribute-package.declarator;
+                        package-kind => nqp::isconcrete($pkgdecl)
+                            ?? ~$pkgdecl
+                            !! $!attribute-package.declarator;
                     if nqp::istype($!attribute-package, RakuAST::Declaration::External::Package) {
                         self.add-worry: $ex;
                     }

--- a/t/02-rakudo/custom-declarator-attributes.t
+++ b/t/02-rakudo/custom-declarator-attributes.t
@@ -1,0 +1,69 @@
+use lib <t/packages/Test-Helpers>;
+use Test;
+use Test::Helpers;
+
+plan 5;
+
+my $tmp = make-temp-dir;
+$tmp.add('ClassHOWCustom.rakumod').spurt: q:to/EOF/;
+my package EXPORTHOW {
+    package DECLARE {
+        constant mything = Metamodel::ClassHOW;
+    }
+}
+EOF
+
+is-run 'use ClassHOWCustom;
+        mything Counter { has $!n = 0; method inc { $!n++ }; method n { $!n } };
+        my $c = Counter.new; $c.inc; $c.inc; print $c.n',
+    'a custom ClassHOW declarator supports attributes',
+    :compiler-args['-I', $tmp.absolute], :out<2>;
+
+$tmp.add('SubclassedClassHOW.rakumod').spurt: q:to/EOF/;
+class MetamodelX::DerivedClassHOW is Metamodel::ClassHOW { }
+my package EXPORTHOW {
+    package DECLARE {
+        constant derived = MetamodelX::DerivedClassHOW;
+    }
+}
+EOF
+
+is-run 'use SubclassedClassHOW;
+        derived Counter { has $!n = 0; method bump { $!n++ }; method n { $!n } };
+        my $c = Counter.new; $c.bump; print $c.n',
+    'a HOW that subclasses ClassHOW (the OO::Monitors shape) supports attributes',
+    :compiler-args['-I', $tmp.absolute], :out<1>;
+
+$tmp.add('ModuleHOWCustom.rakumod').spurt: q:to/EOF/;
+my package EXPORTHOW {
+    package DECLARE {
+        constant mymod = Metamodel::ModuleHOW;
+    }
+}
+EOF
+
+is-run 'use ModuleHOWCustom; mymod Foo { has $!x }',
+    'a non-Attachable HOW emits the typed error for a `has` declaration',
+    :compiler-args['-I', $tmp.absolute],
+    :err(rx/'===SORRY!===' .* "A mymod cannot have attributes, but you tried to declare '\$!x'"/),
+    :exitcode(1);
+
+is-run 'use ModuleHOWCustom; mymod Foo { method m { $!x } }',
+    'a non-Attachable HOW emits a compile-time error for a stray attribute usage',
+    :compiler-args['-I', $tmp.absolute],
+    :err(rx/'===SORRY!===' .* '$!x'/),
+    :exitcode(1);
+
+$tmp.add('RoleHOWCustom.rakumod').spurt: q:to/EOF/;
+my package EXPORTHOW {
+    package DECLARE {
+        constant myrole = Metamodel::ParametricRoleHOW;
+    }
+}
+EOF
+
+is-run 'use RoleHOWCustom; myrole Foo { has $!x }; print "ok"',
+    'a ParametricRoleHOW-backed custom declarator does not crash on attribute usage',
+    :compiler-args['-I', $tmp.absolute], :out<ok>;
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
`stub-package` mapped only the seven built-in declarators (`package`, `role`, `class`, `module`, `grammar`, `knowhow`, `native`) to their `RakuAST::Package` subclasses and fell back to bare `RakuAST::Package` otherwise. Custom declarators registered via `EXPORTHOW::DECLARE` (the way `OO::Monitors` adds `monitor`) became bare `RakuAST::Package`, which is not `Package::Attachable`, so any attribute reference in the body died at BEGIN time with `No such method 'ATTACH-ATTRIBUTE-USAGE' for invocant of type 'RakuAST::Package'`.

Route a custom declarator to `RakuAST::Class` when the HOW can take attributes, otherwise to bare `RakuAST::Package`. The HOW handles compose either way. Matches legacy's `package_def`, which only branches on `$*PKGDECL eq 'role'` and `'grammar'` and parses every other declarator class-like.

`RakuAST::Var::Attribute::PERFORM-BEGIN` raises
`X::Attribute::Package` when the attach target is not Attachable. Both that site and the existing `VarDeclaration::Simple` site read `package-kind` from `nqp::getlexdyn('$*PKGDECL')`, falling back to the attach target's `declarator`. A `mymod Foo { has $!x }` reports `A mymod cannot have attributes` instead of the AST class's hard-coded `package`.

Surfaced by `zef install Terminal::Print`, whose
`Terminal::Print::Grid` is a `unit monitor`.