### PR TITLE
Make an unrecognized `<| >` regex boundary a no-op before 6.e and an error after

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -11651,6 +11651,32 @@ class Perl6::QActions is HLL::Actions does STDActions {
 
 class Perl6::RegexActions is QRegex::P6Regex::Actions does STDActions {
 
+    # Duplicates the QRegex::P6Regex::Actions base, adding the 6.e gate below.
+    # It lives here, not in the base, so NQP's own regexes stay ungated. Keep
+    # the c/w handling in sync with the base.
+    method assertion:sym<|>($/) {
+        my $qast;
+        my $name := ~$<identifier>;
+        if $name eq 'c' {
+            # codepoint boundaries always match in
+            # our current Unicode abstraction level
+            $qast := 0;
+        }
+        elsif $name eq 'w' {
+            $qast := QAST::Regex.new(:rxtype<subrule>, :subtype<method>,
+                                     :node($/), :name(''),
+                                     QAST::NodeList.new(QAST::SVal.new( :value('wb') )) );
+        }
+        else {
+            # Any name other than w/c is a typo: an error from 6.e. Before then
+            # $qast stays null, which the base matches as the empty string.
+            if nqp::getcomp('Raku').language_revision >= 3 {
+                $/.typed_panic('X::Syntax::Regex::UnrecognizedBoundary', :boundary($name));
+            }
+        }
+        make $qast;
+    }
+
     method metachar:sym<:my>($/) {
         my $past := $<statement>.ast;
         make QAST::Regex.new( $past, :rxtype('qastnode'), :subtype('declarative') );

--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -4908,6 +4908,11 @@ class Raku::RegexActions is HLL::Actions does Raku::CommonActions {
         elsif $name eq 'w' {
             $ast := Nodify('Regex::Assertion::Named').new(:name(Nodify('Name').from-identifier('wb')));
         }
+        else {
+            # An unrecognized boundary name matches the empty string, same as
+            # legacy, rather than leaving the AST null and dying later.
+            $ast := Nodify('Regex::Assertion::Pass').new;
+        }
         make $ast;
     }
 

--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -4909,9 +4909,15 @@ class Raku::RegexActions is HLL::Actions does Raku::CommonActions {
             $ast := Nodify('Regex::Assertion::Named').new(:name(Nodify('Name').from-identifier('wb')));
         }
         else {
-            # An unrecognized boundary name matches the empty string, same as
-            # legacy, rather than leaving the AST null and dying later.
-            $ast := Nodify('Regex::Assertion::Pass').new;
+            # Only `w` and `c` are real boundaries, so any other name is a typo.
+            # Pre-6.e code already compiles it as a silent no-op, so the error is
+            # gated on 6.e to keep that working.
+            if nqp::getcomp('Raku').language_revision >= 3 {
+                $/.typed-panic: 'X::Syntax::Regex::UnrecognizedBoundary', :boundary($name);
+            }
+            else {
+                $ast := Nodify('Regex::Assertion::Pass').new;
+            }
         }
         make $ast;
     }

--- a/src/core.c/Exception.rakumod
+++ b/src/core.c/Exception.rakumod
@@ -2252,6 +2252,14 @@ my class X::Syntax::Regex::UnrecognizedModifier does X::Syntax {
     method message() { "Unrecognized regex modifier :$.modifier" }
 }
 
+my class X::Syntax::Regex::UnrecognizedBoundary does X::Syntax {
+    has $.boundary;
+    method message() {
+        "Unrecognized regex boundary '<|$.boundary>'. The known boundaries are "
+          ~ "'<|w>' (word) and '<|c>' (codepoint)."
+    }
+}
+
 my class X::Syntax::Regex::NullRegex does X::Syntax {
     method message() { "Null regex not allowed.  Please use .comb if you wanted to produce a sequence of characters from a string.".naive-word-wrapper }
 }

--- a/t/02-rakudo/regex-boundary-assertion.t
+++ b/t/02-rakudo/regex-boundary-assertion.t
@@ -2,18 +2,16 @@ use lib <t/packages/Test-Helpers>;
 use Test;
 use Test::Helpers;
 
-plan 3;
+plan 8;
 
-# A `<| ... >` boundary assertion names a boundary. `w` is a word boundary and
-# `c` a codepoint boundary (always matches at our Unicode level). Any other
-# boundary name is unrecognized and matches the empty string rather than failing
-# to compile.
+# `<| ... >` names a regex boundary; only `<|w>` (word) and `<|c>` (codepoint)
+# are defined. An unknown name no-ops before 6.e and is an error from 6.e on.
 
 is-run q:to/CODE/,
     say so 'ab' ~~ / a <|b> b /;
     CODE
     :out("True\n"),
-    'an unrecognized `<|b>` boundary compiles and matches the empty string';
+    'an unrecognized `<|b>` boundary matches the empty string before 6.e';
 
 is-run q:to/CODE/,
     say so 'ab'  ~~ / a <|w> b /;
@@ -27,5 +25,42 @@ is-run q:to/CODE/,
     CODE
     :out("True\n"),
     '`<|c>` codepoint boundary always matches at our Unicode level';
+
+is-run q:to/CODE/,
+    use v6.e.PREVIEW;
+    'ab' ~~ / a <|b> b /;
+    CODE
+    :err(/"Unrecognized regex boundary '<|b>'"/),
+    :exitcode(1),
+    'an unrecognized boundary is a compile error from 6.e';
+
+is-run q:to/CODE/,
+    use v6.e.PREVIEW;
+    say so 'ab' ~~ / a <|w> b /;
+    CODE
+    :out("False\n"),
+    '`<|w>` is still a valid boundary under 6.e';
+
+is-run q:to/CODE/,
+    use v6.e.PREVIEW;
+    say so 'ab' ~~ / a <|c> b /;
+    CODE
+    :out("True\n"),
+    '`<|c>` is still a valid boundary under 6.e';
+
+is-run q:to/CODE/,
+    use v6.e.PREVIEW;
+    'ab' ~~ / a <|zz> b /;
+    CODE
+    :err(/"Unrecognized regex boundary '<|zz>'"/),
+    :exitcode(1),
+    'a multi-character unrecognized boundary is reported with its full name';
+
+# The no-op must also hold away from the top of the pattern.
+is-run q:to/CODE/,
+    say so 'ax' ~~ / a [ <|b> 'x' | 'y' ] /;
+    CODE
+    :out("True\n"),
+    'an unrecognized boundary no-ops inside an alternation before 6.e';
 
 # vim: expandtab shiftwidth=4

--- a/t/02-rakudo/regex-boundary-assertion.t
+++ b/t/02-rakudo/regex-boundary-assertion.t
@@ -1,0 +1,31 @@
+use lib <t/packages/Test-Helpers>;
+use Test;
+use Test::Helpers;
+
+plan 3;
+
+# A `<| ... >` boundary assertion names a boundary. `w` is a word boundary and
+# `c` a codepoint boundary (always matches at our Unicode level). Any other
+# boundary name is unrecognized and matches the empty string rather than failing
+# to compile.
+
+is-run q:to/CODE/,
+    say so 'ab' ~~ / a <|b> b /;
+    CODE
+    :out("True\n"),
+    'an unrecognized `<|b>` boundary compiles and matches the empty string';
+
+is-run q:to/CODE/,
+    say so 'ab'  ~~ / a <|w> b /;
+    say so 'a b' ~~ / a <|w> ' ' b /;
+    CODE
+    :out("False\nTrue\n"),
+    '`<|w>` is a word boundary';
+
+is-run q:to/CODE/,
+    say so 'ab' ~~ / a <|c> b /;
+    CODE
+    :out("True\n"),
+    '`<|c>` codepoint boundary always matches at our Unicode level';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
A `<| ... >` boundary assertion names a boundary. `<|w>` is a word boundary and `<|c>` a codepoint boundary that always matches at our current Unicode level. Any other name like `<|b>` was never given a meaning.

Previously such a name produced no AST node on RakuAST, and the regex died at compile time with `Cannot find method 'to-begin-time' on object of type NQPMu`. The legacy frontend instead compiled it to a no-op that matches the empty string.

This makes the two frontends agree before 6.e by treating an unrecognized boundary as that same empty-string no-op. From 6.e on it is a compile-time error (`X::Syntax::Regex::UnrecognizedBoundary`) on both frontends, since an unrecognized boundary is almost always a typo (`<|b>` for `<|w>`).
