### PR TITLE
RakuAST: do not sink the result of take

### DIFF
--- a/src/Raku/ast/call.rakumod
+++ b/src/Raku/ast/call.rakumod
@@ -278,6 +278,17 @@ class RakuAST::Call::Name
 
     method needs-resolution() { $!name.is-identifier }
 
+    method needs-sink-call() {
+        # The built-in `take` and `take-rw` hand back the same value they
+        # stash into the enclosing gather, so sinking the result would drain a
+        # value that is not ours to consume. A same-named user routine has no
+        # such aliasing and is sunk like any other call.
+        my $name := $!name.canonicalize;
+        !(($name eq 'take' || $name eq 'take-rw')
+            && self.is-resolved
+            && nqp::istype(self.resolution, RakuAST::Declaration::External::Setting))
+    }
+
     method undeclared-symbol-details() {
         RakuAST::UndeclaredSymbolDescription::Routine.new($!name.canonicalize())
     }

--- a/t/02-rakudo/gather-take-lazy-value.t
+++ b/t/02-rakudo/gather-take-lazy-value.t
@@ -1,0 +1,45 @@
+use Test;
+
+plan 5;
+
+# `take` hands back the same value it stashes into the gather. Sinking that
+# result would drain a lazy value out from under the gather, so a lazy value
+# taken in a sunk position must survive to be pulled from the gather.
+
+{
+    my @vlp = gather for (60, 64, 67) -> $v {
+        take (61, 65, 68).map: * - $v;
+    }
+    is @vlp.map(*.join(',')).join('; '), '1,5,8; -3,1,4; -6,-2,1',
+        'a lazy Seq taken as a sunk for-loop body survives';
+}
+
+{
+    my @taken = gather for 1, 2 -> $v {
+        take (10, 20).map: * + $v;
+    }
+    is @taken.join('; '), '11 21; 12 22',
+        'each taken lazy Seq keeps its own values';
+}
+
+{
+    my @r = gather {
+        my $first = take 5;
+        take $first + 1;
+    }
+    is-deeply @r.List, (5, 6), 'the value returned by take is still usable';
+}
+
+{
+    my @a = 1, 2, 3;
+    .=succ for gather { take-rw @a[1] }
+    is @a.join(','), '1,3,3', 'take-rw still yields a writable container';
+}
+
+{
+    my $iterated = 0;
+    my sub take($x) { (^2).map: { ++$iterated } }
+    take 1;
+    is $iterated, 2,
+        'a user routine named take is sunk like any other call';
+}


### PR DESCRIPTION
`take` and `take-rw` stash their argument into the enclosing gather and hand the very same value back. When such a call sits in sink context, for example as the last statement of a `for` loop body inside a gather, its result was sunk. Sinking a Seq drains and clears its iterator, so the value the gather had already stored was consumed before anything could pull it, and reading it back died with "The iterator of this Seq is already in use/consumed by another Seq".

    gather for @a -> $v { take @b.map: * - $v }

Mark a call that resolves to the built-in `take` or `take-rw` as not needing a sink call, so the stored value is left intact. A same-named user routine has no such aliasing and is left to sink as usual.