### PR TITLE
RakuAST: fatalize try blocks and lower single-emit supplies

### DIFF
--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -1516,6 +1516,10 @@ class RakuAST::Block
         self.IMPL-UNWRAP-LIST(self.get-implicit-lookups)[1].resolution.compile-time-value;
     }
 
+    method IMPL-FATALIZE-RESOLVED() {
+        self.IMPL-UNWRAP-LIST(self.get-implicit-lookups)[1].is-resolved
+    }
+
     method IMPL-IS-IN-METHOD() {
         $!is-in-method
     }

--- a/src/Raku/ast/scoping.rakumod
+++ b/src/Raku/ast/scoping.rakumod
@@ -24,12 +24,21 @@ class RakuAST::LexicalScope
     has Bool $.tell-worries;
     has Bool $.soft;
 
+    # Set by `try` to throw (and then catch) Failures produced in this scope,
+    # the runtime half of `use fatal`, without the compile-time half that turns
+    # worries into sorries. `use fatal` sets $!fatal, which does both.
+    has Bool $.fatalize-failures;
+
     method set-fatal(Bool $on) {
         nqp::bindattr(self, RakuAST::LexicalScope, '$!fatal', $on);
     }
 
     method set-soft(Bool $on) {
         nqp::bindattr(self, RakuAST::LexicalScope, '$!soft', $on);
+    }
+
+    method set-fatalize-failures(Bool $on) {
+        nqp::bindattr(self, RakuAST::LexicalScope, '$!fatalize-failures', $on);
     }
 
     method set-worries(Bool $on) {
@@ -437,8 +446,16 @@ class RakuAST::LexicalScope
         nqp::die("IMPL-FATALIZE NYI on " ~ self.HOW.name(self));
     }
 
+    # Whether the &FATALIZE lookup this scope would wrap calls with has been
+    # resolved. In the setting a block compiled before &FATALIZE is declared
+    # has no resolution to wrap with.
+    method IMPL-FATALIZE-RESOLVED {
+        1
+    }
+
     method IMPL-MAYBE-FATALIZE-QAST($qast) {
-        self.IMPL-FATALIZE-QAST($qast, 0) if $!fatal;
+        self.IMPL-FATALIZE-QAST($qast, 0)
+            if $!fatal || $!fatalize-failures && self.IMPL-FATALIZE-RESOLVED;
 
         $qast
     }

--- a/src/Raku/ast/statementprefixes.rakumod
+++ b/src/Raku/ast/statementprefixes.rakumod
@@ -150,6 +150,20 @@ class RakuAST::StatementPrefix::Try
   is RakuAST::SinkPropagator
   is RakuAST::ImplicitLookups
 {
+    method new(RakuAST::Blorst $blorst) {
+        # A try block throws a Failure produced inside it, then catches it here,
+        # rather than letting it leak out as a value (for example as the
+        # argument of a `return`). This is the runtime half of `use fatal`; it
+        # does not turn the block's compile-time worries into sorries the way
+        # `use fatal` does, so code that merely warns still compiles. An explicit
+        # `use fatal`/`no fatal` in the block sets its own flag and is left
+        # alone.
+        $blorst.set-fatalize-failures(True)
+          if nqp::istype($blorst, RakuAST::Block)
+          && !nqp::isconcrete($blorst.fatal);
+        nqp::findmethod(RakuAST::StatementPrefix, 'new')(self, $blorst)
+    }
+
     method type() { "try" }
 
     method propagate-sink(Bool $is-sunk) {
@@ -184,31 +198,40 @@ class RakuAST::StatementPrefix::Try
 
             my $tmp := QAST::Node.unique('fatalizee');
             my $qast := self.IMPL-CALLISH-QAST($context);
+
+            # Success path puts Nil into $! and evaluates to the block.
+            my $success := QAST::Stmts.new(
+                :resultchild(0),
+                QAST::Op.new(
+                    :op('bind'),
+                    QAST::Var.new( :name($tmp), :scope('local'), :decl('var') ),
+                    $qast
+                )
+            );
+            # A block result that is a Failure is sunk, so the block evaluates
+            # to it without it going off later. Under an explicit `no fatal`
+            # the block keeps soft Failures as values, so leave the result be.
+            unless nqp::istype($blorst, RakuAST::Block)
+              && nqp::isconcrete($blorst.fatal) && !$blorst.fatal {
+                $success.push(QAST::Op.new(
+                    :op('if'),
+                    QAST::Op.new(
+                        :op('istype'),
+                        QAST::Var.new( :name($tmp), :scope('local') ),
+                        $Failure,
+                    ),
+                    QAST::Op.new(
+                        :op('callmethod'), :name('sink'),
+                        QAST::Var.new( :name($tmp), :scope('local') )
+                    )
+                ));
+            }
             QAST::Op.new(
                 :op('handle'),
 
-                # Success path puts Nil into $! and evaluates to the block.
                 QAST::Stmt.new(
                     :resultchild(0),
-                    QAST::Stmts.new(
-                        :resultchild(0),
-                        QAST::Op.new(
-                            :op('bind'),
-                            QAST::Var.new( :name($tmp), :scope('local'), :decl('var') ),
-                            $qast
-                        ),
-                        QAST::Op.new(
-                            :op('if'),
-                            QAST::Op.new(
-                                :op('istype'),
-                                QAST::Var.new( :name($tmp), :scope('local') ),
-                                $Failure,
-                            ),
-                            QAST::Op.new(
-                                :op('callmethod'), :name('sink'),
-                                QAST::Var.new( :name($tmp), :scope('local') )
-                            )
-                        )),
+                    $success,
                     QAST::Op.new( :op('p6store'), $bang, $nil )
                 ),
 

--- a/src/Raku/ast/statementprefixes.rakumod
+++ b/src/Raku/ast/statementprefixes.rakumod
@@ -603,7 +603,52 @@ class RakuAST::StatementPrefix::React
 class RakuAST::StatementPrefix::Supply
   is RakuAST::StatementPrefix::Wheneverable
 {
+    has int $!one-emit;
+
     method type() { "supply" }
+
+    method PERFORM-BEGIN(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
+        self.IMPL-LOWER-ONE-EMIT();
+        nqp::findmethod(RakuAST::StatementPrefix::Blorst, 'PERFORM-BEGIN')(self, $resolver, $context)
+    }
+
+    # A supply whose whole body is a single `emit EXPR` doesn't need the
+    # supply concurrency machinery: rewrite the body to just EXPR and route
+    # it to &SUPPLY-ONE-EMIT, whose tappable evaluates the block and emits
+    # its return value, quitting on a thrown or failed evaluation.
+    method IMPL-LOWER-ONE-EMIT() {
+        unless self.IMPL-WHENEVER-COUNT {
+            my $blorst := self.blorst;
+            my $stmt;
+            if nqp::istype($blorst, RakuAST::Block) {
+                my @stmts := $blorst.body.statement-list.IMPL-NON-EMPTY-CODE-STATEMENTS;
+                $stmt := @stmts[0] if nqp::elems(@stmts) == 1;
+            }
+            else {
+                $stmt := $blorst;
+            }
+            if nqp::istype($stmt, RakuAST::Statement::Expression)
+              && !$stmt.condition-modifier && !$stmt.loop-modifier {
+                my $call := $stmt.expression;
+                if nqp::istype($call, RakuAST::Call::Name)
+                  && $call.name.is-identifier
+                  && $call.name.canonicalize eq 'emit'
+                  && $call.args.IMPL-IS-ONE-POS-ARG {
+                    $stmt.set-expression($call.args.arg-at-pos(0));
+                    nqp::bindattr_i(self, RakuAST::StatementPrefix::Supply, '$!one-emit', 1);
+                }
+            }
+        }
+        Nil
+    }
+
+    method IMPL-EXPR-QAST(RakuAST::IMPL::QASTContext $context) {
+        $!one-emit
+            ?? QAST::Op.new(
+                 :op<call>, :name('&SUPPLY-ONE-EMIT'), self.IMPL-CLOSURE-QAST($context)
+               )
+            !! nqp::findmethod(RakuAST::StatementPrefix::Wheneverable, 'IMPL-EXPR-QAST')(self, $context)
+    }
 }
 
 # Done by all phasers. Serves as little more than a marker for phasers, for

--- a/t/02-rakudo/supply-one-emit.t
+++ b/t/02-rakudo/supply-one-emit.t
@@ -1,0 +1,58 @@
+use Test;
+
+plan 6;
+
+# A supply whose whole body is a single `emit EXPR` is lowered to
+# SUPPLY-ONE-EMIT, whose tappable emits the block's return value and quits
+# when evaluating the block throws or fails.
+
+# The lowered form still emits its value.
+is do {
+    my @got;
+    react {
+        whenever (supply emit 42) -> $v { @got.push($v) }
+    }
+    @got.join(',')
+}, '42', 'a single-emit supply statement emits its value';
+
+# The block form is lowered the same way.
+is do {
+    my @got;
+    react {
+        whenever (supply { emit 42 }) -> $v { @got.push($v) }
+    }
+    @got.join(',')
+}, '42', 'a single-emit supply block emits its value';
+
+# A Failure produced while evaluating the emitted expression quits the
+# supply instead of being emitted as a value.
+{
+    sub failing() { fail "boom" }
+    my @got;
+    dies-ok {
+        react {
+            whenever (supply emit failing()) -> $v { @got.push($v.WHAT.^name) }
+        }
+    }, 'a Failure from the emitted expression quits the supply';
+    is @got.join(','), '', 'the Failure was not emitted as a value';
+}
+
+# A supply with more than one emit is not lowered and still works.
+is do {
+    my @got;
+    react {
+        whenever (supply { emit 1; emit 2 }) -> $v { @got.push($v) }
+    }
+    @got.join(',')
+}, '1,2', 'a two-emit supply block emits both values';
+
+# A statement modifier keeps the generic supply path and still works.
+is do {
+    my @got;
+    react {
+        whenever (supply emit 42 if True) -> $v { @got.push($v) }
+    }
+    @got.join(',')
+}, '42', 'a single emit with a statement modifier emits its value';
+
+# vim: expandtab shiftwidth=4

--- a/t/02-rakudo/try-fatalizes-block.t
+++ b/t/02-rakudo/try-fatalizes-block.t
@@ -1,0 +1,56 @@
+use lib <t/packages/Test-Helpers>;
+use Test;
+use Test::Helpers;
+
+plan 7;
+
+# A try block runs with `use fatal` semantics: a Failure produced inside it
+# is thrown and caught, so a `return` of a failing expression never happens
+# and control falls through after the try.
+is do {
+    sub f($v) { try { return $v.Int }; 'fell-through' }
+    f("abc")
+}, 'fell-through', 'a Failure as a return argument in a try is caught, not returned';
+
+# A successful conversion still returns its value.
+is do {
+    sub g($v) { try { return $v.Int }; 'fell-through' }
+    g("42")
+}, 42, 'a successful return in a try returns its value';
+
+# A Failure assigned and then returned is likewise caught.
+is do {
+    sub h($v) { try { my $n = $v.Int; return $n }; 0 }
+    h("xyz")
+}, 0, 'a Failure bound then returned in a try is caught';
+
+# An explicit `no fatal` in the block is honored: the try does not fatalize,
+# so a returned Failure stays soft rather than being caught.
+is do {
+    sub k($v) { try { no fatal; return $v.Int }; 'fell-through' }
+    k("abc").WHAT.^name
+}, 'Failure', 'no fatal in a try block leaves a returned Failure soft';
+
+# Under `no fatal` a soft Failure that is the block's value is kept, rather
+# than the try sinking it away.
+is do {
+    my $r = try { no fatal; "abc".Int };
+    $r.WHAT.^name
+}, 'Failure', 'no fatal in a try keeps a soft Failure result value';
+
+# Fatalizing the block is the runtime half of `use fatal`. It must not turn the
+# block's compile-time worries into sorries: a sunk statement that merely warns
+# still compiles and runs inside a try.
+is-run 'try { 42; 1 }; print "compiled"',
+    :out("compiled"),
+    :err(/'Useless use of constant integer 42 in sink context'/),
+    'a worry inside a try stays a warning, the block still compiles';
+
+# Explicit `use fatal` does turn a worry into a compile error, so the runtime
+# and compile-time halves stay separate.
+is-run 'use fatal; |4..5',
+    :exitcode(* != 0),
+    :err(/'parenthesize'/),
+    'use fatal still promotes the worry to a compile error';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously `supply emit EXPR` compiled to the generic `&SUPPLY` under RakuAST, so a Failure produced while evaluating EXPR was emitted as an ordinary value instead of quitting the supply. Cro::CBOR relies on the legacy behavior. Its WebSocket body serializer is `supply emit cbor-encode($body)`, and an unserializable body must make the send die. Blin flagged its t/02-websocket-client.rakutest failing under RakuAST.

Two changes, one per commit:

The first makes a try block run with the runtime half of `use fatal`, as the legacy frontend does. Previously a Failure produced inside a try leaked out as a value. `try { return $v.Int }` returned the Failure rather than falling through, and a Failure returned into the block through a call and then sunk never went off. A new `fatalize-failures` scope flag drives the fatalization without setting the `fatal` flag that worry promotion keys on, so code that merely warns still compiles inside a try. An explicit `use fatal`/`no fatal` in the block is left alone. This also applies while compiling the setting. A setting block compiled before `&FATALIZE` is declared has nothing to wrap calls with, so it skips fatalization instead of failing the build.

The second lowers a supply whose whole body is a single `emit EXPR` to `&SUPPLY-ONE-EMIT`, rewriting the body to just EXPR, the same as the legacy frontend. Its tappable emits the block's return value and quits when evaluating the block throws or fails.

Both are needed for the Cro case. The generic `&SUPPLY` path emits the block's value without ever sinking it, so the lowering routes it to `OneEmitTappable`, and `OneEmitTappable` only quits on the returned Failure because its try block now fatalizes.

Tested with both frontends and both CORE builds: t/02-rakudo/try-fatalizes-block.t, t/02-rakudo/supply-one-emit.t, and Cro::CBOR's t/02-websocket-client.rakutest now pass in all four combinations.
