### PR TITLE
RakuAST: Take the value of a standalone smiley-keyed colonpair

### DIFF
--- a/src/Raku/Grammar.nqp
+++ b/src/Raku/Grammar.nqp
@@ -1276,6 +1276,7 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
         }
 
         :my $*IN-TYPENAME;      # fallback for inside typename flag
+        :my $*COLONPAIR-AS-TERM; # fallback for standalone colonpair term flag
         :my $*ADVERB-AS-INFIX;  # fallback for fake infix handling
 
         :my @*LEADING-DOC := [];         # temp storage leading declarator doc
@@ -3214,7 +3215,7 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
         <key=.identifier> <.fatty> <.ws> <val=.EXPR('i<=')>
     }
 
-    token term:sym<colonpair> { <colonpair> }
+    token term:sym<colonpair> { :my $*COLONPAIR-AS-TERM := 1; <colonpair> }
 
     token term:sym<variable> {
         <variable>
@@ -3528,7 +3529,10 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
             { $*KEY := $<identifier> }
             [
               <.unspace>?
-              <?{ !$*IN-TYPENAME && !self.type-smiley(~$*KEY) }>
+              # A standalone colonpair always takes its value, so `:D(1)` is the
+              # pair D => 1. After a type name a smiley takes no value, leaving
+              # `(...)` as the coercion target of `Str:D(...)`.
+              <?{ $*COLONPAIR-AS-TERM || (!$*IN-TYPENAME && !self.type-smiley(~$*KEY)) }>
               :dba('pair value')
               <coloncircumfix($*KEY)>
             ]?
@@ -5278,6 +5282,9 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
     }
 
     token longname($*IN-TYPENAME = 0) {
+        # A colonpair here is attached to a name, so a smiley takes no value
+        # even when the name appears as the value of a standalone colonpair.
+        :my $*COLONPAIR-AS-TERM := 0;
         <name>
         {}
         [

--- a/t/02-rakudo/colonpair-smiley-key-value.t
+++ b/t/02-rakudo/colonpair-smiley-key-value.t
@@ -1,0 +1,50 @@
+use Test;
+
+plan 16;
+
+# A colonpair with a smiley key still takes a value outside a type name. The
+# pairs are bound to variables first so they stay positional rather than
+# becoming named arguments to is-deeply.
+my $d = :D(1);
+is-deeply $d, (D => 1), ':D(1) is the pair D => 1';
+my $u = :U(2);
+is-deeply $u, (U => 2), ':U(2) is the pair U => 2';
+my $underscore = :_(3);
+is-deeply $underscore, (_ => 3), ':_(3) is the pair _ => 3';
+
+my $b = :D[4, 5];
+is-deeply $b, (D => [4, 5]), ':D[...] takes its value';
+
+my @list = :A(1), :B(1), :C(1), :D(1);
+is-deeply @list, [A => 1, B => 1, C => 1, D => 1],
+    'a smiley-keyed pair in a list keeps its value';
+
+my $t = :D;
+is-deeply $t, (D => True), 'valueless :D is D => True';
+
+# The smiley keeps its definedness meaning inside a type name.
+ok 5 ~~ Int:D, 'Int:D matches a defined Int';
+nok Int ~~ Int:D, 'Int:D does not match an undefined Int';
+ok Int ~~ Int:U, 'Int:U matches an undefined Int';
+my Int:D $x = 5;
+is $x, 5, 'Int:D constraint on a variable works';
+lives-ok { sub f(Int:D $a) { $a }; f(7) }, 'Int:D parameter constraint works';
+
+# After a type name the `(...)` is a coercion target, not a colonpair value.
+sub g(Str:D(Numeric) $a) { $a }
+is g(pi), pi.Str, 'Str:D(Numeric) coerces a Num to a defined Str';
+my Str:U(Numeric) $coerced-undef;
+ok $coerced-undef ~~ Str:U, 'Str:U(Numeric) keeps its undefinedness smiley';
+my $val = Str:D(Numeric).^name;
+is $val, 'Str:D(Numeric)', 'Str:D(Numeric) used as a value is the coercion type';
+
+# The standalone-pair handling must not leak into a coercion type nested in a
+# colonpair value.
+my $nested = :foo(Str:D(Numeric));
+is $nested.value.^name, 'Str:D(Numeric)',
+    'a coercion type as a colonpair value keeps its coercion';
+sub h(*%h) { %h }
+is h(:bar(Str:D(Numeric)))<bar>.^name, 'Str:D(Numeric)',
+    'a coercion type as a named-argument value keeps its coercion';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
A standalone colonpair whose key is a smiley dropped its value, so `:D(1)` parsed as the True-valued pair `:D` followed by a postfix call `(1)` on it, dying with "No such method 'CALL-ME' for invocant of type 'Pair'".

A smiley only means definedness after a type name, where the `(...)` is the coercion target of `Str:D(Numeric)`. A standalone colonpair has no type name, so `:D(1)` is just the pair D => 1.

Flag the standalone case in `term:sym<colonpair>` so it always takes the value. A colonpair attached to a name keeps the old behavior, and `longname` clears the flag so a coercion type nested in a colonpair value still parses. Legacy has no smiley check in its colonpair token and always takes the value.