### PR TITLE
RakuAST: Initialize attribute defaults that are type objects at construction

### DIFF
--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -992,7 +992,10 @@ class RakuAST::VarDeclaration::Simple
 
             if $!initializer {
                 my $initializer := $!initializer;
-                if nqp::istype($initializer, RakuAST::Initializer::Assign) && $initializer.expression.has-compile-time-value && nqp::isconcrete($initializer.expression.maybe-compile-time-value) && !nqp::istype($initializer.expression, RakuAST::Code) {
+                if nqp::istype($initializer, RakuAST::Initializer::Assign)
+                  && (my $expression := $initializer.expression).has-compile-time-value
+                  && nqp::isconcrete($expression.maybe-compile-time-value)
+                  && !nqp::istype($expression, RakuAST::Code) {
                     # Only a concrete default known at compile time becomes the
                     # build value directly. A default that is a type object would
                     # leave the build not concrete. Then the attribute is not
@@ -1000,7 +1003,7 @@ class RakuAST::VarDeclaration::Simple
                     # which races under concurrency. Such a default goes through
                     # the method below, which makes the build concrete.
                     self.add-trait(
-                        RakuAST::Trait::WillBuild.new($initializer.expression).to-begin-time($resolver, $context)
+                        RakuAST::Trait::WillBuild.new($expression).to-begin-time($resolver, $context)
                     );
                 }
                 else {

--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -992,7 +992,13 @@ class RakuAST::VarDeclaration::Simple
 
             if $!initializer {
                 my $initializer := $!initializer;
-                if nqp::istype($initializer, RakuAST::Initializer::Assign) && $initializer.expression.has-compile-time-value && !nqp::istype($initializer.expression, RakuAST::Code) {
+                if nqp::istype($initializer, RakuAST::Initializer::Assign) && $initializer.expression.has-compile-time-value && nqp::isconcrete($initializer.expression.maybe-compile-time-value) && !nqp::istype($initializer.expression, RakuAST::Code) {
+                    # Only a concrete default known at compile time becomes the
+                    # build value directly. A default that is a type object would
+                    # leave the build not concrete. Then the attribute is not
+                    # initialized at construction and its slot is vivified lazily,
+                    # which races under concurrency. Such a default goes through
+                    # the method below, which makes the build concrete.
                     self.add-trait(
                         RakuAST::Trait::WillBuild.new($initializer.expression).to-begin-time($resolver, $context)
                     );

--- a/t/02-rakudo/attribute-typeobject-default.t
+++ b/t/02-rakudo/attribute-typeobject-default.t
@@ -1,0 +1,62 @@
+use Test;
+
+plan 5;
+
+# An attribute whose default is a type object (e.g. `has T $.x = T`) must be
+# initialized at construction. If the build is left not concrete, the metamodel
+# does not initialize the attribute at construction, and the slot is vivified
+# lazily on the first read. That vivification is not synchronized, so it
+# fragments lock-free structures under concurrency, and an untyped attribute
+# reads back as Any.
+
+my class U { has $.x is rw = Int; }
+is U.new.x.^name, 'Int',
+    'untyped attribute whose default is a type object is initialized to that type';
+
+my class N { has N $.next is rw = N; }
+is N.new.next.WHICH, N.WHICH,
+    'typed attribute whose default is its own type object holds that object';
+
+my class C { has Int $.n is rw = 42; }
+is C.new.n, 42, 'a concrete default still works';
+
+my class M {}
+my class P { has M $.m is rw = M; }
+is P.new.m.^name, 'M', 'a default that is a sibling type object is initialized';
+
+# The concurrency symptom: a lock-free Michael-Scott queue whose nodes default
+# `.next` to the type object. Without initialization at construction the chain
+# fragments.
+my class Node { has $.value; has Node $.next is rw = Node; }
+my class Queue {
+    has Node $.head is rw;
+    has Node $.tail is rw;
+    submethod BUILD(--> Nil) { $!head = $!tail = Node.new }
+    method enqueue($value) {
+        my $node = Node.new(:$value);
+        my $tail;
+        loop {
+            $tail = $!tail;
+            my $next = $tail.next;
+            if $tail === $!tail {
+                if $next.DEFINITE { cas($!tail, $tail, $next) }
+                else { last if cas($tail.next, $next, $node) === $next }
+            }
+        }
+        cas($!tail, $tail, $node);
+    }
+    method depth {
+        my $n = $!head.next;
+        my $c = 0;
+        while $n.DEFINITE { $c++; $n = $n.next }
+        $c
+    }
+}
+my $queue = Queue.new;
+my constant THREADS = 4;
+my constant PER = 10000;
+await do for ^THREADS { start { $queue.enqueue($_) for ^PER } }
+is $queue.depth, THREADS * PER,
+    'concurrent lock-free enqueue does not fragment the chain';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
An attribute whose default is a type object (`has T $.x = T`) compiled to a build value that is not concrete. The metamodel only initializes the attribute at construction when the build is concrete, so it was never initialized there. The slot was left to MoarVM, which vivifies it lazily on the first read, and that vivification is not synchronized. Under concurrency a node published with an unset `.next` (Concurrent::Queue, for example) then races while it materializes the slot, and the chain fragments. An untyped attribute also read back as Any instead of the default.

The `WillBuild` fast path took any default known at compile time as the build value directly. Legacy does that only for a concrete value, and wraps a default that is a type object in a method so the build stays concrete. Add the same `nqp::isconcrete` check so a default that is a type object takes the method path.