### PR TITLE
RakuAST: give the S meta-operator its base operator's properties

### DIFF
--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -1668,14 +1668,16 @@ class RakuAST::MetaInfix::Sequence
     method new(RakuAST::Infixish $infix) {
         my $obj := nqp::create(self);
         nqp::bindattr($obj, RakuAST::MetaInfix::Sequence, '$!infix', $infix);
+        # Sequencing only pins the evaluation order of the operands; the
+        # operator itself keeps its precedence and associativity.
         nqp::bindattr($obj, RakuAST::MetaInfix::Sequence, '$!properties',
-          $infix.properties.associative-reversed);
+          $infix.properties);
         $obj
     }
 
     method action { 'sequence the args of' }
 
-    method reducer-name() { '' } # NYI
+    method reducer-name() { $!infix.reducer-name }
 
     method visit-children(Code $visitor) {
         $visitor($!infix);

--- a/t/12-rakuast/xx-fixed-in-rakuast.rakutest
+++ b/t/12-rakuast/xx-fixed-in-rakuast.rakutest
@@ -2,7 +2,7 @@ use Test;
 use lib <t/packages/Test-Helpers>;
 use Test::Helpers;
 
-plan 123;
+plan 126;
 
 # t/spec/S03-sequence/misc.t
 # https://github.com/rakudo/rakudo/issues/5520
@@ -898,6 +898,16 @@ subtest 'use of &?ROUTINE and &?BLOCK' => {
         print ?G.parse("(123")|.AST.EVAL
     ｣, :out("False"), :err("paren expr\n"),
         ':dba names the regex region and FAILGOAL receives it';
+}
+
+# src/Raku/ast/expressions.rakumod
+# The S sequencing meta-operator crashes at runtime under the legacy
+# frontend. Under RakuAST it also chained with reversed associativity
+# and could not be used with the reduce meta-operator.
+{
+    is Q| 1 S+ 2 |.AST.EVAL, 3, 'S applies the base operator';
+    is Q| 1 S- 2 S- 3 |.AST.EVAL, -4, 'chained S keeps the base associativity';
+    is Q| [S+] 1, 2, 3 |.AST.EVAL, 6, 'a sequenced operator can be reduced';
 }
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
The sequence meta-operator took its base operator's properties with the associativity reversed, apparently borrowed from the reverse meta-operator, so 1 S- 2 S- 3 parsed right associatively and gave 2 instead of -4. Sequencing only pins the evaluation order of the operands; the operator keeps its precedence and associativity.

Its reducer-name was also a stubbed empty string marked NYI, which made a reduce like [S+] fail with an internal empty-name lookup error. It now delegates to the base operator, so [S+] reduces left, [S**] reduces right, and the triangle forms work.

No behavior to compare against: the legacy frontend crashes at run time on every use of S.