### PR TITLE
RakuAST: re-resolve `Call::Name` at CHECK to pick up a forward `sub`

### DIFF
--- a/src/Raku/ast/call.rakumod
+++ b/src/Raku/ast/call.rakumod
@@ -346,6 +346,20 @@ class RakuAST::Call::Name
             self.PERFORM-BEGIN($resolver, $context);
         }
 
+        # A `sub foo { }` declaration is hoisted to the start of its
+        # lexical scope. When the existing resolution is an `External`
+        # (typically `CORE`), re-query and adopt the closer non-`External`
+        # match if one is present.
+        if $!name.is-identifier
+            && self.is-resolved
+            && nqp::istype(self.resolution, RakuAST::Declaration::External)
+        {
+            my $lexical := $resolver.resolve-lexical('&' ~ $name);
+            if $lexical && !nqp::istype($lexical, RakuAST::Declaration::External) {
+                self.set-resolution($lexical);
+            }
+        }
+
         if !self.is-resolved && ($name eq 'pi' || $name eq 'tau' || $name eq 'e') {
             self.add-sorry:
                 $resolver.build-exception: 'X::Undeclared',

--- a/t/02-rakudo/forward-sub-lookup.t
+++ b/t/02-rakudo/forward-sub-lookup.t
@@ -1,0 +1,47 @@
+use Test;
+
+plan 5;
+
+# A `sub foo` declaration is hoisted to the start of its enclosing
+# lexical scope, so a call earlier in the same scope must resolve to
+# the local declaration rather than to an outer (typically `CORE`)
+# routine of the same name.
+
+sub forward-shadows-core() {
+    my @x; my @y;
+    my $r = reduce(@x, @y);
+    sub reduce(@a, @b) { 'local' }
+    $r
+}
+is forward-shadows-core(), 'local',
+    'a forward call resolves to a same-scope `sub` shadowing CORE';
+
+sub forward-without-shadow() {
+    my $r = inner();
+    sub inner { 'inner' }
+    $r
+}
+is forward-without-shadow(), 'inner',
+    'a forward call resolves to a same-scope `sub` with no CORE name in play';
+
+is reduce(&[+], 1, 2, 3), 6,
+    'a sub-form call with no same-scope `sub` shadow still resolves through CORE';
+
+sub forward-multi-shadows-core() {
+    my $r = process(42);
+    multi sub process(Int $x) { "int: $x" }
+    multi sub process(Str $x) { "str: $x" }
+    $r
+}
+is forward-multi-shadows-core(), 'int: 42',
+    'a forward call resolves to a same-scope `multi sub`';
+
+sub forward-our-sub() {
+    my $r = ours();
+    our sub ours { 'ours' }
+    $r
+}
+is forward-our-sub(), 'ours',
+    'a forward call resolves to a same-scope `our sub`';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
`Call::Name::PERFORM-BEGIN` resolves the call's name against the resolver's lexical chain. A `my`-scoped `sub foo { }` declared later in the same scope is hoisted to the start of that scope, but the hoist happens at parse time of the declaration, which is *after* the call's BEGIN-time pass. The call therefore resolved against an `External` declaration in an outer scope (typically `CORE`) and stuck there because `PERFORM-CHECK` only retried resolution when nothing had been picked up yet.

For `sub outer { reduce(@x, @y); sub reduce(@a, @b) { @a } }` the call's BEGIN-time lookup landed on `CORE::&reduce` and trial-bind reported `Calling reduce(Positional, Positional) will never work`, even though the local `&reduce` shadowed `CORE`.

`Call::Name::PERFORM-CHECK` now re-queries the resolver for the lexical name when the existing resolution is a
`RakuAST::Declaration::External`, and adopts the new resolution if it is not itself `External`. The hoisted local declaration is in scope by CHECK time, so a closer non-`External` match wins; `CORE`-only calls keep their `External::Setting` resolution and pay no churn.

Resolves #6238.