### PR TITLE
RakuAST: parse the `my :(...)` signature literal declaration

### DIFF
--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -2749,7 +2749,8 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
               !! Nodify('Initializer');
 
             $ast := Nodify('VarDeclaration::Signature').new:
-              :signature($<signature>.ast), :$scope, :$type, :$initializer;
+              :signature($<signature>.ast), :$scope, :$type, :$initializer,
+              :sig-literal($<sig-literal> ?? 1 !! 0);
             for $<trait> {
                 $ast.add-trait($_.ast);
             }

--- a/src/Raku/Grammar.nqp
+++ b/src/Raku/Grammar.nqp
@@ -3982,6 +3982,7 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
 
           | [
               :my $*DEFAULT-RW := 1;
+              [ $<sig-literal>=':' ]?
               '(' ~ ')' <signature(:ON-VARDECLARATION)> [ <.ws> <trait>+ ]? [ <.ws> <initializer> ]?
           ]
 

--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -1674,15 +1674,20 @@ class RakuAST::VarDeclaration::Signature
     has RakuAST::Initializer $.initializer;
     has RakuAST::Package $!attribute-package;
     has Mu $!package;
+    # True for the signature literal form `my :($a, $b)`, which binds only
+    # and requires an initializer, versus the list form `my ($a, $b)`.
+    has Bool $.sig-literal;
 
     method new(RakuAST::Signature :$signature!, RakuAST::Type :$type, RakuAST::Initializer :$initializer,
-               str :$scope) {
+               str :$scope, Bool :$sig-literal) {
         my $obj := nqp::create(self);
         nqp::bindattr($obj, RakuAST::VarDeclaration::Signature, '$!signature', $signature);
         nqp::bindattr_s($obj, RakuAST::Declaration, '$!scope', $scope);
         nqp::bindattr($obj, RakuAST::VarDeclaration::Signature, '$!type', $type // RakuAST::Type);
         nqp::bindattr($obj, RakuAST::VarDeclaration::Signature, '$!initializer',
             $initializer // RakuAST::Initializer);
+        nqp::bindattr($obj, RakuAST::VarDeclaration::Signature, '$!sig-literal',
+            $sig-literal ?? True !! False);
         $obj
     }
 
@@ -1805,12 +1810,23 @@ class RakuAST::VarDeclaration::Signature
         self.add-trait-sorries;
 
         unless $!initializer {
-            for self.IMPL-UNWRAP-LIST(self.signature.parameters) -> $param {
-                if nqp::istype($param.target, RakuAST::ParameterTarget::Term) {
-                    self.add-sorry($resolver.build-exception: 'X::Syntax::Term::MissingInitializer');
-                    last;
+            if $!sig-literal {
+                self.add-sorry($resolver.build-exception:
+                    'X::Syntax::Variable::SignatureWithoutInitializer');
+            }
+            else {
+                for self.IMPL-UNWRAP-LIST(self.signature.parameters) -> $param {
+                    if nqp::istype($param.target, RakuAST::ParameterTarget::Term) {
+                        self.add-sorry($resolver.build-exception: 'X::Syntax::Term::MissingInitializer');
+                        last;
+                    }
                 }
             }
+        }
+
+        if $!sig-literal && nqp::istype($!initializer, RakuAST::Initializer::Assign) {
+            self.add-sorry($resolver.build-exception:
+                'X::Syntax::Variable::SignatureAssignment');
         }
     }
 

--- a/t/02-rakudo/signature-literal-declaration.t
+++ b/t/02-rakudo/signature-literal-declaration.t
@@ -1,0 +1,38 @@
+use Test;
+use MONKEY-SEE-NO-EVAL;
+
+plan 5;
+
+# A `my :(...)` signature literal declaration binds the right-hand side
+# against the signature. It binds only (`:=`) and requires an initializer,
+# unlike the list form `my (...)`.
+
+{
+    my :($a, $b) := (1, 2);
+    is "$a $b", "1 2", 'my :(...) := list binds positionally';
+}
+
+{
+    my :(:$x, :$y) := \(x => 5, y => 6);
+    is "$x $y", "5 6", 'my :(...) := capture binds named arguments';
+}
+
+{
+    our :($a, $b) := (1, 2);
+    is "$a $b", "1 2", 'our :(...) := binds';
+}
+
+# Assignment is not allowed for a signature literal: it binds, so `=` is an
+# error pointing at `:=` or the list form.
+throws-like {
+    EVAL 'my :($a, $b) = (1, 2)'
+}, X::Syntax::Variable::SignatureAssignment,
+    'assignment to a signature literal declaration is rejected';
+
+# A signature literal declaration requires an initializer.
+throws-like {
+    EVAL 'my :($a, $b)'
+}, X::Syntax::Variable::SignatureWithoutInitializer,
+    'signature literal declaration without an initializer is rejected';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously `my :($a, $b) := (1, 2)` failed to parse under RakuAST with "Malformed my". The declarator grammar accepted the list form `my ($a, $b)` but not the signature literal form with a leading colon.

Accept an optional colon before the parenthesized signature in the declarator and carry a sig-literal flag onto the declaration. A signature literal binds, so it requires an initializer and rejects assignment with `=`. The two errors, X::Syntax::Variable::SignatureWithoutInitializer and X::Syntax::Variable::SignatureAssignment, now come from the declaration's check the way the legacy frontend reports them.