### PR TITLE
RakuAST: leave no backtrack point after a ratchet regex

### DIFF
--- a/src/Raku/ast/regex.rakumod
+++ b/src/Raku/ast/regex.rakumod
@@ -23,13 +23,16 @@ class RakuAST::Regex
         QRegex::P6Regex::Actions.alt_nfas($code-object, $regex-qast, $context.sc-handle);
 
         # Wrap in scan/pass as appropriate.
+        my $pass-qast := $name
+          ?? QAST::Regex.new(:rxtype('pass'), :$name)
+          !! QAST::Regex.new(:rxtype('pass'));
+        # A ratchet regex leaves no backtrack point, so its cursor keeps no
+        # restart continuation and is not re-entered for a further match.
+        $pass-qast.backtrack('r') if %mods<r>;
         my $wrap-qast := QAST::Regex.new(
             :rxtype('concat'),
             $regex-qast,
-            ($name
-              ?? QAST::Regex.new(:rxtype('pass'), :$name)
-              !! QAST::Regex.new(:rxtype('pass'))
-            )
+            $pass-qast
         );
         unless $no-scan {
             $wrap-qast.unshift(QAST::Regex.new( :rxtype('scan') ));

--- a/t/02-rakudo/regex-token-arg-backtrack.t
+++ b/t/02-rakudo/regex-token-arg-backtrack.t
@@ -1,0 +1,43 @@
+use Test;
+
+plan 6;
+
+# A token (or rule) is ratchet, so when a call to it is backtracked over the
+# cursor must not be re-entered to look for another match. A token that takes
+# an argument would otherwise be re-invoked without it.
+
+{
+    my token t ($x) { $x }
+    ok 'xaby' ~~ / 'x' [ <&t: 'a'> | <&t: 'ab'> ] 'y' /,
+        'backtracking an alternation of argument tokens tries the next branch';
+}
+
+{
+    my token t ($x) { $x }
+    nok 'xaz' ~~ / 'x' [ <&t: 'a'> | <&t: 'ab'> ] 'y' /,
+        'exhausting both branches fails cleanly instead of erroring';
+}
+
+{
+    my token t ($x) { $x }
+    ok 'xaby' ~~ / 'x' [ <&t: 'a'> || <&t: 'ab'> ] 'y' /,
+        'sequential alternation of argument tokens backtracks too';
+}
+
+{
+    my token t ($x) { $x }
+    ok 'ab' ~~ / <&t: 'ab'> /, 'a single argument token call still matches';
+}
+
+{
+    my token t { 'a' }
+    my token u { 'ab' }
+    ok 'xaby' ~~ / 'x' [ <t> | <u> ] 'y' /,
+        'backtracking argumentless tokens is unaffected';
+}
+
+{
+    my regex r ($x) { $x+ }
+    ok 'xaaaz' ~~ / 'x' <&r: 'a'> 'z' /,
+        'a regex (non-ratchet) with an argument can still be backtracked into';
+}


### PR DESCRIPTION
A token or rule is ratchet, so a call to one cannot be re-entered to look for a further match. That is arranged by the regex's terminating `pass` node carrying a ratchet backtrack, which keeps the cursor from storing a restart continuation. The RakuAST frontend built that pass node without it, so every token's cursor kept a restart pointing back at the token's own regex sub.

When such a call was backtracked over, the engine re-invoked that sub through the cursor with no arguments. An argumentless token survived, but a token declared with a parameter died with "Too few positionals passed":

    my token t ($x) { $x }
    "xaby" ~~ / "x" [ <&t: "a"> | <&t: "ab"> ] "y" /

Mark the pass node ratchet when the regex is a token or rule, as the legacy frontend does.