### PR TITLE
RakuAST: Run NEXT phasers in a value-producing loop

### DIFF
--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -653,12 +653,22 @@ class RakuAST::ExpressionThunk
     has RakuAST::ExpressionThunk $.next;
     has RakuAST::Signature $!signature;
 
+    # A callback producing QAST (or Mu) to run at the start of the thunk body,
+    # before the wrapped expression. A callback, not stored QAST, because its
+    # content (a loop's NEXT phasers) is only known once the body compiles.
+    has Mu $!prelude-producer;
+
     method new() {
         nqp::create(self)
     }
 
     method set-next(RakuAST::ExpressionThunk $next) {
         nqp::bindattr(self, RakuAST::ExpressionThunk, '$!next', $next);
+        Nil
+    }
+
+    method IMPL-SET-PRELUDE-PRODUCER(Mu $producer) {
+        nqp::bindattr(self, RakuAST::ExpressionThunk, '$!prelude-producer', $producer);
         Nil
     }
 
@@ -744,6 +754,11 @@ class RakuAST::ExpressionThunk
 
         $block.push($stmts) if $stmts.list;
         $block.arity($signature.arity);
+
+        if nqp::isconcrete($!prelude-producer) {
+            my $prelude := $!prelude-producer($context);
+            $block.push($prelude) if nqp::isconcrete($prelude);
+        }
 
         # If there's an inner thunk the body evaluates to that.
         if $!next {

--- a/src/Raku/ast/statements.rakumod
+++ b/src/Raku/ast/statements.rakumod
@@ -1249,6 +1249,12 @@ class RakuAST::Statement::Loop
                 $!condition.wrap-with-thunk($thunk);
                 $thunk.ensure-begin-performed($resolver, $context);
                 nqp::bindattr(self, RakuAST::Statement::Loop, '$!condition-thunk', $thunk);
+                # A `repeat` loop has no afterwards slot, but it checks its
+                # condition after each iteration (and on an explicit `next`), so
+                # fold the body's NEXT phasers into the condition thunk there.
+                if self.repeat {
+                    $thunk.IMPL-SET-PRELUDE-PRODUCER(-> $ctx { self.IMPL-NEXT-PHASER-QAST($ctx) });
+                }
             }
 
             if ($!increment) {
@@ -1256,8 +1262,32 @@ class RakuAST::Statement::Loop
                 $!increment.wrap-with-thunk($thunk);
                 $thunk.ensure-begin-performed($resolver, $context);
                 nqp::bindattr(self, RakuAST::Statement::Loop, '$!increment-thunk', $thunk);
+                # Fold the body's NEXT phasers into the increment thunk so they
+                # run each iteration, including on an explicit `next`.
+                $thunk.IMPL-SET-PRELUDE-PRODUCER(-> $ctx { self.IMPL-NEXT-PHASER-QAST($ctx) });
             }
         }
+    }
+
+    # QAST that calls each of the body's NEXT phasers, or Mu if there are none.
+    method IMPL-NEXT-PHASER-QAST(RakuAST::IMPL::QASTContext $context) {
+        my $phasers := nqp::getattr($!body.meta-object, Block, '$!phasers');
+        my @next-phasers := nqp::ishash($phasers) && nqp::existskey($phasers, 'NEXT') ?? $phasers<NEXT> !! [];
+        return Mu unless @next-phasers;
+        my $qast := QAST::Stmts.new;
+        for @next-phasers {
+            $context.ensure-sc($_);
+            $qast.push(QAST::Op.new(:op('call'), QAST::WVal.new(:value($_))));
+        }
+        $qast
+    }
+
+    # A Code that runs each of the given NEXT phasers, for use as a from-loop
+    # afterwards argument.
+    method IMPL-NEXT-PHASER-AFTERWARDS-QAST(RakuAST::IMPL::QASTContext $context, @next-phasers) {
+        my $run-phasers := -> { $_() for @next-phasers };
+        $context.ensure-sc($run-phasers);
+        QAST::WVal.new(:value($run-phasers))
     }
 
     method IMPL-TO-QAST(RakuAST::IMPL::QASTContext $context) {
@@ -1324,6 +1354,12 @@ class RakuAST::Statement::Loop
                     $Seq,
                     $!body.IMPL-TO-QAST($context),
                 );
+                if @next-phasers {
+                    # No real condition or increment, so pass the "no condition"
+                    # sentinel to make room for a phaser-running afterwards thunk.
+                    $loop-qast.push(QAST::WVal.new(:value(Code)));
+                    $loop-qast.push(self.IMPL-NEXT-PHASER-AFTERWARDS-QAST($context, @next-phasers));
+                }
                 if @labels {
                     my $label-qast := @labels[0].IMPL-LOOKUP-QAST($context);
                     $label-qast.named('label');
@@ -1340,13 +1376,19 @@ class RakuAST::Statement::Loop
                     $!condition.IMPL-TO-QAST($context),
                 );
                 $qast.push: $!increment.IMPL-TO-QAST($context) if $!increment;
+                # A plain while or until has no increment or condition thunk to
+                # fold the NEXT phasers into, so here they become a dedicated
+                # afterwards thunk, which the iterator runs each iteration and on
+                # an explicit `next`.
+                if @next-phasers && !$!increment && !self.repeat {
+                    $qast.push(self.IMPL-NEXT-PHASER-AFTERWARDS-QAST($context, @next-phasers));
+                }
                 $qast.push: QAST::IVal.new(:value(1), :named('repeat')) if self.repeat;
                 if @labels {
                     my $label-qast := @labels[0].IMPL-LOOKUP-QAST($context);
                     $label-qast.named('label');
                     $qast.push($label-qast);
                 }
-                #TODO next-phasers
                 if @last-phasers {
                     $qast := QAST::Stmts.new(:resultchild(0), $qast);
                     for @last-phasers {
@@ -1384,9 +1426,7 @@ class RakuAST::Statement::Loop
                 $qast.push($label-qast);
             }
             if @next-phasers {
-                my $run-phasers := -> { $_() for @next-phasers };
-                $context.ensure-sc($run-phasers);
-                $qast.push(QAST::WVal.new(:value($run-phasers)));
+                $qast.push(self.IMPL-NEXT-PHASER-AFTERWARDS-QAST($context, @next-phasers));
             }
             if @last-phasers {
                 $qast := QAST::Stmts.new(:resultchild(0), $qast);

--- a/t/02-rakudo/loop-next-phaser.t
+++ b/t/02-rakudo/loop-next-phaser.t
@@ -1,0 +1,56 @@
+use Test;
+
+plan 8;
+
+# A NEXT phaser runs after each iteration of a value-producing loop, the same
+# as it does for a sunk loop. These cover the from-loop code paths a loop in
+# value context takes, which used to drop the phaser.
+
+# C-style loop with an increment.
+{
+    my $n = 0;
+    my @r = (loop (my $i = 0; $i < 3; $i++) { NEXT { $n++ }; $i });
+    is $n, 3, 'NEXT runs each iteration of a value-producing C-style loop';
+    is @r.join(','), '0,1,2', 'the C-style loop still yields its values';
+}
+
+# An explicit `next` still triggers the NEXT phaser for that iteration.
+{
+    my $n = 0;
+    my @r = (loop (my $i = 0; $i < 5; $i++) { next if $i == 2; NEXT { $n++ }; $i });
+    is $n, 5, 'NEXT runs on an explicit next as well';
+    is @r.join(','), '0,1,3,4', 'the skipped value is omitted';
+}
+
+# C-style loop with an empty increment slot uses an afterwards-only thunk.
+{
+    my $n = 0;
+    my @r = (loop (my $i = 0; $i < 3; ) { NEXT { $n++ }; my $v = $i; $i++; $v });
+    is $n, 3, 'NEXT runs when the C-style increment slot is empty';
+}
+
+# A plain while loop in value context has no increment to fold into.
+{
+    my $n = 0;
+    my $i = 0;
+    my @r = (while $i < 3 { NEXT { $n++ }; my $v = $i; $i++; $v });
+    is $n, 3, 'NEXT runs each iteration of a value-producing while loop';
+}
+
+# A repeat loop checks its condition after the body, so the phaser folds there.
+{
+    my $n = 0;
+    my $i = 0;
+    my @r = (repeat { NEXT { $n++ }; my $v = $i; $i++; $v } while $i < 3);
+    is $n, 3, 'NEXT runs each iteration of a value-producing repeat loop';
+}
+
+# A bare infinite loop has neither condition nor increment.
+{
+    my $n = 0;
+    my $i = 0;
+    my @r = (loop { last if $i >= 3; NEXT { $n++ }; my $v = $i; $i++; $v });
+    is $n, 3, 'NEXT runs each iteration of a value-producing bare loop';
+}
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
A loop used in value context compiles to a `from-loop` call whose body, condition and increment become thunks driven by the loop iterator. The iterator runs its `afterwards` thunk after each iteration and on an explicit `next`, which is exactly when a NEXT phaser should fire, but the phasers were dropped here. Only sunk loops ran them.

Fold the body's NEXT phasers into that per-iteration slot: the increment thunk for a C-style loop, the condition thunk for a `repeat` loop (which checks its condition after the body), and a dedicated afterwards thunk for a plain while/until. The fold into a thunk body is lazy via a producer callback, since the body's phasers are only known once it compiles.