### PR TITLE
Allow resizing the pty of a  non-started Proc::Async

### DIFF
--- a/src/core.c/Proc/Async.rakumod
+++ b/src/core.c/Proc/Async.rakumod
@@ -135,7 +135,9 @@ my class Proc::Async {
     method resize-pty(Int :$cols, Int :$rows) {
         $!pty-cols := $cols;
         $!pty-rows := $rows;
-        nqp::syscall('pty-resize', $!process_handle, nqp::unbox_i($!pty-cols), nqp::unbox_i($!pty-rows));
+        if $!started {
+            nqp::syscall('pty-resize', $!process_handle, nqp::unbox_i($!pty-cols), nqp::unbox_i($!pty-rows));
+        }
     }
 
     proto method new(|) {*}


### PR DESCRIPTION
Since the the dimensions are passed to the VM when starting, this is safe to do.