### PR TITLE
Key precompilation stores per compiler frontend

### DIFF
--- a/src/core.c/CompUnit/PrecompilationRepository.rakumod
+++ b/src/core.c/CompUnit/PrecompilationRepository.rakumod
@@ -42,8 +42,14 @@ class CompUnit::PrecompilationRepository::Default
     my $resolved-lock := Lock.new;
     my $first-repo-id;
 
-    my constant $compiler-id =
-      CompUnit::PrecompilationId.new-without-check(Compiler.id);
+    # The compiler id incorporates the active frontend, which is only
+    # known at run time, so it cannot be captured while the setting is
+    # being compiled.
+    my $compiler-id;
+    sub compiler-id() {
+        $compiler-id //=
+          CompUnit::PrecompilationId.new-without-check(Compiler.id)
+    }
 
     # If $loaded{$key} has a Promise in it, await it. If it's broken, try
     # again, return the result if it's kept. If there's nothing there at
@@ -136,7 +142,7 @@ class CompUnit::PrecompilationRepository::Default
     ) {
         $!RMD("Trying to load $id.repo-id") if $!RMD;
         for @precomp-stores -> $store {
-            with $store.load-repo-id($compiler-id, $id) {
+            with $store.load-repo-id(compiler-id(), $id) {
                 $!RMD("  Loaded from $store.prefix()") if $!RMD;
                 return $_;
             }
@@ -150,7 +156,7 @@ class CompUnit::PrecompilationRepository::Default
     ) {
         $!RMD("Trying to load $id") if $!RMD;
         for @precomp-stores -> $store {
-            with $store.load-unit($compiler-id, $id) {
+            with $store.load-unit(compiler-id(), $id) {
                 $!RMD("  Loaded from $store.prefix()") if $!RMD;
                 return $_;
             }
@@ -165,7 +171,7 @@ class CompUnit::PrecompilationRepository::Default
         $!RMD("Trying to load refreshed $id") if $!RMD;
         for @precomp-stores -> $store {
             $store.remove-from-cache($id);
-            with $store.load-unit($compiler-id, $id) {
+            with $store.load-unit(compiler-id(), $id) {
                 $!RMD("  Loaded from $store.prefix()") if $!RMD;
                 return $_;
             }
@@ -229,7 +235,7 @@ Need to re-check dependencies.")
             }
 
             my $dependency-precomp := @precomp-stores
-                .map({ $_.load-unit($compiler-id, $dependency.id) })
+                .map({ $_.load-unit(compiler-id(), $dependency.id) })
                 .first(*.defined)
                 or do {
                     $!RMD("Could not find $dependency.spec()") if $!RMD;
@@ -281,12 +287,12 @@ Need to re-check dependencies.")
 
         if $resolve {
             if self.store.destination(
-                 $compiler-id,
+                 compiler-id(),
                  $precomp-unit.id,
                  :extension<.repo-id>
             ) {
                 self.store.store-repo-id(
-                  $compiler-id,
+                  compiler-id(),
                   $precomp-unit.id,
                   :repo-id($REPO-id)
                 );
@@ -409,7 +415,7 @@ Need to re-check dependencies.")
 
         # obtain destination, lock the store for other processes
         my $store := self.store;
-        my $io    := $store.destination($compiler-id, $id);
+        my $io    := $store.destination(compiler-id(), $id);
         return False unless $io;
 
         if $force {
@@ -579,9 +585,9 @@ Need to re-check dependencies.")
         $!RMD("Writing dependencies and byte code to $io.tmp for source checksum: $source-checksum")
           if $!RMD;
 
-        $store.store-repo-id($compiler-id, $id, :repo-id($REPO.id));
+        $store.store-repo-id(compiler-id(), $id, :repo-id($REPO.id));
         $store.store-unit(
-            $compiler-id,
+            compiler-id(),
             $id,
             $store.new-unit(
               :$id,

--- a/src/core.c/Compiler.rakumod
+++ b/src/core.c/Compiler.rakumod
@@ -2,14 +2,27 @@ class Compiler does Systemic {
     my constant $compiler = nqp::getcomp("Raku");
     my constant $config =
       nqp::gethllsym('default','SysConfig').rakudo-build-config;
-    my constant $compilation-id = nqp::box_s(
+    my constant $compilation-base-id = nqp::box_s(
       nqp::sha1((nqp::getlexdyn('$*CU') ?? $*CU.comp-unit-name !! $*W.handle.Str) ~ nqp::atkey($config,'source-digest')),Str
     );
+    # The id also distinguishes the frontend the process compiles with.
+    # Bytecode produced by one frontend must not be loaded by a process
+    # compiling with the other, so everything keyed by the compiler id,
+    # the precompilation stores in particular, is kept per frontend. The
+    # frontend is only known at run time, from the symbol the compiler
+    # entry point binds, so the id is computed on first use.
+    my $compilation-id;
+    sub compilation-id() {
+        $compilation-id //= nqp::box_s(nqp::sha1(
+          $compilation-base-id
+            ~ nqp::ifnull(nqp::gethllsym('Raku','COMPILER-FRONTEND'),'')
+        ),Str)
+    }
     my constant $backend = $compiler.backend;
     my constant $name    = $backend.name;
 
     # XXX Various issues with this stuff on JVM
-    has $.id       is built(:bind) = $compilation-id;
+    has $.id       is built(:bind) = compilation-id();
     has $.release  is built(:bind) =
       BEGIN nqp::ifnull(nqp::atkey($config,'release-number'),"");
     has $.codename is built(:bind) =
@@ -30,8 +43,8 @@ class Compiler does Systemic {
     method flavor()  { #RAKUDO_FLAVOR# }
 
     proto method id(|) {*}
-    multi method id(Compiler:U:) { $compilation-id }
-    multi method id(Compiler:D:) { $!id            }
+    multi method id(Compiler:U:) { compilation-id() }
+    multi method id(Compiler:D:) { $!id             }
 
     method verbose-config(:$say) {
 

--- a/src/main.nqp
+++ b/src/main.nqp
@@ -16,12 +16,14 @@ nqp::bindhllsym('default', 'SysConfig', Perl6::SysConfig.new(%rakudo-build-confi
 my $comp := Perl6::Compiler.new();
 $comp.language('Raku');
 if +nqp::getenvhash()<RAKUDO_RAKUAST> {
+    nqp::bindhllsym('Raku', 'COMPILER-FRONTEND', 'rakuast');
     $comp.parsegrammar(Raku::Grammar);
     $comp.parseactions(Raku::Actions);
     $comp.addstage('syntaxcheck', :before<ast>);
     $comp.addstage('qast', :after<ast>);
 }
 else {
+    nqp::bindhllsym('Raku', 'COMPILER-FRONTEND', 'legacy');
     $comp.parsegrammar(Perl6::Grammar);
     $comp.parseactions(Perl6::Actions);
     $comp.addstage('syntaxcheck', :before<ast>);

--- a/t/02-rakudo/compiler-id-frontend.t
+++ b/t/02-rakudo/compiler-id-frontend.t
@@ -1,0 +1,27 @@
+use Test;
+
+plan 3;
+
+# The compiler id keys every precompilation store, so each frontend must
+# have its own: bytecode produced by one frontend must never be loaded
+# by a process compiling with the other. Both frontends are pinned
+# explicitly in subprocesses here, so the assertions hold no matter
+# which frontend runs this file.
+
+my $code = 'print $*RAKU.compiler.id';
+
+my %with-rakuast = %*ENV;
+%with-rakuast<RAKUDO_RAKUAST> = 1;
+my %without-rakuast = %*ENV;
+%without-rakuast<RAKUDO_RAKUAST>:delete;
+
+my $rakuast-id = run($*EXECUTABLE.absolute, '-e', $code, :env(%with-rakuast), :out)
+    .out.slurp(:close);
+my $legacy-id = run($*EXECUTABLE.absolute, '-e', $code, :env(%without-rakuast), :out)
+    .out.slurp(:close);
+
+ok $rakuast-id ~~ /^ <[0..9 A..F]> ** 40 $/, 'RakuAST frontend compiler id is a 40 digit hex digest';
+ok $legacy-id  ~~ /^ <[0..9 A..F]> ** 40 $/, 'legacy frontend compiler id is a 40 digit hex digest';
+isnt $rakuast-id, $legacy-id, 'the two frontends have distinct compiler ids';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
The compiler id was a constant baked while CORE.setting compiled, a sha1 over the setting handle and the source digest, so both frontends of one build shared it, and with it every precompilation store directory. Bytecode precompiled by one frontend then got loaded by processes compiling with the other. The visible damage ranged from "New type Stash for ContainerDescriptor::Untyped is not a mixin type" at startup to subtler staleness: any module that bakes frontend-dependent state into a compile-time constant, like the QAST test helper choosing a compilation target by probing for the optimize stage, serves the wrong answer to the other frontend.

The compiler entry point now binds the active frontend as the COMPILER-FRONTEND hll symbol, and the compiler id is a sha1 over the build stamp and that symbol, computed on first use since the frontend is only known at run time. The constant snapshot of the id in CompUnit::PrecompilationRepository becomes lazy for the same reason. Each frontend thereby precompiles into and loads from its own store subtree; nothing one frontend produces is visible to the other. A frontend that did not build the installation pays a one-time recompilation of distributed modules instead of loading precomp that was never compiled for it.
