### PR TITLE
RakuAST: assert the condition modifier thunk stays innermost

### DIFF
--- a/src/Raku/ast/statement-mods.rakumod
+++ b/src/Raku/ast/statement-mods.rakumod
@@ -358,7 +358,12 @@ class RakuAST::StatementModifier::Condition::Thunk
     method IMPL-THUNK-CODE-QAST(RakuAST::IMPL::QASTContext $context, Mu $target,
             RakuAST::Expression $expression) {
 
-        #TODO handle inner thunks
+        # Statement::Expression wraps this thunk before any loop thunk, so it
+        # is always innermost and the expression can be emitted directly. A
+        # caller that chained it over another thunk would silently lose that
+        # thunk, so refuse it.
+        nqp::die('Condition modifier thunk cannot wrap an inner thunk')
+            if self.next;
         $target.push($!condition.IMPL-WRAP-QAST($context, $expression.IMPL-EXPR-QAST($context)));
     }
 


### PR DESCRIPTION
The condition modifier thunk emitted its expression directly with a TODO about handling inner thunks. There are none to handle: Statement::Expression is the only thing that wraps this thunk, and it always does so before the loop or expression thunk, leaving the condition thunk innermost in every chain. Rather than carry speculative chain handling for a shape that cannot occur, refuse it loudly: a future caller that chained another thunk under this one would otherwise have it silently dropped. The guard survives the CORE build and the statement modifier tests, which exercise the combined condition and loop modifier forms.