### PR TITLE
RakuAST: Hyper the postfixes the legacy frontend hypers

### DIFF
--- a/src/Raku/ast/call.rakumod
+++ b/src/Raku/ast/call.rakumod
@@ -1006,9 +1006,7 @@ class RakuAST::Call::PrivateMethod
 
     method needs-resolution() { False }
 
-    method can-be-used-with-hyper() {
-        $!name && $!name.is-multi-part
-    }
+    method can-be-used-with-hyper() { True }
 
     method PERFORM-PARSE(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
         nqp::bindattr(self, RakuAST::Call::PrivateMethod, '$!package', $resolver.current-package);
@@ -1114,19 +1112,29 @@ class RakuAST::Call::PrivateMethod
     }
 
     method IMPL-POSTFIX-HYPER-QAST(RakuAST::IMPL::QASTContext $context, Mu $operand-qast) {
-        my $name := $!name.canonicalize;
-        my $call;
-        my @parts := nqp::split('::', $name);
-
-        $name := @parts[ nqp::elems(@parts)-1 ];
-
-        $call := QAST::Op.new:
+        my $name := $!name.last-part.name;
+        # The package to look the private method up in: a qualified name
+        # resolves it directly, an unqualified name uses the current package
+        # (the parametric form going through the `::?CLASS` lookup, as the
+        # non-hyper path does).
+        my $package-qast;
+        if $!name.is-multi-part {
+            $package-qast := self.resolution.IMPL-TO-QAST($context);
+        }
+        elsif $!package.HOW.archetypes.parametric {
+            $package-qast := self.IMPL-UNWRAP-LIST(self.get-implicit-lookups)[0].IMPL-EXPR-QAST($context);
+        }
+        else {
+            $context.ensure-sc($!package);
+            $package-qast := QAST::WVal.new( :value($!package) );
+        }
+        my $call := QAST::Op.new:
             :op('callmethod'), :name('dispatch:<hyper>'),
             $operand-qast,
             QAST::SVal.new( :value($name) ),
             QAST::SVal.new( :value('dispatch:<!>') ),
             QAST::SVal.new( :value($name) ),
-            self.resolution.IMPL-TO-QAST($context);
+            $package-qast;
         self.args.IMPL-ADD-QAST-ARGS($context, $call);
         $call
     }
@@ -1157,6 +1165,15 @@ class RakuAST::Call::MetaMethod
         my $call := QAST::Op.new( :op('p6callmethodhow'), :name($!name), $invocant-qast );
         self.args.IMPL-ADD-QAST-ARGS($context, $call);
         $call
+    }
+
+    method can-be-used-with-hyper() { True }
+
+    method IMPL-POSTFIX-HYPER-QAST(RakuAST::IMPL::QASTContext $context, Mu $invocant-qast) {
+        # A meta-method acts on the meta-object, so the hyper has no effect: it
+        # calls the meta-method once on the operand, matching the legacy
+        # frontend (`@a>>.^name` is `@a.^name`).
+        self.IMPL-POSTFIX-QAST($context, $invocant-qast)
     }
 }
 

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -2934,6 +2934,20 @@ class RakuAST::Postfix::Power
         Nil
     }
 
+    # Unlike the vulgar postfix (which is really an infix `+` and which the
+    # legacy frontend rejects under a hyper), the power postfix is a real
+    # postfix routine that hypers element-wise (`(1,2,3)>>²` is `(1,4,9)`).
+    method can-be-used-with-hyper() { True }
+
+    method IMPL-POSTFIX-HYPER-QAST(RakuAST::IMPL::QASTContext $context, Mu $operand-qast) {
+        $context.ensure-sc(self.power);
+        QAST::Op.new:
+            :op('callstatic'), :name('&METAOP_HYPER_POSTFIX_ARGS'),
+            $operand-qast,
+            QAST::WVal.new( :value(self.power) ),
+            self.resolution.IMPL-LOOKUP-QAST($context)
+    }
+
     method power() { nqp::getattr(self,RakuAST::Postfix::Literal,'$!value') }
 }
 

--- a/t/02-rakudo/postfix-hyper.t
+++ b/t/02-rakudo/postfix-hyper.t
@@ -1,0 +1,33 @@
+use Test;
+
+plan 6;
+
+# Hypering a postfix should work for the same postfixes the legacy frontend
+# accepts, not just method calls and postcircumfix indexing.
+
+# The power postfix hypers element-wise.
+is ((1, 2, 3)>>²).join(','), '1,4,9',
+    'a hyper power postfix applies element-wise';
+
+# A meta-method acts on the meta-object, so the hyper applies it once to the
+# operand rather than distributing (matching the legacy frontend).
+my @a = 1, 'x', 3.0;
+is @a>>.^name, 'Array', 'a hyper meta-method call acts on the operand itself';
+is (Int)>>.^name, 'Int', 'a hyper meta-method call on a type object resolves';
+
+# A simple (unqualified) private method hypers.
+class WithPriv {
+    method !twice { 42 }
+    method run { (self, self)>>!twice }
+}
+is WithPriv.run.join(','), '42,42',
+    'a hyper unqualified private method call applies element-wise';
+
+# Forms that already worked keep working.
+is ((1, 2, 3)>>.succ).join(','), '2,3,4',
+    'a hyper method call applies element-wise';
+my @nested = [1, 2], [3, 4];
+is (@nested>>[0]).join(','), '1,3',
+    'a hyper postcircumfix index applies element-wise';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
`>>` on a postfix rejected several postfixes with "Cannot hyper this postfix" that the legacy frontend accepts. Brought the set in line with legacy:

- A meta-method call (`@a>>.^name`, `(Range)>>.^compose`) had no hyper support. A meta-method acts on the meta-object, so the hyper has no effect: it calls the meta-method once on the operand, as the legacy frontend does (`@a>>.^name` is `@a.^name`).

- The power postfix (`(1,2,3)>>²`) is a real postfix routine that hypers element-wise. The support goes on RakuAST::Postfix::Power, not its RakuAST::Postfix::Literal base, so the vulgar postfix (really an infix `+`, which legacy rejects under a hyper) keeps erroring.

- An unqualified private method (`(self, self)>>!meth`) was rejected because the hyper code generation sourced the lookup package only from a qualified name's resolution; an unqualified name now uses the current package, as the non-hyper path does.