### PR TITLE
RakuAST: support DOC-prefixed use statements

### DIFF
--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -977,6 +977,12 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
     }
 
     method statement-control:sym<use>($/) {
+        # A DOC-prefixed use is inert unless compiling documentation.
+        if nqp::chars(~$<doc>) && !%*COMPILING<%?OPTIONS><doc> {
+            self.attach: $/, Nodify('Statement::Empty').new;
+            return;
+        }
+
         my str $name := $/.pragma2str(~$<module-name>);
         my $Pragma   := Nodify('Pragma');
         my $argument := $<arglist><EXPR>;

--- a/src/Raku/Grammar.nqp
+++ b/src/Raku/Grammar.nqp
@@ -1763,9 +1763,14 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
         <.ws>
     }
 
+    # Unlike the legacy grammar, this does not re-enter the parse through the
+    # braid when a loaded module replaces the MAIN slang, so a module that
+    # switches the language mid-parse is not supported yet.
     token statement-control:sym<use> {
         :my $*IN-DECL := 'use';
-        # TODO this is massively simplified
+        # A DOC-prefixed use loads the module only when compiling
+        # documentation.
+        $<doc>=[ <.phaser-DOC> \h+ ]?
         <.use-use>
         <.ws>
         [

--- a/t/02-rakudo/99-misc.t
+++ b/t/02-rakudo/99-misc.t
@@ -2,7 +2,7 @@ use lib <t/packages/Test-Helpers>;
 use Test;
 use Test::Helpers;
 
-plan 11;
+plan 12;
 
 subtest 'IO::Handle.raku.EVAL roundtrips' => {
     plan 7;
@@ -153,5 +153,15 @@ subtest 'Temporal', {
     my $posix = 915148800.999_999_999_999_9;
     todo 'Needs more time or expertise';
     is Instant.from-posix-nanos( ($posix * 10**9).Int ), Instant.from-posix( $posix), '.from-posix-nanos vs .from-posix';
+}
+
+subtest 'DOC use loads only when compiling documentation', {
+    plan 2;
+    is-run ｢DOC use NoSuchModuleAnywhere; print "ran"｣,
+        :out<ran>,
+        'a DOC-prefixed use is inert without --doc';
+    is-run ｢DOC use NoSuchModuleAnywhere;｣,
+        :compiler-args['--doc'], :err(/'Could not find NoSuchModuleAnywhere'/), :exitcode(1),
+        'a DOC-prefixed use loads the module under --doc';
 }
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
The use statement carried a TODO calling it massively simplified next to the legacy grammar. Most of the difference is deliberate, but one form was missing: 'DOC use Module', which loads the module only when compiling documentation, failed to parse at all. The use token now accepts the DOC prefix and the action attaches an empty statement when not compiling under --doc, matching the legacy behavior in both modes. The doc capture is tested through its string like the legacy frontend does; testing the capture object itself misfired for every plain use and broke the CORE build.

The remaining genuine simplification is noted where the TODO was: a use that replaces the MAIN slang does not re-enter the parse through the braid, so language-switching modules are not supported yet.