### PR TITLE
NativeCall: enforce definiteness constraints on native signatures

### DIFF
--- a/lib/NativeCall.rakumod
+++ b/lib/NativeCall.rakumod
@@ -244,7 +244,11 @@ my sub return_hash_for(
 }
 
 my sub type_code_for(Mu ::T) {
-    nqp::ifnull(
+    # A definiteness-constrained type such as `--> Foo:D` carries a DefiniteHOW;
+    # it maps to the same native code as its base type.
+    nqp::istype(T.HOW, Metamodel::DefiniteHOW)
+      ?? type_code_for(T.HOW.base_type(T))
+      !! nqp::ifnull(
       nqp::atkey($type_map,T.^shortname),
       nqp::ifnull(
         nqp::atkey($repr_map,T.REPR),
@@ -315,6 +319,7 @@ our role Native[
 ] {
     has Callsite $!call is box_target;
     has Mu       $!rettype;
+    has Mu       $!ret-constraint;
     has          $!cpp-name-mangler;
     has Pointer  $!entry-point;
     has int      $!arity;
@@ -325,8 +330,9 @@ our role Native[
 
     method CUSTOM-DISPATCHER(--> str) { 'raku-nativecall' }
 
-    method call()    { $!call    }
-    method rettype() { $!rettype }
+    method call()           { $!call           }
+    method rettype()        { $!rettype        }
+    method ret-constraint() { $!ret-constraint }
 
     INIT my Lock $setup-lock .= new;
     method !setup() {
@@ -357,8 +363,17 @@ our role Native[
             my Mu $arg_info := param_list_for($signature, $!variadic, $routine);
             my str $conv     = self.?native_call_convention || '';
 
-            $!rettype := nqp::decont(map_return_type($routine.returns))
+            my $returns := $routine.returns;
+            $!rettype := nqp::decont(map_return_type($returns))
               unless $!rettype;
+
+            # A definiteness-constrained return type such as `--> Foo:D`
+            # is mapped to its base type for the native call itself, so
+            # keep the constraint for checking the returned value. Mu
+            # marks an unconstrained return.
+            $!ret-constraint := nqp::istype($returns.HOW,Metamodel::DefiniteHOW)
+              ?? nqp::decont($returns)
+              !! Mu;
             $!arity    = $signature.arity;
 
             my int $m = nqp::elems($params);
@@ -440,7 +455,13 @@ our role Native[
                         ++$i;
                     }
                 }
-                nqp::nativecall($!rettype, self, $args)
+                my $result := nqp::nativecall($!rettype, self, $args);
+                nqp::eqaddr(nqp::decont($!ret-constraint), Mu)
+                  || $!ret-constraint.ACCEPTS($result)
+                  ?? $result
+                  !! X::TypeCheck::Return.new(
+                       :got($result), :expected($!ret-constraint)
+                     ).throw
             }
 
             my $do := nqp::getattr($replacement, Code, '$!do');

--- a/lib/NativeCall/Dispatcher.rakumod
+++ b/lib/NativeCall/Dispatcher.rakumod
@@ -41,6 +41,22 @@ my $do-resume := nqp::getattr(&raku-nativecall-deproxy-resume, Code, '$!do');
 nqp::forceouterctx($do-resume, nqp::getattr(MY::, PseudoStash, '$!ctx'));
 nqp::register('raku-nativecall-deproxy', $do, $do-resume);
 
+#- raku-nativecall-check-return ------------------------------------------------
+
+# Invoked (via boot-code-constant) in place of the plain tail delegation to
+# 'boot-foreign-code' when the return type carries a definiteness constraint.
+# The resumption (raku-nativecall-core's resume callback) performs the native
+# call, so its result arrives back here where it can be checked before being
+# handed to the caller.
+my sub raku-nativecall-check-return(Mu $type is raw) {
+    my $result := nqp::dispatch('boot-resume', nqp::const::DISP_DECONT);
+    $type.ACCEPTS($result)
+      ?? $result
+      !! X::TypeCheck::Return.new(:got($result), :expected($type)).throw
+}
+my $check-return-do := nqp::getattr(&raku-nativecall-check-return, Code, '$!do');
+nqp::forceouterctx($check-return-do, nqp::getattr(MY::, PseudoStash, '$!ctx'));
+
 #- raku-nativecall -------------------------------------------------------------
 
 my $PROXY-READERS := nqp::gethllsym('Raku', 'PROXY-READERS');
@@ -111,7 +127,11 @@ nqp::register('raku-nativecall', $do);
 
 #- raku-nativecall-core --------------------------------------------------------
 
-my sub raku-nativecall-core(Mu $capture is raw) {
+# Marshals the arguments of the given capture (with the callee as argument
+# 0) and tail-delegates to the VM's native call dispatcher. Called when
+# recording the initial dispatch for an unconstrained return type, and when
+# recording the return checker's resumption for a constrained one.
+my sub marshal-and-delegate-native-call(Mu $capture is raw) {
     my $callee      := nqp::captureposarg($capture, 0);
     my $params      := nqp::getattr($callee.signature.params, List, '$!reified');
     my $param-elems := nqp::elems($params);
@@ -206,6 +226,26 @@ my sub raku-nativecall-core(Mu $capture is raw) {
                 $arg := nqp::decont($arg);
             }
 
+            # The signature binder never runs for a native sub, so a
+            # definiteness constraint such as `Foo:D $x` must be enforced
+            # here, on the decontainerized argument.
+            unless $variadic {
+                my str $modifier = $param.modifier;
+                if $modifier eq ':D' || $modifier eq ':U' {
+                    nqp::guard('concreteness', $Tvalue);
+                    my int $definite = $modifier eq ':D';
+                    if nqp::isconcrete_nd($arg) != $definite {
+                        X::Parameter::InvalidConcreteness.new(
+                          :expected($param.type.^name),
+                          :got($arg.^name),
+                          :routine($callee.name),
+                          :param($param.name),
+                          :should-be-concrete(?$definite),
+                        ).throw
+                    }
+                }
+            }
+
             # Get to the actual low-level code if Code
             set-arg-i-value(
               $Tvalue := nqp::track('attr', $Tvalue, Code, '$!do')
@@ -292,9 +332,57 @@ my sub raku-nativecall-core(Mu $capture is raw) {
     );
 }
 
+my sub raku-nativecall-core(Mu $capture is raw) {
+    my $ret-constraint :=
+      nqp::decont(nqp::captureposarg($capture, 0).ret-constraint);
+
+    # No constraint on the returned value: straight to the native call.
+    if nqp::eqaddr($ret-constraint, Mu) {
+        marshal-and-delegate-native-call($capture);
+    }
+
+    # The return type carries a definiteness constraint, and a tail
+    # delegation to the native call gives no seam to check the value it
+    # produces. Instead stash the arguments as the resumption state (they
+    # must remain unmarshalled: resume init args cannot contain tracked
+    # values) and invoke the checker, which resumes into the native call
+    # and receives its result.
+    else {
+        nqp::syscall('dispatcher-set-resume-init-args', $capture);
+        nqp::delegate('boot-code-constant',
+          nqp::syscall('dispatcher-insert-arg-literal-obj',
+            nqp::syscall('dispatcher-insert-arg-literal-obj',
+              nqp::syscall('dispatcher-drop-n-args',
+                $capture, 0, nqp::unbox_i(nqp::captureposelems($capture))
+              ),
+              0, $ret-constraint
+            ),
+            0, $check-return-do
+          )
+        );
+    }
+}
+
+my sub raku-nativecall-core-resume(Mu $capture is raw) {
+    nqp::guard('literal', nqp::track('arg', $capture, 0));
+
+    if nqp::captureposarg_i($capture, 0) == nqp::const::DISP_DECONT {
+        my $orig-capture := nqp::syscall('dispatcher-get-resume-init-args');
+
+        # The return checker is shared by all natives with a constrained
+        # return type, so the resumption must be pinned to this callee for
+        # its native call to be the one recorded in the dispatch program.
+        nqp::guard('literal', nqp::track('arg', $orig-capture, 0));
+
+        marshal-and-delegate-native-call($orig-capture);
+    }
+}
+
 # Set up actual dispatcher and its context
 $do := nqp::getattr(&raku-nativecall-core, Code, '$!do');
 nqp::forceouterctx($do, nqp::getattr(MY::, PseudoStash, '$!ctx'));
-nqp::register('raku-nativecall-core', $do);
+$do-resume := nqp::getattr(&raku-nativecall-core-resume, Code, '$!do');
+nqp::forceouterctx($do-resume, nqp::getattr(MY::, PseudoStash, '$!ctx'));
+nqp::register('raku-nativecall-core', $do, $do-resume);
 
 # vim: expandtab shiftwidth=4

--- a/lib/NativeCall/Types.rakumod
+++ b/lib/NativeCall/Types.rakumod
@@ -10,7 +10,13 @@ my constant $ok-REPRs = nqp::hash(
 #- helper subs -----------------------------------------------------------------
 # Helper sub for type mapping, also used in NativeCall
 my proto sub map_return_type(|) is export {*}
-my multi sub map_return_type(Mu $type) { $type }
+my multi sub map_return_type(Mu $type) {
+    # A definiteness-constrained return type such as `--> Foo:D` maps as its
+    # base type; its own REPR is Uninstantiable and cannot back a native call.
+    nqp::istype($type.HOW, Metamodel::DefiniteHOW)
+      ?? map_return_type($type.HOW.base_type($type))
+      !! $type
+}
 my multi sub map_return_type(Int     ) { Int   }
 my multi sub map_return_type(Num     ) { Num   }
 

--- a/t/04-nativecall/04-pointers.t
+++ b/t/04-nativecall/04-pointers.t
@@ -4,7 +4,7 @@ use NativeCall;
 use NativeCall::Types;
 use Test;
 
-plan 23;
+plan 31;
 
 compile_test_lib('04-pointers');
 
@@ -76,6 +76,55 @@ else {
 # https://github.com/rakudo/rakudo/issues/4483
 {
     is-deeply +Pointer, 0, 'Numerifying Pointer class works';
+}
+
+# A definiteness-constrained native return type maps as its base type, rather
+# than raising "Unknown type ...:D used in native call" from type_code_for.
+{
+    sub ReturnSomePointerD(--> Pointer:D) is symbol('ReturnSomePointer')
+      is native('./04-pointers') { * }
+    ok ReturnSomePointerD(), 'a Pointer:D native return type works';
+
+    my class CPtr is repr('CPointer') {
+        our sub make(--> ::?CLASS:D) is symbol('ReturnSomePointer')
+          is native('./04-pointers') { * }
+    }
+    ok CPtr::make().defined, 'a repr(CPointer) class `--> ::?CLASS:D` native return works';
+}
+
+# Definiteness constraints on a native signature are enforced like on a
+# normal routine: a violating return value or argument throws rather than
+# being silently passed along.
+{
+    sub ReturnNullPointerD(--> Pointer:D) is symbol('ReturnNullPointer')
+      is native('./04-pointers') { * }
+    throws-like { ReturnNullPointerD() }, X::TypeCheck::Return,
+      'a NULL return violating --> Pointer:D throws';
+
+    my class CPtrD is repr('CPointer') {
+        our sub make(--> CPtrD:D) is symbol('ReturnNullPointer')
+          is native('./04-pointers') { * }
+    }
+    throws-like { CPtrD::make() }, X::TypeCheck::Return,
+      'a NULL return violating a CPointer class :D return type throws';
+
+    sub CompareSomePointerD(Pointer:D $ptr) returns int32
+      is symbol('CompareSomePointer') is native('./04-pointers') { * }
+    ok CompareSomePointerD(ReturnSomePointer()),
+      'a concrete argument satisfies a Pointer:D parameter';
+    throws-like { CompareSomePointerD(Pointer) },
+      X::Parameter::InvalidConcreteness,
+      'a type object violating a Pointer:D parameter throws';
+    my Pointer $undefined;
+    throws-like { CompareSomePointerD($undefined) },
+      X::Parameter::InvalidConcreteness,
+      'an undefined value in a container violating a Pointer:D parameter throws';
+
+    sub TakeUndefinedPointer(Pointer:U $ptr) returns int32
+      is symbol('CompareSomePointer') is native('./04-pointers') { * }
+    throws-like { TakeUndefinedPointer(ReturnSomePointer()) },
+      X::Parameter::InvalidConcreteness,
+      'a concrete argument violating a Pointer:U parameter throws';
 }
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously a definiteness constraint on a native sub was broken in two ways. A constrained type could not even be mapped: `--> Foo:D` (or `--> ::?CLASS:D` under RakuAST, which keeps the `:D` where the legacy frontend resolves it to the bare `Foo`) died during setup, first with "Unknown type Foo:D used in native call" from type_code_for, and past that with "expected return type with CPointer representation" because map_return_type passed the Uninstantiable DefiniteHOW type through as the return type. This blocked PDF::Native, whose COS native subs return `--> ::?CLASS:D`. And where a constrained signature did compile, the constraint was silently ignored: `sub f(Foo:D $x --> Bar:D)` accepted a type object for $x and handed it to C, and a C function returning NULL handed back the Bar type object with no error.

This resolves a DefiniteHOW type to its base type in type_code_for and map_return_type, so `Foo:D` maps exactly as `Foo`, and enforces the constraint on both sides, matching normal routine semantics:

- Parameters: the dispatcher never runs the signature binder, so the marshalling loop now checks a `:D`/`:U` parameter against the decontainerized argument and throws X::Parameter::InvalidConcreteness on violation. The check happens while recording the dispatch program, backed by a concreteness guard, so the cached call path is unaffected.

- Returns: a tail delegation to boot-foreign-code gives no seam to inspect the result, so a constrained return is instead routed through a checker code object that resumes into the native call (the same shape as the Proxy removal machinery), receives the result, and throws X::TypeCheck::Return unless the constraint ACCEPTS it. Unconstrained returns keep the plain tail delegation. Resume init args cannot contain tracked values, so the decision happens before marshalling and the resumption re-enters the marshalling code with the original capture. The resume callback pins the callee with a literal guard, since the checker is shared by all natives with a constrained return.

The non-dispatcher path checks the constraint directly on the result of nqp::nativecall. Nominal types and where clauses on native signatures remain unchecked.

Note this changes behavior for native subs that declare `--> T:D` but rely on NULL coming back as the type object: such calls now throw.