### PR TITLE
Fix IS-SETTING-ONLY-U so a user ACCEPTS is not skipped

### DIFF
--- a/src/core.c/Routine.rakumod
+++ b/src/core.c/Routine.rakumod
@@ -283,32 +283,32 @@ my class Routine { # declared in BOOTSTRAP
           !! self.Mu::iterator
     }
 
-    # Return 1 if all candidates of the given proto have a :U invocant
-    # constraint, else 0.
+    # Return 1 if every candidate that can run for an undefined invocant comes
+    # from the setting, else 0. The invocant's definiteness lives in the
+    # parameter flags, not in its type, which carries no smiley.
     method IS-SETTING-ONLY-U() is implementation-detail {
         for self.candidates(:!local, :with-proto) -> &cand {
             next unless nqp::istype(&cand, Method)
                      || nqp::istype(&cand, Submethod);
 
-            my $invocant-type := &cand.signature.params[0].type;
-            next unless $invocant-type.^archetypes.definite
-                     && $invocant-type.^definite;
+            next if nqp::getattr_i(nqp::decont(&cand.signature.params[0]),
+                      Parameter, '$!flags') +& nqp::const::SIG_ELEM_DEFINED_ONLY;
 
             return 0 unless &cand.file.starts-with: 'SETTING::';
         }
         1
     }
 
-    # Return 1 if all candidates of the given proto have a :D invocant
-    # constraint, else 0.
+    # Return 1 if every candidate that can run for a defined invocant comes
+    # from the setting, else 0. The invocant's definiteness lives in the
+    # parameter flags, not in its type, which carries no smiley.
     method IS-SETTING-ONLY-D() is implementation-detail {
         for self.candidates(:!local, :with-proto) -> &cand {
             next unless nqp::istype(&cand, Method)
                      || nqp::istype(&cand, Submethod);
 
-            my $invocant-type := &cand.signature.params[0].type;
-            next if $invocant-type.^archetypes.definite
-                 && $invocant-type.^definite;
+            next if nqp::getattr_i(nqp::decont(&cand.signature.params[0]),
+                      Parameter, '$!flags') +& nqp::const::SIG_ELEM_UNDEFINED_ONLY;
 
             return 0 unless &cand.file.starts-with: 'SETTING::';
         }

--- a/t/02-rakudo/smartmatch-user-accepts.t
+++ b/t/02-rakudo/smartmatch-user-accepts.t
@@ -1,0 +1,45 @@
+use Test;
+
+plan 10;
+
+# A type object with a user-defined ACCEPTS runs it for a smartmatch rather than
+# reducing to a type check (rakudo #5762).
+{
+    my $ran = 0;
+    my class C { method ACCEPTS($) { ++$ran; True } }
+    ok 42 ~~ C, 'a type object with a user ACCEPTS runs it for a smartmatch';
+    is $ran, 1, 'the user ACCEPTS ran once';
+}
+
+# An ACCEPTS mixed in by a role onto a built-in type is user-defined too, the
+# shape Needle::Compile's StrType relies on.
+{
+    my $ran = 0;
+    my role R { method ACCEPTS($) { ++$ran; True } }
+    my constant T = Int but R;
+    ok 42 ~~ T, 'a role-supplied ACCEPTS on a but-mixed type object is called';
+    is $ran, 1, 'the role ACCEPTS ran once';
+}
+
+# A candidate constrained to a defined invocant cannot run for a type object, so
+# the type check applies and that ACCEPTS is not called.
+{
+    my $ran = 0;
+    my class D { multi method ACCEPTS(D:D: $) { ++$ran; True } }
+    nok 42 ~~ D, 'a :D-only ACCEPTS does not run for a type-object right side';
+    is $ran, 0, 'so the type check applies and the ACCEPTS is not called';
+}
+
+# Negation runs the same ACCEPTS and inverts its result.
+{
+    my $ran = 0;
+    my class N { method ACCEPTS($) { ++$ran; False } }
+    ok 42 !~~ N, 'a negated smartmatch runs the user ACCEPTS and inverts it';
+    is $ran, 1, 'the user ACCEPTS ran once for the negated form';
+}
+
+# A type whose ACCEPTS comes from the setting still reduces to a type check.
+ok  42  ~~ Int, 'a setting type still type checks, a match';
+nok "x" ~~ Int, 'a setting type still type checks, a non-match';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Smartmatch against a type object reduces to a type check when the type's ACCEPTS comes only from the setting, which the dispatcher decides with IS-SETTING-ONLY-U. That method read the invocant's definiteness from `.signature.params[0].type`, but a parameter's type carries no :D or :U smiley, so the `.^archetypes.definite` test never matched and every candidate was skipped. It returned 1 for any ACCEPTS, so `$x ~~ SomeType` reduced to a type check even when SomeType defines its own ACCEPTS, never calling it.

This reads the definiteness from the parameter flags and skips a candidate constrained to a defined invocant, which cannot run for an undefined one. The defined-invocant mirror IS-SETTING-ONLY-D carried the same dead check and gets the same fix. That side produced no wrong result, since leaving every candidate in play already reported a user ACCEPTS as not setting-only.

Fixes #5762