### PR TITLE
RakuAST: let nested string EVAL see the caller's lexicals

### DIFF
--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -318,7 +318,12 @@ class RakuAST::Code
                             QAST::Var.new(:scope<lexical>, :decl<static>, :$name, :$value)
                         );
                     }
-                    elsif $name ne '$_' { #TODO figure out why we specifially don't declare $_ in ExpressionThunks
+                    # The specials $_, $/, $! and $¢ live in a frame of the
+                    # calling code, but the declaration they resolve to
+                    # produces a fresh container as its compile-time value.
+                    # Skipping them keeps their references late-bound, so
+                    # the runtime lookup reaches the caller's container.
+                    elsif $name ne '$_' && $name ne '$/' && $name ne '$!' && $name ne '$¢' {
                         my $decl := $parse-time-resolver.resolve-lexical-constant($name);
                         if $decl {
                             $decl.to-begin-time($resolver, $context); # Ensure any required lookups are resolved

--- a/src/Raku/ast/resolver.rakumod
+++ b/src/Raku/ast/resolver.rakumod
@@ -1084,9 +1084,13 @@ class RakuAST::Resolver::Compile
         my $setting := $resolver
             ?? nqp::getattr($resolver, RakuAST::Resolver, '$!setting')
             !! self.IMPL-SETTING-FROM-CONTEXT($context);
+        # The cloned scopes of an enclosing compilation are consulted
+        # first, but lexicals living in an already-running caller frame
+        # (like $/ and $!) are only reachable through the runtime context
+        # chain, which also ends in the setting.
         self.new(
             :$setting,
-            :outer($resolver ?? $setting !! $context),
+            :outer($context),
             :$global,
             :scopes($resolver ?? nqp::clone(nqp::getattr($resolver, RakuAST::Resolver::Compile, '$!scopes')) !! Mu),
             :attach-targets($resolver ?? $resolver.IMPL-CLONE-ATTACH-TARGETS !! Mu),

--- a/t/02-rakudo/21-begin-time-eval-context.t
+++ b/t/02-rakudo/21-begin-time-eval-context.t
@@ -1,0 +1,51 @@
+use MONKEY-SEE-NO-EVAL;
+use Test;
+
+plan 9;
+
+# Each EVAL below runs at BEGIN time, while this file is still being
+# compiled, so the EVAL'd unit is nested inside the file's compilation.
+
+my $slash;
+BEGIN { "abc" ~~ /b/; $slash = EVAL Q[$/] }
+is $slash.Str, 'b', 'BEGIN-time string EVAL sees the caller $/';
+
+my $bang;
+BEGIN { try die "boom"; $bang = EVAL Q[$!] }
+is $bang.message, 'boom', 'BEGIN-time string EVAL sees the caller $!';
+
+my $topic;
+sub topic-read() { $_ = 42; EVAL Q[$_] }
+BEGIN { $topic = topic-read }
+is $topic, 42, 'BEGIN-time string EVAL sees the caller $_';
+
+my $assigned;
+sub topic-write() { $_ = 0; EVAL Q[$_ = 5]; $_ }
+BEGIN { $assigned = topic-write }
+is $assigned, 5, 'BEGIN-time string EVAL writes through to the caller $_';
+
+my $local;
+BEGIN { my $x = 99; $local = EVAL Q[$x] }
+is $local, 99, 'BEGIN-time string EVAL sees a lexical of the calling block';
+
+my $pkg;
+class PackageFromEval {
+    BEGIN { $pkg = EVAL Q[$?PACKAGE] }
+}
+ok $pkg === PackageFromEval, 'BEGIN-time string EVAL sees the caller $?PACKAGE';
+
+class OurVarFromEval {
+    BEGIN { EVAL Q[our $from-eval = 42] }
+}
+is OurVarFromEval::<$from-eval>, 42,
+    'our-scoped variable EVALed at BEGIN time lands in the caller package';
+nok GLOBAL::<$from-eval>:exists,
+    'our-scoped variable EVALed at BEGIN time does not leak into GLOBAL';
+
+class OurSubFromEval {
+    BEGIN { EVAL Q[our sub from-eval() { "made-in-eval" }] }
+}
+is OurSubFromEval::from-eval(), 'made-in-eval',
+    'our-scoped sub EVALed at BEGIN time lands in the caller package';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
A string EVAL that runs while another compilation is in progress (most commonly at BEGIN time) resolved `$/` and `$!` to fresh Nil containers instead of the caller's, could not see lexicals of the calling block at all, and sent our-scoped declarations to GLOBAL instead of the caller's package, dying "Object of type GLOBAL in QAST::WVal, but not in SC" for an our-scoped variable. The AST form of EVAL and the legacy frontend resolve all of these in the caller.

Resolver::Compile.from-context replaced the resolver's outer context chain with the setting whenever an outer resolver was supplied, so any name not found in the cloned compile-time scopes skipped the caller's frames entirely. Keep the runtime context as the outer chain: the cloned scopes are still consulted first, and the chain ends in the setting, so setting symbols still resolve. Resolver::EVAL already works this way. This makes lexicals of the calling block resolvable and gives the EVAL'd unit the caller's `$?PACKAGE`, so our-scoped declarations land in the package that is visible at the EVAL site.

IMPL-FIXUP-DYNAMICALLY-COMPILED-BLOCK bakes externally resolved lexicals into a nested unit as static declarations carrying their compile-time values, so the unit can survive serialization. For the specials `$/`, `$!` and `$¢` that value is a freshly produced Scalar, disconnected from the container the caller reads and writes. Exclude them from baking the same way `$_` already is, leaving their references late-bound so the runtime lookup reaches the caller's container through the forced outer context.