### PR TITLE
RakuAST: Join a my-scoped role group inside a package

### DIFF
--- a/src/Raku/ast/package.rakumod
+++ b/src/Raku/ast/package.rakumod
@@ -683,7 +683,12 @@ class RakuAST::Role
     }
 
     method install-in-scope(RakuAST::Resolver $resolver, str $scope, RakuAST::Name $name, RakuAST::Name $full-name) {
-        my $found    := $resolver.resolve-name-constant($full-name, :current-scope-only(self.scope eq 'my'));
+        # Look up the group under the name this role installs with: a `my` role
+        # is lexical under its simple name, else it is in the package under its
+        # qualified name.
+        my $lexical  := $scope eq 'my';
+        my $found    := $resolver.resolve-name-constant(
+          $lexical ?? $name !! $full-name, :current-scope-only($lexical));
         my $existing := $found ?? $found.compile-time-value !! Mu;
         # A name resolving only to the setting's symbol is shadowed; one
         # declared in this compilation unit is joined (when it is a role group)

--- a/t/02-rakudo/my-role-group-in-package.t
+++ b/t/02-rakudo/my-role-group-in-package.t
@@ -1,0 +1,63 @@
+use Test;
+
+plan 6;
+
+# A `my`-scoped parametric role declared with several variants inside a package
+# body forms one role group. The later variants must join the group, not be
+# rejected as a redeclaration. A `my` role installs lexically under its simple
+# name, so the group lookup must use that name and not the package-qualified one.
+
+lives-ok {
+    EVAL q:to/CODE/;
+        class C {
+            my role R[Str $c]     { method m { "one:$c" } }
+            my role R[Str $c, $x] { method m { "two:$c:$x" } }
+            my role R[Str $c, &a] { method m { "fn:$c" } }
+        }
+    CODE
+}, 'three my-role variants in a class body form a group';
+
+lives-ok {
+    EVAL q:to/CODE/;
+        role X {
+            my role R[Str $c]     { }
+            my role R[Str $c, $x] { }
+        }
+    CODE
+}, 'my-role variants join the group inside a role body too';
+
+# The joined group dispatches to the correct variant by signature.
+my $dispatch = EVAL q:to/CODE/;
+    class D {
+        my role R[Str $c]     { method m { "one:$c" } }
+        my role R[Str $c, $x] { method m { "two:$c:$x" } }
+        method one { (Any but R["hi"]).m }
+        method two { (Any but R["hi", "there"]).m }
+    }
+    D
+CODE
+is $dispatch.one, 'one:hi',        'group dispatches to the single-arg variant';
+is $dispatch.two, 'two:hi:there',  'group dispatches to the two-arg variant';
+
+# A `my` role group still shadows an outer same-named lexical rather than
+# colliding with it, matching a top-level group.
+lives-ok {
+    EVAL q:to/CODE/;
+        my class R { }
+        class E {
+            my role R[Str $c]     { }
+            my role R[Str $c, $x] { }
+        }
+    CODE
+}, 'a my-role group inside a package shadows an outer lexical of the same name';
+
+# A genuine redeclaration is still rejected.
+throws-like q:to/CODE/, X::Redeclaration,
+    class F {
+        my role R[Str $c] { }
+        my class R { }
+    }
+    CODE
+    'redeclaring the group name as a class is still an error';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
A `my`-scoped parametric role declared with several variants inside a package body was rejected at the second variant with `Redeclaration of symbol`. At the top level it worked.

`install-in-scope` resolves an existing role group to join, then installs the new variant. The install uses the role's simple name, but the lookup used the package-qualified name from `IMPL-FULL-NAME`. For an `our` role those agree, because it lives in the enclosing package under its qualified name. For a `my` role the symbol is lexical under its simple name, so the qualified lookup missed the first variant's group and the second variant tried to install a fresh symbol over it. At the top level the qualified name equals the simple name, so it happened to work there.

This resolves by the simple name for a `my`-scoped role, matching where it is installed, so later variants join the group. A genuine redeclaration is still caught.