### PR TITLE
RakuAST: Give a non-constant lexical its BEGIN value in a constant

### DIFF
--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -328,28 +328,63 @@ class RakuAST::Code
                     # Skipping them keeps their references late-bound, so
                     # the runtime lookup reaches the caller's container.
                     elsif $name ne '$_' && $name ne '$/' && $name ne '$!' && $name ne '$¢' {
-                        my $decl := $parse-time-resolver.resolve-lexical-constant($name);
-                        if $decl {
-                            $decl.to-begin-time($resolver, $context); # Ensure any required lookups are resolved
-                            my $value := $decl.compile-time-value;
-                            $context.ensure-sc($value);
-                            %seen{$name} := 1;
-                            $block[0].push(
-                                QAST::Var.new(:scope<lexical>, :decl<static>, :$name, :$value)
-                            );
-                        }
-                        elsif nqp::eqat($name, '!__REGEX_CAPTURE_', 0) {
-                            # A regex capture lexical is bound and used within
-                            # this compiled unit, but its declaration lives in
-                            # an enclosing scope outside the unit. Declare it
-                            # here, as that scope otherwise would.
-                            %seen{$name} := 1;
-                            $block[0].push(
-                                QAST::Var.new(:scope<lexical>, :decl<var>, :$name)
-                            );
+                        my $lexical := $parse-time-resolver.resolve-lexical($name);
+                        if $lexical
+                          && !nqp::istype($lexical, RakuAST::Declaration::External)
+                          && !nqp::istype($lexical, RakuAST::CompileTimeValue)
+                          && !nqp::eqat($name, '!__REGEX_CAPTURE_', 0)
+                          # A dynamic variable (a `*` twigil) resolves by a
+                          # runtime stack-walk, not from a lexical container, so
+                          # leave it to the handling below.
+                          && nqp::substr($name, 1, 1) ne '*' {
+                            # A declared but non-constant lexical in an active
+                            # scope (for example a sigilless `my \x` or a `my
+                            # $x`), unbound at this BEGIN point. Reproduce the
+                            # value it holds there, as the legacy frontend does
+                            # by referring to it in place.
+                            if nqp::index('$@%&', nqp::substr($name, 0, 1)) >= 0 {
+                                # A sigil'd variable has a container; leaving the
+                                # reference late-bound lets the runtime lookup
+                                # reach that container for its default value (Any,
+                                # an empty Array, an empty Hash).
+                            }
+                            else {
+                                # A sigilless binding has no container, so a
+                                # late-bound lookup would yield a raw VMNull. Its
+                                # unbound value is Mu, so inline that.
+                                my $mu := $parse-time-resolver.resolve-lexical-constant('Mu');
+                                my $value := $mu ?? $mu.compile-time-value !! Mu;
+                                $context.ensure-sc($value);
+                                %seen{$name} := 1;
+                                $block[0].push(
+                                    QAST::Var.new(:scope<lexical>, :decl<static>, :$name, :$value)
+                                );
+                            }
                         }
                         else {
-                            nqp::die("Could not find a compile-time-value for lexical $name");
+                            my $decl := $parse-time-resolver.resolve-lexical-constant($name);
+                            if $decl {
+                                $decl.to-begin-time($resolver, $context); # Ensure any required lookups are resolved
+                                my $value := $decl.compile-time-value;
+                                $context.ensure-sc($value);
+                                %seen{$name} := 1;
+                                $block[0].push(
+                                    QAST::Var.new(:scope<lexical>, :decl<static>, :$name, :$value)
+                                );
+                            }
+                            elsif nqp::eqat($name, '!__REGEX_CAPTURE_', 0) {
+                                # A regex capture lexical is bound and used within
+                                # this compiled unit, but its declaration lives in
+                                # an enclosing scope outside the unit. Declare it
+                                # here, as that scope otherwise would.
+                                %seen{$name} := 1;
+                                $block[0].push(
+                                    QAST::Var.new(:scope<lexical>, :decl<var>, :$name)
+                                );
+                            }
+                            else {
+                                nqp::die("Could not find a compile-time-value for lexical $name");
+                            }
                         }
                     }
                 }

--- a/t/02-rakudo/constant-nonconstant-lexical.t
+++ b/t/02-rakudo/constant-nonconstant-lexical.t
@@ -1,0 +1,43 @@
+use Test;
+
+plan 7;
+
+# A `constant` is evaluated at BEGIN. Referencing a non-constant outer lexical
+# in its initializer (here a sigilless `my \elements`, whose binding runs later
+# at mainline time) must not die with "Symbol 'elements' does not have a
+# compile-time value". The lexical is unbound at that BEGIN, so it resolves to
+# Mu, the same as the legacy frontend, which refers to it in place.
+my \elements = 1, 2, 3;
+constant WithNonConstant = [elements];
+is WithNonConstant.elems, 1,
+    'a constant referencing a non-constant my-\ lexical compiles';
+nok WithNonConstant[0].defined,
+    'the unbound lexical resolves to its undefined value at the constant BEGIN';
+
+# Consumed as a bare value rather than inside a list, the constant must hold a
+# real Mu, not a raw VMNull (which would have no methods).
+my \bare = 42;
+constant Bare = bare;
+nok Bare.defined,
+    'a non-constant sigilless lexical yields Mu when held as the bare value';
+
+# A sigil'd variable has a container, so it yields that container default at
+# BEGIN: Any for a scalar, an empty Array for a positional.
+my $scalar;
+constant FromScalar = $scalar;
+nok FromScalar.defined, 'a non-constant scalar lexical yields its Any default';
+my @positional;
+constant FromArray = @positional;
+is FromArray.elems, 0, 'a non-constant array lexical yields its empty default';
+
+# A constant referencing a real constant still inlines its value, including a
+# constant resolved from an enclosing (EVAL) scope.
+constant Base = 5;
+constant Derived = Base * 2;
+is Derived, 10, 'a constant referencing a constant still binds its value';
+is EVAL(q:to/CODE/), 10, 'a constant referencing an outer-scope constant inlines it';
+    constant Inner = Base * 2;
+    Inner
+    CODE
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
A `constant` initializer is evaluated at BEGIN and compiled as a standalone block, so finalizing it inlines the compile-time values of the outer lexicals it references. An outer lexical with no compile-time value, such as a sigilless `my \x` whose binding runs later at mainline time, died with "Symbol 'x' does not have a compile-time value".

The lexical is declared but unbound at that BEGIN, so it holds only its default value. Reproduce that, as the legacy frontend does by referring to the lexical in place. A sigil'd variable has a container, so the reference is left late-bound and the runtime lookup reaches it for Any, an empty Array or an empty Hash. A sigilless binding has no container, so a late-bound lookup would yield a raw VMNull. Its unbound value is Mu, so inline that.

Constants, including one resolved from an enclosing EVAL scope, regex captures and dynamic variables keep their existing handling, and undeclared names still error.