### PR TITLE
RakuAST: detect a DEPARSE slang name with a type check

### DIFF
--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -563,7 +563,7 @@ class RakuAST::Node {
     method DEPARSE(*@roles) {
         my $class := my $core := nqp::gethllsym('Raku','DEPARSE');
         for @roles {
-            if $_.HOW.name($_) eq 'Str' {  # XXX better way to detect HLL Str?
+            if nqp::istype($_, Str) {
                 $class := self.mixin-role($class, $core.slang($_));
             }
             elsif nqp::can($_.HOW,'pun') {  # it's a role


### PR DESCRIPTION
The DEPARSE argument loop recognized a slang name by comparing the argument's HOW name against 'Str', with an XXX asking for a better way. nqp::istype against the bootstrap Str type is that way, and it also classifies correctly where the name comparison did not: a Str subclass passed as a slang name fell through to be treated as a replacement deparser class, failing with a confusing 'No such method deparse' error instead of the L10N module lookup it was asking for.