### PR TITLE
RakuAST: Resolve an indirect name with a non-literal expression at runtime

### DIFF
--- a/src/Raku/ast/name.rakumod
+++ b/src/Raku/ast/name.rakumod
@@ -518,9 +518,10 @@ class RakuAST::Name::Part::Expression
     }
 
     method is-empty() {
-        return False unless nqp::can($!expr, 'literalize');
-        my $name := $!expr.literalize;
-        nqp::defined($!expr) && $!expr eq ''
+        my $name := try $!expr.literalize;
+        nqp::defined($name)
+          && (nqp::istype($name, Str) || nqp::isstr($name))
+          && $name eq ''
     }
 }
 

--- a/t/02-rakudo/indirect-name-dynamic.t
+++ b/t/02-rakudo/indirect-name-dynamic.t
@@ -1,0 +1,27 @@
+use Test;
+
+plan 6;
+
+# An indirect name `::(expr)` whose expression is not compile-time known, e.g.
+# one mentioning a dynamic variable, resolves at runtime rather than dying.
+my $*FOO = "Int";
+is ::($*FOO).^name, 'Int', 'indirect lookup through a dynamic variable';
+
+is ::($*UNSET || "Str").^name, 'Str',
+    'indirect lookup through a dynamic-variable expression';
+
+my $*BAR = "Rat";
+is ::($*BAR).^name, 'Rat', 'indirect lookup of a bare dynamic variable';
+
+is ::("Num").^name, 'Num', 'indirect lookup through a literal string';
+
+# An empty indirect name is the empty symbol, which does not exist.
+throws-like { ::("") }, X::NoSuchSymbol, 'an empty indirect name has no symbol';
+
+# require uses the same indirect-name resolution path.
+lives-ok {
+    my $*LIB;
+    try require ::($*LIB || "Test");
+}, 'require of an indirect name with a dynamic-variable expression';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
`::($expr)` where $expr is not compile-time known, for instance `::($*FOO || 'Bar')`, crashed with "literalize on RakuAST::Var::Dynamic NYI".

Resolving the name calls RakuAST::Name::Part::Expression.is-empty, which called `.literalize` on the expression node unguarded. For a dynamic variable, or any other non-literal node, that dies.

Guard the call with `try`, as the sibling `has-compile-time-name` already does, and test the literalized name rather than the expression node. A name part whose expression cannot be literalized is then simply not empty, and resolution falls back to runtime. `::($*FOO)` and `::($*FOO || 'Bar')` now resolve at runtime, the same as the legacy frontend.