### PR TITLE
RakuAST: Allow a nested-scope constant to shadow an outer one

### DIFF
--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -501,9 +501,8 @@ class RakuAST::VarDeclaration::Constant
             );
             my $name := nqp::getattr_s(self, RakuAST::VarDeclaration::Constant, '$!name');
             my $stash := $resolver.IMPL-STASH-HASH($!package);
-            if nqp::existskey($stash, $name) {
-                nqp::die("already have an 'our constant $name' in the package");
-            }
+            # A same-scope redeclaration is caught by the lexical check, so a
+            # name already present here is a nested shadow that overwrites.
             nqp::bindkey($stash, $name, $!value);
         }
 

--- a/t/02-rakudo/our-constant-shadow.t
+++ b/t/02-rakudo/our-constant-shadow.t
@@ -1,0 +1,38 @@
+use Test;
+
+# A `constant` defaults to `our`. One declared in a nested block shadows
+# an outer constant of the same name and overwrites the package entry,
+# rather than failing to compile with "already have an 'our constant ...'".
+
+plan 4;
+
+use MONKEY-SEE-NO-EVAL;
+
+is EVAL(q:to/CODE/), 2,
+        constant T = 1;
+        { constant T = 2; T }
+        CODE
+    'a nested-block constant shadows the outer one of the same name';
+
+is EVAL(q:to/CODE/), 1,
+        constant T = 1;
+        { constant T = 2 }
+        T
+        CODE
+    'the outer constant is unchanged lexically outside the block';
+
+is EVAL(q:to/CODE/), 2,
+        constant T = 1;
+        { constant T = 2 }
+        OUR::<T>
+        CODE
+    'the nested constant overwrites the package entry';
+
+throws-like {
+    EVAL q:to/CODE/
+        constant T = 1;
+        constant T = 2;
+        CODE
+}, X::Redeclaration, 'a same-scope constant redeclaration still fails';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
A bare `constant` is `our`, so one in a nested block found the outer same-named constant in the package and died with "already have an 'our constant NAME' in the package", though it is a valid shadow. This broke installing IO::Blob. A same-scope redeclaration is still caught by the lexical declaration check.