### PR TITLE
RakuAST: allow a `*` slurpy on a callable parameter

### DIFF
--- a/src/Raku/ast/signature.rakumod
+++ b/src/Raku/ast/signature.rakumod
@@ -2380,10 +2380,11 @@ class RakuAST::Parameter::Slurpy::Flattened
                 )
             ));
         }
-        elsif $sigil eq '$' {
-            # Slurpiness on scalar parameters does not actually have any effect.
-            # That this is allowed is probably from some early design and should
-            # have been forbidden, but there are spec tests that use this syntax.
+        elsif $sigil eq '$' || $sigil eq '&' {
+            # Slurpiness on scalar and callable parameters does not actually have
+            # any effect. That this is allowed is probably from some early design
+            # and should have been forbidden, but there are spec tests that use
+            # this syntax.
         }
         else {
             nqp::die("Parameter * quantifier not applicable to sigil '$sigil'");

--- a/t/02-rakudo/slurpy-callable-param.t
+++ b/t/02-rakudo/slurpy-callable-param.t
@@ -1,0 +1,16 @@
+use Test;
+
+plan 4;
+
+# A `*` slurpy on a `&`-sigil parameter is accepted and, like a `*$`, has no
+# slurpy effect: it binds a single Callable, exactly as `&code` would.
+
+sub with-star($t, *&code) { code($t) }
+is with-star(21, * * 2), 42, 'a `*&` parameter binds and calls a single Callable';
+
+my $param = &with-star.signature.params[1];
+nok $param.slurpy, 'a `*&` parameter is not actually slurpy';
+is $param.sigil, '&', 'a `*&` parameter keeps its callable sigil';
+
+dies-ok { with-star(1, {;}, {;}) },
+    'a `*&` parameter still takes a single argument, not many';


### PR DESCRIPTION
`sub f(*&code) {}` died with "Parameter * quantifier not applicable to sigil '&'", while the legacy frontend accepted it. As with a `$` sigil, the slurpiness has no effect there: the parameter binds a single Callable, just as `&code` would.

Treat a `*`-quantified `&` parameter the same as a `$` one, which the code already tolerates for the same reason.