### PR TITLE
Make .return check the routine it actually returns from

### DIFF
--- a/src/core.c/Mu.rakumod
+++ b/src/core.c/Mu.rakumod
@@ -71,17 +71,18 @@ my class Mu { # declared in BOOTSTRAP
         take self;
     }
 
-    # Check signature of caller Routine for definite value being returned
+    # Check signature of lexically enclosing Routine for definite value being returned
     my sub check-signature(Mu $value, str $method) {
-        my int $index = 2;
+        my $ctx := nqp::ctxcallerskipthunks(nqp::ctxcallerskipthunks(nqp::ctx()));
+        my $callable;
         nqp::until(
-          nqp::isnull(my $cf := callframe($index))
-            || nqp::istype((my $callable := $cf.code),Routine),
-          ++$index
+          nqp::isnull($ctx)
+            || nqp::istype(($callable := nqp::getcodeobj(nqp::ctxcode($ctx))),Routine),
+          $ctx := nqp::ctxouterskipthunks($ctx)
         );
 
         die "Cannot return $value.raku() with $method when return value $_.raku() is already specified in the signature of $callable.raku.subst(/ "(" .* /)".naive-word-wrapper
-          with $callable.signature.returns;
+          with (nqp::isnull($ctx) ?? Nil !! $callable.signature.returns);
     }
     method return-rw(Mu \SELF: |) {  # same code as control.rakumod's return-rw
         check-signature(SELF, '.return-rw');

--- a/t/02-rakudo/return-method-in-sunk-for.t
+++ b/t/02-rakudo/return-method-in-sunk-for.t
@@ -1,0 +1,26 @@
+use Test;
+
+# The .return method returns from the routine it is lexically in, the same as
+# the `return` control. Its signature check must look at that routine too, not
+# at an internal routine such as sink-all that a sunk loop interposes on the
+# dynamic call stack.
+
+plan 5;
+
+sub sunk-for { for <a b c> { .return if $_ eq 'b' }; 'fell-through' }
+is sunk-for(), 'b', '.return in a sunk for loop returns from the routine';
+
+sub sunk-map { <a b c>.map({ .return if $_ eq 'b' }).sink; 'fell-through' }
+is sunk-map(), 'b', '.return in a sunk .map(...).sink returns from the routine';
+
+sub typed(--> Int) { 5.return }
+is typed(), 5, '.return of a value matching the return type works';
+
+throws-like { sub f(--> 42) { 27.return }; f }, X::AdHoc, message => /'return value 42'/,
+    '.return still honors a literal return constraint';
+
+throws-like { sub f(--> Int) { for <a b c> { .return if $_ eq 'b' } }; f },
+    X::TypeCheck::Return,
+    'a type-constrained .return in a sunk for reports the routine type-check error';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
.return validates the enclosing routine's return constraint before throwing (added in #6086 to catch a literal constraint the compiler cannot). It found the routine by walking the dynamic call stack, but .return unwinds to the lexically enclosing routine. The two disagree when an internal routine is interposed: a sunk `for` runs its body inside sink-all (--> IterationEnd), so `for @x { .return if ... }` died with "Cannot return ... in the signature of method sink-all". An explicit `.map({ .return }).sink` failed the same way on any frontend.

Walk the lexical outer chain instead, the routine throwpayloadlexcaller reaches. The #6086 literal-constraint check is preserved.