### PR TITLE
RakuAST: capture bracketed groups as a whole

### DIFF
--- a/src/Raku/ast/regex.rakumod
+++ b/src/Raku/ast/regex.rakumod
@@ -52,6 +52,11 @@ class RakuAST::Regex
         )
     }
 
+    # The node a named capture of this one would capture. Quantification
+    # and backtrack modifiers are transparent to capturing, so those
+    # wrappers return the target of the atom they wrap.
+    method IMPL-CAPTURE-TARGET() { self }
+
     method IMPL-APPLY-LITERAL-MODS(Mu $qast, %mods) {
         if %mods<i> && %mods<m> {
             $qast.subtype('ignorecase+ignoremark')
@@ -475,7 +480,17 @@ class RakuAST::Regex::NamedCapture
 
     method IMPL-REGEX-QAST(RakuAST::IMPL::QASTContext $context, %mods) {
         my $qast := $!regex.IMPL-REGEX-QAST($context, %mods);
-        if ($qast.rxtype eq 'quant' || $qast.rxtype eq 'dynquant') &&
+        if nqp::istype($!regex.IMPL-CAPTURE-TARGET, RakuAST::Regex::Group) {
+            # A bracketed group is captured as a whole, no matter its content,
+            # also when quantified or backtrack-modified. Its QAST cannot be
+            # told apart from that of its content, since the group compiles
+            # as a pass-through, so decide by the AST node: the subrule
+            # aliasing below must only apply to bare assertions like
+            # $<x>=<foo> and their quantified forms.
+
+            $qast := QAST::Regex.new( :rxtype<subcapture>, :name($!name), $qast );
+        }
+        elsif ($qast.rxtype eq 'quant' || $qast.rxtype eq 'dynquant') &&
                 $qast[0].rxtype eq 'subrule' {
             self.IMPL-SUBRULE-ALIAS($qast[0], $!name);
         }
@@ -1959,6 +1974,8 @@ class RakuAST::Regex::QuantifiedAtom
         Nil
     }
 
+    method IMPL-CAPTURE-TARGET() { $!atom.IMPL-CAPTURE-TARGET }
+
     method PERFORM-CHECK(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
         unless $!atom.quantifiable {
             self.add-sorry:
@@ -2154,6 +2171,8 @@ class RakuAST::Regex::BacktrackModifiedAtom
         my $atom := $!atom.IMPL-REGEX-QAST($context, %mods);
         $atom.backtrack ?? $atom !! $!backtrack.IMPL-QAST-APPLY($atom, %mods)
     }
+
+    method IMPL-CAPTURE-TARGET() { $!atom.IMPL-CAPTURE-TARGET }
 
     method visit-children(Code $visitor) {
         $visitor($!atom);

--- a/t/02-rakudo/regex-group-named-capture.t
+++ b/t/02-rakudo/regex-group-named-capture.t
@@ -1,0 +1,65 @@
+use Test;
+
+plan 8;
+
+# A named capture of a bracketed group captures the group as a whole,
+# no matter what the group contains. The subrule-aliasing treatment is
+# reserved for bare assertions, as in $<x>=<foo> and quantified forms
+# thereof. CSS::Grammar's unicode-range rule depends on the quantified
+# case: $<from>=[<.xdigit>**1..6] must produce one Match spanning the
+# run, not one Match per repetition.
+
+{
+    my grammar UR {
+        token ur { 'U+' $<from>=[<.xdigit>**1..6] }
+    }
+    my $m = UR.parse("U+200", :rule<ur>);
+    is ~$m<from>, '200',
+        'named capture of a group with a quantified atom spans the run';
+    nok $m<from> ~~ Positional,
+        'and binds a single Match, not a list of repetitions';
+}
+
+{
+    my grammar Inner {
+        token al { $<i>=\w \w* }
+        token ur { 'U+' $<x>=[<al>] }
+    }
+    my $m = Inner.parse("U+abc", :rule<ur>);
+    is ~$m<x>, 'abc', 'named capture of a group containing a subrule';
+    nok $m<x><i>:exists,
+        'the group capture does not adopt the subrule inner captures';
+    is ~$m<al><i>, 'a', 'the subrule captures under its own name';
+}
+
+{
+    my grammar Bare {
+        token al { \w }
+        token ur { 'U+' $<x>=<al>**3 }
+    }
+    my $m = Bare.parse("U+abc", :rule<ur>);
+    is $m<x>.map(~*).join(','), 'a,b,c',
+        'a quantified bare subrule alias captures per repetition';
+}
+
+{
+    my grammar Quantified {
+        token al { \w }
+        token ur { 'U+' $<x>=[<al>]**3 }
+    }
+    my $m = Quantified.parse("U+abc", :rule<ur>);
+    is ~$m<x>, 'abc',
+        'named capture of a quantified group spans the whole run';
+}
+
+{
+    my grammar Ratcheted {
+        token al { $<i>=\w \w* }
+        token ur { 'U+' $<x>=[<al>]: }
+    }
+    my $m = Ratcheted.parse("U+abc", :rule<ur>);
+    nok $m<x><i>:exists,
+        'a backtrack-modified group capture does not adopt inner captures';
+}
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
A named capture decides between subrule aliasing and a subcapture by inspecting the QAST of its target: bare assertions like `$<x>=<foo>` alias the subrule, and the quantified form captures per repetition. A bracketed group compiles as a pass-through, so its QAST cannot be told apart from that of its content, and a group whose content is a single assertion or quantified assertion took the aliasing paths meant for the bare forms. The legacy frontend distinguishes the same way but its groups always compile to a concat node, which lands in the subcapture branch.

Decide by the AST node instead. Quantification and backtrack modifiers are transparent to capturing, so the new IMPL CAPTURE-TARGET unwraps them to find the node a named capture would capture, and a group target always becomes a subcapture spanning the whole group. This fixes `$<from>=[<.xdigit>**1..6]` producing one Match per repetition instead of one Match for the run (the form CSS::Grammar's unicode-range rule uses, where `~$<from>` came out as '2 0 0' rather than '200'), the same for the quantified group form `$<x>=[<al>]**3`, and `$<x>=[<al>]` as well as its backtrack-modified formc adopting the subrule's inner captures rather than capturing the span.