### PR TITLE
RakuAST: preserve enclosing declarations across a heredoc splice

### DIFF
--- a/src/Raku/Grammar.nqp
+++ b/src/Raku/Grammar.nqp
@@ -427,18 +427,13 @@ role Raku::Common {
         \h*
         <?before \n | '#'>
 
-        :my $R;
-        :my $scope;
-        {
-            $R     := $*R;
-            # <.ws> is where the heredoc body splices in. Leave this scope for
-            # it, then restore the same one. Re-entering a fresh scope would
-            # drop the declarations already registered into it, so begin-time
-            # code later could not resolve any enclosing lexical.
-            $scope := $R.leave-scope;
-        }
+        # <.ws> is where the heredoc body splices in. Leave this scope for
+        # it, then restore the same one. Re-entering a fresh scope would
+        # drop the declarations already registered into it, so begin-time
+        # code later could not resolve any enclosing lexical.
+        :my $scope := $*R.leave-scope;
         <.ws>
-        { $R.re-enter-scope($scope) }
+        { $*R.re-enter-scope($scope) }
         <?MARKER('end-statement')>
     }
 

--- a/src/Raku/Grammar.nqp
+++ b/src/Raku/Grammar.nqp
@@ -431,11 +431,14 @@ role Raku::Common {
         :my $scope;
         {
             $R     := $*R;
-            $scope := $R.current-scope;
-            $R.leave-scope;
+            # <.ws> is where the heredoc body splices in. Leave this scope for
+            # it, then restore the same one. Re-entering a fresh scope would
+            # drop the declarations already registered into it, so begin-time
+            # code later could not resolve any enclosing lexical.
+            $scope := $R.leave-scope;
         }
         <.ws>
-        { $R.enter-scope($scope) }
+        { $R.re-enter-scope($scope) }
         <?MARKER('end-statement')>
     }
 

--- a/t/02-rakudo/heredoc-phaser-scope.t
+++ b/t/02-rakudo/heredoc-phaser-scope.t
@@ -1,0 +1,58 @@
+use Test;
+
+plan 7;
+
+# A BEGIN-time assignment whose value is a heredoc writes the enclosing lexical,
+# and that write is visible once the mainline runs.
+my $written;
+BEGIN $written = q:to/END/;
+line one
+line two
+END
+is $written, "line one\nline two\n", 'BEGIN assignment of a heredoc reaches the outer lexical';
+
+my $prefixed;
+BEGIN $prefixed = 'p-' ~ q:to/END/;
+body
+END
+is $prefixed, "p-body\n", 'BEGIN assignment of a heredoc within an expression reaches the outer lexical';
+
+# A CHECK phaser writing a heredoc behaves the same as BEGIN.
+my $checked;
+CHECK $checked = q:to/END/;
+checked
+END
+is $checked, "checked\n", 'CHECK assignment of a heredoc reaches the outer lexical';
+
+# The mainline may consume a lexical a BEGIN populated: a gather reading the
+# heredoc-holding variable sees what the BEGIN stored, even though the gather
+# appears before the BEGIN in the source.
+my $data;
+my %counts = gather for $data.lines -> $line {
+    take $line => $line.chars;
+}
+BEGIN $data = q:to/END/;
+aa
+bbb
+END
+is %counts<aa>, 2, 'a gather over a BEGIN-set heredoc lexical sees the value';
+is %counts<bbb>, 3, 'the gather processed every line of the heredoc';
+
+# A later phaser must resolve enclosing lexicals too, not just the first.
+my $first;
+my $second;
+BEGIN $first = q:to/END/;
+one
+END
+BEGIN $second = "have-" ~ $first.chomp;
+is $second, 'have-one', 'a phaser after a heredoc phaser still resolves the outer lexical';
+
+# A read of an enclosing lexical from a heredoc BEGIN resolves it as well. The
+# lexical is set at BEGIN time, so the read observes that value.
+my $greeting;
+BEGIN $greeting = 'hi';
+my $composed;
+BEGIN $composed = $greeting ~ q:to/END/;
+!
+END
+is $composed, "hi!\n", 'a heredoc BEGIN reading a BEGIN-set outer lexical observes its value';


### PR DESCRIPTION
The `cheat-heredoc` token leaves the current lexical scope so the heredoc body can splice in during the following `<.ws>`, then brings it back. Previously it did so through `enter-scope`, which builds a fresh scope holding none of the declarations registered into the original. Any phaser body run at parse time past that point could then resolve no enclosing lexical, not even `$?PACKAGE`. `BEGIN $x = q:to/END/ ... END` died with "Could not find a compile-time-value for lexical $x", and a heredoc BEGIN reading an outer lexical saw an unbound value.

Keep the scope object that `leave-scope` returns and restore it with `re-enter-scope`, so the declarations survive the splice.