### PR TITLE
RakuAST: make every variable declaration a declarator doc target

### DIFF
--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -768,7 +768,10 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
     }
 
     # Helper method to connect any leading declarator doc that was
-    # collected already to the given declarand
+    # collected already to the given declarand.  A declarand that does
+    # not surface documentation in $=pod, such as a lexical, does not
+    # consume the leading doc: it stays collected for the next declarand
+    # that does, e.g. an anon sub in the lexical's initializer.
     method set-declarand($/, $it) {
 
         # Ignoring this one
@@ -790,7 +793,7 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
             $*DECLARAND          := $it;
             $*LAST-TRAILING-LINE := +$*ORIGIN-SOURCE.original-line($from);
 
-            if @*LEADING-DOC -> @leading {
+            if $it.podifiable && @*LEADING-DOC -> @leading {
                 $it.set-leading(@leading);
                 @*LEADING-DOC := [];
             }
@@ -2920,7 +2923,7 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
                 $decl.set-already-declared;
             }
 
-            self.set-declarand($/, $decl) if $scope eq 'has';
+            self.set-declarand($/, $decl);
         }
         else {
             $scope ne 'my' && $scope ne 'state'

--- a/src/Raku/ast/doc-declarator.rakumod
+++ b/src/Raku/ast/doc-declarator.rakumod
@@ -15,7 +15,10 @@ class RakuAST::Doc::Declarator
         $obj.set-leading($leading);
         $obj.set-trailing($trailing);
 
-        if nqp::isconcrete($*LEGACY-POD-INDEX) {
+        # A target that does not surface its documentation in $=pod must
+        # not reserve a position there, as it would never be filled in.
+        if nqp::isconcrete($*LEGACY-POD-INDEX)
+          && (!nqp::isconcrete($WHEREFORE) || $WHEREFORE.podifiable) {
             nqp::bindattr_i($obj,RakuAST::Doc::Declarator,
               '$!pod-index', $*LEGACY-POD-INDEX++);
         }
@@ -54,11 +57,13 @@ class RakuAST::Doc::Declarator
     method PERFORM-CHECK(RakuAST::Resolver $resolver,
                 RakuAST::IMPL::QASTContext $context) {
         if $!WHEREFORE {
-            my $meta := $!WHEREFORE.meta-object;
-            if $meta.HOW.name($meta) ne 'Any' {
-                $resolver.find-attach-target('compunit').set-pod-content(
-                  $!pod-index, self.podify($meta)
-                );
+            if $!WHEREFORE.podifiable {
+                my $meta := $!WHEREFORE.meta-object;
+                if $meta.HOW.name($meta) ne 'Any' {
+                    $resolver.find-attach-target('compunit').set-pod-content(
+                      $!pod-index, self.podify($meta)
+                    );
+                }
             }
         }
         else {
@@ -72,6 +77,14 @@ class RakuAST::Doc::Declarator
 # Role for objects that can have a Doc::Declarator attached
 class RakuAST::Doc::DeclaratorTarget {
     has RakuAST::Doc::Declarator $.WHY;
+
+    # Whether the documentation on this target is surfaced through the
+    # legacy pod system: turned into a Pod::Block::Declarator in $=pod
+    # and set as the .WHY of the target's meta-object.  Targets without
+    # a runtime meta-object to carry the documentation, such as lexical
+    # variable declarations, return False: their documentation lives on
+    # the AST node only and is available through $=rakudoc.
+    method podifiable() { True }
 
     # A special method to create a a Declarator and connect it to the
     # target.  Intended to be used for a .raku representation

--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -842,6 +842,11 @@ class RakuAST::VarDeclaration::Simple
         $scope eq 'has' || $scope eq 'HAS'
     }
 
+    # Only an attribute has a meta-object that can carry documentation
+    # at runtime. The documentation of other variable declarations is
+    # only available through $=rakudoc.
+    method podifiable() { self.is-attribute }
+
     method IMPL-OF-TYPE() {
         $!type
             ?? (nqp::istype($!type, RakuAST::Lookup)

--- a/t/02-rakudo/lexical-declarator-doc.t
+++ b/t/02-rakudo/lexical-declarator-doc.t
@@ -1,0 +1,101 @@
+use lib <t/packages/Test-Helpers>;
+use Test;
+use Test::Helpers;
+
+plan 8;
+
+# A trailing declarator doc (`#=`) attaches to the declaration it follows,
+# including a lexical variable declaration. A clean run (no warning on
+# stderr) shows the doc attached to its declaration instead of being
+# reported as a missing declarand.
+is-run q:to/CODE/,
+        my $lock;      #= the lock
+        my %registry;  #= the registry
+        sub helper { }
+        print "ok";
+        CODE
+    :out("ok"), :err(""),
+    'a trailing declarator doc on a lexical does not warn about a missing declarand';
+
+is-run q:to/CODE/,
+        our $global;  #= the global
+        sub tick { state $n;  #= the counter
+        }
+        print "ok";
+        CODE
+    :out("ok"), :err(""),
+    'trailing declarator docs on our and state declarations do not warn either';
+
+# A lexical only takes trailing doc. A leading `#|` before it still falls
+# through to the next documentable declarand (here the anon sub), rather than
+# being consumed by the lexical, where it would be hidden from $=pod.
+is-run q:to/CODE/,
+        #| documented
+        my $f = anon sub bar { };
+        print $=pod.elems;
+        CODE
+    :out("1"), :err(""),
+    'leading declarator doc before a lexical falls through to the next declarand';
+
+# A lexical has no runtime meta-object to carry documentation, so its doc
+# must not be surfaced through the meta-object of its *type*.
+is-run q:to/CODE/,
+        my Int $x;  #= int doc
+        sub helper { }
+        print Int.WHY.defined ?? "leaked" !! "clean";
+        print $=pod.elems;
+        CODE
+    :out("clean0"), :err(""),
+    'a trailing declarator doc on a typed lexical does not become the WHY of its type';
+
+is-run q:to/CODE/,
+        #| class doc
+        class C {}
+        my C $c;  #= var doc
+        print C.WHY.leading;
+        CODE
+    :out("class doc"), :err(""),
+    'a trailing declarator doc on a typed lexical does not replace the class doc';
+
+# The lexical's doc does not appear in $=pod, so it must not reserve a
+# position there either.
+is-run q:to/CODE/,
+        my $x;  #= var doc
+        #| sub doc
+        sub f() {}
+        print $=pod.elems;
+        print "|";
+        print $=pod[0].defined;
+        CODE
+    :out("1|True"), :err(""),
+    'a documented lexical does not leave a hole in $=pod';
+
+# A HAS attribute is documentable just like a has attribute.
+is-run q:to/CODE/,
+        class Point is repr("CStruct") { has num64 $.x }
+        class Line is repr("CStruct") {
+            HAS Point $!start;  #= start point
+        }
+        print Line.^attributes[0].WHY;
+        CODE
+    :out("start point"), :err(""),
+    'a trailing declarator doc attaches to a HAS attribute without warning';
+
+# The doc of a lexical stays on its RakuAST declaration node, where the
+# $=rakudoc collection picks it up.
+if %*ENV<RAKUDO_RAKUAST> {
+    is-run q:to/CODE/,
+            my $lock;  #= the lock
+            sub helper { }
+            print $=rakudoc.elems;
+            print "|";
+            print $=rakudoc[0].WHY.trailing;
+            CODE
+        :out("1|the lock"), :err(""),
+        'the declarator doc of a lexical is available through $=rakudoc';
+}
+else {
+    skip 'the $=rakudoc variable requires the RakuAST frontend';
+}
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously only attributes were made the declarand when a variable is declared, so a trailing #= doc after a my, state, our or HAS declaration had nothing to attach to. The doc was left orphaned and the next declarand reported it with "Missing declarand for trailing declarator doc", a warning the legacy frontend does not emit. S26 specifies lexicals as valid declarator doc targets:

    #| This is a special chainsaw
    #| (Why, you ask?)
    my SwissArmy $chainsaw    #= (It has a rocket launcher!)

This makes every named variable declaration the declarand. A lexical has no runtime meta-object to carry documentation the way an Attribute does, so its doc must not be turned into a Pod::Block::Declarator: doing so would set the .WHY of the *type* of the variable (documenting `my Int $x` would overwrite the documentation of Int) and produce a bogus `$=pod` entry. The new Doc::DeclaratorTarget.podifiable method captures this distinction. A declarand that is not podifiable keeps its doc on the AST node, where the `$=rakudoc` collection picks it up, does not reserve a $=pod position, and does not consume collected leading doc, which still falls through to the next podifiable declarand, e.g. an anon sub in the lexical's initializer, as the legacy frontend does.

The legacy frontend attaches a trailing doc after a lexical to whatever declarand came earlier, e.g. an unrelated sub several lines up. The doc now attaches to the lexical itself.

HAS attributes are now declarands like has attributes, so their trailing docs attach to the Attribute instead of warning.