### PR TITLE
RakuAST: optimize for loops

### DIFF
--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -713,6 +713,7 @@ class RakuAST::Node {
             self.IMPL-MARK-NATIVE-METAOP($resolver, $expr);
             self.IMPL-MARK-SCALAR-METAOP($resolver, $expr);
             self.IMPL-MARK-DOT-ASSIGN($resolver, $expr);
+            self.IMPL-MARK-RANGE-FOR($resolver, $expr);
         }
 
         # A replacement stands where the original stood, so it must carry the
@@ -858,6 +859,36 @@ class RakuAST::Node {
                 $call.IMPL-SET-INLINE if $dispatcher && $dispatcher eq 'dispatch:<.=>';
             }
         }
+        Nil
+    }
+
+    # Mark a for loop whose source is an integer range built by a CORE range
+    # constructor (`..` and its exclusive variants, prefix `^`, or `reverse`
+    # of one) for lowering to a native counting loop at code generation. Both
+    # the statement form and the statement modifier form qualify. Only the
+    # source shape and the operator's origin are decided here; code generation
+    # checks the loop itself (sunk, serial, simple body) and the bounds, and
+    # falls back to the ordinary compilation when those disqualify.
+    method IMPL-MARK-RANGE-FOR(RakuAST::Resolver $resolver, Mu $expr) {
+        my $for;
+        if nqp::istype($expr, RakuAST::Statement::For) {
+            $for := $expr;
+        }
+        elsif nqp::istype($expr, RakuAST::Statement::Expression)
+            && nqp::isconcrete($expr.loop-modifier)
+            && nqp::istype($expr.loop-modifier, RakuAST::StatementModifier::For) {
+            $for := $expr.loop-modifier;
+        }
+        else {
+            return Nil;
+        }
+        my $source := nqp::istype($for, RakuAST::Statement::For)
+            ?? $for.source
+            !! $for.expression;
+        my $operator := $for.IMPL-RANGE-FOR-OPERATOR($source);
+        $for.IMPL-SET-CAN-LOWER-RANGE()
+            if nqp::isconcrete($operator)
+            && self.IMPL-OPERATOR-IS-CORE($resolver, $operator);
         Nil
     }
 

--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -926,9 +926,14 @@ class RakuAST::Node {
     # bound to a lexical variable has no compile-time value and throws, which
     # declines the lowering. A user `multi` or `sub` that shadows or extends the
     # operator produces a distinct routine object whose file may still read
-    # SETTING::, so the file alone is not enough: when the setting provides the
-    # name, the resolved routine must be the setting's very own. When it does not
-    # (the operator is being defined as CORE itself compiles), the file vouches.
+    # SETTING::, so the file alone is not enough. The name is resolved again in
+    # the scope of the node being offered: a lexical declaration is visible to
+    # that walk wherever it sits in its block, so a user operator declared after
+    # a use of the name still turns the lowering off, where the resolution
+    # stored on the node (made when the declaration had not been parsed yet)
+    # would still claim the CORE routine. When the walk reaches no declaration
+    # at all (the operator is being defined as CORE itself compiles), the file
+    # vouches.
     method IMPL-OPERATOR-IS-CORE(RakuAST::Resolver $resolver, Mu $operator) {
         CATCH {
             return False;
@@ -939,10 +944,10 @@ class RakuAST::Node {
         my str $category := nqp::istype($operator, RakuAST::Postfix) ?? '&postfix'
                          !! nqp::istype($operator, RakuAST::Prefix)  ?? '&prefix'
                          !! '&infix';
-        my $setting := $resolver.resolve-lexical-constant-in-setting(
+        my $current := $resolver.resolve-lexical(
           $category ~ $resolver.IMPL-CANONICALIZE-PAIR($operator.operator));
-        nqp::istype($setting, RakuAST::Declaration::External::Constant)
-          ?? nqp::eqaddr($routine, $setting.compile-time-value)
+        nqp::isconcrete($current)
+          ?? nqp::eqaddr($routine, nqp::decont($current.compile-time-value))
           !! True
     }
 

--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -1115,6 +1115,21 @@ class RakuAST::ScopePhaser {
         nqp::getattr(self, RakuAST::ScopePhaser, '$!is-loop-body') // False
     }
 
+    method has-loop-phasers() {
+        return True if $!FIRST || $!NEXT || $!LAST;
+        if nqp::istype(self, RakuAST::Meta) {
+            my $phasers := nqp::getattr(self.meta-object, Block, '$!phasers');
+            nqp::ishash($phasers) && (
+                nqp::existskey($phasers, 'FIRST')
+                || nqp::existskey($phasers, 'NEXT')
+                || nqp::existskey($phasers, 'LAST')
+            ) ?? True !! False
+        }
+        else {
+            False
+        }
+    }
+
     method add-list-to-code-object(Str $attr, $code-object) {
         my $list := nqp::getattr(self, RakuAST::ScopePhaser, $attr);
         if $list {

--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -1130,6 +1130,20 @@ class RakuAST::ScopePhaser {
         }
     }
 
+    method has-any-phasers() {
+        return True
+          if $!ENTER || $!LEAVE || $!KEEP  || $!UNDO || $!FIRST || $!NEXT
+          || $!LAST  || $!PRE   || $!POST  || $!QUIT || $!TEMP  || $!CLOSE
+          || $!let   || $!temp;
+        if nqp::istype(self, RakuAST::Meta) {
+            nqp::isconcrete(nqp::getattr(self.meta-object, Block, '$!phasers'))
+              ?? True !! False
+        }
+        else {
+            False
+        }
+    }
+
     method add-list-to-code-object(Str $attr, $code-object) {
         my $list := nqp::getattr(self, RakuAST::ScopePhaser, $attr);
         if $list {

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -3754,6 +3754,7 @@ class RakuAST::Statement::For
   is RakuAST::SinkPropagator
   is RakuAST::BlockStatementSensitive
   is RakuAST::ImplicitBlockSemanticsProvider
+  is RakuAST::ImplicitLookups
 {
     # The thing to iterate over.
     has RakuAST::Expression $.source;
@@ -3810,6 +3811,14 @@ class RakuAST::Statement::For
         # Avoid worries about sink context
     }
 
+    method PRODUCE-IMPLICIT-LOOKUPS() {
+        [
+            RakuAST::Var::Lexical::Setting.new(
+                :desigilname(RakuAST::Name.from-identifier('IterationEnd'))),
+            RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('Nil')),
+        ]
+    }
+
     method IMPL-TO-QAST(RakuAST::IMPL::QASTContext $context) {
         # Figure out the execution mode modifiers to apply.
         my str $mode := $!mode;
@@ -3826,10 +3835,26 @@ class RakuAST::Statement::For
             $after-mode := self.IMPL-DISCARD-RESULT ?? 'sink' !! 'eager';
         }
 
+        my @labels := self.IMPL-UNWRAP-LIST(self.labels);
+
+        # A sunk serial for loop with a simple enough body iterates its
+        # source directly rather than delegating to its map method.
+        if $mode eq 'serial' && $after-mode eq 'sink'
+            && self.IMPL-CAN-USE-STATEMENT-FORM($!body) {
+            my @lookups := self.IMPL-UNWRAP-LIST(self.get-implicit-lookups);
+            return self.IMPL-TO-QAST-STATEMENT(
+              $context,
+              $!source.IMPL-TO-QAST($context),
+              $!body.IMPL-TO-QAST($context),
+              @labels ?? @labels[0] !! RakuAST::Label,
+              @lookups[0].resolution.compile-time-value,
+              @lookups[1].resolution.compile-time-value
+            );
+        }
+
         # Delegate to the for loop compilation helper (which we pass various
         # attributes to in order to make it callable for the statement modifier
         # form also).
-        my @labels := self.IMPL-UNWRAP-LIST(self.labels);
         my $qast := self.IMPL-FOR-QAST(
           $context,
           $mode,

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -3768,6 +3768,14 @@ class RakuAST::Statement::For
     # The mode of evaluation, (defaults to serial, may be race or hyper also).
     has str $.mode;
 
+    # Set when the optimize pass has approved lowering a CORE integer-range
+    # source to a native counting loop.
+    has int $!can-lower-range;
+
+    method IMPL-SET-CAN-LOWER-RANGE() {
+        nqp::bindattr_i(self, RakuAST::Statement::For, '$!can-lower-range', 1)
+    }
+
     method new(
       RakuAST::Expression :$source!,
            RakuAST::Block :$body!,
@@ -3842,13 +3850,27 @@ class RakuAST::Statement::For
         if $mode eq 'serial' && $after-mode eq 'sink'
             && self.IMPL-CAN-USE-STATEMENT-FORM($!body) {
             my @lookups := self.IMPL-UNWRAP-LIST(self.get-implicit-lookups);
+            my $Nil := @lookups[1].resolution.compile-time-value;
+            my $body-qast := $!body.IMPL-TO-QAST($context);
+
+            # An integer-range source the optimize pass approved becomes a
+            # native counting loop, unless a bound turns out not to be a
+            # native-friendly integer.
+            if $!can-lower-range
+                && nqp::elems(@labels) == 0
+                && !$!body.has-any-phasers {
+                my $range-qast := self.IMPL-TO-QAST-RANGE(
+                    $context, $!source, $body-qast, $Nil);
+                return $range-qast unless $range-qast =:= Mu;
+            }
+
             return self.IMPL-TO-QAST-STATEMENT(
               $context,
               $!source.IMPL-TO-QAST($context),
-              $!body.IMPL-TO-QAST($context),
+              $body-qast,
               @labels ?? @labels[0] !! RakuAST::Label,
               @lookups[0].resolution.compile-time-value,
-              @lookups[1].resolution.compile-time-value
+              $Nil
             );
         }
 

--- a/src/Raku/ast/statement-mods.rakumod
+++ b/src/Raku/ast/statement-mods.rakumod
@@ -300,6 +300,14 @@ class RakuAST::StatementModifier::For
   is RakuAST::ForLoopImplementation
   is RakuAST::ImplicitLookups
 {
+    # Set when the optimize pass has approved lowering a CORE integer-range
+    # source to a native counting loop.
+    has int $!can-lower-range;
+
+    method IMPL-SET-CAN-LOWER-RANGE() {
+        nqp::bindattr_i(self, RakuAST::StatementModifier::For, '$!can-lower-range', 1)
+    }
+
     method PRODUCE-IMPLICIT-LOOKUPS() {
         [
             RakuAST::Var::Lexical::Setting.new(
@@ -323,14 +331,28 @@ class RakuAST::StatementModifier::For
                  && self.IMPL-CAN-USE-STATEMENT-FORM($expression)
             !! True) {
             my @lookups := self.IMPL-UNWRAP-LIST(self.get-implicit-lookups);
-            $for-qast := self.IMPL-TO-QAST-STATEMENT(
-                $context,
-                $source-qast,
-                $statement-qast,
-                RakuAST::Label,
-                @lookups[0].resolution.compile-time-value,
-                @lookups[1].resolution.compile-time-value
-            );
+            my $Nil := @lookups[1].resolution.compile-time-value;
+
+            # An integer-range source the optimize pass approved becomes a
+            # native counting loop, unless a bound turns out not to be a
+            # native-friendly integer.
+            if $!can-lower-range
+                && !($block && nqp::istype($expression, RakuAST::Code)
+                      && $expression.has-any-phasers) {
+                $for-qast := self.IMPL-TO-QAST-RANGE(
+                    $context, $source, $statement-qast, $Nil);
+            }
+
+            if !nqp::isconcrete($for-qast) {
+                $for-qast := self.IMPL-TO-QAST-STATEMENT(
+                    $context,
+                    $source-qast,
+                    $statement-qast,
+                    RakuAST::Label,
+                    @lookups[0].resolution.compile-time-value,
+                    $Nil
+                );
+            }
         }
         else {
             $for-qast := self.IMPL-FOR-QAST(

--- a/src/Raku/ast/statement-mods.rakumod
+++ b/src/Raku/ast/statement-mods.rakumod
@@ -222,7 +222,7 @@ class RakuAST::StatementModifier::WhileUntil
         ]
     }
 
-    method IMPL-WRAP-QAST(RakuAST::IMPL::QASTContext $context, Mu $statement-qast, Bool :$sink, Bool :$block) {
+    method IMPL-WRAP-QAST(RakuAST::IMPL::QASTContext $context, Mu $statement-qast, Bool :$sink, Bool :$block, Mu :$expression) {
         if $sink {
             QAST::Op.new(
                 :op(self.negate ?? 'until' !! 'while'),
@@ -275,7 +275,7 @@ class RakuAST::StatementModifier::Given
 {
     method handles-condition() { False }
 
-    method IMPL-WRAP-QAST(RakuAST::IMPL::QASTContext $context, Mu $statement-qast, Bool :$sink, Bool :$block) {
+    method IMPL-WRAP-QAST(RakuAST::IMPL::QASTContext $context, Mu $statement-qast, Bool :$sink, Bool :$block, Mu :$expression) {
         if $block {
             if $sink {
                 $statement-qast[0].push(self.expression.IMPL-TO-QAST($context));
@@ -298,27 +298,52 @@ class RakuAST::StatementModifier::Given
 class RakuAST::StatementModifier::For
   is RakuAST::StatementModifier::Loop
   is RakuAST::ForLoopImplementation
+  is RakuAST::ImplicitLookups
 {
-    method IMPL-WRAP-QAST(RakuAST::IMPL::QASTContext $context, Mu $statement-qast, Bool :$sink, Bool :$block) {
-        my $expression := self.expression;
-        my $expression-qast := $expression.IMPL-TO-QAST($context);
+    method PRODUCE-IMPLICIT-LOOKUPS() {
+        [
+            RakuAST::Var::Lexical::Setting.new(
+                :desigilname(RakuAST::Name.from-identifier('IterationEnd'))),
+            RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('Nil')),
+        ]
+    }
+
+    method IMPL-WRAP-QAST(RakuAST::IMPL::QASTContext $context, Mu $statement-qast, Bool :$sink, Bool :$block, Mu :$expression) {
+        my $source := self.expression;
+        my $source-qast := $source.IMPL-TO-QAST($context);
         $statement-qast := $sink ?? $statement-qast[0][0] !! $statement-qast[0] if $block;
 
-        nqp::istype($expression, RakuAST::QuotedRegex)
-                        ??
-            self.IMPL-TEMPORARIZE-TOPIC(
-                $expression-qast,
-                self.IMPL-FOR-QAST(
-                    $context, 'serial',
-                    ($sink ?? 'sink' !! 'eager'),
-                    $expression-qast,
-                    $statement-qast))
-                        !!
-             self.IMPL-FOR-QAST(
+        # A sunk modifier for loop with a simple enough body iterates its
+        # source directly rather than delegating to its map method. A
+        # thunked statement always takes the one topic argument; an
+        # explicit block is checked like the statement form.
+        my $for-qast;
+        if $sink && ($block
+            ?? nqp::istype($expression, RakuAST::Code)
+                 && self.IMPL-CAN-USE-STATEMENT-FORM($expression)
+            !! True) {
+            my @lookups := self.IMPL-UNWRAP-LIST(self.get-implicit-lookups);
+            $for-qast := self.IMPL-TO-QAST-STATEMENT(
+                $context,
+                $source-qast,
+                $statement-qast,
+                RakuAST::Label,
+                @lookups[0].resolution.compile-time-value,
+                @lookups[1].resolution.compile-time-value
+            );
+        }
+        else {
+            $for-qast := self.IMPL-FOR-QAST(
                 $context, 'serial',
                 ($sink ?? 'sink' !! 'eager'),
-                $expression-qast,
-                $statement-qast)
+                $source-qast,
+                $statement-qast
+            );
+        }
+
+        nqp::istype($source, RakuAST::QuotedRegex)
+            ?? self.IMPL-TEMPORARIZE-TOPIC($source-qast, $for-qast)
+            !! $for-qast
     }
 
     method expression-thunk() {

--- a/src/Raku/ast/statements.rakumod
+++ b/src/Raku/ast/statements.rakumod
@@ -178,6 +178,122 @@ class RakuAST::ForLoopImplementation
             $body-qast, $label // RakuAST::Label)
     }
 
+    # Whether a sunk statement-level for loop with the given body can
+    # compile to the direct iterator-driven form. The body must be known
+    # to take exactly one argument and have no loop phasers, which only
+    # the map-driven form runs.
+    method IMPL-CAN-USE-STATEMENT-FORM(RakuAST::Code $body) {
+        my $count := nqp::getattr(
+            nqp::getattr($body.meta-object, Code, '$!signature'),
+            Signature, '$!count');
+        nqp::isconcrete($count) && $count == 1 && !$body.has-loop-phasers
+    }
+
+    # The iterator-driven form for a sunk statement-level `for` loop.
+    # This drives the source's iterator directly rather than calling its
+    # `map` method, so a user-supplied `map` override never sees the
+    # loop. It only applies when the body takes exactly one argument and
+    # has no loop phasers, matching the legacy p6forstmt op.
+    method IMPL-TO-QAST-STATEMENT(RakuAST::IMPL::QASTContext $context,
+            Mu $source-qast, Mu $body-qast, RakuAST::Label $label,
+            Mu $IterationEnd, Mu $Nil) {
+        # Bind the source into a temporary.
+        my $for-target-name := QAST::Node.unique('for_target');
+        my $bind-target := QAST::Op.new(
+            :op('bind'),
+            QAST::Var.new( :name($for-target-name), :scope('local'), :decl('var') ),
+            $source-qast
+        );
+
+        # Get the iterator. A source in a container iterates as a single
+        # item, except a Slip, which flattens. Wrapping it with
+        # `infix:<,>` gives both.
+        my $iterator-name := QAST::Node.unique('for_iterator');
+        my $bind-iterator := QAST::Op.new(
+            :op('bind'),
+            QAST::Var.new( :name($iterator-name), :scope('local'), :decl('var') ),
+            QAST::Op.new(
+                :op('callmethod'), :name('iterator'),
+                QAST::Op.new(
+                    :op('if'),
+                    QAST::Op.new(
+                        :op('iscont'),
+                        QAST::Var.new( :name($for-target-name), :scope('local') )
+                    ),
+                    QAST::Op.new(
+                        :op('callstatic'), :name('&infix:<,>'),
+                        QAST::Var.new( :name($for-target-name), :scope('local') )
+                    ),
+                    QAST::Var.new( :name($for-target-name), :scope('local') )
+                )
+            )
+        );
+
+        $context.ensure-sc($IterationEnd);
+        my $iteration-end-name := QAST::Node.unique('for_iterationend');
+        my $bind-iteration-end := QAST::Op.new(
+            :op('bind'),
+            QAST::Var.new( :name($iteration-end-name), :scope('local'), :decl('var') ),
+            QAST::WVal.new( :value($IterationEnd) )
+        );
+
+        # Bind the underlying VM code ref of the body so each iteration
+        # invokes it without going through the code object.
+        my $block-name := QAST::Node.unique('for_block');
+        my $bind-block := QAST::Op.new(
+            :op('bind'),
+            QAST::Var.new( :name($block-name), :scope('local'), :decl('var') ),
+            QAST::Op.new(
+                :op('getattr'),
+                $body-qast,
+                QAST::WVal.new( :value(Code) ),
+                QAST::SVal.new( :value('$!do') )
+            )
+        );
+
+        # Pull values until IterationEnd, calling the body with each one.
+        my $iter-val-name := QAST::Node.unique('for_iterval');
+        my $loop := QAST::Op.new(
+            :op('until'),
+            QAST::Op.new(
+                :op('eqaddr'),
+                QAST::Op.new(
+                    :op('decont'),
+                    QAST::Op.new(
+                        :op('bind'),
+                        QAST::Var.new( :name($iter-val-name), :scope('local'), :decl('var') ),
+                        QAST::Op.new(
+                            :op('callmethod'), :name('pull-one'),
+                            QAST::Var.new( :name($iterator-name), :scope('local') )
+                        )
+                    )
+                ),
+                QAST::Var.new( :name($iteration-end-name), :scope('local') )
+            ),
+            QAST::Op.new(
+                :op('call'),
+                QAST::Var.new( :name($block-name), :scope('local') ),
+                QAST::Var.new( :name($iter-val-name), :scope('local') )
+            )
+        );
+        if $label {
+            my $label-qast := $label.IMPL-LOOKUP-QAST($context);
+            $label-qast.named('label');
+            $loop.push($label-qast);
+        }
+
+        $context.ensure-sc($Nil);
+        self.IMPL-SET-NODE(
+            QAST::Stmts.new(
+                $bind-target,
+                $bind-iterator,
+                $bind-iteration-end,
+                $bind-block,
+                $loop,
+                QAST::WVal.new( :value($Nil) )
+            ), :key)
+    }
+
     # The most general, least optimized, form for a `for` loop, which
     # delegates to `map`.
     method IMPL-TO-QAST-GENERAL(RakuAST::IMPL::QASTContext $context, str $mode,
@@ -738,7 +854,8 @@ class RakuAST::Statement::Expression
         if $!loop-modifier {
             my $sink := self.IMPL-DISCARD-RESULT;
             $qast := $!loop-modifier.IMPL-WRAP-QAST($context, $qast, :$sink,
-                :block(nqp::istype(self.expression, RakuAST::Block)));
+                :block(nqp::istype(self.expression, RakuAST::Block)),
+                :expression($!expression));
         }
         $qast
     }

--- a/src/Raku/ast/statements.rakumod
+++ b/src/Raku/ast/statements.rakumod
@@ -178,6 +178,185 @@ class RakuAST::ForLoopImplementation
             $body-qast, $label // RakuAST::Label)
     }
 
+    # Strip parentheses that are pure syntactic grouping around a single
+    # expression, returning the expression inside.
+    method IMPL-UNWRAP-RANGE-EXPRESSION(Mu $node) {
+        my $expr := $node;
+        while nqp::istype($expr, RakuAST::Circumfix::Parentheses) {
+            my @statements := self.IMPL-UNWRAP-LIST($expr.semilist.statements);
+            last unless nqp::elems(@statements) == 1
+                && nqp::istype(@statements[0], RakuAST::Statement::Expression);
+            $expr := @statements[0].expression;
+        }
+        $expr
+    }
+
+    # The operator node of a for source that is shaped like an integer
+    # range: an infix range constructor, a ^ prefix, or an argument-less
+    # reverse method call on either. Returns Nil for any other shape.
+    method IMPL-RANGE-FOR-OPERATOR(Mu $source) {
+        my $expr := self.IMPL-UNWRAP-RANGE-EXPRESSION($source);
+        if nqp::istype($expr, RakuAST::ApplyPostfix)
+            && nqp::istype($expr.postfix, RakuAST::Call::Method)
+            && $expr.postfix.name.canonicalize eq 'reverse'
+            && !(nqp::isconcrete($expr.postfix.args) && $expr.postfix.args.arity) {
+            $expr := self.IMPL-UNWRAP-RANGE-EXPRESSION($expr.operand);
+        }
+        if nqp::istype($expr, RakuAST::ApplyInfix)
+            && nqp::istype($expr.infix, RakuAST::Infix) {
+            my str $op := $expr.infix.operator;
+            return $expr.infix
+                if $op eq '..' || $op eq '..^' || $op eq '^..' || $op eq '^..^';
+        }
+        elsif nqp::istype($expr, RakuAST::ApplyPrefix)
+            && nqp::istype($expr.prefix, RakuAST::Prefix)
+            && $expr.prefix.operator eq '^' {
+            return $expr.prefix;
+        }
+        Nil
+    }
+
+    # QAST for one bound of a lowered range loop: an integer known at
+    # compile time, or a native int variable, with the exclusivity
+    # adjustment folded in. Returns Mu for a bound that cannot be turned
+    # into a native int without changing behaviour. Compile-time values
+    # stay within 32 bits so the loop's native arithmetic cannot overflow.
+    method IMPL-RANGE-BOUND-QAST(RakuAST::IMPL::QASTContext $context, Mu $node, int $extra) {
+        if $node.has-compile-time-value {
+            my $value := nqp::decont($node.maybe-compile-time-value);
+            if nqp::istype($value, Int) && nqp::isconcrete($value) {
+                my num $test := nqp::tonum_I($value) + $extra;
+                if $test > -2147483648e0 && $test < 2147483647e0 {
+                    return QAST::IVal.new(
+                        :value(nqp::add_i(nqp::unbox_i($value), $extra)));
+                }
+            }
+        }
+        elsif nqp::istype($node, RakuAST::Var::Lexical) && $node.is-resolved
+            && nqp::objprimspec($node.return-type) == 1 {
+            my $qast := $node.IMPL-TO-QAST($context);
+            return $extra
+                ?? QAST::Op.new( :op<add_i>, :returns(int),
+                     $qast, QAST::IVal.new( :value($extra) ) )
+                !! $qast;
+        }
+        Mu
+    }
+
+    # The native counting loop for a sunk statement-level `for` over an
+    # integer range, the equivalent of the legacy optimizer's for-range
+    # rewrite. Steps a native int from start to end and calls the body
+    # with it, never building the Range or its iterator. Returns Mu when
+    # a bound disqualifies; the caller then falls back to the iterator
+    # form. The caller has already verified the operator is the CORE one
+    # via the optimize pass and that the body is a simple one-argument
+    # block with no phasers.
+    method IMPL-TO-QAST-RANGE(RakuAST::IMPL::QASTContext $context,
+            Mu $source, Mu $body-qast, Mu $Nil) {
+        my $expr := self.IMPL-UNWRAP-RANGE-EXPRESSION($source);
+        my int $reverse := 0;
+        if nqp::istype($expr, RakuAST::ApplyPostfix)
+            && nqp::istype($expr.postfix, RakuAST::Call::Method)
+            && $expr.postfix.name.canonicalize eq 'reverse'
+            && !(nqp::isconcrete($expr.postfix.args) && $expr.postfix.args.arity) {
+            $reverse := 1;
+            $expr := self.IMPL-UNWRAP-RANGE-EXPRESSION($expr.operand);
+        }
+
+        my $start-node;
+        my $end-node;
+        my int $start-extra := 0;
+        my int $end-extra   := 0;
+        if nqp::istype($expr, RakuAST::ApplyInfix)
+            && nqp::istype($expr.infix, RakuAST::Infix) {
+            my str $op := $expr.infix.operator;
+            return Mu
+                unless $op eq '..' || $op eq '..^' || $op eq '^..' || $op eq '^..^';
+            $start-extra := 1 if $op eq '^..' || $op eq '^..^';
+            $end-extra := -1 if $op eq '..^' || $op eq '^..^';
+            $start-node := $expr.left;
+            $end-node := $expr.right;
+        }
+        elsif nqp::istype($expr, RakuAST::ApplyPrefix)
+            && nqp::istype($expr.prefix, RakuAST::Prefix)
+            && $expr.prefix.operator eq '^' {
+            $end-node := $expr.operand;
+            $end-extra := -1;
+        }
+        else {
+            return Mu;
+        }
+
+        my $start-qast := $start-node
+            ?? self.IMPL-RANGE-BOUND-QAST($context, $start-node, $start-extra)
+            !! QAST::IVal.new( :value(0) );
+        return Mu if $start-qast =:= Mu;
+        my $end-qast := self.IMPL-RANGE-BOUND-QAST($context, $end-node, $end-extra);
+        return Mu if $end-qast =:= Mu;
+
+        my int $step := 1;
+        if $reverse {
+            my $swap := $start-qast;
+            $start-qast := $end-qast;
+            $end-qast := $swap;
+            $step := -1;
+        }
+
+        # Bind the iteration and end values into native int temporaries,
+        # and the body closure into a temporary. The iteration value
+        # starts one step early because the loop condition steps it.
+        my $it-name     := QAST::Node.unique('range_it');
+        my $last-name   := QAST::Node.unique('range_last');
+        my $callee-name := QAST::Node.unique('range_callee');
+        my $bind-it := QAST::Op.new( :op<bind>,
+            QAST::Var.new(
+                :name($it-name), :scope<local>, :decl<var>, :returns(int) ),
+            nqp::istype($start-qast, QAST::IVal)
+                ?? QAST::IVal.new( :value($start-qast.value - $step) )
+                !! QAST::Op.new( :op<sub_i>, :returns(int),
+                     $start-qast, QAST::IVal.new( :value($step) ) )
+        );
+        my $bind-last := QAST::Op.new( :op<bind>,
+            QAST::Var.new(
+                :name($last-name), :scope<local>, :decl<var>, :returns(int) ),
+            $end-qast
+        );
+        my $bind-callee := QAST::Op.new( :op<bind>,
+            QAST::Var.new( :name($callee-name), :scope<local>, :decl<var> ),
+            $body-qast
+        );
+
+        # Step the iteration value and call the body with it while it is
+        # on the start side of the end value.
+        my $loop := QAST::Op.new( :op<while>,
+            QAST::Op.new(
+                :op($step < 0 ?? 'isge_i' !! 'isle_i'),
+                QAST::Op.new( :op<bind>,
+                    QAST::Var.new( :name($it-name), :scope<local>, :returns(int) ),
+                    QAST::Op.new( :op<add_i>, :returns(int),
+                        QAST::Var.new( :name($it-name), :scope<local>, :returns(int) ),
+                        QAST::IVal.new( :value($step) )
+                    )
+                ),
+                QAST::Var.new( :name($last-name), :scope<local>, :returns(int) )
+            ),
+            QAST::Op.new( :op<call>,
+                QAST::Var.new( :name($callee-name), :scope<local> ),
+                QAST::Var.new( :name($it-name), :scope<local>, :returns(int) )
+            )
+        );
+
+        $context.ensure-sc($Nil);
+        self.IMPL-SET-NODE(
+            QAST::Stmts.new(
+                $bind-it,
+                $bind-last,
+                $bind-callee,
+                $loop,
+                QAST::WVal.new( :value($Nil) )
+            ), :key)
+    }
+
     # Whether a sunk statement-level for loop with the given body can
     # compile to the direct iterator-driven form. The body must be known
     # to take exactly one argument and have no loop phasers, which only

--- a/t/02-rakudo/for-range-native-loop.t
+++ b/t/02-rakudo/for-range-native-loop.t
@@ -1,0 +1,95 @@
+use Test;
+
+plan 14;
+
+# A sunk statement-level `for` loop over a CORE integer range compiles to a
+# native counting loop. These tests pin the observable behavior: the values
+# each range constructor produces, control flow, and the cases that must
+# keep the general compilation.
+
+{
+    my @seen;
+    for 1..5 { @seen.push($_) }
+    is-deeply @seen, [1, 2, 3, 4, 5], 'an inclusive .. range produces its values';
+}
+
+{
+    my @seen;
+    for 1..^5 { @seen.push($_) }
+    is-deeply @seen, [1, 2, 3, 4], 'a ..^ range excludes its right endpoint';
+}
+
+{
+    my @seen;
+    for 1^..5 { @seen.push($_) }
+    is-deeply @seen, [2, 3, 4, 5], 'a ^.. range excludes its left endpoint';
+}
+
+{
+    my @seen;
+    for 1^..^5 { @seen.push($_) }
+    is-deeply @seen, [2, 3, 4], 'a ^..^ range excludes both endpoints';
+}
+
+{
+    my @seen;
+    for ^4 { @seen.push($_) }
+    is-deeply @seen, [0, 1, 2, 3], 'a ^N range counts from zero';
+}
+
+{
+    my @seen;
+    for (1..4).reverse { @seen.push($_) }
+    is-deeply @seen, [4, 3, 2, 1], 'a reversed range counts down';
+}
+
+{
+    my @seen;
+    for -2..2 { @seen.push($_) }
+    is-deeply @seen, [-2, -1, 0, 1, 2], 'a range with negative bounds produces its values';
+}
+
+{
+    my @seen;
+    for 5..1 { @seen.push($_) }
+    is-deeply @seen, [], 'a range with start past end runs zero times';
+}
+
+{
+    my @seen;
+    @seen.push($_) for ^3;
+    is-deeply @seen, [0, 1, 2], 'a modifier for over a range produces its values';
+}
+
+{
+    my int $n = 3;
+    my @seen;
+    for 1..$n { @seen.push($_) }
+    is-deeply @seen, [1, 2, 3], 'a native int variable works as a range bound';
+}
+
+{
+    my @seen;
+    for 10_000_000_000..10_000_000_002 { @seen.push($_) }
+    is-deeply @seen, [10_000_000_000, 10_000_000_001, 10_000_000_002],
+        'a range with bounds past 32 bits still produces its values';
+}
+
+{
+    sub infix:<..>($a, $b) { (42,) }
+    my @seen;
+    for 3..4 { @seen.push($_) }
+    is-deeply @seen, [42], 'a lexically redefined range constructor is honored';
+}
+
+{
+    my @seen;
+    for 1..10 { last if $_ > 3; @seen.push($_) }
+    is-deeply @seen, [1, 2, 3], 'last works in a range for loop';
+}
+
+{
+    my @seen;
+    for 1..6 { next if $_ %% 2; @seen.push($_) }
+    is-deeply @seen, [1, 3, 5], 'next works in a range for loop';
+}

--- a/t/02-rakudo/for-statement-iterator-protocol.t
+++ b/t/02-rakudo/for-statement-iterator-protocol.t
@@ -1,0 +1,68 @@
+use Test;
+
+plan 12;
+
+# A sunk statement-level `for` loop drives the source's iterator directly
+# rather than calling its `map` method, so an object that overrides `map`
+# (e.g. a query-building DSL) still iterates its rows.
+
+my class OverridesMap does Iterable {
+    has @.map-calls;
+    method iterator { (1, 2, 3).iterator }
+    method map(|c) { @!map-calls.push(c); nextsame }
+}
+
+{
+    my $source = OverridesMap.new;
+    my @seen;
+    for $source<> -> $x { @seen.push($x) }
+    is-deeply @seen, [1, 2, 3], 'statement for with a pointy block iterates via the iterator';
+    is $source.map-calls.elems, 0, 'statement for with a pointy block does not call a user map override';
+}
+
+{
+    my $source = OverridesMap.new;
+    my @seen;
+    for $source<> { @seen.push($_) }
+    is-deeply @seen, [1, 2, 3], 'statement for with a bare block iterates via the iterator';
+    is $source.map-calls.elems, 0, 'statement for with a bare block does not call a user map override';
+}
+
+{
+    my $source = OverridesMap.new;
+    my @seen;
+    for $source<> -> $x { last if $x == 2; @seen.push($x) }
+    is-deeply @seen, [1], 'last works in a directly iterated for loop';
+}
+
+{
+    my $source = OverridesMap.new;
+    my @seen;
+    TOP: for $source<> -> $x {
+        for $source<> -> $y { next TOP if $y == 2; @seen.push($x ~ $y) }
+    }
+    is-deeply @seen, ['11', '21', '31'], 'a labeled next reaches the outer directly iterated for loop';
+}
+
+{
+    my $source = OverridesMap.new;
+    my @seen;
+    @seen.push($_) for $source<>;
+    is-deeply @seen, [1, 2, 3], 'modifier for iterates via the iterator';
+    is $source.map-calls.elems, 0, 'modifier for does not call a user map override';
+}
+
+{
+    my $source = OverridesMap.new;
+    my @seen;
+    { @seen.push($_) } for $source<>;
+    is-deeply @seen, [1, 2, 3], 'block modifier for iterates via the iterator';
+    is $source.map-calls.elems, 0, 'block modifier for does not call a user map override';
+}
+
+{
+    my $source = OverridesMap.new;
+    my @seen = do for $source<> -> $x { $x * 2 };
+    is-deeply @seen, [2, 4, 6], 'an expression do-for still collects its values';
+    is $source.map-calls.elems, 1, 'an expression do-for still dispatches to a user map override';
+}

--- a/t/02-rakudo/optimize-operator-late-decl.t
+++ b/t/02-rakudo/optimize-operator-late-decl.t
@@ -1,0 +1,32 @@
+use Test;
+
+plan 4;
+
+# The optimize pass only lowers an operator to a raw op when the name
+# resolves to the CORE routine in the scope of its use. A lexical operator
+# declaration is visible throughout its block, including before its textual
+# position, so a use of the name earlier in the block must dispatch to the
+# user routine rather than being lowered.
+
+{
+    my int $i = 1;
+    my @seen;
+    $i++;
+    is $i, 99, 'a native int increment honors a postfix:<++> declared later in the block';
+    sub postfix:<++>($x is rw) { @seen.push("called"); $x = 99 }
+    is-deeply @seen, ["called"], 'the later-declared postfix:<++> was called';
+}
+
+{
+    my @seen;
+    for 3..4 { @seen.push($_) }
+    is-deeply @seen, [42], 'a range for loop honors an infix:<..> declared later in the block';
+    sub infix:<..>($a, $b) { (42,) }
+}
+
+{
+    my @seen;
+    @seen.push($_) for ^3;
+    is-deeply @seen, [7, 8], 'a modifier for loop honors a prefix:<^> declared later in the block';
+    sub prefix:<^>($n) { (7, 8) }
+}


### PR DESCRIPTION
Previously RakuAST compiled every `for` loop through the most general form: a call
to the `map` method on the source. The legacy frontend only uses that form for the
expression case (`my @a = do for ...`), and compiles the common cases through two
specialized forms: a sunk statement level loop drives the source's iterator
directly (the `p6forstmt` op), and the optimizer rewrites loops over integer
ranges into native counting loops. This PR gives RakuAST both forms, mimicking legacy.

The iterator form is a behavior fix as well as an optimization: a statement level
`for` no longer calls the source's user visible `map` method, so an object that
overrides `map` still iterates through its iterator, as it does under legacy.

```raku
class Foo does Iterable {
    method iterator { (1,2,3).iterator }
    method map(|c)  { note "map called"; nextsame }
}
for Foo.new { }
# RakuAST before this PR: "map called". Legacy: silence.
```

`Red::ResultSeq` overrides `map` to build SQL, so under RakuAST
`for me.tickets -> $t { ... }` ran in query building mode instead of iterating
rows and then hung in Red's fallback handler. With this PR Red 0.2.4
`t/04-ticket.rakutest` passes 19/19 under RakuAST. Red's remaining test failures
under RakuAST are unchanged by this PR and reproduce without it.

Along the way this also makes `IMPL-OPERATOR-IS-CORE` resolve the operator name in
the scope of the node being offered to the optimize pass, instead of trusting the
resolution stored at parse time. A user operator declared after a use of its name
now turns the lowerings off, as it should. That check is shared, so this also
applies to the existing increment, metaop, and dot-assign lowerings.