### PR TITLE
RakuAST: declare a constant's anonymous variable in its own thunk

### DIFF
--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -732,6 +732,17 @@ class RakuAST::ExpressionThunk
                 }
             }
         }
+        # A `my`-scoped anonymous variable declared in the expression can never
+        # be named from outside, so it belongs to this thunk. Emit its
+        # declaration here rather than leaving it in the enclosing scope, where a
+        # thunk compiled on its own (as a constant's value is) would not find its
+        # storage. State variables keep their own persistence machinery.
+        my $anon-decl := -> $node {
+            nqp::istype($node, RakuAST::VarDeclaration::Anonymous) && $node.scope eq 'my'
+        };
+        if $anon-decl($expression) {
+            nqp::push($stmts, $expression.IMPL-QAST-DECL($context));
+        }
         my @code-todo := [$expression];
         while @code-todo {
             my $visit := @code-todo.shift;
@@ -742,6 +753,9 @@ class RakuAST::ExpressionThunk
                             nqp::push($stmts, $decl.IMPL-QAST-DECL($context));
                         }
                     }
+                }
+                if $anon-decl($node) {
+                    nqp::push($stmts, $node.IMPL-QAST-DECL($context));
                 }
                 unless nqp::istype($node, RakuAST::LexicalScope) {
                     @code-todo.push($node);

--- a/t/02-rakudo/constant-anon-var-value.t
+++ b/t/02-rakudo/constant-anon-var-value.t
@@ -1,0 +1,30 @@
+use Test;
+
+plan 6;
+
+# A `constant`'s value is computed by a thunk compiled on its own. An
+# anonymous variable declared in that value must be declared in the thunk,
+# not in the enclosing scope where the thunk cannot reach its storage.
+
+is (constant C1 = (my uint32 $ = -1)), 4294967295,
+    'anonymous native unsigned variable initialises the constant';
+
+is (constant C2 = (my int $ = 5)), 5,
+    'anonymous native int variable initialises the constant';
+
+is (constant C3 = (my num64 $ = 1.5e0)), 1.5,
+    'anonymous native num variable initialises the constant';
+
+is (constant C4 = (my $ = 42)), 42,
+    'anonymous object variable initialises the constant';
+
+{
+    constant C5 = (my uint32 $ = 7);
+    my $after = 3;
+    is $after, 3, 'a declaration after the constant is unaffected';
+}
+
+{
+    sub f($x = (my uint32 $ = 9)) { $x }
+    is f(), 9, 'anonymous native variable in a parameter default works';
+}


### PR DESCRIPTION
A constant computes its value with a thunk that is compiled on its own. An anonymous variable declared in that value, such as the `(my uint32 $ = -1)` idiom for a native constant, had its declaration left in the enclosing scope. The thunk then referred to storage it could not reach and compilation died with "No lexical found with name '$ANON_VAR_2'".

An anonymous variable can never be named from outside, so it belongs to the thunk. Emit its declaration in the thunk block. A named variable keeps its current handling, and a state variable keeps its own persistence machinery.