### PR TITLE
RakuAST: Register a Label's meta-object in the SC at declaration

### DIFF
--- a/src/Raku/ast/statements.rakumod
+++ b/src/Raku/ast/statements.rakumod
@@ -47,9 +47,11 @@ class RakuAST::Label
     }
 
     method IMPL-QAST-DECL(RakuAST::IMPL::QASTContext $context) {
+        my $label := self.meta-object;
+        $context.ensure-sc($label);
         QAST::Var.new(
             :scope('lexical'), :decl('static'), :name($!name),
-            :value(self.meta-object)
+            :value($label)
         )
     }
 

--- a/t/02-rakudo/labels.t
+++ b/t/02-rakudo/labels.t
@@ -1,0 +1,8 @@
+use Test;
+
+plan 1;
+
+is EVAL('FOO: { 21 * 2 }'), 42,
+    'a labeled block with an unreferenced label compiles and yields its value';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
A labeled statement declares a Label via a `static` lexical whose value is the Label meta-object. `RakuAST::Label.IMPL-QAST-DECL` built that QAST::Var without registering the Label in the serialization context, so a labeled block whose label is never referenced (only IMPL-QAST-DECL runs, never IMPL-LOOKUP-QAST) died at codegen with "Object of type Label in QAST::Var value, but not in SC". A labeled loop happened to work only because the label is also looked up.

Ensure-sc the meta-object in IMPL-QAST-DECL, as IMPL-LOOKUP-QAST already does.