### PR TITLE
Fix Array.shift on holes in arrays

### DIFF
--- a/src/core.c/Array.rakumod
+++ b/src/core.c/Array.rakumod
@@ -1006,7 +1006,7 @@ my class Array { # declared in BOOTSTRAP
           && nqp::elems($reified)
           ?? nqp::ifnull(  # handle holes
                nqp::shift($reified),
-               Nil
+               nqp::getattr($!descriptor,ContainerDescriptor,'$!default')
              )
           !! nqp::isconcrete(my $todo := nqp::getattr(self,List,'$!todo'))
                && $todo.reify-at-least(1)


### PR DESCRIPTION
Unlike the needed Array.pop fix in 415fa4b069 to prevent a segfault, Array.shift was already guarded against returning an nqp::null.

However, it was set to return Nil, rather than the default value of the array.  This commit changes that to be more in line with Array.pop.

However, this breaks one spectest in t/spec/S32-array/shift.t which literally expects Nil to be returned.  However the test does not actually want to test that, just that it didn't return a Failure (according to the comment with the test).

It feels to me that the test should be changed, and that Array.shift on a hole in an Array, should return the default value, just like Array.pop does now.