### PR TITLE
RakuAST: Accept the macron negative sign in a superscript power exponent

### DIFF
--- a/src/core.c/RakuAST/Fixups.rakumod
+++ b/src/core.c/RakuAST/Fixups.rakumod
@@ -1499,7 +1499,7 @@ augment class RakuAST::Postfix::Power {
     method from-superscripts(Mu $/) {
         self.new:
           val(
-            nqp::hllize($/).Str.trans("⁰¹²³⁴⁵⁶⁷⁸⁹⁻⁺ⁱ" => "0123456789-+i")
+            nqp::hllize($/).Str.trans("⁰¹²³⁴⁵⁶⁷⁸⁹⁻¯⁺ⁱ" => "0123456789--+i")
           ).Numeric
     }
 }

--- a/t/02-rakudo/superscript-power-macron.t
+++ b/t/02-rakudo/superscript-power-macron.t
@@ -1,0 +1,16 @@
+use Test;
+
+plan 5;
+
+# A negative superscript power exponent may be written with either the high
+# minus `⁻` (U+207B) or the macron `¯` (U+00AF); the grammar accepts both as a
+# super-sign, so both must yield the same negative exponent.
+is 10¯²⁴, 1e-24, '10 with a macron-signed negative exponent';
+is 10⁻²⁴, 1e-24, '10 with a high-minus negative exponent';
+is-deeply (10¯²⁴), (10⁻²⁴), 'macron and high-minus exponents agree';
+is 2¯³, 0.125, 'macron negative exponent on a small base';
+
+# Positive exponents are unaffected.
+is 10²⁴, 1000000000000000000000000, 'positive superscript exponent';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
A superscript power exponent may be written with the high minus `⁻` (U+207B) or the macron `¯` (U+00AF), and the grammar's super-sign token accepts both. But RakuAST::Postfix::Power.from-superscripts translated only `⁻` to `-`, so a macron-signed exponent like `10¯²⁴` reached `val("¯24")`, whose `.Numeric` is a Failure. That Failure became the power node's literal value, and serializing it through its backtrace failed precompilation with "missing static code ref for closure ''".

Translate `¯` to `-` as well, matching how the integer superscript path already treats `⁻` and `¯` as the same negative sign. So `10¯²⁴` is 1e-24, the same as `10⁻²⁴`.