### PR TITLE
RakuAST: Declare a block's type captures as block-local

### DIFF
--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -1401,6 +1401,17 @@ class RakuAST::Block
         if $!fresh-exception {
             nqp::push(@implicit, RakuAST::VarDeclaration::Implicit::Special.new(:name('$!')));
         }
+        # Declare a parameter's type captures block-local, so they shadow
+        # rather than rebind an outer same-named capture.
+        my $signature := self.signature;
+        if $signature {
+            for self.IMPL-UNWRAP-LIST($signature.parameters) {
+                my $type-captures := self.IMPL-UNWRAP-LIST($_.type-captures);
+                for $type-captures {
+                    nqp::push(@implicit, $_);
+                }
+            }
+        }
         @implicit
     }
 

--- a/t/02-rakudo/block-type-capture.t
+++ b/t/02-rakudo/block-type-capture.t
@@ -1,0 +1,32 @@
+use Test;
+
+plan 4;
+
+# A type capture in a pointy block declares a fresh lexical inside that
+# block, the way a routine declares its own. A block reusing a name from an
+# enclosing routine must not rebind the outer capture.
+
+# Reusing the enclosing routine's capture name in a loop block leaves the
+# outer capture intact.
+is do {
+    sub f(::T $x) { for 'a', 'b' -> ::T { }; T.^name }
+    f(42)
+}, 'Int', 'capture in loop block does not leak into enclosing routine capture';
+
+# A distinct capture name in the block does not disturb the outer one.
+is do {
+    sub g(::T $x) { for 'a', 'b' -> ::U { }; T.^name }
+    g(42)
+}, 'Int', 'distinct capture in loop block leaves enclosing capture intact';
+
+# A block binds its own capture to the argument type.
+is do {
+    my $b = -> ::U { U.^name };
+    $b('hello')
+}, 'Str', 'pointy block binds its own type capture to the argument type';
+
+# A nested block capture sees its own binding, not the outer one.
+is do {
+    sub h(::T $x) { (-> ::T { T.^name })(3.14) }
+    h(42)
+}, 'Rat', 'nested block capture binds to its own argument, shadowing outer';


### PR DESCRIPTION
A type capture on a pointy or loop block's signature parameter was not declared as a lexical inside that block. The capture bound an outer same-named lexical instead, so `for ... -> ::T { }` inside a routine that already had a `::T` parameter overwrote the routine's capture.

RakuAST::Routine already declares its parameters' type captures in PRODUCE-IMPLICIT-DECLARATIONS. Do the same in RakuAST::Block so blocks with their own signature (pointy blocks, loop blocks) declare theirs too.