### PR TITLE
RakuAST: Accept a Mu lhs and rhs in the test-assign metaops

### DIFF
--- a/src/core.c/metaops.rakumod
+++ b/src/core.c/metaops.rakumod
@@ -3,53 +3,53 @@ sub METAOP_ASSIGN(\op) is implementation-detail {
     Rakudo::Internals.METAOP_ASSIGN(op)
 }
 
-sub METAOP_TEST_ASSIGN:<//>(\lhs, $rhs) is raw is implementation-detail {
+sub METAOP_TEST_ASSIGN:<//>(Mu \lhs, Mu $rhs) is raw is implementation-detail {
     lhs // (lhs = $rhs())
 }
-sub METAOP_TEST_ASSIGN:<||>(\lhs, $rhs) is raw is implementation-detail {
+sub METAOP_TEST_ASSIGN:<||>(Mu \lhs, Mu $rhs) is raw is implementation-detail {
     lhs || (lhs = $rhs())
 }
-sub METAOP_TEST_ASSIGN:<&&>(\lhs, $rhs) is raw is implementation-detail {
+sub METAOP_TEST_ASSIGN:<&&>(Mu \lhs, Mu $rhs) is raw is implementation-detail {
     lhs && (lhs = $rhs())
 }
-sub METAOP_TEST_ASSIGN:<or>(\lhs, $rhs) is raw is implementation-detail {
+sub METAOP_TEST_ASSIGN:<or>(Mu \lhs, Mu $rhs) is raw is implementation-detail {
     lhs or (lhs = $rhs())
 }
-sub METAOP_TEST_ASSIGN:<and>(\lhs, $rhs) is raw is implementation-detail {
+sub METAOP_TEST_ASSIGN:<and>(Mu \lhs, Mu $rhs) is raw is implementation-detail {
     lhs and (lhs = $rhs())
 }
-sub METAOP_TEST_ASSIGN:<andthen>(\lhs, $rhs) is raw is implementation-detail {
+sub METAOP_TEST_ASSIGN:<andthen>(Mu \lhs, Mu $rhs) is raw is implementation-detail {
     lhs andthen (lhs = $rhs())
 }
-sub METAOP_TEST_ASSIGN:<notandthen>(\lhs, $rhs) is raw is implementation-detail {
+sub METAOP_TEST_ASSIGN:<notandthen>(Mu \lhs, Mu $rhs) is raw is implementation-detail {
     lhs notandthen (lhs = $rhs())
 }
-sub METAOP_TEST_ASSIGN:<orelse>(\lhs, $rhs) is raw is implementation-detail {
+sub METAOP_TEST_ASSIGN:<orelse>(Mu \lhs, Mu $rhs) is raw is implementation-detail {
     lhs orelse (lhs = $rhs())
 }
 
-sub METAOP_TEST_ASSIGN_VALUE:<//>(\lhs, $rhs) is raw is implementation-detail {
+sub METAOP_TEST_ASSIGN_VALUE:<//>(Mu \lhs, Mu $rhs) is raw is implementation-detail {
     lhs // (lhs = $rhs)
 }
-sub METAOP_TEST_ASSIGN_VALUE:<||>(\lhs, $rhs) is raw is implementation-detail {
+sub METAOP_TEST_ASSIGN_VALUE:<||>(Mu \lhs, Mu $rhs) is raw is implementation-detail {
     lhs || (lhs = $rhs)
 }
-sub METAOP_TEST_ASSIGN_VALUE:<&&>(\lhs, $rhs) is raw is implementation-detail {
+sub METAOP_TEST_ASSIGN_VALUE:<&&>(Mu \lhs, Mu $rhs) is raw is implementation-detail {
     lhs && (lhs = $rhs)
 }
-sub METAOP_TEST_ASSIGN_VALUE:<or>(\lhs, $rhs) is raw is implementation-detail {
+sub METAOP_TEST_ASSIGN_VALUE:<or>(Mu \lhs, Mu $rhs) is raw is implementation-detail {
     lhs or (lhs = $rhs)
 }
-sub METAOP_TEST_ASSIGN_VALUE:<and>(\lhs, $rhs) is raw is implementation-detail {
+sub METAOP_TEST_ASSIGN_VALUE:<and>(Mu \lhs, Mu $rhs) is raw is implementation-detail {
     lhs and (lhs = $rhs)
 }
-sub METAOP_TEST_ASSIGN_VALUE:<andthen>(\lhs, $rhs) is raw is implementation-detail {
+sub METAOP_TEST_ASSIGN_VALUE:<andthen>(Mu \lhs, Mu $rhs) is raw is implementation-detail {
     lhs andthen (lhs = $rhs)
 }
-sub METAOP_TEST_ASSIGN_VALUE:<notandthen>(\lhs, $rhs) is raw is implementation-detail {
+sub METAOP_TEST_ASSIGN_VALUE:<notandthen>(Mu \lhs, Mu $rhs) is raw is implementation-detail {
     lhs notandthen (lhs = $rhs)
 }
-sub METAOP_TEST_ASSIGN_VALUE:<orelse>(\lhs, $rhs) is raw is implementation-detail {
+sub METAOP_TEST_ASSIGN_VALUE:<orelse>(Mu \lhs, Mu $rhs) is raw is implementation-detail {
     lhs orelse (lhs = $rhs)
 }
 

--- a/t/02-rakudo/test-assign-metaop-mu.t
+++ b/t/02-rakudo/test-assign-metaop-mu.t
@@ -1,0 +1,42 @@
+use Test;
+
+plan 6;
+
+{
+    my Mu $x;
+    $x //= 42;
+    is $x, 42, '//= assigns into an undefined Mu-typed container';
+}
+
+{
+    my Mu $x;
+    $x ||= 7;
+    is $x, 7, '||= assigns into a false Mu-typed container';
+}
+
+{
+    my Mu $x = 5;
+    $x //= 99;
+    is $x, 5, '//= leaves a defined Mu-typed container alone';
+}
+
+{
+    sub f(Mu :$dir is copy) { $dir //= 'default'; $dir }
+    is f(), 'default', '//= works on a Mu-typed parameter';
+}
+
+# A literal Mu on the right routes to the _VALUE helper, which binds the
+# value rather than thunking it.
+{
+    my $x;
+    $x //= Mu;
+    is $x.^name, 'Mu', '//= assigns a Mu value on the right';
+}
+
+{
+    my $x = 0;
+    $x ||= Mu;
+    is $x.^name, 'Mu', '||= assigns a Mu value on the right';
+}
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
The test-assign metaops (//=, ||=, &&=, and the loose and control forms) take their left and right sides through a sigilless \lhs and a $rhs, both of which default to an Any type constraint. The legacy frontend inlines these so it never binds the parameters, but the RakuAST frontend calls the helper, so a Mu on either side died with "expected Any but got Mu".

A Mu lhs shows up as a Mu-typed container, e.g. my Mu $x; $x //= 42. A Mu rhs shows up when the right side is a literal Mu, which routes to the _VALUE helper that binds the value directly (a non-constant right side is thunked and so always binds a Callable). Constrain both to Mu so the helpers bind a Mu container and a Mu value too.

Found via the paths module, whose paths sub has a Mu :$dir is copy that it //=s a default onto.