### PR TITLE
RakuAST: Resolve forward references in a role body before composing it

### DIFF
--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -2453,12 +2453,40 @@ class RakuAST::RoleBody
         Nil
     }
 
-    method IMPL-FINISH-ROLE-BODY(RakuAST::IMPL::QASTContext $context) {
+    method IMPL-FINISH-ROLE-BODY(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
         unless self.is-stub {
+            self.IMPL-RESOLVE-FORWARD-LEXICALS($resolver);
             my $*IMPL-COMPILE-DYNAMICALLY := 1;
             my $body-qast := self.IMPL-QAST-BLOCK($context, :blocktype<immediate>);
             self.IMPL-BEGIN-TIME-LEXICAL-FIXUP($context, $body-qast, $!fixup);
         }
+    }
+
+    # The body is code-generated here, ahead of the compilation unit's check
+    # pass, so a forward reference inside it (for example a parameter or
+    # attribute default naming a `sub` declared later in the body) is still
+    # unresolved from its parse-time lookup. Resolve those now, pushing each
+    # lexical scope as we descend so a lookup is re-resolved against its own
+    # scope chain. This reaches declarations hoisted into a method, a nested
+    # block, or a package nested in the body, not only body-level ones. Only
+    # lookups that are still unresolved are touched, so an outer or CORE match
+    # is never replaced and a role-local declaration still shadows an outer one.
+    method IMPL-RESOLVE-FORWARD-LEXICALS(RakuAST::Resolver $resolver) {
+        self.IMPL-RESOLVE-FORWARD-LEXICALS-IN($resolver, self);
+    }
+
+    method IMPL-RESOLVE-FORWARD-LEXICALS-IN(RakuAST::Resolver $resolver, $node) {
+        my int $is-scope := nqp::istype($node, RakuAST::LexicalScope);
+        $resolver.push-scope($node) if $is-scope;
+        $node.visit-children(-> $child {
+            if nqp::istype($child, RakuAST::Var::Lexical)
+              && $child.needs-resolution && !$child.is-resolved {
+                my $resolved := $resolver.resolve-lexical($child.name);
+                $child.set-resolution($resolved) if $resolved;
+            }
+            self.IMPL-RESOLVE-FORWARD-LEXICALS-IN($resolver, $child);
+        });
+        $resolver.pop-scope() if $is-scope;
     }
 }
 

--- a/src/Raku/ast/package.rakumod
+++ b/src/Raku/ast/package.rakumod
@@ -800,7 +800,7 @@ class RakuAST::Role
         # See Package.IMPL-COMPOSE; $resolver/$context are mandatory and
         # the first meta-object access fills the cache.
         self.meta-object(:$resolver, :$context);
-        self.body.IMPL-FINISH-ROLE-BODY($context);
+        self.body.IMPL-FINISH-ROLE-BODY($resolver, $context);
     }
 }
 

--- a/src/Raku/ast/variable-access.rakumod
+++ b/src/Raku/ast/variable-access.rakumod
@@ -98,7 +98,17 @@ class RakuAST::Var::Lexical
     }
 
     method IMPL-EXPR-QAST(RakuAST::IMPL::QASTContext $context) {
-        self.resolution.IMPL-LOOKUP-QAST($context)
+        # An unresolved lookup only reaches code generation in an eager
+        # (compose-time) context such as a role body, where a forward reference
+        # to a declaration made later cannot be resolved yet. Emit a late-bound
+        # lexical lookup rather than dying, as RakuAST::Call::Name does for an
+        # unresolved call; finalizing the dynamically-compiled body binds it to
+        # a declaration that is in scope by then, and a name that is not in
+        # scope by then errors there. In ordinary code an undeclared lookup is
+        # caught at check time, before this point.
+        self.is-resolved
+            ?? self.resolution.IMPL-LOOKUP-QAST($context)
+            !! QAST::Var.new(:name(self.name), :scope('lexical'))
     }
 
     method IMPL-BIND-QAST(RakuAST::IMPL::QASTContext $context, QAST::Node $source-qast) {

--- a/t/02-rakudo/role-forward-lexical-default.t
+++ b/t/02-rakudo/role-forward-lexical-default.t
@@ -1,0 +1,53 @@
+use Test;
+
+plan 8;
+
+# A role body is code-generated when the role is composed, ahead of the
+# compilation unit's check pass. A forward reference inside the body to a `sub`
+# declared later must still resolve, the same as it does in a class.
+
+# Forward reference in a parameter default.
+role R1 { method m(&cb = &helper) { cb() }; sub helper { 42 } }
+class C1 does R1 {}
+is C1.m, 42, 'a forward sub reference in a role method parameter default resolves';
+
+# Forward reference in an attribute default.
+role R2 { has &.cb = &helper; sub helper { 43 } }
+class C2 does R2 {}
+is C2.new.cb.(), 43, 'a forward sub reference in a role attribute default resolves';
+
+# Forward reference in a method body.
+role R3 { method m { my &c = &helper; c() }; sub helper { 44 } }
+class C3 does R3 {}
+is C3.m, 44, 'a forward sub reference in a role method body resolves';
+
+# Forward reference to a method-local declaration (deeper than the body scope).
+role R4 { method m { my $c = &helper; my sub helper { 45 }; $c() } }
+class C4 does R4 {}
+is C4.m, 45, 'a forward reference to a method-local sub in a role resolves';
+
+# Forward reference inside a package nested in the role body.
+role R5 { my class Inner { method i(&cb = &g) { cb() }; sub g { 46 } }; method m { Inner.new.i } }
+class C5 does R5 {}
+is C5.m, 46, 'a forward sub reference inside a package nested in a role resolves';
+
+# Reference to a sub declared later in the enclosing compilation unit, outside
+# the role, but in scope by the time the role is consumed. (A sub declared
+# after the consumer cannot be resolved at compose time and is not handled.)
+role R6 { method m(&cb = &outer-helper) { cb() } }
+sub outer-helper { 47 }
+class C6 does R6 {}
+is C6.m, 47, 'a reference to a later outer sub, in scope by consumption, resolves';
+
+# Still works when the sub precedes the method (no regression).
+role R7 { sub helper { 48 }; method m(&cb = &helper) { cb() } }
+class C7 does R7 {}
+is C7.m, 48, 'a backward sub reference in a role still resolves';
+
+# A role-local sub shadows an outer sub of the same name.
+sub shadowed { 100 }
+role R8 { method m(&cb = &shadowed) { cb() }; sub shadowed { 200 } }
+class C8 does R8 {}
+is C8.m, 200, 'a role-local sub wins over an outer sub of the same name';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
A role body is code-generated when the role is composed, which happens during the enclosing package declaration ahead of the compilation unit's check pass. A forward reference inside the body, such as a parameter or attribute default that names a `sub` declared later, resolves to nothing at parse time and relies on that later check pass to re-resolve it. Because the role body is generated first, the reference was still unresolved and code generation died with "This element has not been resolved. Type: RakuAST::Var::Lexical". A class does not hit this: its method bodies are generated after the check pass.

Two parts:

Before generating the body, walk it and re-resolve its still-unresolved lexical lookups, pushing each lexical scope as we descend so a lookup is resolved against its own scope chain. This reaches declarations hoisted into a method, a nested block, or a package nested in the body, not only body-level ones. Only unresolved lookups are touched, so an outer or CORE match is never replaced and a role-local declaration still shadows an outer one.

A reference to a declaration made later in the enclosing unit (outside the role) cannot be resolved at compose time. For that, an unresolved lexical lookup now emits a late-bound lexical access rather than dying, the same as RakuAST::Call::Name does for an unresolved call; finalizing the dynamically-compiled body binds it to a declaration that is in scope by then. In ordinary code an undeclared lookup is still caught at check time, before code generation.