### PR TITLE
RakuAST: keep an operator name's colonpair in its package lookup key

### DIFF
--- a/src/Raku/ast/name.rakumod
+++ b/src/Raku/ast/name.rakumod
@@ -365,6 +365,7 @@ class RakuAST::Name
             $result := self.IMPL-QAST-PSEUDO-PACKAGE-LOOKUP($context, :$sigil);
         }
         else {
+            my str $suffix := self.colonpair-suffix;
             for $!parts {
                 if $first { # skip GLOBAL or lexically found first part, already taken care of
                     $first := 0;
@@ -372,7 +373,7 @@ class RakuAST::Name
                 else { # get the Stash from all real packages
                     # We do .WHO on the current package, followed by the index into it.
                     $result := QAST::Op.new( :op('who'), $result );
-                    $result := $_.IMPL-QAST-PACKAGE-LOOKUP-PART($context, $result, $_ =:= $final, :$sigil, :$global-fallback);
+                    $result := $_.IMPL-QAST-PACKAGE-LOOKUP-PART($context, $result, $_ =:= $final, :$sigil, :$global-fallback, :suffix($_ =:= $final ?? $suffix !! ''));
                 }
             }
         }
@@ -447,12 +448,17 @@ class RakuAST::Name::Part::Simple
         $!name eq ''
     }
 
-    method IMPL-QAST-PACKAGE-LOOKUP-PART(RakuAST::IMPL::QASTContext $context, Mu $stash-qast, Int $is-final, str :$sigil, Bool :$global-fallback) {
+    method IMPL-QAST-PACKAGE-LOOKUP-PART(RakuAST::IMPL::QASTContext $context, Mu $stash-qast, Int $is-final, str :$sigil, Bool :$global-fallback, str :$suffix) {
+        my str $key := $is-final && $sigil ?? $sigil ~ $!name !! $!name;
+        # The name's colonpair suffix, as in `infix:<+>`. The container is
+        # bound into the stash under the full canonicalized name, so the key
+        # needs it too.
+        $key := $key ~ $suffix if $is-final && $suffix;
         my $op := QAST::Op.new(
             :op('callmethod'),
             :name($is-final ?? 'AT-KEY' !! 'package_at_key'),
             $stash-qast,
-            QAST::SVal.new( :value($is-final && $sigil ?? $sigil ~ $!name !! $!name) )
+            QAST::SVal.new( :value($key) )
         );
         $op.push(QAST::WVal.new(:value(True), :named<global_fallback>)) if $is-final && $global-fallback;
         $op
@@ -492,7 +498,7 @@ class RakuAST::Name::Part::Expression
         )
     }
 
-    method IMPL-QAST-PACKAGE-LOOKUP-PART(RakuAST::IMPL::QASTContext $context, Mu $stash-qast, Int $is-final, str :$sigil, Bool :$global-fallback) {
+    method IMPL-QAST-PACKAGE-LOOKUP-PART(RakuAST::IMPL::QASTContext $context, Mu $stash-qast, Int $is-final, str :$sigil, Bool :$global-fallback, str :$suffix) {
         QAST::Op.new(
             :op('callmethod'),
             :name($is-final ?? 'AT-KEY' !! 'package_at_key'),
@@ -537,7 +543,7 @@ class RakuAST::Name::Part::Empty
         $stash-qast
     }
 
-    method IMPL-QAST-PACKAGE-LOOKUP-PART(RakuAST::IMPL::QASTContext $context, Mu $stash-qast, Int $is-final, str :$sigil, Bool :$global-fallback) {
+    method IMPL-QAST-PACKAGE-LOOKUP-PART(RakuAST::IMPL::QASTContext $context, Mu $stash-qast, Int $is-final, str :$sigil, Bool :$global-fallback, str :$suffix) {
         $stash-qast
     }
 

--- a/t/02-rakudo/our-operator-var-container.t
+++ b/t/02-rakudo/our-operator-var-container.t
@@ -1,0 +1,37 @@
+use Test;
+
+plan 6;
+
+# An `our`-scoped operator variable must use one container for both its
+# lexical and its package entry, so a value assigned to it is visible through
+# the package (which is what `is export` hands to importers). The package key
+# has to carry the operator's colonpair, matching the lexical name.
+
+{
+    sub c(@a, @b) { |@a, |@b }
+    our &infix:<qq> = &c;
+    ok OUR::{'&infix:<qq>'} === &c,
+        'the package entry holds the value assigned to the operator';
+    is-deeply (1, 2) qq (3, 4), (1, 2, 3, 4),
+        'the assigned operator works when used';
+}
+
+{
+    sub double($n) { $n * 2 }
+    our &prefix:<§> = &double;
+    ok OUR::{'&prefix:<§>'} === &double,
+        'a prefix operator variable also reaches its package entry';
+    is §21, 42, 'the assigned prefix operator works';
+}
+
+{
+    module M {
+        sub c(@a, @b) { |@a, |@b }
+        our &infix:<qq> is export = &c;
+    }
+    my $exported = M::EXPORT::DEFAULT::{'&infix:<qq>'};
+    isa-ok $exported, Sub,
+        'an exported operator variable exports the assigned routine, not the empty container';
+    is-deeply $exported((1, 2), (3, 4)), (1, 2, 3, 4),
+        'the exported operator is invocable';
+}


### PR DESCRIPTION
An `our`-scoped operator variable such as `our &infix:<++> = &concat` is reached at runtime through a package lookup, while the container is bound into the package under the name's full canonical form. A name's colonpairs live on the name rather than on its parts, and the package lookup built its key from the parts alone, so the lookup asked for `&infix` while the container was bound under `&infix:<++>`.

The two never met. The lexical held the assigned routine, the package entry stayed an empty Callable, and `is export` hands the package entry to importers, so an imported operator variable arrived unusable and invoking it died with "Impossible coercion from 'List' into 'Callable'".

Append the name's colonpair suffix to the final part of the lookup key, so it matches what canonicalize (and the bind) produce.