### PR TITLE
RakuAST: drop the dead second-chance resolution for qualified calls

### DIFF
--- a/src/Raku/ast/call.rakumod
+++ b/src/Raku/ast/call.rakumod
@@ -939,15 +939,6 @@ class RakuAST::Call::Method
               $resolver.build-exception: 'X::AdHoc',
                   payload => 'Cannot use ' ~ self.dispatch ~ ' on a non-identifier method call';
         }
-
-        if $!name && $!name.is-multi-part {
-            my $Qualified := self.IMPL-UNWRAP-LIST(self.get-implicit-lookups)[0];
-            unless $Qualified.is-resolved {
-                # Give it a second chance to resolve.
-                #FIXME Calling IMPL-BEGIN seems like the wrong tool though.
-                $Qualified.IMPL-BEGIN($resolver, $context);
-            }
-        }
     }
 }
 


### PR DESCRIPTION
Call::Method.PERFORM-CHECK gave the implicit lookup of a qualified method call's package a second chance to resolve by calling IMPL-BEGIN on it, with a FIXME doubting that was the right tool. It was no tool at all: parse time is where a Type::Simple resolves, the lookup's parse already ran when the call node was driven to begin time, and ensure-parse-performed is guarded, so the call could never re-resolve anything. Instrumented to die if the block ever changed a lookup to resolved, nothing fired across the CORE build, the method call tests, and S12-methods/qualified.t, and everything also passes with the block removed. An unresolved qualifier keeps compiling to the run time lookup, which is what handles a forward declared or missing package either way.