### PR TITLE
RakuAST: Record a label's source line and surrounding text

### DIFF
--- a/src/Raku/ast/statements.rakumod
+++ b/src/Raku/ast/statements.rakumod
@@ -42,8 +42,20 @@ class RakuAST::Label
     method PRODUCE-META-OBJECT(:$resolver, :$context) {
         my $label-type :=
           self.IMPL-UNWRAP-LIST(self.get-implicit-lookups)[0].resolution.compile-time-value;
-        # TODO line, prematch, postmatch
-        $label-type.new(:name($!name), :line(0), :prematch(''), :postmatch(''))
+        my int $line;
+        my str $prematch  := '';
+        my str $postmatch := '';
+        my $origin := self.origin;
+        if nqp::isconcrete($origin) && nqp::isconcrete($origin.source) {
+            my $source   := $origin.source;
+            my str $orig := $source.orig;
+            my int $from := $origin.from;
+            my int $to   := $from + nqp::chars($!name);
+            $line      := $source.line-of-pos($from);
+            $prematch  := nqp::substr($orig, $from > 20 ?? $from - 20 !! 0, $from > 20 ?? 20 !! $from);
+            $postmatch := nqp::substr($orig, $to, 20);
+        }
+        $label-type.new(:name($!name), :$line, :$prematch, :$postmatch)
     }
 
     method IMPL-QAST-DECL(RakuAST::IMPL::QASTContext $context) {

--- a/t/02-rakudo/label-source-location.t
+++ b/t/02-rakudo/label-source-location.t
@@ -1,0 +1,19 @@
+use Test;
+
+plan 4;
+
+# A label records the source location and surrounding text of its declaration.
+
+FOO: my $foo-line = $?LINE;
+is FOO.line, $foo-line, 'a label reports the source line of its declaration';
+is FOO.name, 'FOO', 'a label reports its name';
+
+# The 20-character window after the name shows up in the gist's postmatch.
+ok FOO.gist.contains(': my $foo-line'),
+    'a label gist includes the text following the label name';
+
+# A second label on a later line reports a different line.
+BAR: my $bar-line = $?LINE;
+isnt BAR.line, FOO.line, 'distinct labels report distinct source lines';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
The Label meta-object was built with a stub line of 0 and empty prematch and postmatch, so `FOO.line` reported 0 and `FOO.gist` lost the surrounding source. Compute them from the declaration's origin: the line of the label position, the 20 characters before it, and the 20 after the name, matching the legacy frontend.