### PR TITLE
RakuAST: make a term visible within its own initializer

### DIFF
--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -2801,15 +2801,10 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
             $ast := $<regex-declarator>.ast;
         }
         elsif $<defterm> {
-            my str $scope   := $*SCOPE;
-            my     $type    := $*OFTYPE ?? $*OFTYPE.ast !! Nodify('Type');
-            my     $name    := $<defterm>.ast;
-            my $initializer := $<term-init>.ast;
-
-            $ast := Nodify('VarDeclaration::Term').new:
-              :$scope, :$type, :$name, :$initializer;
-            $/.typed-sorry('X::Redeclaration', :symbol($name))
-              if $*R.declare-lexical($ast);
+            # The declaration was installed after <defterm> so it could be
+            # seen within its own initializer; here we just complete it.
+            $ast := $*TERM-DECL;
+            $ast.set-initializer($<term-init>.ast);
         }
         else {
             nqp::die('Unimplemented declarator');

--- a/src/Raku/Grammar.nqp
+++ b/src/Raku/Grammar.nqp
@@ -3983,9 +3983,11 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
 
     token declarator {
         :my $*LEFTSIGIL := '';
+        :my $*TERM-DECL;
         [
           | '\\'
             <defterm>
+            { $*TERM-DECL := self.declare-defterm($<defterm>.ast) }
             [    <.ws> <term-init=initializer>
               || <.typed-panic: "X::Syntax::Term::MissingInitializer">
             ]
@@ -4318,6 +4320,19 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
             my $canname := $cat ~ ':sym' ~ $canop;
             self.add-categorical($cat, ~$categorical[0][1], $canname, ~$categorical[0], :current-scope);
         }
+    }
+
+    # Install a sigilless term declaration before its initializer is parsed,
+    # so the term resolves within its own initializer.
+    method declare-defterm($name) {
+        my $decl := self.Nodify('VarDeclaration::Term').new(
+          :scope($*SCOPE),
+          :type($*OFTYPE ?? $*OFTYPE.ast !! self.Nodify('Type')),
+          :$name,
+        );
+        self.typed-sorry('X::Redeclaration', :symbol($name.canonicalize))
+          if $*R.declare-lexical($decl);
+        $decl
     }
 
     token type-declarator:sym<constant> {

--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -2142,7 +2142,7 @@ class RakuAST::VarDeclaration::Term
     has RakuAST::Initializer $.initializer;
 
     method new(str :$scope, RakuAST::Type :$type, RakuAST::Name :$name!,
-            RakuAST::Initializer :$initializer!) {
+            RakuAST::Initializer :$initializer) {
         my $obj := nqp::create(self);
         nqp::bindattr_s($obj, RakuAST::Declaration, '$!scope', $scope);
         nqp::bindattr($obj, RakuAST::VarDeclaration::Term, '$!type', $type // RakuAST::Type);
@@ -2150,6 +2150,13 @@ class RakuAST::VarDeclaration::Term
         nqp::bindattr($obj, RakuAST::VarDeclaration::Term, '$!initializer',
             $initializer // RakuAST::Initializer);
         $obj
+    }
+
+    # The declaration is installed before its initializer is parsed, so the
+    # term is visible within its own initializer (a self-referential lazy
+    # binding such as `my \S := gather { ... S ... }`).
+    method set-initializer(RakuAST::Initializer $initializer) {
+        nqp::bindattr(self, RakuAST::VarDeclaration::Term, '$!initializer', $initializer);
     }
 
     method lexical-name() {

--- a/t/02-rakudo/term-self-reference.t
+++ b/t/02-rakudo/term-self-reference.t
@@ -1,0 +1,45 @@
+use Test;
+
+plan 5;
+
+# A sigilless term declaration is installed before its initializer is parsed,
+# so the term can refer to itself from within that initializer. This is what
+# makes a self-referential lazy binding (such as a Hamming-number sequence)
+# work.
+
+{
+    my \S := gather {
+        take 1;
+        take S.head + 10;
+    }
+    is S[^2].join(','), '1,11', 'a term is visible inside its own initializer';
+}
+
+{
+    my \Hammings := gather {
+        my %i = (2, 3, 5) Z=> (Hammings.iterator for ^3);
+        my %n = (2, 3, 5) Z=> 1 xx *;
+        loop {
+            take my $n := %n{*}.min;
+            -> \k { %n{k} = %i{k}.pull-one * k if %n{k} == $n } for (2, 3, 5);
+        }
+    }
+    is Hammings[^10].join(' '), '1 2 3 4 5 6 8 9 10 12',
+        'a term self-reference drives a recursive lazy sequence';
+}
+
+{
+    my \a := 1;
+    my \b := a + 1;
+    is b, 2, 'a term may reference an earlier term';
+}
+
+{
+    my Int \typed := 42;
+    is typed, 42, 'a typed term binding still works';
+}
+
+{
+    my \untouched := 5;
+    is untouched, 5, 'a term with no self-reference is unaffected';
+}


### PR DESCRIPTION
A sigilless term declaration was installed only after its initializer had been parsed, so a reference to the term from inside that initializer could not resolve. A self-referential lazy binding, such as a sequence defined in terms of itself, failed to compile.

    my \S := gather { ...; take S.pull-one * 2 }

Install the declaration right after the term name is parsed and before its initializer, then fill in the initializer once it is available, so the term resolves within its own initializer as it does under the legacy frontend.