### PR TITLE
RakuAST: allow binding to a topic call

### DIFF
--- a/src/Raku/ast/term.rakumod
+++ b/src/Raku/ast/term.rakumod
@@ -214,6 +214,22 @@ class RakuAST::Term::TopicCall
             !! $postfix-ast
     }
 
+    method can-be-bound-to() {
+        $!call.can-be-bound-to
+    }
+
+    method build-bind-exception(RakuAST::Resolver $resolver) {
+        $!call.build-bind-exception($resolver)
+    }
+
+    method IMPL-BIND-QAST(RakuAST::IMPL::QASTContext $context, QAST::Node $source-qast) {
+        $!call.IMPL-BIND-POSTFIX-QAST(
+          $context,
+          self.IMPL-UNWRAP-LIST(self.get-implicit-lookups)[0],
+          $source-qast
+        )
+    }
+
     method visit-children(Code $visitor) {
         $visitor($!call);
     }

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -2601,7 +2601,12 @@ CODE
     }
 
     multi method deparse(RakuAST::Term::TopicCall:D $ast --> Str:D) {
-        self.deparse($ast.call)
+        my $call := $ast.call;
+        # A methodish call deparses with its own leading dot (.foo); a postfix
+        # such as a postcircumfix (.<k>, .[0], .{...}) does not, so supply it.
+        nqp::istype($call, RakuAST::Call::Methodish)
+          ?? self.deparse($call)
+          !! '.' ~ self.deparse($call)
     }
 
     multi method deparse(RakuAST::Term::Whatever:D $ --> Str:D) {

--- a/t/02-rakudo/topic-call-bind.t
+++ b/t/02-rakudo/topic-call-bind.t
@@ -1,0 +1,35 @@
+use Test;
+
+plan 4;
+
+# A topic call `.<k> := $v` binds the element like the explicit `$_<k> := $v`.
+
+{
+    my $x = 1;
+    my %h;
+    given %h { .<c> := $x }
+    $x = 99;
+    is %h<c>, 99, 'binding to a .<key> topic call aliases the hash element';
+}
+
+{
+    my $x = 1;
+    my %h;
+    given %h { .{'c'} := $x }
+    $x = 99;
+    is %h<c>, 99, 'binding to a .{...} topic call aliases the hash element';
+}
+
+{
+    my $x = 1;
+    my @a;
+    given @a { .[0] := $x }
+    $x = 99;
+    is @a[0], 99, 'binding to a .[i] topic call aliases the array element';
+}
+
+throws-like 'given (my $o) { .foo := 5 }', Exception,
+    'binding to a methodish .foo topic call is a compile error',
+    message => /'bind operator'/;
+
+# vim: expandtab shiftwidth=4

--- a/t/12-rakuast/terms.rakutest
+++ b/t/12-rakuast/terms.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 13;
+plan 14;
 
 my $ast;
 my $deparsed;
@@ -104,6 +104,55 @@ given "argh" {
 CODE
 
     is-deeply $_, 'ARGH', @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'Topic call can be bound to' => {
+    # given %(:a(1)) { .<c> := .<a>; $_ }
+    ast RakuAST::Statement::Given.new(
+      source => RakuAST::Contextualizer::Hash.new(
+        RakuAST::StatementSequence.new(
+          RakuAST::Statement::Expression.new(
+            expression => RakuAST::ColonPair::Value.new(
+              key   => 'a',
+              value => RakuAST::IntLiteral.new(1)
+            )
+          )
+        )
+      ),
+      body => RakuAST::Block.new(
+        body => RakuAST::Blockoid.new(
+          RakuAST::StatementList.new(
+            RakuAST::Statement::Expression.new(
+              expression => RakuAST::ApplyInfix.new(
+                left  => RakuAST::Term::TopicCall.new(
+                  RakuAST::Postcircumfix::LiteralHashIndex.new(
+                    index => RakuAST::QuotedString.new(
+                      processors => <words val>,
+                      segments   => (RakuAST::StrLiteral.new('c'),)
+                    )
+                  )
+                ),
+                infix => RakuAST::Infix.new(':='),
+                right => RakuAST::Term::TopicCall.new(
+                  RakuAST::Postcircumfix::LiteralHashIndex.new(
+                    index => RakuAST::QuotedString.new(
+                      processors => <words val>,
+                      segments   => (RakuAST::StrLiteral.new('a'),)
+                    )
+                  )
+                )
+              )
+            ),
+            RakuAST::Statement::Expression.new(
+              expression => RakuAST::Var::Lexical.new('$_')
+            )
+          )
+        )
+      )
+    );
+
+    is-deeply $_, {:a(1), :c(1)}, @type[$++]
       for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
 }
 


### PR DESCRIPTION
Binding to a topic call such as `.<key> := $value` died with "Cannot compile bind to RakuAST::Term::TopicCall". Term::TopicCall inherited can-be-bound-to as False and had no bind path, so the bind operator refused it even though the explicit `$_<key> := $value` compiled fine.

Give Term::TopicCall the same bind delegation ApplyPostfix uses: forward can-be-bound-to and build-bind-exception to the wrapped call, and add IMPL-BIND-QAST that hands the implicit $_ to the postfix's IMPL-BIND-POSTFIX-QAST. Binds to `.<k>`, `.{...}` and `.[i]` now work; a methodish `.foo := $v` still reports "Cannot use bind operator with this left-hand side".

A postcircumfix topic call also deparsed without its leading dot, so `.<c>` round-tripped to a bare `<c>` term. Deparse now supplies the dot for a non-methodish call.