### PR TITLE
Add Date/Datetime.yyyy-mm method

### DIFF
--- a/src/core.c/Dateish.rakumod
+++ b/src/core.c/Dateish.rakumod
@@ -157,6 +157,17 @@ my role Dateish {
         nqp::join($sep,$parts)
     }
 
+    method mm-dd(str $sep = "-" --> Str:D) {
+        my $parts := nqp::list_s;
+        nqp::push_s($parts,
+          nqp::concat(nqp::x('0',nqp::islt_i($!month,10)),$!month)
+        );
+        nqp::push_s($parts,
+          nqp::concat(nqp::x('0',nqp::islt_i($!day,10)),$!day)
+        );
+        nqp::join($sep,$parts)
+    }
+
     method yyyy-mm-dd(str $sep = "-" --> Str:D) {
         my $parts := nqp::list_s;
         nqp::push_s($parts, $!year < 1000 || $!year > 9999

--- a/src/core.c/Dateish.rakumod
+++ b/src/core.c/Dateish.rakumod
@@ -145,6 +145,18 @@ my role Dateish {
           + ($!month > 2 && IS-LEAP-YEAR($!year));
     }
 
+    method yyyy-mm(str $sep = "-" --> Str:D) {
+        my $parts := nqp::list_s;
+        nqp::push_s($parts, $!year < 1000 || $!year > 9999
+          ?? self!year-Str
+          !! nqp::tostr_I(nqp::getattr_i(self,$?CLASS,'$!year'))
+        );
+        nqp::push_s($parts,
+          nqp::concat(nqp::x('0',nqp::islt_i($!month,10)),$!month)
+        );
+        nqp::join($sep,$parts)
+    }
+
     method yyyy-mm-dd(str $sep = "-" --> Str:D) {
         my $parts := nqp::list_s;
         nqp::push_s($parts, $!year < 1000 || $!year > 9999


### PR DESCRIPTION
Faster / shorter way to just get a YYYY-MM representation, as mentioned in: https://irclogs.raku.org/raku/2026-06-17.html#21:08

This is about 25% faster than the suggested user solution:
  Date.today.yyyy-mm-dd.substr(0,7)