### PR TITLE
RakuAST: give onlystar bodies a source location

### DIFF
--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -2845,6 +2845,16 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
         self.attach: $/, $<method-def>.ast;
     }
 
+    # An onlystar body is created directly rather than through an action
+    # method of its own, so position information is attached here. The
+    # body's dispatch op is the only code in the proto's frame, making
+    # this origin the source of the code object's reported file and line.
+    method onlystar-body($/) {
+        my $body := Nodify('OnlyStar').new;
+        self.SET-NODE-ORIGIN($/, $body);
+        $body
+    }
+
     method routine-def($/) {
         my $routine := $*BLOCK;
 
@@ -2862,7 +2872,7 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
         }
 
         $routine.replace-body($<onlystar>
-          ?? Nodify('OnlyStar').new
+          ?? self.onlystar-body($<onlystar>)
           !! $<blockoid>
             ?? $<blockoid>.ast
             !! Nodify("Blockoid").new($<statementlist>.ast)  # unit sub MAIN
@@ -2891,7 +2901,7 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
             }
         }
         $method.replace-body($<onlystar>
-          ?? Nodify('OnlyStar').new
+          ?? self.onlystar-body($<onlystar>)
           !! $<blockoid>.ast
         );
         # Entering scope again to ensure implicits are attached to the method
@@ -2918,7 +2928,10 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
         if $<signature> {
             $regex.replace-signature($<signature>.ast);
         }
-        $regex.replace-body($<onlystar> ?? Nodify('OnlyStar').new !! $<nibble>.ast);
+        $regex.replace-body($<onlystar>
+          ?? self.onlystar-body($<onlystar>)
+          !! $<nibble>.ast
+        );
         # Entering scope again to ensure implicits are attached to the method
         $*R.enter-scope($regex);
         self.attach: $/, $regex;

--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -58,10 +58,21 @@ class RakuAST::OnlyStar
     }
 
     method IMPL-EXPR-QAST(RakuAST::IMPL::QASTContext $context) {
-        QAST::Op.new(
-            :op('dispatch'),
-            QAST::SVal.new( :value('boot-resume') ),
-            QAST::IVal.new( :value(nqp::const::DISP_ONLYSTAR) ));
+        # The dispatch op is the only code in an onlystar body, and a
+        # frame's location, as reported by Code.file and Code.line, comes
+        # from its first annotation. Carry the origin on a statement node
+        # so the frame is annotated at all. Without one the location
+        # degrades to the bytecode file, which breaks consumers that
+        # recognize setting routines by the SETTING:: file prefix, the
+        # way Routine.IS-SETTING-ONLY-D does for the smartmatch
+        # dispatcher's junction handling.
+        self.IMPL-SET-NODE(
+            QAST::Stmts.new(
+                QAST::Op.new(
+                    :op('dispatch'),
+                    QAST::SVal.new( :value('boot-resume') ),
+                    QAST::IVal.new( :value(nqp::const::DISP_ONLYSTAR) ))),
+            :key);
     }
 
     method IMPL-REGEX-TOP-LEVEL-QAST(

--- a/t/02-rakudo/12-proto-location.t
+++ b/t/02-rakudo/12-proto-location.t
@@ -1,0 +1,23 @@
+use Test;
+
+plan 4;
+
+# A proto with an onlystar body compiles to a frame whose only code is the
+# dispatch instruction, so the code object's reported location comes from
+# the position attached to that body.
+proto sub zp(|) {*}
+multi sub zp() { 1 }
+
+is &zp.file.IO.absolute, $?FILE.IO.absolute,
+    'an onlystar proto reports the file it was declared in';
+is &zp.line, 8, 'an onlystar proto reports the line it was declared on';
+
+# The setting's own onlystar protos carry the SETTING:: file prefix that
+# Routine.IS-SETTING-ONLY-D relies on, which the smartmatch dispatcher
+# consults to keep junction autothreading on definite type matches.
+ok Str.^find_method('ACCEPTS').IS-SETTING-ONLY-D,
+    'the ACCEPTS proto is recognized as setting-only';
+is-deeply <a b c>.all ~~ Str:D, True,
+    'a junction smartmatched against a definite type autothreads';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
A proto's onlystar body compiles to a frame whose only code is the dispatch instruction, and that frame carried no location annotation. The OnlyStar node is created directly in the routine actions rather than through an action method of its own, so it never received an origin, and its QAST carried no node to annotate from. Code.file and Code.line on such a proto fell back to the bytecode file, and on the RakuAST frontend a user-defined proto reported a null file.

This also broke detection of setting routines when CORE is built with the RakuAST frontend. The setting build inserts #line directives that prefix locations with SETTING::, and Routine.IS-SETTING-ONLY-D checks candidates, including the proto, for that prefix. With the proto reporting the bytecode file the check failed for every core proto, and the raku-smartmatch dispatcher, which consults it to decide whether junction autothreading must be preserved when matching against a definite type, degraded `<a b c>.all ~~ Str:D` to a plain type check that answers False.

Attach the origin to the onlystar body in the routine, method, and regex actions, and have the body's QAST carry it as a statement node so the frame is annotated.