### PR TITLE
RakuAST: Don't parameterise a sub-signature's bound role by its type

### DIFF
--- a/src/Raku/ast/signature.rakumod
+++ b/src/Raku/ast/signature.rakumod
@@ -1037,7 +1037,9 @@ class RakuAST::Parameter
             # Match legacy: store the bare element type and treat `:D`/`:U`
             # as a separate definedness flag. Role parameterisation is
             # invariant, so the wrapped form would reject `my Str @x` defaults.
-            $!type
+            # Only a real `@`/`%`/`&` variable parameterises the role; a
+            # sub-signature only forces the sigil and binds the bare role.
+            $!type && $!target.sigil eq $sigil
                 ?? $sigil-type.HOW.parameterize($sigil-type,
                         RakuAST::Type.IMPL-MAYBE-NOMINALIZE($!type.meta-object))
                 !! $sigil-type

--- a/t/02-rakudo/subsig-nominal-type.t
+++ b/t/02-rakudo/subsig-nominal-type.t
@@ -1,0 +1,34 @@
+use Test;
+
+plan 6;
+
+# A sub-signature forces an `@` sigil on its parameter, but unlike a real array
+# variable the leading type does not parameterise the bound role. The bound type
+# stays a bare `Positional` so a plain Array still binds and destructures.
+
+sub typed-subsig(Int [$a, $b]) { "$a $b" }
+is typed-subsig([1, 2]), '1 2',
+    'a typed anonymous sub-signature binds and destructures a plain Array';
+
+sub untyped-subsig([$a, $b]) { "$a $b" }
+is untyped-subsig([3, 4]), '3 4',
+    'an untyped anonymous sub-signature still binds a plain Array';
+
+is &typed-subsig.signature.params[0].type.^name, 'Positional',
+    'a typed sub-signature parameter is a bare Positional, not Positional[Int]';
+
+# A real `@` variable keeps parameterising the role by its element type.
+sub real-array(Int @a) { @a.elems }
+is &real-array.signature.params[0].type.^name, 'Positional[Int]',
+    'a real typed array parameter still parameterises Positional by its element type';
+
+my Int @ints = 1, 2, 3;
+is real-array(@ints), 3,
+    'a real typed array parameter still binds a matching Positional';
+
+# A real `@` variable that also carries a sub-signature keeps its element type.
+sub array-with-subsig(Int @a [$a, $b]) { @a.elems }
+is &array-with-subsig.signature.params[0].type.^name, 'Positional[Int]',
+    'a real typed array with a sub-signature keeps Positional[Int]';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously `sub f(Int [$a, $b]) {}` bound its parameter to `Positional[Int]` and rejected a plain `Array`, while legacy bound a bare `Positional` and destructured it.

A sub-signature forces an `@` sigil on its parameter the same way a real array variable does, but RakuAST also parameterised the bound role by the leading type. This only parameterises the role when the sigil comes from a real `@`/`%`/`&` variable. `Int @a [$a, $b]` and `Int @c` keep `Positional[Int]`. `Int [$a, $b]` now binds and destructures a plain array on both frontends.