### PR TITLE
RakuAST: handle custom package declarators like legacy does

### DIFF
--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -2601,8 +2601,21 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
             'knowhow', 'Knowhow',
             'native', 'Native',
         );
-        my $package := Nodify(nqp::existskey(%special, $declarator) ?? %special{$declarator} !! 'Package').new(
-          :$how, :$name, :$scope, :$augmented
+        my str $ast-class;
+        if nqp::existskey(%special, $declarator) {
+            $ast-class := %special{$declarator};
+        }
+        else {
+            # A custom declarator registered via EXPORTHOW::DECLARE. Route to
+            # RakuAST::Class when the HOW can take attributes so the body's
+            # `has` declarations have an attach target; otherwise to bare
+            # RakuAST::Package so attribute usage emits the typed
+            # `cannot have attributes` error rather than a method-missing
+            # crash. The HOW handles compose either way.
+            $ast-class := nqp::can($how, 'add_attribute') ?? 'Class' !! 'Package';
+        }
+        my $package := Nodify($ast-class).new(
+          :$how, :$name, :$scope, :$augmented, :parsed-declarator($declarator)
         );
 
         $package.to-parse-time($*R, $*CU.context);

--- a/src/Raku/ast/attaching.rakumod
+++ b/src/Raku/ast/attaching.rakumod
@@ -46,6 +46,8 @@ class RakuAST::Declaration::External::Package
                         !! nqp::die("Unexpected HOW: " ~ $how.HOW.name($how));
     }
 
+    method parsed-declarator() { self.declarator }
+
     method stubbed-meta-object() {
         self.compile-time-value
     }

--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -2468,7 +2468,7 @@ class RakuAST::Methodish
                 $resolver.add-worry:  # XXX should be self.add-worry
                   $resolver.build-exception: 'X::Useless::Declaration',
                     name  => $name,
-                    where => "a " ~ $package.declarator
+                    where => "a " ~ $package.parsed-declarator
             }
         }
         elsif self.scope eq 'has' {

--- a/src/Raku/ast/package.rakumod
+++ b/src/Raku/ast/package.rakumod
@@ -23,6 +23,7 @@ class RakuAST::Package
     has Mu            $.how;
     has Str           $.repr;
     has Bool          $.augmented;
+    has str           $!parsed-declarator;
 
     has Mu   $!block-semantics-applied;
     has Bool $.is-stub;
@@ -53,6 +54,7 @@ class RakuAST::Package
                          Str :$repr,
                         Bool :$augmented,
                         Bool :$is-require-stub,
+                         str :$parsed-declarator,
     RakuAST::Doc::Declarator :$WHY
     ) {
         my $obj := nqp::create(self);
@@ -65,6 +67,7 @@ class RakuAST::Package
         nqp::bindattr($obj, RakuAST::Package, '$!repr', $repr // Str);
         nqp::bindattr($obj, RakuAST::Package, '$!augmented',$augmented // False);
         nqp::bindattr($obj, RakuAST::Package, '$!is-require-stub',$is-require-stub // False);
+        nqp::bindattr_s($obj, RakuAST::Package, '$!parsed-declarator', $parsed-declarator);
 
         $obj.set-traits($traits) if $traits;
         $obj.replace-body($body, $parameterization);
@@ -75,6 +78,12 @@ class RakuAST::Package
 
         $obj
     }
+
+    # The literal declarator string the parser saw, e.g. `monitor` for a
+    # custom `EXPORTHOW::DECLARE` keyword. Diagnostics that want to echo
+    # what the user typed prefer this over `declarator`, which returns
+    # the AST class's static name.
+    method parsed-declarator() { $!parsed-declarator || self.declarator }
 
     # Informational methods
     method declarator()  { "package"             }
@@ -131,14 +140,14 @@ class RakuAST::Package
                 else {
                     self.add-sorry:
                         $resolver.build-exception: 'X::Augment::NoSuchType',
-                            :package(self.name.canonicalize), :package-kind(self.declarator);
+                            :package(self.name.canonicalize), :package-kind(self.parsed-declarator);
                     $resolver.add-node-with-check-time-problems(self);
                 }
             }
             else {
                 self.add-sorry:
                     $resolver.build-exception: 'X::Anon::Augment',
-                        :package-kind(self.declarator);
+                        :package-kind(self.parsed-declarator);
                 $resolver.add-node-with-check-time-problems(self);
             }
         }
@@ -505,6 +514,7 @@ class RakuAST::Package::Attachable
                           Mu :$how,
                          Str :$repr,
                         Bool :$augmented,
+                         str :$parsed-declarator,
     RakuAST::Doc::Declarator :$WHY
     ) {
         my $obj := nqp::create(self);
@@ -516,6 +526,7 @@ class RakuAST::Package::Attachable
           nqp::eqaddr($how,NQPMu) ?? $obj.default-how !! $how);
         nqp::bindattr($obj, RakuAST::Package, '$!repr', $repr // Str);
         nqp::bindattr($obj, RakuAST::Package, '$!augmented',$augmented // False);
+        nqp::bindattr_s($obj, RakuAST::Package, '$!parsed-declarator', $parsed-declarator);
 
         $obj.set-traits($traits) if $traits;
         $obj.replace-body($body, $parameterization);

--- a/src/Raku/ast/signature.rakumod
+++ b/src/Raku/ast/signature.rakumod
@@ -2087,7 +2087,7 @@ class RakuAST::ParameterTarget::Var
                     self.add-sorry:
                       $resolver.build-exception: 'X::Attribute::Undeclared',
                         symbol       => $!name,
-                        package-kind => $!attribute-package.declarator,
+                        package-kind => $!attribute-package.parsed-declarator,
                         package-name => $!attribute-package.name.canonicalize,
                         what         => 'attribute';
                 }

--- a/src/Raku/ast/variable-access.rakumod
+++ b/src/Raku/ast/variable-access.rakumod
@@ -267,14 +267,19 @@ class RakuAST::Var::Attribute
     method PERFORM-BEGIN(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
         my $package := $resolver.find-attach-target('package');
         if $package {
-            # We can't check attributes exist until we compose the
-            # package, since they may come from roles. Thus we need to
-            # attach them to the package.
-            $package.ATTACH-ATTRIBUTE-USAGE(self);
-            nqp::bindattr(self, RakuAST::Var::Attribute, '$!package', $package);
-        }
-        else {
-            # TODO check-time error
+            if nqp::istype($package, RakuAST::Package::Attachable) {
+                # We can't check attributes exist until we compose the
+                # package, since they may come from roles. Thus we need to
+                # attach them to the package.
+                $package.ATTACH-ATTRIBUTE-USAGE(self);
+                nqp::bindattr(self, RakuAST::Var::Attribute, '$!package', $package);
+            }
+            else {
+                self.add-sorry:
+                    $resolver.build-exception: 'X::Attribute::Package',
+                        package-kind => $package.parsed-declarator,
+                        name         => $!name;
+            }
         }
     }
 
@@ -284,7 +289,7 @@ class RakuAST::Var::Attribute
             my $package := $!package.stubbed-meta-object;
 
             self.add-sorry: $resolver.build-exception: 'X::Attribute::Undeclared',
-                :symbol($!name), :package-kind($!package.declarator),
+                :symbol($!name), :package-kind($!package.parsed-declarator),
                 :package-name($package.HOW.name), :what('attribute')
                 unless $package.HOW.has_attribute($package, $!name);
         }

--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -851,7 +851,7 @@ class RakuAST::VarDeclaration::Simple
                 if self.is-attribute && !$!attribute-package.can-have-attributes {
                     my $ex := $resolver.build-exception: 'X::Attribute::Package',
                         name         => self.name,
-                        package-kind => $!attribute-package.declarator;
+                        package-kind => $!attribute-package.parsed-declarator;
                     if nqp::istype($!attribute-package, RakuAST::Declaration::External::Package) {
                         self.add-worry: $ex;
                     }

--- a/t/02-rakudo/custom-declarator-attributes.t
+++ b/t/02-rakudo/custom-declarator-attributes.t
@@ -1,0 +1,69 @@
+use lib <t/packages/Test-Helpers>;
+use Test;
+use Test::Helpers;
+
+plan 5;
+
+my $tmp = make-temp-dir;
+$tmp.add('ClassHOWCustom.rakumod').spurt: q:to/EOF/;
+my package EXPORTHOW {
+    package DECLARE {
+        constant mything = Metamodel::ClassHOW;
+    }
+}
+EOF
+
+is-run 'use ClassHOWCustom;
+        mything Counter { has $!n = 0; method inc { $!n++ }; method n { $!n } };
+        my $c = Counter.new; $c.inc; $c.inc; print $c.n',
+    'a custom ClassHOW declarator supports attributes',
+    :compiler-args['-I', $tmp.absolute], :out<2>;
+
+$tmp.add('SubclassedClassHOW.rakumod').spurt: q:to/EOF/;
+class MetamodelX::DerivedClassHOW is Metamodel::ClassHOW { }
+my package EXPORTHOW {
+    package DECLARE {
+        constant derived = MetamodelX::DerivedClassHOW;
+    }
+}
+EOF
+
+is-run 'use SubclassedClassHOW;
+        derived Counter { has $!n = 0; method bump { $!n++ }; method n { $!n } };
+        my $c = Counter.new; $c.bump; print $c.n',
+    'a HOW that subclasses ClassHOW (the OO::Monitors shape) supports attributes',
+    :compiler-args['-I', $tmp.absolute], :out<1>;
+
+$tmp.add('ModuleHOWCustom.rakumod').spurt: q:to/EOF/;
+my package EXPORTHOW {
+    package DECLARE {
+        constant mymod = Metamodel::ModuleHOW;
+    }
+}
+EOF
+
+is-run 'use ModuleHOWCustom; mymod Foo { has $!x }',
+    'a non-Attachable HOW emits the typed error for a `has` declaration',
+    :compiler-args['-I', $tmp.absolute],
+    :err(rx/'===SORRY!===' .* "A mymod cannot have attributes, but you tried to declare '\$!x'"/),
+    :exitcode(1);
+
+is-run 'use ModuleHOWCustom; mymod Foo { method m { $!x } }',
+    'a non-Attachable HOW emits a compile-time error for a stray attribute usage',
+    :compiler-args['-I', $tmp.absolute],
+    :err(rx/'===SORRY!===' .* '$!x'/),
+    :exitcode(1);
+
+$tmp.add('RoleHOWCustom.rakumod').spurt: q:to/EOF/;
+my package EXPORTHOW {
+    package DECLARE {
+        constant myrole = Metamodel::ParametricRoleHOW;
+    }
+}
+EOF
+
+is-run 'use RoleHOWCustom; myrole Foo { has $!x }; print "ok"',
+    'a ParametricRoleHOW-backed custom declarator does not crash on attribute usage',
+    :compiler-args['-I', $tmp.absolute], :out<ok>;
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
`stub-package` mapped only the seven built-in declarators (`package`, `role`, `class`, `module`, `grammar`, `knowhow`, `native`) to their `RakuAST::Package` subclasses and fell back to bare `RakuAST::Package` otherwise. Custom declarators registered via `EXPORTHOW::DECLARE` (the way `OO::Monitors` adds `monitor`) became bare `RakuAST::Package`, which is not `Package::Attachable`, so any attribute reference in the body died at BEGIN time with `No such method 'ATTACH-ATTRIBUTE-USAGE' for invocant of type 'RakuAST::Package'`.

Route a custom declarator to `RakuAST::Class` when the HOW can take attributes, otherwise to bare `RakuAST::Package`. The HOW handles compose either way. Matches legacy's `package_def`, which only branches on `$*PKGDECL eq 'role'` and `'grammar'` and parses every other declarator class-like.

`RakuAST::Var::Attribute::PERFORM-BEGIN` raises
`X::Attribute::Package` when the attach target is not Attachable. `RakuAST::Package` carries the literal declarator string from the parse site in a new `$!parsed-declarator` attribute exposed via `parsed-declarator`. Both that site and `VarDeclaration::Simple` read `package-kind` from it, so a `mymod Foo { has $!x }` reports `A mymod cannot have attributes` instead of the AST class's hard-coded `package`. Peer diagnostics (`X::Attribute::Undeclared`, `X::Augment::NoSuchType`, `X::Anon::Augment`, `X::Useless::Declaration`) also switch to `parsed-declarator` so a custom declarator renders as the user-typed keyword across error wording rather than landing as `class` for declarations routed to `RakuAST::Class`.

Surfaced by `zef install Terminal::Print`, whose `Terminal::Print::Grid` is a `unit monitor`.