### PR TITLE
RakuAST: Don't rebind a bare topic on the smartmatch RHS to the LHS

### DIFF
--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -435,9 +435,7 @@ class RakuAST::Infix
             self.IMPL-ASSIGN-OP($left-qast, $right-qast);
         }
         elsif nqp::existskey(OP-SMARTMATCH, $op)
-            && (
-                !nqp::istype($right, RakuAST::Var)
-                || (nqp::istype($right, RakuAST::Var::Lexical) && $right.is-topic))
+            && !nqp::istype($right, RakuAST::Var)
             && !$right.IMPL-IS-CONSTANT
             && (!nqp::istype($left, RakuAST::ApplyInfix) || !nqp::istype($left.infix, RakuAST::OperatorProperties) || !$left.infix.properties.chain)
         {

--- a/src/Raku/ast/variable-access.rakumod
+++ b/src/Raku/ast/variable-access.rakumod
@@ -77,10 +77,6 @@ class RakuAST::Var::Lexical
             !! Nil
     }
 
-    method is-topic() {
-        self.name eq '$_'
-    }
-
     method return-type() {
         self.is-resolved
             ?? self.resolution.return-type

--- a/t/02-rakudo/smartmatch-topic-rhs.t
+++ b/t/02-rakudo/smartmatch-topic-rhs.t
@@ -1,0 +1,25 @@
+use Test;
+
+plan 5;
+
+# A bare topic variable on the right of a smartmatch refers to the outer topic,
+# the same as any other variable. It is not rebound to the left-hand side.
+
+is (given 99 { 14 ~~ $_ }), False,
+    'a bare $_ on the smartmatch RHS matches against the outer topic, not the LHS';
+
+is (given 14 { 14 ~~ $_ }), True,
+    'a bare $_ on the smartmatch RHS that equals the LHS still matches';
+
+# Reusing the topic on the RHS must not consume the LHS iterator. JSON::Schema
+# does `$_.unique ~~ $_` to test a list is unique, which threw X::Seq::Consumed.
+is (given <a b a> { .unique ~~ $_ }), False,
+    'reusing the topic on the smartmatch RHS does not consume the LHS';
+lives-ok { given <a b a> { .unique ~~ $_ } },
+    'a Seq LHS against the topic RHS does not throw';
+
+# A block on the RHS still topicalises the LHS.
+is (5 ~~ { $_ > 3 }), True,
+    'a block on the smartmatch RHS still binds $_ to the LHS';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Commit 790c7ac94 made `X ~~ $_` route through the topicalising smartmatch codegen so that a bare `$_` on the right would refer to the left-hand side, on the reasoning that `14 ~~ $_` should be an equality check returning True.

That rebinds the topic to the LHS unconditionally, so `given 99 { 14 ~~ $_ }` returned True under RakuAST instead of legacy's False, and `$_.unique ~~ $_` matched a Seq against itself and threw `X::Seq::Consumed`. JSON::Schema uses that idiom to test a type list is unique and could not be installed.

A bare variable on the smartmatch RHS is a plain value match. A bare `$_` there is the outer topic, the same as any other variable, so this drops the special case and lets it take the ordinary `infix:<~~>` path. Block, regex and other expression RHS forms still topicalise the LHS as before.