### PR TITLE
RakuAST: align operator sink-warning purity with the legacy frontend

### DIFF
--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -922,6 +922,20 @@ class RakuAST::Node {
         nqp::can($routine, 'is-pure') ?? 1 !! 0
     }
 
+    # Whether an operator is pure. A pure operator has no effect, so the
+    # sink-context warning flags discarding its result as useless. A resolved
+    # simple operator answers from its routine's `is pure` trait, the basis
+    # the legacy frontend uses, so a user-defined operator with side effects
+    # is not flagged. A meta operator or one not yet resolved keeps the
+    # operator node's own classification.
+    method IMPL-SUNK-OPERATOR-PURE(Mu $operator) {
+        (nqp::istype($operator, RakuAST::Infix)
+          || nqp::istype($operator, RakuAST::Prefix))
+          && $operator.is-resolved
+            ?? self.IMPL-PURE-ROUTINE($operator)
+            !! $operator.is-pure
+    }
+
     # Whether a computed value is reasonable to embed in the compilation
     # unit. Each restriction carries its own explanation, and a new one
     # belongs here with the same treatment.

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -2192,7 +2192,9 @@ class RakuAST::ApplyInfix
         }
 
         self.add-sunk-worry($resolver, self.origin ?? self.origin.Str !! self.DEPARSE)
-            if self.infix.is-pure && self.sunk && !self.infix.short-circuit;
+            if self.sunk
+            && !self.infix.short-circuit
+            && self.IMPL-SUNK-OPERATOR-PURE(self.infix);
 
         True
     }
@@ -2358,10 +2360,10 @@ class RakuAST::ApplyListInfix
         }
 
         self.add-sunk-worry($resolver, self.origin ?? self.origin.Str !! self.DEPARSE)
-            if self.infix.is-pure
-            && self.sunk
+            if self.sunk
             && !self.infix.short-circuit
-            && !self.IMPL-IS-LIST-LITERAL;
+            && !self.IMPL-IS-LIST-LITERAL
+            && self.IMPL-SUNK-OPERATOR-PURE(self.infix);
     }
 
     method IMPL-IS-VALID-FEED-STAGE($stage) {
@@ -2727,7 +2729,7 @@ class RakuAST::ApplyPrefix
 
     method PERFORM-CHECK(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
         self.add-sunk-worry($resolver, self.origin ?? self.origin.Str !! self.DEPARSE)
-            if self.prefix.is-pure && self.sunk;
+            if self.sunk && self.IMPL-SUNK-OPERATOR-PURE(self.prefix);
     }
 
     method IMPL-EXPR-QAST(RakuAST::IMPL::QASTContext $context) {

--- a/t/02-rakudo/sink-warnings-legacy-parity.t
+++ b/t/02-rakudo/sink-warnings-legacy-parity.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 8;
+plan 14;
 
 sub stderr-of(Str $code) {
     run($*EXECUTABLE.absolute, '-e', $code, :err).err.slurp(:close)
@@ -48,5 +48,36 @@ for 'rand', '*', '**' -> $term {
     nok useless-of($err, $term),
         "`$term` is not a useless-use subject at statement level";
 }
+
+# An operator is useless in sink context only when its routine carries the
+# `is pure` trait, matching the legacy frontend.
+
+# `temp` and `let` localize a variable and restore it when the scope leaves,
+# so they have an effect even though their result is discarded.
+nok useless-lines(stderr-of 'my $x = 1; sub f { temp $x; 42 }; f()').elems,
+    '`temp` is not a useless-use subject in sink context';
+
+nok useless-lines(stderr-of 'my $x = 1; sub f { let $x; 42 }; f()').elems,
+    '`let` is not a useless-use subject in sink context';
+
+nok useless-lines(
+        stderr-of 'sub prefix:<sidef>($x) { $x }; my $y = 1; sub f { sidef $y; 42 }; f()'
+    ).elems,
+    'a user-defined prefix without `is pure` is not a useless-use subject';
+
+nok useless-lines(
+        stderr-of 'sub infix:<sidef>($a, $b) { $a }; my $y = 1; sub f { $y sidef $y; 42 }; f()'
+    ).elems,
+    'a user-defined infix without `is pure` is not a useless-use subject';
+
+ok useless-lines(
+        stderr-of 'sub prefix:<puref>($x) is pure { $x }; my $y = 1; sub f { puref $y; 42 }; f()'
+    ).elems,
+    'a user-defined prefix declared `is pure` is a useless-use subject';
+
+ok useless-lines(
+        stderr-of 'sub infix:<puref>($a, $b) is pure { $a }; my $y = 1; sub f { $y puref $y; 42 }; f()'
+    ).elems,
+    'a user-defined infix declared `is pure` is a useless-use subject';
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
The "useless use in sink context" warning asked the operator node's own `is-pure`, which answers from a table that treats every operator outside a small set as pure. So `temp %h;` as a statement was flagged useless even though it localizes its target and restores it when the scope leaves, and any user defined prefix or infix without side effect free semantics was flagged the same way.

The legacy frontend instead decides a simple operator is pure only when its routine carries the `is pure` trait. Route the three sink-warning checks through a helper that does the same for a resolved simple prefix or infix, and keeps the operator node's own classification for meta operators and for operators not yet resolved.

The operator node's `is-pure` is left in place. It still drives code generation through `needs-sink-call`, where treating an unmarked operator as pure matches what the legacy frontend emits.