### PR TITLE
RakuAST: use Scalar as the container type of $ sigil variables

### DIFF
--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -255,7 +255,7 @@ class RakuAST::ContainerCreator {
             }
             else {
                 $container-base-type := Scalar;
-                $container-type := $of; #FIXME pretty sure container-type should also be Scalar
+                $container-type := Scalar;
                 $bind-constraint := $of;
             }
         }
@@ -1376,7 +1376,13 @@ class RakuAST::VarDeclaration::Simple
 
             my $meta-object := $!attribute-package.attribute-type.new(
               name => self.sigil ~ '!' ~ self.desigilname.canonicalize,
-              type => $scope eq 'HAS' ?? self.IMPL-CONTAINER-TYPE($of) !! $type,
+              # An inlined attribute with an explicit container type (e.g.
+              # `HAS ... is CArray[int32]`) needs the parameterized container
+              # as its type for the REPR to lay it out; the bind constraint
+              # is a bare Mu on that path.
+              type => $scope eq 'HAS' && self.IMPL-HAS-EXPLICIT-CONTAINER-BASE-TYPE
+                ?? self.IMPL-CONTAINER-TYPE($of)
+                !! $type,
               has_accessor          => self.twigil eq '.',
               container_descriptor  => $descriptor,
               auto_viv_container    => self.IMPL-CONTAINER($of, $descriptor, :attribute),


### PR DESCRIPTION
Previously ContainerCreator set the container type of an ordinary scalar variable to its value type, with a FIXME noting it should be Scalar like the container base type. The legacy frontend sets its container_type to Scalar for the $ sigil as well.

The one consumer that saw the value type was the attribute meta-object built for a HAS declaration. It only needs the container type when an explicit container type was given (e.g. HAS ... is CArray[int32]), where the bind constraint is a bare Mu. Gate it on that case so a native or inlined struct attribute takes its type from the bind constraint, which is what the legacy frontend passes for every attribute.