### PR TITLE
RakuAST: Allow adverbs on user-defined terms

### DIFF
--- a/src/Raku/ast/term.rakumod
+++ b/src/Raku/ast/term.rakumod
@@ -226,11 +226,22 @@ class RakuAST::Term::Named
   is RakuAST::ParseTime
 {
     has str $.name;
+    has RakuAST::ArgList $.args;
 
     method new(str $name) {
         my $obj := nqp::create(self);
         nqp::bindattr_s($obj, RakuAST::Term::Named, '$!name', $name);
+        nqp::bindattr($obj, RakuAST::Term::Named, '$!args', RakuAST::ArgList.new);
         $obj
+    }
+
+    method add-colonpair(RakuAST::ColonPair $pair) {
+        $!args.push($pair);
+        Nil
+    }
+
+    method visit-children(Code $visitor) {
+        $visitor($!args);
     }
 
     method PERFORM-PARSE(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
@@ -242,7 +253,9 @@ class RakuAST::Term::Named
     }
 
     method IMPL-EXPR-QAST(RakuAST::IMPL::QASTContext $context) {
-        QAST::Op.new( :op('call'), :name(self.resolution.lexical-name) )
+        my $call := QAST::Op.new( :op('call'), :name(self.resolution.lexical-name) );
+        $!args.IMPL-ADD-QAST-ARGS($context, $call);
+        $call
     }
 }
 

--- a/t/02-rakudo/term-adverbs.t
+++ b/t/02-rakudo/term-adverbs.t
@@ -1,0 +1,13 @@
+use Test;
+
+plan 3;
+
+proto term:<FOO>(*%) {*}
+multi term:<FOO>(Int :$of!) { "of=$of" }
+multi term:<FOO>(Str :$to!) { "to=$to" }
+
+is FOO:of(5),         'of=5',    'colonpair adverb on a custom term becomes a named arg';
+is FOO:to("x"),       'to=x',    'a different adverb selects a different term multi';
+is FOO:to(FOO:of(5)), 'to=of=5', 'adverbed terms nest as arguments';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
A user-defined `term:<foo>` could not take colonpair adverbs, so `foo:bar(1)` died with "You can't adverb foo". `RakuAST::Term::Named` had no way to carry arguments. Give it an `ArgList` and an `add-colonpair` so the adverbs become named arguments to the term call, the way the legacy frontend handles them.