### PR TITLE
Implement the appending feed operators <<== and ==>>

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -7593,16 +7593,13 @@ class Perl6::Actions is HLL::Actions does STDActions {
     sub make_feed($/) {
         # Assemble into list of AST of each step in the pipeline.
         my @stages;
-        if $/<infix><sym> eq '==>' {
+        my $sym := ~$/<infix><sym>;
+        my int $appending := $sym eq '==>>' || $sym eq '<<==';
+        if $sym eq '==>' || $sym eq '==>>' {
             for @($/) { @stages.push($_); }
         }
-        elsif $/<infix><sym> eq '<==' {
-            for @($/) { @stages.unshift($_); }
-        }
         else {
-            $*W.throw($/, 'X::Comp::NYI',
-                feature => $/<infix> ~ " feed operator"
-            );
+            for @($/) { @stages.unshift($_); }
         }
 
         # Check what's in each stage and make a chain of blocks
@@ -7628,7 +7625,8 @@ class Perl6::Actions is HLL::Actions does STDActions {
             elsif nqp::istype($stage, QAST::Var) {
                 # It's a variable. We need code that gets the results, pushes
                 # them onto the variable and then returns them (since this
-                # could well be a tap.
+                # could well be a tap. The appending forms instead pass on
+                # the variable's whole contents, prior values included.
                 my $tmp := QAST::Node.unique('feed_tmp');
                 $stage := QAST::Stmts.new(
                     QAST::Op.new(
@@ -7643,9 +7641,10 @@ class Perl6::Actions is HLL::Actions does STDActions {
                         :op('callmethod'), :name('append'),
                         $stage,
                         QAST::Var.new( :scope('local'), :name($tmp) )
-                    ),
-                    QAST::Var.new( :scope('local'), :name($tmp) )
+                    )
                 );
+                $stage.push(QAST::Var.new( :scope('local'), :name($tmp) ))
+                    unless $appending;
                 $stage := QAST::Op.new( :op('locallifetime'), $stage, $tmp );
             }
             else {

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -811,7 +811,6 @@ class RakuAST::Mixin
 
 class RakuAST::Feed
   is RakuAST::Infix
-  is RakuAST::BeginTime
 {
     method new(str $operator) {
         my $obj := nqp::create(self);
@@ -821,23 +820,15 @@ class RakuAST::Feed
 
     method is-pure() { False }
 
-    method PERFORM-BEGIN(Resolver $resolver, Context $context) {
-        my $operator := nqp::getattr_s(self, RakuAST::Infix, '$!operator');
-        if $operator eq "==>>" || $operator eq "<<==" {
-            self.add-sorry:
-              $resolver.build-exception: 'X::Comp::NYI',
-                :feature($operator ~ " feed operator");
-        }
-    }
-
     method IMPL-LIST-INFIX-QAST(RakuAST::IMPL::QASTContext $context, Mu $operands) {
         my @stages;
         my $operator := nqp::getattr_s(self, RakuAST::Infix, '$!operator');
-        if $operator eq "==>" {
+        my int $appending := $operator eq "==>>" || $operator eq "<<==";
+        if $operator eq "==>" || $operator eq "==>>" {
             for $operands {
                 @stages.push: $_;
             }
-        } else {  # "<<==" and "==>>" are NYI
+        } else {
             for $operands {
                 @stages.unshift: $_;
             }
@@ -878,7 +869,8 @@ class RakuAST::Feed
             elsif nqp::istype($stage, QAST::Var) {
                 # It's a variable. We need code that gets the results, pushes
                 # them onto the variable and then returns them (since this
-                # could well be a tap.
+                # could well be a tap. The appending forms instead pass on
+                # the variable's whole contents, prior values included.
                 my $tmp := QAST::Node.unique('feed_tmp');
                 $stage := QAST::Stmts.new(
                     QAST::Op.new(
@@ -893,9 +885,10 @@ class RakuAST::Feed
                         :op('callmethod'), :name('append'),
                         $stage,
                         QAST::Var.new( :scope('local'), :name($tmp) )
-                        ),
-                    QAST::Var.new( :scope('local'), :name($tmp) )
+                        )
                     );
+                $stage.push(QAST::Var.new( :scope('local'), :name($tmp) ))
+                    unless $appending;
                 $stage := QAST::Op.new( :op('locallifetime'), $stage, $tmp );
             }
             else {

--- a/t/02-rakudo/rakuast-feed-validation.t
+++ b/t/02-rakudo/rakuast-feed-validation.t
@@ -2,7 +2,7 @@ use lib <t/packages/Test-Helpers>;
 use Test;
 use Test::Helpers;
 
-plan 23;
+plan 26;
 
 # Compile-time validation of `==>` / `<==` stages, matching the
 # legacy frontend's `make_feed` in src/Perl6/Actions.nqp.
@@ -98,6 +98,18 @@ is-run q|say ((1..3) ==> map(* + 10))|,
 is-run q|my @a <== gather for 1..3 -> $i { take $i }; say @a|,
     'bare my @a <== source compiles (declaration acts as Var)',
     :out("[1 2 3]\n");
+
+is-run q|my @sink = <a>; 1..6 ==>> grep(* %% 2) ==>> @sink; say @sink|,
+    'forward appending feed keeps existing sink contents',
+    :out("[a 2 4 6]\n");
+
+is-run q|my @sink = <a>; @sink <<== grep(* %% 2) <<== 1..6; say @sink|,
+    'backward appending feed keeps existing sink contents',
+    :out("[a 2 4 6]\n");
+
+is-run q|my @tap = <t>; my @out; 1..3 ==>> @tap ==>> @out; say @out|,
+    'appending feed tap passes on its whole contents, prior values included',
+    :out("[t 1 2 3]\n");
 
 # A feed stage receives the fed value as an extra argument at code-gen
 # time, so its arity must not be trial-bound against the arguments


### PR DESCRIPTION
Previously both frontends threw X::Comp::NYI for the appending feed operators. This implements them in make_feed and RakuAST::Feed as the rightward and leftward pipeline builders they already half-expected, with one difference from ==> and <==: a variable stage passes on its whole contents after the append rather than just the values fed into it, so `my @c = do { @a ==>> @b }` yields @b's prior contents followed by @a's values, matching S03-feeds/basic.t.

The S03 behavior where ==>> looks ahead to a downstream @(*) stage remains unimplemented along with the rest of the whatever-feed machinery.