### PR TITLE
RakuAST: let a real routine override an imported stub

### DIFF
--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -2309,6 +2309,8 @@ class RakuAST::Sub
     }
 
     method IMPL-COMPILE-BODY(RakuAST::IMPL::QASTContext $context) {
+        # A stub body sets the yada bit so .yada and .raku report it as a stub.
+        self.meta-object.set_yada if self.is-stub;
         self.IMPL-CALCULATE-SINK unless self.sink-calculated;
         self.IMPL-WRAP-RETURN-HANDLER($context,
             self.IMPL-WRAP-SCOPE-HANDLER-QAST($context,

--- a/src/Raku/ast/scoping.rakumod
+++ b/src/Raku/ast/scoping.rakumod
@@ -304,12 +304,25 @@ class RakuAST::LexicalScope
             my $lexical-name := $_.lexical-name;
             if $lexical-name {
                 if nqp::existskey(%lookup, $lexical-name) {
-                    self.add-sorry:
-                      $resolver.build-exception: 'X::Redeclaration',
-                        :symbol($_.declaration-name),
-                        :what($_.declaration-kind),
-                        :postfix(nqp::istype($_, RakuAST::VarDeclaration::Placeholder) ?? 'as a placeholder parameter' !! '')
-                    unless %lookup{$lexical-name} =:= $_;
+                    my $shadower := %lookup{$lexical-name};
+                    unless $shadower =:= $_ {
+                        my $imported := nqp::istype($_, RakuAST::Declaration::Import)
+                          ?? $_.compile-time-value !! Nil;
+                        if $imported && nqp::can($imported, 'yada') && $imported.yada
+                          && nqp::can($shadower, 'set-replace-stub') {
+                            # A routine declaration that shadows an imported stub of
+                            # the same name reuses the imported lexical slot rather
+                            # than declaring its own.
+                            $shadower.set-replace-stub(1);
+                        }
+                        else {
+                            self.add-sorry:
+                              $resolver.build-exception: 'X::Redeclaration',
+                                :symbol($_.declaration-name),
+                                :what($_.declaration-kind),
+                                :postfix(nqp::istype($_, RakuAST::VarDeclaration::Placeholder) ?? 'as a placeholder parameter' !! '');
+                        }
+                    }
                 }
                 else {
                     %lookup{$lexical-name} := $_;

--- a/src/Raku/ast/scoping.rakumod
+++ b/src/Raku/ast/scoping.rakumod
@@ -288,11 +288,13 @@ class RakuAST::LexicalScope
             my $lexical-name := $_.lexical-name;
             if $lexical-name && !($_ =:= self) {
                 if nqp::existskey(%lookup, $lexical-name) {
+                    my $prev := %lookup{$lexical-name};
                     self.add-worry:
                       $resolver.build-exception: 'X::Redeclaration',
                         :symbol($_.declaration-name), :what($_.declaration-kind)
                     # It will be two worries for var declaration, so skip one, not sure about others.
-                    unless nqp::istype($_, RakuAST::VarDeclaration);
+                    unless nqp::istype($_, RakuAST::VarDeclaration)
+                        || (nqp::istype($prev, RakuAST::Routine) && $prev.is-stub);
                 }
                 else {
                     %lookup{$lexical-name} := $_;

--- a/t/02-rakudo/routine-overrides-imported-stub.t
+++ b/t/02-rakudo/routine-overrides-imported-stub.t
@@ -1,0 +1,23 @@
+use lib <t/packages/02-rakudo/lib>;
+use Test;
+use MONKEY-SEE-NO-EVAL;
+use SubsStubHelper;   # exports a `...` stub `&stub-export` and a real `&real-export`
+
+plan 4;
+
+# A routine whose body is just a stub (`...`) reports itself as a stub.
+is (sub { ... }).yada, True, 'a stub sub reports .yada';
+nok (sub { 42 }).yada, 'a non-stub sub does not report .yada';
+
+# A real routine declaration may override an imported stub of the same name.
+sub stub-export() { "overridden" }
+is stub-export(), "overridden",
+    'a real routine overrides an imported stub of the same name';
+
+# Overriding a non-stub imported routine is still a redeclaration.
+throws-like
+    'use SubsStubHelper; sub real-export() { 0 }',
+    X::Redeclaration,
+    'overriding a non-stub imported routine is rejected';
+
+# vim: expandtab shiftwidth=4

--- a/t/02-rakudo/stub-routine-redefinition.t
+++ b/t/02-rakudo/stub-routine-redefinition.t
@@ -1,0 +1,29 @@
+use lib <t/packages/Test-Helpers>;
+use Test;
+use Test::Helpers;
+
+plan 4;
+
+# A stub routine (`...`) is a forward declaration. Defining a routine of the
+# same name later replaces it, with no redeclaration warning or error.
+
+is-run 'sub foo {...}; sub foo { 42 }; print foo()',
+    'a definition replaces a forward-declared stub without a warning',
+    :out("42"), :err("");
+
+is-run 'sub foo {...}; sub foo {...}; print "ok"',
+    'a second stub replaces a forward-declared stub without a warning',
+    :out("ok"), :err("");
+
+# Redefining a non-stub routine is still a redeclaration.
+is-run 'sub foo { 1 }; sub foo { 2 }',
+    'redefining a non-stub routine is rejected',
+    :err(/'Redeclaration of routine'/),
+    :exitcode(1);
+
+is-run 'sub foo { 1 }; sub foo {...}',
+    'a stub does not replace an existing non-stub routine',
+    :err(/'Redeclaration of routine'/),
+    :exitcode(1);
+
+# vim: expandtab shiftwidth=4

--- a/t/packages/02-rakudo/lib/SubsStubHelper.rakumod
+++ b/t/packages/02-rakudo/lib/SubsStubHelper.rakumod
@@ -1,0 +1,6 @@
+unit module SubsStubHelper;
+
+# Exports a stub routine (body is just `...`) and a real routine, so a using
+# program can try to override each with a declaration of the same name.
+sub stub-export() is export { ... }
+sub real-export() is export { "real-export" }


### PR DESCRIPTION
`use subs <foo>; sub foo { ... }` (the `subs` pragma predeclares stub routines that real definitions later fill in) died "Redeclaration of symbol '&foo'". An imported symbol is a generated lexical declaration, so a real declaration of the same name collided with it in the scope's redeclaration check.

Two parts. RakuAST::Sub now sets the yada flag on a routine whose body is a stub, the way RakuAST::Method already does, so `sub { ... }.yada` is True as on the legacy frontend. The scope redeclaration check then treats a real declaration that shadows an imported stub as an override rather than a redeclaration, reusing the imported lexical slot. Overriding a non-stub imported routine is still rejected.

Fixes installing the subs module under RakuAST.