### PR TITLE
RakuAST: emit the lexical self when a self term has no resolution

### DIFF
--- a/src/Raku/ast/term.rakumod
+++ b/src/Raku/ast/term.rakumod
@@ -169,7 +169,11 @@ class RakuAST::Term::Self
     method IMPL-IS-CONSTANT() { True }
 
     method IMPL-EXPR-QAST(RakuAST::IMPL::QASTContext $context) {
-        self.resolution.IMPL-LOOKUP-QAST($context)
+        # The lookup is the lexical `self` whether or not a resolution
+        # was recorded, so emit it directly when there is none.
+        self.is-resolved
+            ?? self.resolution.IMPL-LOOKUP-QAST($context)
+            !! QAST::Var.new( :name('self'), :scope('lexical') )
     }
 }
 

--- a/t/02-rakudo/self-in-regex.t
+++ b/t/02-rakudo/self-in-regex.t
@@ -1,0 +1,58 @@
+use Test;
+
+plan 7;
+
+# `self` inside a regex code block or assertion resolves to the
+# invocant, including when the regex is declared in a role. Where no
+# invocant is available it is still rejected at compile time.
+
+# These type declarations default to `our` scope and install into GLOBAL,
+# so each EVAL uses a distinct name to avoid colliding with the others in
+# the one process running the test.
+
+lives-ok {
+    EVAL q:to/CODE/
+        role R1 { token t { . { my $ = self } } }
+        CODE
+}, 'self in a regex code block in a role compiles';
+
+lives-ok {
+    EVAL q:to/CODE/
+        role R2 { token t { . <?{ self.defined }> } }
+        CODE
+}, 'self in a regex predicate assertion in a role compiles';
+
+is EVAL(q:to/CODE/),
+        role R3 { method tag { "Z" }; token t { . <?{ self.tag eq "Z" }> } }
+        grammar G3 does R3 { token TOP { <t> } }
+        G3.parse("x") ?? "matched" !! "no-match"
+        CODE
+    'matched', 'self in a role regex calls the right method';
+
+is EVAL(q:to/CODE/),
+        grammar G4 { has $.v = 42; token TOP { . <?{ self.v == 42 }> } }
+        G4.new.parse("x") ?? "ok" !! "no"
+        CODE
+    'ok', 'self in a class/grammar regex still works';
+
+dies-ok {
+    EVAL q:to/CODE/
+        sub no-self() { self }
+        CODE
+}, 'self with no available object still fails at compile time';
+
+# A regex that is not a method has no invocant, so self there must still
+# be rejected rather than falling back to a lexical lookup.
+dies-ok {
+    EVAL q:to/CODE/
+        role RNoSelf { / . { self } / }
+        CODE
+}, 'self in a non-method regex in a role still fails at compile time';
+
+dies-ok {
+    EVAL q:to/CODE/
+        role RMainline { my $ = self }
+        CODE
+}, 'self in a role body mainline still fails at compile time';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
A role body is compiled at compose time, ahead of the compilation unit's check pass. A `self` term inside a regex in a role is reached through that early compilation, so it arrives at code generation without a resolution recorded by the check pass and dies with "This element has not been resolved".

The lookup for `self` is the lexical `self` whether or not a resolution was recorded. It is the same QAST the resolved path produces. Fall back to that lexical directly when no resolution is present. A `self` used where no object is available is still reported at check time, in the contexts the check pass reaches, so that diagnostic is unaffected.