### PR TITLE
RakuAST: Support anon subset declarations

### DIFF
--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -2036,9 +2036,12 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
             if nqp::istype($node, RakuAST::LexicalScope) {
                 0
             }
-            # If it's a declaration, it blocks; walk no futher
+            # A declaration that installs an enclosing symbol blocks; an `anon`
+            # one that installs none (e.g. an anon subset) is just a value.
             elsif nqp::istype($node, RakuAST::Declaration) {
-                $seen-decl-or-topic := 1;
+                if $node.IMPL-INSTALLS-ENCLOSING-SYMBOL {
+                    $seen-decl-or-topic := 1;
+                }
                 0
             }
             # If it's a usage of the topic, it also blocks; walk no further

--- a/src/Raku/ast/scoping.rakumod
+++ b/src/Raku/ast/scoping.rakumod
@@ -1041,8 +1041,10 @@ class RakuAST::PackageInstaller {
         RakuAST::Package $current-package,
         Mu :$meta-object
     ) {
-        # Anonymous declarations install no symbol.
+        # Anonymous declarations install no symbol, whether the name itself
+        # is anonymous or the declaration is `anon`-scoped.
         return Nil unless $name.is-installable;
+        return Nil if $scope eq 'anon';
         my $orig-scope := $scope;
         my $target;
         my $final;

--- a/src/Raku/ast/scoping.rakumod
+++ b/src/Raku/ast/scoping.rakumod
@@ -586,6 +586,15 @@ class RakuAST::Declaration
         self.is-lexical
     }
 
+    # Whether this declaration installs a symbol into the enclosing scope.
+    # Used by the block-or-hash disambiguation: a `{ }` with a leading pair is
+    # a block if it declares a symbol. An `anon`-scoped declaration installs
+    # none, so it does not, unless it installs more than its own name (an enum
+    # installs its values) and overrides this.
+    method IMPL-INSTALLS-ENCLOSING-SYMBOL() {
+        self.scope ne 'anon'
+    }
+
     method report-redeclaration() {
         True
     }

--- a/src/Raku/ast/type.rakumod
+++ b/src/Raku/ast/type.rakumod
@@ -770,6 +770,10 @@ class RakuAST::Type::Enum
     method is-lexical() { True }
     method is-simple-lexical-declaration() { False }
 
+    # An enum installs its enumerated values into the enclosing scope even
+    # when the enum itself is `anon`-scoped.
+    method IMPL-INSTALLS-ENCLOSING-SYMBOL() { True }
+
     # IMPL-EXPR-QAST yields null in void context, where a sink call would
     # instead run ENUM_VALUES.
     method needs-sink-call() { False }

--- a/src/Raku/ast/type.rakumod
+++ b/src/Raku/ast/type.rakumod
@@ -1069,7 +1069,7 @@ class RakuAST::Type::Subset
 
     method default-scope() { 'our' }
 
-    method allowed-scopes() { self.IMPL-WRAP-LIST(['my', 'our']) }
+    method allowed-scopes() { self.IMPL-WRAP-LIST(['anon', 'my', 'our']) }
 
     method dba() { 'subset' }
 

--- a/t/02-rakudo/anon-decl-hash-literal.t
+++ b/t/02-rakudo/anon-decl-hash-literal.t
@@ -1,0 +1,25 @@
+use Test;
+
+plan 4;
+
+# A `{ }` whose only entry is a pair is a hash, not a block, even when the
+# pair's value is an `anon` declaration that installs no symbol, such as an
+# anon subset. RakuAST previously mis-detected this as a block, then failed to
+# bind it to a hash.
+my $subset-hash = { day => (anon subset NumericDay of Int where * <= 31) };
+isa-ok $subset-hash, Hash,
+    'a pair whose value is an anon subset makes a hash';
+ok (5 ~~ $subset-hash<day>) && !(99 ~~ $subset-hash<day>),
+    'the anon-subset value is stored in the hash and still type-checks';
+
+# An anon enum still installs its enumerated values into the enclosing scope,
+# so a `{ }` with such a value stays a block, the same as the legacy frontend.
+my $enum-block = { k => (anon enum AnonRGB <ARED AGRN ABLU>) };
+isa-ok $enum-block, Callable,
+    'a pair whose value is an anon enum stays a block';
+
+# A plain pair is a hash.
+my $plain = { a => 1 };
+isa-ok $plain, Hash, 'a plain pair makes a hash';
+
+# vim: expandtab shiftwidth=4

--- a/t/02-rakudo/anon-subset.t
+++ b/t/02-rakudo/anon-subset.t
@@ -1,0 +1,25 @@
+use Test;
+
+plan 6;
+
+# An `anon subset` compiles and the resulting subset still type-checks.
+my $subset = (anon subset NumericDay of Int where * <= 31);
+is $subset.^name, 'NumericDay', 'an anon subset carries its declared name';
+ok 5 ~~ $subset, 'an anon subset accepts a matching value';
+nok 99 ~~ $subset, 'an anon subset rejects a non-matching value';
+
+# `anon` means the name is not installed in the enclosing scope.
+throws-like 'anon subset Foo of Int where * < 5; Foo', X::Undeclared::Symbols,
+    'an anon subset does not install its name';
+
+# The same holds for an anon enum: both reach the shared package installer.
+throws-like 'anon enum Bar <a b c>; Bar', X::Undeclared::Symbols,
+    'an anon enum does not install its name';
+
+# A named subset still installs its name and type-checks.
+{
+    my subset Small of Int where * < 5;
+    ok 3 ~~ Small, 'a my-scoped subset still installs and type-checks';
+}
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously `anon subset Foo of Int where * <= 31` died with `Cannot use 'anon' with subset declaration` under RakuAST, while the legacy frontend accepted it. `RakuAST::Type::Subset` allowed only `my` and `our` scopes, even though `RakuAST::Type::Enum` already allowed `anon`. This adds `anon` to the subset's allowed scopes.

An `anon`-scoped type declaration should not install its name. The shared package installer skipped a declaration whose name is anonymous, but not one that is named yet `anon`-scoped, so `anon subset Foo` and `anon enum Foo` both left `Foo` resolvable. This skips installation for `anon` scope too. A class or role declaration was already correct, as it only installs for `my` and `our`.

With those in place, `{ day => (anon subset Foo of Int where * <= 31) }` was still compiled as a block rather than a hash. The block-or-hash disambiguation treats a `{ }` with a leading pair as a block when it declares a symbol, but it counted every declaration, including an `anon` one that installs nothing. This adds `RakuAST::Declaration.IMPL-INSTALLS-ENCLOSING-SYMBOL`, false for an `anon`-scoped declaration, so an anon subset value no longer forces a block. An enum overrides it to true, since an anon enum still installs its values, so a pair with an anon enum value stays a block as before.

Together these let `Path::Router` install and pass its tests under RakuAST.
