### PR TITLE
RakuAST: don't redeclare a special variable bound in a sub signature

### DIFF
--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -2021,6 +2021,11 @@ class RakuAST::Routine
                     nqp::push(@declarations, $_);
                 }
             }
+            # A special variable bound inside a sub-signature, such as the $_ in
+            # `(:value($_))`, is not a top-level parameter, so catch it too.
+            $slash := 0            if $slash && $!signature.IMPL-HAS-PARAMETER('$/');
+            $exclamation-mark := 0 if $exclamation-mark && $!signature.IMPL-HAS-PARAMETER('$!');
+            $underscore := 0       if $underscore && $!signature.IMPL-HAS-PARAMETER('$_');
         }
         nqp::push(@declarations, RakuAST::VarDeclaration::Implicit::Special.new(:name('$/'))) if $slash;
         nqp::push(@declarations, RakuAST::VarDeclaration::Implicit::Special.new(:name('$!'))) if $exclamation-mark;

--- a/src/Raku/ast/signature.rakumod
+++ b/src/Raku/ast/signature.rakumod
@@ -179,6 +179,7 @@ class RakuAST::Signature
         if $!parameters {
             for $!parameters {
                 return True if $_.target && $_.target.lexical-name eq $name;
+                return True if $_.sub-signature && $_.sub-signature.IMPL-HAS-PARAMETER($name);
             }
         }
         False

--- a/t/02-rakudo/sub-signature-special-var.t
+++ b/t/02-rakudo/sub-signature-special-var.t
@@ -1,0 +1,39 @@
+use Test;
+
+plan 5;
+
+# A special variable ($_, $/, $!) bound inside a destructuring sub-signature is
+# a real parameter, so the routine or block must not also declare an implicit
+# one. Doing both declared the same lexical twice, which failed to compile.
+
+{
+    my @seen;
+    for (a => 1, b => 2) -> (:key($k), :value($_)) {
+        @seen.push("$k=$_");
+    }
+    is @seen.join(','), 'a=1,b=2',
+        '$_ in a for-loop destructuring sub-signature binds the value';
+}
+
+{
+    sub k(($_)) { $_ }
+    is k((7,)), 7, '$_ in a positional sub-signature binds the destructured value';
+}
+
+{
+    sub g(($/)) { $/ }
+    is g((2,)), 2, '$/ in a sub-signature binds without a redeclaration';
+}
+
+{
+    sub h(($!)) { $! }
+    is h((1,)), 1, '$! in a sub-signature binds without a redeclaration';
+}
+
+{
+    my @seen;
+    for ((5,), (6,)) -> ($!) { @seen.push($!) }
+    is @seen.join(','), '5,6', '$! in a for-loop sub-signature binds without a redeclaration';
+}
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
A block or routine declares an implicit `$_`, `$/`, and `$!` unless its signature already binds one. The check for an existing binding only looked at top level parameters, so a special variable bound inside a destructuring sub signature, such as the `$_` in `-> (:value($_))`, went unnoticed. The implicit one was then declared alongside it, and the two declarations of the same lexical failed to compile with "Lexical '$_' already declared".

This looks into sub-signatures when deciding whether a signature already binds a special variable.

Found via `App::Rak`, which loops with `-> (:key($option), :value($_))`.