### PR TITLE
RakuAST: Collect $=rakudoc from inside package bodies

### DIFF
--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -2730,6 +2730,14 @@ class RakuAST::VarDeclaration::Implicit::Doc::Rakudoc
                   && $expression.WHY {
                     nqp::push($RAKUDOC,$expression);
                 }
+                # Descend into a package or routine/block body so docs declared
+                # inside, such as in a `unit class`, are collected too.
+                if nqp::can($expression,'body') {
+                    my $body := $expression.body;
+                    $body := $body.body if nqp::istype($body,RakuAST::Block);
+                    self.fetch-blocks($body.statement-list)
+                      if nqp::istype($body,RakuAST::Blockoid);
+                }
             }
             elsif nqp::istype($_,RakuAST::Blockoid) {
                 self.fetch-blocks($_.statement-list);

--- a/t/02-rakudo/rakudoc-unit-package.t
+++ b/t/02-rakudo/rakudoc-unit-package.t
@@ -1,0 +1,28 @@
+use nqp;
+use Test;
+use MONKEY-SEE-NO-EVAL;
+
+plan 1;
+
+# $=rakudoc is only populated by the RakuAST frontend; skip elsewhere.
+if nqp::gethllsym('Raku', 'COMPILER-FRONTEND') eq 'rakuast' {
+    # Docs declared inside a `unit class` must reach $=rakudoc, the same as a
+    # top-level declaration. The collection used to skip package bodies, so
+    # $=rakudoc came out empty for unit-scoped programs (and --rakudoc printed
+    # nothing).
+    my @blocks = EVAL q:to/PROGRAM/;
+        unit class Things;
+        #| Process a thing.
+        method thing(
+            Str $foo #= the foo
+        ) { }
+        $=rakudoc
+        PROGRAM
+    ok @blocks.elems > 0,
+        '$=rakudoc collects docs declared inside a unit class';
+}
+else {
+    skip '$=rakudoc requires the RakuAST frontend';
+}
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
$=rakudoc was filled by walking the compunit statement list, descending only into bare blocks. Docs declared inside a package body, as in a `unit class`, were never reached, so $=rakudoc came out empty and --rakudoc printed nothing for such files. Descend into a package or routine/block body as well, so its declarator docs and doc blocks are collected too.

Fixes #6183