### PR TITLE
RakuAST: Allow an anonymous package inside a role

### DIFF
--- a/src/Raku/ast/scoping.rakumod
+++ b/src/Raku/ast/scoping.rakumod
@@ -527,9 +527,9 @@ class RakuAST::Declaration
             my $anonymous-package := False;
             if nqp::istype(self, RakuAST::PackageInstaller) {
                 my $name := self.name;
-                $anonymous-package := nqp::istype($name, RakuAST::Name)
+                $anonymous-package := !(nqp::istype($name, RakuAST::Name)
                     && nqp::isconcrete($name)
-                    && !$name.is-installable;
+                    && $name.is-installable);
             }
             unless $anonymous-package {
                 self.add-sorry:


### PR DESCRIPTION
The our-scope-in-role check rejected any `our`-scoped package installer in a role unless it had a non-installable name. A truly anonymous package (e.g. `role { }` used as a value) carries the RakuAST::Name type object rather than a concrete empty name, so the isconcrete guard treated it as named and the check wrongly fired with "Cannot declare our-scoped role inside of a role". An anonymous package installs no symbol, so there is nothing ambiguous to reject.

Treat a name that is not a concrete installable Name as anonymous.