### PR TITLE
RakuAST: Defer an unresolved qualified-method-call qualifier to runtime

### DIFF
--- a/src/Raku/ast/call.rakumod
+++ b/src/Raku/ast/call.rakumod
@@ -715,12 +715,11 @@ class RakuAST::Call::Method
                 }
             }
             else {
-# TODO: In base behavior, the attempt to dispatch is performed before
-# determining whether the type actually exists in this scope (throwing
-# a X::Method::InvalidQualifier).  The resolution below will die if the
-# type object cannot be found, deviating from base.
-                my $Qualified := self.IMPL-UNWRAP-LIST(self.get-implicit-lookups)[0].resolution.compile-time-value;
-                $context.ensure-sc($Qualified);
+                # Emit the qualifier through its own QAST so a name that does
+                # not resolve at compile time (for example a type only loaded
+                # by the consuming program) becomes a runtime lookup rather
+                # than a compile-time failure.
+                my $qualified-qast := self.IMPL-UNWRAP-LIST(self.get-implicit-lookups)[0].IMPL-EXPR-QAST($context);
                 $name := @parts[ nqp::elems(@parts)-1 ];
                 my $dispatcher := self.dispatcher;
 
@@ -731,7 +730,7 @@ class RakuAST::Call::Method
                         QAST::SVal.new( :value('dispatch:<::>') ),
                         $invocant-qast,
                         QAST::SVal.new(:value($name)),
-                        QAST::WVal.new(:value($Qualified));
+                        $qualified-qast;
                 }
                 else {
                     my $temp := QAST::Node.unique('inv_once');
@@ -749,7 +748,7 @@ class RakuAST::Call::Method
                                 QAST::Var.new( :name($temp), :scope('local') ),
                             ),
                             QAST::SVal.new(:value($name)),
-                            QAST::WVal.new(:value($Qualified)),
+                            $qualified-qast,
                             QAST::Var.new( :name($temp), :scope('local') ),
                         )
                     );
@@ -790,8 +789,7 @@ class RakuAST::Call::Method
                        QAST::SVal.new( :value($name) );
             }
             else {
-                my $Qualified := self.IMPL-UNWRAP-LIST(self.get-implicit-lookups)[0].resolution.compile-time-value;
-                $context.ensure-sc($Qualified);
+                my $qualified-qast := self.IMPL-UNWRAP-LIST(self.get-implicit-lookups)[0].IMPL-EXPR-QAST($context);
                 $name := @parts[ nqp::elems(@parts)-1 ];
                 my $dispatcher := self.dispatcher;
 
@@ -803,14 +801,14 @@ class RakuAST::Call::Method
                        QAST::SVal.new( :value($dispatcher) ),
                        QAST::SVal.new( :value('dispatch:<::>') ),
                        QAST::SVal.new( :value($name) ),
-                       QAST::WVal.new( :value($Qualified) )
+                       $qualified-qast
                   !! QAST::Op.new:
                        :op('callmethod'), :name('dispatch:<hyper>'),
                        $operand-qast,
                        QAST::SVal.new( :value($name) ),
                        QAST::SVal.new( :value('dispatch:<::>') ),
                        QAST::SVal.new( :value($name) ),
-                       QAST::WVal.new( :value($Qualified) );
+                       $qualified-qast;
             }
         }
         else {

--- a/t/02-rakudo/qualified-method-call-unresolved.t
+++ b/t/02-rakudo/qualified-method-call-unresolved.t
@@ -1,0 +1,32 @@
+use Test;
+
+plan 4;
+
+# A qualified method call `self.Some::Type::method` whose qualifier is not
+# resolvable at compile time (for example a type only loaded by the consuming
+# program) must compile, deferring the qualifier to a runtime lookup, rather
+# than failing to compile.
+lives-ok { EVAL 'role R { method m { self.No::Such::Type::foo } }' },
+    'a qualified call to a not-in-scope qualifier compiles';
+
+# A qualifier that is in scope still dispatches to that type's method.
+is do {
+    class A { method m { 'A' } }
+    class B is A { method m { self.A::m } }
+    B.new.m
+}, 'A', 'a qualified call to an in-scope type dispatches to its method';
+
+# Deferring to runtime keeps the diagnostic: a qualifier that resolves to
+# nothing reports an invalid qualifier when the call runs.
+throws-like { my class C { method m { self.No::Such::Type::foo } }; C.new.m },
+    X::Method::InvalidQualifier,
+    'a qualifier that resolves to nothing reports an invalid qualifier at runtime';
+
+# The hyper form takes the same path.
+is do {
+    class HA { method m { 'A' } }
+    class HB is HA { method m { 'B' } }
+    (HB.new, HB.new)>>.HA::m
+}, ('A', 'A'), 'a hyper qualified call dispatches to the qualifier type';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
A qualified method call such as `self.Some::Type::method` took the qualifier's type object from the implicit lookup's resolution at code-gen and died when that type was not resolvable in the current scope. A type that is only brought in by the consuming program was rejected at compile time even though the legacy frontend defers it. `Terminal::Widgets` hits this: a role calls `self.Terminal::Widgets::Widget::handle-event` without using `Widget`.

Emit the qualifier through its own IMPL-EXPR-QAST instead. A resolved qualifier still compiles to its type object, and an unresolved multi-part qualifier becomes a runtime package lookup, matching the legacy frontend.