### PR TITLE
RakuAST: resolve the 'maybe also check?' questions on synthesized nodes

### DIFF
--- a/src/Raku/ast/package.rakumod
+++ b/src/Raku/ast/package.rakumod
@@ -993,7 +993,9 @@ class RakuAST::CompilerServices
         );
         $!resolver.push-scope($!package);
         $!resolver.push-scope($accessor);
-        $accessor.to-begin-time($!resolver, $!context); # TODO maybe also check?
+        # No check time: the accessor is fully synthetic, with no user
+        # code a check could diagnose.
+        $accessor.to-begin-time($!resolver, $!context);
         $!resolver.pop-scope();
         $!resolver.pop-scope();
         $!qast.push: $accessor.IMPL-QAST-BLOCK($!context);

--- a/src/Raku/ast/type.rakumod
+++ b/src/Raku/ast/type.rakumod
@@ -1214,7 +1214,8 @@ class RakuAST::Type::Subset
                 ),
             );
             nqp::bindattr(self, RakuAST::Type::Subset, '$!block', $block);
-            $block.IMPL-BEGIN($resolver, $context); # TODO maybe also check?
+            # Check time reaches the block through visit-children.
+            $block.IMPL-BEGIN($resolver, $context);
         }
 
         # set up the meta object

--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -1126,7 +1126,10 @@ class RakuAST::VarDeclaration::Simple
             );
             # Get around RakuAST compiler deconting all arguments:
             nqp::bindattr($target, RakuAST::TraitTarget::Variable, '$!cont', $meta);
-            $target.to-begin-time($resolver, $context); # TODO maybe also check?
+            # No check time: the target's PERFORM-CHECK would only replay
+            # trait sorries, and the apply-traits call below records those
+            # on the declaration itself.
+            $target.to-begin-time($resolver, $context);
 
             if self.twigil eq '.' {
                 my $variable-access := RakuAST::Var::Lexical.new(self.name);
@@ -1142,7 +1145,8 @@ class RakuAST::VarDeclaration::Simple
                 );
                 nqp::bindattr(self, RakuAST::VarDeclaration::Simple, '$!accessor', $accessor);
                 $resolver.push-scope($accessor);
-                $accessor.to-begin-time($resolver, $context); # TODO maybe also check?
+                # Check time reaches the accessor through visit-children.
+                $accessor.to-begin-time($resolver, $context);
                 $resolver.pop-scope();
             }
 


### PR DESCRIPTION
Four synthesized nodes were sent to begin time with a TODO asking whether they should also get check time. The answer is no in each case, for two different reasons.

The subset where block and the non-attribute accessor are bound to attributes that visit-children exposes, so the check pass that walks the tree from the compilation unit reaches them like any parsed node. A check-time sorry raised from inside a synthesized where wrapper (e.g. 'subset S of Int where $!foo') confirms this.

The MOP-generated attribute accessor and the variable trait target never join the tree, but they have nothing for a check to do. The accessor is fully synthetic, with an empty body and signature and no user code. The trait target's PERFORM-CHECK would only replay trait sorries, and the apply-traits call that produces those records them on the declaration node, which replays them in its own PERFORM-CHECK.