### PR TITLE
RakuAST: return Nil from a QUIT phaser when its when/default succeeds

### DIFF
--- a/src/Raku/ast/scoping.rakumod
+++ b/src/Raku/ast/scoping.rakumod
@@ -16,6 +16,7 @@ class RakuAST::LexicalScope
 
     # Handlers related to this scope.
     has int $!need-succeed-handler;
+    has int $!nil-on-succeed;
     has Mu $!catch-handlers;
     has Mu $!control-handlers;
 
@@ -268,6 +269,15 @@ class RakuAST::LexicalScope
         Nil
     }
 
+    # A QUIT phaser reports whether it handled the exception by what it
+    # returns: Nil after a when/default succeeds, the exception otherwise.
+    # Its block's succeed handler therefore produces Nil, with the payload
+    # sunk, rather than the payload a succeed normally evaluates to.
+    method set-nil-on-succeed() {
+        nqp::bindattr_i(self, RakuAST::LexicalScope, '$!nil-on-succeed', 1);
+        Nil
+    }
+
     method attach-catch-handler(RakuAST::Statement::Catch $catch) {
         if $!catch-handlers {
             nqp::push($!catch-handlers, $catch);
@@ -405,7 +415,12 @@ class RakuAST::LexicalScope
             my $handle := QAST::Op.new( :op('handle'), $statements );
             if $!need-succeed-handler {
                 $handle.push('SUCCEED');
-                $handle.push(QAST::Op.new( :op('p6return'), QAST::Op.new( :op('getpayload'), QAST::Op.new( :op('exception') ) ) ));
+                my $payload := QAST::Op.new( :op('getpayload'), QAST::Op.new( :op('exception') ) );
+                $handle.push(QAST::Op.new( :op('p6return'), $!nil-on-succeed
+                    ?? QAST::Stmts.new(
+                           QAST::Op.new( :op('p6sink'), $payload ),
+                           QAST::WVal.new( :value(Nil) ))
+                    !! $payload ));
             }
             if $!catch-handlers {
                 self.IMPL-ADD-HANDLER($handle, 'CATCH');

--- a/src/Raku/ast/statementprefixes.rakumod
+++ b/src/Raku/ast/statementprefixes.rakumod
@@ -829,6 +829,7 @@ class RakuAST::StatementPrefix::Phaser::Quit
 
         if nqp::istype(self.blorst, RakuAST::Block) {
             self.blorst.set-needs-result(True);
+            self.blorst.set-nil-on-succeed();
             self.blorst.body.statement-list.add-statement(
                 RakuAST::Statement::Expression.new(
                     :expression(

--- a/t/02-rakudo/quit-phaser-succeed.t
+++ b/t/02-rakudo/quit-phaser-succeed.t
@@ -1,0 +1,54 @@
+use Test;
+
+plan 5;
+
+# A QUIT phaser reports whether it handled the exception by what it returns:
+# Nil after a when/default succeeds, the exception otherwise. The supply
+# machinery keys on that to decide between closing the tap and rethrowing.
+
+# A default in a whenever's QUIT intercepts the quit, so the react block
+# completes instead of dying.
+is do {
+    my $q = "not-run";
+    react {
+        whenever (supply { die "boom" }) -> $v {
+            QUIT { default { $q = "QUIT:" ~ .^name } }
+        }
+    }
+    $q
+}, 'QUIT:X::AdHoc', 'a default in a whenever QUIT handles the quit and react completes';
+
+# The same interception works for a whenever inside a supply block.
+is do {
+    my $q = "not-run";
+    my $s = supply {
+        whenever (supply { die "boom" }) -> $v {
+            QUIT { default { $q = "QUIT:" ~ .^name } }
+        }
+    }
+    react { whenever $s -> $v { } }
+    $q
+}, 'QUIT:X::AdHoc', 'a default in a supply-block whenever QUIT handles the quit';
+
+# A QUIT whose when clauses do not match leaves the quit unhandled, so the
+# react block dies with the original exception.
+{
+    my $q = "not-run";
+    throws-like {
+        react {
+            whenever (supply { die "boom" }) -> $v {
+                QUIT { when X::OutOfRange { $q = "wrong" } }
+            }
+        }
+    }, Exception, message => /boom/,
+        'a QUIT with no matching when rethrows and the react block dies';
+    is $q, "not-run", 'the non-matching when clause did not run';
+}
+
+# The phaser itself returns Nil when a default succeeds.
+is do {
+    my $b = -> $v { QUIT { default { 42 } }; 1 };
+    $b.phasers("QUIT")[0](X::AdHoc.new(payload => "x")) === Nil
+}, True, 'a QUIT phaser returns Nil after its default succeeds';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously a whenever block's QUIT phaser never intercepted the quit under the RakuAST frontend: the react or supply block died with the original exception even though a default clause matched. The supply machinery decides whether a QUIT phaser handled the exception by what the phaser returns, Nil when handled, and treats anything else as unhandled and rethrows. The RakuAST-compiled phaser block ended in the generic succeed handler, which returns the succeed payload, so a matching when/default made the phaser return that payload instead of Nil and the quit was always considered unhandled.

This makes a QUIT phaser block's succeed handler produce Nil, with the payload sunk, the way the legacy frontend rewrites it. A QUIT whose when clauses do not match still returns the exception, so an unhandled quit rethrows as before, and succeed handlers of ordinary blocks are unaffected.