### PR TITLE
RakuAST: don't adopt a setting builtin's WHO when a package shadows it

### DIFF
--- a/src/Raku/ast/scoping.rakumod
+++ b/src/Raku/ast/scoping.rakumod
@@ -1156,8 +1156,14 @@ class RakuAST::PackageInstaller {
         }
 
         my %stash := $resolver.IMPL-STASH-HASH($target);
-        # upgrade a lexically imported package stub to package scope if it exists
-        if $lexical {
+        # Upgrade a lexically imported package stub to package scope if it
+        # exists, but only an actual PackageHOW stub. A name resolving to a
+        # concrete builtin (e.g. `grammar Grammar` finding the CORE Grammar)
+        # is shadowed by this declaration, not adopted; injecting it makes
+        # the silent-replace below steal the builtin's WHO out of the
+        # setting's serialization context, which breaks precompilation.
+        if $lexical
+          && nqp::istype($lexical.compile-time-value.HOW, Perl6::Metamodel::PackageHOW) {
             %stash{$final} := $lexical.compile-time-value;
         }
         if $scope eq 'our' {

--- a/t/02-rakudo/grammar-named-as-core-type-precomp.t
+++ b/t/02-rakudo/grammar-named-as-core-type-precomp.t
@@ -1,0 +1,22 @@
+use lib <t/02-rakudo/test-packages>;
+use Test;
+
+plan 3;
+
+# Declaring a package whose short name matches a setting builtin (here a
+# grammar named Grammar, as YAMLish does) inside an outer package must
+# create a fresh, distinct package that shadows the builtin, not adopt
+# the builtin's WHO. Adopting it put any nested `our` package into the
+# already-serialized setting SC, which broke precompilation with
+# "Object does not exist in serialization context". This test imports a
+# precompiled module of that exact shape; loading it forces the
+# deserialization that used to fail.
+
+use GrammarNamedLikeCore;
+
+ok GrammarNamedLikeCore::Grammar.parse("abc"),
+    'a precompiled grammar named like a setting builtin loads and parses';
+nok GrammarNamedLikeCore::Grammar =:= CORE::Grammar,
+    'and it is a distinct type shadowing the builtin, not the builtin itself';
+is GrammarNamedLikeCore::Grammar::Actions.greet, 'hi',
+    'its nested our-scoped package precompiled and is reachable';

--- a/t/02-rakudo/test-packages/GrammarNamedLikeCore.rakumod
+++ b/t/02-rakudo/test-packages/GrammarNamedLikeCore.rakumod
@@ -1,0 +1,7 @@
+unit module GrammarNamedLikeCore;
+grammar Grammar {
+    token TOP { \w+ }
+    our class Actions {
+        method greet() { 'hi' }
+    }
+}


### PR DESCRIPTION
When installing an our-scoped package, the resolved lexical of the same short name is injected into the target stash to upgrade a forward-declared package stub to package scope. When that lexical was a concrete setting builtin rather than a stub (for example declaring `grammar Grammar { }`, which finds the CORE Grammar), this manufactured a self-collision that the silent-replace path resolved by stealing the builtin's WHO via nqp::setwho. The stolen WHO lives in the already-serialized setting serialization context, so a nested our-scoped package installed into it was claimed by that context; precompiling the module then died with "Object does not exist in serialization context" when the setting SC was serialized referencing the module-SC stash. YAMLish hits this: its grammar is named Grammar and nests an our class Actions.

Restrict the stub upgrade to PackageHOW stubs, matching its stated intent. A concrete builtin sharing the name is shadowed by a fresh package, not adopted, so no collision is manufactured and the new package keeps its own WHO in the module's SC.