### PR TITLE
RakuAST: give an attributive parameter its declaring package for the full binder

### DIFF
--- a/src/Raku/ast/signature.rakumod
+++ b/src/Raku/ast/signature.rakumod
@@ -551,6 +551,7 @@ class RakuAST::Parameter
     has RakuAST::Expression        $.array-shape;
     has RakuAST::Node              $.owner;
     has RakuAST::Package           $!package;
+    has Mu                         $!attr-package;
     has RakuAST::Signature         $.sub-signature;
     has List                       $!type-captures;
     has RakuAST::Signature         $.signature-constraint;
@@ -824,6 +825,15 @@ class RakuAST::Parameter
             $resolver.find-attach-target('block'));
         nqp::bindattr(self, RakuAST::Parameter, '$!package',
             $resolver.find-attach-target('package'));
+        # A private attributive parameter binds into an attribute, and the full
+        # binder reaches it through the parameter's attr_package. Capture $?CLASS
+        # now, while a resolver is available, so a role keeps its generic package
+        # and is instantiated to the pun on composition.
+        if nqp::istype($!target, RakuAST::ParameterTarget::Var) && $!target.attribute {
+            my $found := $resolver.resolve-lexical-constant('$?CLASS');
+            nqp::bindattr(self, RakuAST::Parameter, '$!attr-package',
+                $found.compile-time-value) if $found;
+        }
     }
 
     method visit-children(Code $visitor) {
@@ -914,6 +924,9 @@ class RakuAST::Parameter
                 $!target.set-rw if $rw eq 'rw';
                 $!target.set-ro(False);
             }
+        }
+        unless nqp::isnull($!attr-package) {
+            nqp::bindattr($parameter, Parameter, '$!attr_package', $!attr-package);
         }
         my @post_constraints;
         if nqp::defined($!value) {

--- a/t/02-rakudo/attributive-param-nested-alias.t
+++ b/t/02-rakudo/attributive-param-nested-alias.t
@@ -1,0 +1,52 @@
+use Test;
+
+plan 4;
+
+# A three-name alias parameter (`:x(:y(:$z))`) forces the full binder for the
+# whole signature. A private attributive parameter in that signature is then
+# bound by the binder, which reaches the attribute through the parameter's
+# declaring package.
+{
+    my class C {
+        has @.path;
+        submethod BUILD(:@!path!, :x(:y(:$z))) { }
+        multi method new(@path) { self.bless(:@path) }
+    }
+    is C.new([1,2,3]).path.join(','), '1,2,3',
+        'a private array attributive parameter binds under the full binder';
+}
+
+# The same for a scalar attribute.
+{
+    my class C {
+        has $.v;
+        submethod BUILD(:$!v!, :x(:y(:$z))) { }
+    }
+    is C.bless(v => 42).v, 42,
+        'a scalar attributive parameter binds under the full binder';
+}
+
+# In a role the declaring package is generic, so it must instantiate to the
+# class the role is composed into rather than stay the role.
+{
+    my role R {
+        has @.a;
+        submethod BUILD(:@!a!, :x(:y(:$z))) { }
+    }
+    my class D does R {
+        multi method new(@a) { self.bless(:@a) }
+    }
+    is D.new([4,5,6]).a.join(','), '4,5,6',
+        'an attributive parameter in a composed role binds to the pun';
+}
+
+# A two-name alias keeps the inline bindings path, which must still work.
+{
+    my class C {
+        has @.a;
+        submethod BUILD(:@!a!, :x(:$z)) { }
+        multi method new(@a) { self.bless(:@a) }
+    }
+    is C.new([7,8]).a.join(','), '7,8',
+        'the inline bindings path is unaffected';
+}


### PR DESCRIPTION
A parameter with a three-name alias (`:x(:y(:$z))`) forces the whole signature through the full binder. A private attributive parameter (`:$!x`) in such a signature was bound with no declaring package, so the binder fetched the attribute off Mu and died with "no such attribute". The inline bindings path was fine because it reaches the attribute through its own lookup.

Capture `$?CLASS` while parsing an attributive parameter and store it as the Parameter's attr_package, which the binder reads. `$?CLASS` keeps a role generic so the parameter instantiates to its pun on composition, as the legacy frontend already records.