### PR TITLE
RakuAST: let a role shadow a setting type of the same name

### DIFF
--- a/src/Raku/ast/package.rakumod
+++ b/src/Raku/ast/package.rakumod
@@ -721,9 +721,10 @@ class RakuAST::Role
     # being compiled there is no outer setting, so its own declarations are not
     # shadowable.
     method IMPL-SYMBOL-FROM-SETTING(RakuAST::Resolver $resolver, RakuAST::Name $full-name, Mu $symbol) {
-        return False if $*COMPILING_CORE_SETTING;
-        my $setting := $resolver.resolve-name-constant-in-setting($full-name);
-        $setting && nqp::eqaddr($setting.compile-time-value, $symbol)
+        $*COMPILING_CORE_SETTING
+          ?? False
+          !! (my $setting := $resolver.resolve-name-constant-in-setting($full-name))
+               && nqp::eqaddr($setting.compile-time-value, $symbol)
     }
 
     method install-extra-declarations(RakuAST::Resolver $resolver) {

--- a/src/Raku/ast/package.rakumod
+++ b/src/Raku/ast/package.rakumod
@@ -679,17 +679,28 @@ class RakuAST::Role
     }
 
     method install-in-scope(RakuAST::Resolver $resolver, str $scope, RakuAST::Name $name, RakuAST::Name $full-name) {
-        # Find an appropriate existing role group
-        my $group := $resolver.resolve-name-constant($full-name, :current-scope-only(self.scope eq 'my'));
-        if $group && !nqp::istype($group.compile-time-value.HOW, Perl6::Metamodel::PackageHOW) {
-            $group := $group.compile-time-value;
+        my $found    := $resolver.resolve-name-constant($full-name, :current-scope-only(self.scope eq 'my'));
+        my $existing := $found ?? $found.compile-time-value !! Mu;
+        # A name resolving only to the setting's symbol is shadowed; one
+        # declared in this compilation unit is joined (when it is a role group)
+        # or, failing that, a redeclaration.
+        my $from-setting := $found && self.IMPL-SYMBOL-FROM-SETTING($resolver, $full-name, $existing);
+
+        my $group;
+        if !$from-setting && nqp::can($existing.HOW, 'add_possibility') {
+            # An existing role group in this compilation unit: add ourselves to it.
+            $group := $existing;
+        }
+        else {
+            # A non-package symbol declared in this compilation unit is a
+            # redeclaration. A plain package or a setting symbol is instead
+            # shadowed by the fresh role group.
             $resolver.panic(
                 $resolver.build-exception('X::Redeclaration', :symbol(self.name.canonicalize))
-            ) unless nqp::can($group.HOW, 'add_possibility');
-        }
+            ) if $found
+              && !$from-setting
+              && !nqp::istype($existing.HOW, Perl6::Metamodel::PackageHOW);
 
-        # No existing one found - create a role group
-        else {
             my $group-name := $full-name.canonicalize(:colonpairs(0));
             $group := Perl6::Metamodel::ParametricRoleGroupHOW.new_type(
               :name($group-name), :repr(self.repr)
@@ -703,6 +714,16 @@ class RakuAST::Role
         my $type-object := self.stubbed-meta-object;
         $type-object.HOW.set_group($type-object, $group);
         nqp::bindattr(self,RakuAST::Package::Attachable,'$!role-group',$group);
+    }
+
+    # Whether $symbol is the symbol the name resolves to in the setting, i.e.
+    # nothing in this compilation unit shadows it. While the setting itself is
+    # being compiled there is no outer setting, so its own declarations are not
+    # shadowable.
+    method IMPL-SYMBOL-FROM-SETTING(RakuAST::Resolver $resolver, RakuAST::Name $full-name, Mu $symbol) {
+        return False if $*COMPILING_CORE_SETTING;
+        my $setting := $resolver.resolve-name-constant-in-setting($full-name);
+        $setting && nqp::eqaddr($setting.compile-time-value, $symbol)
     }
 
     method install-extra-declarations(RakuAST::Resolver $resolver) {

--- a/t/02-rakudo/role-shadows-setting-type.t
+++ b/t/02-rakudo/role-shadows-setting-type.t
@@ -1,0 +1,30 @@
+use Test;
+use MONKEY-SEE-NO-EVAL;
+
+plan 6;
+
+# A role declaration may shadow a type of the same name that comes from the
+# setting (e.g. the `Hash::Ordered` module declares `role Hash::Ordered`, which
+# shares its name with CORE's `Hash::Ordered` class).
+lives-ok { EVAL 'role Hash::Ordered { }' },
+    'a role can shadow a setting class of the same compound name';
+lives-ok { EVAL 'role Int { method r { 1 } }' },
+    'a role can shadow a setting class of the same simple name';
+
+# Shadowing applies to a setting role too: the fresh role replaces the setting
+# one rather than being added as a candidate to the setting's role group.
+is EVAL('role Numeric { }; so 3.5 ~~ Numeric'), False,
+    'a role shadows a setting role of the same name instead of joining it';
+
+# A same-name declaration in the compilation unit is still a redeclaration,
+# whether in the same scope or an enclosing one.
+throws-like 'class Foo { }; role Foo { }', X::Redeclaration,
+    'a role redeclaring a same-scope class is rejected';
+throws-like 'class Outer { }; { role Outer { } }', X::Redeclaration,
+    'a role redeclaring an enclosing-scope class is rejected';
+
+# Several same-named roles still combine into one role group.
+lives-ok { EVAL 'role G { }; role G[::T] { }' },
+    'same-named roles still form a role group';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Declaring a role whose name matches a type from the setting died or misbehaved. The Hash::Ordered module's `role Hash::Ordered` (CORE has a `Hash::Ordered` class) died "Redeclaration of symbol 'Hash::Ordered'", and `role Numeric` (CORE has a `Numeric` role) was added as a candidate to CORE's role group rather than replacing it. Installing a role looked the name up across all scopes: a found class is not a role group so it was rejected, and a found role group was joined.

Shadow the setting symbol instead. When the name resolves only to the setting's symbol, install a fresh role group whatever the setting holds, the way a class declaration of the same name already shadows it. A symbol declared in the compilation unit is still joined (an existing role group) or rejected (anything else). The setting's own declarations are not shadowable while the setting itself is being compiled.

Fixes installing the Hash::Ordered module under RakuAST.