### PR TITLE
RakuAST: box the evaluated argument of pragmas, use, import, and require

### DIFF
--- a/src/Raku/ast/begintime.rakumod
+++ b/src/Raku/ast/begintime.rakumod
@@ -84,6 +84,21 @@ class RakuAST::BeginTime
         }
     }
 
+    # Evaluate the argument of a pragma, use, import, or require into an
+    # argument list, boxing the result, which is consumed as a Raku List.
+    method IMPL-BEGIN-TIME-ARGLIST(
+                   RakuAST::Node $argument,
+               RakuAST::Resolver $resolver,
+      RakuAST::IMPL::QASTContext $context
+    ) {
+        $argument
+          ?? nqp::hllizefor(
+               self.IMPL-BEGIN-TIME-EVALUATE($argument, $resolver, $context),
+               'Raku'
+             ).List.FLATTENABLE_LIST
+          !! Nil
+    }
+
     # Called when a BEGIN-time construct wants to evaluate a resolved code
     # with a set of arguments.
     method IMPL-BEGIN-TIME-CALL(

--- a/src/Raku/ast/pragma.rakumod
+++ b/src/Raku/ast/pragma.rakumod
@@ -80,11 +80,8 @@ class RakuAST::Pragma
         my $name    := $!name;
         my $LANG    := $*LANG;
         my int $on  := nqp::not_i($!off);
-        my $arglist := $!argument
-          ?? self.IMPL-BEGIN-TIME-EVALUATE(
-               $!argument, $resolver, $context
-             ).List.FLATTENABLE_LIST
-          !! Nil;
+        my $arglist :=
+          self.IMPL-BEGIN-TIME-ARGLIST($!argument, $resolver, $context);
 
         if self.IS-NYI($name) {
             $resolver.build-exception(

--- a/src/Raku/ast/statements.rakumod
+++ b/src/Raku/ast/statements.rakumod
@@ -2037,9 +2037,7 @@ class RakuAST::Statement::Use
             $ex.rethrow;
         }
         # Evaluate the argument to the module load, if any.
-        my $arglist := $!argument
-            ?? self.IMPL-BEGIN-TIME-EVALUATE($!argument, $resolver, $context).List.FLATTENABLE_LIST
-            !! Nil;
+        my $arglist := self.IMPL-BEGIN-TIME-ARGLIST($!argument, $resolver, $context);
 
         my $comp-unit := self.IMPL-LOAD-MODULE($resolver, $context, $!module-name);
         self.IMPL-IMPORT($resolver, $comp-unit.handle, $arglist, :module($!module-name.canonicalize));
@@ -2125,9 +2123,7 @@ class RakuAST::Statement::Import
 
     method PERFORM-BEGIN(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
         # Evaluate the argument to the import, if any.
-        my $arglist := $!argument
-            ?? self.IMPL-BEGIN-TIME-EVALUATE($!argument, $resolver, $context).List.FLATTENABLE_LIST
-            !! Nil;
+        my $arglist := self.IMPL-BEGIN-TIME-ARGLIST($!argument, $resolver, $context);
 
         my $module := self.resolution.compile-time-value;
         my $CompUnitHandle := self.IMPL-UNWRAP-LIST(self.get-implicit-lookups())[0].compile-time-value;
@@ -2175,9 +2171,7 @@ class RakuAST::Statement::Require
 
     method PERFORM-BEGIN(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
         # Evaluate the argument to the import, if any.
-        my @arglist := $!argument
-            ?? self.IMPL-BEGIN-TIME-EVALUATE($!argument, $resolver, $context).List.FLATTENABLE_LIST
-            !! Nil;
+        my @arglist := self.IMPL-BEGIN-TIME-ARGLIST($!argument, $resolver, $context);
         nqp::bindattr(self, RakuAST::Statement::Require, '$!arglist', @arglist);
 
         my $target-scope := $resolver.current-scope;

--- a/t/02-rakudo/use-lib-interpolated.t
+++ b/t/02-rakudo/use-lib-interpolated.t
@@ -1,0 +1,20 @@
+use Test;
+
+plan 3;
+
+# The path only has a value at BEGIN time, as in the common
+# `use lib "{$*PROGRAM.dirname}/../lib"` pattern.
+{
+    use lib "{$*PROGRAM.dirname}/lib";
+    pass 'use lib with a block interpolation compiles';
+}
+
+use MONKEY-SEE-NO-EVAL;
+
+lives-ok { EVAL 'use lib "x{ 1 + 1 }y"; 1' },
+    'use lib with an interpolated expression compiles';
+
+lives-ok { EVAL 'use lib "{ "a" }b", "c{ "d" }"; 1' },
+    'use lib with multiple interpolated strings compiles';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
`use lib "{$*PROGRAM.dirname}/../lib"` failed to compile with "Cannot find method 'List' on object of type BOOTStr". The pragma evaluates its argument at BEGIN time, and an expression without a compile-time value is compiled into a thunk and called. The call returns the block's value as the VM sees it, so the interpolated string came back as an unboxed native string and the `.List` on it died. Git::Wrapper's whole test suite failed to compile on this.

Add IMPL-BEGIN-TIME-ARGLIST, which evaluates a pragma, use, import, or require argument into its argument list, boxing the result on the way, and taking over the `.List.FLATTENABLE_LIST` and no-argument handling those four sites each repeated. The boxing stays out of IMPL-BEGIN-TIME-EVALUATE itself, since consumers such as constant initializers rely on the raw value there. A CORE constant holding an nqp list must stay one, or the nqp::atpos done on it at runtime dies.