### PR TITLE
RakuAST: Handle a pod block before an `is repr(...)` class

### DIFF
--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -3149,13 +3149,24 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
         my $circumfix := $<circumfix>;
         if $circumfix {
             my $ast  := $circumfix.ast;
-            my $repr := nqp::istype($ast,Nodify('Circumfix'))
-                ?? $ast.IMPL-UNWRAP-LIST($ast.semilist.statements)[0]
-                !! nqp::istype($ast,Nodify('QuotedString'))
-                    ?? $ast
-                    !! nqp::die(
-                         "NYI trait_mod circumfix " ~ $ast.HOW.name($ast)
-                       );
+            my $repr;
+            if nqp::istype($ast,Nodify('Circumfix')) {
+                # A leading pod block parses into the circumfix as a Doc::Block.
+                # The circumfix is consumed here, so hand the block back for
+                # attachment to the following declaration, else it never reaches
+                # $=pod. The repr value is the remaining code statement.
+                for $ast.IMPL-UNWRAP-LIST($ast.semilist.statements) {
+                    $*DOC-BLOCKS-COLLECTED.push($_)
+                        if nqp::istype($_, Nodify('Doc::Block'));
+                }
+                $repr := $ast.semilist.code-statements[0];
+            }
+            elsif nqp::istype($ast,Nodify('QuotedString')) {
+                $repr := $ast;
+            }
+            else {
+                nqp::die("NYI trait_mod circumfix " ~ $ast.HOW.name($ast));
+            }
 
             unless $repr.IMPL-CAN-INTERPRET {
                 $/.typed-panic: 'X::Value::Dynamic',

--- a/t/02-rakudo/repr-trait-after-pod.t
+++ b/t/02-rakudo/repr-trait-after-pod.t
@@ -1,0 +1,63 @@
+use Test;
+
+plan 6;
+
+# A pod block before a class must not be taken for the `is repr(...)` value,
+# and must still reach $=pod even though the trait circumfix is consumed.
+
+my $with-pod = EVAL q:to/CODE/;
+    =begin pod
+    Some documentation.
+    =end pod
+    class WithPod is repr('CStruct') { has int64 $.frames; }
+    WithPod
+CODE
+is $with-pod.REPR, 'CStruct',
+    'is repr(...) after a pod block sets the representation';
+
+my $multi-pod = EVAL q:to/CODE/;
+    =begin pod
+    First.
+    =end pod
+    =begin pod
+    Second.
+    =end pod
+    class MultiPod is repr('CStruct') { has int32 $.rate; }
+    MultiPod
+CODE
+is $multi-pod.REPR, 'CStruct',
+    'is repr(...) after several pod blocks still sets the representation';
+
+my $dq = EVAL q:to/CODE/;
+    =begin pod
+    Doc.
+    =end pod
+    class Dq is repr("CStruct") { has int64 $.f; }
+    Dq
+CODE
+is $dq.REPR, 'CStruct',
+    'is repr(...) with a double-quoted value works after a pod block';
+
+my $no-pod = EVAL 'class NoPod is repr(\'CStruct\') { has int64 $.f; }; NoPod';
+is $no-pod.REPR, 'CStruct',
+    'is repr(...) without a pod block is unchanged';
+
+my $pod-count = EVAL q:to/CODE/;
+    =begin pod
+    Kept.
+    =end pod
+    class Kept is repr('CStruct') { has int64 $.f; }
+    $=pod.elems
+CODE
+is $pod-count, 1, 'the pod block before an is repr(...) class still reaches $=pod';
+
+my $pod-text = EVAL q:to/CODE/;
+    =begin pod
+    The text.
+    =end pod
+    class Texted is repr('CStruct') { has int64 $.f; }
+    ~$=pod[0].contents[0].contents[0]
+CODE
+is $pod-text, 'The text.', 'the preserved pod keeps its content';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
A pod block before a class parses into the following `is repr('CStruct')` trait's circumfix as a leading Doc::Block statement, so the circumfix holds two statements: the doc block and the repr value. `handle-is-repr` took the first statement of the circumfix, which was then the doc block, and reported `is repr(...) trait value must be known at compile time`.

`handle-is-repr` consumes the circumfix and drops it, so the doc block trapped inside it never reached `$=pod` either, unlike a pod block before any other class.

This reads the repr value from the circumfix's code-statements, which exclude doc blocks, and hands any doc block back to the pending collection so it attaches to the following declaration and reaches `$=pod` as it does elsewhere.