### PR TITLE
RakuAST: accept lexical regexes in the grammar sanity check

### DIFF
--- a/src/core.c/RakuAST/Fixups.rakumod
+++ b/src/core.c/RakuAST/Fixups.rakumod
@@ -1495,6 +1495,21 @@ augment class RakuAST::Postfix::Power {
 
 augment class RakuAST::Grammar {
 
+    # Did a named assertion resolve to a lexically visible regex, as a
+    # capturing <foo> does when there is a `my token foo` in scope? Such
+    # an assertion compiles to a call to that lexical rather than to a
+    # method of the grammar.
+    my sub resolved-lexically($node) {
+        my $lookups := $node.get-implicit-lookups;
+        $lookups.elems
+          && (my $lookup := $lookups[0]).is-resolved
+          && nqp::istype(
+               (my $resolution := $lookup.resolution),
+               RakuAST::CompileTimeValue
+             )
+          && nqp::istype($resolution.compile-time-value, Regex)
+    }
+
     # Check general sanity of the grammar
     method check-sanity() {
         my $grammar := self.meta-object;
@@ -1503,7 +1518,8 @@ augment class RakuAST::Grammar {
         self.map: -> $node {
             if nqp::istype($node,RakuAST::Regex::Assertion::Named) {
                 if $node.name.simple-identifier -> $name {
-                    unless nqp::isconcrete($grammar.^find_method($name)) {
+                    unless nqp::isconcrete($grammar.^find_method($name))
+                      || resolved-lexically($node) {
                         my int $i;
                         nqp::while(
                           (my $parent := $node.parent(++$i))

--- a/t/02-rakudo/grammar-lexical-regex-assertion.t
+++ b/t/02-rakudo/grammar-lexical-regex-assertion.t
@@ -1,0 +1,31 @@
+use Test;
+
+plan 3;
+
+# A capturing <foo> assertion resolves to a lexically visible regex when
+# the grammar has no method of that name, and compiles to a call to that
+# lexical. The grammar sanity check must treat such an assertion as
+# resolved rather than reporting an unresolved reference; grammars like
+# Cro::HTTP::Cookie::CookieString rely on this.
+
+{
+    my token domain { \w+ }
+    my grammar G {
+        token TOP { <domain> }
+    }
+    my $m = G.parse("abc");
+    ok $m, 'grammar using a lexical token via <name> compiles and parses';
+    is ~$m<domain>, 'abc', 'and the assertion captures under its name';
+}
+
+{
+    my token wins { \d+ }
+    my grammar Both {
+        token wins { \w+ }
+        token TOP { <wins> }
+    }
+    nok Both.parse("abc"),
+        'a lexical regex takes precedence over a method of the same name';
+}
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
A capturing <foo> assertion resolves to a lexically visible regex when there is one, and compiles to a call to it rather than to a method of the grammar; Assertion::Named registers and resolves the &foo lookup for exactly this purpose. The grammar sanity check only consulted the composed methods, so a grammar using such an assertion died at compile time with unresolved references even though the reference resolves. Cro::HTTP::Cookie declares cookie-name, cookie-value and friends as file-scoped my-tokens and uses them from its CookieString grammar that way.

Skip assertions whose lookup resolved to a compile-time Regex, the same condition under which the assertion compiles to the lexical call.