### PR TITLE
RakuAST: Treat a parenthesized whatever `where` as a closure

### DIFF
--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -154,6 +154,17 @@ class RakuAST::Expression
     method IMPL-ADJUST-QAST-FOR-LVALUE(Mu $qast) {
         $qast
     }
+
+    # Strip grouping parens from around a single curried expression, so
+    # `where (* > 0)` is used as the WhateverCode it is, like `where * > 0`.
+    # Otherwise a caller wraps it in an ACCEPTS block whose body re-curries and
+    # trips the double-closure check.
+    method IMPL-UNWRAP-WHERE-PARENS() {
+        nqp::istype(self, RakuAST::Circumfix::Parentheses)
+          && (my $curried := self.IMPL-SINGULAR-CURRIED-EXPRESSION)
+            ?? $curried
+            !! self
+    }
 }
 
 #-------------------------------------------------------------------------------

--- a/src/Raku/ast/signature.rakumod
+++ b/src/Raku/ast/signature.rakumod
@@ -1067,6 +1067,8 @@ class RakuAST::Parameter
     }
 
     method PERFORM-BEGIN(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
+        nqp::bindattr(self, RakuAST::Parameter, '$!where', $!where.IMPL-UNWRAP-WHERE-PARENS)
+            if $!where;
         if $!where && (! nqp::istype($!where, RakuAST::Code) || nqp::istype($!where, RakuAST::RegexThunk)) && !$!where.IMPL-CURRIED {
             my $block := RakuAST::Block.new(
                 body => RakuAST::Blockoid.new(

--- a/src/Raku/ast/type.rakumod
+++ b/src/Raku/ast/type.rakumod
@@ -1154,6 +1154,10 @@ class RakuAST::Type::Subset
         self.apply-traits($resolver, $context, self);
 
         my $block := $!block;
+        if $block {
+            $block := $block.IMPL-UNWRAP-WHERE-PARENS;
+            nqp::bindattr(self, RakuAST::Type::Subset, '$!block', $block);
+        }
         if $block
           && !$block.IMPL-CURRIED
           && (!nqp::istype($block, RakuAST::Code)

--- a/t/02-rakudo/where-paren-whatever.t
+++ b/t/02-rakudo/where-paren-whatever.t
@@ -1,0 +1,42 @@
+use Test;
+
+plan 11;
+
+# A parenthesized WhateverCode in a `where` is the same closure as the
+# unparenthesized form. `where (* > 0)` must not be mistaken for an explicit
+# block `where { * > 0 }`, which is a genuine double closure. This holds for
+# parameter, subset, and variable constraints alike.
+
+sub simple($x where (* > 0)) { $x }
+is simple(2), 2, 'where (* > 0) accepts a value that satisfies it';
+throws-like { simple(-1) }, X::TypeCheck::Binding,
+    'where (* > 0) still rejects a value that fails it';
+
+sub chained($x where (1 <= * <= 4)) { $x }
+is chained(3), 3, 'where (1 <= * <= 4) accepts an in-range value';
+throws-like { chained(9) }, X::TypeCheck::Binding,
+    'where (1 <= * <= 4) rejects an out-of-range value';
+
+# Two parameters each with a parenthesized whatever constraint, as in
+# Game::Concentration::Role.show.
+sub two($row where (1 <= * <= 4), $col where (1 <= * <= 13)) { "$row;$col" }
+is two(2, 7), '2;7', 'multiple parenthesized whatever constraints compile and bind';
+
+# A non-whatever parenthesized constraint keeps working.
+sub plain($x where (5)) { $x }
+is plain(5), 5, 'where (5) still works';
+
+# The same in a subset.
+subset Positive of Int where (* > 0);
+lives-ok { my Positive $s = 5 }, 'subset where (* > 0) accepts a valid value';
+dies-ok  { my Positive $s = -1 }, 'subset where (* > 0) rejects an invalid value';
+
+# And in a variable constraint, which routes through the subset machinery.
+lives-ok { my $v where (1 <= * <= 4) = 3 }, 'variable where (1 <= * <= 4) accepts';
+dies-ok  { my $v where (1 <= * <= 4) = 9 }, 'variable where (1 <= * <= 4) rejects';
+
+# An explicit block wrapping a whatever is still a double closure error.
+throws-like 'sub f($x where { * > 0 }) { }', X::Syntax::Malformed,
+    'where { * > 0 } is still rejected as a double closure';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
A `where (* > 0)` constraint is the same WhateverCode as `where * > 0`. The parentheses only group. The unparenthesized form is recognized as curried and used directly, but the parenthesized form was not, because `Circumfix::Parentheses` keeps an empty thunk chain (the CurryThunk sits on the inner expression) and so reports `IMPL-CURRIED` false. It was then wrapped in a synthetic `ACCEPTS($_).Bool` block. On a parameter that block's body still curries the whatever, which the double-closure check flagged as `Malformed double closure; WhateverCode is already a closure without curlies`. On a subset it merely took the wrapper path unnecessarily.

`IMPL-UNWRAP-WHERE-PARENS` drops the grouping parentheses off a `where` when they wrap a single curried expression, so it uses the curried closure directly like the unparenthesized form. The parameter and subset paths both apply it, and variable constraints route through the subset path. It reuses `IMPL-SINGULAR-CURRIED-EXPRESSION`, the same helper the currying engine uses to look inside grouping parentheses. An explicit `where { * > 0 }` block is still a genuine double closure and is still rejected.