### PR TITLE
RakuAST: don't run a parameter type's ACCEPTS when checking multi signatures

### DIFF
--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -2305,10 +2305,11 @@ class RakuAST::Sub
         return Nil if nqp::can($meta, 'default');
         return Nil if $*COMPILING_CORE_SETTING == 1; # No chance in early bootstrap
 
-        my int $has-post-constraints;
-        for self.IMPL-UNWRAP-LIST($signature.params) {
-            $has-post-constraints := 1 if $_.constraint_list;
-        }
+        # Checking two candidates for equivalence smartmatches their signatures,
+        # which runs each parameter type's ACCEPTS. A where-clause constraint or
+        # a type whose ACCEPTS is defined outside the setting would run user code
+        # at compile time, so a signature carrying either is left out of the check.
+        return Nil unless self.IMPL-SIGNATURE-STATICALLY-COMPARABLE($signature);
 
         # If there is a revision gated proto, we don't want to worry about throwing
         # re-declaration exceptions. Otherwise, crawl the candidates and ensure that
@@ -2325,15 +2326,11 @@ class RakuAST::Sub
 
                 my $other-signature := $_.signature;
                 next unless $signature.arity == $other-signature.arity;
-
-                my $other-has-post-constraints;
-                for self.IMPL-UNWRAP-LIST($other-signature.params) {
-                    $other-has-post-constraints := 1 if $_.constraint_list
-                }
+                next unless self.IMPL-SIGNATURE-STATICALLY-COMPARABLE($other-signature);
 
                 @seen-accepts.push($_)
-                    if !($has-post-constraints || $other-has-post-constraints)
-                            && (try $other-signature.ACCEPTS($signature) && try $signature.ACCEPTS($other-signature));
+                    if try $other-signature.ACCEPTS($signature)
+                        && try $signature.ACCEPTS($other-signature);
 
                 if @seen-accepts > 0 {
                     my %args;
@@ -2350,6 +2347,21 @@ class RakuAST::Sub
                 }
             }
         }
+    }
+
+    method IMPL-SIGNATURE-STATICALLY-COMPARABLE($signature) {
+        for self.IMPL-UNWRAP-LIST($signature.params) {
+            return False if $_.constraint_list;
+            my $type := $_.type;
+            unless nqp::isnull($type) {
+                my $accepts := nqp::tryfindmethod($type, 'ACCEPTS');
+                return False
+                  if nqp::defined($accepts)
+                  && nqp::istype($accepts, Code)
+                  && !$accepts.file.starts-with('SETTING::');
+            }
+        }
+        True
     }
 }
 

--- a/t/02-rakudo/multi-redeclaration-accepts.t
+++ b/t/02-rakudo/multi-redeclaration-accepts.t
@@ -1,0 +1,21 @@
+use lib <t/packages/Test-Helpers>;
+use Test::Helpers;
+use Test;
+
+plan 1;
+
+# Checking a new multi candidate against the others for an equivalent signature
+# runs each parameter type's ACCEPTS. A parameter type whose ACCEPTS comes from
+# outside the setting is left out, so its ACCEPTS is not run at compile time.
+
+is-run q:to/CODE/,
+        my role R { method ACCEPTS($) { note "ran"; True } }
+        my constant T = Str but R;
+        multi sub f(T   $x) { }
+        multi sub f(Int $x) { }
+        print "compiled";
+        CODE
+    :out("compiled"), :err(""),
+    'the duplicate-multi check does not run a parameter type ACCEPTS at compile time';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Defining a multi candidate checks whether its signature is equivalent to that of an existing candidate. The check smartmatches the two signatures, which runs each parameter type's ACCEPTS. A parameter carrying a where-clause constraint was already skipped. A parameter whose type has an ACCEPTS that comes from outside the setting, such as a value with a role mixed in, was not, so that ACCEPTS ran while the candidates were being compiled.

This skips a signature whose parameter has such a type, the same way one with a where-clause constraint is skipped.

Found via Needle::Compile, which mixes a role with its own ACCEPTS into Str and uses the result as a parameter type. That ACCEPTS stringifies its argument, so the compile-time calls warned about uninitialized values.