### PR TITLE
RakuAST: honor a version/auth constraint on `require`

### DIFF
--- a/src/Raku/ast/statements.rakumod
+++ b/src/Raku/ast/statements.rakumod
@@ -2204,7 +2204,7 @@ class RakuAST::Statement::Require
                 self,
                 RakuAST::Statement::Require,
                 '$!module',
-                RakuAST::Package.new(:scope<my>, :name($!module-name.without-colonpair('file')), :is-require-stub),
+                RakuAST::Package.new(:scope<my>, :name($!module-name.without-colonpairs), :is-require-stub),
             );
             $!module.to-begin-time($resolver, $context);
             $!module.set-is-stub(True);
@@ -2230,7 +2230,7 @@ class RakuAST::Statement::Require
             }
         }
         else {
-            QAST::SVal.new(:value($!module-name.canonicalize))
+            QAST::SVal.new(:value($!module-name.canonicalize(:colonpairs(0))))
         }
     }
 
@@ -2252,6 +2252,22 @@ class RakuAST::Statement::Require
                 QAST::WVal.new(:value($depspec)),
                 $short-name,
             );
+            # Carry a `require Foo:ver(...):auth(...):api(...):from(...)`
+            # constraint into the dependency specification. Without this the
+            # adverbs stay in the short-name and the module is looked up under a
+            # name like "Foo:ver<...>", which never resolves.
+            my @adverb-keys   := ['ver', 'auth', 'api', 'from'];
+            my @matcher-names := ['version-matcher', 'auth-matcher', 'api-matcher', 'from'];
+            my int $i := 0;
+            while $i < 4 {
+                my $cp := $!module-name.first-colonpair(@adverb-keys[$i]);
+                if $cp {
+                    my $matcher := $cp.IMPL-VALUE-QAST($context);
+                    $matcher.named(@matcher-names[$i]);
+                    $spec.push($matcher);
+                }
+                $i := $i + 1;
+            }
             $compunit-qast := QAST::Op.new(
                 :op('callmethod'), :name('need'),
                 QAST::Op.new(
@@ -2340,7 +2356,7 @@ class RakuAST::Statement::Require
         $qast.push($require-qast);
         unless self.sunk {
             $qast.push: $!module-name
-                ?? $!module-name.IMPL-QAST-INDIRECT-LOOKUP($context)
+                ?? $!module-name.without-colonpairs.IMPL-QAST-INDIRECT-LOOKUP($context)
                 !! $!file.IMPL-TO-QAST($context);
         }
         $qast

--- a/t/12-rakuast/xx-fixed-in-rakuast.rakutest
+++ b/t/12-rakuast/xx-fixed-in-rakuast.rakutest
@@ -2,7 +2,7 @@ use Test;
 use lib <t/packages/Test-Helpers>;
 use Test::Helpers;
 
-plan 116;
+plan 122;
 
 # t/spec/S03-sequence/misc.t
 # https://github.com/rakudo/rakudo/issues/5520
@@ -860,6 +860,30 @@ subtest 'use of &?ROUTINE and &?BLOCK' => {
     $c = 8;
     todo "mixed named and positional args leak the native reference in legacy grammar" unless %*ENV<RAKUDO_RAKUAST>;
     is $s, 5, 'a native argument following a named argument is a snapshot';
+}
+
+# `require Foo:ver(...)` (and :auth/:api) built the dependency specification
+# with the whole adverbed name as the short-name and no matchers, so it
+# looked up a module literally named "Foo:ver<...>" and never found one.
+# The legacy grammar instead silently drops the adverbs and loads by base
+# name, so an unsatisfiable constraint is only enforced under RakuAST.
+{
+    lives-ok { require Test:ver<6.0.0+> },
+        'require loads a module through a satisfiable :ver constraint';
+    lives-ok { require Test:api },
+        'require loads a module with a bare boolean adverb';
+    is (do { require Test:ver<6.0.0+> }).^name, 'Test',
+        'a require with an adverb used as a block value returns the module';
+    {
+        require Test:ver<6.0.0+> <&pass>;
+        ok &pass ~~ Sub, 'a require with an adverb still imports the requested symbol';
+    }
+    todo "the legacy grammar ignores an unsatisfiable :ver on require" unless %*ENV<RAKUDO_RAKUAST>;
+    dies-ok { require Test:ver<999999.1> },
+        'require fails on an unsatisfiable :ver constraint';
+    todo "the legacy grammar ignores an unsatisfiable :auth on require" unless %*ENV<RAKUDO_RAKUAST>;
+    dies-ok { require Test:auth<nobody> },
+        'require fails on an unsatisfiable :auth constraint';
 }
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
`require Foo:ver(...)` (and :auth/:api/:from) built the dependency specification with the whole `Foo:ver<...>` string as the short-name and no matchers, so it looked up a module literally named "Foo:ver<...>" and never found it. Only a plain `require Foo` worked.

This strips the adverbs from the short-name (also from the require stub package and the statement's result-value lookup) and passes them as version/auth/api matchers, so require resolves the candidate that satisfies the constraint and fails when none does. Legacy silently ignores the constraint and loads by name. This honors it.