### PR TITLE
RakuAST: Interpolate a non string constant into a regex

### DIFF
--- a/src/Raku/ast/regex.rakumod
+++ b/src/Raku/ast/regex.rakumod
@@ -1048,9 +1048,15 @@ class RakuAST::Regex::Interpolation
         if nqp::istype($!var, RakuAST::Lookup) && $!var.is-resolved {
             my $resolution := $!var.resolution;
             if nqp::istype($resolution, RakuAST::VarDeclaration::Constant) {
-                return self.IMPL-APPLY-LITERAL-MODS:
-                    QAST::Regex.new( :rxtype<literal>, nqp::unbox_s($resolution.compile-time-value) ),
-                    %mods
+                my $value := $resolution.compile-time-value;
+                # Only a string constant becomes a regex literal. A constant
+                # that is not a string (e.g. a list) interpolates at runtime
+                # via the slow path below.
+                if nqp::istype($value, Str) {
+                    return self.IMPL-APPLY-LITERAL-MODS:
+                        QAST::Regex.new( :rxtype<literal>, nqp::unbox_s($value) ),
+                        %mods
+                }
             }
             if !%mods<m> && nqp::istype($resolution, RakuAST::VarDeclaration::Simple) &&
                     $resolution.sigil eq '$' {

--- a/t/02-rakudo/regex-constant-interpolation.t
+++ b/t/02-rakudo/regex-constant-interpolation.t
@@ -1,0 +1,21 @@
+use Test;
+
+plan 4;
+
+# A constant that is not a string interpolates into a regex at runtime instead
+# of being treated as a literal.
+ok EVAL('my constant @w = <foo bar baz>; "bar" ~~ / @w /'),
+    'a constant array interpolates as an alternation';
+
+ok EVAL('my constant $n = 42; "x42x" ~~ / $n /'),
+    'a constant integer interpolates by its string value';
+
+ok EVAL('my constant $s = "foo"; "xfoox" ~~ / $s /'),
+    'a constant string is still matched as a literal';
+
+# The grammar pattern from Contact::Name: a token interpolating a constant
+# array under :i.
+ok EVAL('my constant @w = <Mr Dr>; grammar G { token p { :i @w } }; G.parse("dr", :rule<p>)'),
+    'a constant array interpolates in a grammar token under :i';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
A variable interpolated into a regex took a fast path when it resolved to a constant, treating the value as a literal string via `nqp::unbox_s`. That only works for a string. A constant holding a list (`my constant @a = <foo bar>; / @a /`) or any other non-string died with "cannot unbox to a native string".

Take the literal fast path only when the value is a Str. Otherwise fall through to the runtime interpolation path, which already handles a list as an alternation, the same as a non constant variable.

Contact::Name interpolates a constant array of name prefixes into a token.