### PR TITLE
RakuAST: Serialize a WhateverCode role argument

### DIFF
--- a/src/Raku/ast/type.rakumod
+++ b/src/Raku/ast/type.rakumod
@@ -603,6 +603,15 @@ class RakuAST::Type::Parameterized
                 if $expr.has-compile-time-value {
                     $value := $expr.maybe-compile-time-value;
                 }
+                elsif nqp::istype($expr, RakuAST::Expression) && $expr.IMPL-CURRIED {
+                    # A WhateverCode argument. Compile the curry as a static
+                    # block so it is one code object with an outer frame the
+                    # compunit can serialize, rather than one built by running a
+                    # throwaway BEGIN-time thunk. Mirrors the subset `where` path.
+                    $expr.IMPL-CURRIED.IMPL-QAST-BLOCK(
+                      $context, :blocktype<declaration_static>, :expression($expr));
+                    $value := $expr.IMPL-CURRIED.meta-object;
+                }
                 elsif nqp::istype($expr, RakuAST::Expression) {
                     # IMPL-BEGIN-TIME-EVALUATE attaches a thunk to the
                     # expression by mutating its `$!thunks` attribute.
@@ -691,7 +700,25 @@ class RakuAST::Type::Parameterized
 
     method IMPL-CAN-INTERPRET() {
         nqp::istype(self.base-type, RakuAST::CompileTimeValue)
-        && $!args.IMPL-CAN-INTERPRET
+        && ($!args.IMPL-CAN-INTERPRET || self.IMPL-ARGS-COMPILE-TIME-OR-CURRIED)
+    }
+
+    # Whether every argument either has a compile-time value or is a curryable
+    # WhateverCode, which PRODUCE-META-OBJECT can compile as a static block.
+    # This lets a `does Role[* op *]` application interpret the parameterization
+    # rather than run it through a BEGIN-time thunk, whose WhateverCode closure
+    # would not survive precompilation. Any other argument (a runtime
+    # expression, a flattening `|@a`, an unresolved variable) satisfies neither
+    # branch, so the whole parameterization falls back to the thunk path
+    # unchanged. Kept next to the PRODUCE-META-OBJECT loop it must agree with.
+    method IMPL-ARGS-COMPILE-TIME-OR-CURRIED() {
+        for $!args.IMPL-UNWRAP-LIST($!args.args) -> $arg {
+            my $expr := nqp::istype($arg, RakuAST::NamedArg) ?? $arg.named-arg-value !! $arg;
+            return False
+              unless $expr.has-compile-time-value
+                  || (nqp::istype($expr, RakuAST::Expression) && $expr.IMPL-CURRIED);
+        }
+        True
     }
 
     method IMPL-INTERPRET(RakuAST::IMPL::InterpContext $ctx) {

--- a/t/02-rakudo/role-whatever-param-precomp.t
+++ b/t/02-rakudo/role-whatever-param-precomp.t
@@ -1,0 +1,62 @@
+use lib <t/packages/Test-Helpers>;
+use Test;
+use Test::Helpers;
+
+plan 4;
+
+# A role parameterized by a WhateverCode, punned into a class, must survive
+# precompilation. The WhateverCode used to be built by running a throwaway
+# BEGIN-time thunk, so the serialized closure carried an outer frame that no
+# longer matched its static frame on load:
+#   provided outer frame ... does not match expected static frame '<unit>'
+# Compiling the argument as a static block keeps the closure serializable.
+
+sub precomp-and-run($name, $source, $call, $expected, $desc) {
+    my $tmp       = make-temp-dir;
+    my $mod-store = $tmp.add('module-store');
+    $mod-store.mkdir;
+    $mod-store.add("$name.rakumod").spurt: $source;
+
+    my $proc = run :out, :err,
+        $*EXECUTABLE.absolute,
+        '-I', $mod-store.absolute,
+        '-e', "use $name; print $call";
+
+    my $out = $proc.out.slurp(:close);
+    my $err = $proc.err.slurp(:close);
+
+    subtest $desc => {
+        plan 3;
+        is  $proc.exitcode, 0, 'exits cleanly';
+        nok $err.contains('does not match expected static frame'),
+            'no outer frame mismatch';
+        is  $out, $expected, 'produces the expected result';
+    }
+}
+
+my $role = q:to/EOF/;
+proto sub infix:<precedes>($, $) is export {*}
+role Heap[&infix:<precedes> = * cmp * == Less] is export {
+    method top($a, $b) { $a precedes $b }
+}
+class MaxHeap does Heap[* cmp * == More] is export { }
+class MinHeap does Heap[* cmp * == Less] is export { }
+EOF
+
+precomp-and-run 'HeapMax', $role, 'MaxHeap.new.top(1, 2)', 'False',
+    'WhateverCode role argument (max)';
+precomp-and-run 'HeapMin', $role, 'MinHeap.new.top(1, 2)', 'True',
+    'WhateverCode role argument (min)';
+precomp-and-run 'HeapDefault', $role, 'Heap.new.top(1, 2)', 'True',
+    'the role default WhateverCode still works';
+
+# A parameterization mixing a compile-time argument with a WhateverCode must
+# also survive precompilation.
+my $mixed = q:to/EOF/;
+role R[::T, &op] is export { method go($x) { $x.&op } }
+class C does R[Int, * + 1] is export { }
+EOF
+precomp-and-run 'MixedArgs', $mixed, 'C.new.go(41)', '42',
+    'a compile-time argument alongside a WhateverCode';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
A role parameterized by a WhateverCode and punned into a class, like `class C does Role[* cmp * == More]`, died on load from a precompiled module:

    provided outer frame ... does not match expected static frame '<unit>'

`does` applies through IMPL-BEGIN-TIME-CALL, which cannot interpret a WhateverCode argument, so it wrapped the whole application in a BEGIN-time thunk and ran it. Running the thunk built the WhateverCode inside a throwaway dynamically compiled frame, so the serialized closure carried an outer frame that no longer matched its static frame the next time it was invoked. A plain block or sub argument avoided this because it is already a code object.

RakuAST::Type::Parameterized now treats a curryable WhateverCode argument as interpretable and compiles it as a static block, one code object with an outer frame the compunit serializes. `does` then interprets the parameterization instead of thunking it, the same way the subset `where` path already handles a WhateverCode. A block or sub argument is unchanged.