### PR TITLE
RakuAST: Don't iterate worries when promoting under fatal

### DIFF
--- a/src/Raku/ast/checktime.rakumod
+++ b/src/Raku/ast/checktime.rakumod
@@ -54,11 +54,13 @@ class RakuAST::CheckTime
 
     # Called when fatal is active in our lexical scope.
     method promote-worries-to-sorries() {
-        nqp::bindattr(self, RakuAST::CheckTime, '$!sorries', []) unless nqp::isconcrete($!sorries);
-        for $!worries {
-            nqp::push($!sorries, $_);
+        if nqp::isconcrete($!worries) {
+            nqp::bindattr(self, RakuAST::CheckTime, '$!sorries', []) unless nqp::isconcrete($!sorries);
+            for $!worries {
+                nqp::push($!sorries, $_);
+            }
+            nqp::bindattr(self, RakuAST::CheckTime, '$!worries', []);
         }
-        nqp::bindattr(self, RakuAST::CheckTime, '$!worries', []);
     }
 
     # Called when no worries is active in our lexical scope.

--- a/t/02-rakudo/fatal-sorry-no-worries.t
+++ b/t/02-rakudo/fatal-sorry-no-worries.t
@@ -1,0 +1,13 @@
+use Test;
+
+plan 1;
+
+# Under `use fatal`, a check-time problem that is a sorry with no accompanying
+# worry must still report the sorry. Promoting worries to sorries should not
+# iterate the worry list when none was ever recorded.
+
+throws-like 'use fatal; sub f($a?, $b) { }', X::Comp,
+    message => /'required parameter'/,
+    'a sorry under fatal with no accompanying worry reports the sorry';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
A node with a sorry-level check-time problem but no worry under `use fatal` crashed with "Cannot iterate over a Mu type object". The worry list stays a type object until the first worry is added, and promote-worries-to-sorries iterated it unconditionally. Guard the promotion on a worry having been recorded.