### PR TITLE
RakuAST: don't eat the newline after a trailing paren declarator doc

### DIFF
--- a/src/Raku/Grammar.nqp
+++ b/src/Raku/Grammar.nqp
@@ -5798,7 +5798,7 @@ Rakudo significantly on *every* run."
 
     token comment:sym<#=> { '#=' \h $<attachment>=[\N*] }
     token comment:sym<#=(...)> {
-        '#=' <?opener> <attachment=.quibble(self.Quote)> \n?
+        '#=' <?opener> <attachment=.quibble(self.Quote)>
     }
 
 #-------------------------------------------------------------------------------

--- a/t/02-rakudo/99-misc.t
+++ b/t/02-rakudo/99-misc.t
@@ -2,7 +2,7 @@ use lib <t/packages/Test-Helpers>;
 use Test;
 use Test::Helpers;
 
-plan 12;
+plan 13;
 
 subtest 'IO::Handle.raku.EVAL roundtrips' => {
     plan 7;
@@ -163,5 +163,14 @@ subtest 'DOC use loads only when compiling documentation', {
     is-run ｢DOC use NoSuchModuleAnywhere;｣,
         :compiler-args['--doc'], :err(/'Could not find NoSuchModuleAnywhere'/), :exitcode(1),
         'a DOC-prefixed use loads the module under --doc';
+}
+
+subtest 'trailing paren declarator doc directly after a block', {
+    plan 1;
+    use MONKEY-SEE-NO-EVAL;
+    is EVAL(｢sub f() {} #=( attached )
+&f.WHY｣),
+        'attached',
+        'the doc attaches without a separating semicolon';
 }
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
The parenthesized trailing declarator doc comment consumed an optional newline, unlike its legacy counterpart and unlike the leading form. That newline is what the end-statement rule's end-of-line assertion needs when the doc follows a block's closing brace on the same line, so 'sub f() {} #=( doc )' failed to compile with a strange-text-after-block error where the legacy frontend attaches the documentation. Note the plain '#= doc' form was unaffected, as it does not consume its newline either.