### PR TITLE
RakuAST: support the :dba regex modifier and pass it to FAILGOAL

### DIFF
--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -4856,13 +4856,23 @@ class Raku::RegexActions is HLL::Actions does Raku::CommonActions {
               modifier => $modifier, negated => $*NEGATED
             );
         }
+        elsif $modifier eq 'dba' {
+            my $quoted := $<qstr>;
+            $quoted := $quoted[0] if nqp::islist($quoted);
+            if nqp::isconcrete($quoted) {
+                self.attach: $/, Nodify('Regex::InternalModifier::Dba').new(
+                  name => ~$quoted
+                );
+            }
+            else {
+                $/.panic('Internal modifier strings must be literals');
+            }
+        }
         else {
             $/.typed-panic: 'X::Syntax::Regex::UnrecognizedModifier',
               modifier => $modifier;
         }
     }
-
-    method metachar:sym<dba>($/) { Nil }
 
     method metachar:sym<assert>($/) {
         self.attach: $/, $<assertion>.ast;

--- a/src/Raku/Grammar.nqp
+++ b/src/Raku/Grammar.nqp
@@ -6620,8 +6620,8 @@ grammar Raku::RegexGrammar is QRegex::P6Regex::Grammar does Raku::Common {
             '('
                 [
                 | $<n>=[\d+]
-                | <?[']> <quote_EXPR: ':q'>
-                | <?["]> <quote_EXPR: ':qq'>
+                | \' $<qstr>=[<-[']>*] \'
+                | \" $<qstr>=[<-["]>*] \"
                 ]
                 ')'
             ]**0..1

--- a/src/Raku/ast/regex.rakumod
+++ b/src/Raku/ast/regex.rakumod
@@ -472,6 +472,11 @@ class RakuAST::Regex::Nested
     }
 
     method IMPL-REGEX-QAST(RakuAST::IMPL::QASTContext $context, %mods) {
+        my $failgoal := QAST::NodeList.new(
+            QAST::SVal.new( :value('FAILGOAL') ),
+            QAST::SVal.new( :value($!goal.DEPARSE) ));
+        $failgoal.push(QAST::SVal.new( :value(%mods<dba>) ))
+            if nqp::existskey(%mods, 'dba');
         QAST::Regex.new(
             :rxtype<goal>,
             $!goal.IMPL-APPLY-ATOM-RATCHET(
@@ -480,10 +485,7 @@ class RakuAST::Regex::Nested
                 $!expr.IMPL-REGEX-QAST($context, nqp::clone(%mods)), %mods),
             QAST::Regex.new(
                 :rxtype<subrule>, :subtype<method>,
-                QAST::NodeList.new(
-                    QAST::SVal.new( :value('FAILGOAL') ),
-                    QAST::SVal.new( :value($!goal.DEPARSE) ),
-                    ) ) ); #TODO: |@dba) ) );
+                $failgoal ) );
     }
 
     method visit-children(Code $visitor) {
@@ -2068,6 +2070,30 @@ class RakuAST::Regex::InternalModifier::Sigspace
   is RakuAST::Regex::InternalModifier
 {
     method key() { 's' }
+}
+
+# The dba internal modifier, which names the current part of the regex
+# for error reporting purposes.
+class RakuAST::Regex::InternalModifier::Dba
+  is RakuAST::Regex::InternalModifier
+{
+    has Str $.name;
+
+    method new(str :$name!) {
+        my $obj := nqp::create(self);
+        nqp::bindattr_s($obj, RakuAST::Regex::InternalModifier, '$!modifier', 'dba');
+        nqp::bindattr($obj, RakuAST::Regex::InternalModifier, '$!negated', False);
+        nqp::bindattr($obj, RakuAST::Regex::InternalModifier::Dba, '$!name',
+            nqp::box_s($name, Str));
+        $obj
+    }
+
+    method key() { 'dba' }
+
+    method IMPL-REGEX-QAST(RakuAST::IMPL::QASTContext $context, %mods) {
+        %mods<dba> := self.name;
+        QAST::Regex.new( :rxtype<dba>, :name(self.name) )
+    }
 }
 
 # A quantified atom in a regex - that is, an atom with a quantifier and

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -1897,6 +1897,11 @@ CODE
 #- Regex::I --------------------------------------------------------------------
 
     multi method deparse(
+      RakuAST::Regex::InternalModifier::Dba:D $ast --> Str:D) {
+        ':' ~ self.xsyn('adverb-rx', 'dba') ~ '(' ~ $ast.name.raku ~ ') '
+    }
+
+    multi method deparse(
       RakuAST::Regex::InternalModifier:D $ast --> Str:D) {
         ':'
           ~ ($ast.negated ?? '!' !! '')

--- a/src/core.c/RakuAST/Raku.rakumod
+++ b/src/core.c/RakuAST/Raku.rakumod
@@ -873,6 +873,10 @@ augment class RakuAST::Node {
 
 #- Regex::I --------------------------------------------------------------------
 
+    multi method raku(RakuAST::Regex::InternalModifier::Dba:D: --> Str:D) {
+        self!nameds: <name>
+    }
+
     # Generic handler for all RakuAST::Regex::InternalModifier::xxx classes
     multi method raku( RakuAST::Regex::InternalModifier:D: --> Str:D) {
         self!nameds: <modifier negated>

--- a/t/12-rakuast/regex.rakutest
+++ b/t/12-rakuast/regex.rakutest
@@ -1,7 +1,8 @@
 use v6.e.PREVIEW;
+use nqp;
 use Test;
 
-plan 55;
+plan 56;
 
 my $ast;
 my $deparsed;
@@ -755,6 +756,22 @@ subtest 'Match without sigspace' => {
     is-deeply $deparsed, '/o :!s o/', 'deparse';
 
     match-ok "Foo", 'oo';
+}
+
+subtest 'Match with a dba name' => {
+    # /:dba("digits") \d+/
+    ast RakuAST::Regex::Sequence.new(
+      RakuAST::Regex::InternalModifier::Dba.new(name => "digits"),
+      RakuAST::Regex::QuantifiedAtom.new(
+        atom       => RakuAST::Regex::CharClass::Digit.new,
+        quantifier => RakuAST::Regex::Quantifier::OneOrMore.new
+      )
+    );
+    is-deeply $deparsed, '/:dba("digits") \d+/', 'deparse';
+
+    todo('the legacy frontend breaks matching on :dba', 1)
+        unless nqp::gethllsym('Raku', 'COMPILER-FRONTEND') eq 'rakuast';
+    match-ok "42", '42';
 }
 
 # vim: expandtab shiftwidth=4

--- a/t/12-rakuast/xx-fixed-in-rakuast.rakutest
+++ b/t/12-rakuast/xx-fixed-in-rakuast.rakutest
@@ -2,7 +2,7 @@ use Test;
 use lib <t/packages/Test-Helpers>;
 use Test::Helpers;
 
-plan 122;
+plan 123;
 
 # t/spec/S03-sequence/misc.t
 # https://github.com/rakudo/rakudo/issues/5520
@@ -884,6 +884,20 @@ subtest 'use of &?ROUTINE and &?BLOCK' => {
     todo "the legacy grammar ignores an unsatisfiable :auth on require" unless %*ENV<RAKUDO_RAKUAST>;
     dies-ok { require Test:auth<nobody> },
         'require fails on an unsatisfiable :auth constraint';
+}
+
+# src/Raku/ast/regex.rakumod
+# The legacy frontend parses :dba but the regex it produces fails to match
+# at all, and FAILGOAL never receives the name.
+{
+    is-run ｢
+        Q|grammar G {
+            method FAILGOAL($goal, $dba?) { note $dba; callsame }
+            token TOP { :dba("paren expr") "(" ~ ")" \d+ }
+        };
+        print ?G.parse("(123")|.AST.EVAL
+    ｣, :out("False"), :err("paren expr\n"),
+        ':dba names the regex region and FAILGOAL receives it';
 }
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously :dba("...") in a regex died with an unrecognized modifier error: the mod metachar's parenthesized string argument never parsed because HLL::Grammar's quote_EXPR does not match inside the Raku grammar, and no node existed to carry the name. The grammar now parses the quoted string itself, a Regex::InternalModifier::Dba node records it, threads it through the compilation mods like the other internal modifiers, and emits the dba regex node. The goal construct passes it on to FAILGOAL, resolving the TODO there: a grammar overriding FAILGOAL($goal, $dba?) now receives the name.

The legacy frontend parses :dba but the resulting regex fails to match at all, so the new test marks its EVAL of the deparsed form as todo.