### PR TITLE
RakuAST: fire a once in phaser and start bodies

### DIFF
--- a/src/Raku/ast/statementprefixes.rakumod
+++ b/src/Raku/ast/statementprefixes.rakumod
@@ -266,6 +266,27 @@ class RakuAST::StatementPrefix::Thunky
         }
     }
 
+    # True for a thunk that runs once per program (a compile or init phaser).
+    method IMPL-THUNK-RUNS-ONCE() { False }
+
+    # Gather the state variables the thunked statement declares, without
+    # descending into a nested block, which keeps its own state.
+    method IMPL-COLLECT-THUNK-STATE-DECLS($node, @decls) {
+        return Nil if nqp::istype($node, RakuAST::Block);
+        if nqp::istype($node, RakuAST::ImplicitDeclarations) {
+            for self.IMPL-UNWRAP-LIST($node.get-implicit-declarations()) -> $decl {
+                if nqp::istype($decl, RakuAST::VarDeclaration::Implicit::State)
+                    && $decl.is-simple-lexical-declaration {
+                    nqp::push(@decls, $decl);
+                }
+            }
+        }
+        $node.visit-children(-> $child {
+            self.IMPL-COLLECT-THUNK-STATE-DECLS($child, @decls) if nqp::isconcrete($child);
+        });
+        Nil
+    }
+
     method IMPL-QAST-FORM-BLOCK(RakuAST::IMPL::QASTContext $context,
             str :$blocktype, RakuAST::Expression :$expression) {
         if nqp::istype(self.blorst, RakuAST::Block) {
@@ -288,6 +309,15 @@ class RakuAST::StatementPrefix::Thunky
                     if nqp::istype($decl, RakuAST::VarDeclaration::Implicit::State) && $decl.is-simple-lexical-declaration {
                         nqp::push($stmts, $decl.IMPL-QAST-DECL($context));
                     }
+                }
+            }
+            # Declare that state here. Left in the enclosing scope, its
+            # p6stateinit never fires for the thunk call and `once` is skipped.
+            if self.IMPL-THUNK-RUNS-ONCE {
+                my @state-decls := nqp::list();
+                self.IMPL-COLLECT-THUNK-STATE-DECLS(self.blorst, @state-decls);
+                for @state-decls -> $decl {
+                    nqp::push($stmts, $decl.IMPL-QAST-DECL($context));
                 }
             }
             $stmts.push(self.IMPL-QAST-NESTED-BLOCK-DECLS($context));
@@ -583,6 +613,8 @@ class RakuAST::StatementPrefix::Phaser::Begin
 
     method type() { "BEGIN" }
 
+    method IMPL-THUNK-RUNS-ONCE() { True }
+
     # Perform BEGIN-time evaluation.
     method PERFORM-BEGIN(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
         self.IMPL-STUB-CODE($resolver, $context);
@@ -641,6 +673,8 @@ class RakuAST::StatementPrefix::Phaser::Check
 
     method type() { "CHECK" }
 
+    method IMPL-THUNK-RUNS-ONCE() { True }
+
     method new(RakuAST::Blorst $blorst) {
         my $obj := nqp::create(self);
         nqp::bindattr($obj, RakuAST::StatementPrefix, '$!blorst', $blorst);
@@ -674,6 +708,8 @@ class RakuAST::StatementPrefix::Phaser::Init
     has Scalar $.container;
 
     method type() { "INIT" }
+
+    method IMPL-THUNK-RUNS-ONCE() { True }
 
     method new(RakuAST::Blorst $blorst) {
         my $obj := nqp::create(self);
@@ -742,6 +778,8 @@ class RakuAST::StatementPrefix::Phaser::End
   is RakuAST::BeginTime
 {
     method type() { "END" }
+
+    method IMPL-THUNK-RUNS-ONCE() { True }
 
     method PERFORM-BEGIN(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
         $resolver.find-attach-target('compunit').add-end-phaser(self.meta-object);

--- a/src/Raku/ast/statementprefixes.rakumod
+++ b/src/Raku/ast/statementprefixes.rakumod
@@ -443,22 +443,35 @@ class RakuAST::StatementPrefix::Once
   is RakuAST::ImplicitDeclarations
 {
     has str $!state-name;
+    has RakuAST::VarDeclaration::Implicit::State $!state-decl;
 
     method type() { "once" }
 
     method PRODUCE-IMPLICIT-DECLARATIONS() {
         my $state-name := QAST::Node.unique('once_');
         nqp::bindattr_s(self, RakuAST::StatementPrefix::Once, '$!state-name', $state-name);
+        my $state-decl := RakuAST::VarDeclaration::Implicit::State.new($state-name, :sentinel);
+        nqp::bindattr(self, RakuAST::StatementPrefix::Once, '$!state-decl', $state-decl);
 
         [
-            RakuAST::VarDeclaration::Implicit::State.new($state-name)
+            $state-decl
         ]
     }
 
     method IMPL-EXPR-QAST(RakuAST::IMPL::QASTContext $context) {
+        # The state variable starts out holding a private sentinel. Testing
+        # its value rather than nqp::p6stateinit makes the once fire exactly
+        # once per clone of the frame that owns the variable, even when the
+        # once runs inside a phaser or other thunk with a frame of its own.
+        my $sentinel := $!state-decl.sentinel-value;
+        $context.ensure-sc($sentinel);
         QAST::Op.new(:op<decont>,
           QAST::Op.new(:op<if>,
-            QAST::Op.new(:op<p6stateinit>),
+            QAST::Op.new(:op<eqaddr>,
+              QAST::Op.new(:op<decont>,
+                QAST::Var.new(:name($!state-name), :scope<lexical>)),
+              QAST::WVal.new(:value($sentinel))
+            ),
             QAST::Op.new(:op<p6store>,
               QAST::Var.new(:name($!state-name), :scope<lexical>),
               QAST::Op.new(:op<call>, self.IMPL-CLOSURE-QAST($context))
@@ -763,6 +776,16 @@ class RakuAST::StatementPrefix::Phaser::Enter
 
     method IMPL-RESULT-NAME() {
         $!result-name
+    }
+
+    # Call the phaser's code object directly rather than a fresh clone per
+    # entry, so state a `once` or `state` in the body holds persists across
+    # entries. The outer frame is resolved from the running enclosing frame,
+    # so the body still sees the current entry's lexicals.
+    method IMPL-CALLISH-QAST(RakuAST::IMPL::QASTContext $context) {
+        my $block := self.meta-object;
+        $context.ensure-sc($block);
+        QAST::Op.new( :op('call'), QAST::WVal.new( :value($block) ) )
     }
 
     method IMPL-EXPR-QAST(RakuAST::IMPL::QASTContext $context) {

--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -2591,14 +2591,21 @@ class RakuAST::VarDeclaration::Implicit::State
   is RakuAST::Meta
 {
     has int $!init-to-zero;
+    has Mu $!sentinel-value;
 
-    method new(str $name, int :$init-to-zero) {
+    method new(str $name, int :$init-to-zero, int :$sentinel) {
         my $obj := nqp::create(self);
         nqp::bindattr_s($obj, RakuAST::VarDeclaration::Implicit, '$!name', $name);
         nqp::bindattr_s($obj, RakuAST::Declaration, '$!scope', 'state');
         nqp::bindattr_i($obj, RakuAST::VarDeclaration::Implicit::State, '$!init-to-zero', $init-to-zero // 0);
+        # A private initial value no user code can produce, so a first read of
+        # the variable is recognizable by value.
+        nqp::bindattr($obj, RakuAST::VarDeclaration::Implicit::State, '$!sentinel-value',
+            $sentinel ?? nqp::create(Mu) !! Mu);
         $obj
     }
+
+    method sentinel-value() { $!sentinel-value }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
         $!init-to-zero ?? [
@@ -2617,6 +2624,8 @@ class RakuAST::VarDeclaration::Implicit::State
         if $!init-to-zero {
             my $Int := self.IMPL-UNWRAP-LIST(self.get-implicit-lookups)[0].compile-time-value;
             nqp::bindattr($container, Scalar, '$!value', nqp::box_i(0, $Int));
+        } elsif nqp::isconcrete($!sentinel-value) {
+            nqp::bindattr($container, Scalar, '$!value', $!sentinel-value);
         } else {
             nqp::bindattr($container, Scalar, '$!value', $descriptor.default);
         }

--- a/t/02-rakudo/once-in-phasers.t
+++ b/t/02-rakudo/once-in-phasers.t
@@ -1,0 +1,57 @@
+use Test;
+
+plan 8;
+
+{
+    my $n = 0;
+    sub f { ENTER once { $n++ } }
+    f() for ^3;
+    is $n, 1, 'ENTER once in a sub fires on the first entry only';
+}
+
+{
+    my $n = 0;
+    sub f { ENTER { once { $n++ } } }
+    f() for ^3;
+    is $n, 1, 'a once inside an ENTER block fires on the first entry only';
+}
+
+{
+    my @r;
+    sub f { ENTER { state $x = 0; @r.push($x++) } }
+    f() for ^3;
+    is-deeply @r, [0, 1, 2], 'state in an ENTER block persists across entries';
+}
+
+{
+    my @seen;
+    sub f($x) { ENTER { @seen.push($x) } }
+    f(1);
+    f(2);
+    is-deeply @seen, [1, 2], "an ENTER body reads the current entry's arguments";
+}
+
+{
+    my $n = 0;
+    for ^3 { ENTER once { $n++ } }
+    is $n, 1, 'ENTER once in a loop body fires on the first iteration only';
+}
+
+{
+    my $r = await start once { 42 };
+    is $r, 42, 'a once as the body of start runs';
+}
+
+{
+    my $n = 0;
+    sub f { once { $n++ } }
+    f() for ^3;
+    is $n, 1, 'a plain once in a sub still fires once';
+}
+
+{
+    my @a = gather { for ^3 { once { take 9 }; take 1 } };
+    is-deeply @a, [9, 1, 1, 1], 'a once inside gather fires on the first iteration only';
+}
+
+# vim: expandtab shiftwidth=4

--- a/t/02-rakudo/phaser-once-state.t
+++ b/t/02-rakudo/phaser-once-state.t
@@ -1,0 +1,24 @@
+use Test;
+
+plan 4;
+
+# A `once` directly under a run-once phaser (INIT, BEGIN) keeps its state in
+# the phaser's own thunk. RakuAST left that state in the enclosing scope, whose
+# state init never fired for the thunk call, so the body was skipped.
+
+my $init;
+INIT once { $init = 'ran' }
+is $init, 'ran', 'INIT once runs its body';
+
+my $begin;
+BEGIN once { $begin = 'ran' }
+is $begin, 'ran', 'BEGIN once runs its body';
+
+my $val = INIT once 42;
+is $val, 42, 'INIT once yields its value';
+
+my @log;
+INIT once { @log.push: 'a'; @log.push: 'b' }
+is @log.join(','), 'a,b', 'INIT once runs a multi-statement body';
+
+# vim: expandtab shiftwidth=4

--- a/t/12-rakuast/xx-fixed-in-rakuast.rakutest
+++ b/t/12-rakuast/xx-fixed-in-rakuast.rakutest
@@ -2,7 +2,7 @@ use Test;
 use lib <t/packages/Test-Helpers>;
 use Test::Helpers;
 
-plan 111;
+plan 114;
 
 # t/spec/S03-sequence/misc.t
 # https://github.com/rakudo/rakudo/issues/5520
@@ -805,6 +805,29 @@ subtest 'use of &?ROUTINE and &?BLOCK' => {
     my $s2 = BEGIN EVAL 'sub { 1 + 2 }';
     is $s2(), 3,
       'BEGIN-time string-EVAL Sub with setting operator runs';
+}
+
+# A once fires once per clone of the scope that holds its state. The legacy
+# frontend re-runs a once in a LEAVE or UNDO body on every exit, because the
+# exit handler clones the phaser fresh each time, and shares one ENTER once
+# across all clones of the enclosing routine, because it never clones the
+# phaser at all.
+{
+    my $n = 0;
+    Q| sub f { LEAVE once { $n++ } }; f() for ^3 |.AST.EVAL;
+    is $n, 1, 'a once in a LEAVE body fires once across calls of one clone';
+}
+
+{
+    my $n = 0;
+    Q| sub f { UNDO once { $n++ }; fail 'x' }; (try f()) for ^3 |.AST.EVAL;
+    is $n, 1, 'a once in an UNDO body fires once across calls of one clone';
+}
+
+{
+    my @fires;
+    Q| sub mk { sub { ENTER once { @fires.push('x') } } }; my $a = mk; my $b = mk; $a(); $a(); $b() |.AST.EVAL;
+    is +@fires, 2, 'each clone of a routine runs its ENTER once independently';
 }
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously a `once` written directly under a phaser, as in `INIT once { ... }` or `ENTER once { ... }`, never ran its body, and neither did `start once { ... }`. The once's state variable lives in the enclosing scope, but the phaser thunks the statement into a block of its own. The thunk call runs in a fresh frame whose state init never fires for that outer variable, so `nqp::p6stateinit` stayed false and the body was skipped. An ENTER block additionally got a fresh clone on every entry, so state the block itself held reset each time.

```raku
my $x;
INIT once { $x = 42 }
say $x;       # previously (Any), now 42

sub f { ENTER once { say "setup" } }
f; f; f;      # previously never said anything, now says "setup" once

my @r;
sub g { ENTER { state $s = 0; @r.push($s++) } }
g; g; g;
say @r;       # previously [0 0 0], now [0 1 2]

say await start once { 42 };   # previously (Any), the body never ran
```

The first commit handles the phasers that run exactly once for the whole program (BEGIN, CHECK, INIT, END). The state the thunked statement holds is declared inside the thunk block itself, so `nqp::p6stateinit` fires on the single call.

The second commit handles the per-entry bodies, where that placement would be wrong because the thunk runs many times. The once state variable now starts out holding a private sentinel, and the once tests that value rather than `nqp::p6stateinit`. It then fires exactly once per clone of the frame that owns the variable, no matter which frame the once itself runs in. ENTER now also calls its code object directly instead of cloning it per entry, the way INIT already does and the way the legacy frontend calls ENTER, so state an ENTER block holds persists across entries.

The per-entry behavior deliberately diverges from the legacy frontend where legacy is inconsistent with itself. A once in a LEAVE or UNDO body fires once per clone of the enclosing scope. Legacy re-fires it on every exit because the exit handler clones the phaser fresh each time, which makes the `once` do nothing. An ENTER once fires once per clone of the enclosing routine. Legacy shares a single firing across all clones because it never clones the phaser at all. Roast pins none of this. The frontend-agreeing cases are tested in `t/02-rakudo/phaser-once-state.t` and `t/02-rakudo/once-in-phasers.t`, and the divergent ones in `xx-fixed-in-rakuast.rakutest`, which forces the RakuAST frontend via `.AST.EVAL`.

State declared inside a LEAVE block still resets per exit on both frontends, since the exit handler must clone the phaser to close it over the exiting frame.
