### PR TITLE
RakuAST: set attr_package on attributive parameters

### DIFF
--- a/src/Raku/ast/signature.rakumod
+++ b/src/Raku/ast/signature.rakumod
@@ -982,7 +982,6 @@ class RakuAST::Parameter
             }
             nqp::bindattr($parameter, Parameter, '@!type_captures', @type-captures);
         }
-        # TODO further setup
         $parameter
     }
 


### PR DESCRIPTION
Building the Parameter meta-object ended on a TODO about further setup. Comparing against the legacy create_parameter, the one missing piece was `$!attr_package`: the type whose attribute a `$!x` parameter assigns into. The runtime binder's attributive path fetches the attribute through it, and while this frontend compiles that assignment into the signature binding QAST itself, the meta-object should carry what the binder and introspection expect.

The parameter now captures the resolved `$?CLASS` at parse time for a private attributive target, matching the legacy frontend exactly: the class itself in a class body, the generic in a role body (instantiated per consuming class at composition, verified through a does), nothing for public attributive targets, and the existing NoSelf error already covers a `$!x` parameter outside a class where legacy panics. The other create_parameter pieces are already covered: declarator docs through the doc machinery and run time default closures through the thunk path.