### PR TITLE
Carry native return types on compile-time resolved calls

### DIFF
--- a/src/Perl6/Optimizer.nqp
+++ b/src/Perl6/Optimizer.nqp
@@ -3421,7 +3421,13 @@ class Perl6::Optimizer {
                             else {
                                 self.simplify_refs($op, $sig);
                             }
-                            copy_returns($op, $obj);
+                            # A native return replaces the call with a Want,
+                            # so the result must take the call's place.
+                            my $scopes := $!symbols.scopes_in($op.name);
+                            if $scopes == 0 || $scopes == 1 && nqp::can($obj, 'soft') && !$obj.soft {
+                                $op.op('callstatic');
+                            }
+                            return copy_returns($op, $obj);
                         }
                     }
                     elsif $ct_result == -1 {
@@ -4519,6 +4525,39 @@ class Perl6::Optimizer {
         if $scopes == 0 || $scopes == 1 && nqp::can($proto, 'soft') && !$proto.soft {
             $call.op('callstatic');
         }
+
+        # Carry the chosen candidate's native return type on the native-want
+        # alternatives, leaving the bare call as the default so a context
+        # wanting the boxed object never unboxes and escape values like a
+        # Failure still flow through. The scope test is looser than the
+        # callstatic one above, since a closure clone still runs the same
+        # candidates. A soft proto can be wrapped at run time, and a literal
+        # argument reaches the callee boxed, so either one leaves run-time
+        # dispatch free to answer with a different candidate.
+        if $scopes == 0 || nqp::can($proto, 'soft') && !$proto.soft {
+            my int $literal-args := 0;
+            for @($call) {
+                $literal-args := 1
+                    if nqp::istype($_, QAST::Want) && $_.has_compile_time_value;
+            }
+            if !$literal-args
+            && nqp::can($chosen, 'returns') && !(nqp::can($chosen, 'rw') && $chosen.rw) {
+                if nqp::objprimspec($chosen.returns) {
+                    my $native := $call.shallow_clone;
+                    $native.returns($chosen.returns);
+                    $call := QAST::Want.new(
+                        :named($call.named),
+                        $call,
+                        'Ii', $native,
+                        'Nn', $native,
+                        'Ss', $native);
+                    # The type on the Want itself reaches the argument
+                    # analysis of an enclosing call. Codegen picks per
+                    # context between the children above.
+                    $call.returns($chosen.returns);
+                }
+            }
+        }
 #?endif
         $call
     }
@@ -4558,13 +4597,24 @@ class Perl6::Optimizer {
     my @prim_spec_flags := ['', 'Ii', 'Nn', 'Ss', '', '', '', '', '', '', 'Ii']; #FIXME maybe need Iu or even Uu here?
     sub copy_returns($to, $from) {
         if nqp::can($from, 'returns') {
+            # An `is rw` routine yields an assignable container, not a value
+            # to unbox. Leave its result alone so lvalue use keeps working.
+            return $to if nqp::can($from, 'rw') && $from.rw;
             my $ret_type := $from.returns;
-            $to.returns($ret_type) unless nqp::can($from, 'rw') && $from.rw;
-            if nqp::objprimspec($ret_type) -> $primspec {
+            if nqp::objprimspec($ret_type) {
+                # A routine with a native return may still escape with a
+                # Failure or a Nil that only the boxed object can carry, so
+                # the bare call stays the default and every native want
+                # takes the typed alternative, which unboxes directly and
+                # widens across native kinds.
+                my $native := $to.shallow_clone;
+                $native.returns($ret_type);
                 $to := QAST::Want.new(
                     :named($to.named),
-                    QAST::Op.new( :op(@prim_spec_ops[$primspec]), $to ),
-                    @prim_spec_flags[$primspec], $to);
+                    $to,
+                    'Ii', $native,
+                    'Nn', $native,
+                    'Ss', $native);
             }
             $to.returns($ret_type);
         }

--- a/src/Raku/ast/call.rakumod
+++ b/src/Raku/ast/call.rakumod
@@ -261,6 +261,7 @@ class RakuAST::Call::Name
     has RakuAST::Routine $!routine;
     has Mu $!lexical; # For top-level package if we can only partially resolve
     has Mu $!package;
+    has Mu $!native-return-type;
 
     method new(RakuAST::Name :$name!, RakuAST::ArgList :$args) {
         my $obj := nqp::create(self);
@@ -461,6 +462,13 @@ class RakuAST::Call::Name
                                 :$protoguilt,
                         );
                     }
+                    else {
+                        # The call is settled at compile time, so the chosen
+                        # candidate's native return type describes the result.
+                        my $ret := self.IMPL-NATIVE-RETURN-TYPE($routine, @types, @flags);
+                        nqp::bindattr(self, RakuAST::Call::Name,
+                            '$!native-return-type', $ret) unless nqp::isnull($ret);
+                    }
                 }
             }
         }
@@ -570,26 +578,39 @@ class RakuAST::Call::Name
         }
 
         my $qast := self.IMPL-SIMPLIFY-REF-ARGS($call);
-        $!callstatic ?? self.IMPL-COPY-RETURNS($qast) !! $qast
+
+        # A call the check-time analysis settled on one candidate carries
+        # that candidate's native return type. This takes precedence over
+        # the callstatic return copy: the copy's Want offers the raw return
+        # only in its own kind, so a context wanting a different native kind
+        # falls back to the boxed default and the unbox dies, where this
+        # Want widens across native kinds. A dispatcher leaves its return to
+        # its candidates, which the copy declines to guess at, so a settled
+        # multi is covered here as well.
+        my $native-return := $!native-return-type;
+        if !nqp::isnull($native-return) && nqp::objprimspec($native-return) {
+            $qast := self.IMPL-NATIVE-RETURN-WANT($qast, $native-return);
+        }
+        elsif $!callstatic {
+            $qast := self.IMPL-COPY-RETURNS($qast);
+        }
+        $qast
     }
 
     # Copy the resolved callee's declared return type onto the call node, so
-    # code generation downstream may act on it. A native return is offered
-    # both ways through a Want: boxed for object context and raw for native
-    # context. Only a callee bound once is trusted, the condition the static
-    # callee lookup already established, and a dispatcher is left alone since
-    # its candidates decide their own returns, as is an rw callee, whose
-    # return is its container.
+    # code generation downstream may act on it. A native return keeps the
+    # bare call as the default of a Want, since the routine may still escape
+    # with a Failure or a Nil that only the boxed object can carry, and the
+    # native alternatives unbox raw. Only a callee bound once is trusted,
+    # the condition the static callee lookup already established, and a
+    # dispatcher is left alone since its candidates decide their own
+    # returns, as is an rw callee, whose return is its container.
     method IMPL-COPY-RETURNS(Mu $call) {
         # The attribute reads assume the stock Routine layout; a routine of
         # another lineage declines rather than breaks the compile.
         CATCH {
             return $call;
         }
-        my constant BOX-OPS := ['', 'p6box_i', 'p6box_n', 'p6box_s',
-            '', '', '', '', '', '', 'p6box_u'];
-        my constant WANT-FLAGS := ['', 'Ii', 'Nn', 'Ss',
-            '', '', '', '', '', '', 'Ii'];
         my $decl := self.resolution;
         return $call unless nqp::istype($decl, RakuAST::CompileTimeValue)
             || nqp::can($decl, 'maybe-compile-time-value');
@@ -614,13 +635,10 @@ class RakuAST::Call::Name
         my $returns := nqp::ifnull(
             nqp::getattr($signature, Signature, '$!returns'), Mu);
         return $call if $returns =:= Mu;
-        $call.returns($returns);
-        my int $primspec := nqp::objprimspec($returns);
-        if $primspec && BOX-OPS[$primspec] {
-            $call := QAST::Want.new(
-                :named($call.named),
-                QAST::Op.new( :op(BOX-OPS[$primspec]), $call ),
-                WANT-FLAGS[$primspec], $call);
+        if nqp::objprimspec($returns) {
+            $call := self.IMPL-NATIVE-RETURN-WANT($call, $returns);
+        }
+        else {
             $call.returns($returns);
         }
         $call

--- a/src/Raku/ast/circumfix.rakumod
+++ b/src/Raku/ast/circumfix.rakumod
@@ -79,6 +79,26 @@ class RakuAST::Circumfix::Parentheses
         $!semilist.maybe-compile-time-value;
     }
 
+    # Grouping parentheses around a single modifier-free expression forward
+    # its type, so an enclosing operator sees a parenthesized native result
+    # as native. A loop modifier yields a List and a condition modifier can
+    # yield Empty, so a modified statement forwards nothing. Some constructs
+    # build parentheses around a bare expression rather than a semilist, so
+    # the payload shape is checked rather than assumed.
+    method return-type() {
+        if nqp::istype($!semilist, RakuAST::SemiList)
+          && $!semilist.IMPL-IS-SINGLE-EXPRESSION {
+            my $statement := self.IMPL-UNWRAP-LIST($!semilist.statements)[0];
+            nqp::isconcrete($statement.condition-modifier)
+              || nqp::isconcrete($statement.loop-modifier)
+                ?? Mu
+                !! $statement.expression.return-type
+        }
+        else {
+            Mu
+        }
+    }
+
     method IMPL-CAN-INTERPRET() {
         $!semilist.IMPL-CAN-INTERPRET
     }

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -2364,6 +2364,7 @@ class RakuAST::ApplyInfix
 {
     has RakuAST::Infixish $.infix;
     has RakuAST::ArgList  $.args;
+    has Mu $!native-return-type;
 
     method new(
       RakuAST::Infixish   :$infix!,
@@ -2551,7 +2552,55 @@ class RakuAST::ApplyInfix
             && !self.infix.short-circuit
             && self.IMPL-SUNK-OPERATOR-PURE(self.infix);
 
+        self.IMPL-RECORD-NATIVE-RETURN-TYPE;
+
         True
+    }
+
+    # Record the native return type when the operator settles on a single
+    # candidate, so a native-typed target coerces with the matching unbox
+    # and an enclosing operator sees this result as native.
+    method IMPL-RECORD-NATIVE-RETURN-TYPE() {
+        my $infix := $!infix;
+        return Nil unless nqp::istype($infix, RakuAST::Infix) && $infix.is-resolved;
+
+        # Each link of a chain-associative operator dispatches on the
+        # original operands at run time, while this node's left operand is
+        # the preceding link, so the candidate analysis would settle on the
+        # wrong link signature.
+        return Nil if $infix.properties.chain;
+
+        # An adverb reaches the callee as a named argument the trial bind
+        # below never saw, so run-time dispatch may answer differently.
+        return Nil if nqp::elems(self.colonpairs);
+
+        return Nil unless nqp::can($infix.resolution, 'compile-time-value');
+        my $routine := $infix.resolution.compile-time-value;
+        return Nil unless nqp::isconcrete($routine) && nqp::istype($routine, Code);
+
+        my $left := self.left;
+        my $right := self.right;
+        return Nil unless nqp::isconcrete($left) && nqp::isconcrete($right);
+        my $left-type := $left.return-type;
+        return Nil if $left-type =:= Mu
+          || nqp::istype($left-type.HOW, Perl6::Metamodel::SubsetHOW)
+          || nqp::istype($left-type.HOW, Perl6::Metamodel::GenericHOW);
+        my $right-type := $right.return-type;
+        return Nil if $right-type =:= Mu
+          || nqp::istype($right-type.HOW, Perl6::Metamodel::SubsetHOW)
+          || nqp::istype($right-type.HOW, Perl6::Metamodel::GenericHOW);
+
+        my $ret := $infix.IMPL-NATIVE-RETURN-TYPE($routine,
+            [$left-type, $right-type],
+            [nqp::objprimspec($left-type), nqp::objprimspec($right-type)]);
+        nqp::bindattr(self, RakuAST::ApplyInfix, '$!native-return-type', $ret)
+            unless nqp::isnull($ret);
+        Nil
+    }
+
+    method return-type() {
+        my $type := $!native-return-type;
+        !nqp::isnull($type) && nqp::objprimspec($type) ?? $type !! Mu
     }
 
     method IMPL-IS-XX() {
@@ -2563,7 +2612,14 @@ class RakuAST::ApplyInfix
 
     method IMPL-EXPR-QAST(RakuAST::IMPL::QASTContext $context) {
         my $adverb := $!args.arg-at-pos(2) // RakuAST::ColonPairish;
-        $!infix.IMPL-INFIX-COMPILE($context, self.left, self.right, :$adverb)
+        my $qast := $!infix.IMPL-INFIX-COMPILE($context, self.left, self.right, :$adverb);
+        my $type := $!native-return-type;
+        if !nqp::isnull($type) && nqp::objprimspec($type)
+          && nqp::istype($qast, QAST::Op)
+          && ($qast.op eq 'call' || $qast.op eq 'callstatic') {
+            $qast := $!infix.IMPL-NATIVE-RETURN-WANT($qast, $type);
+        }
+        $qast
     }
 
     method visit-children(Code $visitor) {
@@ -3098,6 +3154,7 @@ class RakuAST::ApplyPrefix
 {
     has RakuAST::Prefixish $.prefix;
     has RakuAST::Expression $.operand;
+    has Mu $!native-return-type;
 
     method new(:$prefix!, :$operand!) {
         my $obj := nqp::create(self);
@@ -3132,11 +3189,49 @@ class RakuAST::ApplyPrefix
     method PERFORM-CHECK(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
         self.add-sunk-worry($resolver, self.origin ?? self.origin.Str !! self.DEPARSE)
             if self.sunk && self.IMPL-SUNK-OPERATOR-PURE(self.prefix);
+
+        self.IMPL-RECORD-NATIVE-RETURN-TYPE;
+    }
+
+    # Record the native return type when the operator settles on a single
+    # candidate, so a native-typed target coerces with the matching unbox
+    # and an enclosing operator sees this result as native.
+    method IMPL-RECORD-NATIVE-RETURN-TYPE() {
+        my $prefix := $!prefix;
+        return Nil unless nqp::istype($prefix, RakuAST::Prefix) && $prefix.is-resolved;
+        return Nil unless nqp::can($prefix.resolution, 'compile-time-value');
+        my $routine := $prefix.resolution.compile-time-value;
+        return Nil unless nqp::isconcrete($routine) && nqp::istype($routine, Code);
+
+        my $operand := $!operand;
+        return Nil unless nqp::isconcrete($operand);
+        my $type := $operand.return-type;
+        return Nil if $type =:= Mu
+          || nqp::istype($type.HOW, Perl6::Metamodel::SubsetHOW)
+          || nqp::istype($type.HOW, Perl6::Metamodel::GenericHOW);
+
+        my $ret := $prefix.IMPL-NATIVE-RETURN-TYPE($routine,
+            [$type], [nqp::objprimspec($type)]);
+        nqp::bindattr(self, RakuAST::ApplyPrefix, '$!native-return-type', $ret)
+            unless nqp::isnull($ret);
+        Nil
+    }
+
+    method return-type() {
+        my $type := $!native-return-type;
+        !nqp::isnull($type) && nqp::objprimspec($type) ?? $type !! Mu
     }
 
     method IMPL-EXPR-QAST(RakuAST::IMPL::QASTContext $context) {
         return self.IMPL-NATIVE-INCDEC-QAST($context) if $!native-incdec;
-        $!prefix.IMPL-PREFIX-QAST($context, $!operand.IMPL-TO-QAST($context))
+        my $qast := $!prefix.IMPL-PREFIX-QAST($context, $!operand.IMPL-TO-QAST($context));
+        my $type := $!native-return-type;
+        if !nqp::isnull($type) && nqp::objprimspec($type)
+          && nqp::istype($qast, QAST::Op)
+          && ($qast.op eq 'call' || $qast.op eq 'callstatic') {
+            $qast := $!prefix.IMPL-NATIVE-RETURN-WANT($qast, $type);
+        }
+        $qast
     }
 
     # A native int/num ++ or -- the optimize pass marked: emit the raw op on a

--- a/src/Raku/ast/literals.rakumod
+++ b/src/Raku/ast/literals.rakumod
@@ -87,7 +87,8 @@ class RakuAST::Constant
 class RakuAST::IntLiteral
   is RakuAST::Literal
 {
-    method native-type-flag() { 1 }
+    # A value too wide for a native int cannot take part in a native dispatch.
+    method native-type-flag() { nqp::isbig_I(self.value) ?? Nil !! 1 }
 
     method type-name() { 'integer' }
 

--- a/src/Raku/ast/scoping.rakumod
+++ b/src/Raku/ast/scoping.rakumod
@@ -1044,6 +1044,54 @@ class RakuAST::Lookup
         nqp::bindattr(self, RakuAST::Lookup, '$!resolution', $resolution)
     }
 
+    # Given a resolved routine and the compile-time argument types and native
+    # flags, return the native return type of the single candidate the call
+    # settles on, or NQPMu when it settles on none or on a non-native one.
+    method IMPL-NATIVE-RETURN-TYPE($routine, @types, @flags) {
+        # A literal argument counts as native here while the emitted call
+        # passes the boxed value, so run-time dispatch may answer with
+        # another candidate than the analysis settled on.
+        my int $ARG_IS_LITERAL := 32;
+        for @flags {
+            return NQPMu if $_ +& $ARG_IS_LITERAL;
+        }
+        my $callee := NQPMu;
+        if nqp::can($routine, 'is_dispatcher') && $routine.is_dispatcher {
+            if $routine.onlystar {
+                my @result := $routine.analyze_dispatch(@types, @flags);
+                $callee := @result && @result[0] == 1 ?? @result[1] !! NQPMu;
+            }
+        }
+        elsif nqp::can($routine, 'signature') {
+            $callee := nqp::p6trialbind($routine.signature, @types, @flags) == 1
+                ?? $routine
+                !! NQPMu;
+        }
+        if $callee && nqp::can($callee, 'returns') {
+            # An `is rw` routine yields an assignable container, not a value to
+            # unbox. Leave its result alone so lvalue use keeps working.
+            return NQPMu if nqp::can($callee, 'rw') && $callee.rw;
+            my $ret := $callee.returns;
+            return $ret if !nqp::isnull($ret) && nqp::objprimspec($ret);
+        }
+        NQPMu
+    }
+
+    # Attach a settled native return type to a call. The bare call stays the
+    # default of a QAST::Want, so a context wanting the boxed object never
+    # unboxes and escape values like a Failure or Nil flow through. Every
+    # native want takes the typed alternative, which unboxes into the return
+    # kind and lets the QAST compiler widen across native kinds from there.
+    method IMPL-NATIVE-RETURN-WANT(Mu $call, Mu $type) {
+        my $native := $call.shallow_clone;
+        $native.returns($type);
+        QAST::Want.new(:named($call.named),
+            $call,
+            'Ii', $native,
+            'Nn', $native,
+            'Ss', $native)
+    }
+
     # Returns information to report in an X::Undeclared::Symbols exception.
     # Returns Nil if it should not be reported there, otherwise should be
     # an instance of RakuAST::UndeclaredSymbolDescription.

--- a/t/02-rakudo/native-return-coercion.t
+++ b/t/02-rakudo/native-return-coercion.t
@@ -1,0 +1,158 @@
+use Test;
+
+plan 22;
+
+# Assigning the result of a call to a native-typed container coerces with
+# the unbox that matches the callee's declared native return type. A routine
+# that returns native `int` widens to `num` on assignment. This must work for
+# subs, for multis, and for the built-in operators, including nested and
+# parenthesized expressions, whether or not the call gets inlined.
+
+{
+    sub f(int $a, int $b --> int) { $a * $b }
+    my int $a = 3; my int $b = 4;
+    my num $y; $y = f($a, $b);
+    is $y, 12e0, 'native-return sub widens to num on assignment';
+}
+
+{
+    multi g(int $a, int $b --> int) { $a * $b }
+    my int $a = 3; my int $b = 4;
+    my num $y; $y = g($a, $b);
+    is $y, 12e0, 'native-return multi widens to num on assignment';
+}
+
+{
+    my int $a = 3; my int $b = 4;
+    my num $y; $y = $a * $b;
+    is $y, 12e0, 'int * int widens to num on assignment';
+}
+
+{
+    my int $a = 3; my int $b = 4;
+    my num $y; $y = $a + $b;
+    is $y, 7e0, 'int + int widens to num on assignment';
+}
+
+{
+    my int $two = 2; my int $i = 5; my int $one = 1;
+    my num $y; $y = $two * $i - $one;
+    is $y, 9e0, 'nested native int operators widen to num';
+}
+
+# An operand whose declared type is a boxed numeric settles the dispatch on
+# a boxed candidate, so no native return type is carried and a native-typed
+# target keeps requiring explicit coercion.
+{
+    my int $i = 5;
+    is 2 * $i, 10, 'literal and native int mix computes the boxed result';
+    my Int $two = 2;
+    my num $y;
+    dies-ok { $y = $two * $i }, 'boxed Int operand keeps the result boxed';
+}
+
+{
+    my int $a = 3; my int $b = 4; my int $c = 2; my int $d = 3;
+    my num $y; $y = ($a * $b) + ($c * $d);
+    is $y, 18e0, 'parenthesized native results widen to num';
+}
+
+# A statement modifier changes what grouping parentheses produce, so they
+# forward no type.
+{
+    sub elems-of(Iterable $x) { $x.elems }
+    my int $i = 5;
+    is elems-of(($i for 1..3)), 3, 'a parenthesized loop modifier stays an Iterable';
+}
+
+{
+    my int $a = 2; my int $b = 3; my int $c = 4;
+    my num $y; $y = $a * $b * $c;
+    is $y, 24e0, 'chained native multiply widens to num';
+}
+
+{
+    my int $i = 5;
+    my num $y; $y = -$i * $i;
+    is $y, -25e0, 'native prefix result participates in native dispatch';
+}
+
+{
+    my int $a = 2; my int $b = 3;
+    my num $y; $y = $a ** $b;
+    is $y, 8e0, 'all-native exponentiation widens to num';
+}
+
+{
+    my int $i = 5;
+    my num $y; $y = -$i;
+    is $y, -5e0, 'native prefix negate widens to num';
+}
+
+# Going the other way, a native num result narrows to a native int container.
+{
+    my num $a = 3.5e0; my num $b = 0.5e0;
+    my int $i; $i = $a + $b;
+    is $i, 4, 'num + num narrows to int on assignment';
+}
+
+# A native str return assigns to a native str container.
+{
+    sub st(--> str) { "x" }
+    my str $s; $s = st();
+    is $s, "x", 'native str return assigns to str';
+}
+
+# An `is rw` routine with a native return type yields an assignable container,
+# not a value to unbox. Calling it as an lvalue must keep working.
+{
+    my int $g = 1;
+    sub acc() is rw returns int { $g }
+    acc() = 99;
+    is $g, 99, 'rw routine with native return stays an lvalue';
+}
+
+# Assigning a value whose static type is a boxed numeric stays strict. It is
+# not silently coerced; an explicit coercion is required.
+{
+    my Int $n = 5;
+    my num $y;
+    dies-ok { $y = $n }, 'boxed Int to native num still requires explicit coercion';
+}
+
+# A routine that declares a boxed return type is not a native result; assigning
+# it to a native container stays strict.
+{
+    sub boxed(--> Int) { 5 }
+    my num $y;
+    dies-ok { $y = boxed() }, 'boxed Int return to native num still requires coercion';
+}
+
+# A subset return type is not a native result either.
+{
+    subset Positive of Int where * > 0;
+    sub sub-ret(--> Positive) { 5 }
+    my num $y;
+    dies-ok { $y = sub-ret() }, 'subset return to native num still requires coercion';
+}
+
+# The native div candidate throws on a zero divisor, since a native return
+# cannot carry a Failure. Carrying its return type must not change that.
+{
+    my int $i = 4;
+    my int $z = 0;
+    dies-ok { my $r = $i div $z }, 'div by a native zero throws';
+}
+
+{
+    multi gfail(int $a --> int) { $a > 0 ?? $a !! fail "neg" }
+    my int $i = -3;
+    my $x = gfail($i);
+    is $x // 'default', 'default', 'Failure from a native-return multi flows through //';
+}
+
+{
+    sub sfail(--> int) { fail "boom" }
+    my $r = sfail();
+    is-deeply $r.defined, False, 'Failure from a native-return sub stays soft in object context';
+}

--- a/t/08-performance/22-rakuast-copy-returns.t
+++ b/t/08-performance/22-rakuast-copy-returns.t
@@ -7,22 +7,42 @@ use nqp;
 plan 9;
 
 # A call to a routine bound once carries the callee's declared return type
-# on its QAST, and a native return is offered both boxed and raw through a
-# Want, so a native consumer skips the boxing round trip.
+# on its QAST. A native return is offered raw through a Want alternative, so
+# a native consumer skips the boxing round trip, while the Want's default
+# stays the bare call so an escaping Failure or Nil reaches object context
+# as the boxed object it needs to be.
 
 my $rakuast = nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast';
 
+# Whether a Want offers a raw native alternative that contains a call to
+# $name, its default being something other than a boxing op.
+sub want-offers-raw-call(Mu $qast, $name --> Bool:D) {
+    if nqp::istype($qast, QAST::Want) {
+        my @children = $qast.list;
+        loop (my int $i = 1; $i + 1 < @children.elems; $i = $i + 2) {
+            return True if @children[$i] ~~ Str && @children[$i] eq 'Ii' | 'Nn' | 'Ss'
+                && qast-contains-call(@children[$i + 1], $name);
+        }
+    }
+    if qast-descendable $qast {
+        for $qast.list {
+            want-offers-raw-call($_, $name) and return True;
+        }
+    }
+    False
+}
+
 # These observe the emitted QAST. The legacy optimizer does not offer this
-# shape both ways, so the box assertions hold for the RakuAST frontend only.
-todo 'the legacy optimizer does not box a native return through a Want', 2
+# shape both ways, so the assertions hold for the RakuAST frontend only.
+todo 'the legacy optimizer does not offer a native return through a Want', 2
     unless $rakuast;
 qast-is 'sub cr-a(--> int) { return 3 }; my int $x = cr-a()', -> \v {
-    qast-contains-op(v, 'p6box_i')
-}, 'a native int return is offered boxed through a Want';
+    want-offers-raw-call(v, '&cr-a') and not qast-contains-op(v, 'p6box_i')
+}, 'a native int return is offered raw through a Want without boxing';
 
 qast-is 'sub cr-b(--> num) { return 3e0 }; my num $x = cr-b()', -> \v {
-    qast-contains-op(v, 'p6box_n')
-}, 'a native num return is offered boxed through a Want';
+    want-offers-raw-call(v, '&cr-b') and not qast-contains-op(v, 'p6box_n')
+}, 'a native num return is offered raw through a Want without boxing';
 
 qast-is 'sub cr-c(--> Int) { return 3 }; my $x = cr-c()', -> \v {
     not qast-contains-op(v, 'p6box_i')


### PR DESCRIPTION
When a call gets resolved to a single candidate at compile time the candidate's declared native return type was being lost or carried in a shape that broke at runtime, so assigning the result to a native typed container would use the wrong unbox and die:

```raku
multi g(int $a, int $b --> int) { $a * $b }
my int $a = 3; my int $b = 4;
my num $y = g($a, $b); # This type cannot unbox to a native number: P6opaque, Int
```

This fixes that for both frontends. On the legacy frontend the compile time multi resolution lives in its optimizer, so the type gets carried there (like the rest of the compile time dispatch machinery this only applies at the default optimization level). The RakuAST frontend does the same dispatch analysis at CHECK time for its compile time error checking, so the type is recorded there and applies at every optimization level.

The return type is attached as a `QAST::Want` with the bare call as the default, so contexts that want the boxed object never unbox. That matters because a routine with a native return type may still escape with a Failure, which only the boxed object can carry. The existing return copying (`IMPL-COPY-RETURNS`, and `copy_returns` on the legacy frontend) marked the bare call as returning raw, which force-unboxed an escaping Failure at the default optimization level while `--optimize=off` failed softly:

```raku
sub f(--> int) { fail "boom" }
my $r = f(); # This type cannot unbox to a native integer: P6opaque, Failure
```

That copying also offered the raw return only in the callee's own native kind, so assigning an int return to a num target fell back to the boxed default and died in the unbox. Both frontends now build the same escape-safe Want, whose native alternatives unbox directly and widen across native kinds. The settled candidate's type takes precedence over the callstatic return copy, the copy builds the same shape for the calls the analysis does not settle, and an `is rw` callee is left alone on both frontends, since its result is an assignable container rather than a value to unbox. On the legacy frontend `copy_returns` was additionally having its result discarded at the sub call site, so only its in-place returns marking ever took effect.

The type is only attached when the compile time analysis is guaranteed to match what runtime dispatch will do, so soft protos, `is rw` candidates, adverbed operators, and literal arguments are left alone. A literal argument still gets passed boxed, so which candidate a literal reaches remains decided by the optimizer for now, although there will be a follow up PR that makes literal representation a rule of its own.
