### PR TITLE
RakuAST: add Node.SOURCE method

### DIFF
--- a/src/core.c/RakuAST/Fixups.rakumod
+++ b/src/core.c/RakuAST/Fixups.rakumod
@@ -197,6 +197,17 @@ augment class RakuAST::Node {
 
         ""
     }
+
+    method SOURCE() {
+        with self.origin -> $origin {
+            with $origin.source -> $source {
+                my $from := $origin.from;
+                return $source.orig.substr($from, $origin.to - $from);
+            }
+        }
+
+        Nil
+    }
 }
 
 my class RakuAST::Doc::LegacyRow is RakuAST::Node {


### PR DESCRIPTION
This is mostly intended as a debugging aid.  If a RakuAST tree is built from the Raku grammar, then you can call this method on any RakuAST::Node object in the tree to obtain the source-code that generated it.

This is similar in result as .DEPARSE, however the .SOURCE method will just produce the source verbatim, inclusing any inline comments.

If a tree is synthetically built, then it will return Nil.