### PR TITLE
RakuAST: Handle a trailing :: in an indirect package lookup

### DIFF
--- a/src/Raku/ast/name.rakumod
+++ b/src/Raku/ast/name.rakumod
@@ -381,6 +381,9 @@ class RakuAST::Name
 
     method IMPL-QAST-INDIRECT-LOOKUP(RakuAST::IMPL::QASTContext $context, str :$sigil) {
         my @parts   := self.IMPL-LOOKUP-PARTS;
+        # A trailing `::` designates the package itself and adds no lookup chunk,
+        # so drop the empty final part.
+        nqp::pop(@parts) if nqp::istype(@parts[nqp::elems(@parts) - 1], RakuAST::Name::Part::Empty);
         my $final   := @parts[nqp::elems(@parts) - 1];
         my $lookups := self.IMPL-UNWRAP-LIST(self.get-implicit-lookups);
         my $result  := QAST::Op.new(

--- a/t/02-rakudo/indirect-package-trailing-empty.t
+++ b/t/02-rakudo/indirect-package-trailing-empty.t
@@ -1,0 +1,27 @@
+use Test;
+
+plan 5;
+
+# A `$var::` designates the package that is the variable's value. The trailing
+# `::` is an empty final name part; it adds no lookup, so `$p::` is the package
+# and `$p::.WHO` is its stash.
+
+my $p = Int;
+
+is $p::.WHO.^name, 'Stash',
+    'a trailing :: on a variable gives the package stash';
+ok $p:: === Int,
+    'the package designated by $p:: is the value of $p';
+is $p::<Nonesuch>:exists, False,
+    'subscripting the package designated by $p:: works';
+
+# The other indirect-lookup forms still work.
+my $n = 'Int';
+is ::($n).^name, 'Int',
+    'an indirect name lookup ::($n) still resolves';
+
+module PkgTrailingEmpty { our $sym = 42 }
+is ::PkgTrailingEmpty::<$sym>, 42,
+    'a leading :: qualified lookup still resolves';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
`$p::` designates the package that is the value of `$p`, so `$p::.WHO` is that package's stash. Compiling it died with "No such method 'IMPL-QAST-INDIRECT-LOOKUP-PART' for RakuAST::Name::Part::Empty", so modules using `$pkg::.WHO` such as UML::Translators would not compile.

A trailing `::` is an empty final name part. The indirect lookup already drops a leading empty part but iterated over a trailing one, which has no lookup chunk to contribute. Drop it too, leaving the package the earlier parts resolve to.