### PR TITLE
Allow "unit sub foo;" in 6.e and higher

### DIFF
--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -2209,18 +2209,18 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
                 [
                 || <?{ $*begin_compunit }>
                     {
-                        unless $longname {
-                            $/.panic("Compilation unit cannot be anonymous");
-                        }
-                        unless $*SCOPE eq 'unit' {
-                            if $*PKGDECL eq 'package' {
-                                $/.panic('This appears to be Perl code. If you intended it to be Raku code, please use a Raku style declaration like "unit package Foo;" or "unit module Foo;", or use the block form instead of the semicolon form.');
-                            }
-                            $/.panic("Semicolon form of '$*PKGDECL' without 'unit' is illegal.  You probably want to use 'unit $*PKGDECL'");
-                        }
-                        unless $outer =:= $*UNIT {
-                            $/.typed_panic("X::UnitScope::Invalid", what => $*PKGDECL, where => "in a subscope");
-                        }
+                        $/.panic("Compilation unit cannot be anonymous")
+                          unless $longname;
+
+                        $/.typed_panic("X::UnitScope::MustHaveUnit",
+                          what => $*PKGDECL
+                        ) unless $*SCOPE eq 'unit';
+
+                        $/.typed_panic("X::UnitScope::Invalid",
+                          what  => $*PKGDECL,
+                          where => "in a subscope"
+                        ) unless $outer =:= $*UNIT;
+
                         $*begin_compunit := 0;
                     }
                     { $*IN_DECL := ''; }
@@ -2475,12 +2475,20 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         [
         || ';'
             {
-                if $<deflongname> ne 'MAIN' {
-                    $/.typed_panic("X::UnitScope::Invalid", what => "sub",
-                        where => "except on a MAIN sub", suggestion =>
-                        'Please use the block form. If you did not mean to '
-                        ~ "declare a unit-scoped sub,\nperhaps you accidentally "
-                        ~ "placed a semicolon after routine's definition?"
+                # Allow all subs with ; but require "unit" scope from 6.e
+                if nqp::getcomp('Raku').language_revision >= 3 {
+                    $/.typed_panic("X::UnitScope::MustHaveUnit", :what<sub>)
+                      unless $*SCOPE eq 'unit';
+                }
+
+                # 6.c/d behaviour, doesn't check for "unit", only allows MAIN
+                elsif $<deflongname> ne 'MAIN' {
+                    $/.typed_panic("X::UnitScope::Invalid",
+                      what       => "sub",
+                      where      => "except on a MAIN sub",
+                      suggestion =>
+"Please use the block form. If you did not mean to declare a unit-scoped
+sub, perhaps you accidentally placed a semicolon after routine's definition?"
                     );
                 }
                 unless $*begin_compunit {

--- a/src/Raku/Grammar.nqp
+++ b/src/Raku/Grammar.nqp
@@ -1517,9 +1517,8 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
     token unit-block($decl, $kind = 'Block', :$parameterization) {
         :my $*BLOCK;
         {                                           # entry check
-            unless $*SCOPE eq 'unit' {
-                $/.panic("Semicolon form of '$decl' without 'unit' is illegal. You probably want to use 'unit $decl'");
-            }
+            $/.typed_panic("X::UnitScope::MustHaveUnit",:what($decl))
+              unless $*SCOPE eq 'unit';
         }
         { $*IN-DECL := ''; }                        # not inside declaration
         <.enter-block-scope($kind, $parameterization)>
@@ -4171,7 +4170,14 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
         [
           || ';'
              {
-                 if $<deflongname> ne 'MAIN' {
+                 # Allow all subs with ; but require "unit" scope from 6.e
+                 if nqp::getcomp('Raku').language_revision >= 3 {
+                     $/.typed_panic("X::UnitScope::MustHaveUnit","sub")
+                       unless $*SCOPE eq 'unit';
+                 }
+
+                 # 6.c/d behaviour, doesn't check for "unit", only allows MAIN
+                 elsif $<deflongname> ne 'MAIN' {
                      $/.typed-panic: "X::UnitScope::Invalid",
                         what       => "sub",
                         where      => "except on a MAIN sub",

--- a/src/core.c/Exception.rakumod
+++ b/src/core.c/Exception.rakumod
@@ -3713,6 +3713,13 @@ my class X::UnitScope::Invalid does X::Syntax {
     }
 }
 
+my class X::UnitScope::MustHaveUnit does X::Syntax {
+    has $.what;
+    method message() {
+        "Semicolon form of '$.what' without 'unit' is illegal. You probably want to use 'unit $.what'"
+    }
+}
+
 my class X::UnitScope::TooLate does X::Syntax {
     has $.what;
     method message() {


### PR DESCRIPTION
Turns out the idiom for "unit sub foo is export" is actually quite useful in the case of Air, where generally the logic for each page (part) of a website is stored in a separate Raku .rakumod file.

Since this was technically already possible except for a check on the name of the subroutine (must be "MAIN"), this felt like a straightforward fix to be applied (add feature by removing code!).

However, this showed up quite a few spectest errors.  But even worse, it turned out that the "unit" scope wasn't even checked for!  This means that "sub MAIN($a,$b);" is as valid as "unit sub MAIN($a,$b)".

It felt that adding a check for the "unit" scope now would potentially be a breaking change.  So in order to not break anything in the ecosystem / user code, this approach was not taken.

So this commit really does a number of things:

1. Add typed error X::UnitScope::MustHaveUnit
2. Use this typed error class for package statements lacking "unit" instead of the untyped panic that was there already
3. In 6.e and higher, check for the existence of the "unit" scope with "sub" and throw X::UnitScope::MustHaveUnit error if it is missing
4. In 6.e and higher, allow *any* sub to have "unit" scope, not just MAIN