### PR TITLE
RakuAST: declare sub-signature and list-declaration type captures block-local

### DIFF
--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -110,6 +110,21 @@ class RakuAST::Code
         []
     }
 
+    # Collect the type captures a signature's parameters declare, descending
+    # into sub-signatures, which can declare captures of their own.
+    method IMPL-COLLECT-TYPE-CAPTURES($signature, @captures) {
+        my $parameters := $signature.parameters;
+        if $parameters {
+            for self.IMPL-UNWRAP-LIST($parameters) -> $param {
+                for self.IMPL-UNWRAP-LIST($param.type-captures) {
+                    nqp::push(@captures, $_);
+                }
+                my $sub := $param.sub-signature;
+                self.IMPL-COLLECT-TYPE-CAPTURES($sub, @captures) if $sub;
+            }
+        }
+    }
+
     method set-custom-args() {
         nqp::bindattr(self, RakuAST::Code, '$!custom-args', True);
     }
@@ -1452,16 +1467,10 @@ class RakuAST::Block
             nqp::push(@implicit, RakuAST::VarDeclaration::Implicit::Special.new(:name('$!')));
         }
         # Declare a parameter's type captures block-local, so they shadow
-        # rather than rebind an outer same-named capture.
+        # rather than rebind an outer same-named capture. A sub-signature can
+        # declare captures too, so descend into it.
         my $signature := self.signature;
-        if $signature {
-            for self.IMPL-UNWRAP-LIST($signature.parameters) {
-                my $type-captures := self.IMPL-UNWRAP-LIST($_.type-captures);
-                for $type-captures {
-                    nqp::push(@implicit, $_);
-                }
-            }
-        }
+        self.IMPL-COLLECT-TYPE-CAPTURES($signature, @implicit) if $signature;
         @implicit
     }
 
@@ -2091,11 +2100,8 @@ class RakuAST::Routine
                     $exclamation-mark := 0 if $name eq '$!';
                     $underscore := 0       if $name eq '$_';
                 }
-                my $type-captures := self.IMPL-UNWRAP-LIST($_.type-captures);
-                for $type-captures {
-                    nqp::push(@declarations, $_);
-                }
             }
+            self.IMPL-COLLECT-TYPE-CAPTURES($!signature, @declarations);
             # A special variable bound inside a sub-signature, such as the $_ in
             # `(:value($_))`, is not a top-level parameter, so catch it too.
             $slash := 0            if $slash && $!signature.IMPL-HAS-PARAMETER('$/');

--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -110,21 +110,6 @@ class RakuAST::Code
         []
     }
 
-    # Collect the type captures a signature's parameters declare, descending
-    # into sub-signatures, which can declare captures of their own.
-    method IMPL-COLLECT-TYPE-CAPTURES($signature, @captures) {
-        my $parameters := $signature.parameters;
-        if $parameters {
-            for self.IMPL-UNWRAP-LIST($parameters) -> $param {
-                for self.IMPL-UNWRAP-LIST($param.type-captures) {
-                    nqp::push(@captures, $_);
-                }
-                my $sub := $param.sub-signature;
-                self.IMPL-COLLECT-TYPE-CAPTURES($sub, @captures) if $sub;
-            }
-        }
-    }
-
     method set-custom-args() {
         nqp::bindattr(self, RakuAST::Code, '$!custom-args', True);
     }
@@ -1470,7 +1455,7 @@ class RakuAST::Block
         # rather than rebind an outer same-named capture. A sub-signature can
         # declare captures too, so descend into it.
         my $signature := self.signature;
-        self.IMPL-COLLECT-TYPE-CAPTURES($signature, @implicit) if $signature;
+        $signature.IMPL-COLLECT-TYPE-CAPTURES(@implicit) if $signature;
         @implicit
     }
 
@@ -2101,7 +2086,7 @@ class RakuAST::Routine
                     $underscore := 0       if $name eq '$_';
                 }
             }
-            self.IMPL-COLLECT-TYPE-CAPTURES($!signature, @declarations);
+            $!signature.IMPL-COLLECT-TYPE-CAPTURES(@declarations);
             # A special variable bound inside a sub-signature, such as the $_ in
             # `(:value($_))`, is not a top-level parameter, so catch it too.
             $slash := 0            if $slash && $!signature.IMPL-HAS-PARAMETER('$/');

--- a/src/Raku/ast/signature.rakumod
+++ b/src/Raku/ast/signature.rakumod
@@ -399,6 +399,20 @@ class RakuAST::Signature
         $visitor($!returns) if $!returns;
     }
 
+    # Push the type captures declared by this signature's parameters onto
+    # @captures, descending into sub-signatures, which can declare captures of
+    # their own. Used to surface them as block-local declarations so they
+    # shadow rather than rebind an outer same-named capture.
+    method IMPL-COLLECT-TYPE-CAPTURES(@captures) {
+        for self.IMPL-UNWRAP-LIST(self.parameters) -> $param {
+            for self.IMPL-UNWRAP-LIST($param.type-captures) {
+                nqp::push(@captures, $_);
+            }
+            my $sub := $param.sub-signature;
+            $sub.IMPL-COLLECT-TYPE-CAPTURES(@captures) if $sub;
+        }
+    }
+
     method IMPL-PARAM-POSITION(RakuAST::Parameter $param) {
         my $i := 0;
         my $found := 0;

--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -1728,6 +1728,7 @@ class RakuAST::VarDeclaration::Auto
 class RakuAST::VarDeclaration::Signature
   is RakuAST::Declaration
   is RakuAST::ImplicitLookups
+  is RakuAST::ImplicitDeclarations
   is RakuAST::TraitTarget
   is RakuAST::BeginTime
   is RakuAST::Term
@@ -1780,6 +1781,15 @@ class RakuAST::VarDeclaration::Signature
         # Overridden here because our-scoped variables are really lexical aliases.
         my str $scope := self.scope;
         $scope eq 'my' || $scope eq 'state' || $scope eq 'our'
+    }
+
+    # A list declaration such as `my (::T, $x) := ...` binds its type captures
+    # into the enclosing scope. Surface them so they get a frame slot, matching
+    # how a routine or block declares its own signature's captures.
+    method PRODUCE-IMPLICIT-DECLARATIONS() {
+        my @declarations;
+        self.signature.IMPL-COLLECT-TYPE-CAPTURES(@declarations);
+        @declarations
     }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {

--- a/t/02-rakudo/subsig-type-capture.t
+++ b/t/02-rakudo/subsig-type-capture.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 7;
+plan 10;
 
 # A type capture declared in a sub-signature (`$p (::T, ...)`) must create a
 # block-local `T`, both so the binder can store into it and so the body can
@@ -38,5 +38,18 @@ is nested(((1,), 'z')), 'Int Str', 'nested sub-signature captures each resolve';
 # A top-level capture still works alongside.
 sub both(::Top $x, $p ($n, ::T)) { Top.^name ~ ' ' ~ T.^name }
 is both(1, (2, 'w')), 'Int Str', 'top-level and sub-signature captures coexist';
+
+# List declaration `my (::T, ...) := ...` binds its captures into the
+# enclosing scope.
+my (::LT, $lx) := (Int, 5);
+is LT, Int, 'a list-declaration type capture is visible';
+
+# The captured type is usable as a constraint on a later declaration.
+my LT $constrained = 3;
+is $constrained, 3, 'a list-declaration type capture works as a constraint';
+
+# Nested list declaration captures each resolve.
+my (::NT, (::NU, $ny)) := (Int, (Str, 'x'));
+is NT.^name ~ ' ' ~ NU.^name, 'Int Str', 'nested list-declaration captures each resolve';
 
 # vim: expandtab shiftwidth=4

--- a/t/02-rakudo/subsig-type-capture.t
+++ b/t/02-rakudo/subsig-type-capture.t
@@ -1,0 +1,42 @@
+use Test;
+
+plan 7;
+
+# A type capture declared in a sub-signature (`$p (::T, ...)`) must create a
+# block-local `T`, both so the binder can store into it and so the body can
+# refer to it. RakuAST only declared captures from top-level parameters, so a
+# sub-signature capture was missing from the frame.
+
+# Pointy block (the form Configuration::Utils uses).
+for ((1, 'x'),) -> $p ($n, ::T) {
+    is T, Str, 'a pointy-block sub-signature type capture is visible';
+}
+
+# Declared but never used in the body, as Configuration::Utils does.
+lives-ok {
+    for ((1, 'x'),) -> $p ($n, ::T, |) { }
+}, 'an unused sub-signature type capture binds without error';
+
+# Subroutine.
+sub in-sub($p ($n, ::T)) { T }
+is in-sub((1, 'x')), Str, 'a sub sub-signature type capture is visible';
+
+# Method.
+class C {
+    method m($p ($n, ::T)) { T }
+}
+is C.m((1, 42)), Int, 'a method sub-signature type capture is visible';
+
+# Named sub-signature capture attached to a named parameter.
+sub named-cap($p (::T :$value, |)) { T }
+is named-cap({ value => 'y' }), Str, 'a named sub-signature type capture is visible';
+
+# Nested sub-signatures each declare their own capture.
+sub nested($p ($n (::U), ::T)) { U.^name ~ ' ' ~ T.^name }
+is nested(((1,), 'z')), 'Int Str', 'nested sub-signature captures each resolve';
+
+# A top-level capture still works alongside.
+sub both(::Top $x, $p ($n, ::T)) { Top.^name ~ ' ' ~ T.^name }
+is both(1, (2, 'w')), 'Int Str', 'top-level and sub-signature captures coexist';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously a type capture declared in a sub-signature or a list declaration was never given a frame slot, so referring to it died with `Lexical with name 'T' does not exist in this frame`.

```raku
for %h.kv -> $p ($n, ::T) { }          # died
sub f($p (::T :$value, |)) { }         # died
my (::T, $x) := (Int, 5); say T;       # died
```

PRODUCE-IMPLICIT-DECLARATIONS only walked the top-level parameters when collecting type captures, so a capture nested in a sub-signature was skipped. A routine or block surfaces its own signature's captures this way, but a my (...) declaration binds against a signature it holds rather than one it is, so nothing surfaced its captures at all.

The first commit walks a parameter's sub-signatures when collecting captures, so a routine or block declares the captures nested in its signature. The second moves that walk onto `RakuAST::Signature`, where the parameters and sub-signatures it descends already live, and has `RakuAST::VarDeclaration::Signature` surface its signature's captures the same way, so a list declaration and its nested sub-signatures each get their slots.

Fixes the Configuration ecosystem module, whose accessor loop reads for `$obj.^attributes.grep(*.has_accessor) -> Attribute $attr (::T :$type, |) { }`