### PR TITLE
RakuAST: default a bare `package EXPORTHOW` to `my`

### DIFF
--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -2677,6 +2677,12 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
         my $name       := $name-match ?? $name-match.ast !! Nodify('Name');
 
         my str $scope := $*SCOPE || ($name-match eq '::' ?? 'anon' !! 'our');
+        # EXPORTHOW is a compile-time directive package, read from a module's
+        # lexical scope through its handle to override declarator HOWs. Default
+        # it to `my` rather than `our` so it does not leak into GLOBAL, where on
+        # load it would clash with the setting's own EXPORTHOW. This matches the
+        # setting, which declares `my module EXPORTHOW`.
+        $scope := 'my' if !$*SCOPE && $name-match && $name.canonicalize eq 'EXPORTHOW';
         my $augmented := $scope eq 'augment';
         $/.typed-panic('X::Syntax::Augment::WithoutMonkeyTyping')
           if $augmented && !$*LANG.pragma('MONKEY-TYPING');

--- a/t/02-rakudo/exporthow-my-scope.t
+++ b/t/02-rakudo/exporthow-my-scope.t
@@ -1,0 +1,18 @@
+use lib <t/02-rakudo/test-packages>;
+use Test;
+
+plan 2;
+
+# ExportHowBare overrides the `class` declarator through a bare `package
+# EXPORTHOW`. Loading it must not die "Merging GLOBAL symbols failed: duplicate
+# definition of symbol class", which happened when the bare EXPORTHOW was
+# `our`-scoped, leaked into GLOBAL, and clashed with the setting's own EXPORTHOW.
+# The load happens via EVAL so a regression fails this test rather than aborting
+# the whole file.
+lives-ok { EVAL 'use ExportHowBare; 1' },
+    'a module with a bare `package EXPORTHOW` loads without a GLOBAL clash';
+
+# The override reaches the consumer: a class declared after the use is built by
+# the exported HOW, which adds a `composed-by-bare-exporthow` method at compose.
+is EVAL('use ExportHowBare; class Marker { }; Marker.composed-by-bare-exporthow'),
+    True, 'the bare EXPORTHOW override composes classes with its own HOW';

--- a/t/02-rakudo/test-packages/ExportHowBare.rakumod
+++ b/t/02-rakudo/test-packages/ExportHowBare.rakumod
@@ -1,0 +1,14 @@
+# Exports its own `class` HOW through a bare (non-`my`) EXPORTHOW package, the
+# way InterceptAllMethods does. A bare `package EXPORTHOW` must be lexical, not
+# `our`: an `our` one leaks into GLOBAL and, when this module is used, clashes
+# with the setting's own EXPORTHOW. The HOW adds a marker method at compose time
+# so a consumer can observe that its `class` declarations went through here.
+class MetamodelX::ExportHowBare is Metamodel::ClassHOW {
+    method compose(Mu \type) {
+        self.add_method(type, 'composed-by-bare-exporthow', sub ($) { True });
+        self.Metamodel::ClassHOW::compose(type)
+    }
+}
+package EXPORTHOW {
+    constant class = MetamodelX::ExportHowBare;
+}


### PR DESCRIPTION
A module supplies compile-time declarator overrides by declaring an EXPORTHOW package; the consumer reads it from the module's handle. A bare `package EXPORTHOW` is `our`-scoped, so it landed in GLOBAL and, on load, clashed with the setting's own EXPORTHOW ("Merging GLOBAL symbols failed: duplicate definition of symbol class"). The setting declares `my module EXPORTHOW`, and a bare one should be lexical too.

Default a bare `package EXPORTHOW` (one with no explicit scope) to `my` so it stays out of GLOBAL and no longer clashes with the setting's EXPORTHOW on load.