### PR TITLE
RakuAST: set a stub's yada bit before applying its traits

### DIFF
--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -2084,6 +2084,8 @@ class RakuAST::Routine
         my $stub := self.IMPL-STUB-CODE($resolver, $context);
         nqp::setcodename($stub, $!name.canonicalize) if $!name;
 
+        self.meta-object.set_yada if self.is-stub;
+
         # Apply any traits, with the routine's own scope visible: a trait
         # argument can declare into it, as in `is memoized(my %h)`.
         $resolver.push-scope(self);
@@ -2715,6 +2717,8 @@ class RakuAST::Methodish
 
         my $stub := self.IMPL-STUB-CODE($resolver, $context);
         nqp::setcodename($stub, $name) if $name;
+
+        self.meta-object.set_yada if self.is-stub;
 
         # Apply any traits.
         self.apply-traits($resolver, $context, self)

--- a/t/02-rakudo/yada-trait-timing.t
+++ b/t/02-rakudo/yada-trait-timing.t
@@ -1,0 +1,22 @@
+use Test;
+
+plan 2;
+
+# A stub's yada bit is set before its traits run, so a trait constrained with
+# `where { .yada }` matches the stub and applies. LibXML's `is dom-boxed` is
+# such a trait.
+
+multi trait_mod:<is>(Method:D $m where { .yada }, :$replace-method!) {
+    $m.wrap: method { 'method-replaced' };
+}
+multi trait_mod:<is>(Sub:D $s where { .yada }, :$replace-sub!) {
+    $s.wrap: sub { 'sub-replaced' };
+}
+
+class Widget {
+    method make(--> Str) is replace-method {...}
+}
+sub build(--> Str) is replace-sub {...}
+
+is Widget.new.make, 'method-replaced', 'a where {.yada} trait applies to a stub method';
+is build(),         'sub-replaced',    'a where {.yada} trait applies to a stub sub';


### PR DESCRIPTION
A trait can constrain on a routine being a stub. LibXML's `is dom-boxed` uses `where { .yada }`. Previously RakuAST set the yada bit while compiling the body, which runs after traits are applied, so `.yada` was False when the constraint ran and the trait was rejected as an unknown trait. Set it in PERFORM-BEGIN before apply-traits so the constraint sees the stub.