### PR TITLE
RakuAST: allow a bare Whatever `where` constraint

### DIFF
--- a/src/Raku/ast/signature.rakumod
+++ b/src/Raku/ast/signature.rakumod
@@ -1083,6 +1083,15 @@ class RakuAST::Parameter
     method PERFORM-BEGIN(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
         nqp::bindattr(self, RakuAST::Parameter, '$!where', $!where.IMPL-UNWRAP-WHERE-PARENS)
             if $!where;
+
+        # Catch a double closure in the user's own where block, before it is
+        # wrapped in the synthetic ACCEPTS block below. A bare `where *` is not a
+        # block, so it is left alone and its wrapper is not mistaken for one.
+        if $!where && nqp::istype($!where, RakuAST::Block) {
+            my $sorry := $!where.IMPL-CHECK-DOUBLE-CLOSURE($resolver, $context);
+            self.add-sorry: $sorry if $sorry;
+        }
+
         if $!where && (! nqp::istype($!where, RakuAST::Code) || nqp::istype($!where, RakuAST::RegexThunk)) && !$!where.IMPL-CURRIED {
             my $block := RakuAST::Block.new(
                 body => RakuAST::Blockoid.new(
@@ -1257,11 +1266,6 @@ class RakuAST::Parameter
           && nqp::can($ptype-archetypes, "parametric")
           && $ptype-archetypes.parametric {
             $!owner.set-custom-args;
-        }
-
-        if $!where && nqp::istype($!where, RakuAST::Block) {
-            my $sorry := $!where.IMPL-CHECK-DOUBLE-CLOSURE($resolver, $context);
-            self.add-sorry: $sorry if $sorry;
         }
 
         if $!type {

--- a/t/02-rakudo/where-paren-whatever.t
+++ b/t/02-rakudo/where-paren-whatever.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 11;
+plan 13;
 
 # A parenthesized WhateverCode in a `where` is the same closure as the
 # unparenthesized form. `where (* > 0)` must not be mistaken for an explicit
@@ -34,6 +34,14 @@ dies-ok  { my Positive $s = -1 }, 'subset where (* > 0) rejects an invalid value
 # And in a variable constraint, which routes through the subset machinery.
 lives-ok { my $v where (1 <= * <= 4) = 3 }, 'variable where (1 <= * <= 4) accepts';
 dies-ok  { my $v where (1 <= * <= 4) = 9 }, 'variable where (1 <= * <= 4) rejects';
+
+# A bare `where *` is a Whatever constraint that accepts anything (as in
+# IUP's `Bool :$copy where *`). Its synthetic ACCEPTS wrapper must not be
+# mistaken for a user-written double closure.
+sub bare($x where *) { $x }
+is bare(-99), -99, 'where * accepts any value';
+sub named(Bool :$flag where *) { $flag }
+is named(:flag), True, 'a named parameter where * accepts any value';
 
 # An explicit block wrapping a whatever is still a double closure error.
 throws-like 'sub f($x where { * > 0 }) { }', X::Syntax::Malformed,


### PR DESCRIPTION
A parameter `where *` (as in IUP's `Bool :$copy where *`) died with "Malformed double closure". A bare Whatever is not a WhateverCode, so it was wrapped in a synthetic `{ $where.ACCEPTS($_).Bool }` block, and the `*` inside re-curried; the double-closure check then ran on that wrapper and rejected it. Run the check in PERFORM-BEGIN on the original where, before the wrapper is built, so a bare Whatever is left alone while a user-written `where { * > 0 }` is still caught.