### PR TITLE
RakuAST: Run the optimize pass as its own pipeline stage

### DIFF
--- a/src/Perl6/Compiler.nqp
+++ b/src/Perl6/Compiler.nqp
@@ -246,6 +246,18 @@ class Perl6::Compiler is HLL::Compiler {
     }
 
     method optimize($past, *%adverbs) {
+        # The RakuAST frontend optimizes the AST in place between the ast and
+        # qast stages. Its input is a RakuAST::CompUnit, not QAST. The pass
+        # manages its own scope, so the stage just hands it the resolver.
+        if nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' {
+            my $optimize := %adverbs<optimize>;
+            unless nqp::defined($optimize)
+              && ($optimize eq 'off' || $optimize eq '0') {
+                $past.optimize($past.resolver);
+            }
+            return $past;
+        }
+
         # Apply optimizations.
         my $result := %adverbs<optimize> eq 'off'
             ?? $past

--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -547,17 +547,6 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
         $COMPUNIT.check($RESOLVER);
         self.report-problems();
 
-        # Have optimize time, unless the optimize option turns it off. With it
-        # off, --target=ast also shows the tree as parsed and checked, before
-        # any optimization rewrites it.
-        my %compiling := nqp::getlexdyn('%*COMPILING');
-        my $optimize := nqp::isnull(%compiling)
-            ?? NQPMu
-            !! nqp::atkey(nqp::ifnull(nqp::atkey(%compiling, '%?OPTIONS'), nqp::hash()), 'optimize');
-        unless nqp::defined($optimize) && ($optimize eq 'off' || $optimize eq '0') {
-            $COMPUNIT.optimize($RESOLVER);
-        }
-
         $RESOLVER.leave-scope();
     }
 

--- a/src/Raku/ast/compunit.rakumod
+++ b/src/Raku/ast/compunit.rakumod
@@ -214,11 +214,15 @@ class RakuAST::CompUnit
         }
     }
 
-    # Run the optimize phase over the compilation unit. This is a transforming
-    # AST-to-AST pass, run after check and before QAST generation.
+    # Run the optimize phase: a transforming AST-to-AST pass between check and
+    # QAST generation. It pushes the unit scope itself in batch resolve mode
+    # (the tree is already checked, nothing is being declared), so a caller just
+    # hands over a resolver.
     method optimize(RakuAST::Resolver $resolver) {
+        $resolver.push-scope(self);
         $!mainline.IMPL-OPTIMIZE($resolver);
         self.IMPL-OPTIMIZE($resolver);
+        $resolver.pop-scope;
     }
 
     # Add the AST for handling legacy doc generation, essentially:
@@ -302,6 +306,10 @@ class RakuAST::CompUnit
     # Checks if the compilation unit was created in EVAL mode, meaning that it
     # does not declare its own GLOBAL and so forth.
     method is-eval() { $!is-eval ?? True !! False }
+
+    # The resolver used to compile this CompUnit, exposed so a later pipeline
+    # stage (the optimize stage) can run an AST pass that resolves names.
+    method resolver() { $!resolver }
 
     # The setting context the CompUnit's resolver knows about, if any.
     method setting() {

--- a/src/main.nqp
+++ b/src/main.nqp
@@ -21,6 +21,7 @@ if +nqp::getenvhash()<RAKUDO_RAKUAST> {
     $comp.parseactions(Raku::Actions);
     $comp.addstage('syntaxcheck', :before<ast>);
     $comp.addstage('qast', :after<ast>);
+    $comp.addstage('optimize', :before<qast>);
 }
 else {
     nqp::bindhllsym('Raku', 'COMPILER-FRONTEND', 'legacy');

--- a/t/08-performance/10-rakuast-optimize-phase.t
+++ b/t/08-performance/10-rakuast-optimize-phase.t
@@ -3,21 +3,23 @@ use Test::Helpers;
 use Test;
 use experimental :rakuast;
 
-plan 5;
+plan 7;
 
 # The optimize phase transforms the tree between check and QAST generation.
 # These tests cover where the phase runs and how it is turned off, with
 # constant folding as the observable rewrite.
 
-# The compilation tree shows the rewrite, and --optimize=off prevents it.
-# The --target=ast dump is a RakuAST frontend observable, so the children
-# are pinned to that frontend.
+# --target=optimize shows the rewrite, --optimize=off prevents it, and
+# --target=ast (before the optimize stage) still holds the operator. These
+# dumps are RakuAST frontend output, so the block is pinned to that frontend.
 {
     temp %*ENV<RAKUDO_RAKUAST> = '1';
-    is-run 'my $x = 2 + 3', 'the compilation tree holds no operator application',
-        :compiler-args['--target=ast'], :out({ not .contains('ApplyInfix') });
+    is-run 'my $x = 2 + 3', 'the optimize stage tree holds no operator application',
+        :compiler-args['--target=optimize'], :out({ not .contains('ApplyInfix') });
     is-run 'my $x = 2 + 3', '--optimize=off leaves the operator in the tree',
-        :compiler-args['--optimize=off', '--target=ast'], :out(*.contains('ApplyInfix'));
+        :compiler-args['--optimize=off', '--target=optimize'], :out(*.contains('ApplyInfix'));
+    is-run 'my $x = 2 + 3', 'the ast stage tree holds the operator before optimize',
+        :compiler-args['--target=ast'], :out(*.contains('ApplyInfix'));
 }
 
 # A synthetic AST compiled with EVAL goes through the phase too. The phase
@@ -31,6 +33,16 @@ plan 5;
             right => RakuAST::IntLiteral.new(3))));
     is $ast.EVAL, 5, 'a synthetic AST EVALs to the right value';
     ok $ast.DEPARSE.contains('5'), 'EVAL runs the optimize phase over a synthetic tree';
+}
+
+# Running the pass again over an already-optimized tree is a no-op, so it is
+# safe to re-run (EVAL of a reflected AST optimizes it again).
+{
+    my $cu = Q[my $x = (2 + 3) ?? 4 * 5 !! 0].AST(:compunit);
+    $cu.optimize($cu.resolver);
+    my $once = $cu.DEPARSE;
+    $cu.optimize($cu.resolver);
+    is $cu.DEPARSE, $once, 'the optimize pass is idempotent';
 }
 
 # The same program runs identically with and without optimization.

--- a/t/08-performance/11-rakuast-constant-folding.t
+++ b/t/08-performance/11-rakuast-constant-folding.t
@@ -6,61 +6,64 @@ use experimental :rakuast;
 plan 39;
 
 # Constant folding rewrites a pure operator on constant operands into the
-# literal result. Each scenario asserts the shape of the tree the program
-# compiles to, through Str.AST, which runs the same parse, check, and
-# optimize the compiler runs. The decline scenarios assert the operator
-# survives where folding must not happen.
-my sub tree(Str $source) { $source.AST.DEPARSE }
+# literal result. The helper deparses a source after optimizing it, so
+# each scenario asserts the optimized shape. The decline scenarios assert the
+# operator survives where folding must not happen.
+my sub optimized-deparse(Str $source) {
+    my $cu := $source.AST(:compunit);
+    $cu.optimize($cu.resolver);
+    $cu.DEPARSE
+}
 
 # Operators fold across types and precedence.
-ok tree(Q[my $y = 2 + 3]).contains('= 5'),          'integer arithmetic folds';
-ok tree(Q[my $y = 2 * 3 + 4]).contains('= 10'),     'nested operators fold up the chain';
-ok tree(Q[my $y = 10 - 2 ** 3]).contains('= 2'),    'mixed precedence folds';
-ok tree(Q[my $y = -2 * 5]).contains('= -10'),       'a negated literal folds';
-ok tree(Q[my $y = 6 +& 3]).contains('= 2'),         'a bitwise operator folds';
-ok tree(Q[my $y = "ab" ~ "cd"]).contains('"abcd"'), 'string concatenation folds';
+ok optimized-deparse(Q[my $y = 2 + 3]).contains('= 5'),          'integer arithmetic folds';
+ok optimized-deparse(Q[my $y = 2 * 3 + 4]).contains('= 10'),     'nested operators fold up the chain';
+ok optimized-deparse(Q[my $y = 10 - 2 ** 3]).contains('= 2'),    'mixed precedence folds';
+ok optimized-deparse(Q[my $y = -2 * 5]).contains('= -10'),       'a negated literal folds';
+ok optimized-deparse(Q[my $y = 6 +& 3]).contains('= 2'),         'a bitwise operator folds';
+ok optimized-deparse(Q[my $y = "ab" ~ "cd"]).contains('"abcd"'), 'string concatenation folds';
 {
-    my $t = tree(Q[my $y = 2 min 3]);
+    my $t = optimized-deparse(Q[my $y = 2 min 3]);
     ok $t.contains('= 2'), 'a list-associative operator folds';
     nok $t.contains('min'), 'the folded list-associative operator is gone from the tree';
 }
-ok tree(Q[my $j = 1 | 2]).contains('any(1, 2)'),    'a junction constructor folds to a junction';
-ok tree(Q[my $y = !True]).contains('False'),        'a prefix on an enumeration value folds';
-ok tree(Q[my $y = 7 ** -1]) ~~ / '¹/₇' | '<1/7>' /, 'a negative power folds to a Rat';
-ok tree(Q[my $y = 3 / 4]).contains('= 0.75'),       'integer division folds to a Rat';
+ok optimized-deparse(Q[my $j = 1 | 2]).contains('any(1, 2)'),    'a junction constructor folds to a junction';
+ok optimized-deparse(Q[my $y = !True]).contains('False'),        'a prefix on an enumeration value folds';
+ok optimized-deparse(Q[my $y = 7 ** -1]) ~~ / '¹/₇' | '<1/7>' /, 'a negative power folds to a Rat';
+ok optimized-deparse(Q[my $y = 3 / 4]).contains('= 0.75'),       'integer division folds to a Rat';
 { my $y = 3 / 4; isa-ok $y, Rat, 'a folded division still produces a Rat at runtime'; }
 
 # Folding reaches every expression position.
-ok tree(Q[my $s = (2 ** 10).Str]).contains('1024.Str'),         'a method call invocant folds';
-ok tree(Q[my $p = (status => 6 * 7)]).contains('status => 42'), 'a pair value folds';
-ok tree(Q[my $x = do { 100 - 1 }]).contains('99'),              'a block final value folds';
-ok tree(Q[say "x" if 2 ** 3]).contains('if 8'),                 'a statement modifier condition folds';
-ok tree(Q[my @a = [2 + 3, 4 * 5]]).contains('[5, 20]'),         'array composer elements fold';
-ok tree(Q[my @a; @a[2 + 3]]).contains('[5]'),                   'an index expression folds';
-ok tree(Q[sub f($x = 2 + 3) { }]).contains('= 5'),              'a parameter default folds';
-ok tree(Q[my $x = 5 * 3 + (2 ** 2) - 10 + 2 * 5]).contains('= 19'),
+ok optimized-deparse(Q[my $s = (2 ** 10).Str]).contains('1024.Str'),         'a method call invocant folds';
+ok optimized-deparse(Q[my $p = (status => 6 * 7)]).contains('status => 42'), 'a pair value folds';
+ok optimized-deparse(Q[my $x = do { 100 - 1 }]).contains('99'),              'a block final value folds';
+ok optimized-deparse(Q[say "x" if 2 ** 3]).contains('if 8'),                 'a statement modifier condition folds';
+ok optimized-deparse(Q[my @a = [2 + 3, 4 * 5]]).contains('[5, 20]'),         'array composer elements fold';
+ok optimized-deparse(Q[my @a; @a[2 + 3]]).contains('[5]'),                   'an index expression folds';
+ok optimized-deparse(Q[sub f($x = 2 + 3) { }]).contains('= 5'),              'a parameter default folds';
+ok optimized-deparse(Q[my $x = 5 * 3 + (2 ** 2) - 10 + 2 * 5]).contains('= 19'),
     'parenthesized constants fold into the enclosing expression';
-ok tree(Q[my $x = ((2 ** 3))]).contains('= 8'),                 'nested grouping parentheses fold';
-ok tree(Q[my int $i = 3 * 4]).contains('= 12'),                 'a native int initializer folds';
+ok optimized-deparse(Q[my $x = ((2 ** 3))]).contains('= 8'),                 'nested grouping parentheses fold';
+ok optimized-deparse(Q[my int $i = 3 * 4]).contains('= 12'),                 'a native int initializer folds';
 { my int $i = 3 * 4; is $i, 12, 'a folded native int initializer widens correctly'; }
 
 # Folding declines where the rewrite would not preserve the program.
-ok tree(Q[my $a = 5; my $y = $a + 3]).contains('$a + 3'),
+ok optimized-deparse(Q[my $a = 5; my $y = $a + 3]).contains('$a + 3'),
     'a variable operand keeps the runtime computation';
-ok tree(Q[my $c = 1 < 2 < 2]).contains('1 < 2 < 2'),
+ok optimized-deparse(Q[my $c = 1 < 2 < 2]).contains('1 < 2 < 2'),
     'a chained comparison is not mis-folded as binary operations';
-ok tree(Q[my @a = (1, 2, 3)]).contains('(1, 2, 3)'),
+ok optimized-deparse(Q[my @a = (1, 2, 3)]).contains('(1, 2, 3)'),
     'list parentheses are not mistaken for a foldable value';
 
 # A constant string repetition folds only when the result is small enough to
 # embed in the compilation unit.
-ok tree(Q[my $y = "ab" x 3]).contains('"ababab"'), 'a small string repetition folds';
-ok tree(Q[my str $a = "a" x 2**32-1]).contains(' x '),
+ok optimized-deparse(Q[my $y = "ab" x 3]).contains('"ababab"'), 'a small string repetition folds';
+ok optimized-deparse(Q[my str $a = "a" x 2**32-1]).contains(' x '),
     'an enormous string repetition is left for runtime';
 
 # Division by zero folds to the same zero-denominator Rat the runtime
 # produces, whose use throws just as the unfolded expression would.
-ok tree(Q[my $y = 1 / 0]) ~~ / '¹/₀' | '<1/0>' /, 'division by zero folds to a zero-denominator Rat';
+ok optimized-deparse(Q[my $y = 1 / 0]) ~~ / '¹/₀' | '<1/0>' /, 'division by zero folds to a zero-denominator Rat';
 { my $y = 1 / 0; dies-ok { $y.Str }, 'using a folded zero-denominator Rat throws' }
 
 # Declining a Failure result, the way 1 div 0 produces one, marks it handled
@@ -79,7 +82,7 @@ is-run 'my $y = 1 div 0; print "compiled"', 'a declined Failure does not warn at
 
 # An operator bound to a lexical variable resolves to a declaration with no
 # compile-time value, so folding declines and the runtime binding is used.
-ok tree(Q[my &infix:<zlex> = sub ($a, $b) { $a + $b }; my $y = 1 zlex 2]).contains('1 zlex 2'),
+ok optimized-deparse(Q[my &infix:<zlex> = sub ($a, $b) { $a + $b }; my $y = 1 zlex 2]).contains('1 zlex 2'),
     'an operator bound to a lexical variable is left for runtime';
 
 # Only a routine marked is pure may run at compile time. An unmarked
@@ -109,10 +112,9 @@ ok tree(Q[my &infix:<zlex> = sub ($a, $b) { $a + $b }; my $y = 1 zlex 2]).contai
     is (zfold 4 :x(5)), '4,5', 'a pure prefix operator with an adverb keeps its adverb';
 }
 
-# The unoptimized tree still holds the operator, so the scenarios above are
-# known to be testing the optimizer rather than something upstream.
-is-run 'use experimental :rakuast; print Q[my $x = 2 + 3].AST.DEPARSE',
-    'without optimization the operator survives',
-    :compiler-args['--optimize=off'], :out(*.contains('2 + 3'));
+# Str.AST does not optimize, so the operator survives. The scenarios above
+# therefore test the optimize pass, not something upstream.
+ok Q[my $x = 2 + 3].AST.DEPARSE.contains('2 + 3'),
+    'the unoptimized tree keeps the operator';
 
 # vim: expandtab shiftwidth=4

--- a/t/08-performance/12-rakuast-collapse-ternary.t
+++ b/t/08-performance/12-rakuast-collapse-ternary.t
@@ -6,35 +6,37 @@ use experimental :rakuast;
 plan 8;
 
 # A ternary with a constant condition collapses to the branch the condition
-# selects. Each scenario asserts the shape of the tree the program compiles
-# to, through Str.AST, which runs the same parse, check, and optimize the
-# compiler runs.
-my sub tree(Str $source) { $source.AST.DEPARSE }
+# selects. The helper deparses a source after optimizing it, so each
+# scenario asserts the collapsed shape.
+my sub optimized-deparse(Str $source) {
+    my $cu := $source.AST(:compunit);
+    $cu.optimize($cu.resolver);
+    $cu.DEPARSE
+}
 
-ok tree(Q[my $x = 1 ?? 10 !! 20]).contains('= 10'),
+ok optimized-deparse(Q[my $x = 1 ?? 10 !! 20]).contains('= 10'),
     'a true constant condition selects the then branch';
-ok tree(Q[my $x = 0 ?? 10 !! 20]).contains('= 20'),
+ok optimized-deparse(Q[my $x = 0 ?? 10 !! 20]).contains('= 20'),
     'a false constant condition selects the else branch';
-ok tree(Q[my $x = "0" ?? "t" !! "f"]).contains('= "t"'),
+ok optimized-deparse(Q[my $x = "0" ?? "t" !! "f"]).contains('= "t"'),
     'the condition uses Raku truthiness, where a non-empty string is true';
 
 # The collapse declines when the condition's truth is not a known constant.
-ok tree(Q[my $x = Int ?? "t" !! "f"]).contains('??'),
+ok optimized-deparse(Q[my $x = Int ?? "t" !! "f"]).contains('??'),
     'a type object condition is left for runtime';
-ok tree(Q[my $a = 1; my $x = $a ?? "t" !! "f"]).contains('??'),
+ok optimized-deparse(Q[my $a = 1; my $x = $a ?? "t" !! "f"]).contains('??'),
     'a runtime condition is left for runtime';
-ok tree(Q[my constant C = class :: is Cool { method Bool { die } }.new; my $x = C ?? 1 !! 2]).contains('??'),
+ok optimized-deparse(Q[my constant C = class :: is Cool { method Bool { die } }.new; my $x = C ?? 1 !! 2]).contains('??'),
     'a condition whose truthiness throws is left for runtime';
 
 # The condition is removed by the collapse, so it must be droppable. A
 # condition that declares a variable keeps its binding.
-ok tree(Q[my $x = (my @a := (3, 7)) ?? "t" !! "f"]).contains('??'),
+ok optimized-deparse(Q[my $x = (my @a := (3, 7)) ?? "t" !! "f"]).contains('??'),
     'a condition that declares a variable is left for runtime';
 
-# The unoptimized tree still holds the ternary, so the scenarios above are
-# known to be testing the optimizer rather than something upstream.
-is-run 'use experimental :rakuast; print Q[my $x = 1 ?? 10 !! 20].AST.DEPARSE',
-    'without optimization the ternary survives',
-    :compiler-args['--optimize=off'], :out(*.contains('??'));
+# Str.AST does not optimize, so the ternary survives. The scenarios above
+# therefore test the optimize pass, not something upstream.
+ok Q[my $x = 1 ?? 10 !! 20].AST.DEPARSE.contains('??'),
+    'the unoptimized tree keeps the ternary';
 
 # vim: expandtab shiftwidth=4

--- a/t/08-performance/13-rakuast-collapse-short-circuit.t
+++ b/t/08-performance/13-rakuast-collapse-short-circuit.t
@@ -6,46 +6,49 @@ use experimental :rakuast;
 plan 13;
 
 # A boolean short-circuit with a constant left operand collapses to the side
-# the operator yields, and the dropped side's code is removed. Each scenario
-# asserts the shape of the tree the program compiles to, through Str.AST,
-# which runs the same parse, check, and optimize the compiler runs.
-my sub tree(Str $source) { $source.AST.DEPARSE }
+# the operator yields, and the dropped side's code is removed. The helper
+# deparses a source after optimizing it, so each scenario asserts the collapsed
+# shape.
+my sub optimized-deparse(Str $source) {
+    my $cu := $source.AST(:compunit);
+    $cu.optimize($cu.resolver);
+    $cu.DEPARSE
+}
 
-ok tree(Q[my $y = True && 7]).contains('= 7'),
+ok optimized-deparse(Q[my $y = True && 7]).contains('= 7'),
     'a true left operand of && yields the right side';
 {
-    my $t = tree(Q[sub e() {9}; my $y = False && e()]);
+    my $t = optimized-deparse(Q[sub e() {9}; my $y = False && e()]);
     ok $t.contains('= False'), 'a false left operand of && yields itself';
     nok $t.contains('&&'), 'the dropped side is gone from the tree';
 }
 {
-    my $t = tree(Q[sub e() {9}; my $y = 5 || e()]);
+    my $t = optimized-deparse(Q[sub e() {9}; my $y = 5 || e()]);
     ok $t.contains('= 5'), 'a true left operand of || yields itself';
     nok $t.contains('||'), 'the dropped side of || is gone from the tree';
 }
-ok tree(Q[my $y = (True and 7)]).contains('= 7'),
+ok optimized-deparse(Q[my $y = (True and 7)]).contains('= 7'),
     'the loose form and collapses the same way';
-ok tree(Q[my $y = (False or 7)]).contains('= 7'),
+ok optimized-deparse(Q[my $y = (False or 7)]).contains('= 7'),
     'the loose form or collapses the same way';
 
 # The collapse declines when the left operand's truth is not a known
 # constant, when dropping the other side would lose a declaration, or when
 # the left operand itself declares one.
-ok tree(Q[my $a = 1; my $y = $a && 7]).contains('&&'),
+ok optimized-deparse(Q[my $a = 1; my $y = $a && 7]).contains('&&'),
     'a runtime left operand is left for runtime';
-ok tree(Q[sub e() {9}; my $y = (my @a := (3, 7)) && e()]).contains('&&'),
+ok optimized-deparse(Q[sub e() {9}; my $y = (my @a := (3, 7)) && e()]).contains('&&'),
     'a left operand that declares a variable is left for runtime';
-ok tree(Q[my $y = False && (my $x = 5)]).contains('&&'),
+ok optimized-deparse(Q[my $y = False && (my $x = 5)]).contains('&&'),
     'a side holding a declaration keeps the branch';
-nok tree(Q[my $y = False && do { my $t = 5; $t }]).contains('do'),
+nok optimized-deparse(Q[my $y = False && do { my $t = 5; $t }]).contains('do'),
     'a side whose declarations are confined to a block of its own is dropped';
-ok tree(Q[my $y = False && sub zkeep($a) { $a }]).contains('sub'),
+ok optimized-deparse(Q[my $y = False && sub zkeep($a) { $a }]).contains('sub'),
     'a side declaring a named sub is kept';
 
-# The unoptimized tree still holds the operator, so the scenarios above are
-# known to be testing the optimizer rather than something upstream.
-is-run 'use experimental :rakuast; print Q[my $y = True && 7].AST.DEPARSE',
-    'without optimization the short-circuit survives',
-    :compiler-args['--optimize=off'], :out(*.contains('&&'));
+# Str.AST does not optimize, so the operator survives. The scenarios above
+# therefore test the optimize pass, not something upstream.
+ok Q[my $y = True && 7].AST.DEPARSE.contains('&&'),
+    'the unoptimized tree keeps the short-circuit';
 
 # vim: expandtab shiftwidth=4

--- a/t/packages/Test-Helpers/lib/Test/Helpers/QAST.rakumod
+++ b/t/packages/Test-Helpers/lib/Test/Helpers/QAST.rakumod
@@ -52,7 +52,7 @@ sub qast-descendable (Mu $qast --> Bool:D) is export {
     || nqp::istype($qast, QAST::Want)
 }
 
-my constant $default-target = nqp::getcomp('Raku').exists_stage('optimize') ?? 'optimize' !! 'qast';
+my constant $default-target = nqp::getcomp('Raku').qast-stage;
 sub qast-is (Str:D $code is copy, &test, Str:D $desc,
     Bool:D :$full = False,
     Str:D  :$target where 'optimize'|'qast'|'ast' = $default-target,


### PR DESCRIPTION
Previously the RakuAST frontend ran its optimize pass from the comp-unit action, during the parse stage. The legacy frontend runs its optimizer as an `optimize` pipeline stage after `ast`.

Register an `optimize` stage for the RakuAST frontend between `ast` and `qast` and move the pass there. The stage reads the resolver back off the `RakuAST::CompUnit` it is handed through a new `resolver` accessor and runs the pass. `CompUnit.optimize` pushes the unit scope itself, in the batch resolve mode for an already-checked tree, so the stage and the EVAL path drive the pass the same way.

`--target=optimize` now dumps the optimized AST, a new way to inspect the pass. `--target=ast`, and so `Str.AST`, now return the tree as parsed and checked, before optimization, because the ast stage stops short of the optimize stage. `.AST.EVAL` still gives the optimized result because EVAL runs the pass itself.

The optimize tests follow: the tree helper runs the pass explicitly rather than relying on `Str.AST` to do it, and the firing detectors check that the faithful parse keeps the operator while `--target=optimize` shows it folded.