### PR TITLE
RakuAST: let a lexical shadow the now and time terms

### DIFF
--- a/src/Raku/Grammar.nqp
+++ b/src/Raku/Grammar.nqp
@@ -3150,8 +3150,8 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
     token term:sym<circumfix> { <circumfix> }
 
     token term:sym<self> { <.term-self> <.end-keyword> }
-    token term:sym<now>  { <.term-now>  <.end-keyword> }
-    token term:sym<time> { <.term-time> <.end-keyword> }
+    token term:sym<now>  { <!{ $*R.is-identifier-known('now')  }> <.term-now>  <.end-keyword> }
+    token term:sym<time> { <!{ $*R.is-identifier-known('time') }> <.term-time> <.end-keyword> }
 
     token term:sym<nano> {
         <?{ self.language-revision >= 3

--- a/t/02-rakudo/term-now-time-shadow.t
+++ b/t/02-rakudo/term-now-time-shadow.t
@@ -1,0 +1,45 @@
+use Test;
+
+plan 8;
+
+# `now` and `time` are built-in listop terms, but a lexical of the same name,
+# such as the sigilless `my \time`, must shadow the built-in. RakuAST parsed
+# the bareword as the built-in term regardless of the lexical.
+
+{
+    my \time = 42;
+    is time, 42, 'a sigilless \time shadows the built-in time term';
+}
+
+{
+    my \now = 99;
+    is now, 99, 'a sigilless \now shadows the built-in now term';
+}
+
+# A same-named routine shadows the term too.
+{
+    sub time { 123 }
+    is time, 123, 'a sub named time shadows the built-in time term';
+}
+
+{
+    my &now = { 7 }
+    is now, 7, 'a &now routine variable shadows the built-in now term';
+}
+
+{
+    my \time = DateTime.new(:2020year, :1month, :1day);
+    is time.year, 2020, 'a method call resolves against the lexical, not the built-in';
+}
+
+# Without a lexical in scope the built-ins still resolve.
+is (time ~~ Int),   True, 'unshadowed time still returns the built-in';
+is (now  ~~ Instant), True, 'unshadowed now still returns the built-in';
+
+# The shadow is scoped: the built-in is back once the lexical is out of scope.
+{
+    my \time = 5;
+}
+is (time ~~ Int), True, 'the built-in returns once the lexical is out of scope';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
`now` and `time` are built-in listop terms, but a lexical of the same name should shadow them, so `my \time = calendar-from-posix ...; time.year` reads the binding rather than calling the built-in `&time`. The grammar matched the built-in term tokens unconditionally, so the bareword always became the built-in and a method call on it hit an Int.

Guard the `now` and `time` term tokens on there being no lexical of that name in scope, the way `nano` already guards on its own resolution. is-identifier-known covers both a sigilless `\time` and a routine `&time` or `sub time`, all of which legacy lets shadow the term, while the built-in lives under `&term:<time>` and so does not block itself.