### PR TITLE
RakuAST: Match a CR LF grapheme with a regex \r\n

### DIFF
--- a/src/Raku/ast/regex.rakumod
+++ b/src/Raku/ast/regex.rakumod
@@ -199,10 +199,38 @@ class RakuAST::Regex::Sequence
         self.IMPL-WRAP-LIST($!terms)
     }
 
+    # A `\r` directly followed by `\n` matches the single `\r\n` grapheme, so
+    # fuse the pair into one literal. As separate atoms neither half matches the
+    # combined grapheme. Mirrors the legacy frontend's handling in
+    # QRegex::P6Regex::Actions.termish.
+    method IMPL-FUSE-CRLF($terms) {
+        my @fused;
+        my int $i := 0;
+        my int $n := nqp::elems($terms);
+        while $i < $n {
+            my $term := nqp::atpos($terms, $i);
+            if $i + 1 < $n
+              && nqp::istype($term, RakuAST::Regex::CharClass::CarriageReturn)
+              && !$term.negated
+              && nqp::istype((my $next := nqp::atpos($terms, $i + 1)),
+                   RakuAST::Regex::CharClass::Newline)
+              && !$next.negated
+            {
+                @fused.push(RakuAST::Regex::Literal.new("\r\n"));
+                $i := $i + 2;
+            }
+            else {
+                @fused.push($term);
+                $i := $i + 1;
+            }
+        }
+        @fused
+    }
+
     method IMPL-REGEX-QAST(RakuAST::IMPL::QASTContext $context, %mods) {
         my str $collect-literals := '';
         my @terms;
-        for $!terms {
+        for self.IMPL-FUSE-CRLF($!terms) {
             if nqp::istype($_, RakuAST::Regex::Literal) {
                 $collect-literals := $collect-literals ~ $_.text;
             }

--- a/t/02-rakudo/regex-crlf-grapheme.t
+++ b/t/02-rakudo/regex-crlf-grapheme.t
@@ -1,0 +1,41 @@
+use Test;
+
+plan 9;
+
+# In NFG strings a CR followed by an LF is a single `\r\n` grapheme. A regex
+# `\r\n` must match that grapheme even though neither `\r` nor `\n` alone does.
+
+ok "a\r\nb" ~~ /\r\n/,
+    'a regex \r\n matches a combined CR LF grapheme';
+
+is ("a\r\nb\r\nc".split(/\r\n/)).join('|'), 'a|b|c',
+    'splitting on /\r\n/ breaks at each CR LF grapheme';
+
+"a\r\nb" ~~ /\r\n/;
+is "$/.from()-$/.to()", '1-2',
+    'a /\r\n/ match consumes exactly the one combined grapheme';
+
+ok "head\r\n\r\nbody" ~~ /\r\n\r\n/,
+    'a regex \r\n\r\n matches a blank-line header terminator';
+
+# A negated half must not fuse into the CR LF literal.
+ok "a\r\nb" ~~ /\R\n/,
+    'a negated \R followed by \n does not fuse and still matches';
+nok "a\r\nb" ~~ /\r\N/,
+    'a \r followed by a negated \N does not fuse';
+
+# A lone \n still matches a combined grapheme through the newline class.
+ok "a\r\nb" ~~ /\n/,
+    'a lone \n still matches a CR LF grapheme via the newline class';
+
+# Fusion keys off the \r and \n metachars, not any CR/LF source form. A CR
+# written as a codepoint escape is a different node and must not fuse with \n.
+nok "a\r\nb" ~~ /\x0D\n/,
+    'a \x0D codepoint escape does not fuse with \n';
+
+# A quantified \n+ is its own atom, so \r does not fuse with it and is left as
+# a bare CR matcher, which finds no bare CR (the CR is in the \r\n grapheme).
+nok "x\r\ny" ~~ /\r\n+/,
+    'a \r followed by a quantified \n+ does not fuse into a \r\n literal';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
In an NFG string a CR immediately followed by an LF is a single `\r\n` grapheme. A regex `\r\n` compiled to a `\r` enumcharlist followed by the newline character class, and neither half matches the combined grapheme, so `"a\r\nb" ~~ /\r\n/` failed and `.split(/\r\n/)` did not split. This broke modules that parse CRLF protocols such as LWP::Simple.

When a non-negated `\r` is directly followed by a non-negated `\n`, fuse the pair into a single `\r\n` literal so it matches the combined grapheme. This mirrors the legacy frontend's handling in QRegex::P6Regex::Actions.termish.