### PR TITLE
Render a parameter's declarator doc once under --doc

### DIFF
--- a/lib/Pod/To/Text.rakumod
+++ b/lib/Pod/To/Text.rakumod
@@ -84,6 +84,9 @@ sub table2text($pod) {
 
 sub declarator2text($pod) {
     next unless $pod.WHEREFORE.WHY;
+    # A parameter's declarator doc is already shown inline in its routine's
+    # signature, so don't emit it again as a standalone block.
+    next if $pod.WHEREFORE ~~ Parameter;
     my $what = do given $pod.WHEREFORE {
         when Method {
             my @params = $_.signature.params.skip;

--- a/t/02-rakudo/doc-param-declarator-once.t
+++ b/t/02-rakudo/doc-param-declarator-once.t
@@ -1,0 +1,27 @@
+use lib <t/packages/Test-Helpers>;
+use Test;
+use Test::Helpers;
+
+plan 2;
+
+# A parameter's `#=` declarator doc is shown inline in its routine's rendered
+# signature. It must not also appear as a standalone block (a parameter is not
+# a class), so the doc text shows exactly once under --doc.
+
+is-run '#| the sub
+sub thing(Str $foo #= the foo doc
+) { }',
+    'a parameter declarator doc renders once under --doc',
+    :compiler-args['-Ilib', '--doc'],
+    :out({ .comb('the foo doc').elems == 1 });
+
+is-run 'class C {
+    #| a method
+    method m(Int $n #= the n param
+    ) { }
+}',
+    'a method parameter declarator doc renders once under --doc',
+    :compiler-args['-Ilib', '--doc'],
+    :out({ .comb('the n param').elems == 1 });
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
A `#=` doc on a routine parameter was shown twice: once inline in the rendered signature, and again as a standalone block. The standalone form came from declarator2text treating the parameter like a class, since a Parameter object's HOW is a ClassHOW, so it fell into the `class ...` branch. Skip parameters in declarator2text; their doc already appears inline in the routine signature.

Fixes #6182