### PR TITLE
RakuAST: don't drop a declaration when collapsing a constant conditional

### DIFF
--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -709,21 +709,24 @@ class RakuAST::Node {
 
     # A ternary with a constant condition becomes the branch the condition
     # selects. The branches are expressions, so the value is preserved, and the
-    # unselected branch is one the running program would not have evaluated.
+    # unselected branch is one the running program would not have evaluated. The
+    # condition is removed as well, so it too must be droppable.
     method IMPL-COLLAPSE-TERNARY(RakuAST::Resolver $resolver, Mu $expr) {
         return $expr unless nqp::istype($expr, RakuAST::Ternary);
         my int $truth := self.IMPL-CONSTANT-TRUTH($resolver, $expr.condition);
         return $expr if $truth < 0;
         my $keep := $truth ?? $expr.then !! $expr.else;
         my $drop := $truth ?? $expr.else !! $expr.then;
-        self.IMPL-DROPPABLE($drop) ?? $keep !! $expr
+        self.IMPL-DROPPABLE($expr.condition) && self.IMPL-DROPPABLE($drop)
+          ?? $keep !! $expr
     }
 
     # A boolean short-circuit (&& and ||, or their loose forms `and` and `or`)
     # with a constant left operand becomes the side the operator yields: an
     # `and` gives the right side when the left is true and the left otherwise,
     # an `or` the mirror. The dropped side is one the running program would not
-    # have evaluated, so its code is removed too.
+    # have evaluated, so its code is removed too. The left's constant truth
+    # stands in for the runtime test only when the left is droppable.
     method IMPL-COLLAPSE-SHORT-CIRCUIT(RakuAST::Resolver $resolver, Mu $expr) {
         return $expr unless nqp::istype($expr, RakuAST::ApplyInfix);
         my $infix := $expr.infix;
@@ -745,7 +748,8 @@ class RakuAST::Node {
             ?? ($truth ?? $right !! $left)
             !! ($truth ?? $left  !! $right);
         my $drop := $keep =:= $left ?? $right !! $left;
-        self.IMPL-DROPPABLE($drop) ?? $keep !! $expr
+        self.IMPL-DROPPABLE($left) && self.IMPL-DROPPABLE($drop)
+          ?? $keep !! $expr
     }
 
     # Raku truth value of a node, or -1 when it cannot be determined safely.

--- a/t/08-performance/12-rakuast-collapse-ternary.t
+++ b/t/08-performance/12-rakuast-collapse-ternary.t
@@ -3,7 +3,7 @@ use Test::Helpers;
 use Test;
 use experimental :rakuast;
 
-plan 7;
+plan 8;
 
 # A ternary with a constant condition collapses to the branch the condition
 # selects. Each scenario asserts the shape of the tree the program compiles
@@ -25,6 +25,11 @@ ok tree(Q[my $a = 1; my $x = $a ?? "t" !! "f"]).contains('??'),
     'a runtime condition is left for runtime';
 ok tree(Q[my constant C = class :: is Cool { method Bool { die } }.new; my $x = C ?? 1 !! 2]).contains('??'),
     'a condition whose truthiness throws is left for runtime';
+
+# The condition is removed by the collapse, so it must be droppable. A
+# condition that declares a variable keeps its binding.
+ok tree(Q[my $x = (my @a := (3, 7)) ?? "t" !! "f"]).contains('??'),
+    'a condition that declares a variable is left for runtime';
 
 # The unoptimized tree still holds the ternary, so the scenarios above are
 # known to be testing the optimizer rather than something upstream.

--- a/t/08-performance/13-rakuast-collapse-short-circuit.t
+++ b/t/08-performance/13-rakuast-collapse-short-circuit.t
@@ -3,7 +3,7 @@ use Test::Helpers;
 use Test;
 use experimental :rakuast;
 
-plan 12;
+plan 13;
 
 # A boolean short-circuit with a constant left operand collapses to the side
 # the operator yields, and the dropped side's code is removed. Each scenario
@@ -29,9 +29,12 @@ ok tree(Q[my $y = (False or 7)]).contains('= 7'),
     'the loose form or collapses the same way';
 
 # The collapse declines when the left operand's truth is not a known
-# constant, or when dropping the other side would lose a declaration.
+# constant, when dropping the other side would lose a declaration, or when
+# the left operand itself declares one.
 ok tree(Q[my $a = 1; my $y = $a && 7]).contains('&&'),
     'a runtime left operand is left for runtime';
+ok tree(Q[sub e() {9}; my $y = (my @a := (3, 7)) && e()]).contains('&&'),
+    'a left operand that declares a variable is left for runtime';
 ok tree(Q[my $y = False && (my $x = 5)]).contains('&&'),
     'a side holding a declaration keeps the branch';
 nok tree(Q[my $y = False && do { my $t = 5; $t }]).contains('do'),


### PR DESCRIPTION
Previously the ternary (`?? !!`) and short-circuit (`&&`/`||` and their loose `and`/`or` forms) collapses replaced the whole expression with the branch the constant condition selected, but only checked that the dropped branch was droppable, not the condition they also removed. A condition like `(my @a := (3, 7))` declares and binds a variable, so folding it away lost the binding and let the empty declared array decide the branch instead of the bound value. This makes both collapses require the condition to be droppable too, so a condition that declares a variable is left for runtime.