### PR TITLE
RakuAST: Vivify an is-typed container before a BEGIN-time STORE

### DIFF
--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -131,6 +131,10 @@ class RakuAST::ContainerCreator {
     has Mu $.container-type;
     has ContainerDescriptor $.container-descriptor;
     has Mu $.bind-constraint;
+    # 1 when the explicit base type is one of the immutable QuantHashes that
+    # must be bare-created. Resolved by identity at BEGIN time, where a
+    # resolver is available, and read at code-gen.
+    has int $!explicit-base-bare-create;
 
     method IMPL-SET-EXPLICIT-CONTAINER-BASE-TYPE(RakuAST::Type $ast) {
         if self.IMPL-HAS-EXPLICIT-CONTAINER-BASE-TYPE {
@@ -322,15 +326,36 @@ class RakuAST::ContainerCreator {
         }
     }
 
+    # Resolve, by identity against the setting's Set/Bag/Mix, whether the
+    # explicit base type is one of the immutable QuantHashes that must be
+    # bare-created. A resolver is only available at BEGIN time, so the result
+    # is cached for code-gen to read. In-setting resolution finds the core
+    # type even when a same-named lexical shadows it; the lexical fallback
+    # covers compiling the setting itself, where the core type is not yet in
+    # an outer setting.
+    method IMPL-RESOLVE-CONTAINER-VIVIFY-MODE(RakuAST::Resolver $resolver) {
+        my $base := self.IMPL-EXPLICIT-CONTAINER-BASE-TYPE;
+        my int $bare := 0;
+        for nqp::list_s('Set', 'Bag', 'Mix') -> str $type-name {
+            my $name  := RakuAST::Name.from-identifier($type-name);
+            my $found := $resolver.resolve-name-constant-in-setting($name)
+                      || $resolver.resolve-name-constant($name);
+            if $found && nqp::eqaddr($base, $found.compile-time-value) {
+                $bare := 1;
+                last;
+            }
+        }
+        nqp::bindattr_i(self, RakuAST::ContainerCreator, '$!explicit-base-bare-create', $bare);
+    }
+
     # QAST that produces a fresh instance of an explicit container base type.
-    # Set/Bag/Mix keep pristine empty sentinels, so create rather than run
-    # their .new (see issue #6246).
+    # Set/Bag/Mix keep pristine empty sentinels, so bare-create them rather
+    # than run their .new (see issue #6246).
     method IMPL-EXPLICIT-CONTAINER-VIVIFY-QAST(RakuAST::IMPL::QASTContext $context, Mu $of) {
         my $class := self.IMPL-CONTAINER-TYPE($of);
         $context.ensure-sc($class);
-        my str $name := $class.HOW.name($class); # XXX needs lookup solution
         my $wval := QAST::WVal.new(:value($class));
-        $name eq 'Set' || $name eq 'Bag' || $name eq 'Mix'
+        $!explicit-base-bare-create
             ?? QAST::Op.new(:op<create>, $wval)
             !! QAST::Op.new(:op<callmethod>, :name<new>, $wval)
     }
@@ -956,6 +981,9 @@ class RakuAST::VarDeclaration::Simple
 
         # Apply any traits.
         self.set-traits(self.IMPL-WRAP-LIST(@late-traits));
+
+        self.IMPL-RESOLVE-CONTAINER-VIVIFY-MODE($resolver)
+            if self.IMPL-HAS-EXPLICIT-CONTAINER-BASE-TYPE;
 
         if self.is-attribute {
             if ($!sigil eq '@' && $!shape) || self.IMPL-HAS-EXPLICIT-CONTAINER-BASE-TYPE || $subset {

--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -321,6 +321,19 @@ class RakuAST::ContainerCreator {
             self.IMPL-EXPLICIT-CONTAINER-BASE-TYPE
         }
     }
+
+    # QAST that produces a fresh instance of an explicit container base type.
+    # Set/Bag/Mix keep pristine empty sentinels, so create rather than run
+    # their .new (see issue #6246).
+    method IMPL-EXPLICIT-CONTAINER-VIVIFY-QAST(RakuAST::IMPL::QASTContext $context, Mu $of) {
+        my $class := self.IMPL-CONTAINER-TYPE($of);
+        $context.ensure-sc($class);
+        my str $name := $class.HOW.name($class); # XXX needs lookup solution
+        my $wval := QAST::WVal.new(:value($class));
+        $name eq 'Set' || $name eq 'Bag' || $name eq 'Mix'
+            ?? QAST::Op.new(:op<create>, $wval)
+            !! QAST::Op.new(:op<callmethod>, :name<new>, $wval)
+    }
 }
 
 class RakuAST::TraitTarget::Variable
@@ -1398,16 +1411,8 @@ class RakuAST::VarDeclaration::Simple
                     :value($container)
                 );
                 if self.IMPL-HAS-EXPLICIT-CONTAINER-BASE-TYPE {
-                    my $class := self.IMPL-CONTAINER-TYPE($of);
-                    my $wval  := QAST::WVal.new(:value($class));
-                    $context.ensure-sc($class);
-
-                    my str $name := $class.HOW.name($class); # XXX needs lookup solution
                     $qast := QAST::Op.new( :op('bind'), $qast,
-                      $name eq 'Set' || $name eq 'Bag' || $name eq 'Mix'
-                        ?? QAST::Op.new(:op<create>, $wval)
-                        !! QAST::Op.new(:op<callmethod>, :name<new>, $wval)
-                    );
+                      self.IMPL-EXPLICIT-CONTAINER-VIVIFY-QAST($context, $of) );
                 }
                 $qast
             }
@@ -1559,9 +1564,24 @@ class RakuAST::VarDeclaration::Simple
                                 $method-call.args.IMPL-ADD-QAST-ARGS($context, $perform-init-qast);
                             }
                             else {
+                                my $invocant := $var-access;
+                                # At BEGIN time the declaration's own
+                                # vivification has not run, so an `is SomeType`
+                                # container is still a type object here. A
+                                # custom Associative STORE needs a defined
+                                # invocant, so vivify it when undefined.
+                                if self.IMPL-HAS-EXPLICIT-CONTAINER-BASE-TYPE {
+                                    $invocant := QAST::Op.new( :op('if'),
+                                      QAST::Op.new( :op('isconcrete'),
+                                        QAST::Var.new( :$name, :scope<lexical> ) ),
+                                      QAST::Var.new( :$name, :scope<lexical> ),
+                                      QAST::Op.new( :op('bind'),
+                                        QAST::Var.new( :$name, :scope<lexical> ),
+                                        self.IMPL-EXPLICIT-CONTAINER-VIVIFY-QAST($context, $of) ) );
+                                }
                                 $perform-init-qast := QAST::Op.new(
                                   :op('callmethod'), :name('STORE'),
-                                  $var-access,
+                                  $invocant,
                                   $init-qast,
                                   QAST::WVal.new( :named('INITIALIZE'), :value(True) )
                                 );

--- a/t/02-rakudo/begin-is-container-store.t
+++ b/t/02-rakudo/begin-is-container-store.t
@@ -1,0 +1,20 @@
+use Test;
+
+plan 3;
+
+# A `my %h is SomeType = ...` evaluated in a BEGIN must vivify the container
+# before the initializing STORE. At BEGIN the declaration's own vivification
+# has not run yet, so the container is still a type object, and an immutable
+# Associative (Map, Set, ...) whose STORE needs a defined invocant would fail.
+
+is do { my $x := BEGIN my %h is Map = (a => 1, b => 2); $x<a> }, 1,
+    'my %h is Map initialized in a BEGIN';
+
+is do { my $x := BEGIN my %h is Set = <a b c>; $x<b> }, True,
+    'my %h is Set initialized in a BEGIN';
+
+# Outside a BEGIN the same declaration keeps working.
+is do { my %h is Map = (a => 1); %h<a> }, 1,
+    'my %h is Map initialized outside a BEGIN';
+
+# vim: expandtab shiftwidth=4

--- a/t/02-rakudo/is-container-shadowed-quanthash.t
+++ b/t/02-rakudo/is-container-shadowed-quanthash.t
@@ -1,0 +1,28 @@
+use Test;
+
+plan 2;
+
+# `my %h is SomeType` bare-creates the container only for the core immutable
+# QuantHashes (Set/Bag/Mix), matched by identity against the setting. A
+# user type that merely shares the name Set must be built with .new, so its
+# BUILD runs.
+
+is do {
+    my class Set does Associative {
+        has $.tag = 'built';   # only set when .new/BUILD runs, not bare create
+        has %.store;
+        method STORE(\pairs, :$INITIALIZE) {
+            %!store = pairs.list.map(*.kv).flat;
+            self
+        }
+        method AT-KEY($k) { %!store{$k} }
+    }
+    my %h is Set = (a => 1);
+    %h.tag
+}, 'built', 'a user type named Set is built with .new, not bare-created';
+
+# The core Set is still bare-created and keeps its empty sentinel.
+is do { my %h is Set = (); %h === set() }, True,
+    'the core Set keeps its empty sentinel';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
A `my %h is SomeType = ...` declaration binds `%h` to a fresh `SomeType` instance at block entry, then calls `STORE` to perform the initial assignment. When the declaration is evaluated in a `BEGIN`, the `STORE` runs before that block-entry vivification, so it was called on the `SomeType` type object instead of an instance.

A `Hash` or `Array` tolerates a type-object invocant, but an immutable `Associative` such as `Map` or `Set`, whose `STORE` wants a defined invocant, dies at BEGIN time with `X::Parameter::InvalidConcreteness` ("Invocant of method 'STORE' must be an object instance ..."). This is what blocks installing `Text::Emoji`, which has a `BEGIN my %x is Map::Match = ...`.

The first commit vivifies the `STORE` invocant when it is still a type object, so the `BEGIN`-time path matches the block-entry one.

The second commit fixes how that vivification picks `nqp::create` over `.new`. `Set`, `Bag` and `Mix` are bare-created so their empty sentinels stay pristine (see #6246). Previously the choice compared the type's name against `Set`/`Bag`/`Mix`, so a user type that merely shared one of those names was bare-created and its `.new` never ran. It now resolves the setting's `Set`/`Bag`/`Mix` and compares by identity, the way the legacy frontend already does.