### PR TITLE
RakuAST: look the GLOBAL package up at run time

### DIFF
--- a/src/Raku/ast/variable-access.rakumod
+++ b/src/Raku/ast/variable-access.rakumod
@@ -881,7 +881,17 @@ class RakuAST::Var::Package
                 if self.is-resolved {
                     my $name := self.resolution.lexical-name;
                     nqp::shift(@parts);
-                    if nqp::istype(self.resolution, RakuAST::CompileTimeValue) {
+                    if $name eq 'GLOBAL' {
+                        # Each compilation unit has its own GLOBAL package,
+                        # and they merge into the process-wide one as units
+                        # load. A serialized reference to the compilation's
+                        # own GLOBAL would keep addressing that unit's copy,
+                        # whose stash nobody else sees, so the merged package
+                        # must be looked up at run time instead.
+                        $result := QAST::Op.new(
+                            :op<getcurhllsym>, QAST::SVal.new( :value<GLOBAL> ));
+                    }
+                    elsif nqp::istype(self.resolution, RakuAST::CompileTimeValue) {
                         # The leading package may be one we vivified for our own
                         # name (`Foo` for a `unit class Foo::Bar`), which has no
                         # serialization context yet, so make sure it gets one.

--- a/t/02-rakudo/global-package-var-cross-unit.t
+++ b/t/02-rakudo/global-package-var-cross-unit.t
@@ -1,0 +1,34 @@
+use lib <t/packages/Test-Helpers>;
+use Test;
+use Test::Helpers;
+
+plan 3;
+
+# A GLOBAL package variable written at run time by a precompiled module
+# must be visible outside that module. Each compilation unit has its own
+# GLOBAL package that merges into the process-wide one at load time, so a
+# reference compiled into the module must look the merged package up at
+# run time rather than address the unit's own serialized copy.
+
+my $mod-store = make-temp-dir;
+$mod-store.add('GlobalWriter.rakumod').spurt: q:to/EOF/;
+    unit module GlobalWriter;
+    sub set-it is export { %GLOBAL::CROSS-UNIT-DEFAULTS = (default => 42) }
+    sub get-dynamic is export { %*CROSS-UNIT-DEFAULTS<default> }
+    sub set-scalar is export { $GLOBAL::cross-unit-scalar = 5 }
+    EOF
+my @compiler-args = '-I', $mod-store.absolute;
+
+is-run 'use GlobalWriter; set-it; print %GLOBAL::CROSS-UNIT-DEFAULTS<default>',
+    :@compiler-args, :out<42>,
+    'a hash written to GLOBAL by a module is readable outside it';
+
+is-run 'use GlobalWriter; set-it; print get-dynamic()',
+    :@compiler-args, :out<42>,
+    'a GLOBAL hash reaches the dynamic variable fallback';
+
+is-run 'use GlobalWriter; set-scalar; print $*cross-unit-scalar',
+    :@compiler-args, :out<5>,
+    'a scalar written to GLOBAL by a module reaches the dynamic fallback';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously a GLOBAL-rooted package variable compiled to a reference to the compilation unit's own GLOBAL package object. Each unit has its own GLOBAL, and they merge into the process-wide one as units load, so a precompiled module that wrote %GLOBAL::CONFIG at run time wrote into its unit's copy, whose stash nothing else consults. The write was invisible to other units and to the dynamic variable fallback, which reads the merged GLOBAL. The legacy frontend compiles the same access as a run-time lookup of the current GLOBAL and does not have the problem.

This makes a resolved GLOBAL root compile to that same run-time lookup. The unresolved-name path already did this.