### PR TITLE
RakuAST: key an our-scoped twigil variable's package slot by its full name

### DIFF
--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -2510,9 +2510,9 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
             my $origin-source := $*ORIGIN-SOURCE;
             if !$desigilname.is-identifier {
                 # A package-qualified $? variable like $?CALLER::PACKAGE looks
-                # up $?<name> through the package, twigil folded into the sigil.
+                # up $?<name> through the package.
                 $ast := Nodify('Var::Package').new(
-                  :sigil($sigil ~ $twigil), :name($desigilname)
+                  :$sigil, :$twigil, :name($desigilname)
                 );
             }
             elsif $name eq '$?LINE' {

--- a/src/Raku/ast/name.rakumod
+++ b/src/Raku/ast/name.rakumod
@@ -322,7 +322,7 @@ class RakuAST::Name
         @parts
     }
 
-    method IMPL-QAST-PSEUDO-PACKAGE-LOOKUP(RakuAST::IMPL::QASTContext $context, str :$sigil) {
+    method IMPL-QAST-PSEUDO-PACKAGE-LOOKUP(RakuAST::IMPL::QASTContext $context, str :$sigil, str :$twigil) {
         my @parts := self.IMPL-LOOKUP-PARTS;
         my $final := @parts[nqp::elems(@parts) - 1];
         my $PseudoStash-lookup := self.IMPL-UNWRAP-LIST(self.get-implicit-lookups)[1];
@@ -339,7 +339,7 @@ class RakuAST::Name
             else { # get the Stash from all real packages
                 $result := QAST::Op.new( :op('who'), $result );
             }
-            $result := $_.IMPL-QAST-PSEUDO-PACKAGE-LOOKUP-PART($context, $result, $_ =:= $final, :$sigil);
+            $result := $_.IMPL-QAST-PSEUDO-PACKAGE-LOOKUP-PART($context, $result, $_ =:= $final, :$sigil, :$twigil);
         }
         $result
     }
@@ -362,8 +362,7 @@ class RakuAST::Name
             $result := QAST::WVal.new(:value($start-package));
         }
         if self.is-pseudo-package {
-            # Pseudo-packages (CALLER, DYNAMIC, ...) never carry a twigil.
-            $result := self.IMPL-QAST-PSEUDO-PACKAGE-LOOKUP($context, :$sigil);
+            $result := self.IMPL-QAST-PSEUDO-PACKAGE-LOOKUP($context, :$sigil, :$twigil);
         }
         else {
             my str $suffix := self.colonpair-suffix;
@@ -381,7 +380,7 @@ class RakuAST::Name
         $result
     }
 
-    method IMPL-QAST-INDIRECT-LOOKUP(RakuAST::IMPL::QASTContext $context, str :$sigil) {
+    method IMPL-QAST-INDIRECT-LOOKUP(RakuAST::IMPL::QASTContext $context, str :$sigil, str :$twigil) {
         my @parts   := self.IMPL-LOOKUP-PARTS;
         # A trailing `::` designates the package itself and adds no lookup chunk,
         # so drop the empty final part.
@@ -397,7 +396,9 @@ class RakuAST::Name
                 $lookups[1].IMPL-TO-QAST($context),
             ),
         );
-        nqp::push($result, QAST::SVal.new(:value($sigil))) if $sigil;
+        # The runtime lookup takes a single sigil-decoration argument, so a
+        # twigil like the `?` of `$?FOO::($bar)` joins the sigil here.
+        nqp::push($result, QAST::SVal.new(:value($sigil ~ $twigil))) if $sigil;
         for @parts {
             nqp::push($result, $_.IMPL-QAST-INDIRECT-LOOKUP-PART($context, $result, $_ =:= $final));
         }
@@ -458,8 +459,8 @@ class RakuAST::Name::Part::Simple
     # key needs all of them. Earlier parts are keyed by bare name.
     method IMPL-STASH-KEY(int $is-final, str $sigil, str $twigil?, str $suffix?) {
         return $!name unless $is-final;
-        my str $key := $sigil ?? $sigil ~ ($twigil ?? $twigil !! '') ~ $!name !! $!name;
-        $suffix ?? $key ~ $suffix !! $key
+        my str $key := $sigil ?? $sigil ~ $twigil ~ $!name !! $!name;
+        $key ~ $suffix
     }
 
     method IMPL-QAST-PACKAGE-LOOKUP-PART(RakuAST::IMPL::QASTContext $context, Mu $stash-qast, Int $is-final, str :$sigil, str :$twigil, Bool :$global-fallback, str :$suffix) {
@@ -473,12 +474,12 @@ class RakuAST::Name::Part::Simple
         $op
     }
 
-    method IMPL-QAST-PSEUDO-PACKAGE-LOOKUP-PART(RakuAST::IMPL::QASTContext $context, Mu $stash-qast, Int $is-final, str :$sigil) {
+    method IMPL-QAST-PSEUDO-PACKAGE-LOOKUP-PART(RakuAST::IMPL::QASTContext $context, Mu $stash-qast, Int $is-final, str :$sigil, str :$twigil) {
         QAST::Op.new(
             :op('call'),
             :name('&postcircumfix:<{ }>'),
             $stash-qast,
-            QAST::SVal.new( :value(self.IMPL-STASH-KEY($is-final, $sigil)) )
+            QAST::SVal.new( :value(self.IMPL-STASH-KEY($is-final, $sigil, $twigil)) )
         )
     }
 
@@ -498,7 +499,7 @@ class RakuAST::Name::Part::Expression
         $obj
     }
 
-    method IMPL-QAST-PSEUDO-PACKAGE-LOOKUP-PART(RakuAST::IMPL::QASTContext $context, Mu $stash-qast, Int $is-final, str :$sigil) {
+    method IMPL-QAST-PSEUDO-PACKAGE-LOOKUP-PART(RakuAST::IMPL::QASTContext $context, Mu $stash-qast, Int $is-final, str :$sigil, str :$twigil) {
         QAST::Op.new(
             :op('call'),
             :name('&postcircumfix:<{ }>'),
@@ -548,7 +549,7 @@ class RakuAST::Name::Part::Empty
         nqp::create(self);
     }
 
-    method IMPL-QAST-PSEUDO-PACKAGE-LOOKUP-PART(RakuAST::IMPL::QASTContext $context, Mu $stash-qast, Int $is-final, str :$sigil) {
+    method IMPL-QAST-PSEUDO-PACKAGE-LOOKUP-PART(RakuAST::IMPL::QASTContext $context, Mu $stash-qast, Int $is-final, str :$sigil, str :$twigil) {
         $stash-qast
     }
 

--- a/src/Raku/ast/name.rakumod
+++ b/src/Raku/ast/name.rakumod
@@ -344,7 +344,7 @@ class RakuAST::Name
         $result
     }
 
-    method IMPL-QAST-PACKAGE-LOOKUP(RakuAST::IMPL::QASTContext $context, Mu $start-package, RakuAST::Declaration :$lexical, str :$sigil, Bool :$global-fallback) {
+    method IMPL-QAST-PACKAGE-LOOKUP(RakuAST::IMPL::QASTContext $context, Mu $start-package, RakuAST::Declaration :$lexical, str :$sigil, str :$twigil, Bool :$global-fallback) {
         my $result;
         my $final := $!parts[nqp::elems($!parts) - 1];
         my int $first;
@@ -362,6 +362,7 @@ class RakuAST::Name
             $result := QAST::WVal.new(:value($start-package));
         }
         if self.is-pseudo-package {
+            # Pseudo-packages (CALLER, DYNAMIC, ...) never carry a twigil.
             $result := self.IMPL-QAST-PSEUDO-PACKAGE-LOOKUP($context, :$sigil);
         }
         else {
@@ -373,7 +374,7 @@ class RakuAST::Name
                 else { # get the Stash from all real packages
                     # We do .WHO on the current package, followed by the index into it.
                     $result := QAST::Op.new( :op('who'), $result );
-                    $result := $_.IMPL-QAST-PACKAGE-LOOKUP-PART($context, $result, $_ =:= $final, :$sigil, :$global-fallback, :suffix($_ =:= $final ?? $suffix !! ''));
+                    $result := $_.IMPL-QAST-PACKAGE-LOOKUP-PART($context, $result, $_ =:= $final, :$sigil, :$twigil, :$global-fallback, :suffix($_ =:= $final ?? $suffix !! ''));
                 }
             }
         }
@@ -451,17 +452,22 @@ class RakuAST::Name::Part::Simple
         $!name eq ''
     }
 
-    method IMPL-QAST-PACKAGE-LOOKUP-PART(RakuAST::IMPL::QASTContext $context, Mu $stash-qast, Int $is-final, str :$sigil, Bool :$global-fallback, str :$suffix) {
-        my str $key := $is-final && $sigil ?? $sigil ~ $!name !! $!name;
-        # The name's colonpair suffix, as in `infix:<+>`. The container is
-        # bound into the stash under the full canonicalized name, so the key
-        # needs it too.
-        $key := $key ~ $suffix if $is-final && $suffix;
+    # The final part's stash key carries its sigil and, for a variable like
+    # `our @.foo`, its twigil, plus any colonpair suffix as in `infix:<+>`. The
+    # container is bound into the stash under the full canonicalized name, so the
+    # key needs all of them. Earlier parts are keyed by bare name.
+    method IMPL-STASH-KEY(int $is-final, str $sigil, str $twigil?, str $suffix?) {
+        return $!name unless $is-final;
+        my str $key := $sigil ?? $sigil ~ ($twigil ?? $twigil !! '') ~ $!name !! $!name;
+        $suffix ?? $key ~ $suffix !! $key
+    }
+
+    method IMPL-QAST-PACKAGE-LOOKUP-PART(RakuAST::IMPL::QASTContext $context, Mu $stash-qast, Int $is-final, str :$sigil, str :$twigil, Bool :$global-fallback, str :$suffix) {
         my $op := QAST::Op.new(
             :op('callmethod'),
             :name($is-final ?? 'AT-KEY' !! 'package_at_key'),
             $stash-qast,
-            QAST::SVal.new( :value($key) )
+            QAST::SVal.new( :value(self.IMPL-STASH-KEY($is-final, $sigil, $twigil, $suffix)) )
         );
         $op.push(QAST::WVal.new(:value(True), :named<global_fallback>)) if $is-final && $global-fallback;
         $op
@@ -472,12 +478,12 @@ class RakuAST::Name::Part::Simple
             :op('call'),
             :name('&postcircumfix:<{ }>'),
             $stash-qast,
-            QAST::SVal.new( :value($is-final && $sigil ?? $sigil ~ $!name !! $!name) )
+            QAST::SVal.new( :value(self.IMPL-STASH-KEY($is-final, $sigil)) )
         )
     }
 
     method IMPL-QAST-INDIRECT-LOOKUP-PART(RakuAST::IMPL::QASTContext $context, Mu $stash-qast, Int $is-final, str :$sigil) {
-        QAST::SVal.new( :value($is-final && $sigil ?? $sigil ~ $!name !! $!name) )
+        QAST::SVal.new( :value(self.IMPL-STASH-KEY($is-final, $sigil)) )
     }
 }
 
@@ -501,7 +507,7 @@ class RakuAST::Name::Part::Expression
         )
     }
 
-    method IMPL-QAST-PACKAGE-LOOKUP-PART(RakuAST::IMPL::QASTContext $context, Mu $stash-qast, Int $is-final, str :$sigil, Bool :$global-fallback, str :$suffix) {
+    method IMPL-QAST-PACKAGE-LOOKUP-PART(RakuAST::IMPL::QASTContext $context, Mu $stash-qast, Int $is-final, str :$sigil, str :$twigil, Bool :$global-fallback, str :$suffix) {
         QAST::Op.new(
             :op('callmethod'),
             :name($is-final ?? 'AT-KEY' !! 'package_at_key'),
@@ -546,7 +552,7 @@ class RakuAST::Name::Part::Empty
         $stash-qast
     }
 
-    method IMPL-QAST-PACKAGE-LOOKUP-PART(RakuAST::IMPL::QASTContext $context, Mu $stash-qast, Int $is-final, str :$sigil, Bool :$global-fallback, str :$suffix) {
+    method IMPL-QAST-PACKAGE-LOOKUP-PART(RakuAST::IMPL::QASTContext $context, Mu $stash-qast, Int $is-final, str :$sigil, str :$twigil, Bool :$global-fallback, str :$suffix) {
         $stash-qast
     }
 

--- a/src/Raku/ast/variable-access.rakumod
+++ b/src/Raku/ast/variable-access.rakumod
@@ -825,16 +825,19 @@ class RakuAST::Var::Package
   is RakuAST::CheckTime
 {
     has str $.sigil;
+    has str $.twigil;
     has RakuAST::Name $.name;
 
-    method new(RakuAST::Name :$name!, :$sigil) {
+    method new(RakuAST::Name :$name!, :$sigil, :$twigil) {
         my $obj := nqp::create(self);
         nqp::bindattr($obj, RakuAST::Var::Package, '$!name', $name);
         nqp::bindattr_s($obj, RakuAST::Var::Package, '$!sigil', $sigil);
+        nqp::bindattr_s($obj, RakuAST::Var::Package, '$!twigil', $twigil);
         $obj
     }
 
-    method sigil() { $!sigil }
+    method sigil()  { $!sigil }
+    method twigil() { $!twigil }
 
     method can-be-bound-to() {
         self.is-resolved ?? self.resolution.can-be-bound-to !! $!name.is-pseudo-package
@@ -859,16 +862,17 @@ class RakuAST::Var::Package
         if !self.is-resolved && !$!name.is-installable {
             my $name := $!name.canonicalize;
             self.add-sorry:
-                $resolver.build-exception: 'X::Undeclared', :symbol($!sigil ~ $name),
+                $resolver.build-exception: 'X::Undeclared', :symbol($!sigil ~ $!twigil ~ $name),
                     :suggestions($resolver.suggest-lexicals($name));
         }
     }
 
     method IMPL-EXPR-QAST(RakuAST::IMPL::QASTContext $context) {
-        my str $sigil := $!sigil;
+        my str $sigil  := $!sigil;
+        my str $twigil := $!twigil;
         if $!name.is-simple {
             if $!name.is-pseudo-package {
-                $!name.IMPL-QAST-PSEUDO-PACKAGE-LOOKUP($context, :$sigil);
+                $!name.IMPL-QAST-PSEUDO-PACKAGE-LOOKUP($context, :$sigil, :$twigil);
             }
             else {
                 my @parts := $!name.IMPL-LOOKUP-PARTS;
@@ -894,13 +898,13 @@ class RakuAST::Var::Package
                 }
                 for @parts {
                     $result := QAST::Op.new( :op('who'), $result );
-                    $result := $_.IMPL-QAST-PACKAGE-LOOKUP-PART($context, $result, $_ =:= $final, :$sigil);
+                    $result := $_.IMPL-QAST-PACKAGE-LOOKUP-PART($context, $result, $_ =:= $final, :$sigil, :$twigil);
                 }
                 $result
             }
         }
         else {
-            $!name.IMPL-QAST-INDIRECT-LOOKUP($context, :$sigil)
+            $!name.IMPL-QAST-INDIRECT-LOOKUP($context, :$sigil, :$twigil)
         }
     }
 
@@ -911,7 +915,7 @@ class RakuAST::Var::Package
     }
 
     method IMPL-BIND-QAST(RakuAST::IMPL::QASTContext $context, QAST::Node $source-qast) {
-        my $qast := $!name.IMPL-QAST-PSEUDO-PACKAGE-LOOKUP($context, :sigil($!sigil));
+        my $qast := $!name.IMPL-QAST-PSEUDO-PACKAGE-LOOKUP($context, :sigil($!sigil), :twigil($!twigil));
         $source-qast.named('BIND');
         $qast.push($source-qast);
         $qast

--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -1461,7 +1461,11 @@ class RakuAST::VarDeclaration::Simple
             # a lookup in the package.
             my $container := self.meta-object;
             $context.ensure-sc($container);
-            my $lookup := $!desigilname.IMPL-QAST-PACKAGE-LOOKUP($context, $!package, :sigil($!sigil), :global-fallback);
+            # Look the package slot up under the full name, sigil and twigil
+            # both, as self.name and the meta-object installation use. Without
+            # the twigil the lookup would miss the slot and global-fallback would
+            # vivify an orphan under the twigil-less name.
+            my $lookup := $!desigilname.IMPL-QAST-PACKAGE-LOOKUP($context, $!package, :sigil($!sigil), :twigil(self.twigil), :global-fallback);
             $lookup.name('VIVIFY-KEY');
             QAST::Op.new(
               :op('bind'),

--- a/t/02-rakudo/our-twigil-package-key.t
+++ b/t/02-rakudo/our-twigil-package-key.t
@@ -1,0 +1,20 @@
+use lib <t/02-rakudo/test-packages>;
+
+# An `our @.foo` / `our %.foo` in a class keys its package slot by the full name
+# including the twigil, as the meta-object installation does. Looking it up
+# without the twigil vivified an orphan package symbol, so pulling the class in
+# through two paths (directly and via a module that also uses it) died "Merging
+# GLOBAL symbols failed: duplicate definition of symbol @operations". Reaching
+# this file's own compilation means that diamond merged cleanly.
+use OurTwigilLeaf;
+use OurTwigilMid;
+
+use Test;
+
+plan 2;
+
+is OurTwigilLeaf.operations.join(','), 'plus,minus',
+    'the `our @.operations` accessor returns its bound value';
+
+is OurTwigilLeaf.table<a>, 1,
+    'the `our %.table` accessor returns its bound value';

--- a/t/02-rakudo/test-packages/OurTwigilLeaf.rakumod
+++ b/t/02-rakudo/test-packages/OurTwigilLeaf.rakumod
@@ -1,0 +1,7 @@
+unit class OurTwigilLeaf;
+
+my @ops = <plus minus>;
+our @.operations := @ops;
+
+my %tab = :a(1), :b(2);
+our %.table := %tab;

--- a/t/02-rakudo/test-packages/OurTwigilMid.rakumod
+++ b/t/02-rakudo/test-packages/OurTwigilMid.rakumod
@@ -1,0 +1,3 @@
+unit class OurTwigilMid;
+
+use OurTwigilLeaf;


### PR DESCRIPTION
Previously `use` of a module with an `our @.foo` (or `our %.foo`) in a class could die at compile with `Merging GLOBAL symbols failed: duplicate definition of symbol @foo`, when the class was pulled in through two paths, directly and via a module that also uses it. `Math::Symbolic` hits this: its `Math::Symbolic::Language` has `our @.operations := @operations;` and is used both directly by `Math::Symbolic` and through `Math::Symbolic::Grammar`.

An `our @.foo` installs its package slot under the full name including the twigil, `@.foo`, the same name `self.name` and the meta-object use. The declaration looked the slot up without the twigil, as `@foo`, so it missed the installed slot and `global-fallback` vivified an orphan `@foo` in GLOBAL. In a diamond the two merge paths then carry distinct orphan containers, which collide.

`IMPL-QAST-PACKAGE-LOOKUP` now takes a `:twigil` alongside `:sigil` and looks the slot up under the full name, so it finds what was installed and no orphan is created. A variable with no twigil passes an empty twigil and is unchanged.

The second commit carries the same treatment to `Var::Package`. A package-qualified `$?` variable like `$?CALLER::PACKAGE` built its node with the twigil concatenated onto the sigil, `:sigil($sigil ~ $twigil)`, so its lookup, bind and error paths all saw a `$?` "sigil". It now carries its own twigil and passes sigil and twigil separately, matching the package-lookup path.
