### PR TITLE
RakuAST: Declare a regex capture lexical in a BEGIN-time argument

### DIFF
--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -334,6 +334,16 @@ class RakuAST::Code
                                 QAST::Var.new(:scope<lexical>, :decl<static>, :$name, :$value)
                             );
                         }
+                        elsif nqp::eqat($name, '!__REGEX_CAPTURE_', 0) {
+                            # A regex capture lexical is bound and used within
+                            # this compiled unit, but its declaration lives in
+                            # an enclosing scope outside the unit. Declare it
+                            # here, as that scope otherwise would.
+                            %seen{$name} := 1;
+                            $block[0].push(
+                                QAST::Var.new(:scope<lexical>, :decl<var>, :$name)
+                            );
+                        }
                         else {
                             nqp::die("Could not find a compile-time-value for lexical $name");
                         }

--- a/t/02-rakudo/begin-time-call-regex-arg.t
+++ b/t/02-rakudo/begin-time-call-regex-arg.t
@@ -1,0 +1,39 @@
+use Test;
+
+# A capturing regex used as a BEGIN-time argument (a trait argument or a
+# BEGIN-evaluated call) must compile and reach the callee as a working Regex.
+# A capture generates a !__REGEX_CAPTURE__N lexical whose declaration was lost
+# when the argument was compiled outside its enclosing scope.
+
+plan 3;
+
+use MONKEY-SEE-NO-EVAL;
+
+is EVAL(q:to/CODE/), '7',
+        my @log;
+        multi sub trait_mod:<is>(Attribute:D $a, :$validated!) {
+            @log.push: ("7X" ~~ $validated[0]) ?? ~$0 !! 'no'
+        }
+        class C { has $.a is validated(/^(\d)X$/, 'msg'); }
+        @log[0]
+        CODE
+    'a capturing regex in an attribute trait argument compiles and matches';
+
+is EVAL(q:to/CODE/), '7',
+        sub id($x, $y) { $x }
+        my $rx = BEGIN id(/^(\d)X$/, 'msg');
+        ("7X" ~~ $rx) ?? ~$0 !! 'no'
+        CODE
+    'a capturing regex in a BEGIN-evaluated call compiles and matches';
+
+is EVAL(q:to/CODE/), '7',
+        my @log;
+        multi sub trait_mod:<is>(Attribute:D $a, :$validated!) {
+            @log.push: ("7X" ~~ $validated) ?? ~$<n> !! 'no'
+        }
+        class D { has $.a is validated(/^$<n>=(\d)X$/); }
+        @log[0]
+        CODE
+    'a named-capture regex in a trait argument compiles and matches';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
A capturing regex used as a BEGIN-time argument, such as a trait argument or an argument to a BEGIN-evaluated call, died with "Could not find a compile-time-value for lexical !__REGEX_CAPTURE__1".

A capture generates a !__REGEX_CAPTURE__N lexical. Its declaration is normally emitted by the enclosing lexical scope. A BEGIN-time argument is compiled in its own unit with no enclosing scope, so the bind and the regex closure travel with it but the declaration does not. The fixup walker then meets the undeclared lexical and dies.

Declare the capture lexical in the compiled unit when the walker meets it, as the enclosing scope otherwise would.