### PR TITLE
RakuAST: fix a heredoc used as an attribute default

### DIFF
--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -1041,7 +1041,12 @@ class RakuAST::VarDeclaration::Simple
                 if nqp::istype($initializer, RakuAST::Initializer::Assign)
                   && (my $expression := $initializer.expression).has-compile-time-value
                   && nqp::isconcrete($expression.maybe-compile-time-value)
-                  && !nqp::istype($expression, RakuAST::Code) {
+                  && !nqp::istype($expression, RakuAST::Code)
+                  # A heredoc's body is spliced in at the end of the line, after
+                  # this attribute has begun. Reading its value now would capture
+                  # the placeholder, so leave it to the method path, which compiles
+                  # the expression once the body is present.
+                  && !nqp::istype($expression, RakuAST::Heredoc) {
                     # Only a concrete default known at compile time becomes the
                     # build value directly. A default that is a type object would
                     # leave the build not concrete. Then the attribute is not

--- a/t/02-rakudo/heredoc-attribute-default.t
+++ b/t/02-rakudo/heredoc-attribute-default.t
@@ -1,0 +1,17 @@
+use Test;
+
+plan 3;
+
+# A heredoc as an attribute default: its body is parsed after the attribute
+# declaration line, so the default must pick up the body, not the terminator.
+class WithString {
+    has $.style = q:to/CSS/;
+      #deckgl { height: 95vh; width: 95vw; }
+      #deckwrapper { border: 1px solid black; }
+      CSS
+}
+
+my $style = WithString.new.style;
+is $style.lines.elems, 2, 'a heredoc attribute default holds its whole body';
+ok $style.contains('height: 95vh'), 'the body content is present, not the terminator';
+isnt $style.trim, 'CSS', 'the default is not the heredoc terminator word';


### PR DESCRIPTION
An attribute whose default is a value known at compile time takes it as the build value straight away, when the attribute is begun. A heredoc's body is not spliced in until the end of the line, after that point, so the value taken there was the placeholder (the terminator word) rather than the heredoc body. `has $.style = q:to/END/; ... END` ended up as "END".

Leave a heredoc default to the method path, which compiles the expression once the body is in place.