### PR TITLE
Smartmatch a Junction topic over its eigenstates

### DIFF
--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -644,38 +644,23 @@ class RakuAST::Infix
                 $sm-call);
         }
 
-        my $accepts-call;
-        if $negate {
-            $accepts-call := QAST::Op.new(
-                :op<callmethod>, :name<not>,
-                QAST::Op.new(
-                    :op('callmethod'), :name('ACCEPTS'),
-                    $right.IMPL-TO-QAST($context),
-                    QAST::Var.new(:name<$_>, :scope<lexical>)));
+        # Only the RHS evaluation needs $_ bound to the topic; the match
+        # itself is the plain infix operator, which keeps the smartmatch
+        # semantics (Junction topics, Regex and custom ACCEPTS matchers) in
+        # one place.
+        my $name;
+        if self.is-resolved || !$*COMPILING_CORE_SETTING {
+            $name := self.resolution.lexical-name;
         }
         else {
-            my $rhs-local := QAST::Node.unique('!sm-rhs');
-            $accepts-call := QAST::Op.new(
-                :op('callmethod'), :name('ACCEPTS'),
-                QAST::Var.new( :name($rhs-local), :scope<local> ),
-                QAST::Var.new(:name<$_>, :scope<lexical>));
-            $accepts-call := QAST::Op.new(
-                :op<if>,
-                QAST::Op.new(
-                    :op<istype>,
-                    QAST::Op.new(
-                        :op<bind>,
-                        QAST::Var.new( :name($rhs-local), :scope<local>, :decl<var> ),
-                        $right.IMPL-TO-QAST($context),
-                    ),
-                    QAST::WVal.new( :value(Regex) )),
-                $accepts-call,
-                QAST::Op.new(
-                    :op<callmethod>,
-                    :name<Bool>,
-                    $accepts-call ));
+            $name := '&infix' ~ RakuAST::Resolver.IMPL-CANONICALIZE-PAIR($!operator);
         }
-        self.IMPL-TEMPORARIZE-TOPIC( $left.IMPL-TO-QAST($context), $accepts-call )
+        self.IMPL-TEMPORARIZE-TOPIC(
+            $left.IMPL-TO-QAST($context),
+            QAST::Op.new(
+                :op<call>, :$name,
+                QAST::Var.new( :name<$_>, :scope<lexical> ),
+                $right.IMPL-TO-QAST($context)))
     }
 
     method IMPL-LIST-INFIX-QAST(RakuAST::IMPL::QASTContext $context, Mu $operands) {

--- a/src/core.c/Match.rakumod
+++ b/src/core.c/Match.rakumod
@@ -423,5 +423,37 @@ sub make(Mu \made) {
         !! X::Make::MatchRequired.new(:got($slash)).throw
 }
 
+# A concrete Match matcher is a match result already, so the smartmatch
+# returns it as-is rather than boolifying, the same way matching against a
+# regex returns the Match. The raku-smartmatch dispatcher implements the
+# same rule.
+multi sub infix:<~~>(Mu \topic, Match:D $matcher) {
+    $matcher
+}
+multi sub infix:<!~~>(Mu \topic, Match:D $matcher) {
+    $matcher.not
+}
+# Disambiguate from the Junction topic candidates: a Junction topic still
+# matches over its eigenstates.
+multi sub infix:<~~>(Junction:D \topic, Match:D $matcher) {
+#?if moar
+    nqp::dispatch('raku-smartmatch', topic, $matcher, nqp::unbox_i(1))
+#?endif
+#?if !moar
+    SETTING-ONLY-ACCEPTS($matcher)
+      ?? topic.BOOLIFY-ACCEPTS($matcher)
+      !! $matcher.ACCEPTS(topic).Bool
+#?endif
+}
+multi sub infix:<!~~>(Junction:D \topic, Match:D $matcher) {
+#?if moar
+    nqp::dispatch('raku-smartmatch', topic, $matcher, nqp::unbox_i(-1))
+#?endif
+#?if !moar
+    SETTING-ONLY-ACCEPTS($matcher)
+      ?? topic.BOOLIFY-ACCEPTS($matcher, 1)
+      !! $matcher.ACCEPTS(topic).not
+#?endif
+}
 
 # vim: expandtab shiftwidth=4

--- a/src/core.c/Mu.rakumod
+++ b/src/core.c/Mu.rakumod
@@ -1408,11 +1408,51 @@ proto sub defined(Mu, *%) is pure {*}
 multi sub defined(Mu \x) { x.defined }
 
 proto sub infix:<~~>(Mu, Mu, *%) {*}
+# BOOLIFY-ACCEPTS is only valid for matchers using the setting's ACCEPTS; a
+# class that adds its own ACCEPTS candidates may handle a whole Junction topic
+# itself. Mirrors is-method-setting-only in src/vm/moar/dispatchers.nqp.
+my sub SETTING-ONLY-ACCEPTS(Mu \matcher) is implementation-detail {
+    my \accepts := nqp::tryfindmethod(nqp::decont(matcher),'ACCEPTS');
+    nqp::defined(accepts)
+      ?? nqp::istype(accepts,Routine)
+        ?? accepts.IS-SETTING-ONLY(nqp::const::SIG_ELEM_DEFINED_ONLY)
+        !! nqp::istype(accepts,Code)
+          ?? accepts.file.starts-with('SETTING::')
+          !! True
+      !! True
+}
+# A Junction topic smartmatches over its eigenstates. Handing the whole
+# Junction to ACCEPTS gives the wrong answer for matchers whose ACCEPTS does
+# not distribute it (an Associative sees the entire Junction), so reverse the
+# call via BOOLIFY-ACCEPTS, which matches each eigenstate against the matcher.
+# On MoarVM the raku-smartmatch dispatcher implements the same rule, and its
+# callsite caching answers the setting-only question with guards rather than
+# a candidate walk on every call.
+multi sub infix:<~~>(Junction:D \topic, Mu \matcher) {
+#?if moar
+    nqp::dispatch('raku-smartmatch', topic, matcher, nqp::unbox_i(1))
+#?endif
+#?if !moar
+    SETTING-ONLY-ACCEPTS(matcher)
+      ?? topic.BOOLIFY-ACCEPTS(matcher)
+      !! matcher.ACCEPTS(topic).Bool
+#?endif
+}
 multi sub infix:<~~>(Mu \topic, Mu \matcher) {
     matcher.ACCEPTS(topic).Bool;
 }
 
 proto sub infix:<!~~>(Mu, Mu, *%) {*}
+multi sub infix:<!~~>(Junction:D \topic, Mu \matcher) {
+#?if moar
+    nqp::dispatch('raku-smartmatch', topic, matcher, nqp::unbox_i(-1))
+#?endif
+#?if !moar
+    SETTING-ONLY-ACCEPTS(matcher)
+      ?? topic.BOOLIFY-ACCEPTS(matcher, 1)
+      !! matcher.ACCEPTS(topic).not
+#?endif
+}
 multi sub infix:<!~~>(Mu \topic, Mu \matcher) {
     matcher.ACCEPTS(topic).not;
 }

--- a/src/core.c/Regex.rakumod
+++ b/src/core.c/Regex.rakumod
@@ -140,5 +140,15 @@ multi sub infix:<~~>(Junction:D \topic, Regex:D $matcher) {
     $/ := nqp::getlexrelcaller(nqp::ctxcallerskipthunks(nqp::ctx()),'$/');
     $matcher.ACCEPTS(topic)
 }
+# The negated smartmatch also binds the caller's $/, so a capture from the
+# match remains available after `$str !~~ /.../`.
+multi sub infix:<!~~>(Mu \topic, Regex:D $matcher) {
+    $/ := nqp::getlexrelcaller(nqp::ctxcallerskipthunks(nqp::ctx()),'$/');
+    $matcher.ACCEPTS(topic).not
+}
+multi sub infix:<!~~>(Junction:D \topic, Regex:D $matcher) {
+    $/ := nqp::getlexrelcaller(nqp::ctxcallerskipthunks(nqp::ctx()),'$/');
+    $matcher.ACCEPTS(topic).not
+}
 
 # vim: expandtab shiftwidth=4

--- a/src/core.c/Regex.rakumod
+++ b/src/core.c/Regex.rakumod
@@ -134,5 +134,11 @@ multi sub infix:<~~>(Mu \topic, Regex:D $matcher) {
     $/ := nqp::getlexrelcaller(nqp::ctxcallerskipthunks(nqp::ctx()),'$/');
     $matcher.ACCEPTS(topic)
 }
+# Disambiguates from the Junction topic candidate of infix:<~~>. Regex.ACCEPTS
+# autothreads a Junction topic itself, returning a Junction of match results.
+multi sub infix:<~~>(Junction:D \topic, Regex:D $matcher) {
+    $/ := nqp::getlexrelcaller(nqp::ctxcallerskipthunks(nqp::ctx()),'$/');
+    $matcher.ACCEPTS(topic)
+}
 
 # vim: expandtab shiftwidth=4

--- a/t/02-rakudo/smartmatch-junction-topic.t
+++ b/t/02-rakudo/smartmatch-junction-topic.t
@@ -1,0 +1,76 @@
+use Test;
+
+plan 24;
+
+# A Junction on the left of a smartmatch matches over its eigenstates, even
+# against a matcher (such as a Hash) whose ACCEPTS sees the whole topic rather
+# than distributing the Junction itself. Acme::BaseCJK relies on this in
+# `subset ... where .comb.all ~~ %table`.
+
+my %h = a => 1, b => 1;
+my constant %con = (a => 1, b => 1);
+
+is (all('a', 'b')  ~~ %h),   True,  'all-Junction against a Hash, every key present';
+is (all('a', 'x')  ~~ %h),   False, 'all-Junction against a Hash, a key missing';
+is (any('x', 'b')  ~~ %h),   True,  'any-Junction against a Hash, one key present';
+is (none('x', 'y') ~~ %h),   True,  'none-Junction against a Hash, no key present';
+is (none('a', 'y') ~~ %h),   False, 'none-Junction against a Hash, a key present';
+is (one('a', 'x')  ~~ %h),   True,  'one-Junction against a Hash, exactly one key present';
+is (all('a', 'b')  ~~ %con), True,  'all-Junction against a Hash constant';
+
+# Negated smartmatch distributes too.
+is (all('a', 'b') !~~ %h), False, 'negated all-Junction against a Hash, every key present';
+is (all('x', 'y') !~~ %h), True,  'negated all-Junction against a Hash, no key present';
+
+# Type object matcher held in a variable.
+my $t = Int;
+is (any(1, 's') ~~ $t), True, 'any-Junction against a type held in a variable';
+
+# A Junction on both sides.
+is (any('a', 'z') ~~ any('a', 'b')), True, 'Junction on both sides of a smartmatch';
+
+# A variable holding a regex on the right still returns the Match and sets $/.
+my $rx = /f(o+)/;
+my $r = 'foo' ~~ $rx;
+isa-ok $r, Match, 'a regex held in a variable returns a Match';
+is ~$/[0], 'oo', 'a regex held in a variable sets $/';
+
+# The pattern from Acme::BaseCJK: a subset whose where-clause threads a
+# Junction over a constant Map.
+my constant %T = Map.new: ('a' .. 'e').map({ $_ => $++ });
+subset S of Str:D where .comb.all ~~ %T;
+ok  'abc' ~~ S, 'subset where-clause threading all() over a Map accepts a member';
+nok 'xyz' ~~ S, 'subset where-clause rejects a non-member';
+
+# A matcher class with its own ACCEPTS receives the whole Junction rather than
+# having it distributed for it.
+my Mu $topic-seen;
+my class JunctionAware {
+    multi method ACCEPTS(Junction:D \topic) { $topic-seen = topic.WHAT; True  }
+    multi method ACCEPTS(Mu \topic)         { $topic-seen = topic.WHAT; False }
+}
+my $aware = JunctionAware.new;
+my $j = any(1, 2);
+is ($j ~~ $aware), True, 'a matcher with its own Junction ACCEPTS candidate decides the match';
+ok $topic-seen === Junction, 'that ACCEPTS candidate received the whole Junction';
+is ($j !~~ $aware), False, 'negated smartmatch defers to the custom ACCEPTS too';
+
+my class WholeTopic {
+    method ACCEPTS(Mu \topic) { $topic-seen = topic.WHAT; True }
+}
+$topic-seen = Nil;
+is ($j ~~ WholeTopic.new), True, 'a non-multi custom ACCEPTS decides the match';
+ok $topic-seen === Junction, 'a non-multi custom ACCEPTS received the whole Junction';
+
+# A Junction topic against a regex held in a variable: Regex.ACCEPTS
+# autothreads the Junction itself and returns a Junction of match results.
+my $rxa = /a/;
+my $jm = any('cat', 'dog');
+my $matched = $jm ~~ $rxa;
+isa-ok $matched, Junction, 'Junction topic against a regex variable returns a Junction';
+ok $matched.so, 'the match Junction collapses to True when an eigenstate matches';
+my $jn = any('xxx', 'yyy');
+nok ($jn ~~ $rxa).so, 'the match Junction collapses to False when no eigenstate matches';
+is ($jn !~~ $rxa), True, 'negated smartmatch of a Junction against a regex variable';
+
+# vim: expandtab shiftwidth=4

--- a/t/02-rakudo/smartmatch-junction-topic.t
+++ b/t/02-rakudo/smartmatch-junction-topic.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 29;
+plan 31;
 
 # A Junction on the left of a smartmatch matches over its eigenstates, even
 # against a matcher (such as a Hash) whose ACCEPTS sees the whole topic rather
@@ -34,6 +34,12 @@ my $rx = /f(o+)/;
 my $r = 'foo' ~~ $rx;
 isa-ok $r, Match, 'a regex held in a variable returns a Match';
 is ~$/[0], 'oo', 'a regex held in a variable sets $/';
+
+# The negated smartmatch sets $/ too, so captures from the match remain
+# available after a successful `nok`-style check.
+$/ = Nil;
+is ('foo' !~~ $rx), False, 'negated smartmatch against a matching regex variable';
+is ~$/[0], 'oo', 'the negated smartmatch still sets $/';
 
 # The pattern from Acme::BaseCJK: a subset whose where-clause threads a
 # Junction over a constant Map.

--- a/t/02-rakudo/smartmatch-junction-topic.t
+++ b/t/02-rakudo/smartmatch-junction-topic.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 24;
+plan 29;
 
 # A Junction on the left of a smartmatch matches over its eigenstates, even
 # against a matcher (such as a Hash) whose ACCEPTS sees the whole topic rather
@@ -72,5 +72,17 @@ ok $matched.so, 'the match Junction collapses to True when an eigenstate matches
 my $jn = any('xxx', 'yyy');
 nok ($jn ~~ $rxa).so, 'the match Junction collapses to False when no eigenstate matches';
 is ($jn !~~ $rxa), True, 'negated smartmatch of a Junction against a regex variable';
+
+# A complex right side (not a variable or constant) matches the same way as
+# a variable one.
+is (all('a', 'b') ~~ %h.Map), True, 'all-Junction against a complex expression yielding a Map';
+$topic-seen = Nil;
+my %matchers = m => JunctionAware.new;
+is ($j ~~ %matchers<m>), True, 'a custom ACCEPTS matcher from a complex expression decides the match';
+ok $topic-seen === Junction, 'that matcher received the whole Junction';
+my %rxs = k => /f(o+)/;
+my $cm = 'foo' ~~ %rxs<k>;
+isa-ok $cm, Match, 'a regex from a complex expression returns a Match';
+is ~$/[0], 'oo', 'a regex from a complex expression sets $/';
 
 # vim: expandtab shiftwidth=4

--- a/t/02-rakudo/smartmatch-match-matcher.t
+++ b/t/02-rakudo/smartmatch-match-matcher.t
@@ -1,0 +1,26 @@
+use Test;
+
+plan 9;
+
+# A concrete Match on the right of a smartmatch is a match result already,
+# so the operator returns it as-is, the way matching against a regex returns
+# the Match and the way the raku-smartmatch dispatcher behaves.
+
+my $m = 'foo' ~~ /o+/;
+my $r = 'bar' ~~ $m;
+isa-ok $r, Match, 'smartmatch against a Match returns a Match';
+ok $r === $m, 'the matcher itself is the result';
+is ('bar' !~~ $m), False, 'negated smartmatch against a successful Match';
+
+my $empty = Match.new;
+ok ('bar' ~~ $empty) === $empty, 'a constructed Match is returned as-is too';
+is ('bar' !~~ $empty), False, 'a constructed Match is truthy, so its negated smartmatch is False';
+
+# A Junction topic still matches over its eigenstates, collapsing to a Bool
+# from each eigenstate's smartmatch against the Match.
+isa-ok (any('a', 'b') ~~ $m), Bool, 'Junction topic against a Match collapses to Bool';
+is (any('a', 'b') ~~ $m),  True,  'any-Junction against a successful Match';
+is (none('a', 'b') ~~ $m), False, 'none-Junction against a successful Match';
+is (all('a', 'b') !~~ $m), False, 'negated all-Junction against a successful Match';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously `all("a","b") ~~ %hash` returned `False` under the RakuAST frontend and under the legacy frontend with `--optimize=off`, but `True` under optimized legacy. The base `infix:<~~>` handed a Junction topic whole to `matcher.ACCEPTS`, and a matcher whose `ACCEPTS` does not distribute a Junction itself mangles it (an Associative sees the entire Junction as one topic). Only the legacy optimizer's rewrite gave the correct answer, so what a smartmatch meant depended on which compilation route ran. Noticed as an Acme::BaseCJK failure, `subset ... where .comb.all ~~ %TO`.

This makes the operator itself define smartmatch semantics, leaving the `raku-smartmatch` dispatcher and the legacy optimizer as pure optimizations:

- `infix:<~~>` and `infix:<!~~>` get a `Junction:D` topic candidate that matches each eigenstate against the matcher. On MoarVM it delegates to the `raku-smartmatch` dispatcher, whose junction branch short-circuits and still hands the whole Junction to a matcher with its own `ACCEPTS` candidates. Other backends decide the same way directly, through `Routine.IS-SETTING-ONLY` and `BOOLIFY-ACCEPTS`.
- The RakuAST frontend compiles a smartmatch whose right side is not a variable or constant by calling the operator after binding `$_` to the topic, rather than through an inline `ACCEPTS` on the whole topic. `m//`, `s///` and `tr///` still compile through the dispatcher, which their in-place semantics require.
- `$x ~~ $match` against a concrete Match returns the Match itself everywhere, the way the dispatcher and matching against a regex always did. The operator used to boolify it.
- `infix:<!~~>` gets the `Regex:D` candidates that `infix:<~~>` already had, so `$str !~~ /.../` binds the caller's `$/` and captures from the match stay available. Fixes S05-capture/subrule.t under RakuAST. The variable-held form `$str !~~ $rx` never set `$/` on any frontend before and now does.

Optimized legacy behavior is unchanged in all common forms; these changes make RakuAST and `--optimize=off` agree with it. On MoarVM the Junction candidate delegates to the same dispatcher the legacy optimizer emits, so a junction smartmatch compiled as a plain operator call (all of RakuAST, legacy with --optimize=off) performs like the optimized form rather than re-checking the matcher's ACCEPTS on every call.
