### PR TITLE
RakuAST: iterate a sunk `xx` result so its thunk runs

### DIFF
--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -336,6 +336,9 @@ class RakuAST::Infix
         SC{$!operator} // False
     }
 
+    # A pure operator's sink call rides on this classification, so an impure
+    # operator whose result is a lazy producer must also be listed in
+    # IMPL-RESULT-NEEDS-ITERATION to keep being sunk.
     method is-pure() {
         my constant NP := nqp::hash(
           ':=',   False,
@@ -350,6 +353,11 @@ class RakuAST::Infix
         );
         nqp::atkey(NP,$!operator) // True
     }
+
+    # `A xx *` returns a lazy Seq, so a sunk result must be iterated to run its
+    # side effects. A finite count reifies eagerly and would run them without a
+    # sink, but the count is not always known at compile time.
+    method IMPL-RESULT-NEEDS-ITERATION() { $!operator eq 'xx' }
 
     method IMPL-OPERATOR() {
         self.resolution.compile-time-value

--- a/t/02-rakudo/xx-sink-lazy.t
+++ b/t/02-rakudo/xx-sink-lazy.t
@@ -1,0 +1,24 @@
+use Test;
+
+plan 3;
+
+# `A xx *` produces a lazy Seq, so when its value is sunk (here, the final
+# statement of a gather block) it must be iterated for the thunk to run each
+# time. Bounded with head so the infinite repetition terminates.
+is (gather do { take 1 } xx *).head(3).elems, 3,
+    'takes from the thunk of a sunk `xx *` reach the enclosing gather';
+
+# The same lazy repetition run through an explicit sink also fires its thunk.
+{
+    my $count = 0;
+    (do { $count++ } xx *).head(3).sink;
+    is $count, 3, 'a bounded lazy `xx *` runs its thunk when sunk';
+}
+
+# A finite count reifies eagerly, so a sunk `A xx N` runs its thunk N times
+# with no extra sink needed. Guards against over-correcting the lazy case.
+{
+    my $count = 0;
+    do { $count++ } xx 4;
+    is $count, 4, 'a finite `xx N` in sink context runs its thunk N times';
+}


### PR DESCRIPTION
Previously `gather do { take 1 } xx *` collected nothing under RakuAST. A sunk `A xx *` returns a lazy Seq, and nothing iterated it, so the repeated thunk never ran and its takes never reached the gather.

ApplyInfix.needs-sink-call is `infix.is-pure || infix.IMPL-RESULT-NEEDS-ITERATION`. Both were False for `xx`, so no sink call was emitted. A finite `A xx N` reifies eagerly and ran its thunk regardless, which hid the gap. Have Infix report IMPL-RESULT-NEEDS-ITERATION True for `xx` so a sunk result is iterated.