### PR TITLE
RakuAST: Also declare ::?PACKAGE at the compunit mainline

### DIFF
--- a/src/Raku/ast/compunit.rakumod
+++ b/src/Raku/ast/compunit.rakumod
@@ -498,6 +498,9 @@ class RakuAST::CompUnit
                 add(RakuAST::VarDeclaration::Implicit::Constant.new(
                     name => '$?PACKAGE', value => $global.compile-time-value
                 ));
+                add(RakuAST::VarDeclaration::Implicit::Constant.new(
+                    name => '::?PACKAGE', value => $global.compile-time-value
+                ));
             }
 
             # GLOBAL package is always added so generated-global can find it


### PR DESCRIPTION
The mainline of a compunit declared `$?PACKAGE` but not its `::?` form. Declare `::?PACKAGE` alongside `$?PACKAGE`.