### PR TITLE
RakuAST: resolve `$?FILE` at parse time so it matches legacy

### DIFF
--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -2166,6 +2166,25 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
         self.attach: $/, $<variable>.ast
     }
 
+    # Resolve the current source file as an interned string for `$?FILE`.
+    # Mirrors the legacy frontend's current_file in src/Perl6/World.nqp:
+    # prepend the cwd unless the name is already an absolute path or one
+    # of the non-path names a compilation can have ('-e', '<unknown file>').
+    # An EVAL's pseudo-file like 'EVAL_0' names no on-disk source, so it
+    # is also passed through as-is.
+    method IMPL-SOURCE-FILE($origin-source) {
+        my str $file := $origin-source.original-file;
+        $*LITERALS.intern-Str(
+          nqp::eqat($file,'/',0)      # absolute path
+            || nqp::eqat($file,'-',0) # '-e', '-'
+            || nqp::eqat($file,':',1) # Windows drive letter
+            || nqp::eqat($file,'<',0) # '<unknown file>'
+            || nqp::isconcrete(nqp::atkey(%*COMPILING<%?OPTIONS>,'outer_ctx'))
+            ?? $file
+            !! nqp::cwd() ~ '/' ~ $file
+        )
+    }
+
     method term:sym<package-declarator>($/) {
         self.attach: $/, $<package-declarator>.ast
     }
@@ -2517,6 +2536,11 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
                 $ast := Nodify('Var::Package').new(
                   :$sigil, :$twigil, :name($desigilname)
                 );
+            }
+            elsif $name eq '$?FILE' {
+                $ast := Nodify('Var::Compiler::File').new(
+                   self.IMPL-SOURCE-FILE($origin-source)
+                )
             }
             elsif $name eq '$?LINE' {
                 $ast := Nodify('Var::Compiler::Line').new(

--- a/src/Raku/ast/compunit.rakumod
+++ b/src/Raku/ast/compunit.rakumod
@@ -542,22 +542,12 @@ class RakuAST::CompUnit
           value => nqp::hllizefor($!checksum, 'Raku')
         ));
 
-        my sub relative-source-filename() {
-            if $*LITERALS {
-                my str $file := $*ORIGIN-SOURCE.original-file;
-                my str $cwd  := nqp::cwd();
-                $*LITERALS.intern-Str(nqp::eqat($file,$cwd,0)
-                  ?? nqp::substr($file,nqp::chars($cwd) + 1)
-                  !! $file
-                )
-            }
-            else {
-                '<unknown>'
-            }
-        }
-        add(RakuAST::VarDeclaration::Implicit::Constant.new(
-          name  => '$?FILE', value => relative-source-filename()
-        ));
+        # `$?FILE` is deliberately not declared here. The `?` twigil action
+        # in src/Raku/Actions.nqp resolves it at parse time to a string
+        # literal via RakuAST::Var::Compiler::File. A per-compunit lexical
+        # would leak into `SETTING::` when CORE is the compunit being
+        # compiled, and would embed the source path in the string heap of
+        # every compilation unit whether or not it mentions `$?FILE`.
 
         add(RakuAST::VarDeclaration::Implicit::Cursor.new());
 

--- a/t/02-rakudo/03-corekeys-6c.t
+++ b/t/02-rakudo/03-corekeys-6c.t
@@ -823,7 +823,7 @@ my %nyi-for-backend = (
 );
 
 if SETTING::{'!RAKUAST_MARKER'}:exists {
-    @expected.push: Q{!RAKUAST_MARKER}, Q{$?FILE};
+    @expected.push: Q{!RAKUAST_MARKER};
     @expected = @expected.grep(* ne '!INIT_VALUES').list;
     # TODO: legacy doesn't put $¢ in CORE::v6c, but RakuAST's CompUnit
     # PRODUCE-IMPLICIT-DECLARATIONS installs it unconditionally.  Drop

--- a/t/02-rakudo/03-corekeys-6d.t
+++ b/t/02-rakudo/03-corekeys-6d.t
@@ -823,7 +823,7 @@ my %nyi-for-backend = (
 );
 
 if SETTING::{'!RAKUAST_MARKER'}:exists {
-    @expected.push: Q{!RAKUAST_MARKER}, Q{$?FILE};
+    @expected.push: Q{!RAKUAST_MARKER};
     @expected = @expected.grep(* ne '!INIT_VALUES').list;
     # TODO: legacy doesn't put $¢ in this v6.d CORE:: view, but RakuAST's
     # CompUnit PRODUCE-IMPLICIT-DECLARATIONS installs it.  Drop this push

--- a/t/02-rakudo/03-corekeys-6e.t
+++ b/t/02-rakudo/03-corekeys-6e.t
@@ -833,7 +833,7 @@ my %nyi-for-backend = (
 );
 
 if SETTING::{'!RAKUAST_MARKER'}:exists {
-    @expected.push: Q{!RAKUAST_MARKER}, Q{$?FILE};
+    @expected.push: Q{!RAKUAST_MARKER};
     @expected = @expected.grep(* ne '!INIT_VALUES').list;
 }
 

--- a/t/02-rakudo/03-corekeys.t
+++ b/t/02-rakudo/03-corekeys.t
@@ -879,7 +879,7 @@ my $rakuast-built = SETTING::{'!RAKUAST_MARKER'}:exists;
 for @allowed -> (:key($rev), :value(@syms)) {
     my @adjusted = @syms;
     if $rakuast-built {
-        @adjusted.push: Q{!RAKUAST_MARKER}, Q{$?FILE};
+        @adjusted.push: Q{!RAKUAST_MARKER};
         @adjusted = @adjusted.grep(* ne '!INIT_VALUES').list;
         # TODO: legacy doesn't put $¢ in CORE::v6c, but RakuAST's CompUnit
         # PRODUCE-IMPLICIT-DECLARATIONS installs it unconditionally.  Drop

--- a/t/02-rakudo/04-settingkeys-6c.t
+++ b/t/02-rakudo/04-settingkeys-6c.t
@@ -824,7 +824,6 @@ my %nyi-for-backend = (
 
 if SETTING::{'!RAKUAST_MARKER'}:exists {
     %allowed{'!RAKUAST_MARKER'} = 1;
-    %allowed{'$?FILE'}          = 1;
     %allowed{'!INIT_VALUES'}:delete;
     # TODO: legacy doesn't install $¢ at the v6.c CORE setting, but
     # RakuAST's CompUnit PRODUCE-IMPLICIT-DECLARATIONS does.  Drop this

--- a/t/02-rakudo/04-settingkeys-6d.t
+++ b/t/02-rakudo/04-settingkeys-6d.t
@@ -27,7 +27,6 @@ my %allowed = (
 
 if SETTING::{'!RAKUAST_MARKER'}:exists {
     %allowed{'!RAKUAST_MARKER'} = 1;
-    %allowed{'$?FILE'}          = 1;
 }
 
 my @unknown;

--- a/t/02-rakudo/04-settingkeys-6e.t
+++ b/t/02-rakudo/04-settingkeys-6e.t
@@ -832,7 +832,6 @@ my %nyi-for-backend = (
 
 if SETTING::{'!RAKUAST_MARKER'}:exists {
     %allowed{'!RAKUAST_MARKER'} = 1;
-    %allowed{'$?FILE'}          = 1;
     %allowed{'!INIT_VALUES'}:delete;
 }
 

--- a/t/02-rakudo/file-variable.t
+++ b/t/02-rakudo/file-variable.t
@@ -1,0 +1,28 @@
+use lib <t/packages/Test-Helpers>;
+use Test;
+use Test::Helpers;
+
+plan 4;
+
+# `$?FILE` resolves at parse time to the absolute path of the source file
+# being compiled, matching legacy's current_file in src/Perl6/World.nqp.
+# Non-path source names such as `-e` pass through as-is. The value is a
+# string literal at each use site rather than a lexical declared per
+# compilation unit: a per-compunit lexical leaked into `SETTING::` when
+# the CORE setting itself was the compunit being compiled, and embedded
+# the source path in the string heap of every compilation unit whether
+# or not it mentioned `$?FILE`.
+
+is-run 'say $?FILE', :out("-e\n"),
+  '`$?FILE` of a -e one-liner is -e';
+
+ok $?FILE.IO.is-absolute,
+  '`$?FILE` in a source file is an absolute path';
+
+is $?FILE.IO.basename, 'file-variable.t',
+  '`$?FILE` names the file being compiled';
+
+nok SETTING::{'$?FILE'}:exists,
+  '`$?FILE` does not leak into SETTING:: from the CORE build';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously `$?FILE` was declared as an implicit lexical constant in RakuAST::CompUnit::PRODUCE-IMPLICIT-DECLARATIONS, holding the source path with the cwd prefix stripped, and each `$?FILE` reference compiled to a generic lexical lookup. This had two problems. When the CORE setting itself was the compunit being compiled, the constant leaked into `SETTING::`, e.g. `SETTING::<$?FILE>` was `gen/moar/CORE.d.setting`. And the cwd stripping diverged from the legacy frontend, whose current_file in src/Perl6/World.nqp prepends the cwd instead, producing an absolute path. That divergence breaks ecosystem code which compares `$?FILE` against filesystem APIs that return absolute paths. P5readlink fails this way: its test symlinks `$?FILE` (stored absolute by CORE's `symlink`) and compares `readlink` output against the still-relative `$?FILE`.

Resolve `$?FILE` in the `?` twigil action to a string literal via RakuAST::Var::Compiler::File, which existed for this purpose but was orphaned when 313dfb7df0 introduced the implicit constant, and apply the same absolutifying rule as legacy: prepend the cwd unless the name is already absolute or is a non-path name like `-e` or `<unknown file>`. An EVAL's pseudo-file such as `EVAL_0` also passes through as-is, since it names no on-disk source. Legacy absolutifies those too, which is why the `$?FILE` subtest in t/12-rakuast/var.rakutest is a todo under the legacy frontend.

The cwd stripping was introduced by 840e3eaf5b to keep build paths out of every precompiled module's string heap for the benefit of reproducible packaging, after 313dfb7df0 made the constant part of every compilation unit. Emitting the string only at `$?FILE` use sites addresses that concern as well: a module that never mentions `$?FILE` no longer embeds its source path at all, which is the same exposure the legacy frontend has always had.