### PR TITLE
RakuAST: build the CORE:: PseudoStash at runtime, not compile time

### DIFF
--- a/src/Raku/ast/name.rakumod
+++ b/src/Raku/ast/name.rakumod
@@ -326,23 +326,11 @@ class RakuAST::Name
         my @parts := self.IMPL-LOOKUP-PARTS;
         my $final := @parts[nqp::elems(@parts) - 1];
         my $PseudoStash-lookup := self.IMPL-UNWRAP-LIST(self.get-implicit-lookups)[1];
-        my $result;
-        #TODO Look at Perl6::World::symbol_lookup. Has a separate implementation for compiling the setting
-        if $*IMPL-COMPILE-DYNAMICALLY && !$*COMPILING_CORE_SETTING && $!parts[0].name eq 'CORE' {
-            my $PseudoStash := $PseudoStash-lookup.resolution.compile-time-value;
-            my $package := Perl6::Metamodel::ModuleHOW.new_type(:name('CORE'));
-            my $found-ctx := $context.setting;
-            my $stash := $PseudoStash.new-from-ctx($found-ctx, :$package);
-            $context.ensure-sc($stash);
-            $result := QAST::WVal.new(:value($stash));
-        }
-        else {
-            $result := QAST::Op.new(
-              :op<callmethod>,
-              :name<new>,
-              $PseudoStash-lookup.IMPL-TO-QAST($context)
-            );
-        }
+        my $result := QAST::Op.new(
+          :op<callmethod>,
+          :name<new>,
+          $PseudoStash-lookup.IMPL-TO-QAST($context)
+        );
         my int $first := 1;
         for @parts {
             if $first { # don't call .WHO on the pseudo package itself, index into it instead

--- a/t/02-rakudo/core-pseudo-package-precomp.t
+++ b/t/02-rakudo/core-pseudo-package-precomp.t
@@ -1,0 +1,16 @@
+use lib <t/packages/Test-Helpers t/packages/02-rakudo/lib>;
+use Test;
+use Test::Helpers;
+
+plan 1;
+
+# Referencing a CORE:: symbol at compile time inside a module (here in a role
+# method body) must not pull the setting's context into the serialization
+# context. If it does, precompiling the module dies with
+# "Missing serialize REPR function for REPR MVMContext (BOOTContext)".
+is-run 'use CoreLookupHelper; print "ok"',
+    'a compile-time CORE:: reference in a precompiled module loads',
+    :out("ok"),
+    :compiler-args[<-I t/packages/02-rakudo/lib>];
+
+# vim: expandtab shiftwidth=4

--- a/t/packages/02-rakudo/lib/CoreLookupHelper.rakumod
+++ b/t/packages/02-rakudo/lib/CoreLookupHelper.rakumod
@@ -1,0 +1,8 @@
+unit module CoreLookupHelper;
+
+# A role method that references a CORE:: symbol. The role body is compiled
+# dynamically and serialized when this module is precompiled, so resolving
+# the CORE pseudo-package must not capture the unserializable setting context.
+role Asker is export {
+    method ask($prompt) { &CORE::prompt($prompt) }
+}


### PR DESCRIPTION
Referencing a CORE:: symbol at compile time in a module (for example `&CORE::prompt` in a role method) died "Missing serialize REPR function for REPR MVMContext (BOOTContext)". Dynamically compiled code built the CORE PseudoStash from the setting context and inserted it into the QAST as a literal value. That is fine when the frame is thrown away, but a role body is dynamically compiled and then serialized with its module, and the setting context cannot be serialized.

The special case dates from when the setting was not an outer frame at BEGIN time, so a runtime `PseudoStash.new` could not find CORE. That no longer holds: the runtime lookup resolves CORE:: at BEGIN time too. Drop the special case and always construct the PseudoStash at runtime, which never captures the context.

Fixes #6304.