### PR TITLE
Compile the proxy readers with the Raku HLL

### DIFF
--- a/src/vm/moar/dispatchers.nqp
+++ b/src/vm/moar/dispatchers.nqp
@@ -1982,9 +1982,13 @@ class ProxyReaderFactory {
         }
         $block.push($dispatch);
 
-        # Compile and return it.
+        # Compile and return it. The CompUnit carries the HLL: a dispatch
+        # resumed from inside the reader boxes a native result using the
+        # reader frame's HLL, so without it a native call with a Proxy
+        # argument returns a BOOT type (a BOOTInt for an int) rather than
+        # the Raku type.
         my $comp := nqp::getcomp('Raku');
-        $comp.compile($block, :from($comp.qast-stage))
+        $comp.compile(QAST::CompUnit.new($block, :hll('Raku')), :from($comp.qast-stage))
     }
 }
 my $PROXY-READERS := ProxyReaderFactory.new;

--- a/t/04-nativecall/27-proxy-args.c
+++ b/t/04-nativecall/27-proxy-args.c
@@ -1,0 +1,19 @@
+#include <stdint.h>
+
+#ifdef _WIN32
+#define DLLEXPORT __declspec(dllexport)
+#else
+#define DLLEXPORT extern
+#endif
+
+DLLEXPORT int32_t TakePointerReturnInt(void *p) {
+    return 42;
+}
+
+DLLEXPORT double TakePointerReturnDouble(void *p) {
+    return 1.5;
+}
+
+DLLEXPORT const char * TakePointerReturnString(void *p) {
+    return "hi";
+}

--- a/t/04-nativecall/27-proxy-args.t
+++ b/t/04-nativecall/27-proxy-args.t
@@ -1,0 +1,36 @@
+use lib <t/04-nativecall>;
+use CompileTestLib;
+use NativeCall;
+use Test;
+
+plan 6;
+
+compile_test_lib('27-proxy-args');
+
+class Handle is repr('CPointer') { }
+
+sub TakePointerReturnInt(Handle --> int32) is native('./27-proxy-args') { * }
+sub TakePointerReturnDouble(Handle --> num64) is native('./27-proxy-args') { * }
+sub TakePointerReturnString(Handle --> Str) is native('./27-proxy-args') { * }
+
+# A CArray element is a Proxy, which sends the call through the proxy-reader
+# code the dispatcher compiles at runtime. A dispatch resumed from inside a
+# reader boxes its native result using the reader frame's HLL, so a reader
+# without the Raku HLL handed back BOOT types (a BOOTInt for an int return)
+# on which ordinary method calls like .defined died.
+my $handles = CArray[Handle].new;
+$handles[0] = Handle;
+
+my $int-result = TakePointerReturnInt($handles[0]);
+isa-ok $int-result, Int, 'int return through a Proxy argument boxes to Int';
+is $int-result, 42, 'the boxed int return holds its value';
+
+my $num-result = TakePointerReturnDouble($handles[0]);
+isa-ok $num-result, Num, 'num return through a Proxy argument boxes to Num';
+is $num-result, 1.5e0, 'the boxed num return holds its value';
+
+my $str-result = TakePointerReturnString($handles[0]);
+isa-ok $str-result, Str, 'str return through a Proxy argument boxes to Str';
+is $str-result, 'hi', 'the boxed str return holds its value';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
A native call with a Proxy argument, like an element of a CArray, returned its result as a BOOT type rather than the Raku type: an int32 return came back a BOOTInt on which ordinary method calls like .defined die "No such method". The ONNX::Native test suite hits this passing a CArray[OrtSessionOptionsHandle] element to a native function and checking the returned status code.

    my $opts = CArray[Handle].new;
    ...
    my $rc = some_native_fn($opts[0], $err);   # $rc was a BOOTInt
    $rc.defined;                               # No such method 'defined'

A Proxy argument cannot be read inside a dispatch program, so the dispatcher compiles a reader code object at runtime that reads the proxies and resumes the dispatch with the results. The reader was compiled as a bare QAST::Block with no QAST::CompUnit around it, so its frames carried no HLL, and a dispatch resumed from inside the reader boxed its native result using that frame's HLL: the BOOT types instead of Int, Num, and Str.

Both frontends produce the BOOT-typed result, and a method call on it dies the same way on both. The module's test only failed under the RakuAST frontend because of what happens when the value is passed to a routine afterwards. The legacy static optimizer lowers the variable to a local, so the argument arrives without its Scalar container, and a bare foreign int argument is boxed to Int on the way in. With --optimize=off the legacy frontend fails the same way. The RakuAST frontend passes the container through, the binder deconts it past the point where that boxing happens, and the raw BOOT value fails the nominal type check with "expected Any but got BOOTInt".

Wrap the reader block in a QAST::CompUnit that carries the Raku HLL. This covers both users of the reader factory, native calls and regular dispatch on routines whose arguments include a Proxy.