### PR TITLE
RakuAST: form the meta-op of a setting operator reduce at compile time

### DIFF
--- a/src/Raku/ast/term.rakumod
+++ b/src/Raku/ast/term.rakumod
@@ -530,13 +530,30 @@ class RakuAST::Term::Reduce
     }
 
     method IMPL-EXPR-QAST(RakuAST::IMPL::QASTContext $context) {
-        # Make a call to form the meta-op.
-        # TODO Cache it using a dispatcher when UNIT/SETTING operator
-        my $form-meta := QAST::Op.new(
-            :op<call>, :name($!infix.reducer-name),
-            $!infix.IMPL-HOP-INFIX-QAST($context));
-        if $!triangle {
-            $form-meta.push(QAST::WVal.new( :value(True) ));
+        # A reduce of a setting operator forms its meta-op once at compile
+        # time: the operator lookup yields the same code object at run time,
+        # so the formed meta-op is a constant. This is skipped while
+        # compiling a CORE setting itself, where compiler-formed closures
+        # must not be serialized into the bootstrap. Anything else (lexical
+        # operators, meta-infixes) makes a call to form the meta-op at run
+        # time.
+        my $form-meta;
+        if nqp::istype($!infix, RakuAST::Infix)
+            && $!infix.is-resolved
+            && nqp::istype($!infix.resolution, RakuAST::Declaration::External::Setting)
+            && !($*COMPILING_CORE_SETTING // 0)
+        {
+            my $meta-op := self.IMPL-HOP-INFIX;
+            $context.ensure-sc($meta-op);
+            $form-meta := QAST::WVal.new( :value($meta-op) );
+        }
+        else {
+            $form-meta := QAST::Op.new(
+                :op<call>, :name($!infix.reducer-name),
+                $!infix.IMPL-HOP-INFIX-QAST($context));
+            if $!triangle {
+                $form-meta.push(QAST::WVal.new( :value(True) ));
+            }
         }
 
         # Invoke it with the arguments.

--- a/src/Raku/ast/term.rakumod
+++ b/src/Raku/ast/term.rakumod
@@ -563,8 +563,9 @@ class RakuAST::Term::Reduce
             QAST::Op.new( :op<call>, $form-meta, $arg.IMPL-TO-QAST($context) )
         }
         else {
-            # Form a List of the argumnets and pass it to the reducer
-            # TODO thunk case
+            # Form a List of the arguments and pass it to the reducer. A
+            # thunky operator's arguments were already rewritten into thunks
+            # by the IMPL-THUNK-ARGUMENTS call at begin time.
             my $name :=
               self.IMPL-UNWRAP-LIST(self.get-implicit-lookups)[0].resolution.lexical-name;
             my $form-list := QAST::Op.new(:op('call'), :$name);


### PR DESCRIPTION
Previously every evaluation of a reduce like [+] first called the reducer (e.g. METAOP_REDUCE_LEFT) to form the meta-op and then invoked it, with a TODO suggesting a dispatcher cache for UNIT/SETTING operators. A setting operator does not need a cache: its lookup yields the same code object at run time that it has at compile time, so the meta-op can be formed once during compilation and emitted as a serialized constant. The interpret path already forms it this way in IMPL-HOP-INFIX. A wrap of a setting operator mutates that same code object, so a compile time formed meta-op still sees it.

Lexical operators and meta-infixes keep the run time formation, as does compiling a CORE setting itself, where compiler-formed closures must not be serialized into the bootstrap.