### PR TITLE
RakuAST: Resolve a package lookup or call through a runtime lexical

### DIFF
--- a/src/Raku/ast/call.rakumod
+++ b/src/Raku/ast/call.rakumod
@@ -300,7 +300,11 @@ class RakuAST::Call::Name
         }
 
         if !$resolved && $!name.is-multi-part {
-            my $resolved := $resolver.resolve-lexical-constant($!name.IMPL-UNWRAP-LIST($!name.parts)[0].name);
+            # The leading part may be a runtime lexical (the package is only
+            # known at runtime, e.g. `my \t := SomeType; t::foo()`); codegen
+            # takes .WHO on its value, so resolve it without requiring a
+            # compile-time value.
+            my $resolved := $resolver.resolve-lexical($!name.IMPL-UNWRAP-LIST($!name.parts)[0].name);
             if $resolved {
                 nqp::bindattr(self, RakuAST::Call::Name, '$!lexical', $resolved);
             }

--- a/src/Raku/ast/resolver.rakumod
+++ b/src/Raku/ast/resolver.rakumod
@@ -988,8 +988,10 @@ class RakuAST::Resolver::EVAL
         Nil
     }
 
-    # Resolves a lexical to its declaration. The declaration must have a
-    # compile-time value.
+    # Resolves a name to its lexical declaration if that declaration has a
+    # compile-time value, otherwise Nil. A name bound to a non-constant
+    # (e.g. `my \t := $runtime`) is not a compile-time constant, so the
+    # innermost such binding yields Nil rather than an outer constant.
     method resolve-lexical-constant(Str $name, Bool :$current-scope-only) {
 
         # No need to look further
@@ -1003,15 +1005,9 @@ class RakuAST::Resolver::EVAL
             my $found := nqp::elems(@scopes)
                 ?? @scopes[nqp::elems(@scopes) - 1].find-lexical($name)
                 !! Nil;
-            if nqp::isconcrete($found) {
-                if nqp::istype($found,RakuAST::CompileTimeValue) {
-                    return $found;
-                }
-                else {
-                    nqp::die("Symbol '$name' does not have a compile-time value");
-                }
-            }
-            Nil
+            nqp::isconcrete($found) && nqp::istype($found, RakuAST::CompileTimeValue)
+              ?? $found
+              !! Nil
         }
 
         # Walk active scopes, most nested first.
@@ -1021,11 +1017,7 @@ class RakuAST::Resolver::EVAL
             while $i-- {
                 my $found := @scopes[$i].find-lexical($name);
                 if nqp::isconcrete($found) {
-                    nqp::istype($found,RakuAST::CompileTimeValue)
-                      ?? (return $found)
-                      !! nqp::die(
-                           "Symbol '$name' does not have a compile-time value"
-                         );
+                    return nqp::istype($found, RakuAST::CompileTimeValue) ?? $found !! Nil;
                 }
             }
 
@@ -1254,8 +1246,10 @@ class RakuAST::Resolver::Compile
         self.resolve-lexical-in-outer($name)
     }
 
-    # Resolves a lexical to its declaration. The declaration must have a
-    # compile-time value.
+    # Resolves a name to its lexical declaration if that declaration has a
+    # compile-time value, otherwise Nil. A name bound to a non-constant
+    # (e.g. `my \t := $runtime`) is not a compile-time constant, so the
+    # innermost such binding yields Nil rather than an outer constant.
     method resolve-lexical-constant(Str $name, Bool :$current-scope-only) {
         if $name eq 'GLOBAL' {
             return self.global-package;
@@ -1267,13 +1261,8 @@ class RakuAST::Resolver::Compile
             my int $i := nqp::elems(@scopes);
             if ($i > 0) {
                 my $found := @scopes[$i - 1].find-lexical($name);
-                if nqp::isconcrete($found) {
-                    if nqp::istype($found, RakuAST::CompileTimeValue) {
-                        return $found;
-                    }
-                    else {
-                        nqp::die("Symbol '$name' does not have a compile-time value");
-                    }
+                if nqp::isconcrete($found) && nqp::istype($found, RakuAST::CompileTimeValue) {
+                    return $found;
                 }
             }
             return Nil;
@@ -1286,12 +1275,7 @@ class RakuAST::Resolver::Compile
             my $scope := @scopes[$i];
             my $found := $scope.find-lexical($name);
             if nqp::isconcrete($found) {
-                if nqp::istype($found, RakuAST::CompileTimeValue) {
-                    return $found;
-                }
-                else {
-                    nqp::die("Symbol '$name' does not have a compile-time value");
-                }
+                return nqp::istype($found, RakuAST::CompileTimeValue) ?? $found !! Nil;
             }
         }
 

--- a/t/02-rakudo/18-pseudostash.t
+++ b/t/02-rakudo/18-pseudostash.t
@@ -2,7 +2,7 @@ use lib $*PROGRAM.parent(2).add('packages/Test-Helpers');
 use Test;
 use Test::Helpers;
 
-plan 6;
+plan 7;
 
 use MONKEY-SEE-NO-EVAL;
 
@@ -40,5 +40,9 @@ is EVAL(q/enum E198 <a b c>; my \t := E198; my $k = "b"; ~t::{$k}/), 'b',
     'indirect lookup through a runtime lexical type with a hash-index key';
 is EVAL(q/enum E199 <a b c>; my \t := E199; ~t::<b>/), 'b',
     'indirect lookup through a runtime lexical type with a literal key';
+
+# The same holds for a call qualified by a runtime lexical package.
+is EVAL(q/class K200 { our sub gv { 42 } }; my \t := K200; t::gv()/), 42,
+    'call qualified by a runtime lexical package';
 
 # vim: expandtab shiftwidth=4

--- a/t/02-rakudo/18-pseudostash.t
+++ b/t/02-rakudo/18-pseudostash.t
@@ -2,7 +2,9 @@ use lib $*PROGRAM.parent(2).add('packages/Test-Helpers');
 use Test;
 use Test::Helpers;
 
-plan 4;
+plan 6;
+
+use MONKEY-SEE-NO-EVAL;
 
 { # Make sure CLIENT:: works for code invoked from NQP world
     # Wether or not a code object is invoked by Raku or NQP code is pretty much implementation specific. Moreover,
@@ -30,5 +32,13 @@ plan 4;
     $a = PseudoStash.new for ^9999;
     is $a.gist, 'PseudoStash.new(($_ => 9998))', 'did not hang';
 }
+
+# A lexically-bound type used as a package qualifier resolves the symbol
+# through that lexical's value, rather than requiring it to have a
+# compile-time value (`my \t := SomeEnum; t::{$key}`).
+is EVAL(q/enum E198 <a b c>; my \t := E198; my $k = "b"; ~t::{$k}/), 'b',
+    'indirect lookup through a runtime lexical type with a hash-index key';
+is EVAL(q/enum E199 <a b c>; my \t := E199; ~t::<b>/), 'b',
+    'indirect lookup through a runtime lexical type with a literal key';
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously a name qualified by a lexical that only holds its value at runtime, such as `t::{$key}` after `my \t := SomeEnum`, failed to compile with `Symbol 't' does not have a compile-time value`. Resolving the qualified name `t::` ran the leading part through the constant name resolver, which threw for a lexical that is not itself a constant, so it never reached the runtime lookup that takes `.WHO` on the lexical's value. The legacy frontend compiles this and resolves the symbol at runtime.

This makes `resolve-lexical-constant` a query: it returns the declaration when that declaration has a compile-time value and `Nil` otherwise, instead of throwing for a non-constant lexical. Such a name simply is not a compile-time constant, and every caller already treats the result as a value or `Nil`. The leading part then resolves to the lexical and codegen takes `.WHO` on its value.

A call qualified the same way, `t::foo()`, gets the same treatment: `Call::Name` resolves its leading part as a plain lexical, and the call codegen already does `.WHO` on the bound lexical.

Found while installing `GraphQL`, whose `GraphQL::Types` uses `t::{$value}` over an enum type.
