### PR TITLE
RakuAST: apply the sigil contextualizer to `@<foo>` / `%<foo>` captures

### DIFF
--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -2356,12 +2356,12 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
         if $<index> -> $index {
             self.attach: $/,
               Nodify('Var::PositionalCapture').new(
-                $*LITERALS.intern-Int(~$index)
+                $*LITERALS.intern-Int(~$index), :sigil(~$<sigil>)
               );
         }
         elsif $<postcircumfix> -> $postcircumfix {
             self.attach: $/,
-              Nodify('Var::NamedCapture').new($postcircumfix.ast.index);
+              Nodify('Var::NamedCapture').new($postcircumfix.ast.index, :sigil(~$<sigil>));
         }
         elsif $<contextualizer> -> $contextualizer {
             self.attach: $/, $contextualizer.ast;

--- a/src/Raku/ast/variable-access.rakumod
+++ b/src/Raku/ast/variable-access.rakumod
@@ -3,6 +3,21 @@ class RakuAST::Var
   is RakuAST::Term
 {
     method sigil() { '' }
+
+    # A capture variable (`$<foo>`, `@0`, ...) is a `$/` subscript. The `@` and
+    # `%` sigils put the result into list / hash context (its positional / named
+    # subcaptures); `$`, `&`, or an absent sigil leave it the raw Match.
+    method IMPL-CONTEXTUALIZE-CAPTURE(str $sigil, Mu $qast) {
+        if $sigil eq '@' {
+            QAST::Op.new(:op('callmethod'), :name('list'), $qast)
+        }
+        elsif $sigil eq '%' {
+            QAST::Op.new(:op('callmethod'), :name('hash'), $qast)
+        }
+        else {
+            $qast
+        }
+    }
 }
 
 # A typical lexical variable lookup (e.g. $foo).
@@ -699,11 +714,13 @@ class RakuAST::Var::PositionalCapture
   is RakuAST::ImplicitLookups
 {
     has Int $.index;
+    has str $.sigil;
     has Mu $!colonpairs;
 
-    method new(Int $index) {
+    method new(Int $index, str :$sigil) {
         my $obj := nqp::create(self);
         nqp::bindattr($obj, RakuAST::Var::PositionalCapture, '$!index', $index);
+        nqp::bindattr_s($obj, RakuAST::Var::PositionalCapture, '$!sigil', $sigil);
         nqp::bindattr($obj, RakuAST::Var::PositionalCapture, '$!colonpairs', []);
         $obj
     }
@@ -729,12 +746,16 @@ class RakuAST::Var::PositionalCapture
             $lookups[1].IMPL-TO-QAST($context),
             QAST::WVal.new( :value($index) )
         );
-        for $!colonpairs {
-            my $val-ast := $_.named-arg-value.IMPL-TO-QAST($context);
-            $val-ast.named($_.named-arg-name);
-            $op.push($val-ast);
+        # In list / hash context an adverb is dropped, matching legacy; only the
+        # raw `$<foo>:adverb` form keeps its adverbs.
+        unless $!sigil eq '@' || $!sigil eq '%' {
+            for $!colonpairs {
+                my $val-ast := $_.named-arg-value.IMPL-TO-QAST($context);
+                $val-ast.named($_.named-arg-name);
+                $op.push($val-ast);
+            }
         }
-        $op
+        self.IMPL-CONTEXTUALIZE-CAPTURE($!sigil, $op)
     }
 
     method visit-children(Code $visitor) {
@@ -750,11 +771,13 @@ class RakuAST::Var::NamedCapture
   is RakuAST::ImplicitLookups
 {
     has RakuAST::QuotedString $.index;
+    has str $.sigil;
     has Mu $!colonpairs;
 
-    method new(RakuAST::QuotedString $index) {
+    method new(RakuAST::QuotedString $index, str :$sigil) {
         my $obj := nqp::create(self);
         nqp::bindattr($obj, RakuAST::Var::NamedCapture, '$!index', $index);
+        nqp::bindattr_s($obj, RakuAST::Var::NamedCapture, '$!sigil', $sigil);
         nqp::bindattr($obj, RakuAST::Var::NamedCapture, '$!colonpairs', []);
         $obj
     }
@@ -778,12 +801,16 @@ class RakuAST::Var::NamedCapture
             $lookups[1].IMPL-TO-QAST($context),
         );
         $op.push($!index.IMPL-TO-QAST($context)) unless $!index.is-empty-words;
-        for $!colonpairs {
-            my $val-ast := $_.named-arg-value.IMPL-TO-QAST($context);
-            $val-ast.named($_.named-arg-name);
-            $op.push($val-ast);
+        # In list / hash context an adverb is dropped, matching legacy; only the
+        # raw `$<foo>:adverb` form keeps its adverbs.
+        unless $!sigil eq '@' || $!sigil eq '%' {
+            for $!colonpairs {
+                my $val-ast := $_.named-arg-value.IMPL-TO-QAST($context);
+                $val-ast.named($_.named-arg-name);
+                $op.push($val-ast);
+            }
         }
-        $op
+        self.IMPL-CONTEXTUALIZE-CAPTURE($!sigil, $op)
     }
 
     method visit-children(Code $visitor) {

--- a/t/02-rakudo/capture-var-sigil.t
+++ b/t/02-rakudo/capture-var-sigil.t
@@ -1,0 +1,26 @@
+use Test;
+
+plan 10;
+
+# `@<foo>` and `%<foo>` put a named capture into list / hash context (its
+# positional / named subcaptures), the same as `@($/<foo>)` / `%($/<foo>)`.
+# `$<foo>` stays the raw Match. In particular `@<foo>` of a capture with no
+# positional subcaptures is empty, not a one-element list holding the Match.
+
+ok "y" ~~ / $<a>=<.alpha> /, 'sanity: named capture with no subcaptures';
+isa-ok $<a>, Match, '$<a> is the raw Match';
+is @<a>.elems, 0, '@<a> of a capture with no positional subcaptures is empty';
+is-deeply @<a>.List, @($/<a>).List, '@<a> matches @($/<a>)';
+
+ok "ab" ~~ / $<p>=( (.) (.) ) /, 'sanity: named capture with positional subcaptures';
+is @<p>.elems, 2, '@<p> lists the positional subcaptures';
+
+ok "ab" ~~ / $<h>=( $<x>=(.) $<y>=(.) ) /, 'sanity: named capture with named subcaptures';
+is %<h>.elems, 2, '%<h> hashes the named subcaptures';
+
+# In list / hash context an adverb is dropped, the same as legacy, rather than
+# applying to the subscript (which made `%<h>:exists` call `.hash` on a Bool).
+is-deeply (@<p>:exists).List, @($/<p>).List, '@<p>:exists drops the adverb and stays the list';
+is-deeply (%<h>:exists).Hash, %($/<h>).Hash, '%<h>:exists drops the adverb and stays the hash';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
`@<foo>`, `%<foo>` and `$<foo>` all compiled to the same `$/<foo>` Match, ignoring the sigil. So `@<foo>` was the raw Match rather than its positional captures: `@<foo>` of a single named capture with no positional subcaptures yielded a one-element list holding the Match instead of an empty list, and mapping over it picked up the Match.

Carry the sigil on Var::NamedCapture and Var::PositionalCapture and, for the `@` and `%` sigils, put the `$/` subscript into list or hash context. `$<foo>` is unchanged. As legacy does, an adverb in list / hash context is dropped, so `%<foo>:exists` no longer calls `.hash` on a Bool.

Unblocks grammar-based modules that iterate `@<rule>`, e.g. C::Parser.