### PR TITLE
RakuAST: report compiler worries on the node instead of the resolver

### DIFF
--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -2673,14 +2673,14 @@ class RakuAST::Methodish
                 $package.ATTACH-METHOD(self) if self.scope eq 'has';
             }
             elsif self.scope eq 'has' {
-                $resolver.add-worry:  # XXX should be self.add-worry
+                self.add-worry:
                   $resolver.build-exception: 'X::Useless::Declaration',
                     name  => $name,
                     where => "a " ~ $package.parsed-declarator
             }
         }
         elsif self.scope eq 'has' {
-            $resolver.add-worry:  # XXX should be self.add-worry
+            self.add-worry:
               $resolver.build-exception: 'X::Useless::Declaration',
                 name  => $name,
                 where => 'the mainline';

--- a/src/Raku/ast/compunit.rakumod
+++ b/src/Raku/ast/compunit.rakumod
@@ -193,7 +193,7 @@ class RakuAST::CompUnit
     # during optimization, though will not do any transforms in and of itself.
     method check(RakuAST::Resolver $resolver) {
         if @*LEADING-DOC {
-            $resolver.add-worry:
+            self.add-worry:
               $resolver.build-exception:
                 'X::Syntax::Doc::Declarator::MissingDeclarand',
                 :position<leading>;

--- a/src/Raku/ast/package.rakumod
+++ b/src/Raku/ast/package.rakumod
@@ -311,6 +311,7 @@ class RakuAST::Package
         self.check-scope($resolver, self.declarator);
 
         self.add-trait-sorries;
+        self.add-install-worries($resolver);
 
         if $!is-stub && !$!stub-defused && !$!is-require-stub
             && !self.stubbed-meta-object.HOW.is_composed(self.stubbed-meta-object)

--- a/src/Raku/ast/package.rakumod
+++ b/src/Raku/ast/package.rakumod
@@ -311,7 +311,7 @@ class RakuAST::Package
         self.check-scope($resolver, self.declarator);
 
         self.add-trait-sorries;
-        self.add-install-worries($resolver);
+        self.add-install-worries;
 
         if $!is-stub && !$!stub-defused && !$!is-require-stub
             && !self.stubbed-meta-object.HOW.is_composed(self.stubbed-meta-object)

--- a/src/Raku/ast/scoping.rakumod
+++ b/src/Raku/ast/scoping.rakumod
@@ -1180,9 +1180,9 @@ class RakuAST::PackageInstaller {
     # are kept here and reported at check time instead.
     has Mu $!install-worries;
 
-    method add-install-worries(RakuAST::Resolver $resolver) {
+    method add-install-worries() {
         if nqp::isconcrete($!install-worries) {
-            $resolver.add-worry($_) for $!install-worries;
+            self.add-worry($_) for $!install-worries;
         }
     }
 

--- a/src/Raku/ast/scoping.rakumod
+++ b/src/Raku/ast/scoping.rakumod
@@ -1174,6 +1174,18 @@ class RakuAST::PackageInstaller {
     ### Consuming classes must define:
     #    method IMPL-GENERATE-LEXICAL-DECLARATION(RakuAST::Name $name, Mu $type-object) { ... }
 
+    # Worries from installing the symbol. Installation runs at BEGIN time,
+    # before the parser has attached the node's origin, so a worry raised
+    # right away could never carry the declaration's file and line. They
+    # are kept here and reported at check time instead.
+    has Mu $!install-worries;
+
+    method add-install-worries(RakuAST::Resolver $resolver) {
+        if nqp::isconcrete($!install-worries) {
+            $resolver.add-worry($_) for $!install-worries;
+        }
+    }
+
     method is-stub() { False }
     method defuse-stub() { }
 
@@ -1408,7 +1420,7 @@ class RakuAST::PackageInstaller {
         || $target-from-setting
     }
 
-    # Emit a SameNameAsEnclosing worry when a declaration silently
+    # Queue a SameNameAsEnclosing worry when a declaration silently
     # replaces its enclosing module or package with a non-container
     # kind on pre-6.e code. All gating lives here so the installer
     # call site stays readable.
@@ -1423,11 +1435,13 @@ class RakuAST::PackageInstaller {
                 nqp::istype($type-object.HOW, Perl6::Metamodel::ModuleHOW)
                 || nqp::istype($type-object.HOW, Perl6::Metamodel::PackageHOW);
             if $enclosing-kind ne '' && !$inner-is-containerlike {
-                $resolver.add-worry: $resolver.build-exception:
+                nqp::bindattr(self, RakuAST::PackageInstaller, '$!install-worries', [])
+                  unless nqp::isconcrete($!install-worries);
+                nqp::push($!install-worries, $resolver.build-exception(
                     'X::Package::SameNameAsEnclosing',
                     :kind(self.declarator),
                     :enclosing-kind($enclosing-kind),
-                    :name($existing.HOW.name($existing));
+                    :name($existing.HOW.name($existing))));
             }
         }
     }

--- a/src/Raku/ast/traits.rakumod
+++ b/src/Raku/ast/traits.rakumod
@@ -95,7 +95,8 @@ class RakuAST::TraitTarget {
                 }
                 my $name := (try $_.name.canonicalize) // '';
                 if is-traits-to-warn-on-duplicate{$name} && %seen{$name}++ {
-                    $resolver.add-worry: $resolver.build-exception: 'X::AdHoc', :payload("Duplicate '" ~ $_.IMPL-TRAIT-NAME() ~ " $name' trait");
+                    nqp::bindattr(self, RakuAST::TraitTarget, '$!worries', []) unless nqp::isconcrete($!worries);
+                    nqp::push($!worries, $resolver.build-exception('X::AdHoc', :payload("Duplicate '" ~ $_.IMPL-TRAIT-NAME() ~ " $name' trait")));
                 }
             }
         }

--- a/src/Raku/ast/type.rakumod
+++ b/src/Raku/ast/type.rakumod
@@ -1036,7 +1036,7 @@ class RakuAST::Type::Enum
 
     method PERFORM-CHECK(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
         self.add-trait-sorries;
-        self.add-install-worries($resolver);
+        self.add-install-worries;
 
         self.check-scope($resolver, 'enum');
 
@@ -1248,7 +1248,7 @@ class RakuAST::Type::Subset
 
     method PERFORM-CHECK(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
         self.add-trait-sorries;
-        self.add-install-worries($resolver);
+        self.add-install-worries;
 
         self.check-scope($resolver, 'subset');
     }

--- a/src/Raku/ast/type.rakumod
+++ b/src/Raku/ast/type.rakumod
@@ -1036,6 +1036,7 @@ class RakuAST::Type::Enum
 
     method PERFORM-CHECK(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
         self.add-trait-sorries;
+        self.add-install-worries($resolver);
 
         self.check-scope($resolver, 'enum');
 
@@ -1247,6 +1248,7 @@ class RakuAST::Type::Subset
 
     method PERFORM-CHECK(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
         self.add-trait-sorries;
+        self.add-install-worries($resolver);
 
         self.check-scope($resolver, 'subset');
     }

--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -1297,7 +1297,7 @@ class RakuAST::VarDeclaration::Simple
 
         if self.twigil eq '.' && !self.is-attribute && !$!attribute-package {
             my $package := nqp::getlexdyn('$?PACKAGE');
-            $resolver.add-worry:
+            self.add-worry:
                 $resolver.build-exception('X::AdHoc', payload => "Useless generation of accessor method in " ~
                 (nqp::istype($package.HOW, Perl6::Metamodel::AttributeContainer)
                     ?? $package.HOW.name($package)

--- a/t/05-messages/10-warnings.t
+++ b/t/05-messages/10-warnings.t
@@ -1,8 +1,9 @@
 use lib <t/packages/Test-Helpers>;
+use nqp;
 use Test;
 use Test::Helpers;
 
-plan 9;
+plan 17;
 
 subtest 'Supply.interval with negative value warns' => {
     plan 2;
@@ -91,5 +92,43 @@ is-run ｢use experimental :macros; macro z($) { quasi {} };
 is-run ｢my @a[Int] = 1,2,3; dd @a｣,
     'ignored shape specification issues a warning',
     :err(/'Ignoring [Int] as shape specification'/);
+
+is-run ｢method m() {}; print "ran"｣,
+    'has-scoped method in mainline warns with file and line',
+    :out<ran>, :err(/'Useless declaration of a has-scoped method in' .*? 'at -e:1'/);
+
+is-run ｢package Foo { method m() {} }; print "ran"｣,
+    'has-scoped method in a package warns with file and line',
+    :out<ran>, :err(/'Useless declaration of a has-scoped method in' .*? 'package' .*? 'at -e:1'/);
+
+is-run ｢use fatal; method m() {}; print "ran"｣,
+    'use fatal promotes the useless method declaration worry to an error',
+    :err(/'Useless declaration of a has-scoped method in'/), :exitcode(1);
+
+if nqp::gethllsym('Raku', 'COMPILER-FRONTEND') eq 'rakuast' {
+    is-run ｢#| dangling
+｣,
+        'leading declarator doc without declarand warns with file and line',
+        :err(/'Missing declarand for leading declarator doc' .*? 'at -e:1'/);
+}
+else {
+    skip 'legacy frontend does not warn on a dangling leading declarator doc';
+}
+
+is-run ｢sub f() is export is export {}; print "ran"｣,
+    'duplicate trait warns with file and line',
+    :out<ran>, :err(/'Duplicate' .*? 'is export' .*? 'at -e:1'/);
+
+is-run ｢my $.x; print "ran"｣,
+    'accessor generation outside a package warns with file and line',
+    :out<ran>, :err(/'Useless generation of accessor method in mainline' .*? 'at -e:1'/);
+
+is-run ｢package Foo::Bar { class Foo::Bar {} }; print "ran"｣,
+    'class replacing a same-named enclosing package warns with file and line',
+    :out<ran>, :err(/'inside an enclosing package of the same name' .*? 'at -e:1'/);
+
+is-run ｢use fatal; package Foo::Bar { class Foo::Bar {} }; print "ran"｣,
+    'use fatal promotes the same-named enclosing package worry to an error',
+    :err(/'inside an enclosing package of the same name'/), :exitcode(1);
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously a handful of compile time worries were added directly to the resolver instead of on the node that produced them. Worries added that way skip the node level check time handling, so they printed with no file or line information and were not promoted to errors under `use fatal`. The legacy frontend does both.

    $ RAKUDO_RAKUAST=1 raku -e 'sub f() is export is export {}'
    Potential difficulties:
        Duplicate 'is export' trait
        at line

This converts those sites to record the worry on their node, which fixes both divergences. The SameNameAsEnclosing worry needed a preparatory change since it is produced while installing the symbol at BEGIN time, before the parser has attached the node's origin. It is now collected during install and reported at check time, the same way deferred trait sorries already are. `no worries` continues to suppress all of these.
