### PR TITLE
RakuAST: apply the default parameter type to post-constraint sub signatures

### DIFF
--- a/src/Raku/Grammar.nqp
+++ b/src/Raku/Grammar.nqp
@@ -5084,9 +5084,9 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
         :my $*IN-DECL := '';
         :dba('constraint')
         [
-          | '[' ~ ']' <signature(:DECLARE-TARGETS($*DECLARE-TARGETS))>
+          | '[' ~ ']' <signature(:DECLARE-TARGETS($*DECLARE-TARGETS), :ON-ROUTINE($*ON-ROUTINE))>
 
-          | '(' ~ ')' <signature(:DECLARE-TARGETS($*DECLARE-TARGETS))>
+          | '(' ~ ')' <signature(:DECLARE-TARGETS($*DECLARE-TARGETS), :ON-ROUTINE($*ON-ROUTINE))>
 
           | <.constraint-where> <EXPR('i=')>
         ]

--- a/t/02-rakudo/parameter-sub-signature.t
+++ b/t/02-rakudo/parameter-sub-signature.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 12;
+plan 15;
 
 # Parameter sub signature destructure must compile under both
 # frontends, including when the owning routine is compiled at BEGIN.
@@ -101,5 +101,33 @@ dies-ok {
         my class C does R[self] { }
         CODE
 }, 'role parameterization with self outside object dies cleanly';
+
+# 13. An untyped sub signature parameter takes the same default nominal
+# type as a routine parameter, so an unfilled named key binds to Any.
+is EVAL(q:to/CODE/),
+        sub foo(%h (:$x!, :$y)) { $y.^name }
+        foo({:x(1)})
+        CODE
+    'Any', 'unfilled named sub signature parameter binds to Any';
+
+# 14. The same holds for a missing optional positional element.
+is EVAL(q:to/CODE/),
+        sub foo(@a ($p, $q?)) { $q.^name }
+        foo([1])
+        CODE
+    'Any', 'unfilled positional sub signature parameter binds to Any';
+
+# 15. Because the unfilled value is Any rather than Mu, a downstream
+# call constrained to Any resolves rather than failing to find a
+# candidate.
+is EVAL(q:to/CODE/),
+        my class C {
+            multi method handle(Str:D $_) { "str" }
+            multi method handle($)        { "any" }
+            method run(%h (:$x!, :$comment)) { self.handle($comment) }
+        }
+        C.new.run({:x(1)})
+        CODE
+    'any', 'unfilled sub signature value resolves to an Any candidate';
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
A destructuring sub signature binds like the enclosing routine's parameter list, so an unfilled parameter should bind to Any, the same default an ordinary routine parameter gets. The grammar arranges this by passing `$*ON-ROUTINE` into the nested signature, which lets the signature action install the Any default.

The param-var destructure forms already pass `$*ON-ROUTINE`, but the post constraint forms did not. A destructure written after a sigilled parameter parses the sub signature as a post-constraint, so the `%h (:$x, :$y)` style of destructure never received the default. Its unfilled parameters bound to Mu instead of Any, which diverges from the legacy frontend and makes a value that should reach an Any candidate fail to resolve one.

Pass `$*ON-ROUTINE` through the post-constraint signature as well.