### PR TITLE
RakuAST: Compile a non-interpretable BEGIN-time trait argument

### DIFF
--- a/src/Raku/ast/begintime.rakumod
+++ b/src/Raku/ast/begintime.rakumod
@@ -111,8 +111,8 @@ class RakuAST::BeginTime
 
         # Not ready, wrap in a call and evaluate that
         else {
-            my $call := RakuAST::ApplyPostfix(
-              :postfix(RakuAST::Call::Term.new($args)),
+            my $call := RakuAST::ApplyPostfix.new(
+              :postfix(RakuAST::Call::Term.new(:$args)),
               :operand($callee)
             );
             $call.to-begin-time($resolver, $context);

--- a/src/Raku/ast/parsetime.rakumod
+++ b/src/Raku/ast/parsetime.rakumod
@@ -64,7 +64,9 @@ class RakuAST::ParseTime
             return $resolved(|@pos, |%named);
         }
         else {
-            nqp::die('BEGIN time calls only supported for simple constructs so far')
+            # Args we cannot interpret (e.g. a WhateverCode like `*.flip`) need
+            # the call compiled and evaluated, which the BeginTime version does.
+            RakuAST::BeginTime.IMPL-BEGIN-TIME-CALL($callee, $args, $resolver, $context)
         }
     }
 }

--- a/t/02-rakudo/begin-time-call-whatever-arg.t
+++ b/t/02-rakudo/begin-time-call-whatever-arg.t
@@ -1,0 +1,37 @@
+use Test;
+
+# A trait applied with a WhateverCode argument (e.g. `is foo(*.flip)`) is
+# compiled and evaluated at BEGIN, so the trait receives a working Callable
+# rather than failing with "BEGIN time calls only supported for simple
+# constructs". Each case applies the WhateverCode inside the trait at BEGIN
+# and records the result.
+
+plan 3;
+
+use MONKEY-SEE-NO-EVAL;
+
+is EVAL(q:to/CODE/), 'olleh',
+        my @log;
+        multi sub trait_mod:<is>(Parameter $p, :&conv!) { @log.push(conv("hello")) }
+        sub f($x is conv(*.flip)) {}
+        @log[0]
+        CODE
+    'a WhateverCode argument to a parameter trait reaches it as a Callable';
+
+is EVAL(q:to/CODE/), 11,
+        my @log;
+        multi sub trait_mod:<is>(Routine $r, :&conv!) { @log.push(conv(10)) }
+        sub f() is conv(* + 1) {}
+        @log[0]
+        CODE
+    'a WhateverCode argument to a routine trait reaches it as a Callable';
+
+is EVAL(q:to/CODE/), 'ABC',
+        my @log;
+        multi sub trait_mod:<is>(Variable $v, :&conv!) { @log.push(conv("abc")) }
+        my $x is conv(*.uc);
+        @log[0]
+        CODE
+    'a WhateverCode argument to a variable trait reaches it as a Callable';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
A trait applied with a WhateverCode argument, like `is foo(*.flip)`, died at BEGIN with "BEGIN time calls only supported for simple constructs". A WhateverCode argument cannot be interpreted, so the trait call took the fallback branch, which had two latent bugs no prior path exercised: it called `RakuAST::Call::Term.new($args)` (the `:args` attribute is named) and `RakuAST::ApplyPostfix(...)` without `.new`. On top of that, RakuAST::Parameter, Routine and Package route trait calls through RakuAST::ParseTime's IMPL-BEGIN-TIME-CALL, which had no fallback at all and just died.

Fix the two construction bugs in the BeginTime fallback, and have the ParseTime version delegate to it for arguments it cannot interpret. The trait then receives a real WhateverCode, the same as the legacy frontend.