### PR TITLE
RakuAST: skip compile-time trial-bind for type-capture generics

### DIFF
--- a/src/Raku/ast/call.rakumod
+++ b/src/Raku/ast/call.rakumod
@@ -372,6 +372,7 @@ class RakuAST::Call::Name
                     $ok := 0 if $type =:= Mu; # Don't know the type
                     last unless $ok;
                     $ok := 0 if nqp::istype($type.HOW, Perl6::Metamodel::SubsetHOW); # Avoid side-effects of comparing subset
+                    $ok := 0 if nqp::istype($type.HOW, Perl6::Metamodel::GenericHOW); # These bind at instantiation time
                     nqp::push(@flags, nqp::objprimspec($type));
                 }
                 if $ok {

--- a/t/02-rakudo/21-trial-bind-generic.t
+++ b/t/02-rakudo/21-trial-bind-generic.t
@@ -1,0 +1,15 @@
+use Test;
+
+# RakuAST's compile-time trial-bind in RakuAST::Call::Name::PERFORM-CHECK
+# must skip type-capture generics (Perl6::Metamodel::GenericHOW). They
+# bind to a real type at role/sub instantiation time and match the
+# called sub's signature then. Without the skip, calling any sub from
+# a role body with a type-capture argument errored at parse time.
+use MONKEY-SEE-NO-EVAL;
+lives-ok {
+    EVAL 'sub frob($obj) { $obj }; role R[::T] { my $x = frob(T) }';
+}, 'role body can call a sub with a type-capture argument';
+
+done-testing;
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
`RakuAST::Call::Name::PERFORM-CHECK` walks the call's arguments and trial-binds them against the resolved routine's signature. Each argument's `return-type` is collected, then `nqp::p6trialbind` decides whether the call could ever match.

A type capture `::T` in a role or sub signature resolves to a `RakuAST::Type::Capture` whose meta-object is a
`Perl6::Metamodel::GenericHOW`. Inside the role body, a reference to `T` produces a `RakuAST::Type::Simple` whose `return-type` is that generic placeholder. `nqp::p6trialbind` rejected the generic as unrelated to any concrete parameter type, so calling a sub that takes an unconstrained `$obj` with `T` as the argument parsed under RakuAST as

    Calling frob(T) will never work with declared signature ($obj)

even though the call binds fine at role instantiation time once `T` is replaced with the actual type. Skip the trial-bind when any argument's type uses `GenericHOW`, mirroring the existing skip for `SubsetHOW`.

Surfaced by `zef install NativeHelpers::Blob`, whose `NativeHelpers::CStruct` declares `role LinearArray[::T] { ... nativesizeof(T) ... }` and failed to precompile under RAKUDO_RAKUAST=1.