### PR TITLE
RakuAST: let the NFA see into a <before ...> regex argument

### DIFF
--- a/src/Raku/ast/regex.rakumod
+++ b/src/Raku/ast/regex.rakumod
@@ -1462,7 +1462,11 @@ class RakuAST::Regex::Assertion::Named::RegexArg
         nqp::bindattr(self, RakuAST::Regex::Assertion::Named::RegexArg, '$!body-qast', $body-qast);
         my $qast := self.IMPL-REGEX-QAST-CALL($context);
         my str $name := self.IMPL-UNIQUE-NAME;
-        $qast[0].push(QAST::Var.new( :$name, :scope('lexical') ));
+        my $arg-qast := QAST::Var.new( :$name, :scope('lexical') );
+        # QRegex::NFA reads this annotation to inline a <before ...>
+        # argument's regex into the caller's declarative prefix for LTM.
+        $arg-qast.annotate('orig_qast', $body-qast);
+        $qast[0].push($arg-qast);
         $qast
     }
 

--- a/t/02-rakudo/ltm-before-assertion.t
+++ b/t/02-rakudo/ltm-before-assertion.t
@@ -1,0 +1,50 @@
+use Test;
+
+plan 6;
+
+# In an LTM alternation, a branch that begins with a <before ...> lookahead
+# contributes what the lookahead can match to its declarative prefix. The
+# regex-argument thunk must carry its regex QAST where the NFA builder can
+# find it; without that the prefix ends at the zero-width assertion and the
+# branch loses to shorter alternatives it should beat.
+
+grammar Expr {
+    token TOP { <expression> }
+    rule expression { \s* [<operation>|<term>] }
+    token variable { <alpha> <alnum>* }
+    rule term { \s* <variable> }
+    token operation { <circumfix_operation> | <infix_operation_chain> }
+    token infix_term { <circumfix_operation> | <term> }
+    my $in_ops = "['/'|'-']";
+    rule infix_operation_chain {<before .+? <$in_ops>><infix_term>[ $<op>=<$in_ops> <infix_term>]+}
+    rule circumfix_operation { '(' <expression> ')' }
+}
+
+my $m = Expr.parse('(a-b)/c');
+ok $m, 'a parenthesized subexpression followed by an infix parses';
+ok $m && $m<expression><operation><infix_operation_chain>,
+    'LTM picked the infix chain over the shorter circumfix branch';
+ok Expr.parse('(y2-y1)/(x2-x1)'), 'an infix between two parenthesized subexpressions parses';
+
+# The <?before ...> spelling wraps the same assertion and must rank the same.
+grammar QExpr {
+    token TOP { <expression> }
+    rule expression { \s* [<operation>|<term>] }
+    token variable { <alpha> <alnum>* }
+    rule term { \s* <variable> }
+    token operation { <circumfix_operation> | <infix_operation_chain> }
+    token infix_term { <circumfix_operation> | <term> }
+    my $in_ops = "['/'|'-']";
+    rule infix_operation_chain {<?before .+? <$in_ops>><infix_term>[ $<op>=<$in_ops> <infix_term>]+}
+    rule circumfix_operation { '(' <expression> ')' }
+}
+
+my $qm = QExpr.parse('(a-b)/c');
+ok $qm, 'the <?before ...> spelling also parses the expression';
+ok $qm && $qm<expression><operation><infix_operation_chain>,
+    'the <?before ...> spelling also picks the infix chain';
+
+# A negated lookahead with a regex argument must still veto the match.
+nok 'xbc' ~~ /<!before x> . bc/, '<!before ...> still rejects at a position its argument matches';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously an LTM alternation branch that begins with a <before ...> assertion had its declarative prefix cut off at the zero-width assertion, so it could lose to a shorter branch it should beat. The legacy frontend annotates the regex-argument thunk with its regex QAST as orig_qast, which QRegex::NFA uses to inline the lookahead's content into the declarative prefix, but the RakuAST frontend passed the thunk as a bare lexical with no annotation. This surfaced in Math::Symbolic, whose expression grammar could no longer parse a parenthesized subexpression followed by an infix, such as (a-b)/c.

This annotates the argument reference in RakuAST::Regex::Assertion::Named::RegexArg with the compiled regex QAST so the NFA builder inlines the lookahead as it does under the legacy frontend.