### PR TITLE
Make Blob stringification agree across every route

### DIFF
--- a/src/core.c/Buf.rakumod
+++ b/src/core.c/Buf.rakumod
@@ -1454,10 +1454,6 @@ my constant buf16 = Buf[uint16];
 my constant buf32 = Buf[uint32];
 my constant buf64 = Buf[uint64];
 
-multi sub prefix:<~>(Blob:D \a) {
-    X::Buf::AsStr.new(object => a, method => '~' ).throw
-}
-
 multi sub infix:<~>(Blob:D $a) { $a }
 multi sub infix:<~>(Blob:D $a, Blob:D $b) {
     my $res := nqp::create(nqp::eqaddr($a.WHAT,$b.WHAT) ?? $a !! Buf.^pun);

--- a/src/core.c/Exception.rakumod
+++ b/src/core.c/Exception.rakumod
@@ -1253,9 +1253,11 @@ my class X::Buf::AsStr is Exception {
     has $.object;
     has $.method;
     method message() {
-        my $message = $.method.starts-with('Str')
-          ?? "Stringification of a {$.object.^name} is not done with '$.method'"
-          !! "A {$.object.^name} is not a Str, so using '$.method' will not work";
+        my $message = $.method eq 'Stringy'
+          ?? "Stringification of a {$.object.^name} is not done with 'Stringy', which the '~' operator uses"
+          !! $.method.starts-with('Str')
+            ?? "Stringification of a {$.object.^name} is not done with '$.method'"
+            !! "A {$.object.^name} is not a Str, so using '$.method' will not work";
         ($message ~ ". The 'decode' method should be used to convert a {$.object.^name} to a Str."
         ).naive-word-wrapper
     }

--- a/src/core.c/Rakudo/Internals.rakumod
+++ b/src/core.c/Rakudo/Internals.rakumod
@@ -1711,7 +1711,9 @@ my class Rakudo::Internals {
           &[%], -> Mu \a, Mu \b { a = a.DEFINITE ?? a % b !! "infix:<%>".no-zero-arg },
           &[-], -> Mu \a, Mu \b { a = a.DEFINITE ?? a - b !! -b },
           &[*], -> Mu \a, Mu \b { a = a.DEFINITE ?? a * b !! +b },
-          &[~], -> Mu \a, Mu \b { a = a.DEFINITE ?? a ~ b !! ~b },
+          # '' ~ b rather than ~b, mirroring the generic case, which
+          # concatenates the zero-arg identity with b
+          &[~], -> Mu \a, Mu \b { a = a.DEFINITE ?? a ~ b !! '' ~ b },
         ) -> \op, \metaop {
             metaop.set_name(op.name ~ ' + {assigning}');
             nqp::bindkey($metaop_assign, nqp::objectid(op), metaop);

--- a/t/02-rakudo/metaop-assign-concat-blob.t
+++ b/t/02-rakudo/metaop-assign-concat-blob.t
@@ -1,0 +1,38 @@
+use Test;
+
+plan 5;
+
+# Assigning-concat with an undefined left side takes the identity path of
+# METAOP_ASSIGN, which must concatenate like the defined path does.
+
+{
+    my $x;
+    $x ~= 'abc'.encode;
+    is $x, 'abc', 'undefined variable ~= a Blob stringifies the Blob';
+}
+
+{
+    my Str $r;
+    $r ~= 'abc'.encode;
+    is $r, 'abc', 'undefined Str-typed variable ~= a Blob stringifies the Blob';
+}
+
+{
+    my $x;
+    &infix:<~=>($x, 'abc'.encode);
+    is $x, 'abc', 'the indirect &infix:<~=> call form stringifies the Blob';
+}
+
+{
+    my $x = 'x';
+    $x ~= 'abc'.encode;
+    is $x, 'xabc', 'defined variable ~= a Blob still concatenates';
+}
+
+{
+    my $x;
+    $x ~= 'abc';
+    is $x, 'abc', 'undefined variable ~= a Str still works';
+}
+
+# vim: expandtab shiftwidth=4

--- a/t/02-rakudo/prefix-tilde-blob.t
+++ b/t/02-rakudo/prefix-tilde-blob.t
@@ -1,0 +1,34 @@
+use Test;
+
+plan 8;
+
+# Prefix ~ defers to a Blob type's own Stringy, so the encoding-carrying
+# types decode like they do for .Str, .Stringy, interpolation, and infix ~,
+# while an encoding-less Blob still refuses.
+
+{
+    my $b = 'abc'.encode;
+    is ~$b, 'abc', 'prefix ~ on a utf8 decodes';
+    isa-ok ~$b, Str, 'prefix ~ on a utf8 gives a Str';
+}
+
+is ~'abc'.encode('utf16'), 'abc', 'prefix ~ on a utf16 decodes';
+
+throws-like { ~Buf.new(65) }, X::Buf::AsStr,
+    message => rx/"'~'"/,
+    'prefix ~ on a Buf still throws, naming the ~ operator';
+
+throws-like { '' ~ Buf.new(65) }, X::Buf::AsStr,
+    message => rx/"'~'"/,
+    'concatenating a Buf throws, naming the ~ operator';
+
+throws-like { ~Buf.new(65) }, X::Buf::AsStr,
+    message => rx/decode/,
+    'the error still suggests decode';
+
+throws-like { ~Blob.new(65) }, X::Buf::AsStr,
+    'prefix ~ on a Blob still throws';
+
+is 'abc'.encode ~ 'bar', 'abcbar', 'infix ~ with a utf8 still concatenates';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously the same Blob could stringify or throw depending on which route the stringification took.

```raku
my $x; $x ~= "abc".encode;  # died: A utf8 is not a Str, so using '~' will not work
say ~"abc".encode;          # died the same way
say "" ~ "abc".encode;      # abc
say "abc".encode.Str;       # abc
say "x{"abc".encode}y";     # xabcy
```

The first commit fixes assigning-concat with an undefined left side. The `METAOP_ASSIGN` fast path for `~` handled that case with prefix `~b`, which refuses a Blob, while the defined path and the generic `METAOP_ASSIGN` fallback both concatenate, which stringifies through `.Stringy`. The same statement behaved three different ways depending on the path taken: the legacy optimizer's inlining works, the generic fallback works, and the fast path dies. The RakuAST frontend always calls the fast path, which broke HTTP::Tiny's test suite, and the legacy frontend reaches it too through `&infix:<~=>` or with the optimizer off. The fast path now uses `'' ~ b`, mirroring the generic case.

The second commit restores prefix `~` on the encoding-carrying Blob types. c94f5db60 gave utf8, utf16, and utf32 a `Str` and `Stringy` of `self.decode`, and `~$utf8` decoded through the general prefix `~`, which defers to `Stringy`. 539e96c26 then added a `prefix:<~>(Blob:D)` candidate so the error for stringifying a Buf names `~` and suggests `.decode`, and being narrower than the general candidate it also captured the encoding-carrying types, turning `~$utf8` into a throw. The candidate is removed, so the type's own `Stringy` decides again, and 539e96c26's goal moves into the message: the `Stringy` error says the `~` operator is what uses it, so every spelling still leads to `.decode`.

After both, every route agrees. utf8, utf16, and utf32 stringify by decoding, and an encoding-less Blob or Buf throws `X::Buf::AsStr` everywhere, with the same `.decode` guidance.
