### PR TITLE
RakuAST: let the do statement prefix use its translatable token

### DIFF
--- a/src/Raku/Grammar.nqp
+++ b/src/Raku/Grammar.nqp
@@ -1391,11 +1391,15 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
                  <statement-mod-loop>
                  {
                      unless $*LANG.pragma('p5isms') {
+                         # The do prefix captures its keyword token, which
+                         # a translation may override, so its presence is
+                         # what identifies a do rather than the text.
                          my $sp := $<EXPR><statement-prefix>;
                          $/.obs(
-                           "do..." ~ $<statement-mod-loop><sym>,
+                           "do..."
+                             ~ nqp::atpos(nqp::split(' ', ~$<statement-mod-loop>), 0),
                            "repeat...while or repeat...until"
-                         ) if $sp && $sp<sym> eq 'do';
+                         ) if $sp && $sp<stmt-prefix-do>;
                      }
                  }
             ]?
@@ -1907,8 +1911,7 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
 
     # Simple prefixes that just take a blorst
     token statement-prefix:sym<do> {
-        <.sym> <.kok> <blorst>
-#        <.stmt-prefix-do> <.kok> <blorst>  # XXX needs fixing
+        <stmt-prefix-do> <.kok> <blorst>
     }
     token statement-prefix:sym<eager> {
         <.stmt-prefix-eager> <.kok> <blorst>


### PR DESCRIPTION
The do statement prefix was the one prefix still matching its keyword with <.sym> instead of the sub-classable token a translation can override, left behind with an XXX by the translation readiness work. The obstacle was the obsolete do...while detection in the statement rule, which recognized a do prefix by its sym capture. The prefix now captures its keyword token and the detection tests for that capture, which a translated keyword still produces. The message also names the loop modifier from the matched text again, where it previously concatenated an empty sym: do...while instead of do....; matched text stays correct for a translated modifier too.