### PR TITLE
RakuAST: Type an attribute initializer's $_ as Mu

### DIFF
--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -832,10 +832,19 @@ class RakuAST::VarDeclaration::Simple
         nqp::bindattr(self, RakuAST::VarDeclaration::Simple, '$!block', $block);
 
         if self.is-attribute {
+            # $_ is the attribute's current value; type it Mu so a value
+            # outside Any (e.g. a Junction) can bind. Resolve to the Mu type
+            # object directly, since the name is not resolvable this early
+            # during CORE setting compilation.
+            my $topic-type := RakuAST::Type::Simple.new(
+              RakuAST::Name.from-identifier('Mu'));
+            $topic-type.set-resolution(
+              RakuAST::Declaration::ResolvedConstant.new(:compile-time-value(Mu)));
             my $method := RakuAST::Method::Initializer.new(
               :signature(RakuAST::Signature.new(
                 :parameters([
                   RakuAST::Parameter.new(
+                    :type($topic-type),
                     target => RakuAST::ParameterTarget::Var.new(:name<$_>)
                   )
                 ])

--- a/t/02-rakudo/attribute-junction-default.t
+++ b/t/02-rakudo/attribute-junction-default.t
@@ -1,0 +1,17 @@
+use Test;
+
+# An attribute whose default value is outside Any (e.g. a Junction) must
+# bind during object construction. The generated initializer's $_ (the
+# attribute's current value) was typed Any, which a Junction cannot bind to.
+
+plan 3;
+
+my $jc;
+lives-ok { my class C { has Junction $.c = all() }; $jc = C.new.c },
+    'an attribute with a Junction default value constructs';
+is $jc.^name, 'Junction', 'the Junction default bound as a Junction';
+
+lives-ok { my class C { has $.c = self.seed; method seed { 42 } }; C.new },
+    'a default value referencing self still works';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
An attribute with a default value outside Any, such as `has Junction $.c = all()`, died at construction with `Type check failed in binding to parameter '$_'; expected Any but got Junction`. The generated initializer method binds the attribute's current value to `$_`, but RakuAST left `$_` untyped so it defaulted to Any, which a Junction (a Mu, not an Any) cannot bind. The legacy frontend types it Mu.

Type the initializer's `$_` as Mu, resolved to the Mu type object directly rather than by name, since the name is not yet resolvable while the CORE setting itself is compiling.

Found while installing Getopt::Long, whose Argument types carry a Junction:D default.