### PR TITLE
RakuAST: adopt an imported stub package's WHO when declaring the package

### DIFF
--- a/src/Raku/ast/scoping.rakumod
+++ b/src/Raku/ast/scoping.rakumod
@@ -1177,6 +1177,17 @@ class RakuAST::PackageInstaller {
     method is-stub() { False }
     method defuse-stub() { }
 
+    # Install a symbol via the package's WHO rather than the underlying
+    # storage hash. The serialization write barrier only marks the object
+    # named in the write, and a Stash's storage hash may be a fresh clone
+    # that belongs to no serialization context. Writing to the storage
+    # directly can therefore leave a precompilation without a repossession
+    # entry for a stash it modified, so modules loading it never see the
+    # symbol and same-named packages diverge instead of merging.
+    method IMPL-STASH-BIND(Mu $package, str $key, Mu $value) {
+        nqp::bindkey($package.WHO, $key, $value);
+    }
+
     method IMPL-INSTALL-PACKAGE(
         RakuAST::Resolver $resolver,
         str $scope,
@@ -1289,8 +1300,7 @@ class RakuAST::PackageInstaller {
                         $longname := $longname ~ '::' ~ $_.name;
                         my $package := Perl6::Metamodel::PackageHOW.new_type(name => $longname);
                         $package.HOW.compose($package);
-                        my %stash := $resolver.IMPL-STASH-HASH($target);
-                        %stash{$_.name} := $package;
+                        self.IMPL-STASH-BIND($target, $_.name, $package);
                         $target := $package;
                     }
                 }
@@ -1307,8 +1317,7 @@ class RakuAST::PackageInstaller {
                         :package(self);
                 if $scope eq 'our' {
                     # TODO conflicts
-                    my %stash := $resolver.IMPL-STASH-HASH($current-package);
-                    %stash{$first} := $target;
+                    self.IMPL-STASH-BIND($current-package, $first, $target);
                 }
                 $scope := 'our'; # Ensure we install the package into the generated stub
 
@@ -1317,8 +1326,7 @@ class RakuAST::PackageInstaller {
                     $longname := $longname ~ '::' ~ $_.name;
                     my $package := Perl6::Metamodel::PackageHOW.new_type(name => $longname);
                     $package.HOW.compose($package);
-                    my %stash := $resolver.IMPL-STASH-HASH($target);
-                    %stash{$_.name} := $package;
+                    self.IMPL-STASH-BIND($target, $_.name, $package);
                     $target := $package;
                 }
             }
@@ -1348,7 +1356,7 @@ class RakuAST::PackageInstaller {
         # setting's serialization context, which breaks precompilation.
         if $lexical
           && nqp::istype($lexical.compile-time-value.HOW, Perl6::Metamodel::PackageHOW) {
-            %stash{$final} := $lexical.compile-time-value;
+            self.IMPL-STASH-BIND($target, $final, $lexical.compile-time-value);
         }
         if $scope eq 'our' {
             if nqp::existskey(%stash, $final) && !(%stash{$final} =:= $type-object) {
@@ -1366,7 +1374,7 @@ class RakuAST::PackageInstaller {
                         'X::Redeclaration', :symbol($name.canonicalize);
                 }
             }
-            %stash{$final} := $type-object;
+            self.IMPL-STASH-BIND($target, $final, $type-object);
         }
     }
 

--- a/src/Raku/ast/scoping.rakumod
+++ b/src/Raku/ast/scoping.rakumod
@@ -1203,6 +1203,7 @@ class RakuAST::PackageInstaller {
         my $target;
         my $final;
         my $lexical;
+        my $lexical-stub;
         my $type-object := nqp::eqaddr($meta-object, Mu) ?? self.stubbed-meta-object !! $meta-object;
         # If the multi-part install resolves its parent through the
         # setting / outer lexical chain (cross-compunit reload),
@@ -1222,6 +1223,18 @@ class RakuAST::PackageInstaller {
         if $name.is-identifier {
             $final := $name.canonicalize(:colonpairs(0));
             $lexical := $resolver.resolve-lexical-constant($final);
+            # Capture a stub package an import already installed under this
+            # name. Resolving the name here finds this declaration itself,
+            # and the lexical merge below rebinds the import to this
+            # declaration's type object, so query the generated lexical and
+            # do it before that merge. The stash upgrade further down needs
+            # the stub itself so this package can adopt its WHO, which other
+            # compilation units may already share and write to.
+            my $generated := $resolver.current-scope.find-generated-lexical($final);
+            $lexical-stub := $generated.compile-time-value
+                if $generated
+                && nqp::istype($generated, RakuAST::CompileTimeValue)
+                && nqp::istype($generated.compile-time-value.HOW, Perl6::Metamodel::PackageHOW);
             # `my package EXPORT` names a package the compunit already declares
             # implicitly. Reuse that lexical, pointing it at the new package,
             # rather than declaring a second of the same name and colliding.
@@ -1354,9 +1367,10 @@ class RakuAST::PackageInstaller {
         # is shadowed by this declaration, not adopted; injecting it makes
         # the silent-replace below steal the builtin's WHO out of the
         # setting's serialization context, which breaks precompilation.
-        if $lexical
-          && nqp::istype($lexical.compile-time-value.HOW, Perl6::Metamodel::PackageHOW) {
-            self.IMPL-STASH-BIND($target, $final, $lexical.compile-time-value);
+        # The stub was captured before the lexical merge, which rebinds the
+        # resolved declaration to this declaration's own type object.
+        if !nqp::eqaddr($lexical-stub, NQPMu) && $scope eq 'our' {
+            self.IMPL-STASH-BIND($target, $final, $lexical-stub);
         }
         if $scope eq 'our' {
             if nqp::existskey(%stash, $final) && !(%stash{$final} =:= $type-object) {

--- a/t/02-rakudo/package-adopts-imported-stub-who.t
+++ b/t/02-rakudo/package-adopts-imported-stub-who.t
@@ -1,0 +1,18 @@
+use lib <t/packages/02-rakudo/lib>;
+use Test;
+
+plan 2;
+
+# Importing StealWhoLeaf brings in a stub StealWho package carrying Leaf.
+use StealWhoLeaf;
+my constant $stub-who = ::("StealWho").WHO;
+
+class StealWho {
+}
+
+ok StealWho.WHO<Leaf>:exists,
+    'a symbol from the imported stub package is visible via the class';
+ok StealWho.WHO =:= $stub-who,
+    'the class adopts the imported stub package WHO rather than copying its symbols';
+
+# vim: expandtab shiftwidth=4

--- a/t/packages/02-rakudo/lib/StealWhoLeaf.rakumod
+++ b/t/packages/02-rakudo/lib/StealWhoLeaf.rakumod
@@ -1,0 +1,2 @@
+class StealWho::Leaf {
+}


### PR DESCRIPTION
Previously the RakuAST frontend gave a package declaration its own fresh WHO even when an import had already brought in a stub package of the same name. The legacy frontend steals the stub's WHO in this situation (`World.steal_WHO`), which is what keeps every compilation unit in a dependency graph pointing at one shared stash object per namespace. The RakuAST installer had code intending to do the same, however it resolved the name again at the point of the stash upgrade, and for an identifier that lookup finds the declaration itself. The lexical merge had also already rebound the import to the new type object by then. As such the upgrade never fired, the declaration kept a fresh WHO with the stub's symbols copied in, and different dependency lineages ended up with different stash objects for the same logical namespace.

That divergence shows up after precompilation. Each module records repossessions of whichever stash object its own lineage converged on, and loading two lineages together resolves those conflicts with a latest-wins rebind rather than a union, so symbols imported earlier can vanish:

    $ RAKUDO_RAKUAST=1 raku -e 'use Cro::HTTP::Server; use Cro::HTTP::Router; say Cro::HTTP::Server.^name'
    Could not find symbol '&Server' in 'Cro::HTTP'

(this is how `Cro::HTTP::Test` fails in blin)

This captures the stub from the generated lexical before the merge rebinds it and injects it into the target stash, so the existing silent-replace path adopts the stub's WHO like legacy does. The first commit also makes package installs bind symbols via the stash itself rather than its underlying storage hash. The serialization write barrier only marks the object named in the write, and the storage hash may be a runtime clone belonging to no serialization context, in which case a precompilation could modify a stash from another compilation unit without ever recording a repossession entry for it.
