### PR TITLE
RakuAST: adopt foreign-stubbed code objects at link time

### DIFF
--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -215,6 +215,26 @@ class RakuAST::Code
         my $cuid := $!cuid;
         $block.set-cuid($!cuid);
 
+        # A code object stubbed during another compilation (a tree from
+        # Str.AST handed to EVAL, for example) is unknown to this context,
+        # so IMPL-FIXUP-COMPILED-CODEREFS would never bind its freshly
+        # compiled code ref. Register it here so the fixup finds it.
+        my %sub-id-to-code-object := $context.sub-id-to-code-object();
+        unless nqp::existskey(%sub-id-to-code-object, $cuid) {
+            %sub-id-to-code-object{$cuid} := $code-obj;
+        }
+
+        # The stubbing context schedules the cleanup that nulls @!compstuff.
+        # When another compilation links the code object, that task lives on
+        # a context that never finalizes (Str.AST abandons its parse context)
+        # or already ran, so this compilation must null the compiler state
+        # itself or the compiler thunk leaks into the serialized graph.
+        unless $context.has-stubbed-code-object($code-obj) {
+            $context.add-cleanup-task(sub () {
+                nqp::bindattr($code-obj, Code, '@!compstuff', nqp::null());
+            });
+        }
+
         my $fixups := QAST::Stmts.new();
         unless $context.is-precompilation-mode {
             # We need to do a fixup of the code block for the non-precompiled case.

--- a/src/Raku/ast/impl.rakumod
+++ b/src/Raku/ast/impl.rakumod
@@ -135,6 +135,10 @@ class RakuAST::IMPL::QASTContext {
         Nil
     }
 
+    method has-stubbed-code-object(Mu $code-obj) {
+        nqp::existskey($!stubbed-code-objects, ~nqp::objectid($code-obj))
+    }
+
     method mark-code-object-finalized(Mu $code-obj) {
         my str $key := ~nqp::objectid($code-obj);
         nqp::deletekey($!stubbed-code-objects, $key);

--- a/t/12-rakuast/eval.rakutest
+++ b/t/12-rakuast/eval.rakutest
@@ -1,0 +1,23 @@
+# Tests for the machinery that compiles RakuAST trees handed to EVAL:
+# Str.AST parsing, EVAL of the resulting nodes, and their interaction
+# with an enclosing compilation such as a precompiling module.
+
+use lib <t/packages/Test-Helpers>;
+use Test;
+use Test::Helpers;
+
+plan 1;
+
+# A tree parsed by Str.AST has its code objects stubbed in the parse's
+# abandoned context, so EVALing it at BEGIN time used to leak compiler
+# stub state into the enclosing precompilation, which then died with
+# "missing static code ref for closure".
+{
+    (temp %*ENV)<RAKUDO_RAKUAST> = 1;
+    is-run 'use lib <t/packages/12-rakuast/lib>; use ParsedSubAtBegin; say ParsedSubAtBegin::bump(41);',
+      :out("42\n"),
+      :err(""),
+      'precompiling a module returning a Str.AST.EVAL Sub from BEGIN works';
+}
+
+# vim: expandtab shiftwidth=4

--- a/t/packages/12-rakuast/lib/ParsedSubAtBegin.rakumod
+++ b/t/packages/12-rakuast/lib/ParsedSubAtBegin.rakumod
@@ -1,0 +1,8 @@
+# Precompiling this module used to fail with "missing static code ref for
+# closure": the Sub was stubbed during the Str.AST parse, whose context is
+# abandoned after the parse, so the BEGIN-time EVAL's compilation never
+# registered the code object or cleared its compiler stub state.
+use MONKEY-SEE-NO-EVAL;
+unit module ParsedSubAtBegin;
+my $c = BEGIN 'sub ($x) { $x + 1 }'.AST.EVAL;
+our sub bump($n) { $c($n) }


### PR DESCRIPTION
A tree returned by Str.AST has its code objects stubbed during the parse, whose context is abandoned when the parse stops at the ast target. EVALing that tree from another compilation left the code object unknown to the compiling context: IMPL-FIXUP-COMPILED-CODEREFS never bound the freshly compiled code ref, and the cleanup task that nulls the IMPL-STUB-CODE compiler state sat on the dead context. If the EVAL happened at BEGIN time of a precompiling module, the leaked compiler thunk made serialization die with "missing static code ref for closure".

IMPL-LINK-META-OBJECT now registers the code object with the compiling context when it is missing from sub-id-to-code-object, and schedules the compstuff-nulling cleanup on that context whenever the code object was stubbed elsewhere, using the per-context stubbed code object registry to decide ownership.