### PR TITLE
RakuAST: fix \h and \v inside a character class

### DIFF
--- a/src/Raku/ast/regex.rakumod
+++ b/src/Raku/ast/regex.rakumod
@@ -888,18 +888,27 @@ class RakuAST::Regex::CharClass::VerticalSpace
   is RakuAST::Regex::CharClass::Negatable
   is RakuAST::Regex::CharClassEnumerationElement
 {
+    # The single vertical-space codepoints. On its own, \v also matches the
+    # two-codepoint CR LF grapheme (IMPL-REGEX-QAST appends it); inside a
+    # character class it matches only these codepoints.
+    method IMPL-VSPACE-CHARS() { "\x[0a,0b,0c,0d,85,2028,2029]" }
+
     method IMPL-REGEX-QAST(RakuAST::IMPL::QASTContext $context, %mods) {
         QAST::Regex.new:
             :rxtype('enumcharlist'), :negate(self.negated),
-            "\x[0a,0b,0c,0d,85,2028,2029]\r\n"
+            self.IMPL-VSPACE-CHARS ~ "\r\n"
     }
 
     method IMPL-CCLASS-ENUM-CHARS(%mods) {
-        self.negated ?? "" !! "\x[0a,0b,0c,0d,85,2028,2029]\r\n"
+        self.negated ?? "" !! self.IMPL-VSPACE-CHARS
     }
 
     method IMPL-CCLASS-ENUM-QAST(RakuAST::IMPL::QASTContext $context, %mods, Bool $negate) {
-        self.IMPL-MAYBE-NEGATE(self.IMPL-REGEX-QAST($context, %mods), $negate)
+        self.IMPL-MAYBE-NEGATE(
+            QAST::Regex.new(
+                :rxtype('enumcharlist'), :negate(self.negated),
+                self.IMPL-VSPACE-CHARS),
+            $negate)
     }
 }
 

--- a/src/Raku/ast/regex.rakumod
+++ b/src/Raku/ast/regex.rakumod
@@ -802,10 +802,18 @@ class RakuAST::Regex::CharClass::HorizontalSpace
   is RakuAST::Regex::CharClass::Negatable
   is RakuAST::Regex::CharClassEnumerationElement
 {
+    method IMPL-HSPACE-CHARS() {
+        "\x[09,20,a0,1680,180e,2000,2001,2002,2003,2004,2005,2006,2007,2008,2009,200a,202f,205f,3000]"
+    }
+
     method IMPL-REGEX-QAST(RakuAST::IMPL::QASTContext $context, %mods) {
         QAST::Regex.new:
             :rxtype('enumcharlist'), :negate(self.negated),
-            "\x[09,20,a0,1680,180e,2000,2001,2002,2003,2004,2005,2006,2007,2008,2009,200a,202f,205f,3000]"
+            self.IMPL-HSPACE-CHARS
+    }
+
+    method IMPL-CCLASS-ENUM-CHARS(%mods) {
+        self.negated ?? "" !! self.IMPL-HSPACE-CHARS
     }
 
     method IMPL-CCLASS-ENUM-QAST(RakuAST::IMPL::QASTContext $context, %mods, Bool $negate) {
@@ -884,6 +892,10 @@ class RakuAST::Regex::CharClass::VerticalSpace
         QAST::Regex.new:
             :rxtype('enumcharlist'), :negate(self.negated),
             "\x[0a,0b,0c,0d,85,2028,2029]\r\n"
+    }
+
+    method IMPL-CCLASS-ENUM-CHARS(%mods) {
+        self.negated ?? "" !! "\x[0a,0b,0c,0d,85,2028,2029]\r\n"
     }
 
     method IMPL-CCLASS-ENUM-QAST(RakuAST::IMPL::QASTContext $context, %mods, Bool $negate) {

--- a/t/02-rakudo/charclass-enum-merge.t
+++ b/t/02-rakudo/charclass-enum-merge.t
@@ -1,0 +1,21 @@
+use Test;
+
+plan 6;
+
+# A character class that mixes an enumerable class (\v, \h) with literal
+# characters merges into one enumeration, so it orders correctly against another
+# class under longest-token matching in an alternation.
+
+grammar Link {
+    token TOP { [ <-[\s>|]>+ | <-[\v>|]>+ '|' ] '>' }
+}
+ok Link.parse('ab|>'), 'LTM picks the longer branch of two negated char classes';
+ok Link.parse('Some text|>'), 'the same with a space in the text';
+
+# The merged class still matches the same characters.
+ok "a\tb" ~~ / <[\h]> /, '\h in a class still matches horizontal space';
+ok "x\ny" ~~ / <[\v]> /, '\v in a class still matches vertical space';
+is ("foo,bar" ~~ / <-[\v,]>+ /).Str, 'foo',
+    '\v merged with a literal in a negated class stops at the literal';
+is ("one two" ~~ / <[\h a..z]>+ /).Str, 'one two',
+    '\h merged with a range in a positive class matches both';

--- a/t/02-rakudo/regex-vspace-class-crlf.t
+++ b/t/02-rakudo/regex-vspace-class-crlf.t
@@ -1,0 +1,20 @@
+use Test;
+
+plan 8;
+
+# A "\r\n" is a single CR LF grapheme. On its own, \v matches it; inside a
+# character class, \v matches only the single vertical-space codepoints, so the
+# grapheme is not a member.
+
+my $crlf = "\r\n";
+
+nok $crlf ~~ / ^ <[\v]>  $ /, 'the CR LF grapheme is not a member of <[\v]>';
+nok $crlf ~~ / ^ <[\v x]> $ /, 'nor when \v is merged with a literal in a class';
+ok  $crlf ~~ / ^ <-[\v]> $ /, 'so <-[\v]> matches the CR LF grapheme';
+ok  $crlf ~~ / ^ <[\V]>  $ /, 'and <[\V]> matches it';
+ok  $crlf ~~ / ^ \v      $ /, 'while a standalone \v still matches it';
+
+# The individual vertical-space codepoints remain members of the class.
+ok "\n"    ~~ / ^ <[\v]> $ /, '<[\v]> matches a line feed';
+ok "\x0d"  ~~ / ^ <[\v]> $ /, '<[\v]> matches a carriage return';
+nok "x"    ~~ / ^ <[\v]> $ /, '<[\v]> does not match a non-space character';


### PR DESCRIPTION
Two related fixes for how `\h` and `\v` compile inside a bracketed character class.

Previously a character class combining `\h` or `\v` with literal characters, for example `<-[\v>|]>`, compiled the whitespace class as a separate enumeration from the literals. That leaves the class as two alternatives wrapped in a zerowidth conjunction rather than one `enumcharlist`, and such a class does not order correctly against another one under longest-token matching. So a `token` alternating two of them, `[ <-[\s>|]>+ | <-[\v>|]>+ '|' ]`, picked the wrong branch and failed to match where the legacy frontend matched. This showed up in Pod::Perl5, whose link rule alternates several negated classes. `\h` and `\v` now report their characters like `\t`, `\r`, `\b`, `\e` and `\f` already do, so they merge with adjacent literals into a single enumeration.

The second commit fixes a related divergence found while reviewing the first. On its own `\v` matches the two-codepoint CR LF grapheme as well as the single vertical-space codepoints. Inside a character class it should match only the single codepoints, as the legacy frontend does. `<[\v]>` was matching a `\r\n` grapheme, and `<[\V]>` excluding it. It no longer does. The standalone form is left as it was.
