### PR TITLE
RakuAST: Lower operator and dot assignments in the optimize stage

### DIFF
--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -707,6 +707,12 @@ class RakuAST::Node {
         $result
     }
 
+    # True when the `soft` pragma is in effect in the enclosing scope. It keeps
+    # routines wrappable, so the routine-bypassing lowerings stand down.
+    method IMPL-IN-SOFT-SCOPE(RakuAST::Resolver $resolver) {
+        nqp::istrue($resolver.find-scope-property(-> $scope { $scope.soft }))
+    }
+
     # A ternary with a constant condition becomes the branch the condition
     # selects. The branches are expressions, so the value is preserved, and the
     # unselected branch is one the running program would not have evaluated. The

--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -703,6 +703,7 @@ class RakuAST::Node {
         # which keeps routines wrappable, turns them off.
         if $result =:= $expr && !self.IMPL-IN-SOFT-SCOPE($resolver) {
             self.IMPL-MARK-NATIVE-INCDEC($resolver, $expr);
+            self.IMPL-MARK-NATIVE-METAOP($resolver, $expr);
         }
 
         # A replacement stands where the original stood, so it must carry the
@@ -747,6 +748,41 @@ class RakuAST::Node {
         # A prefix yields the stepped value directly, so it needs no such guard.
         return Nil if $is-postfix && nqp::objprimbits($operand.return-type) != 64;
         $expr.IMPL-SET-NATIVE-INCDEC($spec) if self.IMPL-OPERATOR-IS-CORE($resolver, $op-node);
+        Nil
+    }
+
+    # Mark a native int or num add, subtract, or multiply compound assignment
+    # on a simple lexical with a native operand for lowering to a raw op. Gated
+    # in the optimize pass like the increment case. Only the CORE operator is
+    # lowered.
+    method IMPL-MARK-NATIVE-METAOP(RakuAST::Resolver $resolver, Mu $expr) {
+        return Nil unless nqp::istype($expr, RakuAST::ApplyInfix);
+        my $infix := $expr.infix;
+        return Nil unless nqp::istype($infix, RakuAST::MetaInfix::Assign);
+        my $base := $infix.infix;
+        return Nil unless nqp::istype($base, RakuAST::Infix);
+        my str $op := $base.operator;
+        return Nil unless $op eq '+' || $op eq '-' || $op eq '*';
+        my $left := $expr.left;
+        return Nil unless nqp::istype($left, RakuAST::Var::Lexical) && $left.is-resolved;
+        my int $spec := nqp::objprimspec($left.return-type);
+        return Nil unless $spec == 1 || $spec == 2;
+        # The right operand must be a native value: a native variable of the
+        # same flavour, or a float literal. An integer literal is an `Int`, so
+        # `$i += 1` is an int + Int step that overflows to a bignum the native
+        # cannot hold and throws, like `my int $r = $i + 1`; leave it to the
+        # metaop. A float literal never overflows that way.
+        my $right := $expr.right;
+        my int $rhs-ok := 0;
+        if nqp::istype($right, RakuAST::Var::Lexical) && $right.is-resolved
+          && nqp::objprimspec($right.return-type) == $spec {
+            $rhs-ok := 1;
+        }
+        elsif $spec == 2 && nqp::istype($right, RakuAST::NumLiteral) {
+            $rhs-ok := 1;
+        }
+        return Nil unless $rhs-ok;
+        $infix.IMPL-SET-NATIVE-STEP($spec) if self.IMPL-OPERATOR-IS-CORE($resolver, $base);
         Nil
     }
 

--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -704,6 +704,7 @@ class RakuAST::Node {
         if $result =:= $expr && !self.IMPL-IN-SOFT-SCOPE($resolver) {
             self.IMPL-MARK-NATIVE-INCDEC($resolver, $expr);
             self.IMPL-MARK-NATIVE-METAOP($resolver, $expr);
+            self.IMPL-MARK-SCALAR-METAOP($resolver, $expr);
         }
 
         # A replacement stands where the original stood, so it must carry the
@@ -784,6 +785,50 @@ class RakuAST::Node {
         return Nil unless $rhs-ok;
         $infix.IMPL-SET-NATIVE-STEP($spec) if self.IMPL-OPERATOR-IS-CORE($resolver, $base);
         Nil
+    }
+
+    # Mark a compound assignment on a boxed scalar lexical for inlining to an
+    # assignment of the operator's result, dropping the metaop dispatch. The
+    # left may also be another compound assignment, so chains inline in full;
+    # code generation binds the left to a temporary, so it is evaluated once.
+    method IMPL-MARK-SCALAR-METAOP(RakuAST::Resolver $resolver, Mu $expr) {
+        return Nil unless nqp::istype($expr, RakuAST::ApplyInfix);
+        my $infix := $expr.infix;
+        return Nil unless nqp::istype($infix, RakuAST::MetaInfix::Assign);
+        return Nil if $infix.IMPL-WRAPS-LIST-META;
+        my $base := $infix.infix;
+        return Nil unless nqp::istype($base, RakuAST::Infix);
+        # `orelse`, `andthen`, and `notandthen` compile to a call with a thunked
+        # right, so the inline, which evaluates the right eagerly, cannot keep
+        # them lazy. Leave them to the metaop.
+        my str $op := $base.operator;
+        return Nil if $op eq 'orelse' || $op eq 'andthen' || $op eq 'notandthen';
+        # `^^` and `xor` compile to the `xor` QAST op, which yields a VMNull
+        # when neither operand is the result. The metaop calls the routine,
+        # which returns a Nil there, so leave them to it as well.
+        return Nil if $op eq '^^' || $op eq 'xor';
+        return Nil unless self.IMPL-SCALAR-METAOP-LHS-OK($expr.left);
+        $infix.IMPL-SET-INLINE if self.IMPL-OPERATOR-IS-CORE($resolver, $base);
+        Nil
+    }
+
+    # True when the left of a compound assignment is a boxed scalar the inline
+    # may assign through: a plain scalar lexical, or another compound assignment
+    # whose result is itself such a scalar. Grouping parentheses are seen
+    # through, so a parenthesized chain qualifies.
+    method IMPL-SCALAR-METAOP-LHS-OK(Mu $lhs) {
+        my $node := $lhs;
+        while nqp::istype($node, RakuAST::Circumfix::Parentheses)
+          && $node.semilist.IMPL-IS-SINGLE-EXPRESSION {
+            my $stmt := self.IMPL-UNWRAP-LIST($node.semilist.code-statements)[0];
+            return False if $stmt.condition-modifier || $stmt.loop-modifier;
+            $node := $stmt.expression;
+        }
+        (nqp::istype($node, RakuAST::Var::Lexical) && $node.is-resolved
+          && nqp::eqat($node.name, '$', 0) && nqp::objprimspec($node.return-type) == 0)
+        || (nqp::istype($node, RakuAST::ApplyInfix)
+          && nqp::istype($node.infix, RakuAST::MetaInfix::Assign)
+          && self.IMPL-SCALAR-METAOP-LHS-OK($node.left))
     }
 
     # True when the `soft` pragma is in effect in the enclosing scope. It keeps

--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -697,6 +697,13 @@ class RakuAST::Node {
             $result := self.IMPL-FOLD-CONSTANT($resolver, $expr);
         }
 
+        # Lowerings that direct code generation rather than replacing the
+        # node register their marks here, gated on the optimize pass running.
+        # They each drop a layer of operator dispatch, so the `soft` pragma,
+        # which keeps routines wrappable, turns them off.
+        if $result =:= $expr && !self.IMPL-IN-SOFT-SCOPE($resolver) {
+        }
+
         # A replacement stands where the original stood, so it must carry the
         # original's sunk state for any sink-sensitive code generation.
         if !($result =:= $expr)
@@ -708,9 +715,33 @@ class RakuAST::Node {
     }
 
     # True when the `soft` pragma is in effect in the enclosing scope. It keeps
-    # routines wrappable, so the routine-bypassing lowerings stand down.
+    # routines wrappable, so the lowerings stand down.
     method IMPL-IN-SOFT-SCOPE(RakuAST::Resolver $resolver) {
         nqp::istrue($resolver.find-scope-property(-> $scope { $scope.soft }))
+    }
+
+    # True when the operator resolves to the CORE routine itself. An operator
+    # bound to a lexical variable has no compile-time value and throws, which
+    # declines the lowering. A user `multi` or `sub` that shadows or extends the
+    # operator produces a distinct routine object whose file may still read
+    # SETTING::, so the file alone is not enough: when the setting provides the
+    # name, the resolved routine must be the setting's very own. When it does not
+    # (the operator is being defined as CORE itself compiles), the file vouches.
+    method IMPL-OPERATOR-IS-CORE(RakuAST::Resolver $resolver, Mu $operator) {
+        CATCH {
+            return False;
+        }
+        my $routine := $operator.resolution.compile-time-value;
+        return False
+          unless nqp::can($routine, 'file') && $routine.file.starts-with('SETTING::');
+        my str $category := nqp::istype($operator, RakuAST::Postfix) ?? '&postfix'
+                         !! nqp::istype($operator, RakuAST::Prefix)  ?? '&prefix'
+                         !! '&infix';
+        my $setting := $resolver.resolve-lexical-constant-in-setting(
+          $category ~ $resolver.IMPL-CANONICALIZE-PAIR($operator.operator));
+        nqp::istype($setting, RakuAST::Declaration::External::Constant)
+          ?? nqp::eqaddr($routine, $setting.compile-time-value)
+          !! True
     }
 
     # A ternary with a constant condition becomes the branch the condition

--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -702,6 +702,7 @@ class RakuAST::Node {
         # They each drop a layer of operator dispatch, so the `soft` pragma,
         # which keeps routines wrappable, turns them off.
         if $result =:= $expr && !self.IMPL-IN-SOFT-SCOPE($resolver) {
+            self.IMPL-MARK-NATIVE-INCDEC($resolver, $expr);
         }
 
         # A replacement stands where the original stood, so it must carry the
@@ -712,6 +713,41 @@ class RakuAST::Node {
             $result.mark-sunk();
         }
         $result
+    }
+
+    # Mark a native int or num increment or decrement on a simple lexical for
+    # lowering to a raw op at code generation. Both the postfix (`$i++`) and
+    # prefix (`++$i`) forms qualify. Doing it here, in the optimize pass, gates
+    # it on optimization being on. Only the CORE operator is lowered; a
+    # user-redefined one must still run.
+    method IMPL-MARK-NATIVE-INCDEC(RakuAST::Resolver $resolver, Mu $expr) {
+        my int $is-postfix := nqp::istype($expr, RakuAST::ApplyPostfix);
+        my $op-node;
+        if $is-postfix {
+            $op-node := $expr.postfix;
+            return Nil unless nqp::istype($op-node, RakuAST::Postfix);
+        }
+        elsif nqp::istype($expr, RakuAST::ApplyPrefix) {
+            $op-node := $expr.prefix;
+            return Nil unless nqp::istype($op-node, RakuAST::Prefix);
+        }
+        else {
+            return Nil;
+        }
+        my str $op := $op-node.operator;
+        return Nil unless $op eq '++' || $op eq '--';
+        my $operand := $expr.operand;
+        return Nil unless nqp::istype($operand, RakuAST::Var::Lexical) && $operand.is-resolved;
+        my int $spec := nqp::objprimspec($operand.return-type);
+        return Nil unless $spec == 1 || $spec == 2;
+        # A post-increment recovers the original by reversing the step on the
+        # assigned value, which round-trips only at the full native width. A
+        # narrower type (int8, int16, num32) truncates on assignment, so the
+        # reverse would not give the original back; leave those to the routine.
+        # A prefix yields the stepped value directly, so it needs no such guard.
+        return Nil if $is-postfix && nqp::objprimbits($operand.return-type) != 64;
+        $expr.IMPL-SET-NATIVE-INCDEC($spec) if self.IMPL-OPERATOR-IS-CORE($resolver, $op-node);
+        Nil
     }
 
     # True when the `soft` pragma is in effect in the enclosing scope. It keeps

--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -705,6 +705,7 @@ class RakuAST::Node {
             self.IMPL-MARK-NATIVE-INCDEC($resolver, $expr);
             self.IMPL-MARK-NATIVE-METAOP($resolver, $expr);
             self.IMPL-MARK-SCALAR-METAOP($resolver, $expr);
+            self.IMPL-MARK-DOT-ASSIGN($resolver, $expr);
         }
 
         # A replacement stands where the original stood, so it must carry the
@@ -829,6 +830,52 @@ class RakuAST::Node {
         || (nqp::istype($node, RakuAST::ApplyInfix)
           && nqp::istype($node.infix, RakuAST::MetaInfix::Assign)
           && self.IMPL-SCALAR-METAOP-LHS-OK($node.left))
+    }
+
+    # Mark a dot-assignment for inlining the dispatcher away. It is always a
+    # method call whose result is stored back, with no operator routine to
+    # shadow, so unlike the numeric marks no core-operator guard applies.
+    # Two forms reach it. An explicit target is an ApplyDottyInfix whose infix is
+    # the call-assign operator. A bare call on the topic is a Term::TopicCall
+    # whose call carries the `.=` dispatcher; only a plain Call::Method honors
+    # the inline at code generation, so a quoted or private method is left out.
+    method IMPL-MARK-DOT-ASSIGN(RakuAST::Resolver $resolver, Mu $expr) {
+        if nqp::istype($expr, RakuAST::ApplyDottyInfix) {
+            my $infix := $expr.infix;
+            $infix.IMPL-SET-INLINE if nqp::istype($infix, RakuAST::DottyInfix::CallAssign);
+        }
+        elsif nqp::istype($expr, RakuAST::Term::TopicCall) {
+            my $call := $expr.call;
+            if nqp::istype($call, RakuAST::Call::Method) {
+                my $dispatcher := $call.dispatcher;
+                $call.IMPL-SET-INLINE if $dispatcher && $dispatcher eq 'dispatch:<.=>';
+            }
+        }
+        Nil
+    }
+
+    # Inline a dot-assignment to an assignment of the method call's result,
+    # dropping the dispatcher. The call arrives as a `dispatch:<.=>` callmethod
+    # whose first child is the target and whose second is the method name. The
+    # method name is kept as that second child, so clearing the op name leaves a
+    # plain method call whose result is stored back. A target that is not a plain
+    # variable is bound to a temporary so it is evaluated once.
+    method IMPL-INLINE-DOT-ASSIGN(Mu $call) {
+        my $target := $call[0];
+        $call.name('');
+        if nqp::istype($target, QAST::Var) {
+            QAST::Op.new(:op<p6store>, $target, $call)
+        }
+        else {
+            $target := $call.shift;
+            my str $name := QAST::Node.unique('dot_assign');
+            $call.unshift(QAST::Var.new(:name($name), :scope<local>));
+            QAST::Stmt.new(
+                QAST::Op.new(:op<bind>,
+                    QAST::Var.new(:name($name), :scope<local>, :decl<var>), $target),
+                QAST::Op.new(:op<p6store>,
+                    QAST::Var.new(:name($name), :scope<local>), $call))
+        }
     }
 
     # True when the `soft` pragma is in effect in the enclosing scope. It keeps

--- a/src/Raku/ast/call.rakumod
+++ b/src/Raku/ast/call.rakumod
@@ -597,6 +597,10 @@ class RakuAST::Call::Methodish
 {
     has str $!dispatcher;
 
+    # Set when the optimize pass has marked a `.=` call on the topic for inlining
+    # the method-call-and-assign dispatcher away.
+    has int $!inline;
+
     # expected to be '.?' | '.+' | '.*' | '.=' but custom ones will be codegenned also
     method set-dispatcher($dispatch) {
         nqp::bindattr_s(self, RakuAST::Call::Methodish, '$!dispatcher',
@@ -609,6 +613,11 @@ class RakuAST::Call::Methodish
           ?? nqp::substr($!dispatcher, 10, nqp::chars($!dispatcher) - 11)
           !! ""
     }
+
+    method IMPL-SET-INLINE() {
+        nqp::bindattr_i(self, RakuAST::Call::Methodish, '$!inline', 1)
+    }
+    method IMPL-INLINE() { $!inline }
 
     method default-properties(str $default) {
         OperatorProperties.postfix(self.dispatch || $default)
@@ -696,6 +705,7 @@ class RakuAST::Call::Method
     method IMPL-POSTFIX-QAST(RakuAST::IMPL::QASTContext $context, Mu $invocant-qast) {
         my $name := $!name.canonicalize;
         my $call;
+        my int $inline-dot;
         if $name {
             my @parts := nqp::split('::', $name);
             if nqp::elems(@parts) == 1 {
@@ -708,6 +718,7 @@ class RakuAST::Call::Method
                         $invocant-qast,
                         QAST::SVal.new(:value($name))
                     );
+                    $inline-dot := self.IMPL-INLINE && $dispatcher eq 'dispatch:<.=>';
                 }
                 else {
                     my $op := self.IMPL-SPECIAL-OP($name);
@@ -765,7 +776,7 @@ class RakuAST::Call::Method
             nqp::die('Qualified method calls NYI');
         }
         self.args.IMPL-ADD-QAST-ARGS($context, $call);
-        $call
+        $inline-dot ?? self.IMPL-INLINE-DOT-ASSIGN($call) !! $call
     }
 
     method can-be-used-with-hyper() { True }

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -2737,6 +2737,14 @@ class RakuAST::ApplyPrefix
 
     method operator() { $!prefix }
 
+    # Set by the optimize pass to the native primitive spec when this is a
+    # native increment or decrement to lower to a raw op.
+    has int $!native-incdec;
+
+    method IMPL-SET-NATIVE-INCDEC(int $primspec) {
+        nqp::bindattr_i(self, RakuAST::ApplyPrefix, '$!native-incdec', $primspec)
+    }
+
     method PERFORM-BEGIN(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
         self.IMPL-MAYBE-CURRY($resolver, $context);
     }
@@ -2747,7 +2755,25 @@ class RakuAST::ApplyPrefix
     }
 
     method IMPL-EXPR-QAST(RakuAST::IMPL::QASTContext $context) {
+        return self.IMPL-NATIVE-INCDEC-QAST($context) if $!native-incdec;
         $!prefix.IMPL-PREFIX-QAST($context, $!operand.IMPL-TO-QAST($context))
+    }
+
+    # A native int/num ++ or -- the optimize pass marked: emit the raw op on a
+    # lexicalref instead of calling the operator. A prefix yields the stepped
+    # value, which the assignment already returns, so it needs no reverse step.
+    method IMPL-NATIVE-INCDEC-QAST(RakuAST::IMPL::QASTContext $context) {
+        my int $is-int := $!native-incdec == 1;
+        my str $assign := $is-int ?? 'assign_i' !! 'assign_n';
+        my str $add    := $is-int ?? 'add_i'    !! 'add_n';
+        my str $sub    := $is-int ?? 'sub_i'    !! 'sub_n';
+        my int $is-dec := $!prefix.operator eq '--';
+        my $var     := $!operand.resolution.IMPL-LOOKUP-QAST($context);
+        my $returns := $var.returns;
+        my $one     := $is-int ?? QAST::IVal.new(:value(1)) !! QAST::NVal.new(:value(1.0));
+
+        my $step := QAST::Op.new: :op($is-dec ?? $sub !! $add), :$returns, $var, $one;
+        QAST::Op.new: :op($assign), :$returns, $var, $step
     }
 
     method IMPL-CAN-INTERPRET() { $!operand.IMPL-CAN-INTERPRET && $!prefix.IMPL-CAN-INTERPRET }
@@ -3420,6 +3446,9 @@ class RakuAST::ApplyPostfix
 {
     has RakuAST::Postfixish $.postfix;
     has RakuAST::Expression $.operand;
+    # The operand's native primitive spec when the optimize pass has marked a
+    # native ++/-- for lowering to a raw op; 0 when it has not.
+    has int $!native-incdec;
 
     method new(RakuAST::Postfixish :$postfix!, RakuAST::Expression :$operand!) {
         my $obj := nqp::create(self);
@@ -3486,13 +3515,40 @@ class RakuAST::ApplyPostfix
         }
     }
 
+    method IMPL-SET-NATIVE-INCDEC(int $primspec) {
+        nqp::bindattr_i(self, RakuAST::ApplyPostfix, '$!native-incdec', $primspec)
+    }
+
     method IMPL-EXPR-QAST(RakuAST::IMPL::QASTContext $context) {
+        return self.IMPL-NATIVE-INCDEC-QAST($context) if $!native-incdec;
+
         my $postfix-ast := $!postfix.IMPL-POSTFIX-QAST($context, $!operand.IMPL-TO-QAST($context));
         # Method calls may be to a foreign language, and thus return
         # values may need type mapping into Raku land.
         nqp::istype($!postfix, RakuAST::Call::Methodish)
             ?? QAST::Op.new(:op<hllize>, $postfix-ast)
             !! $postfix-ast
+    }
+
+    # A native int/num ++ or -- the optimize pass marked: emit the raw op on a
+    # lexicalref instead of calling the operator. In sink context just assign
+    # the stepped value; otherwise reverse the step on the assigned value to
+    # yield the original, which a postfix returns, without a temporary.
+    method IMPL-NATIVE-INCDEC-QAST(RakuAST::IMPL::QASTContext $context) {
+        my int $is-int := $!native-incdec == 1;
+        my str $assign := $is-int ?? 'assign_i' !! 'assign_n';
+        my str $add    := $is-int ?? 'add_i'    !! 'add_n';
+        my str $sub    := $is-int ?? 'sub_i'    !! 'sub_n';
+        my int $is-dec := $!postfix.operator eq '--';
+        my $var     := $!operand.resolution.IMPL-LOOKUP-QAST($context);
+        my $returns := $var.returns;
+        my $one     := $is-int ?? QAST::IVal.new(:value(1)) !! QAST::NVal.new(:value(1.0));
+
+        my $step := QAST::Op.new: :op($is-dec ?? $sub !! $add), :$returns, $var, $one;
+        my $store := QAST::Op.new: :op($assign), :$returns, $var, $step;
+        self.sunk
+            ?? $store
+            !! QAST::Op.new(:op($is-dec ?? $add !! $sub), :$returns, $store, $one)
     }
 
     method IMPL-BIND-QAST(RakuAST::IMPL::QASTContext $context, QAST::Node $source-qast) {

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -2551,10 +2551,18 @@ class RakuAST::DottyInfix::Call
 class RakuAST::DottyInfix::CallAssign
   is RakuAST::DottyInfixish
 {
+    # Set when the optimize pass has marked this dot-assignment for inlining the
+    # method-call-and-assign dispatcher away.
+    has int $!inline;
+
     method operator() { '.=' }
 
     method default-operator-properties() {
         OperatorProperties.infix('.=')
+    }
+
+    method IMPL-SET-INLINE() {
+        nqp::bindattr_i(self, RakuAST::DottyInfix::CallAssign, '$!inline', 1)
     }
 
     method IMPL-DOTTY-INFIX-QAST(RakuAST::IMPL::QASTContext $context, Mu $lhs-qast,
@@ -2566,7 +2574,8 @@ class RakuAST::DottyInfix::CallAssign
         $call.name('dispatch:<.=>');
         $call.op('callmethod');
         $call.nosink(1);
-        $call;
+        return $call unless $!inline;
+        self.IMPL-INLINE-DOT-ASSIGN($call)
     }
 }
 

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -1252,6 +1252,9 @@ class RakuAST::MetaInfix::Assign
   is RakuAST::MetaInfix
 {
     has RakuAST::Infixish $.infix;
+    # The operand's native primitive spec when the optimize pass has marked a
+    # native compound assignment for lowering to a raw op; 0 when it has not.
+    has int $!native-step;
 
     method new(RakuAST::Infixish $infix) {
         my $obj := nqp::create(self);
@@ -1319,6 +1322,46 @@ class RakuAST::MetaInfix::Assign
 
     method IMPL-OPERATOR() {
         self.IMPL-UNWRAP-LIST(self.get-implicit-lookups)[0].resolution.compile-time-value
+    }
+
+    method IMPL-SET-NATIVE-STEP(int $primspec) {
+        nqp::bindattr_i(self, RakuAST::MetaInfix::Assign, '$!native-step', $primspec)
+    }
+
+    # The base assigns operands to QAST then calls IMPL-INFIX-QAST. When the
+    # optimize pass marked a native compound assignment, emit the raw op
+    # instead; that path needs the operand ASTs, not their QAST, to take the
+    # left as a lexicalref.
+    method IMPL-INFIX-COMPILE(RakuAST::IMPL::QASTContext $context,
+            RakuAST::Expression $left, RakuAST::Expression $right, RakuAST::ColonPairish :$adverb) {
+        return self.IMPL-NATIVE-STEP-QAST($context, $left, $right) if $!native-step;
+
+        my $qast := self.IMPL-INFIX-QAST($context, $left.IMPL-TO-QAST($context),
+            $right.IMPL-TO-QAST($context));
+        if $adverb {
+            my $val-ast := $adverb.named-arg-value.IMPL-TO-QAST($context);
+            $val-ast.named($adverb.named-arg-name);
+            $qast.push($val-ast);
+        }
+        $qast
+    }
+
+    # A native int or num compound assignment the optimize pass marked: assign
+    # the result of the raw op back to the left, which is a simple native
+    # lexicalref read and written in place.
+    method IMPL-NATIVE-STEP-QAST(RakuAST::IMPL::QASTContext $context,
+            RakuAST::Expression $left, RakuAST::Expression $right) {
+        my int $is-int := $!native-step == 1;
+        my str $base   := $!infix.operator;
+        my str $op;
+        if $base eq '+'    { $op := $is-int ?? 'add_i' !! 'add_n' }
+        elsif $base eq '-' { $op := $is-int ?? 'sub_i' !! 'sub_n' }
+        else               { $op := $is-int ?? 'mul_i' !! 'mul_n' }
+        my $var     := $left.resolution.IMPL-LOOKUP-QAST($context);
+        my $returns := $var.returns;
+        my $rhs     := $right.IMPL-TO-QAST($context);
+        QAST::Op.new(:op($is-int ?? 'assign_i' !! 'assign_n'), :$returns, $var,
+            QAST::Op.new(:op($op), :$returns, $var, $rhs))
     }
 
     method IMPL-INFIX-QAST(RakuAST::IMPL::QASTContext $context, Mu $left-qast, Mu $right-qast) {

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -1255,6 +1255,9 @@ class RakuAST::MetaInfix::Assign
     # The operand's native primitive spec when the optimize pass has marked a
     # native compound assignment for lowering to a raw op; 0 when it has not.
     has int $!native-step;
+    # Set when the optimize pass has marked a boxed scalar compound assignment
+    # for inlining the metaop dispatch away.
+    has int $!inline;
 
     method new(RakuAST::Infixish $infix) {
         my $obj := nqp::create(self);
@@ -1328,6 +1331,53 @@ class RakuAST::MetaInfix::Assign
         nqp::bindattr_i(self, RakuAST::MetaInfix::Assign, '$!native-step', $primspec)
     }
 
+    method IMPL-SET-INLINE() {
+        nqp::bindattr_i(self, RakuAST::MetaInfix::Assign, '$!inline', 1)
+    }
+
+    # A boxed scalar compound assignment the optimize pass marked: assign the
+    # operator's result back to the left rather than dispatching the metaop.
+    # The left is bound to a temporary so it is evaluated once, and the
+    # temporary, a container, is yielded so the result is an lvalue that a
+    # surrounding compound assignment can assign through in turn. For a test
+    # operator (// || &&) the assignment is the right operand of the base
+    # operator, which selects it only when the left side does not, keeping the
+    # assignment conditional; a thunked right operand is invoked there.
+    method IMPL-INLINE-METAOP-QAST(RakuAST::IMPL::QASTContext $context, Mu $left-qast, Mu $right-qast) {
+        my str $temp := QAST::Node.unique('inline_metaop');
+        my $effect;
+        if self.IMPL-IS-TEST {
+            my $rhs := $right-qast.ann('thunked')
+                ?? QAST::Op.new(:op<call>, $right-qast)
+                !! $right-qast;
+            $effect := $!infix.IMPL-INFIX-QAST($context,
+                QAST::Var.new(:scope<local>, :name($temp)),
+                QAST::Op.new(:op<p6assign>,
+                    QAST::Var.new(:scope<local>, :name($temp)), $rhs));
+        }
+        else {
+            # An undefined left is not passed to the operator. The metaop uses
+            # the operator's identity there instead, the value it returns with
+            # no arguments, so `$x += 1` on an undefined `$x` is 1 rather than a
+            # use-of-uninitialized warning.
+            my $left := QAST::Op.new(:op<if>,
+                QAST::Op.new(:op<isconcrete>,
+                    QAST::Op.new(:op<decont>,
+                        QAST::Var.new(:scope<local>, :name($temp)))),
+                QAST::Var.new(:scope<local>, :name($temp)),
+                QAST::Op.new(:op<call>, :name($!infix.resolution.lexical-name)));
+            $effect := QAST::Op.new(:op<p6assign>,
+                QAST::Var.new(:scope<local>, :name($temp)),
+                $!infix.IMPL-INFIX-QAST($context, $left, $right-qast));
+        }
+        QAST::Stmt.new(
+            QAST::Op.new(:op<bind>,
+                QAST::Var.new(:decl<var>, :scope<local>, :name($temp)), $left-qast),
+            $effect,
+            QAST::Var.new(:scope<local>, :name($temp))
+        )
+    }
+
     # The base assigns operands to QAST then calls IMPL-INFIX-QAST. When the
     # optimize pass marked a native compound assignment, emit the raw op
     # instead; that path needs the operand ASTs, not their QAST, to take the
@@ -1365,6 +1415,8 @@ class RakuAST::MetaInfix::Assign
     }
 
     method IMPL-INFIX-QAST(RakuAST::IMPL::QASTContext $context, Mu $left-qast, Mu $right-qast) {
+        return self.IMPL-INLINE-METAOP-QAST($context, $left-qast, $right-qast) if $!inline;
+
         if self.IMPL-IS-TEST {
             QAST::Op.new(
                 :op<callstatic>,

--- a/src/Raku/ast/pragma.rakumod
+++ b/src/Raku/ast/pragma.rakumod
@@ -162,12 +162,16 @@ class RakuAST::Pragma
             }
         }
         elsif $name eq 'soft' {
-            nqp::islist($arglist)
-              ?? $resolver.build-exception(
+            if nqp::islist($arglist) {
+                $resolver.build-exception(
                    'X::NYI',
                    :feature("Arguments to '{$on ?? 'use' !! 'no' } soft'"),
                  ).throw
-              !! $LANG.set_pragma($name, $on);
+            }
+            else {
+                $LANG.set_pragma($name, $on);
+                $resolver.current-scope.set-soft($on ?? True !! False);
+            }
         }
         elsif $name eq 'attributes'
            || $name eq 'invocant'

--- a/src/Raku/ast/scoping.rakumod
+++ b/src/Raku/ast/scoping.rakumod
@@ -22,9 +22,14 @@ class RakuAST::LexicalScope
     # Scope pragmas. Note that the default for these is undefined!
     has Bool $.fatal;
     has Bool $.tell-worries;
+    has Bool $.soft;
 
     method set-fatal(Bool $on) {
         nqp::bindattr(self, RakuAST::LexicalScope, '$!fatal', $on);
+    }
+
+    method set-soft(Bool $on) {
+        nqp::bindattr(self, RakuAST::LexicalScope, '$!soft', $on);
     }
 
     method set-worries(Bool $on) {

--- a/t/08-performance/02-qast-rewrites.t
+++ b/t/08-performance/02-qast-rewrites.t
@@ -56,7 +56,6 @@ subtest 'postfix-inc/dec on natives gets overwritten to prefix' => {
 }
 
 
-todo "optimizer NYI" if %*ENV<RAKUDO_RAKUAST>;
 subtest '.dispatch:<.=> gets rewritten to simple ops' => {
     plan +my @codes :=
       ｢(my Int $x .=new).="{"new"}"(42);｣,

--- a/t/08-performance/02-qast-rewrites.t
+++ b/t/08-performance/02-qast-rewrites.t
@@ -108,9 +108,7 @@ subtest 'for {}' => {
 # https://github.com/rakudo/rakudo/issues/1981
 subtest 'nested metaops get fully rewritten away from &METAOP sub calls' => {
     plan 2;
-    todo "optimizer NYI" if %*ENV<RAKUDO_RAKUAST>;
     qast-is ｢my $a; ($a //= 0) += 1｣, -> \v { not qast-contains-call v, /METAOP/ }, '(//=)+=';
-    todo "optimizer NYI" if %*ENV<RAKUDO_RAKUAST>;
     qast-is ｢my $a; (((($a //= 0) += 1) //= 0) += 1)｣, -> \v { not qast-contains-call v, /METAOP/ },
       '((((//=)+=) //=) +=)';
 }

--- a/t/08-performance/02-qast-rewrites.t
+++ b/t/08-performance/02-qast-rewrites.t
@@ -3,7 +3,6 @@ use Test::Helpers::QAST;
 use Test;
 plan 4;
 
-todo "optimizer NYI" if %*ENV<RAKUDO_RAKUAST>;
 subtest 'postfix-inc/dec on natives gets overwritten to prefix' => {
     plan 8;
     qast-is ｢my int $i; $i++｣, -> \v {

--- a/t/08-performance/14-rakuast-native-incdec.t
+++ b/t/08-performance/14-rakuast-native-incdec.t
@@ -1,0 +1,59 @@
+use lib <t/packages/Test-Helpers>;
+use Test::Helpers::QAST;
+use Test;
+plan 12;
+
+# A native int or num `++`/`--` lowers to a raw op instead of calling the
+# operator. Postfix returns the original value, prefix the stepped one.
+{
+    my int $i = 5; $i++;
+    is $i, 6, 'native int increment steps the value';
+}
+{
+    my int $i = 5; my int $r = $i++;
+    is "$r $i", "5 6", 'native int post-increment returns the original';
+}
+{
+    my int $i = 5; $i--;
+    is $i, 4, 'native int decrement steps the value';
+}
+{
+    my num $n = 2e0; $n++;
+    is $n, 3e0, 'native num increment steps the value';
+}
+{
+    my int $i = 5; my int $r = ++$i;
+    is "$r $i", "6 6", 'native int pre-increment returns the stepped value';
+}
+{
+    my int $i = 5; --$i;
+    is $i, 4, 'native int pre-decrement steps the value';
+}
+
+# A prefix returns the stepped value directly, so unlike a postfix it lowers at
+# a narrow width too, where the assignment truncates correctly.
+{
+    my int8 $a = 127; my $r = ++$a;
+    is "$r $a", "-128 -128", 'a narrow native pre-increment wraps correctly';
+}
+
+{
+    sub postfix:<++>(\x) { 999 }
+    my int $i = 5;
+    is $i++, 999, 'a user-redefined postfix is not lowered';
+}
+{
+    sub prefix:<++>(\x) { 999 }
+    my int $i = 5;
+    is ++$i, 999, 'a user-redefined prefix is not lowered';
+}
+
+# Only a native operand lowers. These observe the emitted QAST.
+qast-is 'my int $i; $i++', -> \v { qast-contains-op v, 'add_i' },
+    'a native postfix operand lowers to a raw op';
+qast-is 'my int $i; ++$i', -> \v { qast-contains-op v, 'add_i' },
+    'a native prefix operand lowers to a raw op';
+qast-is 'my Int $i = 0; $i++', -> \v { not qast-contains-op v, 'add_i' },
+    'a boxed operand keeps the operator call';
+
+# vim: expandtab shiftwidth=4

--- a/t/08-performance/15-rakuast-native-metaop.t
+++ b/t/08-performance/15-rakuast-native-metaop.t
@@ -1,0 +1,66 @@
+use lib <t/packages/Test-Helpers>;
+use Test::Helpers::QAST;
+use Test;
+plan 12;
+
+# A native int or num `+=`/`-=`/`*=` with a native operand lowers to a raw op
+# instead of calling the metaop.
+{
+    my int $i = 5; my int $n = 3; $i += $n;
+    is $i, 8, 'native int += steps by the operand';
+}
+{
+    my int $i = 5; my int $n = 3; $i -= $n;
+    is $i, 2, 'native int -= steps by the operand';
+}
+{
+    my int $i = 5; my int $n = 3; $i *= $n;
+    is $i, 15, 'native int *= steps by the operand';
+}
+{
+    my num $a = 2e0; my num $b = 3e0; $a += $b;
+    is $a, 5e0, 'native num += steps by the operand';
+}
+
+# A float literal lowers too, since a float never overflows to a bignum.
+{
+    my num $a = 2e0; $a += 1.5e0;
+    is $a, 3.5e0, 'native num += a number literal';
+}
+
+# Two native operands step in machine width, so the result wraps on overflow.
+{
+    my int $i = 9223372036854775807; my int $n = 1; $i += $n;
+    is $i, -9223372036854775808, 'an all-native step wraps on overflow';
+}
+
+{
+    sub infix:<+>(\a, \b) { 999 }
+    my int $i = 5; my int $n = 3; $i += $n;
+    is $i, 999, 'a user-redefined operator is not lowered';
+}
+
+# A non-native operand never lowers, so no raw op on either frontend.
+qast-is 'my $a = 0; my $b = 1; $a += $b', -> \v { not qast-contains-op v, 'add_i' },
+    'a non-native operand keeps the metaop call';
+
+# The remaining cases are RakuAST-frontend specific. The frontend leaves an
+# integer literal to the metaop, so `$i += 1` overflows to a bignum and throws
+# rather than wrapping, and it emits the native raw ops directly. The legacy
+# optimizer instead lowers an int literal to a wrapping op and reaches the
+# native ops a different way, so these are pinned to RakuAST.
+if %*ENV<RAKUDO_RAKUAST> {
+    my int $i = 9223372036854775807;
+    dies-ok { $i += 1 }, 'native int += an integer literal throws on overflow';
+    qast-is 'my int $i; $i += 5', -> \v { not qast-contains-op v, 'add_i' },
+        'an integer literal keeps the metaop call';
+    qast-is 'my int $i; my int $n; $i += $n', -> \v { qast-contains-op v, 'add_i' },
+        'native int operands lower to a raw op';
+    qast-is 'my num $a; $a += 1.5e0', -> \v { qast-contains-op v, 'add_n' },
+        'a native float literal lowers to a raw op';
+}
+else {
+    skip 'integer-literal and native lowering shape is RakuAST-specific', 4;
+}
+
+# vim: expandtab shiftwidth=4

--- a/t/08-performance/16-rakuast-scalar-metaop.t
+++ b/t/08-performance/16-rakuast-scalar-metaop.t
@@ -1,0 +1,92 @@
+use lib <t/packages/Test-Helpers>;
+use Test::Helpers::QAST;
+use Test;
+plan 16;
+
+# A compound assignment on a boxed scalar inlines to a direct assignment of the
+# operator's result, dropping the metaop dispatch.
+{
+    my $a = 10; $a += 5;
+    is $a, 15, 'a plain compound assignment steps the value';
+}
+{
+    my $a; $a //= 7;
+    is $a, 7, 'a test assignment assigns when the left is undefined';
+}
+{
+    my $a = 3; $a //= 7;
+    is $a, 3, 'a test assignment keeps a defined left';
+}
+{
+    my $a = 0; $a ||= 5;
+    is $a, 5, 'an or assignment assigns a false left';
+}
+{
+    my $a = 1; $a &&= 5;
+    is $a, 5, 'an and assignment assigns a true left';
+}
+
+# A chain of compound assignments inlines in full and still chains correctly.
+{
+    my $a; ($a //= 0) += 1;
+    is $a, 1, 'a chained compound assignment composes';
+}
+{
+    my $a; (((($a //= 0) += 1) //= 0) += 1);
+    is $a, 2, 'a longer chain composes';
+}
+
+# The right of a test assignment runs only when the left selects it.
+{
+    my $ran = 0; my $a = 5; $a //= do { $ran++; 9 };
+    is "$a $ran", "5 0", 'a defined left does not run the right';
+}
+
+# An undefined left is not passed to the operator. The operator's identity
+# stands in, matching the metaop, so there is no use-of-uninitialized warning.
+{
+    my Int $x; $x += 1;
+    is $x, 1, 'an undefined typed scalar autovivifies';
+}
+{
+    my $a; $a -= 1;
+    is $a, -1, 'an undefined scalar autovivifies for a non-commutative operator';
+}
+
+# A nested metaop whose own left is not a scalar is not a scalar chain, so the
+# outer assignment is left to the metaop.
+{
+    my @a = 20; (@a ||= 42) += 10;
+    is-deeply @a, [11], 'a nested array metaop is left to the metaop';
+}
+
+# orelse, andthen, and notandthen compile to a call rather than a
+# short-circuiting op, so they keep their laziness through the metaop.
+{
+    my $a = 5; $a orelse= 99;
+    is $a, 5, 'orelse keeps a defined left';
+}
+{
+    my $a; $a andthen= 99;
+    nok $a.defined, 'andthen does not assign on an undefined left';
+}
+
+# A xor assignment with two true operands yields Nil. The operator compiles to
+# the xor QAST op, whose neither-selected result is a VMNull, so it is left to
+# the metaop, which calls the routine and returns a proper Nil there.
+{
+    my $a = 42; $a ^^= 15;
+    is $a, Any, 'a xor assignment with two true operands yields Nil';
+}
+
+{
+    sub infix:<+>(\a, \b) { 999 }
+    my $a = 5; $a += 3;
+    is $a, 999, 'a user-redefined operator is not inlined';
+}
+
+# The inlining drops the metaop dispatch. This observes the emitted QAST.
+qast-is 'my $a; $a += 1', -> \v { not qast-contains-call v, /METAOP/ },
+    'a compound assignment inlines the metaop away';
+
+# vim: expandtab shiftwidth=4

--- a/t/08-performance/17-rakuast-dot-assign.t
+++ b/t/08-performance/17-rakuast-dot-assign.t
@@ -1,0 +1,65 @@
+use lib <t/packages/Test-Helpers>;
+use Test::Helpers::QAST;
+use Test;
+plan 11;
+
+# A dot-assignment inlines to a plain method call whose result is stored back,
+# dropping the dispatch:<.=> dispatcher.
+{
+    my $s = 'Hi'; $s .= lc;
+    is $s, 'hi', 'an explicit scalar target stores the result back';
+}
+{
+    my @a = <z a b>; @a .= sort;
+    is @a.join, 'abz', 'an explicit array target stores the result back';
+}
+{
+    class Ctor { has $.v = 9 }
+    my Ctor $c .= new;
+    is $c.v, 9, 'a declaration with a dot-assignment constructs the value';
+}
+
+# A bare dot-assignment on the topic stores back through $_.
+{
+    my $s = 'Hi'; given $s { .=lc }
+    is $s, 'hi', 'a bare topic dot-assignment stores the result back';
+}
+
+# A test modifier on a topic dot-assignment keeps its laziness: the call runs
+# only when the modifier selects it, and the topic is stored back when it does.
+{
+    class Cwith { has $.v = 9 }
+    my $a = Cwith.new(:v(1)); given $a { .=new with $a }
+    is $a.v, 9, 'a with modifier runs the call on a defined topic';
+}
+{
+    my $ran = 0;
+    my $a = Int; given $a { .=new with $a }
+    is $a.defined, False, 'a with modifier skips the call on an undefined topic';
+}
+{
+    my Int $a; given $a { .=new without $a }
+    is $a.defined, True, 'a without modifier runs the call on an undefined topic';
+}
+
+# A chain of topic dot-assignments composes through andthen and orelse.
+{
+    my Int $x; given $x { .=new andthen .=new orelse .=new }
+    is $x.defined, True, 'a chained topic dot-assignment composes';
+}
+
+# A target that is not a plain variable is evaluated once.
+{
+    my $calls = 0; my @a = ['Hi']; sub idx { $calls++; 0 }
+    @a[idx()] .= lc;
+    is "{@a[0]} $calls", 'hi 1', 'a complex target is evaluated once';
+}
+
+# The inlining drops the dispatcher for both the explicit and the topic form.
+# These observe the emitted QAST.
+qast-is 'my $s = "Hi"; $s .= lc', :full, -> \v { not qast-contains-callmethod v, 'dispatch:<.=>' },
+    'an explicit dot-assignment inlines the dispatcher away';
+qast-is 'my $s = "Hi"; given $s { .=lc }', :full, -> \v { not qast-contains-callmethod v, 'dispatch:<.=>' },
+    'a topic dot-assignment inlines the dispatcher away';
+
+# vim: expandtab shiftwidth=4

--- a/t/12-rakuast/xx-fixed-in-rakuast.rakutest
+++ b/t/12-rakuast/xx-fixed-in-rakuast.rakutest
@@ -67,7 +67,11 @@ plan 113;
 
 # t/spec/S06-advanced/wrap.t
 # https://github.com/rakudo/rakudo/issues/1561
-# XXX: Almost certainly just due to lack of optimizations
+# A native increment is lowered to a raw op, which bypasses the operator
+# routine and so does not see a wrap. The `soft` pragma keeps the routine in
+# place, so the wrap applies; legacy does not honor `soft` for this lowering.
+# `soft` is set on the scope it appears in (the unit at the mainline), so this
+# keeps the whole unit with `:compunit`; a bare statement list would drop it.
 # The wrap handlers do not call the original operator, so while a wrap
 # is active the operator is broken for every caller in the process.
 # Compiling any code dispatches postfix:<++> internally, and an
@@ -81,8 +85,8 @@ plan 113;
     is-deeply @result, ["ok"], "wrapping infix:<|> works";
 
     @result = [];
-    Q§ my $handle = &postfix:<++>.wrap: -> | { @result.push("ok2") }; my int $x; $x++; &postfix:<++>.unwrap($handle) §.AST.EVAL;
-    is-deeply @result, ["ok2"], "wrapping postfix:<++> works";
+    Q§ use soft; my $handle = &postfix:<++>.wrap: -> | { @result.push("ok2") }; my int $x; $x++; &postfix:<++>.unwrap($handle) §.AST(:compunit).EVAL;
+    is-deeply @result, ["ok2"], "wrapping postfix:<++> works under soft";
 }
 
 # ???


### PR DESCRIPTION
This adds some lowerings RakuAST is missing (one per commit). Native `int` and `num` `++` and `--`, as well as native compound assignment like `$i += $n`, become a raw op like `add_i`. A boxed scalar compound assignment like `$a += 1` or `$a //= 0` inlines past the metaop. A `.=` dot-assignment inlines past its `dispatch:<.=>` dispatcher.

These share a couple of pieces that land first. One is a guard so a lowering only fires on the actual CORE operator, which leaves a user `sub` or `multi` that redefines it running as before. The other is a hook in the optimize pass where each lowering registers its mark. Since they direct code generation instead of replacing the node, `--optimize=off` keeps the original call and `use soft` turns them off. To make that last part work `soft` is now recorded on the scope the way `fatal` is so the optimize pass can check for it.

