### PR TITLE
RakuAST: interpret pairs, hash composers, and contextualizers

### DIFF
--- a/src/Raku/ast/circumfix.rakumod
+++ b/src/Raku/ast/circumfix.rakumod
@@ -239,6 +239,19 @@ class RakuAST::Circumfix::HashComposer
         $op
     }
 
+    method IMPL-CAN-INTERPRET() {
+        self.is-resolved
+          && nqp::istype(self.resolution, RakuAST::CompileTimeValue)
+          && (!$!expression || $!expression.IMPL-CAN-INTERPRET)
+    }
+
+    method IMPL-INTERPRET(RakuAST::IMPL::InterpContext $ctx) {
+        my $composer := self.resolution.compile-time-value;
+        $!expression
+          ?? $composer($!expression.IMPL-INTERPRET($ctx))
+          !! $composer()
+    }
+
     method visit-children(Code $visitor) {
         $visitor($!expression) if $!expression;
     }

--- a/src/Raku/ast/contextualizer.rakumod
+++ b/src/Raku/ast/contextualizer.rakumod
@@ -19,6 +19,13 @@ class RakuAST::Contextualizer
         )
     }
 
+    method IMPL-CAN-INTERPRET() { $!target.IMPL-CAN-INTERPRET }
+
+    method IMPL-INTERPRET(RakuAST::IMPL::InterpContext $ctx) {
+        my str $method := self.IMPL-METHOD;
+        $!target.IMPL-INTERPRET($ctx)."$method"()
+    }
+
     method visit-children(Code $visitor) {
         $visitor($!target);
     }

--- a/src/Raku/ast/pair.rakumod
+++ b/src/Raku/ast/pair.rakumod
@@ -49,6 +49,14 @@ class RakuAST::FatArrow
         )
     }
 
+    method IMPL-CAN-INTERPRET() { $!value.IMPL-CAN-INTERPRET }
+
+    method IMPL-INTERPRET(RakuAST::IMPL::InterpContext $ctx) {
+        self.IMPL-UNWRAP-LIST(self.get-implicit-lookups)[0].resolution.compile-time-value.new(
+          $!key, $!value.IMPL-INTERPRET($ctx)
+        )
+    }
+
     method visit-children(Code $visitor) {
         $visitor($!value);
     }

--- a/src/Raku/ast/statements.rakumod
+++ b/src/Raku/ast/statements.rakumod
@@ -556,6 +556,33 @@ class RakuAST::StatementSequence
             $stmts
         }
     }
+
+    # Mirror IMPL-TO-QAST rather than inherit StatementList's sink-value
+    # logic, which reaches a second implicit lookup this node does not have.
+    method IMPL-INTERPRET(RakuAST::IMPL::InterpContext $ctx) {
+        my @statements;
+        for self.code-statements {
+            nqp::push(@statements, $_)
+              unless nqp::istype($_, RakuAST::Statement::Empty);
+        }
+
+        my int $n := nqp::elems(@statements);
+        if $n == 1 {
+            nqp::atpos(@statements, 0).IMPL-INTERPRET($ctx)
+        }
+        elsif $n == 0 {
+            my $empty-list :=
+              self.IMPL-UNWRAP-LIST(self.get-implicit-lookups)[0].resolution.compile-time-value;
+            $empty-list()
+        }
+        else {
+            my $result;
+            for @statements {
+                $result := $_.IMPL-INTERPRET($ctx);
+            }
+            $result
+        }
+    }
 }
 
 # Done by all classes that always produce Nil

--- a/t/02-rakudo/role-parameterization-hash-pair-args.t
+++ b/t/02-rakudo/role-parameterization-hash-pair-args.t
@@ -1,0 +1,54 @@
+use Test;
+
+plan 8;
+
+# Role parameterization arguments are evaluated at BEGIN time. Pairs,
+# hash composers, and contextualizers must interpret there, the way
+# simple literals and lists already do; Cro::HTTP parameterizes a role
+# with a %(...) of timeout phases.
+
+{
+    role R1[%h] { method opts { %h } }
+    class C1 does R1[%(a => 1, b => 2)] { }
+    is C1.opts<a> + C1.opts<b>, 3, 'role parameterized with a %(...) hash';
+}
+
+{
+    role R2[%h] { method n { %h.elems } }
+    class C2 does R2[%()] { }
+    is C2.n, 0, 'role parameterized with an empty %()';
+}
+
+{
+    role R3[$x] { method v { $x } }
+    class C3 does R3[(a => 1)] { }
+    is C3.v.raku, Pair.new('a', 1).raku, 'role parameterized with a => pair';
+}
+
+{
+    role R4[%h] { method v { %h<a> } }
+    class C4 does R4[{ a => 5 }] { }
+    is C4.v, 5, 'role parameterized with a { } hash composer';
+}
+
+{
+    role R5[@a] { method v { @a } }
+    class C5 does R5[@(1, 2, 3)] { }
+    is C5.v.join(','), '1,2,3', 'role parameterized with an @(...) list';
+    class C5e does R5[@()] { }
+    is C5e.v.elems, 0, 'role parameterized with an empty @()';
+}
+
+{
+    role R6[$x] { method v { $x } }
+    class C6 does R6[$(42)] { }
+    is C6.v, 42, 'role parameterized with a $(...) item';
+}
+
+{
+    role R7[%h] { method v { %h<body> } }
+    class C7 does R7[%(connection => 60, body => Inf)] { }
+    is C7.v, Inf, 'role parameterized with a mixed-value %(...), as Cro does';
+}
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Role parameterization evaluates its arguments at BEGIN time, through the interpreter where possible. Simple literals and comma lists could already be interpreted, but a => pair, a { } hash composer, and the %( ), @( ), $( ) contextualizers could not, so a role parameterized with any of those died with 'BEGIN time calls only supported for simple constructs so far'. Cro::HTTP::Client parameterizes a role with a %(...) of timeout phases.

Give those nodes IMPL-CAN-INTERPRET and IMPL-INTERPRET:

  - FatArrow builds a Pair, mirroring its QAST and the colonpair interpreters.
  - Circumfix::HashComposer calls its resolved hash circumfix on the interpreted inner expression.
  - Contextualizer coerces the interpreted target with the same method its QAST calls.
  - StatementSequence, the contextualizer target, interprets to match its own QAST instead of inheriting StatementList's sink-value logic, which reaches a second implicit lookup it does not have and so could not interpret an empty %( ).