### PR TITLE
RakuAST: Don't compose a class whose body fails to begin

### DIFF
--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -2619,7 +2619,13 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
             my $context := $*CU.context;
             $ast.body.IMPL-BEGIN($R, $context);
             $ast.to-begin-time($R, $context);
-            $ast.IMPL-COMPOSE($R, $context);
+            # A begin-time error while declaring a body member (a trait that
+            # died, or a begin-time evaluation) defers rather than aborting, so
+            # leave the package uncomposed when that happened, as the legacy
+            # frontend does by unwinding before package composition.
+            # $*PACKAGE-BEGIN-SORRY-BASE is the count at package open.
+            $ast.IMPL-COMPOSE($R, $context)
+              if nqp::iseq_i($R.deferred-begin-sorries, $*PACKAGE-BEGIN-SORRY-BASE);
         }
 
         self.attach: $/, $ast;

--- a/src/Raku/Grammar.nqp
+++ b/src/Raku/Grammar.nqp
@@ -3833,6 +3833,7 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
         :my $*BORG := {};
         :my $*BLOCK;
         :my $*PACKAGE;
+        :my $*PACKAGE-BEGIN-SORRY-BASE := $*R.deferred-begin-sorries;
         :my $scope;
         <!!{ $/.clone_braid_from(self) }>
         <longname>? {}

--- a/src/Raku/ast/begintime.rakumod
+++ b/src/Raku/ast/begintime.rakumod
@@ -43,6 +43,7 @@ class RakuAST::BeginTime
             # Can handle it properly
             if nqp::istype(self,RakuAST::CheckTime) {
                 self.add-sorry: $ex;
+                $resolver.note-deferred-begin-sorry;
             }
 
             # Alas, need to rethrow wil line info if possible

--- a/src/Raku/ast/resolver.rakumod
+++ b/src/Raku/ast/resolver.rakumod
@@ -31,6 +31,19 @@ class RakuAST::Resolver {
     # parents in sibling blocks doesn't collide.
     has Mu $!our-package-decl-map;
 
+    # Count of begin-time errors that were deferred as sorries rather than
+    # aborting (a trait that died, or a begin-time evaluation on a CheckTime
+    # node). A package whose body raises one must not be composed, so a later
+    # redeclaration of the same name silently replaces the incomplete one.
+    has int $!deferred-begin-sorries;
+
+    method note-deferred-begin-sorry() {
+        nqp::bindattr_i(self, RakuAST::Resolver, '$!deferred-begin-sorries',
+          nqp::add_i($!deferred-begin-sorries, 1));
+        Nil
+    }
+    method deferred-begin-sorries() { $!deferred-begin-sorries }
+
     method in-augment-scope() {
         my int $i := nqp::elems($!packages);
         while $i-- {

--- a/src/Raku/ast/scoping.rakumod
+++ b/src/Raku/ast/scoping.rakumod
@@ -1059,9 +1059,17 @@ class RakuAST::PackageInstaller {
                 $target := $current-package;
 
                 my %stash := $resolver.IMPL-STASH-HASH($target);
-                if nqp::existskey(%stash, $final) && !(%stash{$final} =:= $type-object || nqp::istype(%stash{$final}.HOW, Perl6::Metamodel::PackageHOW)) {
+                if nqp::existskey(%stash, $final) {
+                    my $existing := %stash{$final};
+                    # An uncomposed existing type is an incomplete declaration
+                    # (a stub, or one whose body failed to compile); the new one
+                    # replaces it rather than colliding.
                     $resolver.add-sorry: $resolver.build-exception:
-                        'X::Redeclaration', :symbol($final);
+                        'X::Redeclaration', :symbol($final)
+                      unless $existing =:= $type-object
+                          || nqp::istype($existing.HOW, Perl6::Metamodel::PackageHOW)
+                          || (nqp::can($existing.HOW, 'is_composed')
+                              && !$existing.HOW.is_composed($existing));
                 }
             }
         }

--- a/src/Raku/ast/traits.rakumod
+++ b/src/Raku/ast/traits.rakumod
@@ -80,6 +80,7 @@ class RakuAST::TraitTarget {
                             unless nqp::isconcrete($ex);
                     }
                     nqp::push($!sorries, $ex);
+                    $resolver.note-deferred-begin-sorry;
                 }
                 CONTROL {
                     if nqp::getextype($_) == nqp::const::CONTROL_WARN {

--- a/t/02-rakudo/our-package-redeclaration.t
+++ b/t/02-rakudo/our-package-redeclaration.t
@@ -2,7 +2,7 @@ use lib <t/packages/Test-Helpers>;
 use Test;
 use Test::Helpers;
 
-plan 11;
+plan 12;
 
 is-run q:to/CODE/,
     EVAL q[class A {}];
@@ -102,5 +102,15 @@ is-run q:to/CODE/,
     CODE
     :out('42-role'), :err(''),
     'compound named subset vivifies a prefix stub that a later role fills';
+
+is-run q:to/CODE/,
+    use MONKEY-SEE-NO-EVAL;
+    multi sub trait_mod:<is>(Method $m, :$bad!) { die 'trait-died' }
+    sub kind($c) { try EVAL $c; $!.^name }
+    my $code = 'class Bar { method m() is bad {} }';
+    print kind($code) eq kind($code) ?? 'same' !! 'diff';
+    CODE
+    :out('same'), :err(''),
+    'a class whose body trait dies re-throws on a same-name retry, not X::Redeclaration';
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
A begin-time error while declaring a package body member can be deferred as a sorry rather than aborting the parse: a trait that dies, or a begin-time evaluation on a check-time node. The package was then composed and installed as a complete type anyway. Re-declaring that name (as `throws-like { EVAL ... }` does when a test exercises a bad declaration twice) raised a spurious X::Redeclaration, wrapping the real exception in X::Comp::Group.

Count deferred begin-time sorries on the resolver, capture that count at package open, and skip composition when it grew, leaving an uncomposed type the way the legacy frontend does by unwinding before composition. Treat an uncomposed existing type as replaceable in the our-scope redeclaration check, mirroring legacy's is_composed gate.