### PR TITLE
RakuAST: honor a custom declarator's companion attribute type

### DIFF
--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -2699,6 +2699,15 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
           ?? $/.how($declarator)
           !! $/.panic("Cannot resolve meta-object for $declarator");
 
+        # A custom declarator can register a companion attribute meta-object
+        # under `<declarator>-attr`, used for the `has` declarations in its
+        # body. A `value-class` declarator pairs with `value-class-attr`. With
+        # no companion registered, attributes use the standard Attribute.
+        my str $attr-declarator := $declarator ~ '-attr';
+        my $attribute-type := $/.know_how($attr-declarator)
+          ?? $/.how($attr-declarator)
+          !! NQPMu;
+
         # Stub the package AST node.
 
         my $name-match := $*PACKAGE-NAME;
@@ -2738,7 +2747,8 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
             $ast-class := nqp::can($how, 'add_attribute') ?? 'Class' !! 'Package';
         }
         my $package := Nodify($ast-class).new(
-          :$how, :$name, :$scope, :$augmented, :parsed-declarator($declarator)
+          :$how, :$name, :$scope, :$augmented, :$attribute-type,
+          :parsed-declarator($declarator)
         );
 
         $package.to-parse-time($*R, $*CU.context);

--- a/t/02-rakudo/custom-declarator-attributes.t
+++ b/t/02-rakudo/custom-declarator-attributes.t
@@ -2,7 +2,7 @@ use lib <t/packages/Test-Helpers>;
 use Test;
 use Test::Helpers;
 
-plan 5;
+plan 7;
 
 my $tmp = make-temp-dir;
 $tmp.add('ClassHOWCustom.rakumod').spurt: q:to/EOF/;
@@ -65,5 +65,39 @@ EOF
 is-run 'use RoleHOWCustom; myrole Foo { has $!x }; print "ok"',
     'a ParametricRoleHOW-backed custom declarator does not crash on attribute usage',
     :compiler-args['-I', $tmp.absolute], :out<ok>;
+
+# A custom declarator can register a companion attribute meta-object under
+# `<declarator>-attr`. Attributes in its body are built from that class, so its
+# container_initializer and compose take effect. ValueClass relies on this to
+# default `@`/`%` attributes and to reject `is rw`.
+$tmp.add('CompanionAttrHOW.rakumod').spurt: q:to/EOF/;
+class DefaultingAttribute is Attribute {
+    method container_initializer(|) { -> { 42 } }
+}
+class NoRwAttribute is Attribute {
+    method compose(|) {
+        die "companion attribute rejected rw for { self.name }" if self.rw;
+        nextsame;
+    }
+}
+my package EXPORTHOW {
+    package DECLARE {
+        constant defattr       = Metamodel::ClassHOW;
+        constant defattr-attr  = DefaultingAttribute;
+        constant norw          = Metamodel::ClassHOW;
+        constant norw-attr     = NoRwAttribute;
+    }
+}
+EOF
+
+is-run 'use CompanionAttrHOW; defattr Foo { has $.a }; print Foo.new.a',
+    'a companion `-attr` meta-object supplies an attribute default',
+    :compiler-args['-I', $tmp.absolute], :out<42>;
+
+is-run 'use CompanionAttrHOW; norw Foo { has $.a is rw }',
+    'a companion `-attr` meta-object composes attributes, so it can reject `is rw`',
+    :compiler-args['-I', $tmp.absolute],
+    :err(rx/'===SORRY!===' .* 'companion attribute rejected rw'/),
+    :exitcode(1);
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
A package declarator registered through `EXPORTHOW::DECLARE` may also register a companion attribute meta-object under `<declarator>-attr`. The legacy frontend resolves it for every `has` in the declarator's body through `$*PKGDECL ~ '-attr'`. RakuAST's `stub-package` never looked it up, so attributes were always built from the standard `Attribute` and the companion's `compose` and `container_initializer` never ran.

Resolve the companion the same way and hand it to the package node as its `attribute-type`. With no companion registered the lookup finds no HOW and attributes keep using `Attribute`, so nothing changes for the standard declarators.

ValueClass uses the companion to default `@` and `%` attributes to its immutable Tuple and ValueMap and to reject `is rw`. Without it `has @.a` defaulted to a plain Array and the module's value-type check died with "All attributes of value-class should be value types", while `is rw` was silently accepted.