### PR TITLE
RakuAST: release compiler services after composition

### DIFF
--- a/src/Raku/ast/package.rakumod
+++ b/src/Raku/ast/package.rakumod
@@ -430,6 +430,7 @@ class RakuAST::Package
             my $cs := RakuAST::CompilerServices.new(self, $resolver, $context);
             $type.HOW.compose($type, :compiler_services($cs));
             nqp::bindattr(self, RakuAST::Package, '$!accessor-qast', $cs.IMPL-GET-QAST);
+            $cs.IMPL-RELEASE;
         }
         else {
             $type.HOW.compose($type);
@@ -972,4 +973,18 @@ class RakuAST::CompilerServices
     # Return the accumulated accessor QAST so Package can keep it and
     # discard the transient CompilerServices.
     method IMPL-GET-QAST() { $!qast }
+
+    # Drop all compile-time state. The services land in the slurpy
+    # named arguments of metamodel compose methods, and a closure
+    # created in such a frame, as a custom HOW adding methods during
+    # compose does, keeps the frame - and so this object - in the
+    # serialized output. The resolver reaches the setting context,
+    # which cannot be serialized.
+    method IMPL-RELEASE() {
+        nqp::bindattr(self, RakuAST::CompilerServices, '$!package', RakuAST::Package);
+        nqp::bindattr(self, RakuAST::CompilerServices, '$!resolver', RakuAST::Resolver);
+        nqp::bindattr(self, RakuAST::CompilerServices, '$!context', RakuAST::IMPL::QASTContext);
+        nqp::bindattr(self, RakuAST::CompilerServices, '$!qast', QAST::Stmts);
+        Nil
+    }
 }

--- a/t/02-rakudo/compose-added-method-precomp.t
+++ b/t/02-rakudo/compose-added-method-precomp.t
@@ -1,0 +1,18 @@
+use lib <t/02-rakudo/test-packages>;
+use Test;
+use UsesComposeAddsMethod;
+
+plan 2;
+
+# A custom metaclass that creates a closure during compose and adds it
+# as a method, as OO::Monitors does, produces a class whose method table
+# holds a closure over the compose invocation frame. Precompiling a
+# module that declares such a class must serialize that frame chain;
+# the compiler services passed to compose reach the setting context and
+# must be released once composition is done, or serialization dies with
+# "Missing serialize REPR function for REPR MVMContext".
+
+is UsesComposeAddsMethod.new.m, 42,
+    'a precompiled class from a compose-extending metaclass works';
+is UsesComposeAddsMethod.new.compose-tag, 'composed',
+    'the method added during compose is callable and sees its closure';

--- a/t/02-rakudo/test-packages/ComposeAddsMethodHOW.rakumod
+++ b/t/02-rakudo/test-packages/ComposeAddsMethodHOW.rakumod
@@ -1,0 +1,17 @@
+# A metaclass that creates a closure during compose and installs it as a
+# method, the way OO::Monitors wraps methods with lock handling. The
+# closure's outer frame is the compose invocation, whose slurpy named
+# arguments hold the compiler services, so the frame chain must stay
+# serializable once composition is done.
+class MetamodelX::ComposeAddsMethodHOW is Metamodel::ClassHOW {
+    method compose(Mu \type) {
+        my $tag := 'composed';
+        self.add_method(type, 'compose-tag', sub ($self) { $tag });
+        self.Metamodel::ClassHOW::compose(type);
+    }
+}
+my package EXPORTHOW {
+    package DECLARE {
+        constant addsmethod = MetamodelX::ComposeAddsMethodHOW;
+    }
+}

--- a/t/02-rakudo/test-packages/UsesComposeAddsMethod.rakumod
+++ b/t/02-rakudo/test-packages/UsesComposeAddsMethod.rakumod
@@ -1,0 +1,4 @@
+use ComposeAddsMethodHOW;
+addsmethod UsesComposeAddsMethod {
+    method m() { 42 }
+}


### PR DESCRIPTION
The compiler services handed to the metamodel on compose end up in the slurpy named arguments of any compose method along the way, and those live in the method's frame. A custom metaclass that creates a closure during compose and installs it as a method, the way OO::Monitors wraps every method with lock handling, puts that frame on the closure's outer chain, and the frame chain is then serialized along with the class. The services hold the resolver, the resolver reaches the setting context, and a context cannot be serialized as an ordinary object, so precompiling any module declaring a monitor died with a missing serialize REPR function for MVMContext. Cro::HTTP::Client::CookieJar is such a module.

The services are transient by design: the accessor QAST they collect is captured immediately after composition returns. Drop the rest of their compile-time state at that point too, so whatever keeps the object alive serializes a husk.