### PR TITLE
Another solution to fixing my %h is Set = 1,2,3

### DIFF
--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -2004,7 +2004,19 @@ class Perl6::World is HLL::World {
             else {
                 $new-ast := QAST::WVal.new( :value($cont_type) );
             }
-            my $ast := QAST::Op.new( :op('callmethod'), :name('new'), $new-ast );
+
+            # is Set/Bag/Mix need special handling to make sure their
+            # sentinel values for empty Set/Bag/Mix remain pristine
+            # see https://github.com/rakudo/rakudo/issues/6246
+            my $class := $new-ast.value;
+            my $ast := nqp::eqaddr(
+              $class, self.find_single_symbol_in_setting('Set')
+            ) || nqp::eqaddr(
+              $class, self.find_single_symbol_in_setting('Bag')
+            ) || nqp::eqaddr(
+              $class, self.find_single_symbol_in_setting('Mix')
+            ) ?? QAST::Op.new(:op<create>, $new-ast)
+              !! QAST::Op.new(:op<callmethod>, :name<new>, $new-ast );
             $ast.annotate('is-generic', $is-generic);
             $ast
         }

--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -1365,12 +1365,16 @@ class RakuAST::VarDeclaration::Simple
                     :value($container)
                 );
                 if self.IMPL-HAS-EXPLICIT-CONTAINER-BASE-TYPE {
-                    my $value := self.IMPL-CONTAINER-TYPE($of);
-                    $context.ensure-sc($value);
-                    $qast := QAST::Op.new( :op('bind'), $qast, QAST::Op.new(
-                        :op('callmethod'), :name('new'),
-                        QAST::WVal.new( :$value )
-                    ) );
+                    my $class := self.IMPL-CONTAINER-TYPE($of);
+                    my $wval  := QAST::WVal.new(:value($class));
+                    $context.ensure-sc($class);
+
+                    my str $name := $class.HOW.name($class); # XXX needs lookup solution
+                    $qast := QAST::Op.new( :op('bind'), $qast,
+                      $name eq 'Set' || $name eq 'Bag' || $name eq 'Mix'
+                        ?? QAST::Op.new(:op<create>, $wval)
+                        !! QAST::Op.new(:op<callmethod>, :name<new>, $wval)
+                    );
                 }
                 $qast
             }

--- a/src/core.c/Bag.rakumod
+++ b/src/core.c/Bag.rakumod
@@ -2,6 +2,15 @@ my class Bag does Baggy {
     has ValueObjAt $!WHICH;
     has Int        $!total;
 
+    # Make sure to return sentinel on empty Bags
+    multi method SETUP(Bag:U: \elems) {
+        nqp::not_i(nqp::elems(nqp::decont(elems))) && nqp::eqaddr(self,Bag)
+          ?? bag()
+          !! nqp::p6bindattrinvres(
+               nqp::create(self),Bag,'$!elems',nqp::decont(elems)
+             )
+    }
+
     method ^parameterize(Mu \base, Mu \type) {
         my \what := base.^mixin(QuantHash::KeyOf[type]);
         what.^set_name(

--- a/src/core.c/Mix.rakumod
+++ b/src/core.c/Mix.rakumod
@@ -3,6 +3,15 @@ my class Mix does Mixy {
     has Real       $!total;
     has Real       $!total-positive;
 
+    # Make sure to return sentinel on empty Mixes
+    multi method SETUP(Mix:U: \elems) {
+        nqp::not_i(nqp::elems(nqp::decont(elems))) && nqp::eqaddr(self,Mix)
+          ?? mix()
+          !! nqp::p6bindattrinvres(
+               nqp::create(self),Mix,'$!elems',nqp::decont(elems)
+             )
+    }
+
     method ^parameterize(Mu \base, Mu \type) {
         my \what := base.^mixin(QuantHash::KeyOf[type]);
         what.^set_name(

--- a/src/core.c/Set.rakumod
+++ b/src/core.c/Set.rakumod
@@ -1,6 +1,15 @@
 my class Set does Setty {
     has ValueObjAt $!WHICH;
 
+    # Make sure to return sentinel on empty Sets
+    multi method SETUP(Set:U: \elems) {
+        nqp::not_i(nqp::elems(nqp::decont(elems))) && nqp::eqaddr(self,Set)
+          ?? set()
+          !! nqp::p6bindattrinvres(
+               nqp::create(self),Set,'$!elems',nqp::decont(elems)
+             )
+    }
+
     method ^parameterize(Mu \base, Mu \type) {
         my \what := base.^mixin(QuantHash::KeyOf[type]);
         what.^set_name(


### PR DESCRIPTION
This effectively reverts e78c5a7e672786e5ae65 and adds logic to the codegenning to make sure "is Set", "is Bag" and "is Mix" are codegenned with `nqp::create(type)` rather then `type.new`.  This ensures that it will always create a new instance.  Then later the special versions of Set|Bag|Mix.STORE can return the sentinel safely after making sure there are indeed no elements created with the .STORE logic.

The RakuAST version is a bit iffy as I've been unable to come up with a way to check the actual types at that moment in QAST generation.  So it checks the name for now.  Fixes welcome!

Fixes #6246