### PR TITLE
RakuAST: Fix enum declaration with a non string key

### DIFF
--- a/src/Raku/ast/type.rakumod
+++ b/src/Raku/ast/type.rakumod
@@ -771,6 +771,10 @@ class RakuAST::Type::Enum
     method is-simple-lexical-declaration() { False }
     method is-stub() { False }
 
+    # IMPL-EXPR-QAST yields null in void context, where a sink call would
+    # instead run ENUM_VALUES.
+    method needs-sink-call() { False }
+
     method IMPL-EXPR-QAST(RakuAST::IMPL::QASTContext $context) {
         my $qast := QAST::Op.new(:op('call'), :name('&ENUM_VALUES'), $!term.IMPL-EXPR-QAST($context));
         QAST::Want.new(
@@ -933,6 +937,11 @@ class RakuAST::Type::Enum
         for @values -> $pair {
             my $key   := $pair[0];
             my $value := $pair[1];
+
+            # An enum value's name is a string, so coerce a non-Str key.
+            unless nqp::istype($key, Str) {
+                $key := $key.Str;
+            }
 
             unless nqp::defined($value) {
                 $resolver.build-exception('X::NYI',

--- a/t/02-rakudo/enum-numeric-key.t
+++ b/t/02-rakudo/enum-numeric-key.t
@@ -1,0 +1,19 @@
+use Test;
+
+plan 4;
+
+# A numeric-literal key reaches enum building as an Int, not a Str.
+is EVAL('my enum E (A => 1, 12844 => 25); E.enums<12844>'), 25,
+    'enum value with a numeric-literal key is reachable by its string key';
+
+# A sunk declaration must not run ENUM_VALUES, which needs string keys.
+lives-ok { EVAL 'my enum E (A => 1, 12844 => 25); 0' },
+    'a sunk enum declaration with a numeric-literal key composes';
+
+is EVAL('my $t = do { my enum E (A => 1, 12844 => 25); E }; $t.enums<A>'), 1,
+    'enum declared then discarded inside a do block composes';
+
+is EVAL('enum Day <Mon Tue Wed>; Day::Wed.value'), 2,
+    'an enum with identifier keys is unaffected';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
An enum value's name is a string, but a key written as a numeric literal (`12844 => 25`) reaches enum building as an Int. Two paths then failed under RakuAST where legacy did not.

`add_enum_value` unboxes the key to a native string at BEGIN time. Coerce a non Str key with `.Str` first, as legacy does.

A declaration also evaluates to `ENUM_VALUES`, which needs string keys. Legacy skips that call in sink context via a null `sink_ast`. RakuAST ran it through `p6sink` instead. The node already yields null in void context, so mark it as not needing a sink call.

Constants::Sys::Socket declares such an enum for Windows AF values.