### PR TITLE
Add an optimize phase to the RakuAST frontend

### DIFF
--- a/src/Perl6/Compiler.nqp
+++ b/src/Perl6/Compiler.nqp
@@ -234,6 +234,17 @@ class Perl6::Compiler is HLL::Compiler {
         $super(self, |@args, |%options);
     }
 
+    # The stage whose output is the finished QAST tree. Compilation that
+    # starts with an already-built QAST tree passes this as the :from stage.
+    # The legacy frontend produces its final QAST in its optimize stage, the
+    # RakuAST frontend in its qast stage (src/main.nqp). This is keyed on the
+    # qast stage so that a frontend can grow a stage named optimize without
+    # changing the answer, and so a change to either pipeline has a single
+    # definition to update.
+    method qast-stage() {
+        self.exists_stage('qast') ?? 'qast' !! 'optimize'
+    }
+
     method optimize($past, *%adverbs) {
         # Apply optimizations.
         my $result := %adverbs<optimize> eq 'off'

--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -547,6 +547,17 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
         $COMPUNIT.check($RESOLVER);
         self.report-problems();
 
+        # Have optimize time, unless the optimize option turns it off. With it
+        # off, --target=ast also shows the tree as parsed and checked, before
+        # any optimization rewrites it.
+        my %compiling := nqp::getlexdyn('%*COMPILING');
+        my $optimize := nqp::isnull(%compiling)
+            ?? NQPMu
+            !! nqp::atkey(nqp::ifnull(nqp::atkey(%compiling, '%?OPTIONS'), nqp::hash()), 'optimize');
+        unless nqp::defined($optimize) && ($optimize eq 'off' || $optimize eq '0') {
+            $COMPUNIT.optimize($RESOLVER);
+        }
+
         $RESOLVER.leave-scope();
     }
 

--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -672,7 +672,7 @@ class RakuAST::Node {
     method IMPL-OPTIMIZE-EXPRESSION(RakuAST::Resolver $resolver, Mu $expr) {
         return $expr unless nqp::isconcrete($expr);
 
-        my $result := $expr;
+        my $result := self.IMPL-FOLD-CONSTANT($resolver, $expr);
 
         # A replacement stands where the original stood, so it must carry the
         # original's sunk state for any sink-sensitive code generation.
@@ -682,6 +682,20 @@ class RakuAST::Node {
             $result.mark-sunk();
         }
         $result
+    }
+
+    # Whether an expression may serve as an operand for compile-time
+    # evaluation: a literal, an enumeration value such as True, or a quoted
+    # string whose value is known at compile time, which is how a plain string
+    # literal parses. Any of these holds no variable reference, so replacing
+    # it cannot orphan a lowered lexical.
+    method IMPL-FOLDABLE-OPERAND(Mu $operand) {
+        nqp::isconcrete($operand)
+          && (nqp::istype($operand, RakuAST::Literal)
+               || (nqp::istype($operand, RakuAST::QuotedString)
+                    || nqp::istype($operand, RakuAST::Term::Enum))
+                  && $operand.has-compile-time-value)
+            ?? 1 !! 0
     }
 
     # Whether a branch can be removed from the tree. The running program would
@@ -703,6 +717,164 @@ class RakuAST::Node {
         $droppable
     }
 
+    # Constant folding. Given a child expression, if it is a pure operator
+    # applied to constant operands, evaluate it now and return a
+    # RakuAST::Literal holding the result. Otherwise the expression is
+    # returned unchanged. Operands must satisfy IMPL-FOLDABLE-OPERAND (never
+    # variables, even constant ones) so folding never removes a variable
+    # reference, which keeps the later lexical-to-local lowering consistent.
+    # The optimize walk is post-order, so a nested operator that has already
+    # folded is itself a literal here, and nested constant arithmetic folds
+    # up. Evaluation is guarded: a throw keeps the original runtime behaviour,
+    # one-shot or failure-like results are not folded, and folding is declined
+    # before the guard types are available (early bootstrap).
+    method IMPL-FOLD-CONSTANT(RakuAST::Resolver $resolver, Mu $expr) {
+        return $expr unless nqp::isconcrete($expr);
+
+        # Grouping parentheses around a single constant are transparent, so a
+        # parenthesized literal folds into the expression that holds it.
+        my $unparen := self.IMPL-FOLD-PARENS($expr);
+        return $unparen unless $unparen =:= $expr;
+
+        my int $foldable := 0;
+        if nqp::istype($expr, RakuAST::ApplyInfix) {
+            my $infix := $expr.infix;
+            # A chaining comparison (a < b < c) means (a < b) && (b < c), so it
+            # reuses the middle operand and is not the binary operation its
+            # nesting suggests. Folding the inner comparison to a literal would
+            # drop that operand and change the result, so chaining infixes are
+            # left for runtime.
+            $foldable := nqp::istype($infix, RakuAST::Infix)
+                && $infix.is-resolved
+                && self.IMPL-PURE-ROUTINE($infix)
+                && !$infix.properties.chain
+                && !nqp::isconcrete($expr.args.arg-at-pos(2))
+                && self.IMPL-FOLDABLE-OPERAND($expr.left)
+                && self.IMPL-FOLDABLE-OPERAND($expr.right);
+        }
+        elsif nqp::istype($expr, RakuAST::ApplyPrefix) {
+            my $prefix := $expr.prefix;
+            # An adverb on the operator (zpre 4 :x(5)) is a named argument the
+            # interpreter does not pass on, so an operator carrying one is left
+            # for runtime. The infix case is covered by the arg-at-pos check
+            # above, which sees the adverb as a further argument.
+            $foldable := nqp::istype($prefix, RakuAST::Prefix)
+                && $prefix.is-resolved
+                && self.IMPL-PURE-ROUTINE($prefix)
+                && nqp::elems($prefix.colonpairs) == 0
+                && self.IMPL-FOLDABLE-OPERAND($expr.operand);
+        }
+        elsif nqp::istype($expr, RakuAST::ApplyListInfix) {
+            my $infix := $expr.infix;
+            # The comma is skipped without evaluating: it is marked pure, but
+            # its list result would only be declined by the Iterable guard
+            # below, after building a list for every literal list in the
+            # program.
+            if nqp::istype($infix, RakuAST::Infix)
+              && $infix.operator ne ','
+              && $infix.is-resolved
+              && self.IMPL-PURE-ROUTINE($infix)
+              && !$infix.properties.chain
+              && nqp::elems(nqp::getattr($expr, RakuAST::ApplyListInfix, '$!adverbs')) == 0 {
+                my @operands := self.IMPL-UNWRAP-LIST($expr.operands);
+                if nqp::elems(@operands) {
+                    $foldable := 1;
+                    for @operands {
+                        $foldable := 0 unless self.IMPL-FOLDABLE-OPERAND($_);
+                    }
+                }
+            }
+        }
+        return $expr unless $foldable;
+
+        # Evaluation and the value checks rely on setting types, so during
+        # early bootstrap, before Failure resolves, folding declines.
+        return $expr
+            if nqp::isnull(self.IMPL-OPTIMIZE-SETTING-TYPE($resolver, 'Failure'));
+
+        my @result := self.IMPL-CONSTANT-FOLD-EVALUATE($expr);
+        return $expr unless @result[0];
+        my $value := @result[1];
+        return $expr unless self.IMPL-FOLDABLE-VALUE($resolver, $value);
+
+        my $literal := RakuAST::Literal.from-value($value);
+        $literal.set-origin($expr.origin) if nqp::isconcrete($expr.origin);
+        $literal
+    }
+
+    # Interpret the expression at compile time, returning a (success, value)
+    # pair. A throw means folding is declined and the original runtime behaviour
+    # is kept. The handler is a block here rather than nqp::handle, which does
+    # not lower cleanly in this source.
+    method IMPL-CONSTANT-FOLD-EVALUATE(Mu $expr) {
+        CATCH {
+            return nqp::list(0, nqp::null);
+        }
+        nqp::list(1, $expr.IMPL-INTERPRET(RakuAST::IMPL::InterpContext.new))
+    }
+
+    # Whether a resolved operator's routine carries the `is pure` trait, the
+    # declaration that calling it with the same arguments always gives the same
+    # result and has no side effects. The trait mixes in an is-pure method, so
+    # its presence is the signal, the same one the legacy optimizer uses. Only
+    # such a routine may be evaluated at compile time. The operator node's own
+    # is-pure is a name table that claims purity for any unknown operator, which
+    # is fine for the sink warnings it serves but must not license running a
+    # user-defined routine during compilation.
+    method IMPL-PURE-ROUTINE(Mu $operator) {
+        # Asking a resolution without a compile-time value, the way an
+        # operator bound to a lexical variable resolves, throws. Declining
+        # keeps such operators at runtime.
+        CATCH {
+            return 0;
+        }
+        my $routine := $operator.resolution.compile-time-value;
+        nqp::can($routine, 'is-pure') ?? 1 !! 0
+    }
+
+    # Whether a computed value is reasonable to embed in the compilation
+    # unit. Each restriction carries its own explanation, and a new one
+    # belongs here with the same treatment.
+    method IMPL-FOLDABLE-VALUE(RakuAST::Resolver $resolver, Mu $value) {
+        CATCH {
+            return 0;
+        }
+
+        # A Failure stands for an error the runtime raises where the value
+        # is used, so it stays a runtime result. It is marked handled before
+        # declining, since an unused Failure warns when it is destroyed.
+        my $Failure := self.IMPL-OPTIMIZE-SETTING-TYPE($resolver, 'Failure');
+        if !nqp::isnull($Failure) && nqp::istype($value, $Failure) {
+            $value.Bool;
+            return 0;
+        }
+
+        # An Iterable result is potentially lazy or one-shot, so consuming
+        # it at compile time would not preserve the program.
+        my $Iterable := self.IMPL-OPTIMIZE-SETTING-TYPE($resolver, 'Iterable');
+        return 0 if !nqp::isnull($Iterable) && nqp::istype($value, $Iterable);
+
+        # An oversized string stays a runtime computation: the runtime can
+        # represent an enormous repetition cheaply, while a folded constant
+        # is serialized flattened with the unit. This serves the same
+        # purpose as the QAST optimizer's refusal to fold the x operator on
+        # a large count, but measures the result rather than that one
+        # operator's arguments, so any route to an oversized string
+        # declines. The probes stay cheap at any size: the grapheme count
+        # does not flatten a repetition strand, and the codepoint count,
+        # which catches a repetition of bare combiners that is few graphemes
+        # but arbitrarily many codepoints, only runs on strings the grapheme
+        # limit already passed. 1024 is the threshold the QAST optimizer's
+        # own check uses, described there as just a heuristic rather than a
+        # measured boundary, and a larger value may well be fine.
+        if nqp::istype($value, Str) {
+            my str $str := nqp::unbox_s($value);
+            return 0 if nqp::chars($str) > 1024 || nqp::codes($str) > 1024;
+        }
+
+        1
+    }
+
     # Resolve a setting type by name for use as an optimization guard, or return
     # null when it is not available. A null result is how a compile-time rewrite
     # detects early bootstrap, where the type it would test against does not yet
@@ -712,6 +884,28 @@ class RakuAST::Node {
         nqp::isconcrete($decl) && nqp::can($decl, 'compile-time-value')
             ?? $decl.compile-time-value
             !! nqp::null
+    }
+
+    # If the expression is grouping parentheses around a single constant with
+    # no statement modifier, return that constant. Otherwise return the
+    # expression unchanged. A multi-element or comma list does not qualify, so
+    # list parentheses are left alone. The optimize walk is post-order, so a
+    # parenthesized constant expression has already folded by the time this
+    # runs.
+    method IMPL-FOLD-PARENS(Mu $expr) {
+        return $expr unless nqp::istype($expr, RakuAST::Circumfix::Parentheses);
+        # Some constructs build grouping parentheses around a bare expression
+        # rather than a semilist, such as a regex assertion's argument, so the
+        # payload's shape is checked rather than assumed.
+        my $semilist := $expr.semilist;
+        return $expr unless nqp::istype($semilist, RakuAST::SemiList)
+            && $semilist.IMPL-IS-SINGLE-EXPRESSION;
+        my $statement := self.IMPL-UNWRAP-LIST($semilist.statements)[0];
+        return $expr
+            if nqp::isconcrete($statement.condition-modifier)
+            || nqp::isconcrete($statement.loop-modifier);
+        my $inner := $statement.expression;
+        self.IMPL-FOLDABLE-OPERAND($inner) ?? $inner !! $expr
     }
 }
 

--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -205,6 +205,69 @@ class RakuAST::Node {
         Nil
     }
 
+    # Drives the optimize phase, an AST-to-AST pass that runs after check (which
+    # only analyses) and before QAST generation. The walk is post-order: a
+    # node's children are optimized before the node itself. Each child the node
+    # visits is then offered to IMPL-OPTIMIZE-EXPRESSION and a differing result
+    # replaces the child in place, so every node that exposes a child through
+    # visit-children gets the expression-level optimizations without any code
+    # of its own. A node may be replaced by its parent this way, never by
+    # itself. The resolver tracks scopes and packages the same way the check
+    # walk does, so a rewrite may resolve names in the scope of the node it is
+    # looking at. The replacement pass for a node's children runs in the scope
+    # the node lives in, not the scope it defines.
+    method IMPL-OPTIMIZE(RakuAST::Resolver $resolver) {
+        my int $is-scope := nqp::istype(self, RakuAST::LexicalScope);
+        my int $is-package := nqp::istype(self, RakuAST::Package);
+        $resolver.push-scope(self) if $is-scope;
+        $resolver.push-package(self) if $is-package;
+        self.visit-children(-> $child { $child.IMPL-OPTIMIZE($resolver) });
+        $resolver.pop-scope() if $is-scope;
+        $resolver.pop-package() if $is-package;
+
+        my @children;
+        self.visit-children(-> $child { nqp::push(@children, $child) });
+        for @children -> $child {
+            my $result := self.IMPL-OPTIMIZE-EXPRESSION($resolver, $child);
+            self.IMPL-REPLACE-CHILD($child, $result) unless $result =:= $child;
+        }
+        Nil
+    }
+
+    # Replace a directly held child node with another node, locating the slot
+    # that holds it by identity: any object attribute bound to the child, and
+    # any element of any list attribute. All occurrences are replaced. A child
+    # that is visited but not stored on the node itself (for example one a
+    # visit reaches through a computed value) has no slot to find, and the
+    # replacement is then quietly skipped, which only costs the rewrite.
+    method IMPL-REPLACE-CHILD(Mu $old, Mu $new) {
+        # The scan introspects every node class the walk meets, so a surprise
+        # from an unusual meta-object must not break compilation. Skipping the
+        # replacement only costs the rewrite.
+        CATCH {
+            return Nil;
+        }
+        for self.IMPL-UNWRAP-LIST(self.HOW.mro(self)) -> $class {
+            for self.IMPL-UNWRAP-LIST($class.HOW.attributes($class, :local)) -> $attr {
+                next if nqp::objprimspec($attr.type);
+                my $value := nqp::getattr(self, $class, $attr.name);
+                if nqp::eqaddr($value, $old) {
+                    nqp::bindattr(self, $class, $attr.name, $new);
+                }
+                elsif nqp::islist($value) {
+                    my int $i := 0;
+                    my int $n := nqp::elems($value);
+                    while $i < $n {
+                        nqp::bindpos($value, $i, $new)
+                            if nqp::eqaddr(nqp::atpos($value, $i), $old);
+                        $i++;
+                    }
+                }
+            }
+        }
+        Nil
+    }
+
     method IMPL-QAST-NESTED-BLOCK-DECLS(RakuAST::IMPL::QASTContext $context) {
         my $stmts := QAST::Stmts.new;
         my @code-todo := [self];
@@ -590,6 +653,65 @@ class RakuAST::Node {
     # If has-compile-time-value is True, the node must also have a maybe-compile-time-value method.
     method has-compile-time-value() {
         False
+    }
+
+    # Optimize a child expression, returning a node to use in its place (the
+    # same node if nothing applies). The optimize walk offers every visited
+    # child to this method, and this is where the expression-level
+    # optimizations are registered. Each is tried in turn and declines by
+    # returning its input unchanged. The walk is post-order, so a child's own
+    # subexpressions are already optimized when this runs.
+    # A rewrite added here must honour three rules so it stays correct in every
+    # context the phase runs in, including CORE setting compilation. It declines,
+    # returning its input, whenever it is not certain the change preserves the
+    # value. If it evaluates anything at compile time it resolves a setting type
+    # with IMPL-OPTIMIZE-SETTING-TYPE first and declines when that is null, since
+    # during early bootstrap the machinery it relies on is not ready. And it
+    # removes a subtree only when IMPL-DROPPABLE is true of it, so a
+    # declaration's lexical effect is never lost.
+    method IMPL-OPTIMIZE-EXPRESSION(RakuAST::Resolver $resolver, Mu $expr) {
+        return $expr unless nqp::isconcrete($expr);
+
+        my $result := $expr;
+
+        # A replacement stands where the original stood, so it must carry the
+        # original's sunk state for any sink-sensitive code generation.
+        if !($result =:= $expr)
+          && nqp::istype($expr, RakuAST::Sinkable) && $expr.sunk
+          && nqp::istype($result, RakuAST::Sinkable) && !$result.sunk {
+            $result.mark-sunk();
+        }
+        $result
+    }
+
+    # Whether a branch can be removed from the tree. The running program would
+    # not evaluate a dropped branch, so its runtime code is safe to remove, but
+    # a declaration in it has a lexical effect that outlives the branch and must
+    # be kept, so a branch containing one is not dropped. The declaration test
+    # comes first because a node can be both a declaration and a scope, the way
+    # a named sub installs itself in the surrounding scope while its body is a
+    # scope of its own. A node that is only a lexical scope confines anything
+    # declared inside it, so there is no need to look further down.
+    method IMPL-DROPPABLE(Mu $node) {
+        return 1 unless nqp::isconcrete($node);
+        return 0 if nqp::istype($node, RakuAST::Declaration);
+        return 1 if nqp::istype($node, RakuAST::LexicalScope);
+        my int $droppable := 1;
+        $node.visit-children(-> $child {
+            $droppable := 0 unless self.IMPL-DROPPABLE($child);
+        });
+        $droppable
+    }
+
+    # Resolve a setting type by name for use as an optimization guard, or return
+    # null when it is not available. A null result is how a compile-time rewrite
+    # detects early bootstrap, where the type it would test against does not yet
+    # exist, and declines rather than acting on incomplete information.
+    method IMPL-OPTIMIZE-SETTING-TYPE(RakuAST::Resolver $resolver, str $name) {
+        my $decl := $resolver.resolve-lexical($name);
+        nqp::isconcrete($decl) && nqp::can($decl, 'compile-time-value')
+            ?? $decl.compile-time-value
+            !! nqp::null
     }
 }
 

--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -672,7 +672,11 @@ class RakuAST::Node {
     method IMPL-OPTIMIZE-EXPRESSION(RakuAST::Resolver $resolver, Mu $expr) {
         return $expr unless nqp::isconcrete($expr);
 
-        my $result := self.IMPL-FOLD-CONSTANT($resolver, $expr);
+        my $result := self.IMPL-COLLAPSE-TERNARY($resolver, $expr);
+
+        if $result =:= $expr {
+            $result := self.IMPL-FOLD-CONSTANT($resolver, $expr);
+        }
 
         # A replacement stands where the original stood, so it must carry the
         # original's sunk state for any sink-sensitive code generation.
@@ -682,6 +686,44 @@ class RakuAST::Node {
             $result.mark-sunk();
         }
         $result
+    }
+
+    # A ternary with a constant condition becomes the branch the condition
+    # selects. The branches are expressions, so the value is preserved, and the
+    # unselected branch is one the running program would not have evaluated.
+    method IMPL-COLLAPSE-TERNARY(RakuAST::Resolver $resolver, Mu $expr) {
+        return $expr unless nqp::istype($expr, RakuAST::Ternary);
+        my int $truth := self.IMPL-CONSTANT-TRUTH($resolver, $expr.condition);
+        return $expr if $truth < 0;
+        my $keep := $truth ?? $expr.then !! $expr.else;
+        my $drop := $truth ?? $expr.else !! $expr.then;
+        self.IMPL-DROPPABLE($drop) ?? $keep !! $expr
+    }
+
+    # Raku truth value of a node, or -1 when it cannot be determined safely.
+    # Folding only ever evaluates pure operators on foldable operands, while
+    # truthiness has to consider any constant, so this is deliberately narrow:
+    # the value must be a concrete Cool or Bool, whose .Bool is pure and
+    # well-defined. Type objects (not concrete) are declined, since a type used
+    # here is not the instance the running program would test. Resolving the
+    # guard types also declines during early bootstrap, before they are
+    # available.
+    method IMPL-CONSTANT-TRUTH(RakuAST::Resolver $resolver, Mu $expr) {
+        return -1 unless $expr.has-compile-time-value;
+        my $value := $expr.maybe-compile-time-value;
+        return -1 unless nqp::isconcrete($value);
+
+        my $Cool := self.IMPL-OPTIMIZE-SETTING-TYPE($resolver, 'Cool');
+        my $Bool := self.IMPL-OPTIMIZE-SETTING-TYPE($resolver, 'Bool');
+        return -1 if nqp::isnull($Cool) || nqp::isnull($Bool);
+        return -1 unless nqp::istype($value, $Cool) || nqp::istype($value, $Bool);
+
+        # A constant whose .Bool itself throws keeps that throw at runtime,
+        # where the program put it, so the collapse declines.
+        CATCH {
+            return -1;
+        }
+        nqp::istrue($value.Bool) ?? 1 !! 0
     }
 
     # Whether an expression may serve as an operand for compile-time

--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -675,6 +675,10 @@ class RakuAST::Node {
         my $result := self.IMPL-COLLAPSE-TERNARY($resolver, $expr);
 
         if $result =:= $expr {
+            $result := self.IMPL-COLLAPSE-SHORT-CIRCUIT($resolver, $expr);
+        }
+
+        if $result =:= $expr {
             $result := self.IMPL-FOLD-CONSTANT($resolver, $expr);
         }
 
@@ -697,6 +701,35 @@ class RakuAST::Node {
         return $expr if $truth < 0;
         my $keep := $truth ?? $expr.then !! $expr.else;
         my $drop := $truth ?? $expr.else !! $expr.then;
+        self.IMPL-DROPPABLE($drop) ?? $keep !! $expr
+    }
+
+    # A boolean short-circuit (&& and ||, or their loose forms `and` and `or`)
+    # with a constant left operand becomes the side the operator yields: an
+    # `and` gives the right side when the left is true and the left otherwise,
+    # an `or` the mirror. The dropped side is one the running program would not
+    # have evaluated, so its code is removed too.
+    method IMPL-COLLAPSE-SHORT-CIRCUIT(RakuAST::Resolver $resolver, Mu $expr) {
+        return $expr unless nqp::istype($expr, RakuAST::ApplyInfix);
+        my $infix := $expr.infix;
+        return $expr
+            unless nqp::istype($infix, RakuAST::Infix)
+            && $infix.is-resolved && $infix.short-circuit;
+        my str $op := $infix.operator;
+        my int $is-and := $op eq '&&' || $op eq 'and';
+        return $expr unless $is-and || $op eq '||' || $op eq 'or';
+
+        my $left  := $expr.left;
+        my $right := $expr.right;
+        return $expr unless nqp::isconcrete($left) && nqp::isconcrete($right);
+
+        my int $truth := self.IMPL-CONSTANT-TRUTH($resolver, $left);
+        return $expr if $truth < 0;
+
+        my $keep := $is-and
+            ?? ($truth ?? $right !! $left)
+            !! ($truth ?? $left  !! $right);
+        my $drop := $keep =:= $left ?? $right !! $left;
         self.IMPL-DROPPABLE($drop) ?? $keep !! $expr
     }
 

--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -435,9 +435,7 @@ class RakuAST::Code
             $wrapper
         );
         my $comp := $*HLL-COMPILER // nqp::getcomp("Raku");
-        # Legacy frontend registers `optimize`; RakuAST registers `qast`
-        # (src/main.nqp).  Pick whichever is present.
-        my $from := $comp.exists_stage('optimize') ?? 'optimize' !! 'qast';
+        my $from := $comp.qast-stage;
         my $precomp := $comp.compile($qast-compunit, :$from, :compunit_ok(1));
         my $mainline := $comp.backend.compunit_mainline($precomp);
         # Wire the wrapper's outer to the resolver's setting so :name lookups

--- a/src/Raku/ast/compunit.rakumod
+++ b/src/Raku/ast/compunit.rakumod
@@ -214,6 +214,13 @@ class RakuAST::CompUnit
         }
     }
 
+    # Run the optimize phase over the compilation unit. This is a transforming
+    # AST-to-AST pass, run after check and before QAST generation.
+    method optimize(RakuAST::Resolver $resolver) {
+        $!mainline.IMPL-OPTIMIZE($resolver);
+        self.IMPL-OPTIMIZE($resolver);
+    }
+
     # Add the AST for handling legacy doc generation, essentially:
     # INIT {
     #     use Pod::To::$type;

--- a/src/core.c/ForeignCode.rakumod
+++ b/src/core.c/ForeignCode.rakumod
@@ -100,6 +100,14 @@ $lang = 'Raku' if $lang eq 'perl6';
         if $resolver.has-compilation-errors {
             $resolver.produce-compilation-exception.throw;
         }
+        # Run the optimize phase the comp-unit action would run for parsed
+        # code, so a synthetic AST compiles the same way, honouring the
+        # process's optimize option just as the string form forwards it
+        # below. Note the phase rewrites the tree being EVALled in place,
+        # just as begin and check resolve and annotate it in place.
+        my $optimize-option = nqp::getcomp('Raku').cli-options<optimize> // '';
+        $comp-unit.optimize($resolver)
+            unless $optimize-option eq 'off' || $optimize-option eq '0';
         my $from := $compiler.qast-stage;
         my $qast-cu := $comp-unit.IMPL-TO-QAST-COMP-UNIT;
         my $context := $comp-unit.context;

--- a/src/core.c/ForeignCode.rakumod
+++ b/src/core.c/ForeignCode.rakumod
@@ -100,7 +100,7 @@ $lang = 'Raku' if $lang eq 'perl6';
         if $resolver.has-compilation-errors {
             $resolver.produce-compilation-exception.throw;
         }
-        my $from := $compiler.exists_stage('optimize') ?? 'optimize' !! 'qast';
+        my $from := $compiler.qast-stage;
         my $qast-cu := $comp-unit.IMPL-TO-QAST-COMP-UNIT;
         my $context := $comp-unit.context;
         # Run the qast-stage SC bookkeeping that AST EVAL otherwise skips.

--- a/src/vm/moar/dispatchers.nqp
+++ b/src/vm/moar/dispatchers.nqp
@@ -1984,7 +1984,7 @@ class ProxyReaderFactory {
 
         # Compile and return it.
         my $comp := nqp::getcomp('Raku');
-        $comp.compile($block, :from($comp.exists_stage('optimize') ?? 'optimize' !! 'qast'))
+        $comp.compile($block, :from($comp.qast-stage))
     }
 }
 my $PROXY-READERS := ProxyReaderFactory.new;

--- a/t/08-performance/10-rakuast-optimize-phase.t
+++ b/t/08-performance/10-rakuast-optimize-phase.t
@@ -1,0 +1,44 @@
+use lib <t/packages/Test-Helpers>;
+use Test::Helpers;
+use Test;
+use experimental :rakuast;
+
+plan 5;
+
+# The optimize phase transforms the tree between check and QAST generation.
+# These tests cover where the phase runs and how it is turned off, with
+# constant folding as the observable rewrite.
+
+# The compilation tree shows the rewrite, and --optimize=off prevents it.
+# The --target=ast dump is a RakuAST frontend observable, so the children
+# are pinned to that frontend.
+{
+    temp %*ENV<RAKUDO_RAKUAST> = '1';
+    is-run 'my $x = 2 + 3', 'the compilation tree holds no operator application',
+        :compiler-args['--target=ast'], :out({ not .contains('ApplyInfix') });
+    is-run 'my $x = 2 + 3', '--optimize=off leaves the operator in the tree',
+        :compiler-args['--optimize=off', '--target=ast'], :out(*.contains('ApplyInfix'));
+}
+
+# A synthetic AST compiled with EVAL goes through the phase too. The phase
+# rewrites the tree in place, the same way begin and check annotate it in
+# place, so after EVAL the tree holds the literal.
+{
+    my $ast = RakuAST::StatementList.new(
+        RakuAST::Statement::Expression.new(expression => RakuAST::ApplyInfix.new(
+            left  => RakuAST::IntLiteral.new(2),
+            infix => RakuAST::Infix.new('+'),
+            right => RakuAST::IntLiteral.new(3))));
+    is $ast.EVAL, 5, 'a synthetic AST EVALs to the right value';
+    ok $ast.DEPARSE.contains('5'), 'EVAL runs the optimize phase over a synthetic tree';
+}
+
+# The same program runs identically with and without optimization.
+{
+    my $prog = 'say 7 ** -1; say 1 ?? "then" !! "else"; say (False || 42); say (2 ** 10).Str';
+    my $on  = (run $*EXECUTABLE, '-e', $prog, :out).out.slurp(:close);
+    my $off = (run $*EXECUTABLE, '--optimize=off', '-e', $prog, :out).out.slurp(:close);
+    is $on, $off, 'optimized and unoptimized runs produce identical output';
+}
+
+# vim: expandtab shiftwidth=4

--- a/t/08-performance/11-rakuast-constant-folding.t
+++ b/t/08-performance/11-rakuast-constant-folding.t
@@ -1,0 +1,118 @@
+use lib <t/packages/Test-Helpers>;
+use Test::Helpers;
+use Test;
+use experimental :rakuast;
+
+plan 39;
+
+# Constant folding rewrites a pure operator on constant operands into the
+# literal result. Each scenario asserts the shape of the tree the program
+# compiles to, through Str.AST, which runs the same parse, check, and
+# optimize the compiler runs. The decline scenarios assert the operator
+# survives where folding must not happen.
+my sub tree(Str $source) { $source.AST.DEPARSE }
+
+# Operators fold across types and precedence.
+ok tree(Q[my $y = 2 + 3]).contains('= 5'),          'integer arithmetic folds';
+ok tree(Q[my $y = 2 * 3 + 4]).contains('= 10'),     'nested operators fold up the chain';
+ok tree(Q[my $y = 10 - 2 ** 3]).contains('= 2'),    'mixed precedence folds';
+ok tree(Q[my $y = -2 * 5]).contains('= -10'),       'a negated literal folds';
+ok tree(Q[my $y = 6 +& 3]).contains('= 2'),         'a bitwise operator folds';
+ok tree(Q[my $y = "ab" ~ "cd"]).contains('"abcd"'), 'string concatenation folds';
+{
+    my $t = tree(Q[my $y = 2 min 3]);
+    ok $t.contains('= 2'), 'a list-associative operator folds';
+    nok $t.contains('min'), 'the folded list-associative operator is gone from the tree';
+}
+ok tree(Q[my $j = 1 | 2]).contains('any(1, 2)'),    'a junction constructor folds to a junction';
+ok tree(Q[my $y = !True]).contains('False'),        'a prefix on an enumeration value folds';
+ok tree(Q[my $y = 7 ** -1]) ~~ / '¹/₇' | '<1/7>' /, 'a negative power folds to a Rat';
+ok tree(Q[my $y = 3 / 4]).contains('= 0.75'),       'integer division folds to a Rat';
+{ my $y = 3 / 4; isa-ok $y, Rat, 'a folded division still produces a Rat at runtime'; }
+
+# Folding reaches every expression position.
+ok tree(Q[my $s = (2 ** 10).Str]).contains('1024.Str'),         'a method call invocant folds';
+ok tree(Q[my $p = (status => 6 * 7)]).contains('status => 42'), 'a pair value folds';
+ok tree(Q[my $x = do { 100 - 1 }]).contains('99'),              'a block final value folds';
+ok tree(Q[say "x" if 2 ** 3]).contains('if 8'),                 'a statement modifier condition folds';
+ok tree(Q[my @a = [2 + 3, 4 * 5]]).contains('[5, 20]'),         'array composer elements fold';
+ok tree(Q[my @a; @a[2 + 3]]).contains('[5]'),                   'an index expression folds';
+ok tree(Q[sub f($x = 2 + 3) { }]).contains('= 5'),              'a parameter default folds';
+ok tree(Q[my $x = 5 * 3 + (2 ** 2) - 10 + 2 * 5]).contains('= 19'),
+    'parenthesized constants fold into the enclosing expression';
+ok tree(Q[my $x = ((2 ** 3))]).contains('= 8'),                 'nested grouping parentheses fold';
+ok tree(Q[my int $i = 3 * 4]).contains('= 12'),                 'a native int initializer folds';
+{ my int $i = 3 * 4; is $i, 12, 'a folded native int initializer widens correctly'; }
+
+# Folding declines where the rewrite would not preserve the program.
+ok tree(Q[my $a = 5; my $y = $a + 3]).contains('$a + 3'),
+    'a variable operand keeps the runtime computation';
+ok tree(Q[my $c = 1 < 2 < 2]).contains('1 < 2 < 2'),
+    'a chained comparison is not mis-folded as binary operations';
+ok tree(Q[my @a = (1, 2, 3)]).contains('(1, 2, 3)'),
+    'list parentheses are not mistaken for a foldable value';
+
+# A constant string repetition folds only when the result is small enough to
+# embed in the compilation unit.
+ok tree(Q[my $y = "ab" x 3]).contains('"ababab"'), 'a small string repetition folds';
+ok tree(Q[my str $a = "a" x 2**32-1]).contains(' x '),
+    'an enormous string repetition is left for runtime';
+
+# Division by zero folds to the same zero-denominator Rat the runtime
+# produces, whose use throws just as the unfolded expression would.
+ok tree(Q[my $y = 1 / 0]) ~~ / '¹/₀' | '<1/0>' /, 'division by zero folds to a zero-denominator Rat';
+{ my $y = 1 / 0; dies-ok { $y.Str }, 'using a folded zero-denominator Rat throws' }
+
+# Declining a Failure result, the way 1 div 0 produces one, marks it handled
+# so compiling the program stays warning free.
+is-run 'my $y = 1 div 0; print "compiled"', 'a declined Failure does not warn at compile time',
+    :out<compiled>, :err('');
+
+# A throw during compile-time evaluation declines the fold, keeping the
+# throw at runtime where the program put it.
+{
+    sub infix:<zdie>($a, $b) is pure { die "zdie reached runtime" }
+    my $threw = False;
+    my $y = do { 1 zdie 2; CATCH { default { $threw = True } } };
+    ok $threw, 'a throwing pure operator is left to throw at runtime';
+}
+
+# An operator bound to a lexical variable resolves to a declaration with no
+# compile-time value, so folding declines and the runtime binding is used.
+ok tree(Q[my &infix:<zlex> = sub ($a, $b) { $a + $b }; my $y = 1 zlex 2]).contains('1 zlex 2'),
+    'an operator bound to a lexical variable is left for runtime';
+
+# Only a routine marked is pure may run at compile time. An unmarked
+# user-defined operator runs at runtime: if it were folded, the call would
+# run during compilation against the not-yet-initialized counter and the
+# runtime count would be zero.
+{
+    my $count = 0;
+    sub infix:<zimpure>($a, $b) { $count++; $a + $b }
+    is (4 zimpure 5), 9, 'an unmarked user-defined operator gives the right value';
+    is $count, 1, 'an unmarked user-defined operator runs at runtime';
+}
+
+# A wrapped pure operator still gives the original result for literal
+# operands, because the call was folded away before the wrap took effect at
+# runtime.
+{
+    sub infix:<zshape>($a, $b) is pure { $a + $b }
+    &infix:<zshape>.wrap(-> $a, $b { 999 });
+    is (2 zshape 3), 5, 'an is pure operator on literals is evaluated at compile time';
+}
+
+# An adverb on the operator is a named argument folding would drop, so even
+# a pure operator carrying one is left for runtime.
+{
+    sub prefix:<zfold>($a, :$x) is pure { join(",", $a, $x // "U") }
+    is (zfold 4 :x(5)), '4,5', 'a pure prefix operator with an adverb keeps its adverb';
+}
+
+# The unoptimized tree still holds the operator, so the scenarios above are
+# known to be testing the optimizer rather than something upstream.
+is-run 'use experimental :rakuast; print Q[my $x = 2 + 3].AST.DEPARSE',
+    'without optimization the operator survives',
+    :compiler-args['--optimize=off'], :out(*.contains('2 + 3'));
+
+# vim: expandtab shiftwidth=4

--- a/t/08-performance/12-rakuast-collapse-ternary.t
+++ b/t/08-performance/12-rakuast-collapse-ternary.t
@@ -1,0 +1,35 @@
+use lib <t/packages/Test-Helpers>;
+use Test::Helpers;
+use Test;
+use experimental :rakuast;
+
+plan 7;
+
+# A ternary with a constant condition collapses to the branch the condition
+# selects. Each scenario asserts the shape of the tree the program compiles
+# to, through Str.AST, which runs the same parse, check, and optimize the
+# compiler runs.
+my sub tree(Str $source) { $source.AST.DEPARSE }
+
+ok tree(Q[my $x = 1 ?? 10 !! 20]).contains('= 10'),
+    'a true constant condition selects the then branch';
+ok tree(Q[my $x = 0 ?? 10 !! 20]).contains('= 20'),
+    'a false constant condition selects the else branch';
+ok tree(Q[my $x = "0" ?? "t" !! "f"]).contains('= "t"'),
+    'the condition uses Raku truthiness, where a non-empty string is true';
+
+# The collapse declines when the condition's truth is not a known constant.
+ok tree(Q[my $x = Int ?? "t" !! "f"]).contains('??'),
+    'a type object condition is left for runtime';
+ok tree(Q[my $a = 1; my $x = $a ?? "t" !! "f"]).contains('??'),
+    'a runtime condition is left for runtime';
+ok tree(Q[my constant C = class :: is Cool { method Bool { die } }.new; my $x = C ?? 1 !! 2]).contains('??'),
+    'a condition whose truthiness throws is left for runtime';
+
+# The unoptimized tree still holds the ternary, so the scenarios above are
+# known to be testing the optimizer rather than something upstream.
+is-run 'use experimental :rakuast; print Q[my $x = 1 ?? 10 !! 20].AST.DEPARSE',
+    'without optimization the ternary survives',
+    :compiler-args['--optimize=off'], :out(*.contains('??'));
+
+# vim: expandtab shiftwidth=4

--- a/t/08-performance/13-rakuast-collapse-short-circuit.t
+++ b/t/08-performance/13-rakuast-collapse-short-circuit.t
@@ -1,0 +1,48 @@
+use lib <t/packages/Test-Helpers>;
+use Test::Helpers;
+use Test;
+use experimental :rakuast;
+
+plan 12;
+
+# A boolean short-circuit with a constant left operand collapses to the side
+# the operator yields, and the dropped side's code is removed. Each scenario
+# asserts the shape of the tree the program compiles to, through Str.AST,
+# which runs the same parse, check, and optimize the compiler runs.
+my sub tree(Str $source) { $source.AST.DEPARSE }
+
+ok tree(Q[my $y = True && 7]).contains('= 7'),
+    'a true left operand of && yields the right side';
+{
+    my $t = tree(Q[sub e() {9}; my $y = False && e()]);
+    ok $t.contains('= False'), 'a false left operand of && yields itself';
+    nok $t.contains('&&'), 'the dropped side is gone from the tree';
+}
+{
+    my $t = tree(Q[sub e() {9}; my $y = 5 || e()]);
+    ok $t.contains('= 5'), 'a true left operand of || yields itself';
+    nok $t.contains('||'), 'the dropped side of || is gone from the tree';
+}
+ok tree(Q[my $y = (True and 7)]).contains('= 7'),
+    'the loose form and collapses the same way';
+ok tree(Q[my $y = (False or 7)]).contains('= 7'),
+    'the loose form or collapses the same way';
+
+# The collapse declines when the left operand's truth is not a known
+# constant, or when dropping the other side would lose a declaration.
+ok tree(Q[my $a = 1; my $y = $a && 7]).contains('&&'),
+    'a runtime left operand is left for runtime';
+ok tree(Q[my $y = False && (my $x = 5)]).contains('&&'),
+    'a side holding a declaration keeps the branch';
+nok tree(Q[my $y = False && do { my $t = 5; $t }]).contains('do'),
+    'a side whose declarations are confined to a block of its own is dropped';
+ok tree(Q[my $y = False && sub zkeep($a) { $a }]).contains('sub'),
+    'a side declaring a named sub is kept';
+
+# The unoptimized tree still holds the operator, so the scenarios above are
+# known to be testing the optimizer rather than something upstream.
+is-run 'use experimental :rakuast; print Q[my $y = True && 7].AST.DEPARSE',
+    'without optimization the short-circuit survives',
+    :compiler-args['--optimize=off'], :out(*.contains('&&'));
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
The RakuAST frontend goes straight from check to QAST generation, so unlike the legacy frontend there is no place to apply any optimizations (the roadmap calls this out as [step 6](https://github.com/rakudo/rakudo/blob/e78c5a7e672786e5ae658a50cda8515798b04ea9/src/Raku/ast/README.md?plain=1#L29)). This adds that phase along with a few initial optimizations to flesh it out, and is intended to be the starting point the RakuAST optimizer grows from.

The phase is an AST-to-AST pass that runs after check and before QAST generation. It walks the tree post-order and offers every child a node visits to a single dispatch point where the optimizations are registered, replacing the child in place when a rewrite applies. The replacement mechanism locates the slot holding a child via attribute introspection, so coverage is structural: any expression position a node exposes through `visit-children` gets all of the optimizations without needing code of its own. The phase runs for parsed code and for the AST form of `EVAL`, and `--optimize=off` disables it (which also makes `--target=ast` show the tree before any rewrites).

The initial optimizations:

* constant folding: a pure operator (infix, prefix, or list-associative infix) applied to constant operands is evaluated at compile time and replaced with a literal holding the result, e.g. `my $x = 2 ** 10` compiles as `my $x = 1024`
* constant ternary collapse: `my $x = 1 ?? "a" !! "b"` compiles as `my $x = "a"`
* constant short-circuit collapse: `my $x = False || 42` compiles as `my $x = 42`

Each rewrite declines unless it is certain the result preserves the program. Folding only evaluates routines that carry the `is pure` trait (the same signal the legacy optimizer uses) so an unmarked user-defined operator is never run at compile time. Operands must be constants rather than variables, chained comparisons and operators carrying adverbs are left for runtime, and a collapse never drops a branch holding a declaration. Everything also declines during early bootstrap, so the CORE settings build the same way they always have.

On some quick benchmarks the walk costs about 2% at compile time and nothing at runtime. Below are some naive benchmarks with and without these optimizations:

```
# constant folding, 2.6x (most of that is the ** call, which spesh does not eliminate)
time RAKUDO_RAKUAST=1 raku                -e 'my $s = 0; for ^10_000_000 { $s = $s + (2 ** 10 + 7 * 3 - 4) }; say $s'  # ~3.1s
time RAKUDO_RAKUAST=1 raku --optimize=off -e 'my $s = 0; for ^10_000_000 { $s = $s + (2 ** 10 + 7 * 3 - 4) }; say $s'  # ~8.1s

# ternary collapse, ~5%
time RAKUDO_RAKUAST=1 raku                -e 'my $s = 0; for ^50_000_000 { $s = $s + (0 ?? 999 !! 1) }; say $s'        # ~13.3s
time RAKUDO_RAKUAST=1 raku --optimize=off -e 'my $s = 0; for ^50_000_000 { $s = $s + (0 ?? 999 !! 1) }; say $s'        # ~13.9s

# short-circuit collapse, ~18%
time RAKUDO_RAKUAST=1 raku                -e 'my $s = 0; for ^50_000_000 { $s = $s + (False || 1) }; say $s'           # ~13.1s
time RAKUDO_RAKUAST=1 raku --optimize=off -e 'my $s = 0; for ^50_000_000 { $s = $s + (False || 1) }; say $s'           # ~16.0s
```

The two collapses bring their loops down to bare loop overhead. Their numbers are smaller than folding's because spesh already handles constant branches well at runtime.


There is plenty of room to grow from here. Meta operators, defined-or, and folding pure calls the way the legacy optimizer does are potential next steps. Probably easiest to review commit by commit.
