### PR TITLE
 RakuAST: route string EVAL through IMPL-FIXUP and wrap nested EVAL output

### DIFF
--- a/src/Raku/ast/compunit.rakumod
+++ b/src/Raku/ast/compunit.rakumod
@@ -646,10 +646,24 @@ class RakuAST::CompUnit
             $top-level.set_children([$run-main]);
         }
 
+        # Nested EVAL: wrap the inner mainline in an anonymous QAST::Block.
+        # With no Code object and no SC entry, the wrapper's static_code
+        # stays NULL, so the parent's serializer terminates body.outer
+        # walks here instead of reaching the enclosing frame's lexpad and
+        # any non-serializable state it holds (Locks, ConditionVariables,
+        # tap closures). The wrapper declares no symbols of its own and is
+        # marked DYN_COMP_WRAPPER, so lexical lookups from the EVAL'd code
+        # stay late-bound and resolve through the forced outer context to
+        # the caller's `$_`, `$/`, and `$?PACKAGE`. Mirrors legacy's
+        # World.compile_in_context.
+        my $outermost := $!is-eval && $context.is-nested
+            ?? self.IMPL-EVAL-WRAPPER-BLOCK($top-level)
+            !! $top-level;
+
         $context.cleanup-orphan-stubs();
 
         QAST::CompUnit.new:
-            $top-level,
+            $outermost,
             :hll('Raku'),
             :sc($!sc),
             :is_nested($!is-eval == 2),
@@ -665,8 +679,22 @@ class RakuAST::CompUnit
             # have occurred.
             :load(QAST::Op.new(
                 :op('call'),
-                QAST::BVal.new( :value($top-level) ),
+                QAST::BVal.new( :value($outermost) ),
             )),
+    }
+
+    method IMPL-EVAL-WRAPPER-BLOCK($inner) {
+        # `immediate_static` makes the inner mainline auto-invoke when the
+        # wrapper runs and pass its return value through, so EVAL still
+        # returns the user's last-expression value.
+        $inner.blocktype('immediate_static');
+
+        my $wrapper := QAST::Block.new($inner);
+        $wrapper.name('<eval-wrapper>');
+        $wrapper.blocktype('declaration_static');
+        $wrapper.annotate('DYN_COMP_WRAPPER', 1);
+
+        $wrapper
     }
 
     # Emit a QAST::Stmt that, at runtime, ensures the Raku ModuleLoader is

--- a/src/core.c/ForeignCode.rakumod
+++ b/src/core.c/ForeignCode.rakumod
@@ -58,6 +58,21 @@ $lang = 'Raku' if $lang eq 'perl6';
     my $compiled;
     my $eval_ctx := nqp::getattr(nqp::decont($context), PseudoStash, '$!ctx');
 
+    # Compile a RakuAST comp-unit the rest of the way to a code object.
+    # IMPL-TO-QAST-COMP-UNIT runs outside the compiler's qast stage here,
+    # so bind the dynamic that stage provides, and run the comp-unit's
+    # cleanup even when a later stage throws.
+    my sub compile-rakuast-comp-unit($comp-unit) {
+        LEAVE $comp-unit.cleanup;
+        my $*COMPILING_CORE_SETTING := 0;
+        my $qast-cu := $comp-unit.IMPL-TO-QAST-COMP-UNIT;
+        my $eval-context := $comp-unit.context;
+        # Run the qast-stage SC bookkeeping that compiling from QAST skips.
+        my $precomp := $compiler.compile($qast-cu, :from($compiler.qast-stage), :compunit_ok(1));
+        $eval-context.IMPL-FIXUP-COMPILED-CODEREFS(nqp::compunitcodes($precomp));
+        $compiler.backend.compunit_mainline($precomp)
+    }
+
     if nqp::istype($code, RakuAST::Node) {
         # Wrap as required to get compilation unit.
         my $comp-unit := do if nqp::istype($code, RakuAST::CompUnit) {
@@ -108,14 +123,7 @@ $lang = 'Raku' if $lang eq 'perl6';
         my $optimize-option = nqp::getcomp('Raku').cli-options<optimize> // '';
         $comp-unit.optimize($resolver)
             unless $optimize-option eq 'off' || $optimize-option eq '0';
-        my $from := $compiler.qast-stage;
-        my $qast-cu := $comp-unit.IMPL-TO-QAST-COMP-UNIT;
-        my $context := $comp-unit.context;
-        # Run the qast-stage SC bookkeeping that AST EVAL otherwise skips.
-        my $precomp := $compiler.compile($qast-cu, :$from, :compunit_ok(1));
-        $context.IMPL-FIXUP-COMPILED-CODEREFS(nqp::compunitcodes($precomp));
-        $comp-unit.cleanup;
-        $compiled := $compiler.backend.compunit_mainline($precomp);
+        $compiled := compile-rakuast-comp-unit($comp-unit);
     }
     else {
         $code = nqp::istype($code,Blob) ?? $code.decode('utf8') !! $code.Str;
@@ -124,13 +132,22 @@ $lang = 'Raku' if $lang eq 'perl6';
 
         my $LANG := $context<%?LANG>:exists ?? $context<%?LANG> !! Nil;
         my $*INSIDE-EVAL := 1;
-        $compiled := $compiler.compile:
+        # The RakuAST frontend (the only frontend with a qast stage) stops
+        # at the AST so the comp-unit can take the same finishing path as
+        # AST EVAL, fixing up code objects to survive an enclosing
+        # compilation's precomp and wrapping nested EVAL output.
+        my $rakuast-frontend := $compiler.exists_stage('qast');
+        my $result := $compiler.compile:
             $code,
             :outer_ctx($eval_ctx),
             :global(GLOBAL),
             :language_version(nqp::getcomp('Raku').language_version),
+            |(%(:target('ast'), :compunit_ok(1)) if $rakuast-frontend),
             |(:optimize($_) with nqp::getcomp('Raku').cli-options<optimize>),
             |(%(:grammar($LANG<MAIN>), :actions($LANG<MAIN-actions>)) if $LANG);
+        $compiled := $rakuast-frontend
+            ?? compile-rakuast-comp-unit($result)
+            !! $result;
     }
 
     if $check {

--- a/t/02-rakudo/19-begin-time-eval-sub.t
+++ b/t/02-rakudo/19-begin-time-eval-sub.t
@@ -1,0 +1,10 @@
+use lib <t/packages/02-rakudo/lib>;
+use Test;
+
+use StringEvalSubAtBegin;
+is foo(), 'from-precomped-string-eval',
+    'precompiling a module returning a string-EVAL Sub from BEGIN works';
+
+done-testing;
+
+# vim: expandtab shiftwidth=4

--- a/t/02-rakudo/20-begin-time-eval-frame-leak.t
+++ b/t/02-rakudo/20-begin-time-eval-frame-leak.t
@@ -1,0 +1,10 @@
+use lib <t/packages/02-rakudo/lib>;
+use Test;
+
+use BeginFrameLeakEval;
+is x(), 42,
+    'BEGIN block with non-serializable lexicals before EVAL does not leak the BEGIN lexpad through the EVAL Sub';
+
+done-testing;
+
+# vim: expandtab shiftwidth=4

--- a/t/packages/02-rakudo/lib/BeginFrameLeakEval.rakumod
+++ b/t/packages/02-rakudo/lib/BeginFrameLeakEval.rakumod
@@ -1,0 +1,11 @@
+use MONKEY-SEE-NO-EVAL;
+# Pins the nested-EVAL wrapper in RakuAST::CompUnit. BEGIN holds
+# non-serializable state (a Lock and a ConditionVariable). The wrapper
+# terminates the EVAL'd Sub's outer chain walk before the serializer
+# reaches BEGIN's lexpad.
+our &x;
+BEGIN {
+    my $lock = Lock.new;
+    my $cv = $lock.condition;
+    &x = EVAL 'sub () { 42 }';
+}

--- a/t/packages/02-rakudo/lib/StringEvalSubAtBegin.rakumod
+++ b/t/packages/02-rakudo/lib/StringEvalSubAtBegin.rakumod
@@ -1,0 +1,5 @@
+use MONKEY-SEE-NO-EVAL;
+# Pins ForeignCode's string-EVAL path through IMPL-FIXUP-COMPILED-CODEREFS:
+# a BEGIN-time EVAL Sub must survive its outer module's precomp.
+our &foo;
+BEGIN { &foo = EVAL 'sub () { "from-precomped-string-eval" }' }


### PR DESCRIPTION
The string-EVAL branch of ForeignCode skipped IMPL-FIXUP-COMPILED-CODEREFS that the AST-EVAL branch runs. A Sub returned from `BEGIN { &x = EVAL 'sub () { 42 }' }` had a `$!do` coderef whose static_code was not in any SC. Outer-module precomp serialization failed with `missing static code ref for closure`. Route the RakuAST frontend's string EVAL through `:target('ast'), :compunit_ok(1)` and finish through the same helper as the AST-EVAL path: IMPL-TO-QAST-COMP-UNIT, a compile from the qast stage, then IMPL-FIXUP-COMPILED-CODEREFS. The helper binds $*COMPILING_CORE_SETTING to 0, which the bypassed qast stage method otherwise provides, and runs the comp-unit's cleanup from a LEAVE phaser so a failure in a later stage cannot skip it.

When the EVAL'd Sub's outer chain reached BEGIN's frame and BEGIN held non-serializable state (a Lock, a ConditionVariable), the serializer walked the chain into BEGIN's lexpad and tripped on it. RakuAST::CompUnit.IMPL-TO-QAST-COMP-UNIT now interposes an anonymous wrapper QAST::Block when the EVAL is nested. The wrapper declares no symbols and carries the DYN_COMP_WRAPPER annotation, the same shape World.compile_in_context gives the legacy frontend, so lexical lookups from the EVAL'd code stay late-bound and reach the caller's `$_`, `$/`, and `$?PACKAGE` through the forced outer context. It sets the inner mainline's blocktype to `immediate_static` so it auto-invokes and passes its return value through, and has no Code object or SC entry. When the outer serializer walks body.outer from an EVAL'd Sub up to the wrapper frame, closure_to_static_code_ref returns NULL and the walk terminates instead of reaching BEGIN.
