### PR TITLE
RakuAST: parse a custom postcircumfix subscript as a semilist

### DIFF
--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -1388,7 +1388,9 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
         }
 
         elsif nqp::istype($ast, Nodify('Call::Name')) {
-            $ast.args.push: $operand;
+            # A custom postcircumfix's subscript args are already in place, so
+            # the operand must go first to become the sub's invocant argument.
+            $ast.args.unshift: $operand;
             self.attach: $/, $ast;
         }
 

--- a/src/Raku/Grammar.nqp
+++ b/src/Raku/Grammar.nqp
@@ -5548,16 +5548,14 @@ Rakudo significantly on *every* run."
             );
         }
 
-        # Find opener and closer and parse an EXPR between them.
-        # XXX One day semilist would be nice, but right now that
-        # runs us into fun with terminators.
+        # Find opener and closer and parse a semilist between them.
         elsif $category eq 'postcircumfix' {
             my role Postcircumfix[$meth_name, $starter, $stopper] {
                 token ::($meth_name) {
                     :my $*GOAL := $stopper;
                     :my $cursor := nqp::getlex('$¢');
                     :my $stub := $cursor.define_slang('MAIN', %*LANG<MAIN> := $cursor.unbalanced($stopper).WHAT, $cursor.actions);
-                    $starter ~ $stopper [ <.ws> <statement> ]
+                    $starter ~ $stopper <semilist>
                 }
             }
             $grammar-mixin := Postcircumfix.HOW.curry(
@@ -5565,7 +5563,7 @@ Rakudo significantly on *every* run."
             );
         }
 
-        # Find opener and closer and parse an EXPR between them.
+        # Find opener and closer and parse a semilist between them.
         else {  # $category eq 'circumfix'
             my role Circumfix[$meth_name, $starter, $stopper] {
                 token ::($meth_name) {
@@ -5610,7 +5608,7 @@ Rakudo significantly on *every* run."
                 method ::($meth)($/) {
                     my $ast := self.r('Call::Name').new(
                         :name(self.r('Name').from-identifier($subname)),
-                        :args(self.r('ArgList').new($<statement>.ast))
+                        :args(self.r('ArgList').new(|$<semilist>.ast.FLATTENABLE_LIST))
                     );
                     self.attach: $/, $ast;
                 }

--- a/src/Raku/ast/call.rakumod
+++ b/src/Raku/ast/call.rakumod
@@ -62,6 +62,10 @@ class RakuAST::ArgList
         }
     }
 
+    method unshift($arg) {
+        nqp::unshift($!args, $arg)
+    }
+
     method has-args() { nqp::elems($!args) ?? True !! False }
     method arity() { nqp::elems($!args) }
 

--- a/t/12-rakuast/xx-fixed-in-rakuast.rakutest
+++ b/t/12-rakuast/xx-fixed-in-rakuast.rakutest
@@ -2,7 +2,7 @@ use Test;
 use lib <t/packages/Test-Helpers>;
 use Test::Helpers;
 
-plan 126;
+plan 129;
 
 # t/spec/S03-sequence/misc.t
 # https://github.com/rakudo/rakudo/issues/5520
@@ -908,6 +908,20 @@ subtest 'use of &?ROUTINE and &?BLOCK' => {
     is Q| 1 S+ 2 |.AST.EVAL, 3, 'S applies the base operator';
     is Q| 1 S- 2 S- 3 |.AST.EVAL, -4, 'chained S keeps the base associativity';
     is Q| [S+] 1, 2, 3 |.AST.EVAL, 6, 'a sequenced operator can be reduced';
+}
+
+# A custom postcircumfix parsed a single statement between its delimiters,
+# so a semicolon separated subscript (and an empty one) failed to parse in
+# the legacy grammar. The subscript is now a semilist like the core
+# postcircumfix operators use.
+{
+    my $decl = Q| sub postcircumfix:<⌊ ⌋>($obj, *@i) { $obj => @i }; |;
+    is-deeply ($decl ~ Q| 10⌊1;2⌋ |).AST.EVAL, 10 => [1, 2],
+        'a custom postcircumfix parses a semicolon separated subscript';
+    is-deeply ($decl ~ Q| 10⌊⌋ |).AST.EVAL, 10 => [],
+        'a custom postcircumfix parses an empty subscript';
+    is-deeply ($decl ~ Q| 10⌊3⌋ |).AST.EVAL, 10 => [3],
+        'a custom postcircumfix passes the operand as the first argument';
 }
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously a user declared postcircumfix parsed a single statement between its delimiters, carrying over an XXX from the legacy grammar about semilists running into "fun with terminators". The terminator machinery handles custom stoppers fine now, as demonstrated by custom circumfix operators which already parse a semilist through the same $*GOAL setup. This switches the generated postcircumfix token and its action over to match, so semicolon separated subscripts like 10⌊1;2⌋ and empty subscripts like 10⌊⌋ parse instead of failing to find the closer (both still fail in the legacy grammar).

This also fixes the argument order of the generated call. POSTFIX-EXPR pushed the operand onto the end of the argument list, so a custom postcircumfix received its subscript arguments before its invocant, the reverse of the legacy grammar. The operand is now unshifted to the front. Roast never caught this because its only sub form postcircumfix test ignores the subscript argument.