### PR TITLE
RakuAST: streamline sigil -> role mapping

### DIFF
--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -165,16 +165,15 @@ class RakuAST::ContainerCreator {
     }
 
     method IMPL-SIGIL-LOOKUP() {
-        my $types := nqp::hash(
-            '@', 'Positional',
-            '%', 'Associative',
-            '&', 'Callable',
+        my constant SIGIL-LOOKUP := nqp::hash(
+          '@', 'Positional',
+          '%', 'Associative',
+          '&', 'Callable',
         );
-        my $sigil := self.sigil;
 
-        nqp::existskey($types, $sigil)
-            ?? RakuAST::Type::Setting.new(RakuAST::Name.from-identifier($types{$sigil}))
-            !! nqp::null
+        (my str $name := nqp::atkey(SIGIL-LOOKUP,self.sigil))
+          ?? RakuAST::Type::Setting.new(RakuAST::Name.from-identifier($name))
+          !! nqp::null
     }
 
     method IMPL-CALCULATE-TYPES(Mu $of, Mu :$key-type) {


### PR DESCRIPTION
Make the lookup hash a constant, and only look up the sigil once.

Sadly this is too early to make the hash contain RakuAST::Name objects, so we just keep the name and do the instantiation of RakuAST::Name when needed.