### PR TITLE
RakuAST: use the base type for a `is Type:D` container

### DIFF
--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -157,9 +157,14 @@ class RakuAST::ContainerCreator {
     }
 
     method IMPL-EXPLICIT-CONTAINER-BASE-TYPE() {
-        self.IMPL-HAS-EXPLICIT-CONTAINER-BASE-TYPE
-            ?? $!explicit-container-base-type-ast.meta-object
-            !! Mu
+        return Mu unless self.IMPL-HAS-EXPLICIT-CONTAINER-BASE-TYPE;
+        # A container cannot be an instance of a definite type, so `@a is List:D`
+        # uses List as the base. This holds in every language version, unlike the
+        # definite semantics elsewhere, so it is not version-gated.
+        my $type := $!explicit-container-base-type-ast.meta-object;
+        nqp::eqaddr($type.HOW, Perl6::Metamodel::DefiniteHOW)
+            ?? $type.HOW.base_type($type)
+            !! $type
     }
 
     method IMPL-CONFLICTING-BASE-TYPE() {
@@ -255,6 +260,7 @@ class RakuAST::ContainerCreator {
             }
         }
         else {
+            # $explicit-base is already the base type of any `is Type:D`.
             $container-type := self.type
                 ?? $explicit-base.HOW.parameterize($explicit-base, $of)
                 !! $explicit-base;

--- a/t/02-rakudo/container-definite-base.t
+++ b/t/02-rakudo/container-definite-base.t
@@ -1,0 +1,26 @@
+use Test;
+
+plan 5;
+
+# `is Type:D` on a container names a definite type as the container base. A
+# container cannot be an instance of a definite type, so the base type is used,
+# the same as `is Type` (without :D). Getting this wrong died "You cannot create
+# an instance of this type (List:D)".
+
+{
+    my @a is List:D = (1, 2, 3);
+    is-deeply @a.List, (1, 2, 3), 'a `is List:D` array holds its values';
+    is @a.WHAT.^name, 'List', 'a `is List:D` array is built as a List';
+}
+
+{
+    my %h is Map:D = (:a(1), :b(2));
+    is %h<a>, 1, 'a `is Map:D` hash holds its values';
+    is %h.WHAT.^name, 'Map', 'a `is Map:D` hash is built as a Map';
+}
+
+# The non-definite form is unchanged.
+{
+    my @b is Array = (4, 5);
+    is @b.WHAT.^name, 'Array', 'a `is Array` array is still an Array';
+}


### PR DESCRIPTION
`my @a is List:D = ...` names a definite type as the container base. A container cannot be an instance of a definite type, so building one died "You cannot create an instance of this type (List:D)". The sigil-default path (a plain `my @a`) and the legacy frontend use the base type there.

Strip the definiteness in IMPL-EXPLICIT-CONTAINER-BASE-TYPE so every reader of the explicit base sees the base type, covering the `my`, `state`, and meta-object paths alike.