### PR TITLE
RakuAST: name the bracket in the arrow postfix dereference error

### DIFF
--- a/src/Raku/Grammar.nqp
+++ b/src/Raku/Grammar.nqp
@@ -2617,13 +2617,23 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
     token postfix:sym<⚛++> { <sym> }
     token postfix:sym<⚛--> { <sym> }
 
-    # TODO: report the correct bracket in error message
     token postfix:sym«->» {
         <sym>
         [
-          | ['[' | '{' | '(' ]
-            <.obs: '->(), ->{} or ->[] as postfix dereferencer',
-              '.(), .[] or .{} to deref, or whitespace to delimit a pointy block'>
+          | $<bracket>=['[' | '{' | '(' ]
+            {
+                my str $open := ~$<bracket>;
+                my str $pair := $open eq '['
+                  ?? '[]'
+                  !! $open eq '{' ?? '{}' !! '()';
+                $/.obs(
+                  '->' ~ $pair ~ ' as postfix dereferencer',
+                  '.' ~ $pair ~ ' to deref'
+                    ~ ($open eq '['
+                        ?? ''
+                        !! ', or whitespace to delimit a pointy block')
+                );
+            }
 
           | <.obs: '-> as postfix',
               'either . to call a method, or whitespace to delimit a pointy block'>


### PR DESCRIPTION
The Perl 5 style ->[], ->{} and ->() postfix dereferences produced a single error listing all three forms, with a TODO to report the one actually used. The bracket is now captured and the message names its pair, suggesting .[] for indexing and .{} or .() for the forms where whitespace before a pointy block is also a plausible intent.