### PR TITLE
RakuAST: Add the leading package of a qualified lookup to the SC

### DIFF
--- a/src/Raku/ast/variable-access.rakumod
+++ b/src/Raku/ast/variable-access.rakumod
@@ -812,9 +812,17 @@ class RakuAST::Var::Package
                 if self.is-resolved {
                     my $name := self.resolution.lexical-name;
                     nqp::shift(@parts);
-                    $result := nqp::istype(self.resolution, RakuAST::CompileTimeValue)
-                        ?? QAST::WVal.new(:value(self.resolution.compile-time-value))
-                        !! QAST::Var.new(:$name, :scope<lexical>);
+                    if nqp::istype(self.resolution, RakuAST::CompileTimeValue) {
+                        # The leading package may be one we vivified for our own
+                        # name (`Foo` for a `unit class Foo::Bar`), which has no
+                        # serialization context yet, so make sure it gets one.
+                        my $value := self.resolution.compile-time-value;
+                        $context.ensure-sc($value);
+                        $result := QAST::WVal.new(:$value);
+                    }
+                    else {
+                        $result := QAST::Var.new(:$name, :scope<lexical>);
+                    }
                 }
                 else {
                     $result := QAST::Op.new(:op<getcurhllsym>, QAST::SVal.new(:value<GLOBAL>));

--- a/t/02-rakudo/qualified-lookup-parent-package-sc.t
+++ b/t/02-rakudo/qualified-lookup-parent-package-sc.t
@@ -1,0 +1,16 @@
+use lib <t/packages/02-rakudo/lib>;
+use Test;
+
+plan 1;
+
+# Precompiling a unit whose name is nested (here `QualPkgSC::Config`) and which
+# refers at BEGIN time to a qualified symbol led by its own parent package
+# (`@QualPkgSC::Raw::ClassMap`) used to die with "Object of type QualPkgSC in
+# QAST::WVal, but not in SC": the vivified parent package never reached the
+# serialization context. Loading the module exercises that precompilation.
+use QualPkgSC::Config;
+
+is QualPkgSC::Config.names, ('Int', 'Str'),
+    'a constant naming a symbol through the unit own parent package compiles';
+
+# vim: expandtab shiftwidth=4

--- a/t/packages/02-rakudo/lib/QualPkgSC/Config.rakumod
+++ b/t/packages/02-rakudo/lib/QualPkgSC/Config.rakumod
@@ -1,0 +1,10 @@
+unit class QualPkgSC::Config;
+use QualPkgSC::Raw;
+
+# A BEGIN-time `constant` whose initializer names a qualified symbol led by
+# this unit's own parent package (`QualPkgSC`). That parent is vivified for our
+# name and must reach the serialization context, or precompiling this unit dies
+# with "Object of type QualPkgSC in QAST::WVal, but not in SC".
+my constant @Names = @QualPkgSC::Raw::ClassMap.map(*.^name);
+
+method names { @Names }

--- a/t/packages/02-rakudo/lib/QualPkgSC/Raw.rakumod
+++ b/t/packages/02-rakudo/lib/QualPkgSC/Raw.rakumod
@@ -1,0 +1,7 @@
+unit module QualPkgSC::Raw;
+
+our @ClassMap;
+BEGIN {
+    @ClassMap[0] = Int;
+    @ClassMap[1] = Str;
+}


### PR DESCRIPTION
A qualified term like `@Foo::Bar::baz` resolves its leading package and embeds it as a compile-time value. When that package is one vivified for the compiling unit's own name (`Foo` for a `unit class Foo::Bar`), it had no serialization context, so a BEGIN-time use of the term (for example in a `constant` initializer) died at code generation with "Object of type Foo in QAST::WVal, but not in SC".

Ensure the leading package value reaches the serialization context before building its QAST::WVal, as every other compile-time value in this lookup path already does.