### PR TITLE
RakuAST: give a method literal its enclosing package

### DIFF
--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -2554,11 +2554,18 @@ class RakuAST::Methodish
     }
 
     method PERFORM-PARSE(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
+        my $package := $resolver.find-attach-target('package');
         if self.scope eq 'has' || self.scope eq 'our' {
-            my $package := $resolver.find-attach-target('package');
             if $package {
                 nqp::bindattr(self, RakuAST::Routine, '$!package', $package);
             }
+        }
+        else {
+            # An anonymous or lexical method literal still records its enclosing
+            # package, matching a sub and the legacy frontend. It is not attached
+            # as a method of that package (see PERFORM-BEGIN).
+            nqp::bindattr(self, RakuAST::Routine, '$!package',
+                $package // $resolver.global-package);
         }
     }
 
@@ -2566,7 +2573,10 @@ class RakuAST::Methodish
         self.body.to-begin-time($resolver, $context); # In case it's the default created in the ctor.
 
         my $package := nqp::getattr(self, RakuAST::Routine, '$!package');
-        my $package-is-role := $package && $package.declarator eq 'role';
+        # `has`/`our` are the scopes that make this a method of the package;
+        # `my`/`anon` merely record the enclosing package for `.package`.
+        my $is-package-method := self.scope eq 'has' || self.scope eq 'our';
+        my $package-is-role := $package && $is-package-method && $package.declarator eq 'role';
         my $placeholder-signature := self.placeholder-signature;
         if $placeholder-signature {
             $placeholder-signature.set-is-on-method(True);
@@ -2604,11 +2614,11 @@ class RakuAST::Methodish
 
         my str $name := self.name ?? self.name.canonicalize !! '';
 
-        if $package {
+        if $package && nqp::can($package, 'can-have-methods') {
             if $package.can-have-methods {
-                $package.ATTACH-METHOD(self) unless self.scope eq 'our';
+                $package.ATTACH-METHOD(self) if self.scope eq 'has';
             }
-            elsif self.scope ne 'our' {
+            elsif self.scope eq 'has' {
                 $resolver.add-worry:  # XXX should be self.add-worry
                   $resolver.build-exception: 'X::Useless::Declaration',
                     name  => $name,

--- a/t/02-rakudo/method-literal-package.t
+++ b/t/02-rakudo/method-literal-package.t
@@ -1,0 +1,26 @@
+use Test;
+
+plan 4;
+
+# A `method { }` literal records the package it is written in, the same as a
+# sub does. Getting this wrong makes the setting's Mu.raku mistake a type's
+# own `.gist`/`.perl` (added via add_method) for the default one.
+
+module Outer {
+    our $m = method { 42 };
+}
+is Outer::<$m>.package, Outer, 'a method literal records its enclosing package';
+
+my $anon = anon method ($x) { $x };
+is $anon.package, GLOBAL, 'a top-level anon method records GLOBAL';
+
+# A type with a custom `.gist` installed via add_method round-trips through
+# gist/raku instead of crashing in Mu.raku.
+my $type := Metamodel::ClassHOW.new_type(name => 'Boxed');
+$type.HOW.add_attribute($type, Attribute.new(
+    :name('$.inner'), :type(Any), :has_accessor(1), :package($type)));
+$type.HOW.add_method($type, 'gist', method { "Boxed:" ~ self.inner.gist });
+$type.HOW.compose($type);
+my $outer := $type.new(inner => $type.new(inner => 7));
+is $outer.gist, 'Boxed:Boxed:7', 'a custom gist added via add_method works when nested';
+is $outer.inner.raku, 'Boxed.new(inner => 7)', 'the default .raku still works on the inner value';


### PR DESCRIPTION
An anonymous or lexical `method { }` literal, unlike a sub, left its `.package` unset (Mu) rather than recording the enclosing package. The setting's `Mu.raku` decides whether a type has its own `.raku`/`.perl` by testing whether the found method's package is Mu, so a custom `.gist`/`.perl` installed with `add_method` was taken for the default one and `Mu.raku` then died on it ("Cannot resolve caller infix:<==>(NQPMu, Int:D)").

Record the enclosing package on a `my`/`anon` method too, as a sub already does, and drive method attachment from the scope rather than from whether a package happens to be recorded.