### PR TITLE
RakuAST: Treat :$foo in a use/import/no argument as an import selector

### DIFF
--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -2321,9 +2321,15 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
                      key => $key, value => $<coloncircumfix>.ast
                    )
                 !! $<var>
-                  ?? Nodify('ColonPair::Variable').new(
-                       key => $key, value => $<var>.ast
-                     )
+                  ?? (($*IN-DECL eq 'use' || $*IN-DECL eq 'import' || $*IN-DECL eq 'no')
+                       # In a `use`/`import`/`no` argument list `:$foo` selects
+                       # an import by name rather than reading a lexical `$foo`,
+                       # so build the tag and not a variable lookup that would
+                       # demand `$foo` be declared.
+                       ?? Nodify('ColonPair::True').new($key)
+                       !! Nodify('ColonPair::Variable').new(
+                            key => $key, value => $<var>.ast
+                          ))
                   !! Nodify(
                        $<neg> ?? 'ColonPair::False' !! 'ColonPair::True'
                      ).new($key);

--- a/src/Raku/Grammar.nqp
+++ b/src/Raku/Grammar.nqp
@@ -852,6 +852,11 @@ role Raku::Common {
 
         return Nil if nqp::isconcrete($*DECLARE-TARGETS) && $*DECLARE-TARGETS == 0;
 
+        # In a declaration context the variable is not a use of a lexical and
+        # need not be declared. This covers the argument list of `use`/`import`,
+        # where `:$foo` names an import to select rather than reading a lexical.
+        return Nil if $*IN-DECL;
+
         # Nothing to do?
         $ast.ensure-parse-performed($*R, $*CU.context);
         return Nil if $ast.is-resolved;
@@ -1752,6 +1757,7 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
 # Pragma and module loading related statements
 
     token statement-control:sym<no> {
+        :my $*IN-DECL := 'no';
         <.use-no>
         <.ws>
         <module-name=.longname> [ <.spacey> <arglist> ]?
@@ -1759,6 +1765,7 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
     }
 
     token statement-control:sym<use> {
+        :my $*IN-DECL := 'use';
         # TODO this is massively simplified
         <.use-use>
         <.ws>

--- a/t/02-rakudo/colonpair-use-import.t
+++ b/t/02-rakudo/colonpair-use-import.t
@@ -1,0 +1,22 @@
+use lib <t/packages/Test-Helpers t/packages/02-rakudo/lib>;
+use Test;
+use Test::Helpers;
+
+plan 3;
+
+# A `:$foo` colonpair in a `use`/`import` argument list names an import to
+# select (the tag `foo`), it does not read a lexical `$foo`. So it must compile
+# without `$foo` being declared and import the symbol exported under that tag.
+use ColonPairImportHelper :$XML2, :Opaque;
+
+is $XML2, 42, 'use Module :$tag imports the variable exported under that tag';
+is Opaque, 'CPointer', 'use Module :Opaque imports the constant under that tag';
+
+# `no Pragma :$foo` selects by name the same way, so it reaches the pragma
+# rather than failing on an undeclared `$foo`.
+is-run 'no strict :$foo; my $x = 1',
+    :exitcode(* != 0),
+    :err(/'does not take any arguments'/),
+    'no Pragma :$foo parses the colonpair as a selector, not a lexical read';
+
+# vim: expandtab shiftwidth=4

--- a/t/packages/02-rakudo/lib/ColonPairImportHelper.rakumod
+++ b/t/packages/02-rakudo/lib/ColonPairImportHelper.rakumod
@@ -1,0 +1,4 @@
+unit module ColonPairImportHelper;
+
+our $XML2 is export(:XML2) = 42;
+constant Opaque is export(:Opaque) = 'CPointer';


### PR DESCRIPTION
`use Foo :$bar` (and `import Foo :$bar`, `no Foo :$bar`) failed to compile under RakuAST with "Variable '$bar' is not declared", because the `:$bar` colonpair was parsed as the live pair `bar => $bar` and the lexical `$bar` was demanded. In such an argument list `:$bar` names an import to select, the same as the tag `:bar`, so there is no lexical to read.

Set `$*IN-DECL` while parsing a `use`/`no` statement (the `import` statement already did), skip the undeclared-variable check when `$*IN-DECL` is set (matching the legacy frontend), and build `:$foo` in that context as the tag rather than a variable lookup.