### PR TITLE
RakuAST: box native values produced by begin-time evaluation

### DIFF
--- a/src/Raku/ast/begintime.rakumod
+++ b/src/Raku/ast/begintime.rakumod
@@ -59,8 +59,9 @@ class RakuAST::BeginTime
         }
 
         # Can interprete, so do that
+        my $result;
         if $code.IMPL-CAN-INTERPRET {
-            $code.IMPL-INTERPRET(
+            $result := $code.IMPL-INTERPRET(
               RakuAST::IMPL::InterpContext.new(:$resolver, :$context)
             )
         }
@@ -69,7 +70,7 @@ class RakuAST::BeginTime
         # is whatever its cache holds, which is undefined until it runs. Hand
         # that back rather than the block itself.
         elsif nqp::istype($code, RakuAST::StatementPrefix::Phaser::Init) {
-            nqp::ifnull(nqp::decont($code.container), Mu)
+            $result := nqp::ifnull(nqp::decont($code.container), Mu)
         }
 
         # A code literal's begin-time value is its own code object,
@@ -80,7 +81,7 @@ class RakuAST::BeginTime
               # though a phaser is a statement prefix whose caller runs the
               # code object we hand back, so keep those.
               || nqp::istype($code, RakuAST::StatementPrefix::Phaser)) {
-            $code.meta-object
+            $result := $code.meta-object
         }
 
         # Wrap an expression in a thunk
@@ -90,11 +91,27 @@ class RakuAST::BeginTime
             $thunk.IMPL-STUB-CODE($resolver, $context);
             $code.apply-sink(False);
             $thunk.IMPL-QAST-BLOCK($context, :expression($code));
-            $thunk.meta-object()()
+            $result := $thunk.meta-object()()
         }
         else {
             nqp::die('BEGIN time evaluation only supported for simple constructs so far')
         }
+
+        # A native-typed expression evaluates to a bare VM-level box (for
+        # example a BOOTInt) where the same expression at run time would
+        # produce an Int. Such a box has no Raku method table and a null
+        # WHO, so letting it escape into a stash breaks stash consumers
+        # like the compunit GLOBAL merge. Box VM-level scalars into their
+        # Raku types; leave VM-level aggregates alone, as constants holding
+        # nqp hashes and lists rely on staying unboxed.
+        unless nqp::isnull($result) {
+            my $type := nqp::what($result);
+            $result := nqp::hllizefor($result, 'Raku')
+              if nqp::eqaddr($type, nqp::bootint())
+              || nqp::eqaddr($type, nqp::bootnum())
+              || nqp::eqaddr($type, nqp::bootstr());
+        }
+        $result
     }
 
     # Evaluate the argument of a pragma, use, import, or require into an

--- a/t/02-rakudo/constant-native-value.t
+++ b/t/02-rakudo/constant-native-value.t
@@ -1,0 +1,28 @@
+use lib <t/packages/02-rakudo/lib>;
+use Test;
+
+# A constant initialized from a native-typed expression must hold the boxed
+# Raku value, not a bare VM-level box. A bare box has no Raku method table
+# and a null WHO, so it breaks package-qualified access and, when exported
+# through two dependency paths (as HarfBuzz's HB_SET_VALUE_INVALID is), it
+# crashed the compunit GLOBAL merge with "Cannot find method
+# 'FLATTENABLE_HASH' on object of type VMNull".
+
+# Both use lines matter: NativeConstDiamond also uses NativeConstDefs, so
+# the constant reaches this compunit's GLOBAL by two paths and the loader
+# has to merge them.
+use NativeConstDiamond;
+use NativeConstDefs;
+
+plan 4;
+
+is-deeply NATIVE-UINT, 4294967295,
+  'an imported native-valued constant is the boxed value';
+is-deeply NativeConstDefs::NATIVE-UINT, 4294967295,
+  'package-qualified access to a native-valued constant gives the boxed value';
+ok NativeConstDefs::NATIVE-UINT.defined,
+  'method calls work on a package-qualified native-valued constant';
+is-deeply native-uint-via-diamond(), 4294967295,
+  'the constant has the same value when reached through the diamond';
+
+# vim: expandtab shiftwidth=4

--- a/t/packages/02-rakudo/lib/NativeConstDefs.rakumod
+++ b/t/packages/02-rakudo/lib/NativeConstDefs.rakumod
@@ -1,0 +1,3 @@
+unit module NativeConstDefs;
+
+constant NATIVE-UINT is export = (my uint32 $ = -1);

--- a/t/packages/02-rakudo/lib/NativeConstDiamond.rakumod
+++ b/t/packages/02-rakudo/lib/NativeConstDiamond.rakumod
@@ -1,0 +1,5 @@
+unit module NativeConstDiamond;
+
+use NativeConstDefs;
+
+sub native-uint-via-diamond is export { NATIVE-UINT }


### PR DESCRIPTION
Previously a begin-time evaluated expression of a native type, such as the initializer in HarfBuzz's

    constant HB_SET_VALUE_INVALID = (my uint32 $ = -1);

produced a bare VM-level box (a BOOTInt) where the same expression at run time produces an Int. That value has no Raku method table and a null WHO, and it flowed into the constant's lexical value, its package stash entry, and its EXPORT stash entry. Package-qualified access to such a constant then died with "No such method 'defined' for invocant of type 'BOOTInt'", and when the constant reached a consumer's GLOBAL through two dependency paths the GLOBAL merge misclassified the leaf as a package stub, recursed into its null WHO, and died in stash_hash with "Cannot find method 'FLATTENABLE_HASH' on object of type VMNull". This is what prevented HarfBuzz, and everything downstream of it such as Pod::To::PDF, from compiling.

The legacy frontend leaves the same raw BOOTInt in the stash, but its package-qualified lookups go through a Stash.AT-KEY method call and the value gets hllized at that boundary, so the rawness never surfaces there.

This makes IMPL-BEGIN-TIME-EVALUATE box VM-level scalars (BOOTInt, BOOTNum, BOOTStr) into their Raku types, making begin-time evaluation agree with run-time semantics. VM-level aggregates are left alone since constants holding nqp hashes and lists rely on staying unboxed.