### PR TITLE
RakuAST: Run a statement prefix when evaluating a constant

### DIFF
--- a/src/Raku/ast/begintime.rakumod
+++ b/src/Raku/ast/begintime.rakumod
@@ -72,8 +72,14 @@ class RakuAST::BeginTime
             nqp::ifnull(nqp::decont($code.container), Mu)
         }
 
-        # It's already code
-        elsif nqp::istype($code, RakuAST::Code) {
+        # A code literal's begin-time value is its own code object,
+        elsif nqp::istype($code, RakuAST::Code)
+          # unless it is a value-producing statement prefix (gather, start, and
+          # friends), whose value is what running it produces, not the code,
+          && (!nqp::istype($code, RakuAST::StatementPrefix)
+              # though a phaser is a statement prefix whose caller runs the
+              # code object we hand back, so keep those.
+              || nqp::istype($code, RakuAST::StatementPrefix::Phaser)) {
             $code.meta-object
         }
 

--- a/t/02-rakudo/constant-from-gather-precomp.t
+++ b/t/02-rakudo/constant-from-gather-precomp.t
@@ -1,0 +1,19 @@
+use lib <t/02-rakudo/test-packages>;
+use Test;
+use ConstantFromGather;
+
+plan 3;
+
+# Loading the module precompiles it, so this constant comes back through
+# serialization. A `%` gather constant materializes to a Map, so the value is
+# correct and reusable across repeated access; a regression that left the
+# gather block or a single-use Seq in the constant would fail here.
+
+is ConstantFromGather::<%RULES><a>, 1,
+    'a precompiled %-constant from gather holds the gathered pairs';
+is ConstantFromGather::<%RULES>.elems, 2,
+    'a precompiled %-constant from gather has all the pairs';
+is ConstantFromGather::<%RULES><b>, 2,
+    'a precompiled %-constant from gather is reusable across access';
+
+# vim: expandtab shiftwidth=4

--- a/t/02-rakudo/constant-gather.t
+++ b/t/02-rakudo/constant-gather.t
@@ -1,0 +1,27 @@
+use Test;
+
+plan 6;
+
+# A `constant` initialized from a statement prefix such as `gather` is evaluated
+# at compile time. The value is the result of running the prefix, not the block
+# it wraps, so a `%`/`@`/`$` constant gets the gathered values.
+
+my constant %RULES = gather { take 'a' => 1; take 'b' => 2 };
+is %RULES<a>, 1, 'a %-constant from gather holds the gathered pairs';
+is %RULES.elems, 2, 'a %-constant from gather has all the pairs';
+
+my constant @LIST = gather { take 1; take 2; take 3 };
+is @LIST.join(','), '1,2,3', 'an @-constant from gather holds the gathered values';
+
+my constant $SEQ = gather { take 42 };
+is $SEQ.List.join(','), '42', 'a $-constant from gather holds the gathered sequence';
+
+# A `constant` initialized from a block or routine literal still binds the code
+# object itself, not the result of running it.
+my constant &BLOCK = { 99 };
+is BLOCK(), 99, 'a &-constant from a block still binds the block';
+
+my constant $PROMISE = start { 7 };
+is $PROMISE.result, 7, 'a $-constant from start runs and holds the promise';
+
+# vim: expandtab shiftwidth=4

--- a/t/02-rakudo/test-packages/ConstantFromGather.rakumod
+++ b/t/02-rakudo/test-packages/ConstantFromGather.rakumod
@@ -1,0 +1,6 @@
+unit module ConstantFromGather;
+
+# A `%` constant initialized from `gather` is computed at BEGIN time and
+# materialized with .Map, so the serialized value is a plain Map that survives
+# precompilation and is reusable, not the gather block or a single-use Seq.
+our constant %RULES = gather { take 'a' => 1; take 'b' => 2 };


### PR DESCRIPTION
A `constant` initialised from `gather { ... }` got the block as its value rather than the gathered sequence, so `my constant %RULES = gather {...}` died with "Cannot use a Callable as the only argument to store in a Map". This broke modules that build a constant lookup table from a gather, such as PublicSuffix.

IMPL-BEGIN-TIME-EVALUATE returned the meta-object for anything that does RakuAST::Code. A statement prefix like `gather` does RakuAST::Code because it manages a block, but it is a code-using expression whose value is the result of running it, not the block. Skip the meta-object path for a statement prefix so it falls through to the expression branch and is run. A block or routine literal still binds the code object.