### PR TITLE
RakuAST: build constant format string literals at compile time

### DIFF
--- a/src/Perl6/Compiler.nqp
+++ b/src/Perl6/Compiler.nqp
@@ -289,6 +289,13 @@ class Perl6::Compiler is HLL::Compiler {
         my str $setting-name := nqp::can($rakuast, 'setting-name') ?? ($rakuast.setting-name // '') !! '';
         my int $compiling-core := $setting-name eq 'NULL.c' || $setting-name eq 'NULL.d' || $setting-name eq 'NULL.e' ?? 1 !! 0;
         my $*COMPILING_CORE_SETTING := $compiling-core;
+        # An EVAL during QAST generation (a node building a value object at
+        # compile time, like the format string literal) checks $*CU to nest
+        # inside this compilation and share its serialization context. The
+        # parse actions bind it during the parse stage; rebind it here so
+        # such EVALs don't compile into an ephemeral context that breaks
+        # precompilation.
+        my $*CU := $rakuast;
         my $comp_unit := $rakuast.IMPL-TO-QAST-COMP-UNIT;
         $rakuast.cleanup();
         $comp_unit;

--- a/src/Raku/ast/literals.rakumod
+++ b/src/Raku/ast/literals.rakumod
@@ -418,26 +418,9 @@ class RakuAST::QuotedString
             # format string
             if $!processors && $!processors[0] eq 'format' {
                 my $Format := self.IMPL-UNWRAP-LIST(self.get-implicit-lookups)[0].resolution.compile-time-value;
-
-# The below code "should" work, but doesn't because references to internal
-# subs (such as "str-right-justified") appear to be QASTed correctly, but
-# when executed, do *not* call the unit in question, but simply return the
-# arguments that were given.  Not sure what is going on here.  For now,
-# create the format at run-time: it will still get cached, but *will* incur
-# a performance penalty at runtime, which is too bad because the whole idea
-# of a quote string format, was to create all of this at compile time.
-#
-#                my $format := $Format.new($literal-value);
-#                $context.ensure-sc($format);
-#                return QAST::WVal.new(:value($format));
-
-                # for now, until above fixed
-                $context.ensure-sc($literal-value);
-                return QAST::Op.new(
-                  :op('callmethod'), :name('new'),
-                  QAST::WVal.new( :value($Format) ),
-                  QAST::WVal.new( :value($literal-value) )
-                );
+                my $format := $Format.new($literal-value);
+                $context.ensure-sc($format);
+                return QAST::WVal.new(:value($format));
             }
 
             $context.ensure-sc($literal-value);

--- a/src/core.e/Format.rakumod
+++ b/src/core.e/Format.rakumod
@@ -12,7 +12,7 @@ my class Format is Str is Callable {
         my $obj  := nqp::create(self);
 
         nqp::bindattr_s($obj,Str,'$!value',$format);
-        nqp::bindattr($obj,Format,'@!directives',@*DIRECTIVES);
+        nqp::bindattr($obj,Format,'@!directives',$class.directives($format));
         nqp::bindattr($obj,Format,'&!code',&code);
 
         $obj

--- a/src/core.e/Formatter.rakumod
+++ b/src/core.e/Formatter.rakumod
@@ -1390,7 +1390,8 @@ our class Formatter {
     }
 
     # actual workhorse for sprintf()
-    my $FORMATS := nqp::hash;  # where we keep our formats
+    my $FORMATS    := nqp::hash;  # where we keep our formats
+    my $DIRECTIVES := nqp::hash;  # the directives seen for each format
     method new(Str:D $format) {
         nqp::ifnull(
           nqp::atkey($FORMATS,$format),
@@ -1398,18 +1399,34 @@ our class Formatter {
         )
     }
 
+    # The directives seen while producing the format's code, cached
+    # alongside the code so they are also available on a cache hit
+    method directives(Str:D $format) is implementation-detail {
+        self.new($format) unless nqp::existskey($DIRECTIVES,$format);
+        nqp::atkey($DIRECTIVES,$format)
+    }
+
     # Threadsafe cache updater, don't care about multiple threads trying
     # to do the same format, but this way we don't have a lock if the
     # same format is called *many* times over
     method !fetch-new-format(Str:D $format) {
-        my $new := nqp::clone($FORMATS);
+        my @*DIRECTIVES := my str @;  # the directives seen
+        my @*COERCIONS  := my str @;  # any coercions on parameters
+        my $new-formats    := nqp::clone($FORMATS);
+        my $new-directives := nqp::clone($DIRECTIVES);
 
         # remove the first key we encounter if max reached
-        nqp::deletekey($new,nqp::iterkey_s(nqp::shift(nqp::iterator($new))))
-          if nqp::isge_i(nqp::elems($new),100);  # XXX  should be settable
+        if nqp::isge_i(nqp::elems($new-formats),100) {  # XXX  should be settable
+            my str $evict =
+              nqp::iterkey_s(nqp::shift(nqp::iterator($new-formats)));
+            nqp::deletekey($new-formats,$evict);
+            nqp::deletekey($new-directives,$evict);
+        }
 
-        nqp::bindkey($new,$format,my $code := self.CODE($format));
-        $FORMATS := $new;
+        nqp::bindkey($new-formats,$format,my $code := self.CODE($format));
+        nqp::bindkey($new-directives,$format,@*DIRECTIVES);
+        $DIRECTIVES := $new-directives;
+        $FORMATS    := $new-formats;
         $code
     }
 }

--- a/t/02-rakudo/format-string-literal.t
+++ b/t/02-rakudo/format-string-literal.t
@@ -1,0 +1,48 @@
+use v6.e.PREVIEW;
+use lib <t/packages/Test-Helpers>;
+use nqp;
+use Test;
+use Test::Helpers;
+use MONKEY-SEE-NO-EVAL;
+
+plan 7;
+
+# Format.new used to bind a Failure to its directives attribute: the
+# @*DIRECTIVES dynamic it read was only declared inside Formatter.AST.
+# That broke .directives and made instances unserializable, since the
+# Failure's backtrace references live compiler frames.
+is-deeply Format.new('%5d:%3x').directives, ("d", "x"),
+    'Format.new populates .directives';
+is-deeply Format.new('%5d:%3x').directives, ("d", "x"),
+    '.directives is also populated on a Formatter cache hit';
+
+# The format string quote only exists in the RakuAST grammar.
+if nqp::gethllsym('Raku', 'COMPILER-FRONTEND') eq 'rakuast' {
+    my $f = EVAL 'use v6.e.PREVIEW; q:o/%5x/';
+    isa-ok $f, Format, 'q:o produces a Format object';
+    is $f(255), '   ff', 'the format renders its argument';
+    is-deeply $f.directives, ("x",), 'the literal Format knows its directives';
+
+    # A constant format literal is built at compile time and serialized,
+    # so it must survive a precompilation round trip.
+    my $dir = make-temp-dir();
+    $dir.add('FmtLit.rakumod').spurt: q:to/CODE/;
+        use v6.e.PREVIEW;
+        unit module FmtLit;
+        my $f = q:o/%5d/;
+        our sub render($n) { $f($n) }
+        our sub directives() { $f.directives }
+        CODE
+    for 'compiles', 'loads from the precompilation store' -> $stage {
+        is-run 'use FmtLit; print FmtLit::render(42) ~ "|" ~ FmtLit::directives()',
+            :compiler-args['-I', $dir.absolute],
+            :out("   42|d"),
+            :err(""),
+            "a module with a constant format literal $stage";
+    }
+}
+else {
+    skip 'format string literals require the RakuAST frontend', 5;
+}
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously a constant format string literal such as `q:o/%5d/` compiled to a runtime `Format.new` call, so the first use in every process paid the `Formatter` parse and the EVAL of the RakuAST it generates. The compile time construction in `RakuAST::QuotedString` was commented out with a note that the resulting objects misbehaved in a way that was not understood at the time.

Two problems were actually in the way:

- `Format.new` read `@*DIRECTIVES` after calling `Formatter.new`, but that dynamic only ever exists inside `Formatter.AST`, so the directives attribute always received a `Failure`. That broke `Format.directives` at runtime, and it also made every instance unserializable, since the `Failure` backtrace references live compiler frames. Precompiling a module containing a compile time constructed `Format` died with "Serialization Error: missing static code ref for closure". `Formatter` now declares the dynamics around code generation and caches the directives seen alongside the generated code, so a cache hit also knows its directives, and `Format.new` takes them from that cache.

- An EVAL run during QAST generation could not see `$*CU`, which is only bound during the parse stage, so the formatter's code compiled into an ephemeral serialization context that a precompiled module cannot reference. The qast stage now rebinds `$*CU` the way the parse stage does, so such EVALs nest inside the enclosing compilation and share its serialization context.

With both fixed the previously commented out code works as written: the `Format` is constructed once at compile time and serialized as a constant.

The `Format.directives` fix is visible on its own:

```
$ raku -e 'use v6.e.PREVIEW; say q:o/%5d/.directives'
Dynamic variable @*DIRECTIVES not found
```

now gives `(d)`.
