### PR TITLE
RakuAST: Don't warn that a sunk {*} is a useless use

### DIFF
--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -57,6 +57,10 @@ class RakuAST::OnlyStar
         nqp::findmethod(RakuAST::Expression, 'IMPL-TO-QAST')(self, $context)
     }
 
+    method PERFORM-CHECK(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
+        True  # `{*}` dispatches to candidates, so it is never useless when sunk
+    }
+
     method IMPL-EXPR-QAST(RakuAST::IMPL::QASTContext $context) {
         # The dispatch op is the only code in an onlystar body, and a
         # frame's location, as reported by Code.file and Code.line, comes

--- a/t/02-rakudo/sink-warnings-legacy-parity.t
+++ b/t/02-rakudo/sink-warnings-legacy-parity.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 14;
+plan 15;
 
 sub stderr-of(Str $code) {
     run($*EXECUTABLE.absolute, '-e', $code, :err).err.slurp(:close)
@@ -79,5 +79,14 @@ ok useless-lines(
         stderr-of 'sub infix:<puref>($a, $b) is pure { $a }; my $y = 1; sub f { $y puref $y; 42 }; f()'
     ).elems,
     'a user-defined infix declared `is pure` is a useless-use subject';
+
+# `{*}` performs the proto dispatch to its candidates, so it has an effect
+# even in a non-tail (sunk) position in a proto body. Legacy never warns.
+
+nok useless-of(
+        stderr-of('class C { proto method m($x) { {*}; 42 }; multi method m(Int $x) { $x } }; C.m(1)'),
+        '{*}'
+    ),
+    '`{*}` is not a useless-use subject in a non-tail proto body';
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
A `proto` body can place `{*}` before other statements, which sinks the dispatch. `RakuAST::OnlyStar` inherited the default expression check that reports "Useless use of {*} in sink context" for any sunk expression. The dispatch invokes the matching candidates, so it has an effect and is never useless. Override the check on `OnlyStar` to stay silent, as the legacy frontend does.