### PR TITLE
RakuAST: route smartmatch through the smartmatch dispatcher

### DIFF
--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -443,6 +443,19 @@ class RakuAST::Infix
         {
             self.IMPL-SMARTMATCH-QAST($context, $left, $right, nqp::atkey(OP-SMARTMATCH, $op));
         }
+        elsif nqp::existskey(OP-SMARTMATCH, $op) {
+            # A constant or variable right side does not reference the topic, so
+            # it needs no topicalization. The dispatcher still reduces a type
+            # object whose ACCEPTS comes from the setting to a type check.
+            my int $negate := nqp::atkey(OP-SMARTMATCH, $op);
+            QAST::Op.new(
+                :op<dispatch>,
+                QAST::SVal.new( :value<raku-smartmatch> ),
+                $left.IMPL-TO-QAST($context),
+                $right.IMPL-TO-QAST($context),
+                QAST::IVal.new( :value( $negate ?? -1 !! 1 ) )
+            )
+        }
         else {
             my $qast := self.IMPL-INFIX-QAST:
                 $context,
@@ -628,38 +641,20 @@ class RakuAST::Infix
                 $sm-call);
         }
 
-        my $accepts-call;
-        if $negate {
-            $accepts-call := QAST::Op.new(
-                :op<callmethod>, :name<not>,
-                QAST::Op.new(
-                    :op('callmethod'), :name('ACCEPTS'),
-                    $right.IMPL-TO-QAST($context),
-                    QAST::Var.new(:name<$_>, :scope<lexical>)));
-        }
-        else {
-            my $rhs-local := QAST::Node.unique('!sm-rhs');
-            $accepts-call := QAST::Op.new(
-                :op('callmethod'), :name('ACCEPTS'),
-                QAST::Var.new( :name($rhs-local), :scope<local> ),
-                QAST::Var.new(:name<$_>, :scope<lexical>));
-            $accepts-call := QAST::Op.new(
-                :op<if>,
-                QAST::Op.new(
-                    :op<istype>,
-                    QAST::Op.new(
-                        :op<bind>,
-                        QAST::Var.new( :name($rhs-local), :scope<local>, :decl<var> ),
-                        $right.IMPL-TO-QAST($context),
-                    ),
-                    QAST::WVal.new( :value(Regex) )),
-                $accepts-call,
-                QAST::Op.new(
-                    :op<callmethod>,
-                    :name<Bool>,
-                    $accepts-call ));
-        }
-        self.IMPL-TEMPORARIZE-TOPIC( $left.IMPL-TO-QAST($context), $accepts-call )
+        # The topic is bound to the left side so the right side can reference
+        # it. The dispatcher reduces a type object whose ACCEPTS comes from the
+        # setting to a type check, and handles a regex or junction right side.
+        # The boolification flag boolifies a non-regex result, or negates.
+        my $sm-call := QAST::Op.new(
+            :op<dispatch>,
+            QAST::SVal.new( :value<raku-smartmatch> ),
+            QAST::Var.new( :name('$_'), :scope('lexical') ),
+            $right.IMPL-TO-QAST($context),
+            QAST::IVal.new( :value( $negate ?? -1 !! 1 ) )
+        );
+        $sm-call.annotate('smartmatch_accepts', 1);
+        $sm-call.annotate('smartmatch_negated', $negate);
+        self.IMPL-TEMPORARIZE-TOPIC( $left.IMPL-TO-QAST($context), $sm-call )
     }
 
     method IMPL-LIST-INFIX-QAST(RakuAST::IMPL::QASTContext $context, Mu $operands) {

--- a/t/02-rakudo/smartmatch-type-object-accepts.t
+++ b/t/02-rakudo/smartmatch-type-object-accepts.t
@@ -1,0 +1,37 @@
+use Test;
+
+plan 7;
+
+# A type object whose ACCEPTS comes from the setting, even one mixed in from a
+# role, makes a smartmatch a type check rather than an ACCEPTS call.
+
+my $ran = 0;
+my role R { method ACCEPTS($) { ++$ran; True } }
+
+{
+    my $T := Str but R;
+    my $v := "x" but R;
+    ok $v ~~ $T, 'a mixed-in type object in a variable does a type check';
+    nok 42 ~~ $T, 'a value of the wrong type is rejected by the type check';
+}
+
+{
+    my constant T = Str but R;
+    my $v := "y" but R;
+    ok $v ~~ T, 'a mixed-in type object in a constant does a type check';
+    ok ("z" but R) ~~ (Str but R),
+        'a mixed-in type object from an expression does a type check';
+}
+
+{
+    my $T := Str but R;
+    ok 42 !~~ $T, 'negated smartmatch reduces to a type check too';
+}
+
+is $ran, 0, 'the mixed-in ACCEPTS was never called';
+
+# A type object whose ACCEPTS the setting cannot vouch for is still called.
+my role S { method ACCEPTS($) { "matched" } }
+ok "a" ~~ S.new, 'a concrete matcher still runs its own ACCEPTS';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
A smartmatch whose right side is not a regex was compiled to call ACCEPTS on it directly, either inline or, for a constant or variable right side, through the &infix:<~~> sub. Neither reduces a type object whose ACCEPTS comes from the setting to a type check. So a value with a role mixed in that defines its own ACCEPTS had that ACCEPTS run rather than being type checked, where the legacy frontend type checked it.

This compiles such a smartmatch to the raku-smartmatch dispatcher, the same one the legacy frontend compiles to, which performs that reduction.

Found via Needle::Compile, which mixes a role into Str and smartmatches a value against the result expecting a type check.