### PR TITLE
RakuAST: defer private method resolution when the package is composing

### DIFF
--- a/src/Raku/ast/call.rakumod
+++ b/src/Raku/ast/call.rakumod
@@ -1077,7 +1077,7 @@ class RakuAST::Call::PrivateMethod
         if $!name.is-identifier {
             my $name := self.IMPL-UNWRAP-LIST($!name.parts)[0].name;
             my $package := $!package;
-            if nqp::can($package.HOW, 'archetypes') && !$package.HOW.archetypes.generic && !$package.HOW.archetypes.parametric && nqp::can($package.HOW, 'find_private_method') {
+            if self.IMPL-PRIVATE-RESOLVABLE-AT-COMPILE($package) {
                 my $meth := $package.HOW.find_private_method($package, $name);
                 unless nqp::defined($meth) && $meth {
                     self.add-sorry:
@@ -1087,6 +1087,20 @@ class RakuAST::Call::PrivateMethod
                 }
             }
         }
+    }
+
+    # A private method can be resolved at compile time only from a concrete,
+    # non-generic package that has already composed. A package still composing
+    # (a trait applied at BEGIN compiles wrapper methods before its class
+    # composes) may gain the method later, so those calls fall back to the
+    # runtime private-method dispatch instead.
+    method IMPL-PRIVATE-RESOLVABLE-AT-COMPILE(Mu $package) {
+        nqp::can($package.HOW, 'archetypes')
+          && !$package.HOW.archetypes.generic
+          && !$package.HOW.archetypes.parametric
+          && nqp::can($package.HOW, 'find_private_method')
+          && (!nqp::can($package.HOW, 'is_composed')
+                || $package.HOW.is_composed($package))
     }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
@@ -1100,7 +1114,7 @@ class RakuAST::Call::PrivateMethod
         if $!name.is-identifier {
             my $name := self.IMPL-UNWRAP-LIST($!name.parts)[0].name;
             my $package := $!package;
-            if nqp::can($package.HOW, 'archetypes') && !$package.HOW.archetypes.generic && !$package.HOW.archetypes.parametric && nqp::can($package.HOW, 'find_private_method') {
+            if self.IMPL-PRIVATE-RESOLVABLE-AT-COMPILE($package) {
                 my $meth := $package.HOW.find_private_method($package, $name);
                 if nqp::defined($meth) && $meth {
                     $context.ensure-sc($meth);

--- a/t/02-rakudo/private-method-trait-wrapper.t
+++ b/t/02-rakudo/private-method-trait-wrapper.t
@@ -1,0 +1,20 @@
+use Test;
+
+plan 2;
+
+# A trait applied at BEGIN time wraps a method with a closure that is compiled
+# before its class has composed. A private method call in that closure cannot be
+# resolved at compile time, so it falls back to the runtime dispatch rather than
+# erroring. LibXML's `is reader-raw` trait wraps methods this way.
+class C {
+    method !double($n) { $n * 2 }
+    multi trait_mod:<is>(Method:D $m, :$doubling!) {
+        $m.wrap: method { self!double(21) };
+    }
+    method answer() is doubling {...}
+}
+is C.new.answer, 42, 'a trait wrapper resolves the class private method at runtime';
+
+# A private-method typo in a fully composed class is still a compile-time error.
+throws-like 'class D { method !real() {}; method go() { self!bogus() } }',
+    X::Comp, 'a private-method typo in a composed class still fails to compile';


### PR DESCRIPTION
A private method call resolves at compile time by looking the method up on its package. A trait applied at BEGIN wraps methods with closures that are compiled before the class composes, so the lookup found nothing and the call died with "Private method not found" (LibXML's `is reader-raw`). Only resolve at compile time once the package has composed, otherwise emit the runtime private-method dispatch, which finds the method once the class is in place.