### PR TITLE
RakuAST: Route a maybe-method call through raku-meth-call-me-maybe

### DIFF
--- a/src/Raku/ast/call.rakumod
+++ b/src/Raku/ast/call.rakumod
@@ -696,6 +696,35 @@ class RakuAST::Call::Method
             my @parts := nqp::split('::', $name);
             if nqp::elems(@parts) == 1 {
                 my $dispatcher := self.dispatcher;
+                if $dispatcher eq 'dispatch:<.?>' && $!name.is-identifier {
+                    # A maybe-method call ($obj.?meth) with a known method
+                    # name. Resolve the method through the invocant's
+                    # metaclass and call it, or produce Nil. Going through the
+                    # raku-meth-call-me-maybe dispatcher rather than a
+                    # dispatch:<.?> method call lets this reach any object with
+                    # a metaclass, not only Mu-rooted ones.
+                    my $temp := QAST::Node.unique('inv_once');
+                    my $stmts := QAST::Stmts.new(
+                        QAST::Op.new(
+                            :op('bind'),
+                            QAST::Var.new( :name($temp), :scope('local'), :decl('var') ),
+                            $invocant-qast
+                        ),
+                        $call := QAST::Op.new(
+                            :op('dispatch'),
+                            QAST::SVal.new( :value('raku-meth-call-me-maybe') ),
+                            QAST::Op.new(
+                                :op('decont'),
+                                QAST::Var.new( :name($temp), :scope('local') ),
+                            ),
+                            QAST::SVal.new( :value($name) ),
+                            QAST::Var.new( :name($temp), :scope('local') ),
+                        )
+                    );
+                    self.args.IMPL-ADD-QAST-ARGS($context, $call);
+                    return $stmts;
+                }
+
                 if $dispatcher {
                     # A method call going through a dispatch: method
                     $call := QAST::Op.new(

--- a/t/02-rakudo/maybe-method-call.t
+++ b/t/02-rakudo/maybe-method-call.t
@@ -1,0 +1,24 @@
+use Test;
+use nqp;
+
+plan 5;
+
+# A maybe-method call `$obj.?meth` resolves the named method through the
+# invocant's metaclass and calls it, or yields Nil when it is absent.
+
+is 42.?Str, '42', 'a maybe-method call invokes a method that exists';
+ok (42.?no-such-method) =:= Nil, 'a maybe-method call yields Nil when the method is absent';
+
+# It must not require the invocant to be a Mu-rooted object. A raw NQP object
+# has no Raku `dispatch:<.?>` method, so a maybe-method call on one must still
+# resolve through its metaclass rather than dying "dispatch:<.?> not found".
+my $nqp-object := nqp::list(1, 2, 3);
+lives-ok { $nqp-object.?elems }, 'a maybe-method call on a non-Mu object does not throw';
+ok (try $nqp-object.?elems) =:= Nil,
+    'a maybe-method call on a non-Mu object without the method yields Nil';
+
+# A computed (non-identifier) method name still works.
+my $name = 'Str';
+is 42.?"$name"(), '42', 'a maybe-method call with a computed name still works';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
A maybe-method call `$obj.?meth` compiled to a `callmethod dispatch:<.?>`, which requires the invocant to carry the `dispatch:<.?>` method that lives on `Mu`. On an object that is not Mu-rooted, such as an NQP grammar cursor reached from a slang's action methods, that died with "dispatch:<.?> not found".

When the method name is a plain identifier, route the call through the `raku-meth-call-me-maybe` dispatcher instead. It resolves the named method through the invocant's own metaclass and calls it, or produces Nil, so it reaches any object with a metaclass. This matches how qualified and private method calls already lower to the `raku-meth-call-qualified` and `raku-meth-private` dispatchers, and how the legacy frontend's optimizer rewrites `.?`. A computed method name keeps the existing `dispatch:<.?>` call.