### PR TITLE
RakuAST: give each signature-less block its own signature meta-object

### DIFF
--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -1570,28 +1570,36 @@ class RakuAST::Block
             nqp::bindattr($signature.meta-object, Signature, '$!code', $block);
         }
         elsif $!implicit-topic-mode > 0 {
-            my constant REQUIRED-TOPIC-SIG := -> {
+            my constant REQUIRED-TOPIC-PARAM := -> {
                 my $param := nqp::create(Parameter);
                 nqp::bindattr_s($param, Parameter, '$!variable_name', '$_');
-                my $sig := nqp::create(Signature);
-                nqp::bindattr($sig, Signature, '@!params', [$param]);
-                nqp::bindattr_i($sig, Signature, '$!arity', 1);
-                nqp::bindattr($sig, Signature, '$!count', nqp::box_i(1, Int));
-                $sig
+                nqp::bindattr($param, Parameter, '$!type', Mu);
+                nqp::bindattr_i($param, Parameter, '$!flags',
+                    nqp::const::SIG_ELEM_IS_RAW);
+                $param
             }();
-            my constant OPTIONAL-TOPIC-SIG := -> {
+            my constant OPTIONAL-TOPIC-PARAM := -> {
                 my $param := nqp::create(Parameter);
                 nqp::bindattr_s($param, Parameter, '$!variable_name', '$_');
-                nqp::bindattr_i($param, Parameter, '$!flags', 2048 + 16384); # Optional + default from outer
-                my $sig := nqp::create(Signature);
-                nqp::bindattr($sig, Signature, '@!params', [$param]);
-                nqp::bindattr_i($sig, Signature, '$!arity', 0);
-                nqp::bindattr($sig, Signature, '$!count', nqp::box_i(1, Int));
-                $sig
+                nqp::bindattr($param, Parameter, '$!type', Mu);
+                nqp::bindattr_i($param, Parameter, '$!flags',
+                    nqp::const::SIG_ELEM_IS_RAW
+                    +| nqp::const::SIG_ELEM_IS_OPTIONAL
+                    +| nqp::const::SIG_ELEM_DEFAULT_FROM_OUTER);
+                $param
             }();
-            nqp::bindattr($block, Code, '$!signature', $!implicit-topic-mode == 1
-                ?? OPTIONAL-TOPIC-SIG
-                !! REQUIRED-TOPIC-SIG);
+            # The Parameter holds no per-block state and can be shared, but
+            # each block needs its own Signature: the Binder's trial bind
+            # invokes under the signature's $!code, so the backlink must
+            # point at this block.
+            my int $optional := $!implicit-topic-mode == 1;
+            my $sig := nqp::create(Signature);
+            nqp::bindattr($sig, Signature, '@!params',
+                [$optional ?? OPTIONAL-TOPIC-PARAM !! REQUIRED-TOPIC-PARAM]);
+            nqp::bindattr_i($sig, Signature, '$!arity', $optional ?? 0 !! 1);
+            nqp::bindattr($sig, Signature, '$!count', nqp::box_i(1, Int));
+            nqp::bindattr($sig, Signature, '$!code', $block);
+            nqp::bindattr($block, Code, '$!signature', $sig);
         }
         self.add-phasers-to-code-object($block);
         $block

--- a/t/02-rakudo/bare-block-topic-signature.t
+++ b/t/02-rakudo/bare-block-topic-signature.t
@@ -1,0 +1,40 @@
+use Test;
+
+plan 11;
+
+{
+    my $sig = { $_ }.signature;
+    is $sig.raku, ':(;; $_? is raw = OUTER::<$_>)',
+        'bare block signature renders its implicit topic as raw with an outer default';
+    my $param = $sig.params[0];
+    ok $param.raw, 'the implicit topic parameter is raw';
+    ok $param.optional, 'the implicit topic parameter is optional';
+    is $param.type.^name, 'Mu', 'the implicit topic parameter is typed Mu';
+}
+
+# Trial binding invokes under the code object the signature belongs to, so
+# these die if a block's signature has no code object bound.
+{
+    my $b = { $_ };
+    lives-ok { $b.signature.ACCEPTS(\("x")) },
+        'ACCEPTS on a bare block signature does not die';
+    ok $b.signature.ACCEPTS(\("x")), 'a one-argument capture matches a bare block signature';
+    ok $b.signature.ACCEPTS(\()), 'an empty capture matches a bare block signature';
+    is $b.cando(\("x")).elems, 1, 'cando finds a bare block callable with one argument';
+}
+
+ok !({ $_ }.signature === { 42 }.signature),
+    'two bare blocks do not share one signature object';
+
+{
+    my @a = 1, 2, 3;
+    for @a { $_++ }
+    is-deeply @a, [2, 3, 4], 'the implicit topic still aliases the iterated containers';
+}
+
+with 5 {
+    ok &?BLOCK.signature.ACCEPTS(\(5)),
+        'ACCEPTS works on the implicit topic signature of a with block';
+}
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously every signature-less block shared a single constant Signature meta-object for its implicit $_ parameter. That shared Signature never had its $!code attribute bound, so Signature.ACCEPTS and .cando on such a block died with "p6invokeunder first argument has to be a concrete MVMCode" when Binder.is_bindable tried to invoke under the code the signature belongs to. The shared Parameter was also missing the SIG_ELEM_IS_RAW flag that the legacy frontend sets, even though the QAST parameter already binds raw, so introspection rendered the signature as :(;; Mu $_? = OUTER::<$_>) instead of :(;; $_? is raw = OUTER::<$_>).

This makes RakuAST::Block.IMPL-PRODUCE-META-OBJECT create a fresh Signature per block with $!code bound to the block. The Parameter stays a shared constant since it holds no per-block state, now with the raw flag and an explicit Mu type to match what the legacy frontend builds in Actions.nqp.

Fixes the Cro::HTTP router request-body fallback, which dispatches with $handler.signature.ACCEPTS(\(body)) on a bare block handler.