### PR TITLE
RakuAST: Give an empty contextualizer its 6.c $/ semantics

### DIFF
--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -2556,7 +2556,35 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
     }
 
     method contextualizer($/) {
-        self.contextualizer-for-sigil($/, ~$<sigil>, $<coercee>.ast);
+        my $sigil := ~$<sigil>;
+        # In 6.c an empty contextualizer operates on $/. `$()` yields the
+        # smartmatch result of $/ (its made AST if any, else its matched
+        # string), while `@()` and `%()` coerce $/ itself.
+        if nqp::getcomp('Raku').language_revision < 2 && $<coercee> eq '' {
+            if $sigil eq '$' {
+                self.attach: $/, Nodify('Ternary').new(
+                    condition => self.IMPL-MATCH-VAR-METHOD-CALL('ast'),
+                    then      => self.IMPL-MATCH-VAR-METHOD-CALL('ast'),
+                    else      => self.IMPL-MATCH-VAR-METHOD-CALL('Str'),
+                );
+            }
+            else {
+                self.contextualizer-for-sigil($/, $sigil, Nodify('Var::Lexical').new('$/'));
+            }
+        }
+        else {
+            self.contextualizer-for-sigil($/, $sigil, $<coercee>.ast);
+        }
+    }
+
+    # A method call on the match variable $/, e.g. `$/.ast`.
+    method IMPL-MATCH-VAR-METHOD-CALL($name) {
+        Nodify('ApplyPostfix').new(
+            operand => Nodify('Var::Lexical').new('$/'),
+            postfix => Nodify('Call::Method').new(
+                name => Nodify('Name').from-identifier($name)
+            )
+        )
     }
 
     method contextualizer-for-sigil($/, $sigil, $target) {

--- a/src/Raku/ast/contextualizer.rakumod
+++ b/src/Raku/ast/contextualizer.rakumod
@@ -12,7 +12,6 @@ class RakuAST::Contextualizer
     }
 
     method IMPL-EXPR-QAST(RakuAST::IMPL::QASTContext $context) {
-        # TODO 6.c semantics with $/
         QAST::Op.new(
             :op('callmethod'), :name(self.IMPL-METHOD),
             $!target.IMPL-TO-QAST($context)

--- a/t/02-rakudo/contextualizer-6c-topic.t
+++ b/t/02-rakudo/contextualizer-6c-topic.t
@@ -1,0 +1,24 @@
+use v6.c;
+use Test;
+
+plan 4;
+
+# In 6.c an empty contextualizer operates on $/.
+
+# `$()` yields $/.Str when the match made no value.
+"abc" ~~ /b/;
+is $(), 'b', '$() yields the matched string when $/ has no made value';
+
+# `$()` yields the made value when the match made one.
+"abc" ~~ / b { make 99 } /;
+is $(), 99, '$() yields the made value of $/';
+
+# `@()` coerces $/ to its positional captures.
+"abc" ~~ /(b)(c)/;
+is @().elems, 2, '@() yields the positional captures of $/';
+
+# `%()` coerces $/ to its named captures.
+"x4" ~~ /$<k>=(\w) $<v>=(\d)/;
+is %()<k>.Str, 'x', '%() yields the named captures of $/';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
In 6.c an empty `$()`, `@()` or `%()` operates on $/. RakuAST built the contextualizer around the empty coercee instead, so `$()` was an empty item rather than the smartmatch result of $/.

Build the right tree at parse time when the coercee is empty and the language revision is less than 2 (that is, 6.c): `$()` becomes the made value of $/ if there is one and its matched string otherwise, while `@()` and `%()` coerce $/ itself. Later revisions are unchanged.