### PR TITLE
RakuAST: don't flag an `@`/`%`/`&` coercion parameter as coercive

### DIFF
--- a/src/Raku/ast/signature.rakumod
+++ b/src/Raku/ast/signature.rakumod
@@ -999,7 +999,11 @@ class RakuAST::Parameter
             );
         }
         if $!type.is-coercive {
-            $flags := $flags +| nqp::const::SIG_ELEM_IS_COERCIVE;
+            # An `@`/`%`/`&` sigil wraps the coercion in a role, so the parameter
+            # type is `Positional[T()]` etc., not itself a coercion.
+            my str $sigil := self.IMPL-SIGIL;
+            $flags := $flags +| nqp::const::SIG_ELEM_IS_COERCIVE
+              if $sigil ne '@' && $sigil ne '%' && $sigil ne '&';
         }
         if $!type {
             my $meta-object := self.IMPL-NOMINAL-TYPE;

--- a/t/02-rakudo/coercion-sigil-param-dispatch.t
+++ b/t/02-rakudo/coercion-sigil-param-dispatch.t
@@ -1,0 +1,29 @@
+use Test;
+
+plan 6;
+
+# Behind an `@`/`%`/`&` sigil the parameter binds `Positional[T()]` (etc.), a
+# parameterized role, not a coercion. A multi with such a parameter must build
+# its dispatch info without treating the parameter itself as a coercion, or the
+# builder looks for a coercion wrappee on the role and dies.
+
+multi ga(Str $n, Int() @c) { 'coerced' }
+multi ga(Str $n,        @c) { 'plain'   }
+lives-ok { ga('x', [1, 2]) }, 'a multi with a coercive array parameter dispatches';
+is ga('x', [1, 2]), 'plain', 'a plain Array selects the unconstrained candidate';
+is ga('x', Array[Int].new(1, 2)), 'coerced',
+    'a Positional[Int] selects the Int() @c candidate';
+
+multi gh(Str $n, Int() %h) { 'coerced' }
+multi gh(Str $n,        %h) { 'plain'   }
+lives-ok { gh('x', { :a(1) }) }, 'a multi with a coercive hash parameter dispatches';
+
+multi gc(Str $n, Int() &c) { 'coerced' }
+multi gc(Str $n,        &c) { 'plain'   }
+lives-ok { gc('x', { 42 }) }, 'a multi with a coercive callable parameter dispatches';
+
+# A scalar coercion is still flagged coercive and still coerces.
+multi gs(Int() $x) { "int $x" }
+is gs("5"), 'int 5', 'a scalar coercion still coerces';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
A scalar `Int() $x` parameter's type is the coercion. Behind an `@`/`%`/`&` sigil the parameter binds `Positional[Int()]` (a parameterized role), not a coercion.

Previously RakuAST set SIG_ELEM_IS_COERCIVE for the sigil case anyway, from the element type. Building dispatch info for a multi with such a parameter then asked for a coercion wrappee on the role and died with "Cannot find method 'wrappee' on object of type Perl6::Metamodel::CurriedRoleHOW". Legacy derives the flag from the final parameter type, which is not coercive here, so it never set it.

Only set the flag when the coercion is the parameter type itself, not when a sigil wraps it. A scalar coercion is unchanged.