### PR TITLE
RakuAST: Evaluate an expression sym for the <sym> token

### DIFF
--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -4954,7 +4954,9 @@ class Raku::RegexActions is HLL::Actions does Raku::CommonActions {
              )
           !! !$name.is-multi-part && $name.canonicalize eq 'sym' && %*RX<name>
             ?? (my $sym:= %*RX<name>.first-colonpair('sym'))
-                ?? Nodify('Regex::Literal').new($sym.simple-compile-time-quote-value)
+                ?? (nqp::isconcrete(my $sym-value := $sym.simple-compile-time-quote-value)
+                     ?? Nodify('Regex::Literal').new($sym-value)
+                     !! Nodify('Regex::Sym').new($sym))
                 !! $/.panic('Can only use <sym> token in a proto regex')
             !! $<arglist>
               ?? Nodify('Regex::Assertion::Named::Args').new(

--- a/src/Raku/ast/regex.rakumod
+++ b/src/Raku/ast/regex.rakumod
@@ -287,6 +287,43 @@ class RakuAST::Regex::Literal
     }
 }
 
+# The `<sym>` token of a proto regex candidate whose sym is an expression
+# (`token foo:sym(EXPR) {...}`) rather than a literal. The matched text is the
+# stringified value of the expression, evaluated at BEGIN time like the legacy
+# frontend does when forming the candidate name.
+class RakuAST::Regex::Sym
+  is RakuAST::Regex::Atom
+  is RakuAST::CheckTime
+{
+    has RakuAST::ColonPair $.colonpair;
+
+    method new(RakuAST::ColonPair $colonpair) {
+        my $obj := nqp::create(self);
+        nqp::bindattr($obj, RakuAST::Regex::Sym, '$!colonpair', $colonpair);
+        $obj
+    }
+
+    method PERFORM-CHECK(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
+        # Force the sym value now, BEGIN-evaluating it if it is not a simple
+        # compile-time value, so code generation has it. A value that cannot be
+        # produced even at BEGIN time throws here, as it does on legacy.
+        $!colonpair.IMPL-EVAL-COLONPAIR-VALUE($resolver, $context);
+    }
+
+    method IMPL-REGEX-QAST(RakuAST::IMPL::QASTContext $context, %mods) {
+        self.IMPL-APPLY-LITERAL-MODS:
+            QAST::Regex.new(
+                :rxtype<literal>,
+                nqp::unbox_s(~$!colonpair.IMPL-INTERPRETED-VALUE-OR-NIL)
+            ),
+            %mods
+    }
+
+    method visit-children(Code $visitor) {
+        $visitor($!colonpair);
+    }
+}
+
 # A quoted string appearing in the regex. Covers both standard single/double
 # quotes which compile into a literal match of the evaluated string, or
 # quote words, which compile into an LTM alternation of literals.

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -1621,6 +1621,10 @@ CODE
         self.hsyn('literal', self.quote-if-needed($ast.text))
     }
 
+    multi method deparse(RakuAST::Regex::Sym:D $ast --> Str:D) {
+        self.hsyn('assertion', '<sym>')
+    }
+
     multi method deparse(RakuAST::Regex::Alternation:D $ast --> Str:D) {
         self.branches($ast, $.regex-alternation)
     }

--- a/t/02-rakudo/regex-expr-sym.t
+++ b/t/02-rakudo/regex-expr-sym.t
@@ -1,0 +1,61 @@
+use Test;
+
+plan 7;
+
+# A proto regex candidate may name its sym with an expression rather than a
+# literal: `token foo:sym(EXPR) {...}`. The implicit `<sym>` token must match
+# the evaluated value of EXPR, not an empty string.
+
+my enum Opt (MARK => "Q");
+
+grammar G {
+    proto token tok {*}
+    token tok:sym(MARK)     { <option=.sym> <body> }
+    token tok:sym<fallback> { $<option>=[.] <body> }
+    token body { . }
+}
+class GActions {
+    method tok:sym(MARK)($/)     { make 'expr' }
+    method tok:sym<fallback>($/) { make 'fallback' }
+    method body($/) { }
+}
+
+is G.parse("QZ", :rule<tok>, :actions(GActions)).ast, 'expr',
+    'a :sym(EXPR) candidate matches the evaluated sym value';
+is G.parse("QZ", :rule<tok>, :actions(GActions))<option>, 'Q',
+    'the <sym> token captures the evaluated sym value';
+is G.parse("RZ", :rule<tok>, :actions(GActions)).ast, 'fallback',
+    'input not matching the evaluated sym falls through to the other candidate';
+
+# A literal :sym<...> candidate is unaffected.
+grammar S {
+    proto token tok {*}
+    token tok:sym<foo> { <sym> }
+    token tok:sym<x>   { . }
+}
+ok S.parse("foo", :rule<tok>),
+    'a literal :sym<...> candidate still matches its sym';
+ok S.parse("z", :rule<tok>),
+    'a literal :sym<...> proto still falls through to another candidate';
+
+# A sym given by a constant-foldable expression matches its value.
+grammar Folded {
+    proto token tok {*}
+    token tok:sym("a" ~ "b") { <sym> }
+    token tok:sym<x>         { . }
+}
+ok Folded.parse("ab", :rule<tok>),
+    'a constant-foldable expression sym evaluates and matches';
+
+# A sym whose value is only known by running code is evaluated at BEGIN time,
+# the same as the legacy frontend does.
+sub sym-value { "go" }
+grammar BeginTime {
+    proto token tok {*}
+    token tok:sym(sym-value()) { <sym> }
+    token tok:sym<x>           { . }
+}
+ok BeginTime.parse("go", :rule<tok>),
+    'a sym computed by a BEGIN-time call evaluates and matches';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
A proto regex candidate may give its sym as an expression rather than a literal, `token foo:sym(EXPR) {...}`. The `<sym>` token inside matches the candidate's sym. RakuAST built the `<sym>` literal from `simple-compile-time-quote-value`, which is only defined for a literal, so for an expression sym it matched an empty string, every candidate collapsed to the same match, and longest-token matching picked the wrong one. Net::Telnet parsed every NAWS subnegotiation as Unsupported.

Add RakuAST::Regex::Sym, which holds the sym colonpair and evaluates it at BEGIN time, the same as the legacy frontend does when forming the candidate name, then matches the stringified value. A literal sym still becomes a RakuAST::Regex::Literal directly.