### PR TITLE
RakuAST: Fix the value of an INIT statement prefix

### DIFF
--- a/src/Raku/ast/begintime.rakumod
+++ b/src/Raku/ast/begintime.rakumod
@@ -65,6 +65,13 @@ class RakuAST::BeginTime
             )
         }
 
+        # A deferred phaser like INIT has not run at BEGIN time, so its value
+        # is whatever its cache holds, which is undefined until it runs. Hand
+        # that back rather than the block itself.
+        elsif nqp::istype($code, RakuAST::StatementPrefix::Phaser::Init) {
+            nqp::ifnull(nqp::decont($code.container), Mu)
+        }
+
         # It's already code
         elsif nqp::istype($code, RakuAST::Code) {
             $code.meta-object

--- a/src/Raku/ast/statementprefixes.rakumod
+++ b/src/Raku/ast/statementprefixes.rakumod
@@ -692,8 +692,12 @@ class RakuAST::StatementPrefix::Phaser::Init
         $context.ensure-sc($container);
         # The cached result lives in a Scalar; hand back its value, not the
         # container itself, so `my $x = INIT $y` sees the value like the
-        # unphased expression does.
-        QAST::Op.new( :op<decont>, QAST::WVal.new( :value($container) ) )
+        # unphased expression does. A block that bound nothing (e.g. it read a
+        # variable not yet bound at INIT time) leaves a null, so map that to Mu
+        # rather than leak a raw VMNull.
+        QAST::Op.new( :op<ifnull>,
+            QAST::Op.new( :op<decont>, QAST::WVal.new( :value($container) ) ),
+            QAST::WVal.new( :value(Mu) ) )
     }
 
     method IMPL-CALLISH-QAST(RakuAST::IMPL::QASTContext $context) {

--- a/src/Raku/ast/statementprefixes.rakumod
+++ b/src/Raku/ast/statementprefixes.rakumod
@@ -690,7 +690,10 @@ class RakuAST::StatementPrefix::Phaser::Init
     method IMPL-EXPR-QAST(RakuAST::IMPL::QASTContext $context) {
         my $container := $!container;
         $context.ensure-sc($container);
-        QAST::WVal.new( :value($container) )
+        # The cached result lives in a Scalar; hand back its value, not the
+        # container itself, so `my $x = INIT $y` sees the value like the
+        # unphased expression does.
+        QAST::Op.new( :op<decont>, QAST::WVal.new( :value($container) ) )
     }
 
     method IMPL-CALLISH-QAST(RakuAST::IMPL::QASTContext $context) {

--- a/t/02-rakudo/init-phaser-decont.t
+++ b/t/02-rakudo/init-phaser-decont.t
@@ -1,0 +1,32 @@
+use Test;
+
+plan 6;
+
+# The value of an `INIT` statement prefix is the value the block produced, not
+# the Scalar the phaser caches it in. `my $x = INIT $y` must see the same thing
+# as `my $x = $y`, so a later method call reaches the value, not a container.
+
+my $scalar = 42;
+my $init = INIT $scalar;
+isnt $init.WHAT.^name, 'Scalar', 'INIT of a container yields the value, not a container';
+is $init, 42, 'the INIT value is correct';
+is $init + 1, 43, 'the INIT value is usable as a value';
+
+# The pattern from Test::Scheduler: a container captured through INIT and used
+# as an invocant later.
+class Widget { method poke { 'poked' } }
+my $widget = Widget.new;
+my $captured = INIT $widget;
+is $captured.poke, 'poked', 'a method call reaches the value captured through INIT';
+
+# A dynamic variable behaves the same.
+my $*DYN = Widget.new;
+my $from-dyn = INIT $*DYN;
+is $from-dyn.poke, 'poked', 'INIT of a dynamic variable yields its value';
+
+# The block form is likewise decontainerized.
+my $c = 7;
+my $block-init = INIT { $c };
+isnt $block-init.WHAT.^name, 'Scalar', 'the INIT block form also yields the value';
+
+# vim: expandtab shiftwidth=4

--- a/t/02-rakudo/init-phaser-decont.t
+++ b/t/02-rakudo/init-phaser-decont.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 6;
+plan 8;
 
 # The value of an `INIT` statement prefix is the value the block produced, not
 # the Scalar the phaser caches it in. `my $x = INIT $y` must see the same thing
@@ -28,5 +28,17 @@ is $from-dyn.poke, 'poked', 'INIT of a dynamic variable yields its value';
 my $c = 7;
 my $block-init = INIT { $c };
 isnt $block-init.WHAT.^name, 'Scalar', 'the INIT block form also yields the value';
+
+# A block that bound no value (it read a variable not yet bound when INIT ran)
+# yields Mu, not a raw VMNull that dies on use.
+my $src = 42;
+my $alias := $src;
+my $unbound = INIT $alias;
+is $unbound.raku, 'Mu', 'INIT of a not-yet-bound variable yields Mu, not a VMNull';
+
+# A constant initialized from INIT is evaluated at BEGIN, before INIT runs, so
+# it is Mu rather than the phaser block itself.
+my $const = EVAL 'constant K = INIT 42; K';
+is $const.raku, 'Mu', 'a constant from INIT is Mu at BEGIN, not the block';
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
Reading the value of an `INIT` statement prefix produced the wrong thing in several cases, all stemming from how the phaser caches its result.

An `INIT` phaser stores its result in a `Scalar` and handed that container back as its value. So `my $x = INIT $y` bound the container rather than the value in it, and a later `$x.method` dispatched on a `Scalar` instead of the value ("No such method ... for invocant of type 'Scalar'"). This broke `Test::Scheduler`, which keeps `INIT $*SCHEDULER` and later calls `.cue` on it, so any module tested with a `Test::Scheduler` failed. The blin failure was `Concurrent::Progress`.

The first commit decontainerizes the cached value on read, so the prefix yields the value the block produced, the same as the unphased expression and the same as the `ENTER` phaser already does.

The second commit handles two related edge cases. An `INIT` block that bound nothing, for example one reading a variable not yet bound when `INIT` runs, left its cache holding a null, and reading it handed back a raw `VMNull` that died on any method call. That null now maps to `Mu`. And a `constant` initialised from `INIT` is evaluated at BEGIN, before `INIT` runs, so its value is undefined. It fell through to the already-code branch and returned the phaser block. It now returns the cache value, which is `Mu` at BEGIN, matching the legacy frontend.
