### PR TITLE
RakuAST: Decontainerize a sunk block call result

### DIFF
--- a/src/Raku/ast/statements.rakumod
+++ b/src/Raku/ast/statements.rakumod
@@ -684,7 +684,36 @@ class RakuAST::Statement::Expression
         else {
             $qast := $!expression.IMPL-TO-QAST($context);
             if self.sunk && $!expression.needs-sink-call {
-                $qast := QAST::Op.new( :op('p6sink'), $qast );
+                # A routine strips the container off a containerized return;
+                # an `is rw` one skips that strip; a bare block does neither.
+                # So a sunk postfix `()` call of a block must decont its
+                # result, else a returned Failure stays wrapped in a Scalar
+                # and sinking a container is a no-op. A routine callee has a
+                # `rw` method and is left alone.
+                if nqp::istype($!expression, RakuAST::ApplyPostfix)
+                  && nqp::istype($!expression.postfix, RakuAST::Call::Term)
+                  && nqp::istype($qast, QAST::Op) && $qast.op eq 'call' {
+                    my $callee := $qast.shift;
+                    my str $tc  := QAST::Node.unique('sink_callee');
+                    my str $tr  := QAST::Node.unique('sink_result');
+                    $qast.unshift(QAST::Var.new(:name($tc), :scope<local>));
+                    $qast := QAST::Stmts.new(
+                        QAST::Op.new(:op('bind'),
+                            QAST::Var.new(:name($tc), :scope<local>, :decl<var>), $callee),
+                        QAST::Op.new(:op('bind'),
+                            QAST::Var.new(:name($tr), :scope<local>, :decl<var>), $qast),
+                        QAST::Op.new(:op('p6sink'),
+                            QAST::Op.new(:op('if'),
+                                QAST::Op.new(:op('can'),
+                                    QAST::Var.new(:name($tc), :scope<local>),
+                                    QAST::SVal.new(:value('rw'))),
+                                QAST::Var.new(:name($tr), :scope<local>),
+                                QAST::Op.new(:op('decont'),
+                                    QAST::Var.new(:name($tr), :scope<local>)))));
+                }
+                else {
+                    $qast := QAST::Op.new( :op('p6sink'), $qast );
+                }
             }
             $qast := $!condition-modifier.IMPL-WRAP-QAST($context, $qast)
                 if $!condition-modifier && (!$!loop-modifier || !$!loop-modifier.handles-condition);

--- a/t/02-rakudo/sink-postfix-call-failure.t
+++ b/t/02-rakudo/sink-postfix-call-failure.t
@@ -1,0 +1,41 @@
+use Test;
+
+plan 6;
+
+sub returns-failure { fail "boom" }
+
+# A bare block does not decontainerize its return value the way a routine does.
+# So when a postfix `()` call of a block is sunk, its result is decontainerized
+# here, otherwise a returned Scalar holding a Failure stays a container and
+# sinking a container is a no-op. Math::Angle relies on this via
+# `dies-ok { $failure }`.
+my $f = returns-failure();
+dies-ok { $f }, 'a Failure reached through a sunk postfix call throws';
+
+my $g = returns-failure();
+my &blk = { $g };
+dies-ok { blk() }, 'sinking a postfix call returning a Failure throws';
+
+# A routine decontainerizes its own return, and an `is rw` one deliberately
+# keeps its container. So a sunk postfix call of a routine is left alone: an
+# is-rw routine's returned container must not be sunk.
+my $rw-sunk = False;
+my $rw = sub () is rw { my $o = class { method sink { $rw-sunk = True } }.new; $o };
+$rw();
+nok $rw-sunk, 'sinking an is-rw routine call result does not sink its container';
+
+# Likewise for a named is-rw routine (the roast S04 sink.t spec).
+my $sunk = False;
+my sub wrap is rw { my $obj = class { method sink { $sunk = True } }.new; $obj }
+wrap();
+nok $sunk, 'sinking an is-rw container return does not sink its contents';
+
+# Binding a block call result (not sinking) preserves its container.
+my $c = { my $x = 42; $x };
+my $r := $c();
+ok $r.VAR ~~ Scalar, 'binding a block call result preserves its container';
+
+# A non-Failure postfix call result sunk is fine.
+lives-ok { my &b = { 42 }; b() }, 'sinking a non-Failure postfix call result lives';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
A routine decontainerizes its return value, stripping the container off a containerized return. An `is rw` routine skips that step, so a returned container passes through unchanged. A bare block does neither. So when a block held in a variable is called via postfix `()` and the result is sunk, a returned Scalar was sunk as-is, and sinking a container is a no-op, so a returned Failure was never thrown. `dies-ok { $failure }` then saw no exception, as in Math::Angle's tests.

Decontainerize a sunk postfix call's result when the callee is a block, so the value is reached and a Failure throws. A routine callee has a `rw` method and is left alone, so its own return handling stands. A bind or other non-sink use is untouched, so a block call that returns a container still preserves it.