### PR TITLE
RakuAST: Join a role group declared under a setting-named package

### DIFF
--- a/src/Raku/ast/package.rakumod
+++ b/src/Raku/ast/package.rakumod
@@ -691,8 +691,12 @@ class RakuAST::Role
         my $from-setting := $found && self.IMPL-SYMBOL-FROM-SETTING($resolver, $full-name, $existing);
 
         my $group;
-        if !$from-setting && nqp::can($existing.HOW, 'add_possibility') {
-            # An existing role group in this compilation unit: add ourselves to it.
+        if nqp::can($existing.HOW, 'add_possibility')
+          && (!$from-setting || $resolver.is-compunit-role-group($existing)) {
+            # An existing role group: add ourselves to it. A group created in
+            # this compilation unit is joined even when it lives in a setting
+            # package's WHO and so resolves as a setting symbol. A genuine
+            # setting group is instead shadowed below.
             $group := $existing;
         }
         else {
@@ -709,6 +713,7 @@ class RakuAST::Role
             $group := Perl6::Metamodel::ParametricRoleGroupHOW.new_type(
               :name($group-name), :repr(self.repr)
             );
+            $resolver.register-compunit-role-group($group);
             self.IMPL-INSTALL-PACKAGE(
               $resolver, $scope, $name, $resolver.current-package,
               :meta-object($group),

--- a/src/Raku/ast/resolver.rakumod
+++ b/src/Raku/ast/resolver.rakumod
@@ -31,6 +31,17 @@ class RakuAST::Resolver {
     # parents in sibling blocks doesn't collide.
     has Mu $!our-package-decl-map;
 
+    # Parametric role groups created in this compunit, keyed by object id.
+    has Mu $!compunit-role-groups;
+
+    method register-compunit-role-group(Mu $group) {
+        $!compunit-role-groups{nqp::objectid($group)} := $group;
+        Nil
+    }
+    method is-compunit-role-group(Mu $group) {
+        nqp::existskey($!compunit-role-groups, nqp::objectid($group))
+    }
+
     # Count of begin-time errors that were deferred as sorries rather than
     # aborting (a trait that died, or a begin-time evaluation on a CheckTime
     # node). A package whose body raises one must not be composed, so a later
@@ -86,6 +97,8 @@ class RakuAST::Resolver {
           nqp::clone($!packages));
         nqp::bindattr($clone,RakuAST::Resolver,'$!our-package-decl-map',
           nqp::clone($!our-package-decl-map));
+        nqp::bindattr($clone,RakuAST::Resolver,'$!compunit-role-groups',
+          nqp::clone($!compunit-role-groups));
         $clone
     }
 
@@ -891,6 +904,7 @@ class RakuAST::Resolver::EVAL
         nqp::bindattr($obj, RakuAST::Resolver, '$!global', $global);
         nqp::bindattr($obj, RakuAST::Resolver, '$!attach-targets', nqp::hash());
         nqp::bindattr($obj, RakuAST::Resolver, '$!our-package-decl-map', nqp::hash());
+        nqp::bindattr($obj, RakuAST::Resolver, '$!compunit-role-groups', nqp::hash());
         my $cur-package := $obj.resolve-lexical-constant-in-outer('$?PACKAGE');
         nqp::bindattr($obj, RakuAST::Resolver, '$!packages',
             $cur-package ?? [$cur-package] !! []);
@@ -1076,6 +1090,7 @@ class RakuAST::Resolver::Compile
         nqp::bindattr($obj, RakuAST::Resolver, '$!global', $global);
         nqp::bindattr($obj, RakuAST::Resolver, '$!packages', []);
         nqp::bindattr($obj, RakuAST::Resolver, '$!our-package-decl-map', nqp::hash());
+        nqp::bindattr($obj, RakuAST::Resolver, '$!compunit-role-groups', nqp::hash());
 
         nqp::bindattr($obj, RakuAST::Resolver::Compile, '$!scopes',
           $scopes // []);

--- a/t/02-rakudo/role-group-under-core-package.t
+++ b/t/02-rakudo/role-group-under-core-package.t
@@ -1,0 +1,31 @@
+use Test;
+
+plan 5;
+
+# A parametric role declared more than once forms a role group across its
+# variants. This must work even when the compound name's first part is a setting
+# type (e.g. Hash::Sorted), where the group lives in that type's WHO; the second
+# variant must not be rejected as a redeclaration.
+
+role Hash::Variant[::T]            { method which { 'plain' } }
+role Hash::Variant[::T, :$extra!]  { method which { 'extra' } }
+
+is Hash::Variant[Int].new.which, 'plain',
+    'the first variant of a role group under a setting-named package resolves';
+is Hash::Variant[Int, :extra].new.which, 'extra',
+    'the second variant of that role group resolves, not a redeclaration';
+
+# The same holds for a non-setting compound name.
+role My::Variant[::T]           { method which { 'a' } }
+role My::Variant[::T, :$y!]     { method which { 'b' } }
+
+is My::Variant[Str].new.which, 'a',
+    'a role group under a plain compound name still resolves its first variant';
+is My::Variant[Str, :y].new.which, 'b',
+    'a role group under a plain compound name resolves its second variant';
+
+# A genuine redeclaration under a setting-named package is still rejected.
+throws-like 'class Hash::Dup { }; class Hash::Dup { }', X::Redeclaration,
+    'redeclaring a class under a setting-named package is still an error';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Declaring a parametric role more than once forms a role group across its variants. When the compound name's first part was a setting type, the second declaration failed with "Redeclaration of symbol", so a module like Hash::Sorted (`role Hash::Sorted[...]` declared twice) would not compile.

The group lives in the setting type's WHO, so on the second declaration it resolves through the setting and looks like a setting symbol, which is meant to be shadowed rather than joined. A genuine setting role group should still be shadowed, so track the role groups created in this compilation unit and join one of those even when it resolves as a setting symbol.