### PR TITLE
RakuAST: apply val to quoted atoms in quote words literals

### DIFF
--- a/src/Raku/ast/literals.rakumod
+++ b/src/Raku/ast/literals.rakumod
@@ -294,25 +294,21 @@ class RakuAST::QuotedString
         $result
     }
 
-    method IMPL-PROCESS-PART($result, $part) {
+    method IMPL-PROCESS-PART($result, $part, :$protected) {
         return Nil if $part =:= Nil;
         for $!processors {
-            if $_ eq 'words' {
-                return Nil unless nqp::istype($part, Str);
-                my @parts;
-                for self.IMPL-WORDS-AUTODEREF($part) {
-                    nqp::push(@parts, $_);
+            if $_ eq 'words' || $_ eq 'quotewords' {
+                # A part that came from a quoted atom is protected: quote
+                # words splitting keeps it whole, while later processors
+                # such as val still apply to it.
+                unless $protected {
+                    return Nil unless nqp::istype($part, Str);
+                    my @parts;
+                    for self.IMPL-WORDS-AUTODEREF($part) {
+                        nqp::push(@parts, $_);
+                    }
+                    $part := @parts;
                 }
-                $part := @parts;
-            }
-            elsif $_ eq 'quotewords' {
-                return Nil unless nqp::istype($part, Str);
-                #TODO actually implement special handling of « »
-                my @parts;
-                for self.IMPL-WORDS-AUTODEREF($part) {
-                    nqp::push(@parts, $_);
-                }
-                $part := @parts;
             }
             elsif $_ eq 'val' {
                 my $val-lookup := self.IMPL-UNWRAP-LIST(self.get-implicit-lookups)[0];
@@ -358,15 +354,7 @@ class RakuAST::QuotedString
                 && my $nested-str := $_.atom.literal-value
             {
                 return Nil if $nested-str =:= Nil;
-
-                if nqp::istype($nested-str, Str) {
-                    nqp::push(@parts, $nested-str);
-                }
-                elsif nqp::istype($nested-str, List) {
-                    for $nested-str.FLATTENABLE_LIST {
-                        nqp::push(@parts, $_);
-                    }
-                }
+                self.IMPL-PROCESS-PART(@parts, $nested-str, :protected) || return Nil;
             }
             elsif nqp::istype($_, RakuAST::Var::Lexical)
                 && $_.is-resolved

--- a/t/12-rakuast/strings.rakutest
+++ b/t/12-rakuast/strings.rakutest
@@ -4,7 +4,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 13;
+plan 14;
 
 my $ast;
 my $deparsed;
@@ -207,6 +207,26 @@ subtest 'Words processor applied to a quoted string with interpolation' => {
 
     is-deeply $deparsed, 'qq:w:v/ba$stuff 66/', 'deparse';
     is-deeply $_, ('bar', 'baz', <66>), @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'Using the quotewords and val processor' => {
+    # <<1 "2" 3.5>>
+    ast RakuAST::QuotedString.new(
+      :segments[
+        RakuAST::StrLiteral.new('1 '),
+        RakuAST::QuoteWordsAtom.new(
+          RakuAST::QuotedString.new(
+            :segments[RakuAST::StrLiteral.new('2')]
+          )
+        ),
+        RakuAST::StrLiteral.new(' 3.5')
+      ],
+      :processors['quotewords', 'val']
+    );
+
+    is-deeply $deparsed, '<<1 "2" 3.5>>', 'deparse';
+    is-deeply $_, (val("1"), val("2"), val("3.5")), @type[$++]
       for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
 }
 


### PR DESCRIPTION
Previously QuotedString.literal-value treated the quotewords processor exactly like words, and pushed a quoted atom's value into the result untouched. That left the atom out of val processing, so «1 "2" 3.5» compiled to a plain Str "2" where the runtime path and the legacy frontend both produce an IntStr allomorph.

A quoted atom is only protected from word splitting. The remaining processors still apply to it, so the atom's value now goes through IMPL-PROCESS-PART with a flag that skips the splitting step. The words and quotewords branches were identical and are folded together.