### PR TITLE
RakuAST: Skip coercion types in the duplicate-multi check

### DIFF
--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -2373,12 +2373,20 @@ class RakuAST::Sub
             return False if $_.constraint_list;
             my $type := $_.type;
             unless nqp::isnull($type) {
+                # A coercion type erases to its target under the smartmatch,
+                # so distinct coercions would compare as equivalent.
+                return False if $type.HOW.archetypes.coercive;
                 my $accepts := nqp::tryfindmethod($type, 'ACCEPTS');
                 return False
                   if nqp::defined($accepts)
                   && nqp::istype($accepts, Code)
                   && !$accepts.file.starts-with('SETTING::');
             }
+            # Apply the same checks through a sub-signature destructure.
+            my $sub-signature := $_.sub_signature;
+            return False
+              if nqp::isconcrete($sub-signature)
+              && !self.IMPL-SIGNATURE-STATICALLY-COMPARABLE($sub-signature);
         }
         True
     }

--- a/t/02-rakudo/multi-coercion-comparable.t
+++ b/t/02-rakudo/multi-coercion-comparable.t
@@ -1,0 +1,32 @@
+use Test;
+
+plan 2;
+
+# Distinct coercion types are wrongly seen as equivalent by the
+# duplicate-multi check. `use fatal` turns that spurious worry into a compile
+# error, so a clean compile proves the check left these signatures alone.
+
+lives-ok {
+    EVAL q:to/CODE/
+        use fatal;
+        class Id {
+            multi method COERCE(Cool $x) { Id }
+            multi method COERCE(Capture $x) { Id }
+        }
+        multi to-sorter(Id(Cool) $x) { "cool" }
+        multi to-sorter(Id(Capture) $x) { "capture" }
+        CODE
+}, 'distinct coercion types on a multi parameter are not a redeclaration';
+
+# A coercion inside a sub-signature destructure is compared the same way.
+lives-ok {
+    EVAL q:to/CODE/
+        use fatal;
+        role Expr { }
+        class Ident does Expr { multi method COERCE(Any $x) { Ident } }
+        multi expand(Pair (Ident(Any) :$key, Mu :$value)) { "ident" }
+        multi expand(Pair (Expr        :$key, Mu :$value)) { "expr" }
+        CODE
+}, 'a coercion inside a sub-signature is not a redeclaration';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
The duplicate-multi-signature check smartmatches two candidate signatures, which erases a coercion type to its target type. Two coercions that share a target but accept different types (such as `Int(Cool)` and `Int(Str)`) then compare as equivalent and produce a spurious "equivalent signatures would lead to ambiguous dispatch" report, which `use fatal` turns into a compile error.

Leave a signature out of the check when a parameter has a coercion type, the same as the existing exemption for where-constraints and out-of-setting ACCEPTS. Apply the test through sub-signature destructures too.