### PR TITLE
RakuAST: Drop the dead resolve-only flag from IMPL-CHECK

### DIFF
--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -970,7 +970,7 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
         }
         else {
             my $args := $<arglist><EXPR>.ast;
-            $args.IMPL-CHECK($*R, $*CU.context, False);
+            $args.IMPL-CHECK($*R, $*CU.context);
             self.report-problems();
             nqp::die("Don't know how to 'no " ~ $name ~ "'")
         }

--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -155,11 +155,9 @@ class RakuAST::Node {
 
     # Drive CHECK-time activities on this node and its children. Assumes that BEGIN time and
     # parse time has already completely happened.
-    method IMPL-CHECK(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context, Bool $resolve-only) {
-        unless $resolve-only {
-            if nqp::istype(self, RakuAST::SinkBoundary) && !self.sink-calculated {
-                self.calculate-sink();
-            }
+    method IMPL-CHECK(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
+        if nqp::istype(self, RakuAST::SinkBoundary) && !self.sink-calculated {
+            self.calculate-sink();
         }
 
         # Visit children and do their CHECK time.
@@ -167,29 +165,25 @@ class RakuAST::Node {
         my int $is-package := nqp::istype(self, RakuAST::Package);
         $resolver.push-scope(self) if $is-scope;
         $resolver.push-package(self) if $is-package;
-        self.visit-children(-> $child { $child.IMPL-CHECK($resolver, $context, $resolve-only) });
+        self.visit-children(-> $child { $child.IMPL-CHECK($resolver, $context) });
         $resolver.pop-scope() if $is-scope;
         $resolver.pop-package() if $is-package;
 
-        # Unless in resolve-only mode, do other check-time activities.
-        # TODO eliminate resolve-only, since that's just check time.
-        unless $resolve-only {
-            if nqp::istype(self, RakuAST::CheckTime) {
-                self.PERFORM-CHECK($resolver, $context);
-                if self.has-check-time-problems {
-                    if $resolver.find-scope-property(-> $scope { $scope.fatal }) {
-                        self.promote-worries-to-sorries;
-                    }
-                    my $worries := $resolver.find-scope-property(-> $scope { $scope.tell-worries });
-                    if nqp::isconcrete($worries) && !$worries {
-                        self.clear-worries;
-                    }
-                    $resolver.add-node-with-check-time-problems(self) if self.has-check-time-problems;
+        if nqp::istype(self, RakuAST::CheckTime) {
+            self.PERFORM-CHECK($resolver, $context);
+            if self.has-check-time-problems {
+                if $resolver.find-scope-property(-> $scope { $scope.fatal }) {
+                    self.promote-worries-to-sorries;
                 }
+                my $worries := $resolver.find-scope-property(-> $scope { $scope.tell-worries });
+                if nqp::isconcrete($worries) && !$worries {
+                    self.clear-worries;
+                }
+                $resolver.add-node-with-check-time-problems(self) if self.has-check-time-problems;
             }
-            if nqp::istype(self, RakuAST::Lookup) && !self.is-resolved && self.needs-resolution {
-                $resolver.add-node-unresolved-after-check-time(self);
-            }
+        }
+        if nqp::istype(self, RakuAST::Lookup) && !self.is-resolved && self.needs-resolution {
+            $resolver.add-node-unresolved-after-check-time(self);
         }
 
         Nil

--- a/src/Raku/ast/compunit.rakumod
+++ b/src/Raku/ast/compunit.rakumod
@@ -199,8 +199,8 @@ class RakuAST::CompUnit
                 :position<leading>;
         }
 
-        $!mainline.IMPL-CHECK($resolver, $!context, False);
-        self.IMPL-CHECK($resolver, $!context, False);
+        $!mainline.IMPL-CHECK($resolver, $!context);
+        self.IMPL-CHECK($resolver, $!context);
 
         # Not all RakuAST::Doc objects actually have their PERFORM-CHECK
         # method called on them, causing holes to occur in $=pod (albeit

--- a/src/Raku/ast/signature.rakumod
+++ b/src/Raku/ast/signature.rakumod
@@ -1116,7 +1116,7 @@ class RakuAST::Parameter
                 ),
             );
             $block.IMPL-BEGIN($resolver, $context);
-            $block.IMPL-CHECK($resolver, $context, False);
+            $block.IMPL-CHECK($resolver, $context);
             nqp::bindattr(self, RakuAST::Parameter, '$!where', $block);
         }
 
@@ -1149,7 +1149,7 @@ class RakuAST::Parameter
                 ),
             );
             $block.IMPL-BEGIN($resolver, $context);
-            $block.IMPL-CHECK($resolver, $context, False);
+            $block.IMPL-CHECK($resolver, $context);
             nqp::bindattr(self, RakuAST::Parameter, '$!array-shape', $block);
         }
 

--- a/src/Raku/ast/type.rakumod
+++ b/src/Raku/ast/type.rakumod
@@ -1238,7 +1238,7 @@ class RakuAST::Type::Subset
 
         self.meta-object; # Finish meta-object setup so compile time type-checks will be correct
         if $block && $block.IMPL-CURRIED {
-            $block.IMPL-CHECK($resolver, $context, False);
+            $block.IMPL-CHECK($resolver, $context);
             $resolver.panic(Any) if $resolver.all-sorries.elems;
             # Cache QAST with expression as the BEGIN time stub wont know how to get that
             $block.IMPL-CURRIED.IMPL-QAST-BLOCK($context, :blocktype<declaration_static>, :expression($block));


### PR DESCRIPTION
Every caller of IMPL-CHECK passed False for resolve-only, so the resolve-only branches never ran. Remove the parameter and the guards it gated.