### PR TITLE
Give the experimental macros flag a load-independent value

### DIFF
--- a/lib/experimental.rakumod
+++ b/lib/experimental.rakumod
@@ -23,7 +23,11 @@ package EXPORT::cached {
 }
 
 package EXPORT::macros {
-    OUR::<EXPERIMENTAL-MACROS> := nqp::getcomp('Raku').language_revision < 3;
+    # A load-independent marker. This our-symbol is GLOBAL-merged into every
+    # consumer, so a value that varies by language revision collides on merge
+    # once a 6.e consumer is precompiled. The 6.e macro ban lives in the
+    # grammar's experimental token instead.
+    OUR::<EXPERIMENTAL-MACROS> := True;
 }
 
 package EXPORT::smallnatives {

--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -347,7 +347,10 @@ role STD {
     }
 
     token experimental($feature) {
-        <?{ $*COMPILING_CORE_SETTING || try $*W.find_single_symbol('EXPERIMENTAL-' ~ nqp::uc($feature)) }>
+        <?{ $*COMPILING_CORE_SETTING
+            || ((try $*W.find_single_symbol('EXPERIMENTAL-' ~ nqp::uc($feature)))
+                && ($feature ne 'macros'
+                    || nqp::getcomp('Raku').language_revision < 3)) }>
         || <.typed_panic('X::Experimental', :$feature)>
     }
 


### PR DESCRIPTION
A module that does `use v6.e.PREVIEW; use experimental`, once precompiled and loaded with `use` alongside a fresh load of experimental, died at compile time:

    Merging GLOBAL symbols failed: duplicate definition of symbol EXPERIMENTAL-MACROS

EXPERIMENTAL-MACROS is an our-symbol in experimental's EXPORT::macros package, so it is GLOBAL-merged into every consumer regardless of the imported tag. Previously its value was `nqp::getcomp('Raku').language_revision < 3`, evaluated whenever experimental's mainline runs. A precompiled 6.e consumer bakes False into its serialized GLOBAL while a 6.d top-level computes True, and the merge cannot reconcile two different values for one symbol. A shared value such as the old True never had this problem, since every load sees the same object.

Restore the marker to a plain True and move the 6.e macro ban into the grammar's experimental token, which now refuses macros once the language revision reaches 6.e. The X::Experimental message already reports that macros are no longer supported in Raku 6.e, so the behavior is unchanged.