### PR TITLE
RakuAST: Resolve an indirect `is ::Name` parent as a type

### DIFF
--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -3133,15 +3133,26 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
         return self.handle-is-repr($/) if ~$longname eq 'repr';
 
         my $circumfix := $<circumfix>;
-        my $trait := $<typename>
-            ?? Nodify('Trait::Is').new-from-type(
-                :type($<typename>.ast),
-                :argument($circumfix ?? $circumfix.ast !! Mu)
-            )
-            !! Nodify('Trait::Is').new(
-                :name($longname.trait-is2ast),
-                :argument($circumfix ?? $circumfix.ast !! Mu)
-            );
+        my $argument := $circumfix ?? $circumfix.ast !! Mu;
+        my $trait;
+        if $<typename> {
+            $trait := Nodify('Trait::Is').new-from-type(
+                :type($<typename>.ast), :$argument);
+        }
+        # `is ::Foo` names an existing type indirectly. The typename above
+        # rejects the `::` form as a capture, so resolve it here as a type,
+        # like a plain `is Foo`.
+        elsif nqp::eqat(~$longname, '::', 0)
+          && $*R.resolve-name-constant($longname.trait-is2ast) {
+            my $type := Nodify('Type::Simple').new($longname.trait-is2ast);
+            self.SET-NODE-ORIGIN($/, $type);
+            $type.to-begin-time($*R, $*CU.context);
+            $trait := Nodify('Trait::Is').new-from-type(:$type, :$argument);
+        }
+        else {
+            $trait := Nodify('Trait::Is').new(
+                :name($longname.trait-is2ast), :$argument);
+        }
 
         self.attach: $/, $trait;
     }

--- a/t/02-rakudo/is-indirect-parent.t
+++ b/t/02-rakudo/is-indirect-parent.t
@@ -1,0 +1,32 @@
+use Test;
+
+plan 4;
+
+# `is ::Foo` inherits from the existing type Foo, not a fresh type capture,
+# even when the enclosing package shares the name.
+
+is do {
+    class O1 { role Exception is ::Exception { method m { 42 } } }
+    class I1 does O1::Exception { }
+    I1.new.m
+}, 42, 'role inheriting from a same-named outer type via ::Name composes';
+
+ok do {
+    class O2 { role Exception is ::Exception { } }
+    class I2 does O2::Exception { }
+    I2 ~~ Exception
+}, 'the consuming class is-a the outer type';
+
+is do {
+    class C is ::Int { }
+    C.^mro.elems
+}, 5, 'a class inheriting an existing type via ::Name has its real MRO';
+
+# A genuine type capture in a signature is unaffected: it binds to the
+# argument type rather than resolving to an existing same-named type.
+is do {
+    sub f(::Int $x) { Int.^name }
+    f(3.5)
+}, 'Rat', 'a signature ::Name capture still binds to the argument type';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
`is ::Name` names an existing type to inherit from through an indirect lookup. The `is` trait rejects type captures, so `::Name` falls through to the longname branch and was applied as a property name. Its name was then resolved late, after the declaring package's own name was in scope, so a role like `role Exception is ::Exception` resolved its parent to the wrong symbol and ended up an empty parametric role group.

Build a known `::Name` as a type the same way `is Name` does, so it resolves early to the existing type. An unknown name still falls through to the parent path so an unknown parent reports normally. A `::Name` capture in a signature is unaffected and still binds to the argument type.