### PR TITLE
RakuAST: attach a top level variable's `will` phaser to the mainline

### DIFF
--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -828,6 +828,12 @@ class RakuAST::VarDeclaration::Simple
       RakuAST::IMPL::QASTContext $context
     ) {
         my $block := $resolver.find-attach-target('block');
+        unless $block {
+            # The mainline block is not on the attach-target stack, so at the
+            # top level fall back to it as the enclosing block.
+            my $compunit := $resolver.find-attach-target('compunit');
+            $block := $compunit.mainline if $compunit;
+        }
         nqp::bindattr(self, RakuAST::VarDeclaration::Simple, '$!block', $block);
 
         if self.is-attribute {

--- a/t/02-rakudo/will-phaser-mainline.t
+++ b/t/02-rakudo/will-phaser-mainline.t
@@ -1,0 +1,28 @@
+use lib <t/packages/Test-Helpers>;
+use Test;
+use Test::Helpers;
+
+plan 4;
+
+# A `will leave` / `will enter` phaser trait on a top level variable must
+# attach to the compilation unit's mainline block. Previously the mainline
+# had no enclosing block on the attach-target stack, so the trait found no
+# code object and died "No such method 'add_phaser' for invocant of type 'Mu'".
+
+is-run q|my $x will leave { say "leave $_" } = 42; say "body $x";|,
+    'will leave on a top level variable runs at mainline exit',
+    :out("body 42\nleave 42\n");
+
+is-run q|my $x will enter { say "enter" } = 1; say "body";|,
+    'will enter on a top level variable runs before the mainline body',
+    :out("enter\nbody\n");
+
+is-run q|sub f { my $x will leave { say "leave $_" } = 9; say "in f" }; f(); say "after";|,
+    'will leave inside a routine still runs on routine exit',
+    :out("in f\nleave 9\nafter\n");
+
+is-run q|my $x will enter { say "enter" } will leave { say "leave $_" } = 7; say "body $x";|,
+    'will enter and will leave on one top level variable bracket the mainline body',
+    :out("enter\nbody 7\nleave 7\n");
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
A `will leave`/`will enter` (etc.) phaser trait on a top level variable died "No such method 'add_phaser' for invocant of type 'Mu'". The trait attaches the phaser to the variable's enclosing block, found via find-attach-target('block'). At the top level there is no block on the attach-target stack, so the lookup returned Nil and the code object handed to trait_mod:<will> was Mu.

Fall back to the compilation unit's mainline block when no enclosing block is found. The mainline block is the top level code object. The phaser attaches to its meta-object, and the mainline block forms its own QAST and so sets up exit handling once the phaser is present.

Fixes installing the Cache::Dir module under RakuAST.