### PR TITLE
RakuAST: report attributes declared without a package as a sorry

### DIFF
--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -921,27 +921,44 @@ class RakuAST::VarDeclaration::Simple
                 nqp::bindattr(self, RakuAST::VarDeclaration::Simple, '$!attribute-package',
                     $attribute-package);
                 if self.is-attribute && !$!attribute-package.can-have-attributes {
-                    my $ex := $resolver.build-exception: 'X::Attribute::Package',
-                        name         => self.name,
-                        package-kind => $!attribute-package.parsed-declarator;
                     if nqp::istype($!attribute-package, RakuAST::Declaration::External::Package) {
-                        self.add-worry: $ex;
+                        # The external package's compile time is over. When
+                        # its kind takes attributes (class, role), spec tests
+                        # require silently ignoring the declaration; when it
+                        # does not, report a missing package like the legacy
+                        # frontend does.
+                        unless nqp::istype(
+                            $!attribute-package.compile-time-value.HOW,
+                            Perl6::Metamodel::AttributeContainer
+                        ) {
+                            self.add-sorry: $resolver.build-exception:
+                                'X::Attribute::NoPackage', name => self.name;
+                        }
                     }
                     else {
-                        self.add-sorry: $ex;
+                        self.add-sorry: $resolver.build-exception:
+                            'X::Attribute::Package',
+                            name         => self.name,
+                            package-kind => $!attribute-package.parsed-declarator;
                     }
                 }
             }
             else {
-                # TODO check-time error
-                my $package := nqp::getlexdyn('$?PACKAGE');
-                # In class Foo { EVAL q[has $.foo] } we won't find a package attach target
-                # because compile time is long over, yet there will be a $?PACKAGE. Throwing
-                # a NoPackage here would be confusing. It would be better to throw an error
-                # explaining that the package is already composed. Alas there's a spec test
-                # that requires this to be silently ignored, so that's what we do for now.
-                if self.is-attribute && !nqp::can($package.HOW, 'add_attribute') {
-                    $resolver.build-exception('X::Attribute::NoPackage', name => self.name).throw;
+                # An EVAL like class Foo { EVAL q[has $.foo] } has no package
+                # attach target because compile time of the class is long
+                # over, yet its outer scope still provides a $?PACKAGE. A
+                # spec test requires that declaration to be silently ignored
+                # (throwing NoPackage would be confusing there anyway). Only
+                # consult $?PACKAGE when compiling an EVAL: a getlexdyn in a
+                # direct compilation walks into the compiler's own frames and
+                # finds an unrelated $?PACKAGE that can take attributes.
+                my $package := nqp::istype($resolver, RakuAST::Resolver::EVAL)
+                    ?? nqp::getlexdyn('$?PACKAGE')
+                    !! nqp::null;
+                if self.is-attribute
+                    && (nqp::isnull($package) || !nqp::can($package.HOW, 'add_attribute')) {
+                    self.add-sorry:
+                        $resolver.build-exception('X::Attribute::NoPackage', name => self.name);
                 }
             }
         }
@@ -1861,7 +1878,8 @@ class RakuAST::VarDeclaration::Signature
                 }
             }
             else {
-                # TODO check-time error
+                # Each named parameter target declares its own attribute,
+                # whose begin time reports the missing package.
             }
         }
         elsif $scope eq 'our' {

--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -1868,12 +1868,13 @@ class RakuAST::VarDeclaration::Signature
             if $attribute-package {
                 nqp::bindattr(self, RakuAST::VarDeclaration::Signature, '$!attribute-package',
                     $attribute-package);
+                # The declarator scope is only known here on the owning
+                # declaration; push it into each target before their begin
+                # time turns them into attribute declarations. The targets
+                # find their own attribute package at parse time.
                 for self.IMPL-UNWRAP-LIST(self.signature.parameters) {
-                    #TODO this should probably live in the target's attach method
                     if $_.target && nqp::istype($_.target, RakuAST::ParameterTarget::Var) {
                         $_.target.replace-scope($scope);
-                        nqp::bindattr($_.target, RakuAST::ParameterTarget::Var, '$!attribute-package',
-                            $attribute-package);
                     }
                 }
             }

--- a/t/05-messages/03-errors.t
+++ b/t/05-messages/03-errors.t
@@ -2,7 +2,7 @@ use lib <t/packages/Test-Helpers>;
 use Test;
 use Test::Helpers;
 
-plan 26;
+plan 28;
 
 subtest '.map does not explode in optimizer' => {
     plan 3;
@@ -186,5 +186,13 @@ is-run 'bleah:(0)', err => { .contains: 'You can\'t adverb' }, :exitcode{.so},
 # https://github.com/rakudo/rakudo/issues/4178
 is-run 'close $*OUT; say "hi"', err => { .contains: 'closed handle' }, :exitcode{.so},
 'An attempt to use a closed handle results in a proper error message';
+
+is-run ｢has $.x; print "ran"｣,
+    'attribute declaration in the mainline is a compile time error',
+    :err(/'You cannot declare attribute' .*? '$.x'/), :exitcode(1);
+
+is-run ｢has ($.a, $.b); print "ran"｣,
+    'signature attribute declaration in the mainline is a compile time error',
+    :err(/'You cannot declare attribute' .*? '$.a'/), :exitcode(1);
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously an attribute declaration with no package attach target consulted `$?PACKAGE` through getlexdyn unconditionally, with a TODO to make the result a check time error. In a direct compilation that lookup walks into the compiler's own frames and finds an unrelated package that can take attributes, so `has $.x` in the mainline compiled silently where the legacy frontend reports X::Attribute::NoPackage. The signature form `has ($.a, $.b)` crashed with an internal error about a RakuAST::Package type object instead.

The `$?PACKAGE` fallback now only applies when compiling an EVAL, which is the case it exists for: an EVAL inside a class body whose compile time is over must silently ignore the declaration per spec test. A missing or attribute-incapable package is reported as a NoPackage sorry rather than a bare throw, so it aggregates and carries location information.

The same spec silence now also applies when the EVAL finds the enclosing package as an external declaration: an attribute-capable kind is ignored where it previously produced a misleading 'A class cannot have attributes' worry, and other kinds report NoPackage like the legacy frontend instead of a worry.