### PR TITLE
RakuAST: Keep every post-constraint on a parameter

### DIFF
--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -3763,12 +3763,29 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
             $parameter.set-default($<default-value>.ast);
         }
         if $<post-constraint> {
-            my $post-constraint := $<post-constraint>[0];
-            if $post-constraint<EXPR> {
-                $parameter.set-where($post-constraint<EXPR>.ast);
+            my @wheres;
+            my $sub-signature;
+            my int $have-sub-sig;
+            for $<post-constraint> {
+                if $_<EXPR> {
+                    nqp::push(@wheres, $_<EXPR>.ast);
+                }
+                elsif $_<signature> {
+                    $/.panic('Cannot have more than one sub-signature for a parameter')
+                        if $have-sub-sig;
+                    $sub-signature := $_<signature>.ast;
+                    $have-sub-sig := 1;
+                }
             }
-            elsif $post-constraint<signature> {
-                $parameter.set-sub-signature($post-constraint<signature>.ast);
+            $parameter.set-sub-signature($sub-signature) if $have-sub-sig;
+            # Every `where` must hold. Combine multiples into one all-junction.
+            if nqp::elems(@wheres) == 1 {
+                $parameter.set-where(@wheres[0]);
+            }
+            elsif nqp::elems(@wheres) > 1 {
+                $parameter.set-where(Nodify('Call::Name').new(
+                    name => Nodify('Name').from-identifier('all'),
+                    args => Nodify('ArgList').new(|@wheres)));
             }
         }
         if $<param-var><name><sigterm> || $<param-var><sigterm> -> $sig {

--- a/t/02-rakudo/parameter-sub-signature.t
+++ b/t/02-rakudo/parameter-sub-signature.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 15;
+plan 19;
 
 # Parameter sub signature destructure must compile under both
 # frontends, including when the owning routine is compiled at BEGIN.
@@ -129,5 +129,43 @@ is EVAL(q:to/CODE/),
         C.new.run({:x(1)})
         CODE
     'any', 'unfilled sub signature value resolves to an Any candidate';
+
+# 16. A `where` and a sub signature on the same parameter both apply.
+# The parser kept only the first post constraint, so a `where` after a
+# sub signature was silently dropped.
+is EVAL(q:to/CODE/),
+        sub foo(@a (*@items) where { @a.elems == 2 }) { @a.join("|") }
+        foo([3, 4])
+        CODE
+    '3|4', 'where after a sub signature binds the destructure and accepts a valid value';
+
+# 17. The same `where` rejects a value failing the constraint.
+throws-like {
+    EVAL q:to/CODE/
+        sub foo(@a (*@items) where { @a.elems == 2 }) { }
+        foo([1, 2, 3])
+        CODE
+}, X::TypeCheck::Binding::Parameter,
+    'where after a sub signature rejects a value failing the constraint';
+
+# 18. Multiple `where` clauses on one parameter all apply: 0 fails the
+# first, 9 fails the second, 3 passes both.
+is EVAL(q:to/CODE/),
+        sub foo($x where { $_ > 0 } where { $_ < 5 }) { "ok" }
+        ((try foo(0)) // "a") ~ ((try foo(3)) // "b") ~ ((try foo(9)) // "c")
+        CODE
+    'aokc', 'every where clause on a parameter is enforced';
+
+# 19. A where-guarded scalar trait_mod candidate must not shadow the
+# sub signature candidate. A named-pair argument list selects the
+# latter, the dispatch AccessorFacade relies on.
+lives-ok {
+    EVAL q:to/CODE/
+        multi sub trait_mod:<is>(Method $m, :$tag! (*@a) where { so any(@a) !~~ Code }) { die "wrong candidate" }
+        multi sub trait_mod:<is>(Method $m, :@tag! (:&getter!, :&setter!)) { }
+        my sub g($) { 1 }; my sub s($, $) { }
+        my class C { method m() is tag(getter => &g, setter => &s) { } }
+        CODE
+}, 'where-guarded scalar trait candidate does not shadow the named sub signature candidate';
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously only the first post-constraint of a parameter was kept. A parameter can have several. A sub-signature and one or more `where` clauses are all parsed as post-constraints, so a `where` after a sub-signature (`$x (*@a) where {...}`) was dropped, as were the second and later of multiple `where` clauses.

A dropped `where` makes a multi candidate match unconditionally. That broke `is accessor-facade(getter => &g, setter => &s)` from AccessorFacade, whose argument validation lives in a where on a sub-signature parameter, so the wrong trait_mod candidate was chosen and it threw "only takes Callable arguments".

Walk every post-constraint instead of taking the first. A second sub-signature is an error, matching the legacy frontend. Multiple `where` expressions are combined into a single all-junction so each one is enforced.