### PR TITLE
RakuAST: Compile a package-qualified compile-time variable

### DIFF
--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -2482,7 +2482,14 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
         }
         elsif $twigil eq '?' {
             my $origin-source := $*ORIGIN-SOURCE;
-            if $name eq '$?LINE' {
+            if !$desigilname.is-identifier {
+                # A package-qualified $? variable like $?CALLER::PACKAGE looks
+                # up $?<name> through the package, twigil folded into the sigil.
+                $ast := Nodify('Var::Package').new(
+                  :sigil($sigil ~ $twigil), :name($desigilname)
+                );
+            }
+            elsif $name eq '$?LINE' {
                 $ast := Nodify('Var::Compiler::Line').new(
                    $*LITERALS.intern-Int($origin-source.original-line($/.from))
                 )

--- a/t/02-rakudo/18-pseudostash.t
+++ b/t/02-rakudo/18-pseudostash.t
@@ -2,7 +2,7 @@ use lib $*PROGRAM.parent(2).add('packages/Test-Helpers');
 use Test;
 use Test::Helpers;
 
-plan 7;
+plan 9;
 
 use MONKEY-SEE-NO-EVAL;
 
@@ -44,5 +44,12 @@ is EVAL(q/enum E199 <a b c>; my \t := E199; ~t::<b>/), 'b',
 # The same holds for a call qualified by a runtime lexical package.
 is EVAL(q/class K200 { our sub gv { 42 } }; my \t := K200; t::gv()/), 42,
     'call qualified by a runtime lexical package';
+
+# A package-qualified compile-time variable such as $?CALLER::PACKAGE
+# resolves $?<name> through the pseudo-package, like CALLER::<$?PACKAGE>.
+is EVAL('$?CALLER::PACKAGE').^name, 'Nil',
+    '$?CALLER::PACKAGE compiles and resolves through the CALLER pseudo-package';
+is EVAL('$?FOO::PACKAGE').^name, 'Any',
+    '$?PACKAGE through an unknown package is Any';
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
`$?CALLER::PACKAGE` and other `?`-twigil variables with a `::`-qualified name threw "Variable '...' is not declared" at compile time. The action treated the whole qualified name as a flat compiler-variable lookup rather than a `$?<name>` access through the package, so the lexical resolve failed. This broke installing Green.

Route a qualified `?`-twigil variable through Var::Package with the twigil folded into the sigil, so it resolves `$?<name>` through the package, the same as the explicit CALLER::<$?PACKAGE> form.