### PR TITLE
RakuAST: reject an adverb on an operator that can't take one

### DIFF
--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -2077,6 +2077,16 @@ class RakuAST::ApplyInfix
         my $left  := self.left;
         my $right := self.right;
 
+        if nqp::elems(self.colonpairs)
+          && nqp::istype($infix, RakuAST::Infix)
+          && ($infix.short-circuit
+                || nqp::chars($infix.properties.thunky)
+                || $infix.properties.chain) {
+            self.add-sorry:
+              $resolver.build-exception: 'X::Syntax::Adverb',
+                what => '&infix' ~ RakuAST::Resolver.IMPL-CANONICALIZE-PAIR($infix.operator);
+        }
+
         my constant WORRISOME-RANGE := nqp::hash(
           '..', 1,
           '^..', 1,
@@ -2329,6 +2339,16 @@ class RakuAST::ApplyListInfix
     }
 
     method PERFORM-CHECK(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
+        if nqp::elems($!adverbs)
+          && nqp::istype($!infix, RakuAST::Infix)
+          && ($!infix.short-circuit
+                || nqp::chars($!infix.properties.thunky)
+                || $!infix.properties.chain) {
+            self.add-sorry:
+              $resolver.build-exception: 'X::Syntax::Adverb',
+                what => '&infix' ~ RakuAST::Resolver.IMPL-CANONICALIZE-PAIR($!infix.operator);
+        }
+
         if nqp::istype($!infix, RakuAST::Feed) {
             for self.IMPL-FEED-STAGES {
                 my $stage := $_;

--- a/t/02-rakudo/adverb-on-noncall-infix.t
+++ b/t/02-rakudo/adverb-on-noncall-infix.t
@@ -1,0 +1,23 @@
+use Test;
+
+plan 5;
+
+# An adverb is tighter than most infixes, so in `EXPR OP term:adverb` it can bind
+# to OP rather than to the term. A short-circuit, thunky, or chaining operator
+# does not compile to a call and cannot take the adverb as a named argument, so
+# it is rejected instead of silently dropped.
+
+# https://github.com/rakudo/rakudo/issues/5685
+throws-like 'my %h; True && %h<a>:exists', X::Syntax::Adverb,
+    "can't adverb a short-circuit infix";
+throws-like 'my %h; 1 == %h<a>:exists', X::Syntax::Adverb,
+    "can't adverb a chaining infix";
+throws-like 'my %h; True ^^ %h<a>:exists', X::Syntax::Adverb,
+    "can't adverb a thunky list infix";
+
+# The adverb still reaches the subscript when it binds there.
+my %h = a => 1;
+is (%h<a>:exists), True, 'an adverb on a subscript still works';
+is (True and %h<a>:exists), True, 'a loose infix leaves the adverb on the subscript';
+
+# vim: expandtab shiftwidth=4

--- a/t/12-rakuast/xx-fixed-in-rakuast.rakutest
+++ b/t/12-rakuast/xx-fixed-in-rakuast.rakutest
@@ -2,7 +2,7 @@ use Test;
 use lib <t/packages/Test-Helpers>;
 use Test::Helpers;
 
-plan 113;
+plan 111;
 
 # t/spec/S03-sequence/misc.t
 # https://github.com/rakudo/rakudo/issues/5520
@@ -676,15 +676,6 @@ subtest 'use of &?ROUTINE and &?BLOCK' => {
 # https://github.com/rakudo/rakudo/issues/5119
 {
     is-deeply ("{$_}" for ^1).join, "0", 'was $_ set to 0';
-}
-
-# https://github.com/rakudo/rakudo/issues/5685
-{
-    todo q|throws You can't adverb &infix:<&&>|, 2 unless %*ENV<RAKUDO_RAKUAST>;
-    my $answer;
-    lives-ok { Q|my %a = 1 => True; $answer = True && %a<1>:exists|.EVAL },
-            'adverbs to hashes do not accidentally get passed to infixes';
-    ok $answer, 'adverbs to hashes with infixes work as expected';
 }
 
 # https://github.com/rakudo/rakudo/issues/5874#issue-3037890302


### PR DESCRIPTION
An adverb binds tighter than most infixes, so in `EXPR OP term:adverb` it can bind to OP. Only an infix that compiles to a call can take the adverb as a named argument; a short-circuit, chaining, or thunky operator cannot.

Previously RakuAST silently dropped the adverb in that case, so `True && %h<a>:exists` and `1 == %h<a>:exists` ran as if the adverb were not there. The legacy frontend rejects it with "You can't adverb &infix:<...>".

Reject it the same way from ApplyInfix and ApplyListInfix when the infix is short-circuit, chaining, or thunky.