### PR TITLE
RakuAST: iterate from-loop bodies in BEGIN-time initializers

### DIFF
--- a/src/Raku/ast/statements.rakumod
+++ b/src/Raku/ast/statements.rakumod
@@ -1282,6 +1282,7 @@ class RakuAST::Statement::Loop
                     $!condition.IMPL-TO-QAST($context),
                 );
                 $qast.push: $!increment.IMPL-TO-QAST($context) if $!increment;
+                $qast.push: QAST::IVal.new(:value(1), :named('repeat')) if self.repeat;
                 if @labels {
                     my $label-qast := @labels[0].IMPL-LOOKUP-QAST($context);
                     $label-qast.named('label');

--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -470,6 +470,17 @@ class RakuAST::VarDeclaration::Constant
                     nqp::rethrow($ex);
                 }
             }
+            # BEGIN-time evaluation of the initializer runs before the
+            # CompUnit's CHECK-time sink propagation, so a nested
+            # StatementList in the initializer would otherwise leave
+            # non-final statements unsunk and a side-effecting expression
+            # like a `while` loop would emit as a lazy Seq that gets
+            # discarded without iterating. Propagate sink here as if the
+            # initializer's value were wanted. A `.=` initializer carries
+            # a method call rather than an expression and needs no sink
+            # treatment.
+            $!initializer.expression.apply-sink(False)
+                if nqp::istype($!initializer, RakuAST::Initializer::Expression);
             $value := $!initializer.IMPL-COMPILE-TIME-VALUE(
                 $resolver, $context, :invocant-compiler(-> { $!type ?? $!type.IMPL-VALUE-TYPE.meta-object !! Mu }));
         };

--- a/t/02-rakudo/20-begin-time-loop-init.t
+++ b/t/02-rakudo/20-begin-time-loop-init.t
@@ -1,0 +1,70 @@
+use Test;
+
+# `while`/`until`/`repeat-while`/`repeat-until` used as expressions emit
+# through `Seq.from-loop`. When such a loop appears inside a
+# `constant X = do { ... }` initializer that runs at BEGIN, the body
+# must still execute for its side effects, and a `repeat` form must
+# run the body once before the condition is checked. A constant whose
+# final expression is itself the accumulated result also has to keep
+# working - the early sink propagation must not strip the result of
+# the do-block.
+
+constant WHILE-COUNT = do {
+    my $i = 0;
+    while $i < 3 {
+        $i++;
+    }
+    $i
+};
+is WHILE-COUNT, 3,
+  'while body inside a BEGIN-time initializer runs for side effects';
+
+constant UNTIL-COUNT = do {
+    my $i = 0;
+    until $i >= 3 {
+        $i++;
+    }
+    $i
+};
+is UNTIL-COUNT, 3,
+  'until body inside a BEGIN-time initializer runs for side effects';
+
+constant REPEAT-WHILE-COUNT = do {
+    my $i = 0;
+    my @log;
+    repeat {
+        @log.push($i);
+    } while ++$i < 3;
+    @log.elems
+};
+is REPEAT-WHILE-COUNT, 3,
+  'repeat-while body inside a BEGIN-time initializer runs before checking the condition';
+
+constant REPEAT-UNTIL-COUNT = do {
+    my $i = 0;
+    my @log;
+    repeat {
+        @log.push($i);
+    } until ++$i >= 3;
+    @log.elems
+};
+is REPEAT-UNTIL-COUNT, 3,
+  'repeat-until body inside a BEGIN-time initializer runs before checking the condition';
+
+constant ACCUMULATED = do {
+    my @a;
+    my $i = 0;
+    while $i < 3 {
+        @a.push: $i;
+        $i++;
+    }
+    @a
+};
+is ACCUMULATED.elems, 3,
+  'a constant whose value is the side-effect result of a preceding loop is kept';
+is ACCUMULATED[2], 2,
+  'and the accumulated value reflects every iteration of that loop';
+
+done-testing;
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
A `while`/`repeat-while` loop inside `constant X = do { ...; loop; ... }` emits as a `Seq.from-loop(...)` callmethod. Two gaps prevented the body from running at BEGIN time:

* The repeat flag was dropped, so a repeat-while dispatched to the plain while multi and the body never ran when the condition started false.
* The initializer was evaluated before the CompUnit's CHECK-time sink propagation, so intermediate statements in the wrapped `do` block were not marked sunk. The lazy Seq returned by `from-loop` was discarded without iterating, so the body never ran for side effects.

Push `:repeat(1)` to `from-loop` when the loop has the repeat flag, and sink-propagate the initializer expression in
`VarDeclaration::Constant.PERFORM-BEGIN` so StatementList can mark non-final statements as sunk before BEGIN-time evaluation runs.

The `NativeHelpers::Blob` ecosystem module hits both gaps: its `constant Offset = do { ...; repeat { ... } while ar[$i] != p; $i * ptrsize }` never advances past the first iteration without the repeat flag, and the preceding sink miss leaves the iteration as a lazy Seq even after the flag lands.