### PR TITLE
RakuAST: Keep -n/-p declarations in the compunit mainline

### DIFF
--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -64,26 +64,52 @@ sub print-topic() {
     )
 }
 
-# Provide the functionality of '-n' and '-p'
+# Provide the functionality of '-n' and '-p'. Returns a 2-element list of the
+# wrapping statement list and the per-line loop body block; the caller hoists
+# the body's declarations after begin time (see hoist-loop-body-declarations).
 sub wrap-in-for-loop($ast) {
-    Nodify('StatementList').new(
+    my $body := Nodify('PointyBlock').new(
+      signature => Nodify('Signature').new(
+        parameters => (Nodify('Parameter').new(
+          target => Nodify('ParameterTarget::Var').new(name => '$_'),
+          traits => Nodify('Trait::Is').new(
+            name => Nodify('Name').from-identifier('copy')
+          )
+        ))
+      ),
+      body => Nodify('Blockoid').new($ast)
+    );
+    my $statement-list := Nodify('StatementList').new(
       Nodify('Statement::For').new(
         source => Nodify('Call::Name').new(
           name => Nodify('Name').from-identifier('lines')
         ),
-        body   => Nodify('PointyBlock').new(
-          signature => Nodify('Signature').new(
-            parameters => (Nodify('Parameter').new(
-              target => Nodify('ParameterTarget::Var').new(name => '$_'),
-              traits => Nodify('Trait::Is').new(
-                name => Nodify('Name').from-identifier('copy')
-              )
-            ))
-          ),
-          body => Nodify('Blockoid').new($ast)
-        )
+        body   => $body
       )
-    )
+    );
+    nqp::list($statement-list, $body)
+}
+
+# Move the -n/-p program's lexical declarations from the per-line loop body
+# into the compunit mainline, so they persist across iterations and are
+# visible to BEGIN/END and friends, matching the legacy frontend. The loop
+# topic $_ and the body's implicit declarations (e.g. the FIRST-phaser flag,
+# added later at begin time) stay in the loop body. Done before begin time and
+# without forcing the body's declaration cache, so the implicit declarations
+# are not disturbed.
+sub hoist-loop-body-declarations($body, $compunit) {
+    $body.visit-dfs: -> $node {
+        if nqp::istype($node, Nodify('Declaration'))
+          && !nqp::istype($node, Nodify('VarDeclaration::Implicit'))
+          && $node.lexical-name ne '$_'
+          && $node.is-simple-lexical-declaration {
+            $node.set-hoisted-to-outer;
+            $compunit.add-generated-lexical-declaration($node);
+        }
+        # Descend through everything except inner lexical scopes, which own
+        # their own declarations; always descend into the loop body itself.
+        $node =:= $body || !nqp::istype($node, Nodify('LexicalScope'))
+    }
 }
 
 sub monkey-see-no-eval($/) {
@@ -513,7 +539,9 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
         my $statement-list := $<statementlist>.ast;
         if (my $add-print-topic := nqp::existskey(%OPTIONS,'p')) || nqp::existskey(%OPTIONS,'n') {
             $statement-list.add-statement(print-topic()) if $add-print-topic;
-            $statement-list := wrap-in-for-loop($statement-list);
+            my @wrapped := wrap-in-for-loop($statement-list);
+            $statement-list := @wrapped[0];
+            hoist-loop-body-declarations(@wrapped[1], $COMPUNIT);
             # Give the wrapper nodes a chance to do BEGIN time effects
             $statement-list.IMPL-BEGIN($RESOLVER, $COMPUNIT.context);
         }

--- a/src/Raku/ast/scoping.rakumod
+++ b/src/Raku/ast/scoping.rakumod
@@ -111,7 +111,8 @@ class RakuAST::LexicalScope
             my %variables-seen;
             my @not-if-duplicate;
             self.visit-dfs: -> $node {
-                if nqp::istype($node, RakuAST::Declaration) && $node.is-simple-lexical-declaration {
+                if nqp::istype($node, RakuAST::Declaration) && $node.is-simple-lexical-declaration
+                  && !$node.is-hoisted-to-outer {
                     unless %declarations-seen{nqp::objectid($node)} {
                         nqp::push(@declarations, $node);
                         nqp::push(@variables, $node) unless nqp::istype($node, RakuAST::Routine);
@@ -511,6 +512,19 @@ class RakuAST::Declaration
   is RakuAST::Node
 {
     has str $!scope;
+
+    # When set, this declaration's lexpad slot is provided by an outer scope
+    # (as a generated lexical) rather than the scope that textually contains
+    # it. Used by -n/-p so a program's declarations live in the compunit
+    # mainline and persist across the per-line loop, like the legacy frontend.
+    has int $!hoisted-to-outer;
+
+    method set-hoisted-to-outer() {
+        nqp::bindattr_i(self, RakuAST::Declaration, '$!hoisted-to-outer', 1);
+        Nil
+    }
+
+    method is-hoisted-to-outer() { $!hoisted-to-outer ?? True !! False }
 
     # Returns the default scope of this kind of declaration.
     method default-scope() {

--- a/t/02-rakudo/n-flag-mainline-scope.t
+++ b/t/02-rakudo/n-flag-mainline-scope.t
@@ -1,0 +1,40 @@
+use lib <t/packages/Test-Helpers>;
+use Test;
+use Test::Helpers;
+
+plan 5;
+
+# Under -n/-p the program runs once per input line, but its lexical
+# declarations live in the compunit mainline, so they persist across lines and
+# are visible to BEGIN/END. Input is two lines of 2 and 3 words (5 total).
+
+my $in = "a b\nc d e\n";
+
+# A BEGIN-declared variable persists and accumulates (the reported bug).
+is-run 'BEGIN my $w = 0; $w += .words.elems; END say $w',
+    'a BEGIN-declared variable persists across -n lines',
+    :compiler-args['-n'], :in($in), :out("5\n");
+
+# The declaration need not be inside the phaser: a plain `my` assigned in a
+# BEGIN persists too.
+is-run 'my $w; BEGIN { $w = 0 }; $w += .words.elems; END say $w',
+    'a plain my assigned in BEGIN persists across -n lines',
+    :compiler-args['-n'], :in($in), :out("5\n");
+
+# A plain `my $w = 0` re-runs its initializer each line, so it does not
+# accumulate (per-line), matching the legacy frontend.
+is-run 'my $w = 0; $w += .words.elems; END say $w',
+    'a plain my = 0 resets each line',
+    :compiler-args['-n'], :in($in), :out("3\n");
+
+# A name shared by two BEGIN blocks resolves to the same mainline declaration.
+is-run 'BEGIN my $w = 0; BEGIN my $n = 0; $w += .words.elems; $n++; END say "$w $n"',
+    'separate BEGIN-declared variables both persist',
+    :compiler-args['-n'], :in($in), :out("5 2\n");
+
+# -p modifies and prints the (writable) topic each line.
+is-run 's/a/A/',
+    '-p modifies the topic each line',
+    :compiler-args['-p'], :in($in), :out("A b\nc d e\n");
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
-n and -p wrap the program in a per-line for-loop. RakuAST built that loop as an AST node containing the program, so the program's lexical declarations landed in the loop-body scope and were re-instantiated each line. A BEGIN-declared variable therefore did not persist, so `raku -ne 'BEGIN my $w = 0; $w += .words.elems; END say $w'` printed only the last line's count instead of the total.

Hoist the program's own declarations out of the loop body and into the compunit mainline as generated lexicals, so they are created once and persist across iterations, visible to BEGIN/END and friends, as in the legacy frontend. The loop topic $_ and the body's implicit declarations stay in the loop body. This treats the general scope problem, not just phaser-declared variables: a plain `my $w` assigned in a BEGIN persists too, while a plain `my $w = 0` still resets each line because its initializer re-runs.

Fixes #6175