### PR TITLE
RakuAST: Fix issues that AttrX::Mooish runs into

### DIFF
--- a/src/Raku/ast/signature.rakumod
+++ b/src/Raku/ast/signature.rakumod
@@ -199,6 +199,11 @@ class RakuAST::Signature
                         if $!is-on-role-method && $Class.is-resolved {
                             $type := RakuAST::Type::Simple.new(RakuAST::Name.from-identifier('$?CLASS'));
                             $type.set-resolution($Class.resolution);
+                        } elsif $!method-package.declarator eq 'role' {
+                            # An anon or my method in a role is not a role method
+                            # and may be added to an unrelated type, so it takes
+                            # an unconstrained invocant.
+                            $type := Mu;
                         } else {
                             my $package := $!method-package.stubbed-meta-object;
                             my $package-name := $package.HOW.name($package);

--- a/src/Raku/ast/traits.rakumod
+++ b/src/Raku/ast/traits.rakumod
@@ -48,6 +48,13 @@ class RakuAST::TraitTarget {
     # Apply all traits (and already applied will not be applied again).
     method apply-traits(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context, RakuAST::TraitTarget $target, *%named) {
         if $!traits {
+            # The parser leaves the dynamic $*PACKAGE bound to the package's
+            # AST node, whose .HOW is not the metaclass the type is composed
+            # with. Bind it to the package type object so a trait that mixes
+            # into $*PACKAGE.HOW reaches the composed metaclass.
+            my $*PACKAGE := nqp::istype(self, RakuAST::Package)
+                ?? self.compile-time-value
+                !! $resolver.current-package;
             my constant is-traits-to-warn-on-duplicate := nqp::hash(
                 'tighter',  1,  'looser', 1,  'equiv', 1,  'rw',   1,  'default', 1,
                 'readonly', 1,  'raw',    1,  'assoc', 1,  'pure', 1,  'export',  1,

--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -920,9 +920,9 @@ class RakuAST::VarDeclaration::Simple
         my $subset;
         if my $where := $!where {
             my $type := $of-type // self.IMPL-UNWRAP-LIST(self.get-implicit-lookups)[0];
-            my $type-name := $type ?? $type.name.canonicalize !! "Mu";
-            my $subset-name := RakuAST::Name.from-identifier: QAST::Node.unique($type-name ~ '+anon_subset');
-            $subset := RakuAST::Type::Subset.new: :name($subset-name), :of($type || Mu), :$where;
+            # An unnamed subset reports as <anon> in a failed type check,
+            # matching the legacy frontend.
+            $subset := RakuAST::Type::Subset.new: :name(RakuAST::Name.new), :of($type || Mu), :$where;
             $subset.to-begin-time($resolver, $context);
             self.set-type($subset, :replace);
         }

--- a/t/02-rakudo/anon-method-in-role-invocant.t
+++ b/t/02-rakudo/anon-method-in-role-invocant.t
@@ -1,0 +1,32 @@
+use Test;
+
+# A named anon or my method in a role body takes an unconstrained
+# invocant, so it stays callable when added to an unrelated type.
+
+plan 5;
+
+role R {
+    method make-anon() { anon method named() { 'anon-' ~ self.^name } }
+    method make-my()   { my method named()   { 'my-' ~ self.^name } }
+}
+
+class C { }
+C.^add_method('borrowed', R.make-anon);
+is C.new.borrowed, 'anon-C',
+    'a named anon method from a role is callable when added to an unrelated class';
+
+class D { }
+D.^add_method('borrowed', R.make-anon);
+is D.new.borrowed, 'anon-D', 'the same anon method works on a different type';
+
+# A my method in a role body takes the same unconstrained invocant.
+class E { }
+E.^add_method('borrowed', R.make-my);
+is E.new.borrowed, 'my-E', 'a my method from a role is callable when added to an unrelated class';
+
+nok R.make-anon.signature.params[0].type.HOW ~~ Metamodel::ParametricRoleHOW,
+    'the anon method invocant is not constrained to the concrete role';
+nok R.make-my.signature.params[0].type.HOW ~~ Metamodel::ParametricRoleHOW,
+    'the my method invocant is not constrained to the concrete role';
+
+# vim: expandtab shiftwidth=4

--- a/t/02-rakudo/trait-package-metaclass.t
+++ b/t/02-rakudo/trait-package-metaclass.t
@@ -1,0 +1,49 @@
+use Test;
+
+# A trait sees the enclosing package's own metaclass through the
+# dynamic $*PACKAGE.
+
+plan 7;
+
+role Marked { method marked { 'yes' } }
+
+multi trait_mod:<is>(Attribute:D $a, :$mark!) {
+    $*PACKAGE.HOW does Marked unless $*PACKAGE.HOW ~~ Marked;
+}
+class Marker {
+    has $.x is mark;
+}
+ok Marker.HOW ~~ Marked, 'role mixed into $*PACKAGE.HOW from an attribute trait persists to the class';
+is Marker.HOW.marked, 'yes', 'the mixed-in metaclass method is callable on the composed type';
+
+# The HOW the trait sees is the enclosing package's own metaclass: a ClassHOW
+# in a class body, a ParametricRoleHOW in a role body.
+multi trait_mod:<is>(Attribute:D $a, :$branch!) {
+    my $kind = do given $*PACKAGE.HOW {
+        when Metamodel::ParametricRoleHOW { 'role' }
+        when Metamodel::ClassHOW          { 'class' }
+        default                           { 'other' }
+    }
+    $*PACKAGE.^add_method('how-kind', my method () { $kind });
+}
+class InClass { has $.x is branch; }
+role  InRole  { has $.y is branch; }
+class DoesInRole does InRole {}
+is InClass.how-kind, 'class', 'an attribute trait in a class body sees the class metaclass';
+is DoesInRole.how-kind, 'role', 'an attribute trait in a role body sees the role metaclass';
+
+# A trait on the package declaration itself reaches that package's own type
+# object, and for a nested package the inner type, not the enclosing one.
+multi trait_mod:<is>(Mu:U \type, :$selfmark!) {
+    $*PACKAGE.HOW does Marked unless $*PACKAGE.HOW ~~ Marked;
+}
+class SelfMarked is selfmark { }
+ok SelfMarked.HOW ~~ Marked, 'a trait on the package itself reaches the package type object';
+
+class Outer {
+    class Inner is selfmark { }
+}
+ok Outer::Inner.HOW ~~ Marked, 'a package-self trait on a nested package reaches the nested type';
+nok Outer.HOW ~~ Marked, 'and does not reach the enclosing package';
+
+# vim: expandtab shiftwidth=4

--- a/t/02-rakudo/where-subset-anon-name.t
+++ b/t/02-rakudo/where-subset-anon-name.t
@@ -1,0 +1,18 @@
+use Test;
+
+# An inline where-constraint is an anonymous refinement type, reported
+# as <anon> in a failed type check.
+
+plan 2;
+
+throws-like { my Str $x where { $_ ne 'no' }; $x = 'no' },
+    X::TypeCheck,
+    message => /'<anon>'/,
+    'where on a typed variable reports the constraint as <anon>';
+
+throws-like { my class C { has Str $.y is rw where { $_ ne 'no' } }; C.new.y = 'no' },
+    X::TypeCheck,
+    message => /'<anon>'/,
+    'where on a typed attribute reports the constraint as <anon>';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
AttrX::Mooish does a fair amount of metamodel work from a `trait_mod` (it mixes a role into the class's HOW, installs a clone fixup method, and so on) and none of it runs under the RakuAST frontend. It turned out to be a few separate frontend bugs rather than one, so this is three independent commits, each with a test in `t/02-rakudo`. With all three the module's suite passes under RakuAST the same as it does on the legacy frontend.

The first is `$*PACKAGE` during trait application. Previously a `trait_mod` that reached for the enclosing package through the dynamic `$*PACKAGE` got the RakuAST package node, whose `.HOW` isn't the metaclass the type ends up composed with. A trait that mixes a role into `$*PACKAGE.HOW`, which is how AttrX::Mooish adds its behavior, acted on the wrong object and the change was gone by the time the class was composed. This binds `$*PACKAGE` to the package type object while traits run, the way the legacy frontend does.

The second is the name of an inline where-constraint subset. Previously `my Str $x where { ... }` gave the subset a generated name like `Str+anon_subset_1`, which then showed up in the message of a failed type check. The legacy frontend reports an anonymous constraint as `<anon>`. This creates the subset without a name so it reports as `<anon>` too. It also happens to fix `my Int(Str) $x where * > 0 = "5"`, which used to error because the old code called `.name` on the type and a coercion type doesn't have one.

The third is the invocant of an anon or my method declared in a role. Previously a named `anon method` (or `my method`) in a role body was typed with the concrete role as its invocant. That's a problem when the method gets detached and added to some other type, which is exactly what AttrX::Mooish does when its ClassHOW role installs a clone method onto the user's class. The concrete-role invocant then rejects instances of that class. This gives such a method an unconstrained `Mu` invocant, the way meta-methods already are.
