### PR TITLE
RakuAST: streamline begintime handling

### DIFF
--- a/src/Raku/ast/begintime.rakumod
+++ b/src/Raku/ast/begintime.rakumod
@@ -49,7 +49,7 @@ class RakuAST::BeginTime
             else {
                 if nqp::can($ex,'SET_FILE_LINE')
                   && self
-                  && self.origin -> $origin {
+                  && my $origin := self.origin {
                     my $origin-match := $origin.as-match;
                     $ex.SET_FILE_LINE($origin-match.file, $origin-match.line);
                 }

--- a/src/Raku/ast/begintime.rakumod
+++ b/src/Raku/ast/begintime.rakumod
@@ -7,12 +7,19 @@ class RakuAST::BeginTime
     has int $!begin-performed;
 
     # Method implemented by a node to perform its begin-time side-effects.
-    method PERFORM-BEGIN(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
-        nqp::die('Missing PERFORM-BEGIN implementation in ' ~ self.HOW.name(self))
+    # If a class does not implement it, then this will fire
+    method PERFORM-BEGIN(
+               RakuAST::Resolver $resolver,
+      RakuAST::IMPL::QASTContext $context
+    ) {
+        nqp::die('Missing PERFORM-BEGIN implementation in ' ~ self.HOW.name(self));
     }
 
     # Ensure the begin-time effects are performed.
-    method ensure-begin-performed(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context, int :$phase) {
+    method ensure-begin-performed(
+               RakuAST::Resolver $resolver,
+      RakuAST::IMPL::QASTContext $context
+    ) {
         unless $!begin-performed {
             self.PERFORM-BEGIN($resolver, $context);
             nqp::bindattr_i(self, RakuAST::BeginTime, '$!begin-performed', 1);
@@ -22,27 +29,47 @@ class RakuAST::BeginTime
 
     # Called when a BEGIN-time construct needs to evaluate code. Tries to
     # interpret simple things to avoid the cost of compilation.
-    method IMPL-BEGIN-TIME-EVALUATE(RakuAST::Node $code, RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
+    method IMPL-BEGIN-TIME-EVALUATE(
+                   RakuAST::Node $code,
+               RakuAST::Resolver $resolver,
+      RakuAST::IMPL::QASTContext $context
+    ) {
         my $*IMPL-COMPILE-DYNAMICALLY := 1;
+
+        # Handle any execution error appropriately
         CATCH {
             my $ex := $resolver.convert-exception($_);
-            if nqp::istype(self, RakuAST::CheckTime) {
+
+            # Can handle it properly
+            if nqp::istype(self,RakuAST::CheckTime) {
                 self.add-sorry: $ex;
             }
+
+            # Alas, need to rethrow wil line info if possible
             else {
-                if nqp::can($ex, 'SET_FILE_LINE') && self && my $origin := self.origin {
+                if nqp::can($ex,'SET_FILE_LINE')
+                  && self
+                  && self.origin -> $origin {
                     my $origin-match := $origin.as-match;
                     $ex.SET_FILE_LINE($origin-match.file, $origin-match.line);
                 }
                 $ex.rethrow;
             }
         }
+
+        # Can interprete, so do that
         if $code.IMPL-CAN-INTERPRET {
-            $code.IMPL-INTERPRET(RakuAST::IMPL::InterpContext.new(:$resolver, :$context))
+            $code.IMPL-INTERPRET(
+              RakuAST::IMPL::InterpContext.new(:$resolver, :$context)
+            )
         }
+
+        # It's already code
         elsif nqp::istype($code, RakuAST::Code) {
-            $code.meta-object;
+            $code.meta-object
         }
+
+        # Wrap an expression in a thunk
         elsif nqp::istype($code, RakuAST::Expression) {
             my $thunk := RakuAST::ExpressionThunk.new;
             $code.wrap-with-thunk($thunk);
@@ -58,21 +85,38 @@ class RakuAST::BeginTime
 
     # Called when a BEGIN-time construct wants to evaluate a resolved code
     # with a set of arguments.
-    method IMPL-BEGIN-TIME-CALL(RakuAST::Node $callee, RakuAST::ArgList $args,
-            RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
+    method IMPL-BEGIN-TIME-CALL(
+                   RakuAST::Node $callee,
+                RakuAST::ArgList $args,
+               RakuAST::Resolver $resolver,
+      RakuAST::IMPL::QASTContext $context
+    ) {
         my $*IMPL-COMPILE-DYNAMICALLY := 1;
-        if $callee.is-resolved && nqp::istype($callee.resolution, RakuAST::CompileTimeValue) &&
-                $args.IMPL-CAN-INTERPRET {
+
+        # Ready to call
+        if $callee.is-resolved
+          && nqp::istype($callee.resolution, RakuAST::CompileTimeValue)
+          && $args.IMPL-CAN-INTERPRET {
             my $resolved := $callee.resolution.compile-time-value;
-            my @args := $args.IMPL-INTERPRET(RakuAST::IMPL::InterpContext.new(:$resolver, :$context));
-            my @pos := @args[0];
+            my @args := $args.IMPL-INTERPRET(
+              RakuAST::IMPL::InterpContext.new(:$resolver, :$context)
+            );
+
+            # Separate out positional/named args first before flattening
+            # them, as NQP is not as smart as is sometimes expected
+            my @pos   := @args[0];
             my %named := @args[1];
-            return $resolved(|@pos, |%named);
+            $resolved(|@pos, |%named)
         }
+
+        # Not ready, wrap in a call and evaluate that
         else {
-            my $call := RakuAST::ApplyPostfix(:postfix(RakuAST::Call::Term.new($args)), :operand($callee));
+            my $call := RakuAST::ApplyPostfix(
+              :postfix(RakuAST::Call::Term.new($args)),
+              :operand($callee)
+            );
             $call.to-begin-time($resolver, $context);
-            return self.IMPL-BEGIN-TIME-EVALUATE($call, $resolver, $context);
+            self.IMPL-BEGIN-TIME-EVALUATE($call, $resolver, $context)
         }
     }
 }


### PR DESCRIPTION
Actually mostly code esthetics, comment adding, and:
- removed one unused named argument
- removed one unnecessary return statement