### PR TITLE
Map a container-held foreign value when binding a value parameter

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -9665,15 +9665,19 @@ Did you mean a call like '"
                 return NQPMu if $decont_name_invalid;
                 unless $decont_name {
                     # We decont it once before checks that need a decont value,
-                    # to avoid doing so repeatedly.
+                    # to avoid doing so repeatedly. The hllize maps a foreign
+                    # value taken out of a container, which the argument
+                    # handling only does for a bare one.
                     $decont_name := QAST::Node.unique("__lowered_param_decont_");
                     $var.push(QAST::Op.new(
                         :op('bind'),
                         QAST::Var.new( :name($decont_name), :scope('local'), :decl('var') ),
                         QAST::Op.new(
-                            :op('decont'),
-                            QAST::Var.new( :name($name), :scope('local') )
-                        )));
+                            :op('hllize'),
+                            QAST::Op.new(
+                                :op('decont'),
+                                QAST::Var.new( :name($name), :scope('local') )
+                            ))));
                 }
                 $decont_name
             }

--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -406,6 +406,18 @@ my class Binder {
             # HLL-ize.
             $oval := nqp::hllizefor($oval, 'Raku');
 
+            # A foreign value inside a container is out of reach of both the
+            # argument mapping and the hllize above, which only map a bare
+            # value. For a parameter that binds the value rather than the
+            # container, map the content instead.
+            if nqp::iscont($oval) && nqp::not_i($flags +& (
+                nqp::const::SIG_ELEM_IS_RAW +| nqp::const::SIG_ELEM_IS_RW
+            )) {
+                my $decont  := nqp::decont($oval);
+                my $hllized := nqp::hllizefor($decont, 'Raku');
+                $oval := $hllized unless nqp::eqaddr($hllized, $decont);
+            }
+
             # Skip nominal type check if not needed.
             unless $no_param_type_check {
                 # Is the nominal type generic and in need of instantiation?

--- a/src/Raku/ast/signature.rakumod
+++ b/src/Raku/ast/signature.rakumod
@@ -1371,7 +1371,10 @@ class RakuAST::Parameter
             ));
         }
 
-        # We may need to decontainerize it; produce that lazily if so.
+        # We may need to decontainerize it; produce that lazily if so. The
+        # hllize above only maps a bare foreign value, so map the value taken
+        # out of a container too, both for the type checks and as what a
+        # value parameter binds.
         my $decont-qast-var := $was-slurpy ?? $temp-qast-var !! Nil;
         my $get-decont-var := -> {
             unless $decont-qast-var {
@@ -1379,7 +1382,8 @@ class RakuAST::Parameter
                 $param-qast.push(QAST::Op.new(
                     :op('bind'),
                     QAST::Var.new( :$name, :scope('local'), :decl('var') ),
-                    QAST::Op.new( :op('decont'), $temp-qast-var )
+                    QAST::Op.new( :op('hllize'),
+                        QAST::Op.new( :op('decont'), $temp-qast-var ))
                 ));
                 $decont-qast-var := QAST::Var.new( :$name, :scope('local') );
             }

--- a/t/02-rakudo/bind-container-foreign-value.t
+++ b/t/02-rakudo/bind-container-foreign-value.t
@@ -1,0 +1,44 @@
+use Test;
+use nqp;
+
+plan 5;
+
+# A foreign value, like one an nqp op produced, is mapped to its Raku type
+# when passed bare to a routine. One sitting inside a Scalar container gets
+# the same mapping when the parameter binds the value: without it the type
+# check saw the raw foreign value and died "expected Any but got BOOTHash".
+{
+    my $h = nqp::hash('key', 'value');
+    my sub take-hash($x) { $x }
+    is take-hash($h).WHAT.^name, 'Hash',
+        'a container-held nqp hash binds a value parameter as Hash';
+    is take-hash($h)<key>, 'value',
+        'the mapped hash still holds its entries';
+}
+
+{
+    my $l = nqp::list('x', 'y');
+    my sub take-list($x) { $x }
+    is take-list($l).elems, 2,
+        'a container-held nqp list binds a value parameter';
+}
+
+# A raw parameter binds the container itself, so no mapping applies.
+{
+    my $h = nqp::hash('key', 'value');
+    my sub take-raw($x is raw) {
+        nqp::how_nd(nqp::decont($x)).name(nqp::decont($x))
+    }
+    is take-raw($h), 'BOOTHash',
+        'a raw parameter still receives the unmapped foreign value';
+}
+
+# A bound (containerless) foreign value keeps working as before.
+{
+    my $h := nqp::hash('key', 'value');
+    my sub take-bound($x) { $x<key> }
+    is take-bound($h), 'value',
+        'a bare foreign value still binds and maps';
+}
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
HTML::Entity::Fast keeps nqp hashes in Raku scalars and passes them to its subroutines:

    my $w-encode = whitelist-in-encode("<", ">");  # Scalar holding an nqp hash
    encode-html-entities($str, $w-encode);

Binding that argument died "Type check failed in binding to parameter '$Lookup'; expected Any but got BOOTHash". A bare foreign value is mapped to its Raku type on the way into a routine, so passing the nqp hash without the container works, but a container hides the value from that mapping and the type check then sees the raw foreign value. The legacy frontend only appeared to handle this: its static optimizer lowers such a lexical to a local and strips the container, so the value arrives bare, and with --optimize=off it failed the same way.

Map the decontainerized value in the three places that look inside a container to bind a value parameter: the lowered signature binding of both frontends, which already hllize a bare value before type checks, and the runtime Binder. A raw or rw parameter binds the container itself and is unchanged.