### PR TITLE
RakuAST: let a module declare its own `my package EXPORT`

### DIFF
--- a/src/Raku/ast/scoping.rakumod
+++ b/src/Raku/ast/scoping.rakumod
@@ -1077,9 +1077,19 @@ class RakuAST::PackageInstaller {
         if $name.is-identifier {
             $final := $name.canonicalize(:colonpairs(0));
             $lexical := $resolver.resolve-lexical-constant($final);
-            $resolver.current-scope.merge-generated-lexical-declaration:
-                :$resolver,
-                self.IMPL-GENERATE-LEXICAL-DECLARATION($final, $meta-object);
+            # `my package EXPORT` names a package the compunit already declares
+            # implicitly. Reuse that lexical, pointing it at the new package,
+            # rather than declaring a second of the same name and colliding.
+            if $scope eq 'my'
+              && nqp::istype($lexical, RakuAST::VarDeclaration::Implicit::Constant)
+              && nqp::istype($lexical.compile-time-value.HOW, Perl6::Metamodel::PackageHOW) {
+                $lexical.set-value($type-object);
+            }
+            else {
+                $resolver.current-scope.merge-generated-lexical-declaration:
+                    :$resolver,
+                    self.IMPL-GENERATE-LEXICAL-DECLARATION($final, $meta-object);
+            }
             # If `our`-scoped, also put it into the current package.
             if $scope eq 'our' {
                 $target := $current-package;

--- a/t/02-rakudo/my-package-export.t
+++ b/t/02-rakudo/my-package-export.t
@@ -1,0 +1,14 @@
+use Test;
+
+plan 2;
+
+# A module defines its export tags by declaring its own `my package EXPORT`
+# and populating it (here via OUR::<...>). That declaration shares a name with
+# the compunit's implicit EXPORT lexical, so it has to replace that implicit
+# rather than collide with it.
+my package EXPORT {
+    OUR::<MARKER> := 12345;
+}
+
+is EXPORT::<MARKER>, 12345, 'the declared EXPORT package carries its OUR:: symbols';
+is EXPORT.^name, 'EXPORT', 'EXPORT resolves to the user-declared package';


### PR DESCRIPTION
A module defines its export tags by declaring `my package EXPORT` and populating it. That name collides with the compunit's implicit EXPORT lexical, so RakuAST rejected it with "Redeclaration of symbol 'EXPORT'" while the legacy frontend replaced the implicit and carried on.

Install a `my` package whose name resolves to a compunit implicit package by pointing that implicit at the new meta-object, rather than declaring a second lexical of the same name. This matches the legacy frontend, where already_declared treats an existing PackageHOW `my` symbol as replaceable.