### PR TITLE
RakuAST: Don't fatalize a flattening call argument

### DIFF
--- a/src/Raku/ast/scoping.rakumod
+++ b/src/Raku/ast/scoping.rakumod
@@ -466,7 +466,10 @@ class RakuAST::LexicalScope
             }
             else {
                  self.IMPL-FATALIZE-QAST($_, 0) for @($qast);
-                 if !$bool-context && ($op eq 'call' || $op eq 'callmethod') {
+                 # Don't wrap a flattening arg (the synthetic FLATTENABLE_LIST/
+                 # HASH calls): :flat must stay on the real result, not on a
+                 # FATALIZE wrapper. The operand is still fatalized above.
+                 if !$bool-context && ($op eq 'call' || $op eq 'callmethod') && !$qast.flat {
                     if $qast.name eq '&fail' {
                         $qast.name('&die');
                     }

--- a/t/02-rakudo/fatal-flatten-arg.t
+++ b/t/02-rakudo/fatal-flatten-arg.t
@@ -1,0 +1,24 @@
+use Test;
+
+plan 4;
+
+# Under `use fatal`, a flattening call argument (|@a or |%h) compiles the
+# synthetic FLATTENABLE_LIST/FLATTENABLE_HASH calls with a :flat flag. The
+# fatalize pass must not wrap those in FATALIZE, or the flag lands on the
+# wrapper and the callsite flattener dies on a non-array.
+
+lives-ok { use fatal; sub f(:%h) { 42 }; my %c; f(|%c) },
+    'use fatal: flattening an empty hash argument';
+
+lives-ok { use fatal; sub f(*@a) { @a.elems }; my @x = 1, 2, 3; f(|@x) },
+    'use fatal: flattening an array argument';
+
+lives-ok { use fatal; sub f(*@a, *%h) { "{@a.elems}/{%h.elems}" };
+           my @x = 1, 2; my %h = :z(9); f(|@x, |%h) },
+    'use fatal: flattening an array and a hash argument together';
+
+# The operand is still fatalized, so a Failure flowing into the flatten throws.
+dies-ok { use fatal; sub bad() { fail "boom" }; sub g(*@a) { 1 }; g(|bad()) },
+    'use fatal: a Failure flattened into a call still throws';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Under `use fatal`, `f(|%h)` or `f(|@a)` died with "Argument flattening array must be a concrete VMArray or MultiDimArray". The fatalize pass wrapped the synthetic FLATTENABLE_LIST/FLATTENABLE_HASH calls in FATALIZE, which moved the `:flat` flag onto the wrapper, so the callsite flattener received FATALIZE's boxed return value instead of the raw array.

Skip wrapping a node that carries `:flat`. Its operand is still fatalized by the recursion over children, so a Failure flowing into the flatten still throws.