### PR TITLE
RakuAST: Allow adverbs on match-capture variables

### DIFF
--- a/src/Raku/ast/variable-access.rakumod
+++ b/src/Raku/ast/variable-access.rakumod
@@ -689,11 +689,17 @@ class RakuAST::Var::PositionalCapture
   is RakuAST::ImplicitLookups
 {
     has Int $.index;
+    has Mu $!colonpairs;
 
     method new(Int $index) {
         my $obj := nqp::create(self);
         nqp::bindattr($obj, RakuAST::Var::PositionalCapture, '$!index', $index);
+        nqp::bindattr($obj, RakuAST::Var::PositionalCapture, '$!colonpairs', []);
         $obj
+    }
+
+    method add-colonpair(RakuAST::ColonPair $pair) {
+        nqp::push($!colonpairs, $pair);
     }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
@@ -707,12 +713,24 @@ class RakuAST::Var::PositionalCapture
         my $lookups := self.IMPL-UNWRAP-LIST(self.get-implicit-lookups);
         my $index := $!index;
         $context.ensure-sc($index);
-        QAST::Op.new(
+        my $op := QAST::Op.new(
             :op('call'),
             :name($lookups[0].is-resolved ?? $lookups[0].resolution.lexical-name !! '&postcircumfix:<[ ]>'),
             $lookups[1].IMPL-TO-QAST($context),
             QAST::WVal.new( :value($index) )
-        )
+        );
+        for $!colonpairs {
+            my $val-ast := $_.named-arg-value.IMPL-TO-QAST($context);
+            $val-ast.named($_.named-arg-name);
+            $op.push($val-ast);
+        }
+        $op
+    }
+
+    method visit-children(Code $visitor) {
+        for $!colonpairs {
+            $visitor($_);
+        }
     }
 }
 
@@ -722,11 +740,17 @@ class RakuAST::Var::NamedCapture
   is RakuAST::ImplicitLookups
 {
     has RakuAST::QuotedString $.index;
+    has Mu $!colonpairs;
 
     method new(RakuAST::QuotedString $index) {
         my $obj := nqp::create(self);
         nqp::bindattr($obj, RakuAST::Var::NamedCapture, '$!index', $index);
+        nqp::bindattr($obj, RakuAST::Var::NamedCapture, '$!colonpairs', []);
         $obj
+    }
+
+    method add-colonpair(RakuAST::ColonPair $pair) {
+        nqp::push($!colonpairs, $pair);
     }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
@@ -744,11 +768,19 @@ class RakuAST::Var::NamedCapture
             $lookups[1].IMPL-TO-QAST($context),
         );
         $op.push($!index.IMPL-TO-QAST($context)) unless $!index.is-empty-words;
+        for $!colonpairs {
+            my $val-ast := $_.named-arg-value.IMPL-TO-QAST($context);
+            $val-ast.named($_.named-arg-name);
+            $op.push($val-ast);
+        }
         $op
     }
 
     method visit-children(Code $visitor) {
         $visitor($!index);
+        for $!colonpairs {
+            $visitor($_);
+        }
     }
 }
 

--- a/t/02-rakudo/capture-var-adverb.t
+++ b/t/02-rakudo/capture-var-adverb.t
@@ -1,0 +1,26 @@
+use Test;
+
+plan 12;
+
+# An adverb on a match-capture shorthand (`$0:exists`, `$<name>:exists`) applies
+# to the underlying `$/[...]` / `$/<...>` access, the same as on any subscript.
+
+ok "ab" ~~ /(.)(.)/, 'sanity match with positional captures';
+
+is ($0:exists), True,  '$0:exists is True for a matched positional capture';
+is ($1:exists), True,  '$1:exists is True for a matched positional capture';
+is ($2:exists), False, '$2:exists is False for an unmatched positional capture';
+is ($0:k), 0, '$0:k yields the key';
+
+ok "xy" ~~ /$<a>=(.) $<b>=(.)/, 'sanity match with named captures';
+
+is ($<a>:exists), True,  '$<a>:exists is True for a matched named capture';
+is ($<missing>:exists), False, '$<missing>:exists is False for an absent named capture';
+
+# A capture adverb matches the explicit `$/<...>` / `$/[...]` form it is sugar for.
+is ($<a>:exists), ($/<a>:exists), '$<a>:exists matches $/<a>:exists';
+is ($0:exists), ($/[0]:exists), '$0:exists matches $/[0]:exists';
+is-deeply ($<a>:kv), ($/<a>:kv), '$<a>:kv matches $/<a>:kv';
+is ($<missing>:!exists), ($/<missing>:!exists), '$<missing>:!exists matches the explicit form';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
`$0:exists`, `$<foo>:exists` (and `:delete`, `:k`, `:kv`, etc.) failed to compile under RakuAST with "You can't adverb $0". A match-capture shorthand parses to RakuAST::Var::PositionalCapture / RakuAST::Var::NamedCapture, which lower to a `postcircumfix:<[ ]>` / `postcircumfix:<{ }>` call on `$/` but had no way to carry an adverb, so the postfix handler rejected the colonpair.

Give both nodes `add-colonpair` and push each adverb as a named argument on that call, the same as `$/[0]:exists` / `$/<foo>:exists` already does. So `$0:exists` becomes `postcircumfix:<[ ]>($/, 0, :exists)`.