### PR TITLE
Slightly different approach to PR6261

### DIFF
--- a/src/core.c/CompUnit/PrecompilationRepository.rakumod
+++ b/src/core.c/CompUnit/PrecompilationRepository.rakumod
@@ -42,8 +42,9 @@ class CompUnit::PrecompilationRepository::Default
     my $resolved-lock := Lock.new;
     my $first-repo-id;
 
-    my constant $compiler-id =
-      CompUnit::PrecompilationId.new-without-check(Compiler.id);
+    # This needs to be done at runtime so that the correct compiler ID
+    # is used during the transition period towards a RakuAST based frontend
+    my $compiler-id = CompUnit::PrecompilationId.new-without-check(Compiler.id);
 
     # If $loaded{$key} has a Promise in it, await it. If it's broken, try
     # again, return the result if it's kept. If there's nothing there at

--- a/src/core.c/Compiler.rakumod
+++ b/src/core.c/Compiler.rakumod
@@ -2,11 +2,28 @@ class Compiler does Systemic {
     my constant $compiler = nqp::getcomp("Raku");
     my constant $config =
       nqp::gethllsym('default','SysConfig').rakudo-build-config;
-    my constant $compilation-id = nqp::box_s(
-      nqp::sha1((nqp::getlexdyn('$*CU') ?? $*CU.comp-unit-name !! $*W.handle.Str) ~ nqp::atkey($config,'source-digest')),Str
-    );
     my constant $backend = $compiler.backend;
     my constant $name    = $backend.name;
+
+    # This needs to be done at compile time to be able to access the correct
+    # frontend specific dynamic variables
+    my constant $compilation-base-id = nqp::box_s(
+      nqp::sha1(
+        (nqp::getlexdyn('$*CU') ?? $*CU.comp-unit-name !! $*W.handle.Str)
+          ~ nqp::atkey($config,'source-digest')
+      ),
+      Str
+    );
+
+    # This needs to be done at runtime so that the correct compiler ID
+    # is used during the transition period towards a RakuAST based frontend
+    my $compilation-id = nqp::box_s(
+      nqp::sha1(
+        $compilation-base-id
+          ~ nqp::ifnull(nqp::gethllsym('Raku','COMPILER-FRONTEND'),'')
+      ),
+      Str
+    );
 
     # XXX Various issues with this stuff on JVM
     has $.id       is built(:bind) = $compilation-id;

--- a/src/main.nqp
+++ b/src/main.nqp
@@ -16,12 +16,14 @@ nqp::bindhllsym('default', 'SysConfig', Perl6::SysConfig.new(%rakudo-build-confi
 my $comp := Perl6::Compiler.new();
 $comp.language('Raku');
 if +nqp::getenvhash()<RAKUDO_RAKUAST> {
+    nqp::bindhllsym('Raku', 'COMPILER-FRONTEND', 'rakuast');
     $comp.parsegrammar(Raku::Grammar);
     $comp.parseactions(Raku::Actions);
     $comp.addstage('syntaxcheck', :before<ast>);
     $comp.addstage('qast', :after<ast>);
 }
 else {
+    nqp::bindhllsym('Raku', 'COMPILER-FRONTEND', 'legacy');
     $comp.parsegrammar(Perl6::Grammar);
     $comp.parseactions(Perl6::Actions);
     $comp.addstage('syntaxcheck', :before<ast>);

--- a/t/02-rakudo/compiler-frontend-id.t
+++ b/t/02-rakudo/compiler-frontend-id.t
@@ -1,0 +1,27 @@
+use Test;
+
+plan 3;
+
+# The compiler id keys every precompilation store, so each frontend must
+# have its own: bytecode produced by one frontend must never be loaded
+# by a process compiling with the other. Both frontends are pinned
+# explicitly in subprocesses here, so the assertions hold no matter
+# which frontend runs this file.
+
+my $code = 'print $*RAKU.compiler.id';
+
+my %with-rakuast = %*ENV;
+%with-rakuast<RAKUDO_RAKUAST> = 1;
+my %without-rakuast = %*ENV;
+%without-rakuast<RAKUDO_RAKUAST>:delete;
+
+my $rakuast-id = run($*EXECUTABLE.absolute, '-e', $code, :env(%with-rakuast), :out)
+    .out.slurp(:close);
+my $legacy-id = run($*EXECUTABLE.absolute, '-e', $code, :env(%without-rakuast), :out)
+    .out.slurp(:close);
+
+ok $rakuast-id ~~ /^ <[0..9 A..F]> ** 40 $/, 'RakuAST frontend compiler id is a 40 digit hex digest';
+ok $legacy-id  ~~ /^ <[0..9 A..F]> ** 40 $/, 'legacy frontend compiler id is a 40 digit hex digest';
+isnt $rakuast-id, $legacy-id, 'the two frontends have distinct compiler ids';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
- Stole the test file = Stole the changes to main.nqp
- Put initializations in the mainline, instead of hiding it in a subroutine and assigning on each access.
- Adapted comments accordingly