### PR TITLE
RakuAST: give all package installers is-stub and defuse-stub

### DIFF
--- a/src/Raku/ast/scoping.rakumod
+++ b/src/Raku/ast/scoping.rakumod
@@ -1013,6 +1013,9 @@ class RakuAST::PackageInstaller {
     ### Consuming classes must define:
     #    method IMPL-GENERATE-LEXICAL-DECLARATION(RakuAST::Name $name, Mu $type-object) { ... }
 
+    method is-stub() { False }
+    method defuse-stub() { }
+
     method IMPL-INSTALL-PACKAGE(
         RakuAST::Resolver $resolver,
         str $scope,

--- a/src/Raku/ast/type.rakumod
+++ b/src/Raku/ast/type.rakumod
@@ -769,7 +769,6 @@ class RakuAST::Type::Enum
 
     method is-lexical() { True }
     method is-simple-lexical-declaration() { False }
-    method is-stub() { False }
 
     method IMPL-EXPR-QAST(RakuAST::IMPL::QASTContext $context) {
         my $qast := QAST::Op.new(:op('call'), :name('&ENUM_VALUES'), $!term.IMPL-EXPR-QAST($context));

--- a/t/02-rakudo/our-package-redeclaration.t
+++ b/t/02-rakudo/our-package-redeclaration.t
@@ -2,7 +2,7 @@ use lib <t/packages/Test-Helpers>;
 use Test;
 use Test::Helpers;
 
-plan 9;
+plan 11;
 
 is-run q:to/CODE/,
     EVAL q[class A {}];
@@ -85,5 +85,22 @@ is-run q:to/CODE/,
     CODE
     :out('ok'), :err(''),
     'cross-compunit $*REPO.load reload silent-replaces';
+
+is-run q:to/CODE/,
+    enum E::Vol <Lo Hi>;
+    class E { method greet { "cls" } };
+    print E::Vol::Hi ~ "-" ~ E.greet;
+    CODE
+    :out('Hi-cls'), :err(''),
+    'compound named enum vivifies a prefix stub that a later class fills';
+
+is-run q:to/CODE/,
+    subset S::Sub of Int;
+    role S { method tag { "role" } };
+    my S::Sub $n = 42;
+    print "$n-{S.tag}";
+    CODE
+    :out('42-role'), :err(''),
+    'compound named subset vivifies a prefix stub that a later role fills';
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
A compound named `enum` or `subset` such as `enum Foo::Bar` vivifies a stub package for the `Foo` prefix and records the installing node as its owner. Declaring `Foo` afterwards as a class or role merges into that stub and calls `is-stub` and `defuse-stub` on the owner. `RakuAST::Type::Enum` had no `defuse-stub` and `RakuAST::Type::Subset` had neither, so the merge died with a "No such method" error (seen while installing `TAP`).

Only a `RakuAST::Package` can be a forward stub, so move the defaults onto `RakuAST::PackageInstaller` where `Package` overrides them and the other installers inherit.