### PR TITLE
RakuAST: Panic NYI for the variable case of enums

### DIFF
--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -3074,8 +3074,9 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
     }
 
     method type-declarator:sym<enum>($/) {
-        # TODO: <variable> being defined means we should throw an NYI
-        # Need to support anonymous enums
+        if $<variable> {
+            $/.typed-panic('X::Comp::NYI', feature => "Variable case of enums");
+        }
         my $name := $<longname>
           ?? $<longname>.ast
           !! Nodify('Name').from-identifier('');

--- a/t/02-rakudo/enum-variable-nyi.t
+++ b/t/02-rakudo/enum-variable-nyi.t
@@ -1,0 +1,18 @@
+use Test;
+
+plan 3;
+
+# The variable case of an enum (`enum $foo <...>`) is not yet implemented and
+# must be rejected at compile time rather than silently parsed as a no-op.
+throws-like 'enum $foo <a b c>', X::Comp::NYI,
+    'enum with a variable name panics NYI';
+
+# A normal named enum is unaffected.
+is EVAL('enum Day <Mon Tue Wed>; Day::Wed.value'), 2,
+    'a named enum still composes';
+
+# An anonymous enum is unaffected.
+is EVAL('(enum <r g b>).<g>'), 1,
+    'an anonymous enum still composes';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously `enum $foo <a b c>` parsed but the action ignored the `<variable>` match, so the declaration silently became a no-op. The legacy frontend throws an X::Comp::NYI here. Detect the variable name and panic the same way.