### PR TITLE
RakuAST: fix hyper zen slice `>>[]` / `>>{}` / `>><>` selecting nothing

### DIFF
--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -3170,11 +3170,12 @@ class RakuAST::Postcircumfix::ArrayIndex
     method can-be-used-with-hyper() { True }
 
     method IMPL-POSTFIX-HYPER-QAST(RakuAST::IMPL::QASTContext $context, Mu $operand-qast) {
-        QAST::Op.new:
+        my $op := QAST::Op.new:
             :op('callstatic'), :name('&METAOP_HYPER_POSTFIX_ARGS'),
-            $operand-qast,
-            $!index.IMPL-TO-QAST($context),
-            self.resolution.IMPL-LOOKUP-QAST($context)
+            $operand-qast;
+        $op.push($!index.IMPL-TO-QAST($context)) unless $!index.is-empty;
+        $op.push(self.resolution.IMPL-LOOKUP-QAST($context));
+        $op
     }
 }
 
@@ -3256,11 +3257,12 @@ class RakuAST::Postcircumfix::HashIndex
     method can-be-used-with-hyper() { True }
 
     method IMPL-POSTFIX-HYPER-QAST(RakuAST::IMPL::QASTContext $context, Mu $operand-qast) {
-        QAST::Op.new:
+        my $op := QAST::Op.new:
             :op('callstatic'), :name('&METAOP_HYPER_POSTFIX_ARGS'),
-            $operand-qast,
-            $!index.IMPL-TO-QAST($context),
-            self.resolution.IMPL-LOOKUP-QAST($context)
+            $operand-qast;
+        $op.push($!index.IMPL-TO-QAST($context)) unless $!index.is-empty;
+        $op.push(self.resolution.IMPL-LOOKUP-QAST($context));
+        $op
     }
 }
 
@@ -3338,11 +3340,12 @@ class RakuAST::Postcircumfix::LiteralHashIndex
     }
 
     method IMPL-POSTFIX-HYPER-QAST(RakuAST::IMPL::QASTContext $context, Mu $operand-qast) {
-        QAST::Op.new:
+        my $op := QAST::Op.new:
             :op('callstatic'), :name('&METAOP_HYPER_POSTFIX_ARGS'),
-            $operand-qast,
-            $!index.IMPL-TO-QAST($context),
-            self.resolution.IMPL-LOOKUP-QAST($context)
+            $operand-qast;
+        $op.push($!index.IMPL-TO-QAST($context)) unless $!index.is-empty-words;
+        $op.push(self.resolution.IMPL-LOOKUP-QAST($context));
+        $op
     }
 
     method IMPL-BIND-POSTFIX-QAST(RakuAST::IMPL::QASTContext $context,

--- a/t/02-rakudo/postfix-hyper.t
+++ b/t/02-rakudo/postfix-hyper.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 6;
+plan 10;
 
 # Hypering a postfix should work for the same postfixes the legacy frontend
 # accepts, not just method calls and postcircumfix indexing.
@@ -29,5 +29,19 @@ is ((1, 2, 3)>>.succ).join(','), '2,3,4',
 my @nested = [1, 2], [3, 4];
 is (@nested>>[0]).join(','), '1,3',
     'a hyper postcircumfix index applies element-wise';
+
+# An empty index is a zen slice, so each element maps to itself rather than
+# being subscripted with an empty list (which would select nothing).
+is ((1, 2, 3)>>[]).join(','), '1,2,3',
+    'a hyper empty-index zen slice yields each element unchanged';
+is (@nested>>[]).map(*.join('')).join(','), '12,34',
+    'a hyper zen slice preserves nested elements';
+is (1>>[]).join(','), '1',
+    'a hyper zen slice on a single element yields that element';
+
+# A `<>` zen slice over hashes reaches the same limitation as `>>{}` (the
+# postcircumfix carries adverb params, so the element-wise map rejects it), and
+# must error rather than silently selecting nothing.
+dies-ok { ({:a(1)}, {:a(2)})>><> }, 'a hyper `<>` hash zen slice errors, not selects nothing';
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
A `>>[]`, `>>{}` or `>><>` with an empty index is a zen slice and should map each element to itself. The hyper QAST always passed the index to METAOP_HYPER_POSTFIX_ARGS, so an empty index reached the per-element op as `postcircumfix:<[ ]>(elem, ())` (subscript with an empty list, which selects nothing) instead of `postcircumfix:<[ ]>(elem)` (the zen slice). So `(1, 2, 3)>>[]` produced `(() () ())` rather than `(1 2 3)`.

The non-hyper path already guards this with `unless $!index.is-empty`. Apply the same guard in the hyper path for the array, hash and literal-hash index postcircumfixes so an empty index passes no args. The array form then zen slices; the hash forms reach the same per-element arity limit as their non-hyper counterparts and error, rather than silently selecting nothing.