### PR TITLE
RakuAST: Decontainerize the value of an `INIT` prefix

### DIFF
--- a/src/Raku/ast/statementprefixes.rakumod
+++ b/src/Raku/ast/statementprefixes.rakumod
@@ -690,7 +690,10 @@ class RakuAST::StatementPrefix::Phaser::Init
     method IMPL-EXPR-QAST(RakuAST::IMPL::QASTContext $context) {
         my $container := $!container;
         $context.ensure-sc($container);
-        QAST::WVal.new( :value($container) )
+        # The cached result lives in a Scalar; hand back its value, not the
+        # container itself, so `my $x = INIT $y` sees the value like the
+        # unphased expression does.
+        QAST::Op.new( :op<decont>, QAST::WVal.new( :value($container) ) )
     }
 
     method IMPL-CALLISH-QAST(RakuAST::IMPL::QASTContext $context) {

--- a/t/02-rakudo/init-phaser-decont.t
+++ b/t/02-rakudo/init-phaser-decont.t
@@ -1,0 +1,32 @@
+use Test;
+
+plan 6;
+
+# The value of an `INIT` statement prefix is the value the block produced, not
+# the Scalar the phaser caches it in. `my $x = INIT $y` must see the same thing
+# as `my $x = $y`, so a later method call reaches the value, not a container.
+
+my $scalar = 42;
+my $init = INIT $scalar;
+isnt $init.WHAT.^name, 'Scalar', 'INIT of a container yields the value, not a container';
+is $init, 42, 'the INIT value is correct';
+is $init + 1, 43, 'the INIT value is usable as a value';
+
+# The pattern from Test::Scheduler: a container captured through INIT and used
+# as an invocant later.
+class Widget { method poke { 'poked' } }
+my $widget = Widget.new;
+my $captured = INIT $widget;
+is $captured.poke, 'poked', 'a method call reaches the value captured through INIT';
+
+# A dynamic variable behaves the same.
+my $*DYN = Widget.new;
+my $from-dyn = INIT $*DYN;
+is $from-dyn.poke, 'poked', 'INIT of a dynamic variable yields its value';
+
+# The block form is likewise decontainerized.
+my $c = 7;
+my $block-init = INIT { $c };
+isnt $block-init.WHAT.^name, 'Scalar', 'the INIT block form also yields the value';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
`my $x = INIT $y` bound the Scalar the INIT phaser caches its result in, rather than the value in it, so `$x` was a container and a later `$x.method` hit the Scalar instead of the value. It broke Test::Scheduler, which keeps `INIT $*SCHEDULER` and later calls `.cue` on it.

The phaser caches its result in a Scalar and `IMPL-EXPR-QAST` handed that Scalar straight back. Decontainerize it, so the prefix yields the value the block produced, the same as the unphased expression.