### PR TITLE
RakuAST: skip arity check for feed-stage calls

### DIFF
--- a/src/Raku/ast/call.rakumod
+++ b/src/Raku/ast/call.rakumod
@@ -224,6 +224,15 @@ class RakuAST::ArgList
 class RakuAST::Call {
     has RakuAST::ArgList $.args;
 
+    # Set when this call is a stage of a feed operator. The fed value is
+    # appended as an extra argument at QAST time, so the argument count
+    # visible at the AST level is short by one and cannot be trial-bound.
+    has Bool $.feed-stage;
+
+    method set-feed-stage() {
+        nqp::bindattr(self, RakuAST::Call, '$!feed-stage', True);
+    }
+
     method add-colonpair(RakuAST::ColonPair $pair) {
         $!args.push($pair);
         Nil
@@ -369,7 +378,7 @@ class RakuAST::Call::Name
                     :symbol($name);
         }
 
-        if self.is-resolved && (
+        if self.is-resolved && !self.feed-stage && (
             nqp::istype(self.resolution, RakuAST::CompileTimeValue)
             || nqp::can(self.resolution, 'maybe-compile-time-value')
         ) {

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -2319,21 +2319,18 @@ class RakuAST::ApplyListInfix
     method PERFORM-BEGIN(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
         self.IMPL-MAYBE-CURRY($resolver, $context);
 
+        if nqp::istype($!infix, RakuAST::Feed) {
+            for self.IMPL-FEED-STAGES {
+                $_.set-feed-stage if nqp::istype($_, RakuAST::Call);
+            }
+        }
+
         $!infix.IMPL-THUNK-ARGUMENTS($resolver, $context, |self.IMPL-UNWRAP-LIST($!operands));
     }
 
     method PERFORM-CHECK(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
         if nqp::istype($!infix, RakuAST::Feed) {
-            my $op := $!infix.operator;
-            my @stages;
-            if $op eq '==>' || $op eq '==>>' {
-                for $!operands { @stages.push($_) }
-            }
-            else {
-                for $!operands { @stages.unshift($_) }
-            }
-            @stages.shift;  # source operand, not a stage to validate
-            for @stages {
+            for self.IMPL-FEED-STAGES {
                 my $stage := $_;
                 if nqp::istype($stage, RakuAST::Var) && $stage.sigil eq '&' {
                     self.add-sorry(
@@ -2364,6 +2361,23 @@ class RakuAST::ApplyListInfix
             && !self.infix.short-circuit
             && !self.IMPL-IS-LIST-LITERAL
             && self.IMPL-SUNK-OPERATOR-PURE(self.infix);
+    }
+
+    # The operands of a feed in flow order, with the source operand
+    # removed, leaving just the stages. A rightward feed (`==>`, `==>>`)
+    # takes its source from the front; a leftward feed (`<==`, `<<==`)
+    # from the back, so its operands are reversed into flow order first.
+    method IMPL-FEED-STAGES() {
+        my $op := $!infix.operator;
+        my @stages;
+        if $op eq '==>' || $op eq '==>>' {
+            for $!operands { @stages.push($_) }
+        }
+        else {
+            for $!operands { @stages.unshift($_) }
+        }
+        @stages.shift;  # drop the source operand
+        @stages
     }
 
     method IMPL-IS-VALID-FEED-STAGE($stage) {

--- a/t/02-rakudo/rakuast-feed-validation.t
+++ b/t/02-rakudo/rakuast-feed-validation.t
@@ -2,7 +2,7 @@ use lib <t/packages/Test-Helpers>;
 use Test;
 use Test::Helpers;
 
-plan 18;
+plan 23;
 
 # Compile-time validation of `==>` / `<==` stages, matching the
 # legacy frontend's `make_feed` in src/Perl6/Actions.nqp.
@@ -98,5 +98,35 @@ is-run q|say ((1..3) ==> map(* + 10))|,
 is-run q|my @a <== gather for 1..3 -> $i { take $i }; say @a|,
     'bare my @a <== source compiles (declaration acts as Var)',
     :out("[1 2 3]\n");
+
+# A feed stage receives the fed value as an extra argument at code-gen
+# time, so its arity must not be trial-bound against the arguments
+# present in the source text.  A stage calling a sub with one mandatory
+# positional must not SORRY with "will never work with declared signature".
+
+is-run q|sub to-base36($n) { $n.base(36).lc }; say (42 ==> to-base36())|,
+    'feed stage calling sub with one mandatory positional compiles',
+    :out("16\n");
+
+is-run q|sub f($x) { $x }; sub g($x) { $x }; say (5 ==> f() ==> g())|,
+    'chained feed stages each calling a one-positional sub compile',
+    :out("5\n");
+
+is-run q|sub f($x) { $x * 2 }; say (grep(* > 4) <== f() <== 5)|,
+    'backward feed stage calling a one-positional sub compiles',
+    :out("(10)\n");
+
+# The arity check still fires for an ordinary call that is not a feed stage.
+is-run q|sub f($a) { $a }; f(); say "ok"|,
+    'non-feed call with too few arguments still SORRYs',
+    :err(/'will never work with declared signature'/),
+    :exitcode(1);
+
+# Only the stages are marked, never the source operand. A wrong-arity
+# call used as the feed source still gets its arity checked.
+is-run q|sub f($a) { $a }; sub g($x) { $x }; f() ==> g(); say "ok"|,
+    'wrong-arity call as the feed source still SORRYs',
+    :err(/'will never work with declared signature'/),
+    :exitcode(1);
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously a call used as a stage of a `==>` or `<==` feed wrongly reported "Calling foo() will never work with declared signature" when the called sub had a mandatory positional. The fed value is appended as an extra argument at QAST time, so the argument count visible at the AST level is short by one. The check-time trial-bind in RakuAST::Call::Name ran against that incomplete argument list and rejected the call. The legacy frontend does not arity-check feed stages either, since the optimizer's trial-bind bails on the unknown type of the injected value.

Mark each feed-stage call during the begin pass and skip the trial-bind for marked calls. The source operand keeps its check; only stages are marked. The stage list comes from a shared IMPL-FEED-STAGES helper used by both the marking and the existing stage validation.

Fixes installing the CUID module under RakuAST.