### PR TITLE
RakuAST: give a no-initializer list declaration its container list as value

### DIFF
--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -1919,78 +1919,89 @@ class RakuAST::VarDeclaration::Signature
     }
 
     method IMPL-TO-QAST(RakuAST::IMPL::QASTContext $context) {
-        if nqp::isconcrete($!initializer) {
-            my $perform-init-qast;
-            my $value-list   := QAST::Op.new( :op('call'), :name('&infix:<,>') );
-            my @params := self.IMPL-UNWRAP-LIST($!signature.parameters);
-            my @terms;
+        my $value-list   := QAST::Op.new( :op('call'), :name('&infix:<,>') );
+        my @params := self.IMPL-UNWRAP-LIST($!signature.parameters);
+        my @terms;
 
-            for @params {
-                nqp::push(@terms, $_.target) if nqp::istype($_.target, RakuAST::ParameterTarget::Term);
-                if $_.target {
-                    $value-list.push: $_.target.IMPL-LOOKUP-QAST($context);
-                }
-                elsif $_.type {
-                    # Anonymous typed parameter (e.g. Int or Any:D) in a
-                    # list declaration. Create a typed placeholder container
-                    # so it consumes and type-checks the RHS value at this
-                    # position.
-                    my $of := $_.type.meta-object;
-                    my $desc := RakuAST::IMPL::Containers.create-descriptor(
-                        :$of, :default($of), :dynamic(0), :name('anon'));
-                    $context.ensure-sc($desc);
-                    $value-list.push: QAST::Op.new(
-                        :op('p6scalarfromdesc'), QAST::WVal.new(:value($desc))
-                    );
-                }
+        for @params {
+            nqp::push(@terms, $_.target) if nqp::istype($_.target, RakuAST::ParameterTarget::Term);
+            if $_.target {
+                $value-list.push: $_.target.IMPL-LOOKUP-QAST($context);
             }
-            if nqp::istype($!initializer, RakuAST::Initializer::Assign) {
-                my $init-qast := $!initializer.IMPL-TO-QAST($context);
-                my $list := QAST::Op.new( :op('p6store'), $value-list, $init-qast);
-                if 0 < nqp::elems(@terms) {
-                    my $stmts := QAST::Stmts.new(:resultchild(0), $list);
-                    for @terms {
-                        $stmts.push(
-                            $_.IMPL-BIND-QAST(
-                                $context,
-                                QAST::Op.new(:op('decont'), $_.IMPL-LOOKUP-QAST($context))
-                            )
-                        );
-                    }
-                    $perform-init-qast := $stmts;
-                }
-                else {
-                    $perform-init-qast := $list;
-                }
-            }
-            elsif nqp::istype($!initializer, RakuAST::Initializer::Bind) {
-                my $signature := $!signature.meta-object;
-                $context.ensure-sc($signature);
-                my $init-qast := $!initializer.IMPL-TO-QAST($context);
-                $perform-init-qast := QAST::Op.new(
-                    :op('p6bindcaptosig'),
-                    QAST::WVal.new( :value($signature) ),
-                    QAST::Op.new(
-                        :op('callmethod'), :name('Capture'),
-                        $init-qast
-                    )
+            elsif $_.type {
+                # Anonymous typed parameter (e.g. Int or Any:D) in a
+                # list declaration. Create a typed placeholder container
+                # so it consumes and type-checks the RHS value at this
+                # position.
+                my $of := $_.type.meta-object;
+                my $desc := RakuAST::IMPL::Containers.create-descriptor(
+                    :$of, :default($of), :dynamic(0), :name('anon'));
+                $context.ensure-sc($desc);
+                $value-list.push: QAST::Op.new(
+                    :op('p6scalarfromdesc'), QAST::WVal.new(:value($desc))
                 );
             }
-            else {
-                nqp::die('Not yet supported signature initializer: ' ~ $!initializer.HOW.name($!initializer));
-            }
-            if self.scope eq 'state' {
-                $perform-init-qast := QAST::Op.new(
-                  :op('if'),
-                  QAST::Op.new( :op('p6stateinit') ),
-                  $perform-init-qast,
-                  $value-list
-                )
-            }
-            return $perform-init-qast;
         }
 
-        QAST::Op.new(:op<null>);
+        # With no initializer a lexical declaration's value is the list of its
+        # own containers, so it can be used as an rvalue, e.g. bound on the
+        # right of `:=` in `my (\a, \b) := my ($x, $y)`. A sunk declaration
+        # wants nothing, so it keeps the null it used to always return. An
+        # attribute declaration has no container to hand back at class-body
+        # time, so it also stays null.
+        unless nqp::isconcrete($!initializer) {
+            my str $scope := self.scope;
+            my $attribute := $scope eq 'has' || $scope eq 'HAS';
+            return self.sunk || $attribute
+                ?? QAST::Op.new(:op<null>)
+                !! $value-list;
+        }
+
+        my $perform-init-qast;
+        if nqp::istype($!initializer, RakuAST::Initializer::Assign) {
+            my $init-qast := $!initializer.IMPL-TO-QAST($context);
+            my $list := QAST::Op.new( :op('p6store'), $value-list, $init-qast);
+            if 0 < nqp::elems(@terms) {
+                my $stmts := QAST::Stmts.new(:resultchild(0), $list);
+                for @terms {
+                    $stmts.push(
+                        $_.IMPL-BIND-QAST(
+                            $context,
+                            QAST::Op.new(:op('decont'), $_.IMPL-LOOKUP-QAST($context))
+                        )
+                    );
+                }
+                $perform-init-qast := $stmts;
+            }
+            else {
+                $perform-init-qast := $list;
+            }
+        }
+        elsif nqp::istype($!initializer, RakuAST::Initializer::Bind) {
+            my $signature := $!signature.meta-object;
+            $context.ensure-sc($signature);
+            my $init-qast := $!initializer.IMPL-TO-QAST($context);
+            $perform-init-qast := QAST::Op.new(
+                :op('p6bindcaptosig'),
+                QAST::WVal.new( :value($signature) ),
+                QAST::Op.new(
+                    :op('callmethod'), :name('Capture'),
+                    $init-qast
+                )
+            );
+        }
+        else {
+            nqp::die('Not yet supported signature initializer: ' ~ $!initializer.HOW.name($!initializer));
+        }
+        if self.scope eq 'state' {
+            $perform-init-qast := QAST::Op.new(
+              :op('if'),
+              QAST::Op.new( :op('p6stateinit') ),
+              $perform-init-qast,
+              $value-list
+            )
+        }
+        $perform-init-qast
     }
 
     method IMPL-EXPR-QAST(RakuAST::IMPL::QASTContext $context) {

--- a/t/02-rakudo/siglist-decl-rvalue.t
+++ b/t/02-rakudo/siglist-decl-rvalue.t
@@ -1,0 +1,32 @@
+use Test;
+
+plan 7;
+
+# A `my (...)` list declaration with no initializer, used as the right-hand
+# side of a signature bind, produced a null and died at compile time with
+# "No such method 'Capture' for invocant of type 'VMNull'".
+
+{
+    my (\a, \b) := my ($x, $y);
+    ok a =:= $x, 'first sigilless target aliases the first declared container';
+    ok b =:= $y, 'second sigilless target aliases the second declared container';
+    a = 10;
+    b = 20;
+    is-deeply ($x, $y), (10, 20), 'assigning through the aliases writes the underlying containers';
+}
+
+{
+    my @l = (my ($p, $q));
+    is @l.elems, 2, 'a no-initializer list declaration used as an rvalue yields its containers';
+}
+
+lives-ok { my ($m, $n); $m = 1; $n = 2 }, 'a plain sunk list declaration statement still works';
+
+{
+    my ($a, $b) = 1, 2;
+    is-deeply ($a, $b), (1, 2), 'list assignment still binds each element';
+    my ($c, $d) := (3, 4);
+    is-deeply ($c, $d), (3, 4), 'list bind to a literal list still works';
+}
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
A `my (...)` list declaration with no initializer compiled its value to a bare null. In most rvalue positions that was harmless, but binding it on the right of a signature bind, as in `my (\a, \b) := my ($x, $y)`, calls .Capture on that null and died at compile time with "No such method 'Capture' for invocant of type 'VMNull'". Legacy yields the list of the declared containers there instead.

IMPL-TO-QAST now returns that container list for the no-initializer case, so the declaration works as an rvalue. A sunk declaration still returns null, so a plain `my ($a, $b);` statement is unchanged.