### PR TITLE
RakuAST: Allow a pseudo-package nested in a declared name

### DIFF
--- a/src/Raku/ast/name.rakumod
+++ b/src/Raku/ast/name.rakumod
@@ -285,11 +285,11 @@ class RakuAST::Name
 
     method contains-pseudo-package-illegal-for-declaration() {
         return 'GLOBAL' if self.is-identifier && $!parts[0].name eq 'GLOBAL';
-        for $!parts {
-            return $_.name
-                if $_.is-pseudo-package
-                || nqp::istype($_, RakuAST::Name::Part::Simple) && $_.name eq 'PROCESS';
-        }
+        # Only a leading pseudo-package is illegal; nested it is an ordinary part.
+        my $first := $!parts[0];
+        return $first.name
+            if nqp::istype($first, RakuAST::Name::Part::Simple)
+            && ($first.is-pseudo-package || $first.name eq 'PROCESS');
         Nil
     }
 

--- a/t/02-rakudo/pseudo-package-nested.t
+++ b/t/02-rakudo/pseudo-package-nested.t
@@ -1,0 +1,14 @@
+use Test;
+
+plan 3;
+
+lives-ok { EVAL 'class Rakudo::CORE::META { }' },
+    'CORE nested in a declared package name is allowed';
+
+lives-ok { EVAL 'class Foo::MY::Bar { }' },
+    'another pseudo-package nested in a declared name is allowed';
+
+throws-like 'class MY::Foo { }', X::PseudoPackage::InDeclaration,
+    'a leading pseudo-package in a declared name is still rejected';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
A pseudo-package such as CORE or MY is only illegal as the leading component of a declared name. contains-pseudo-package-illegal-for-declaration checked every part, so `Rakudo::CORE::META` was rejected with "Cannot use pseudo package CORE in package name" even though CORE there is an ordinary nested name. Check only the first part, matching the legacy frontend.