### PR TITLE
Keep operator wraps from leaking outside their test

### DIFF
--- a/t/12-rakuast/xx-fixed-in-rakuast.rakutest
+++ b/t/12-rakuast/xx-fixed-in-rakuast.rakutest
@@ -68,22 +68,21 @@ plan 113;
 # t/spec/S06-advanced/wrap.t
 # https://github.com/rakudo/rakudo/issues/1561
 # XXX: Almost certainly just due to lack of optimizations
+# The wrap handlers do not call the original operator, so while a wrap
+# is active the operator is broken for every caller in the process.
+# Compiling any code dispatches postfix:<++> internally, and an
+# increment that no longer increments loops forever. Each wrap is
+# therefore applied, exercised and removed within a single EVAL whose
+# code was compiled before the wrap took effect, and the assertions
+# run only once the operator is restored.
 {
     my @result;
-    {
-        my $handle;
-        Q§ $handle = &infix:<|>.wrap: -> | { @result.push("ok"); True }; -> $ where {$_ ~~ Int|Num} {}(42) §.AST.EVAL;
-        is-deeply @result, ["ok"], "wrapping infix:<|> works";
-        Q§ &infix:<|>.unwrap($handle) §.AST.EVAL;
-    }
+    Q§ my $handle = &infix:<|>.wrap: -> | { @result.push("ok"); True }; -> $ where {$_ ~~ Int|Num} {}(42); &infix:<|>.unwrap($handle) §.AST.EVAL;
+    is-deeply @result, ["ok"], "wrapping infix:<|> works";
 
     @result = [];
-    {
-        my $handle;
-        Q§ $handle = &postfix:<++>.wrap: -> | { @result.push("ok2") }; my int $x; $x++ §.AST.EVAL;
-        is-deeply @result, ["ok2"], "wrapping postfix:<++> works";
-        Q§ &postfix:<++>.unwrap($handle) §.AST.EVAL;
-    }
+    Q§ my $handle = &postfix:<++>.wrap: -> | { @result.push("ok2") }; my int $x; $x++; &postfix:<++>.unwrap($handle) §.AST.EVAL;
+    is-deeply @result, ["ok2"], "wrapping postfix:<++> works";
 }
 
 # ???


### PR DESCRIPTION
The wrap tests for `infix:<|>` and `postfix:<++>` wrapped a setting operator with a handler that does not call the original, asserted with is-deeply, and only then removed the wrap through a separate EVAL. Everything that ran in between, including the compilation of the unwrap EVAL itself, executed with the operator broken for the whole process. Compilation dispatches postfix:<++> internally, and an increment that no longer increments turns whatever loop it controls into an infinite loop that pushes to the test array forever. Whether an internal site dispatches the wrapped routine or was compiled down to native ops depends on how the surrounding code was precompiled, which is why the file would hang the test suite intermittently while passing in isolation, spinning at full CPU with gigabytes of array.

Apply, exercise and remove each wrap within a single EVAL whose code is compiled before the wrap takes effect, and run the assertions only once the operator is restored. Foreign dispatches during the narrow remaining window would now surface as extra elements in the asserted array, a visible failure instead of a hang.