### PR TITLE
RakuAST: snapshot native arguments to non-rw parameters

### DIFF
--- a/src/Raku/ast/call.rakumod
+++ b/src/Raku/ast/call.rakumod
@@ -529,7 +529,7 @@ class RakuAST::Call::Name
             $call.push(QAST::WVal.new(:value($ret.maybe-compile-time-value)));
         }
 
-        $call
+        self.IMPL-SIMPLIFY-REF-ARGS($call)
     }
 
     method IMPL-CAN-INTERPRET() {

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -504,12 +504,12 @@ class RakuAST::Infix
           ?? QAST::Op.new(:$op, $left-qast, $right-qast)
           # Otherwise, it's called by finding the lexical sub to call, and
           # compiling it as chaining if required.
-          !! QAST::Op.new(
+          !! self.IMPL-SIMPLIFY-REF-ARGS(QAST::Op.new(
                :op(self.properties.chain ?? 'chain' !! 'call'),
                :$name,
                $left-qast,
                $right-qast
-             )
+             ))
     }
 
     method IMPL-ASSIGN-OP(QAST::Node $lhs_ast, QAST::Node $rhs_ast) {
@@ -2761,7 +2761,7 @@ class RakuAST::Prefix
         }
         my $op := QAST::Op.new( :op('call'), :$name, $operand-qast );
         self.IMPL-ADD-COLONPAIRS-TO-OP($context, $op);
-        $op
+        self.IMPL-SIMPLIFY-REF-ARGS($op)
     }
 
     method IMPL-HOP-PREFIX-QAST(RakuAST::IMPL::QASTContext $context) {
@@ -3034,7 +3034,7 @@ class RakuAST::Postfix
           :op('call'), :name(self.resolution.lexical-name), $operand-qast
         );
         self.IMPL-ADD-COLONPAIRS-TO-OP($context, $op);
-        $op
+        self.IMPL-SIMPLIFY-REF-ARGS($op)
     }
 
     method IMPL-OPERATOR() {

--- a/src/Raku/ast/scoping.rakumod
+++ b/src/Raku/ast/scoping.rakumod
@@ -987,6 +987,89 @@ class RakuAST::Lookup
     method undeclared-symbol-details() {
         Nil
     }
+
+    # Native variable arguments compile to lexicalref/attributeref scope so
+    # a callee with an "is rw" parameter can write back through them. When
+    # this lookup resolves to a routine and no candidate declares the
+    # matching parameter rw, the argument is compiled as a value read
+    # instead. Otherwise a reference bound to a raw parameter, such as the
+    # value of infix:«=>», would be stored as a live view of the variable
+    # rather than a snapshot of it.
+    method IMPL-SIMPLIFY-REF-ARGS(Mu $call) {
+        unless $*COMPILING_CORE_SETTING {
+            if self.is-resolved
+                && nqp::istype(self.resolution, RakuAST::CompileTimeValue) {
+                my $routine := self.resolution.compile-time-value;
+                if nqp::isconcrete($routine) && nqp::istype($routine, Code) {
+                    # The callee is the first child when the call is not
+                    # made by name.
+                    my int $child := $call.name ?? 0 !! 1;
+                    my int $n := nqp::elems($call.list);
+                    my int $pos := 0;
+                    while $child < $n {
+                        my $arg := $call.list[$child];
+                        # A flattened argument makes the positions of the
+                        # remaining arguments unknowable at compile time.
+                        last if $arg.flat;
+                        unless $arg.named {
+                            if nqp::istype($arg, QAST::Var)
+                                && nqp::objprimspec($arg.returns) {
+                                my str $scope := $arg.scope;
+                                if ($scope eq 'lexicalref' || $scope eq 'attributeref')
+                                    && self.IMPL-PARAM-NEVER-RW($routine, $pos) {
+                                    $arg.scope($scope eq 'lexicalref' ?? 'lexical' !! 'attribute');
+                                }
+                            }
+                            ++$pos;
+                        }
+                        ++$child;
+                    }
+                }
+            }
+        }
+        $call
+    }
+
+    # Whether the parameter binding positional argument $i is known to be
+    # non-rw in every candidate of $routine. Any candidate that cannot be
+    # introspected, or whose signature has optional, slurpy, or capture
+    # parameters, means the reference must be kept.
+    method IMPL-PARAM-NEVER-RW(Mu $routine, int $i) {
+        my @candidates;
+        if nqp::can($routine, 'is_dispatcher') && $routine.is_dispatcher {
+            return 0 unless nqp::can($routine, 'onlystar') && $routine.onlystar;
+            for nqp::getattr($routine, Routine, '@!dispatchees') {
+                nqp::push(@candidates, $_);
+            }
+        }
+        else {
+            nqp::push(@candidates, $routine);
+        }
+        for @candidates {
+            return 0 unless nqp::can($_, 'signature');
+            my $sig := $_.signature;
+            return 0 unless nqp::isconcrete($sig)
+                && nqp::iseq_n($sig.arity, $sig.count);
+            my $param;
+            my int $pos := 0;
+            for nqp::getattr($sig, Signature, '@!params') {
+                my int $flags := nqp::getattr_i($_, Parameter, '$!flags');
+                unless nqp::getattr($_, Parameter, '@!named_names')
+                    || $flags +& (nqp::const::SIG_ELEM_SLURPY_NAMED
+                        +| nqp::const::SIG_ELEM_IS_CAPTURE) {
+                    if $pos == $i {
+                        $param := $_;
+                        last;
+                    }
+                    ++$pos;
+                }
+            }
+            return 0 unless nqp::isconcrete($param);
+            return 0 if nqp::getattr_i($param, Parameter, '$!flags')
+                +& nqp::const::SIG_ELEM_IS_RW;
+        }
+        1
+    }
 }
 
 # Details about an undeclared symbol.

--- a/t/02-rakudo/native-argument-snapshot.t
+++ b/t/02-rakudo/native-argument-snapshot.t
@@ -1,0 +1,94 @@
+use Test;
+
+plan 9;
+
+# A native variable argument must be passed as a snapshot of its value
+# whenever the callee cannot write back through it. A reference that
+# survives into storage reads the variable's current value on every
+# later access, as in the Pair a Font::FreeType iterator builds from a
+# native char-code attribute it then advances.
+
+{
+    my uint32 $c = 32;
+    my $rv := (7 => $c);
+    $c = $c + 1;
+    is $rv.value, 32,
+      'a native lexical as a pair value is snapshotted at construction';
+}
+
+{
+    my class WithNativeAttr {
+        has uint32 $!cc = 32;
+        method go {
+            my $p := (7 => $!cc);
+            $!cc = $!cc + 1;
+            $p.value
+        }
+    }
+    is WithNativeAttr.new.go, 32,
+      'a native attribute as a pair value is snapshotted at construction';
+}
+
+{
+    my $s;
+    sub keep(Mu \v) { $s := v }
+    my int $c = 5;
+    keep($c);
+    $c = 8;
+    is $s, 5,
+      'a native argument stored by a sub through a raw parameter is a snapshot';
+}
+
+{
+    my $s;
+    sub prefix:<grab>(Mu \v) { $s := v; v }
+    my int $c = 5;
+    grab $c;
+    $c = 8;
+    is $s, 5,
+      'a native argument stored by a prefix through a raw parameter is a snapshot';
+}
+
+{
+    my $s;
+    sub postfix:<✔>(Mu \v) { $s := v; v }
+    my int $c = 5;
+    $c✔;
+    $c = 8;
+    is $s, 5,
+      'a native argument stored by a postfix through a raw parameter is a snapshot';
+}
+
+{
+    sub inc(int $x is rw) { $x++ }
+    my int $c = 5;
+    inc($c);
+    is $c, 6, 'a native argument to an rw parameter still writes back';
+}
+
+{
+    sub infix:<bump>(int $x is rw, int $y) { $x = $y }
+    my int $c = 5;
+    $c bump 9;
+    is $c, 9,
+      'a native argument to an infix with an rw parameter stays writable';
+}
+
+{
+    sub f(int $x is rw, :$k) { $x++ }
+    my int $c = 5;
+    f(k => 1, $c);
+    is $c, 6,
+      'a native argument after a named argument still binds rw to its parameter';
+}
+
+{
+    sub f($a, int $x is rw) { $x++ }
+    my @a = 1,;
+    my int $c = 5;
+    f(|@a, $c);
+    is $c, 6,
+      'a native argument after a flattened argument still binds rw to its parameter';
+}
+
+# vim: expandtab shiftwidth=4

--- a/t/12-rakuast/xx-fixed-in-rakuast.rakutest
+++ b/t/12-rakuast/xx-fixed-in-rakuast.rakutest
@@ -2,7 +2,7 @@ use Test;
 use lib <t/packages/Test-Helpers>;
 use Test::Helpers;
 
-plan 114;
+plan 116;
 
 # t/spec/S03-sequence/misc.t
 # https://github.com/rakudo/rakudo/issues/5520
@@ -832,6 +832,34 @@ subtest 'use of &?ROUTINE and &?BLOCK' => {
     my @fires;
     Q| sub mk { sub { ENTER once { @fires.push('x') } } }; my $a = mk; my $b = mk; $a(); $a(); $b() |.AST.EVAL;
     is +@fires, 2, 'each clone of a routine runs its ENTER once independently';
+}
+
+# A native argument bound to a raw parameter must be a snapshot when no
+# candidate can write back through it, or the stored reference reads the
+# variable's current value on every later access. The legacy optimizer
+# only boxes native arguments for calls it can resolve, so an undecided
+# multi or a call mixing named and positional arguments still leaks the
+# reference. The cases both frontends get right are covered in
+# t/02-rakudo/native-argument-snapshot.t.
+{
+    my $s;
+    multi keep(Mu \v) { $s := v }
+    multi keep(Str \v) { }
+    my int $c = 5;
+    keep($c);
+    $c = 8;
+    todo "undecided multi leaks the native reference in legacy grammar" unless %*ENV<RAKUDO_RAKUAST>;
+    is $s, 5, 'a native argument to a multi where no candidate is rw is a snapshot';
+}
+
+{
+    my $s;
+    sub hold(Mu \v, :$k) { $s := v }
+    my int $c = 5;
+    hold(k => 1, $c);
+    $c = 8;
+    todo "mixed named and positional args leak the native reference in legacy grammar" unless %*ENV<RAKUDO_RAKUAST>;
+    is $s, 5, 'a native argument following a named argument is a snapshot';
 }
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously a native lexical or attribute compiled to a lexicalref or attributeref in argument position. When the callee bound it to a raw parameter and stored it, as `infix:«=>»` does when building a Pair, the stored reference remained a live view of the variable, so reading `.value` later saw mutations made after the Pair was built:

    my uint32 $c = 32;
    my $rv := (7 => $c);
    $c = $c + 1;
    say $rv.value;  # 33, should be 32

The legacy frontend has the same base semantics, but its optimizer rewrites native reference arguments to value reads when the resolved candidate does not mark the parameter `is rw` (`simplify_refs` in src/Perl6/Optimizer.nqp).

This does the equivalent when compiling infix, prefix, and postfix operators and named sub calls. When every candidate of the resolved routine declares the matching parameter without `is rw`, `RakuAST::Lookup.IMPL-SIMPLIFY-REF-ARGS` compiles the native argument as a value read, so the callee gets a snapshot. Any candidate that cannot be introspected, or whose signature has optional, slurpy, or capture parameters, keeps the reference. That leaves `infix:<,>` intact for list assignment like `my str ($a, $b) = ...` and keeps write-back through `is rw` parameters working. The argument scan skips the leading callee child of a call without a name, counts positions past named arguments, and stops at a flattened argument since the positions after it are unknowable at compile time.

This fixes the +1 shift in the glyph to char-code maps that Font::FreeType builds with `$!gid => $!char-code`.