### PR TITLE
RakuAST: interpret a curried argument of a BEGIN-time call

### DIFF
--- a/src/Raku/ast/begintime.rakumod
+++ b/src/Raku/ast/begintime.rakumod
@@ -139,6 +139,10 @@ class RakuAST::BeginTime
     ) {
         my $*IMPL-COMPILE-DYNAMICALLY := 1;
 
+        # A curried argument (a WhateverCode) may be interpreted here, as
+        # its static block compiles against a real QAST context.
+        my $*IMPL-INTERPRET-CURRIED := 1;
+
         # Ready to call
         if $callee.is-resolved
           && nqp::istype($callee.resolution, RakuAST::CompileTimeValue)

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -2003,6 +2003,25 @@ class RakuAST::WhateverApplicable
         }
     }
 
+    # A curried expression's value is its WhateverCode, and a BEGIN-time
+    # call may interpret it: the curry compiles as a static block whose
+    # outer is the compunit, so the closure survives serialization into
+    # a precompiled unit. Building it by running a dynamically compiled
+    # thunk instead gives it a throwaway outer frame that no longer
+    # matches after precompilation. Other interpret consumers, such as
+    # constant folding, must not treat the curry as a constant and have
+    # no QAST context to compile the block with, so this is gated by the
+    # dynamic flag the BEGIN-time call paths set.
+    method IMPL-CURRIED-CAN-INTERPRET() {
+        ($*IMPL-INTERPRET-CURRIED // 0) && self.IMPL-CURRIED ?? True !! False
+    }
+
+    method IMPL-CURRIED-INTERPRET(RakuAST::IMPL::InterpContext $ctx) {
+        my $curry := self.IMPL-CURRIED;
+        $curry.IMPL-QAST-BLOCK($ctx.context, :blocktype<declaration_static>, :expression(self));
+        $curry.meta-object
+    }
+
     method IMPL-IS-XX() {
         False
     }
@@ -2330,11 +2349,14 @@ class RakuAST::ApplyInfix
     method needs-sink-call() { $!infix.is-pure || $!infix.IMPL-RESULT-NEEDS-ITERATION }
 
     method IMPL-CAN-INTERPRET() {
-        $!infix.IMPL-CAN-INTERPRET && $!args.IMPL-CAN-INTERPRET
+        self.IMPL-CURRIED-CAN-INTERPRET
+          || $!infix.IMPL-CAN-INTERPRET && $!args.IMPL-CAN-INTERPRET
     }
 
     method IMPL-INTERPRET(RakuAST::IMPL::InterpContext $ctx) {
-        $!infix.IMPL-INTERPRET($ctx, self.IMPL-UNWRAP-LIST($!args.args) );
+        self.IMPL-CURRIED-CAN-INTERPRET
+          ?? self.IMPL-CURRIED-INTERPRET($ctx)
+          !! $!infix.IMPL-INTERPRET($ctx, self.IMPL-UNWRAP-LIST($!args.args) );
     }
 }
 
@@ -2518,6 +2540,7 @@ class RakuAST::ApplyListInfix
     }
 
     method IMPL-CAN-INTERPRET() {
+        return True if self.IMPL-CURRIED-CAN-INTERPRET;
         if $!infix.IMPL-CAN-INTERPRET {
             for self.IMPL-UNWRAP-LIST($!operands) {
                 return False unless $_.IMPL-CAN-INTERPRET;
@@ -2530,7 +2553,9 @@ class RakuAST::ApplyListInfix
     }
 
     method IMPL-INTERPRET(RakuAST::IMPL::InterpContext $ctx) {
-        $!infix.IMPL-INTERPRET($ctx, $!operands)
+        self.IMPL-CURRIED-CAN-INTERPRET
+          ?? self.IMPL-CURRIED-INTERPRET($ctx)
+          !! $!infix.IMPL-INTERPRET($ctx, $!operands)
     }
 }
 
@@ -2901,9 +2926,13 @@ class RakuAST::ApplyPrefix
         QAST::Op.new: :op($assign), :$returns, $var, $step
     }
 
-    method IMPL-CAN-INTERPRET() { $!operand.IMPL-CAN-INTERPRET && $!prefix.IMPL-CAN-INTERPRET }
+    method IMPL-CAN-INTERPRET() {
+        self.IMPL-CURRIED-CAN-INTERPRET
+          || $!operand.IMPL-CAN-INTERPRET && $!prefix.IMPL-CAN-INTERPRET
+    }
 
     method IMPL-INTERPRET(RakuAST::IMPL::InterpContext $ctx) {
+        return self.IMPL-CURRIED-INTERPRET($ctx) if self.IMPL-CURRIED-CAN-INTERPRET;
         my $op := $!prefix.IMPL-INTERPRET($ctx);
         $op($!operand.IMPL-INTERPRET($ctx))
     }
@@ -3688,10 +3717,15 @@ class RakuAST::ApplyPostfix
         $visitor($!postfix);
     }
 
-    method IMPL-CAN-INTERPRET() { $!operand.IMPL-CAN-INTERPRET && $!postfix.IMPL-CAN-INTERPRET }
+    method IMPL-CAN-INTERPRET() {
+        self.IMPL-CURRIED-CAN-INTERPRET
+          || $!operand.IMPL-CAN-INTERPRET && $!postfix.IMPL-CAN-INTERPRET
+    }
 
     method IMPL-INTERPRET(RakuAST::IMPL::InterpContext $ctx) {
-        $!postfix.IMPL-INTERPRET($ctx, -> { $!operand.IMPL-INTERPRET($ctx) })
+        self.IMPL-CURRIED-CAN-INTERPRET
+          ?? self.IMPL-CURRIED-INTERPRET($ctx)
+          !! $!postfix.IMPL-INTERPRET($ctx, -> { $!operand.IMPL-INTERPRET($ctx) })
     }
 }
 

--- a/src/Raku/ast/parsetime.rakumod
+++ b/src/Raku/ast/parsetime.rakumod
@@ -55,6 +55,9 @@ class RakuAST::ParseTime
     # with a set of arguments.
     method IMPL-BEGIN-TIME-CALL(RakuAST::Node $callee, RakuAST::ArgList $args,
             RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
+        # A curried argument (a WhateverCode) may be interpreted here, as
+        # its static block compiles against a real QAST context.
+        my $*IMPL-INTERPRET-CURRIED := 1;
         if $callee.is-resolved && nqp::istype($callee.resolution, RakuAST::CompileTimeValue) &&
                 $args.IMPL-CAN-INTERPRET {
             my $resolved := $callee.resolution.compile-time-value;

--- a/t/02-rakudo/trait-whatever-arg-precomp.t
+++ b/t/02-rakudo/trait-whatever-arg-precomp.t
@@ -1,0 +1,88 @@
+use lib <t/packages/Test-Helpers>;
+use Test;
+use Test::Helpers;
+
+plan 4;
+
+# A WhateverCode trait argument must survive precompilation. The closure
+# used to be built by running a throwaway BEGIN-time thunk, so the
+# serialized closure carried an outer frame that no longer matched its
+# static frame on load:
+#   provided outer frame ... does not match expected static frame '<unit>'
+# Interpreting the curried argument as a static block keeps the closure
+# serializable.
+
+sub precomp-and-run($name, $source, $call, $expected, $desc) {
+    my $tmp       = make-temp-dir;
+    my $mod-store = $tmp.add('module-store');
+    $mod-store.mkdir;
+    $mod-store.add("$name.rakumod").spurt: $source;
+
+    my $proc = run :out, :err,
+        $*EXECUTABLE.absolute,
+        '-I', $mod-store.absolute,
+        '-e', "use $name; print $call";
+
+    my $out = $proc.out.slurp(:close);
+    my $err = $proc.err.slurp(:close);
+
+    subtest $desc => {
+        plan 3;
+        is  $proc.exitcode, 0, 'exits cleanly';
+        nok $err.contains('does not match expected static frame'),
+            'no outer frame mismatch';
+        is  $out, $expected, 'produces the expected result';
+    }
+}
+
+my $attribute-trait = q:to/EOF/;
+unit module AttrTrait;
+my %STORE;
+multi sub trait_mod:<is>(Attribute:D $attr, :&kept!) is export {
+    %STORE{$attr.name} = &kept;
+}
+sub kept-for($name) is export { %STORE{$name} }
+class C is export { has $.x is kept(*.succ) }
+EOF
+precomp-and-run 'AttrTrait', $attribute-trait, q|kept-for('$!x')(41)|, '42',
+    'a WhateverCode argument to an attribute trait';
+
+my $routine-trait = q:to/EOF/;
+unit module SubTrait;
+my %CHECKS;
+multi sub trait_mod:<is>(Routine:D $r, :&check!) is export {
+    %CHECKS{$r.name} = &check;
+}
+sub check-for($name) is export { %CHECKS{$name} }
+sub f() is check(* > 0) is export { }
+EOF
+precomp-and-run 'SubTrait', $routine-trait, q|check-for('f')(5)|, 'True',
+    'a WhateverCode argument to a routine trait';
+
+my $mixed-args = q:to/EOF/;
+unit module MixedTrait;
+my %STORE;
+multi sub trait_mod:<is>(Attribute:D $attr, :$linked!) is export {
+    %STORE{$attr.name} = $linked;
+}
+sub linked-for($name) is export { %STORE{$name} }
+class C is export { has $.x is linked(*.succ, :name<foo>) }
+EOF
+precomp-and-run 'MixedTrait', $mixed-args,
+    Q[do { my ($code, $pair) = |linked-for('$!x'); "{$code(41)} {$pair.key}" }],
+    '42 name',
+    'a WhateverCode alongside other trait arguments';
+
+my $two-args = q:to/EOF/;
+unit module TwoStar;
+my %STORE;
+multi sub trait_mod:<is>(Attribute:D $attr, :&combined!) is export {
+    %STORE{$attr.name} = &combined;
+}
+sub combined-for($name) is export { %STORE{$name} }
+class C is export { has $.x is combined(* + *) }
+EOF
+precomp-and-run 'TwoStar', $two-args, q|combined-for('$!x')(40, 2)|, '42',
+    'a two argument WhateverCode trait argument';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously a BEGIN-time call whose arguments contained a WhateverCode could not interpret its argument list, so the whole call was compiled dynamically and run as a throwaway thunk. The WhateverCode built inside that thunk carried the thunk's frame as its outer, which no longer matches its static frame once the closure is serialized into a precompiled unit, and invoking it then died with "provided outer frame does not match expected static frame". The common shape is a trait argument in a module:

    has Int $.default-foo-id is referencing( *.id, :model<Foo> );

which is how installing Red under RakuAST surfaced it, in the columns of its model declarations. The same shape broke a routine trait like "is check(* > 0)". A role parameterization argument had the same problem and was fixed for Type::Parameterized specifically; this covers the general call path.

This makes a curried expression interpretable: its value is its WhateverCode, produced by compiling the curry as a static block whose outer is the compunit, the same pattern the subset where and role parameterization paths use, so the closure serializes. The interpretability is gated by a dynamic flag only the BEGIN-time call paths set, since other interpret consumers must not treat a curry as a constant, and have no QAST context to compile the block with. Because the gate composes through the normal interpret protocol, an argument list mixing a WhateverCode with other arguments works too.

Four of Red 0.2.4's test files that failed under RakuAST pass with this, two of them frame errors and two misbehaving trait registrations.