### PR TITLE
RakuAST: fix BEGIN-time cloning and routine trait arguments

### DIFF
--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -288,7 +288,14 @@ class RakuAST::Node {
                 }
 
                 if nqp::istype($node, RakuAST::LexicalScope) {
-                    if nqp::istype($node, RakuAST::TraitTarget) {
+                    # A code object emits declarations for the blocks among
+                    # its children itself, including those in its traits.
+                    # Emitting a trait's block here as well would nest the
+                    # same block twice, and this frame's prologue would then
+                    # capture it against the wrong frame. A package produces
+                    # no frame of its own for a trait's block to nest in, so
+                    # its traits' blocks do belong here.
+                    if nqp::istype($node, RakuAST::TraitTarget) && !nqp::istype($node, RakuAST::Code) {
                         $node.visit-traits(-> $trait { @code-todo.push($trait) });
                     }
                 }

--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -357,10 +357,28 @@ class RakuAST::Code
                             # value it holds there, as the legacy frontend does
                             # by referring to it in place.
                             if nqp::index('$@%&', nqp::substr($name, 0, 1)) >= 0 {
-                                # A sigil'd variable has a container; leaving the
-                                # reference late-bound lets the runtime lookup
-                                # reach that container for its default value (Any,
-                                # an empty Array, an empty Hash).
+                                # A sigil'd variable has a container. When the
+                                # declaration can produce it, bind that very
+                                # container here: the declaration's frame need
+                                # not exist at BEGIN time (a routine's, for a
+                                # trait argument like `is memoized(my %h)`),
+                                # and runtime frames start from a copy of it,
+                                # so a BEGIN-time write is visible at runtime.
+                                # An anonymous declaration has no name for
+                                # other code to share the container through,
+                                # so it, and anything else without a producible
+                                # container, stays late-bound for the runtime
+                                # lookup to satisfy.
+                                if nqp::istype($lexical, RakuAST::VarDeclaration::Simple)
+                                    && !nqp::istype($lexical, RakuAST::VarDeclaration::Anonymous)
+                                    && !nqp::objprimspec($lexical.meta-object) {
+                                    my $value := $lexical.meta-object;
+                                    $context.ensure-sc($value);
+                                    %seen{$name} := 1;
+                                    $block[0].push(
+                                        QAST::Var.new(:scope<lexical>, :decl<static>, :$name, :$value)
+                                    );
+                                }
                             }
                             else {
                                 # A sigilless binding has no container, so a
@@ -2058,8 +2076,11 @@ class RakuAST::Routine
         my $stub := self.IMPL-STUB-CODE($resolver, $context);
         nqp::setcodename($stub, $!name.canonicalize) if $!name;
 
-        # Apply any traits.
-        self.apply-traits($resolver, $context, self)
+        # Apply any traits, with the routine's own scope visible: a trait
+        # argument can declare into it, as in `is memoized(my %h)`.
+        $resolver.push-scope(self);
+        self.apply-traits($resolver, $context, self);
+        $resolver.pop-scope();
     }
 
     method set-value(Mu $value) {

--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -227,13 +227,7 @@ class RakuAST::Code
                     QAST::BVal.new( :value($block) )
                 )
             );
-            @compstuff[2] := sub ($orig, $clone) {
-                $context.ensure-sc($clone);
-                $context.add-cleanup-task(sub () {
-                    nqp::bindattr($clone, Code, '@!compstuff', nqp::null());
-                });
-                $context.add-clone-for-cuid($clone, $cuid);
-
+            my $push-clone-fixup := sub ($clone) {
                 my $tmp := $fixups.unique('tmp_block_fixup');
                 $fixups.push(QAST::Stmt.new(
                     QAST::Op.new(
@@ -255,6 +249,26 @@ class RakuAST::Code
                         QAST::Var.new( :name($tmp), :scope('local') ),
                         QAST::WVal.new( :value($clone) )
                     )));
+            };
+            @compstuff[2] := sub ($orig, $clone) {
+                $context.ensure-sc($clone);
+                $context.add-cleanup-task(sub () {
+                    nqp::bindattr($clone, Code, '@!compstuff', nqp::null());
+                });
+                $context.add-clone-for-cuid($clone, $cuid);
+                $push-clone-fixup($clone);
+            }
+            # A clone made before this point, by BEGIN-time code such as
+            # `.wrap` cloning the routine it wraps, was registered by the
+            # stub-time callback, which has no code block to build a fixup
+            # from. Give each one the same load-time replacement of its
+            # compile-time do, so it closes over the runtime frames.
+            my %clones := $context.sub-id-to-cloned-code-objects();
+            if nqp::existskey(%clones, $cuid) {
+                for %clones{$cuid} -> $clone {
+                    $context.ensure-sc($clone);
+                    $push-clone-fixup($clone);
+                }
             }
             @compstuff[3] := $fixups;
         }

--- a/t/02-rakudo/begin-clone-wrap.t
+++ b/t/02-rakudo/begin-clone-wrap.t
@@ -1,0 +1,39 @@
+use Test;
+
+plan 5;
+
+# A code object cloned at BEGIN time, as `.wrap` does to the routine it
+# wraps, kept its compile-time do. Its outer then never pointed at the
+# runtime frames, so the body ran against phantom containers. Such clones
+# get the same load-time replacement of their do that later clones get.
+
+{
+    my $e = 0;
+    sub f() { ++$e }
+    BEGIN &f.wrap(-> | { callsame });
+    f();
+    is $e, 1, 'the body of a BEGIN-wrapped sub reaches the runtime lexical';
+}
+
+{
+    my $e = 0;
+    sub f() { ++$e }
+    my $c;
+    BEGIN $c = &f.clone;
+    $c();
+    is $e, 1, 'a clone made at BEGIN reaches the runtime lexical when called';
+    f();
+    is $e, 2, 'the original still reaches it after the clone ran';
+}
+
+{
+    my $executed = 0;
+    my %cache;
+    sub compute($n) { ++$executed; $n * 2 }
+    BEGIN &compute.wrap(-> |c {
+        my $key = c.raku;
+        %cache{$key}:exists ?? %cache{$key} !! (%cache{$key} = callsame)
+    });
+    is compute(21) + compute(21), 84, 'memoized results are correct';
+    is $executed, 1, 'memoization via a BEGIN-time wrap caches the body call';
+}

--- a/t/02-rakudo/trait-arg-block-capture.t
+++ b/t/02-rakudo/trait-arg-block-capture.t
@@ -1,0 +1,43 @@
+use Test;
+
+plan 4;
+
+# A block passed as a trait argument, as in `is memoized({ ... })`, nests in
+# the routine carrying the trait. The enclosing scope must not emit the same
+# block again, or its own frame prologue captures the block against itself
+# and invoking the block dies with an outer frame mismatch.
+
+{
+    my @keys;
+    sub trait_mod:<is>(Routine:D \r, :$keyed!) {
+        r.wrap(-> |c { $keyed.(c); callsame });
+    }
+    sub f($a) is keyed({ @keys.push(.raku) }) { $a * 2 }
+    is f(21), 42, 'a routine with a block trait argument still runs';
+    like @keys[0], /21/, 'the block ran against the passed capture';
+}
+
+{
+    my int $seen;
+    sub trait_mod:<is>(Routine:D \r, :$count!) {
+        r.wrap(-> |c { $count.(); callsame });
+    }
+    sub g($a) is count({ ++$seen }) { $a }
+    g(1);
+    g(2);
+    is $seen, 2, 'the block reaches a lexical of the enclosing scope';
+}
+
+{
+    my %cache;
+    my int $ran;
+    sub trait_mod:<is>(Routine:D \r, :$memo!) {
+        r.wrap(-> |c {
+            my $k = $memo.(c);
+            %cache{$k}:exists ?? %cache{$k} !! (%cache{$k} = callsame)
+        });
+    }
+    sub h($n) is memo({ .[0].Str }) { ++$ran; $n + 1 }
+    h(5); h(5); h(6);
+    is $ran, 2, 'a keymaker block drives memoization correctly';
+}

--- a/t/02-rakudo/trait-arg-declares-var.t
+++ b/t/02-rakudo/trait-arg-declares-var.t
@@ -1,0 +1,31 @@
+use Test;
+
+plan 5;
+
+# A trait argument on a routine can declare a variable, as in
+# `is memoized(my %h)`. The declaration goes into the routine's scope, and
+# the trait receives the declaration's container, so a value the trait
+# leaves in it is what runtime frames start from.
+
+my %trait-saw;
+multi sub trait_mod:<is>(Routine:D \r, :$stash!) {
+    %trait-saw{r.name} = $stash;
+    $stash<from-trait> = 1 if $stash ~~ Associative;
+}
+
+{
+    sub f() is stash(my %h) { %h<from-trait> }
+    is f(), 1, 'the body starts from the container the trait wrote to';
+    is %trait-saw<f><from-trait>, 1, 'the trait received a usable Hash';
+}
+
+{
+    sub g() is stash(my $x) { }
+    ok %trait-saw<g>:exists, 'a scalar declaration in a trait argument works';
+}
+
+{
+    sub h() is stash(my %h) { %h<n>++; %h<n> }
+    is h(), 1, 'first call sees the count it just wrote';
+    is h(), 2, 'a container the trait wrote to is shared across calls';
+}


### PR DESCRIPTION
Previously `Sub::Memoized` failed all of its tests under the RakuAST frontend. Its `is memoized` trait does three things at BEGIN time that each hit a separate bug: it wraps the routine, which clones it, it can be given a variable declared right in the trait argument, and it can be given a block. With these fixes its test suite passes 85/85.

The first commit fixes code objects cloned at BEGIN time. A compile-time code object carries a clone callback in `@!compstuff` that gives each clone a load-time fixup, replacing its do with a fresh clone of the unit's own code ref so the clone closes over the runtime frames. That callback is installed when the code's QAST is produced, which under RakuAST happens after the whole unit has parsed. A clone made earlier by BEGIN-time code, such as `.wrap` cloning the routine it wraps, only met the stub-time callback, which registers the clone but cannot build a fixup yet. The clone kept its compile-time do, whose outer never points at the runtime frames, so the body read and wrote phantom containers.

```raku
my $e = 0;
sub f() { ++$e }
BEGIN &f.wrap(-> | { callsame });
f();
say $e;    # was 0, now 1
```

The second commit lets a trait argument declare a variable. `sub f($a) is memoized(my %h) { }` died at compile time with "Could not find a compile-time-value for lexical %h". Traits are applied after the parser has left the routine's scope, so the argument's thunk could not resolve `%h`, and the routine's frame does not exist at BEGIN time for a late-bound lookup to find. Trait application now runs with the routine's scope pushed, and the thunk binds the declaration's own container. Runtime frames start from a copy of that container, so what the trait leaves in it is what calls of the routine see.

The third commit fixes a block as a trait argument. `sub foo($a) is memoized({ .[0].Str }) { }` compiled but invoking the block died with "provided outer frame '<unit>' does not match expected static frame 'foo'". The walk that emits declarations for nested blocks stops at a nested lexical scope but emitted the scope's traits' blocks anyway. A routine already emits its own traits' blocks, so the block was emitted twice, and the enclosing frame's prologue captured it against the wrong frame. The walk now leaves a code object's traits to the code object itself. A package produces no frame of its own for a trait's block to nest in, so its traits keep the enclosing emission.

As a side effect of the third commit, `role R is tag({ ... }) { }` now works under RakuAST. It dies with "lang-call cannot invoke object of type 'VMNull'" under the legacy frontend.
