### PR TITLE
RakuAST: ratchet the atom position, not the quantifier

### DIFF
--- a/src/Raku/ast/regex.rakumod
+++ b/src/Raku/ast/regex.rakumod
@@ -2,6 +2,19 @@
 class RakuAST::Regex
   is RakuAST::Node
 {
+    # In a ratchet regex each atom position carries the ratchet on its
+    # outermost compiled node, once any significant whitespace is attached, so
+    # a quantifier inside can still give its match back across that whitespace
+    # while the position as a whole does not backtrack. Callers hand this the
+    # compiled QAST of a nested body they embed: a sequence or an alternation
+    # overrides it to do nothing, since those ratchet their own terms and
+    # branches and stay re-enterable for a further match themselves.
+    method IMPL-APPLY-ATOM-RATCHET(Mu $qast, %mods) {
+        $qast.backtrack('r')
+          if %mods<r> && nqp::istype($qast, QAST::Regex) && !$qast.backtrack;
+        $qast
+    }
+
     method IMPL-REGEX-TOP-LEVEL-QAST(
       RakuAST::IMPL::QASTContext  $context,
                               Mu  $code-object,
@@ -14,6 +27,7 @@ class RakuAST::Regex
         my $regex-qast := $body-qast
           // self.IMPL-REGEX-QAST($context, %mods)
           // QAST::Regex.new( :rxtype<anchor>, :subtype<pass> );
+        self.IMPL-APPLY-ATOM-RATCHET($regex-qast, %mods);
 
         # Store its captures and NFA.
         $code-object.SET_CAPS(QRegex::P6Regex::Actions.capnames($regex-qast, 0));
@@ -101,6 +115,9 @@ class RakuAST::Regex::Branching
     method branches() {
         self.IMPL-WRAP-LIST($!branches)
     }
+
+    # The branches carry the ratchet below.
+    method IMPL-APPLY-ATOM-RATCHET(Mu $qast, %mods) { $qast }
 
     method IMPL-REGEX-QAST(RakuAST::IMPL::QASTContext $context, %mods) {
         my $qast := QAST::Regex.new(:rxtype(self.IMPL-QAST-REGEX-TYPE));
@@ -201,6 +218,9 @@ class RakuAST::Regex::Sequence
     method terms() {
         self.IMPL-WRAP-LIST($!terms)
     }
+
+    # The terms carry the ratchet below.
+    method IMPL-APPLY-ATOM-RATCHET(Mu $qast, %mods) { $qast }
 
     # A `\r` directly followed by `\n` matches the single `\r\n` grapheme, so
     # fuse the pair into one literal. As separate atoms neither half matches the
@@ -454,8 +474,10 @@ class RakuAST::Regex::Nested
     method IMPL-REGEX-QAST(RakuAST::IMPL::QASTContext $context, %mods) {
         QAST::Regex.new(
             :rxtype<goal>,
-            $!goal.IMPL-REGEX-QAST($context, nqp::clone(%mods)),
-            $!expr.IMPL-REGEX-QAST($context, nqp::clone(%mods)),
+            $!goal.IMPL-APPLY-ATOM-RATCHET(
+                $!goal.IMPL-REGEX-QAST($context, nqp::clone(%mods)), %mods),
+            $!expr.IMPL-APPLY-ATOM-RATCHET(
+                $!expr.IMPL-REGEX-QAST($context, nqp::clone(%mods)), %mods),
             QAST::Regex.new(
                 :rxtype<subrule>, :subtype<method>,
                 QAST::NodeList.new(
@@ -515,7 +537,8 @@ class RakuAST::Regex::CapturingGroup
     }
 
     method IMPL-REGEX-QAST(RakuAST::IMPL::QASTContext $context, %mods) {
-        my $body-qast := $!regex.IMPL-REGEX-QAST($context, nqp::clone(%mods));
+        my $body-qast := $!regex.IMPL-APPLY-ATOM-RATCHET(
+            $!regex.IMPL-REGEX-QAST($context, nqp::clone(%mods)), %mods);
         nqp::bindattr(self, RakuAST::Regex::CapturingGroup, '$!body-qast', $body-qast);
         QAST::Regex.new(
             :rxtype('subrule'), :subtype('capture'),
@@ -547,7 +570,8 @@ class RakuAST::Regex::NamedCapture
     }
 
     method IMPL-REGEX-QAST(RakuAST::IMPL::QASTContext $context, %mods) {
-        my $qast := $!regex.IMPL-REGEX-QAST($context, %mods);
+        my $qast := $!regex.IMPL-APPLY-ATOM-RATCHET(
+            $!regex.IMPL-REGEX-QAST($context, %mods), %mods);
         if nqp::istype($!regex.IMPL-CAPTURE-TARGET, RakuAST::Regex::Group) {
             # A bracketed group is captured as a whole, no matter its content,
             # also when quantified or backtrack-modified. Its QAST cannot be
@@ -1434,6 +1458,7 @@ class RakuAST::Regex::Assertion::Named::RegexArg
     method IMPL-REGEX-QAST(RakuAST::IMPL::QASTContext $context, %mods) {
         my $body-qast := $!regex-arg.IMPL-REGEX-QAST($context, %mods);
         $body-qast := self.IMPL-FLIP-QAST($body-qast) if self.name.canonicalize eq 'after';
+        $!regex-arg.IMPL-APPLY-ATOM-RATCHET($body-qast, %mods);
         nqp::bindattr(self, RakuAST::Regex::Assertion::Named::RegexArg, '$!body-qast', $body-qast);
         my $qast := self.IMPL-REGEX-QAST-CALL($context);
         my str $name := self.IMPL-UNIQUE-NAME;
@@ -2082,7 +2107,8 @@ class RakuAST::Regex::QuantifiedAtom
         my $atom := $!atom.IMPL-REGEX-QAST($context, %mods);
         my $quantified := $!quantifier.IMPL-QAST-QUANTIFY($context, $atom, %mods);
         if $!separator {
-            my $separator-qast := $!separator.IMPL-REGEX-QAST($context, %mods);
+            my $separator-qast := $!separator.IMPL-APPLY-ATOM-RATCHET(
+                $!separator.IMPL-REGEX-QAST($context, %mods), %mods);
             $quantified.push($separator-qast);
             if $!trailing-separator {
                 QAST::Regex.new(
@@ -2288,7 +2314,9 @@ class RakuAST::Regex::Backtrack
     method new() { self }
 
     method IMPL-QAST-APPLY(Mu $quant-qast, %mods) {
-        $quant-qast.backtrack('r') if %mods<r>;
+        # A default quantifier carries no backtrack of its own. In a ratchet
+        # regex the enclosing atom position applies the ratchet via
+        # IMPL-APPLY-ATOM-RATCHET, once any significant whitespace is attached.
         $quant-qast
     }
 }

--- a/t/02-rakudo/rule-quantifier-whitespace-backtrack.t
+++ b/t/02-rakudo/rule-quantifier-whitespace-backtrack.t
@@ -1,0 +1,76 @@
+use Test;
+
+plan 10;
+
+# In a `rule` (ratchet + sigspace) the ratchet of a quantified atom belongs on
+# the atom together with the whitespace the rule inserts after it, not on the
+# quantifier itself. So a default quantifier can still give back its match
+# across that whitespace when what follows needs the same input. Ratcheting the
+# quantifier directly stopped `<foo>? <bar>` from backtracking, so a rule where
+# `<foo>` could also match `<bar>`'s text failed.
+
+grammar G {
+    token word { \w+ }
+    token val  { 'FALSE' }
+    rule  optword { <word>? <val> }
+    token tokword { <word>? <val> }
+}
+
+ok G.parse('FALSE', :rule<optword>),
+    'a default subrule quantifier in a rule backtracks across inserted whitespace';
+
+ok G.parse('id FALSE', :rule<optword>),
+    'the same rule still matches when the optional subrule is present';
+
+# A token is ratchet without sigspace, so its quantifier does not backtrack.
+nok G.parse('FALSE', :rule<tokword>),
+    'the same shape in a token does not backtrack (ratchet, no whitespace)';
+
+# The reduced ASN.1 case that surfaced this: a SEQUENCE field with a DEFAULT.
+grammar Seq {
+    rule  TOP   { 'SEQUENCE' '{' <field>+ % ',' '}' }
+    rule  field { <name> <type> <default>? }
+    token name  { \w+ }
+    token type  { 'BOOLEAN' | 'INTEGER' }
+    rule  default { 'DEFAULT' <name>? <bool> }
+    token bool  { 'TRUE' | 'FALSE' }
+}
+ok Seq.parse('SEQUENCE { a BOOLEAN DEFAULT FALSE }'),
+    'DEFAULT FALSE parses: the optional name gives FALSE back to the value';
+ok Seq.parse('SEQUENCE { a BOOLEAN DEFAULT def TRUE }'),
+    'DEFAULT with an explicit name still parses';
+
+# An explicit ratchet modifier on the quantifier is honoured, not backtracked.
+grammar E {
+    token word { \w+ }
+    token val  { 'FALSE' }
+    rule  r { <word>?: <val> }
+}
+nok E.parse('FALSE', :rule<r>),
+    'an explicit ratchet quantifier (?:) in a rule does not backtrack';
+
+# The same give-back applies to the other quantifier shapes in a rule.
+grammar Q {
+    token word { \w+ }
+    token val  { 'FALSE' }
+    rule  sep { <word>+ %% ' ' <val> }
+    rule  dyn { <word> ** {0..1} <val> }
+}
+ok Q.parse('abc FALSE', :rule<sep>),
+    'a %%-separated quantifier in a rule gives an iteration back';
+ok Q.parse('FALSE', :rule<dyn>),
+    'a ** {..} block-range quantifier in a rule backtracks';
+
+# The ratchet still applies inside positions that own their own body.
+{
+    my token cap { (\w+) . }
+    nok 'abc' ~~ /^ <cap> $/,
+        'a quantifier inside a capture group in a token stays ratcheted';
+}
+{
+    my token alt { 'ab' | 'a' }
+    ok 'ax' ~~ / <alt> 'x' /,
+        'a token alternation can still be re-entered for its other branch';
+}
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
In a `rule`, `<foo>? <bar>` where `<foo>` can also match `<bar>`'s input failed to parse. ASN::Grammar hits this: its `optional-or-default` rule has `'DEFAULT' <id-string>? <value>`, and `<id-string>` also matches the FALSE that `<value>` needs, so a `criticality BOOLEAN DEFAULT FALSE` line no longer parsed and the whole module returned Any. `<word>+ %% ' '` and `<word> ** {0..1}` before another atom failed the same way.

A quantified atom in a ratchet regex must not backtrack once matched, but the whitespace a rule inserts after the atom is part of that atom's position: the ratchet belongs on the atom together with its whitespace, so a default quantifier can still give its match back across the whitespace to what follows. The default quantifier applied the ratchet directly to its own quant node, which stopped that.

Move the default ratchet from the quantifier to the atom position, as the legacy frontend has it: a new IMPL-APPLY-ATOM-RATCHET on the regex base ratchets a compiled body's outermost node, a sequence or alternation overrides it to do nothing since they already ratchet their own terms and branches, and the positions that embed a body apply it: the top of the regex, a capturing group, a named capture, an assertion's regex argument, a quantifier's separator, and the goal and expression of `~`. An explicit backtrack modifier on the quantifier is applied as before and takes precedence everywhere.