### PR TITLE
RakuAST: produce a once's state declaration when reached first

### DIFF
--- a/src/Raku/ast/statementprefixes.rakumod
+++ b/src/Raku/ast/statementprefixes.rakumod
@@ -482,6 +482,11 @@ class RakuAST::StatementPrefix::Once
     }
 
     method IMPL-EXPR-QAST(RakuAST::IMPL::QASTContext $context) {
+        # A once in a sub in a role body reaches code generation before the
+        # enclosing scope has produced this once's implicit state declaration,
+        # so produce it now. The declaration itself is emitted afterwards, when
+        # the block gathers its declarations.
+        self.get-implicit-declarations unless nqp::isconcrete($!state-decl);
         # The state variable starts out holding a private sentinel. Testing
         # its value rather than nqp::p6stateinit makes the once fire exactly
         # once per clone of the frame that owns the variable, even when the

--- a/t/02-rakudo/once-in-role-sub.t
+++ b/t/02-rakudo/once-in-role-sub.t
@@ -1,0 +1,37 @@
+use Test;
+
+plan 5;
+
+# A `once` inside a `sub` in a role body reaches code generation before the
+# role's scope has produced the once's implicit state declaration, which left
+# that declaration a bare type object and the role failed to compile.
+
+my $count = 0;
+role Ronce {
+    sub bump() { once { ++$count } }
+    method fire() { bump() }
+}
+my class C does Ronce {}
+my $c = C.new;
+
+is $c.fire, 1, 'once in a role sub returns its value';
+is $c.fire, 1, 'once in a role sub does not re-run on a later call';
+is $count, 1, 'the once body ran exactly once';
+
+# A `once` with a bare expression rather than a block, in a role sub.
+role Rval {
+    sub answer() { once 40 + 2 }
+    method get() { answer() }
+}
+my class D does Rval {}
+is D.new.get, 42, 'once with an expression in a role sub returns its value';
+
+# An exported sub in a role, as in the module that surfaced this.
+role Rexp {
+    sub tag() is export { once 'TAG' }
+    method t() { tag() }
+}
+my class E does Rexp {}
+is E.new.t, 'TAG', 'once in an exported sub in a role works';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
A `once` in a sub in a role body reaches code generation before the enclosing scope has produced the once's implicit state declaration, so its `$!state-decl` was still a bare type object and reading `.sentinel-value` died "Cannot look up attributes in a RakuAST::VarDeclaration::Implicit::State type object". A `once` in a sub in a class or module, or in a method in a role, was already fine.

Produce the declaration in `IMPL-EXPR-QAST` when it has not been produced yet. `IMPL-COMPILE-BODY` runs before the block gathers its declarations, so the declaration is still emitted afterwards from the cached result.