### PR TITLE
RakuAST: Report a leading pseudo-package cleanly instead of crashing

### DIFF
--- a/src/Raku/ast/package.rakumod
+++ b/src/Raku/ast/package.rakumod
@@ -153,8 +153,12 @@ class RakuAST::Package
         }
         elsif $!name {
             my $full-name := self.IMPL-FULL-NAME($resolver);
-            # First try to find it using the fully qualified name
-            my $resolved := $resolver.resolve-name-constant($full-name, :current-scope-only(self.scope eq 'my'));
+            # First try to find it using the fully qualified name. A bare
+            # GLOBAL declaration reduces to an empty name here, which is not a
+            # resolvable constant; the illegal-name check reports it later.
+            my $resolved := $full-name.is-empty
+                ?? Nil
+                !! $resolver.resolve-name-constant($full-name, :current-scope-only(self.scope eq 'my'));
             # If not found try locally using just the declared name
             $resolved := $resolver.resolve-name-constant($!name, :current-scope-only)
                 unless nqp::isconcrete($resolved);

--- a/src/Raku/ast/resolver.rakumod
+++ b/src/Raku/ast/resolver.rakumod
@@ -327,6 +327,7 @@ class RakuAST::Resolver {
         my $name     := $root.name;
         my str $setting-rev;
         if ($name eq 'CORE') {
+            return Nil unless @parts;  # bare CORE has nothing to resolve
             $root := nqp::shift(@parts);
             if nqp::istype($root, RakuAST::Name::Part::Empty) {
                 return Nil;

--- a/t/02-rakudo/leading-pseudo-package-error.t
+++ b/t/02-rakudo/leading-pseudo-package-error.t
@@ -1,0 +1,25 @@
+use Test;
+
+plan 4;
+
+# A leading pseudo-package in a declared name must report a clean error
+# rather than crashing the name resolver. CORE and GLOBAL took special
+# resolution paths that crashed ("Can't shift from an empty array",
+# "Empty name lookup not possible as a constant").
+
+throws-like 'class CORE::Foo { }', X::PseudoPackage::InDeclaration,
+    'a leading CORE in a declared name reports cleanly';
+
+throws-like 'class CORE { }', X::PseudoPackage::InDeclaration,
+    'a bare CORE declaration reports cleanly';
+
+# The two frontends reject a bare GLOBAL with different exception types
+# (X::PseudoPackage::InDeclaration vs X::AdHoc), so match on the message.
+throws-like 'class GLOBAL { }', Exception, message => /'package GLOBAL'/,
+    'a bare GLOBAL declaration reports cleanly';
+
+# A CORE pseudo-stash lookup is unaffected.
+is-deeply EVAL('CORE::<Int>'), Int,
+    'a CORE pseudo-stash lookup still resolves';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
A pseudo-package leading a declared name is rejected with a sorry, but for CORE and GLOBAL the name resolver crashed before that sorry was reported. `class CORE::Foo` died with "Can't shift from an empty array" because the CORE branch shifted an already-empty part list, and `class GLOBAL` died with "Empty name lookup not possible as a constant" because a bare GLOBAL reduces to an empty name in IMPL-FULL-NAME. Return Nil for a bare CORE and skip resolving an empty full name, so both report the normal error like the other pseudo-packages do.