### PR TITLE
Compare revision-gated candidate signatures structurally

### DIFF
--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -3852,10 +3852,54 @@ BEGIN {
       nqp::getstaticcode(sub ($self, $caller-revision, @candidates) {
         $self := nqp::decont($self);
 
+        # Whether two signatures are interchangeable for revision gating:
+        # the same parameter shapes and types in the same order, differing
+        # at most in parameter names. Anything a name-blind comparison
+        # cannot vouch for (named, slurpy, capture or sub-signature
+        # parameters, constraints, type captures) makes them
+        # non-interchangeable, so such candidates each stand on their own,
+        # as any two distinct signatures do.
+        my sub signatures-equivalent($sig-a, $sig-b) {
+          my @params-a := nqp::getattr($sig-a, Signature, '@!params');
+          my @params-b := nqp::getattr($sig-b, Signature, '@!params');
+          return 0 unless nqp::elems(@params-a) == nqp::elems(@params-b);
+
+          my int $n := nqp::elems(@params-a);
+          my int $i := -1;
+          while ++$i < $n {
+            my $a := nqp::atpos(@params-a, $i);
+            my $b := nqp::atpos(@params-b, $i);
+
+            my int $flags := nqp::getattr_i($a, Parameter, '$!flags');
+            return 0 unless $flags == nqp::getattr_i($b, Parameter, '$!flags');
+            return 0 if $flags +& (nqp::const::SIG_ELEM_SLURPY_POS
+                                +| nqp::const::SIG_ELEM_SLURPY_NAMED
+                                +| nqp::const::SIG_ELEM_SLURPY_LOL
+                                +| nqp::const::SIG_ELEM_SLURPY_ONEARG
+                                +| nqp::const::SIG_ELEM_IS_CAPTURE);
+            return 0 unless nqp::isnull(nqp::getattr($a, Parameter, '@!named_names'))
+                         && nqp::isnull(nqp::getattr($b, Parameter, '@!named_names'));
+            return 0 unless nqp::isnull(nqp::getattr($a, Parameter, '@!post_constraints'))
+                         && nqp::isnull(nqp::getattr($b, Parameter, '@!post_constraints'));
+            return 0 unless nqp::isnull(nqp::getattr($a, Parameter, '@!type_captures'))
+                         && nqp::isnull(nqp::getattr($b, Parameter, '@!type_captures'));
+            return 0 if nqp::getattr($a, Parameter, '$!sub_signature')
+                     || nqp::getattr($b, Parameter, '$!sub_signature');
+            return 0 if nqp::defined(nqp::getattr($a, Parameter, '$!signature_constraint'))
+                     || nqp::defined(nqp::getattr($b, Parameter, '$!signature_constraint'));
+
+            return 0 unless nqp::eqaddr(
+              nqp::getattr($a, Parameter, '$!type'),
+              nqp::getattr($b, Parameter, '$!type'));
+          }
+          1
+        }
+
         my int $idx := 0;
         my int $allowed-idx := 0;
         my @allowed-candidates;
         my %gated-candidates;
+        my @gated-idxs;
         while $idx < nqp::elems(@candidates) {
           my $candidate := nqp::atpos(@candidates, $idx++);
 
@@ -3869,22 +3913,43 @@ BEGIN {
           my $is-revision-specified := nqp::isconcrete($required-revision);
           if !$is-revision-specified || $required-revision <= $caller-revision  {
             if (nqp::existskey($candidate, 'signature')) && $is-revision-specified {
-              my $signature := nqp::atkey($candidate, 'signature').raku;
+              my $sig := nqp::atkey($candidate, 'signature');
+              my $signature := $sig.raku;
+
+              # Find the admitted candidate this one supersedes or is
+              # superseded by. The rendered signature catches the exact
+              # same text cheaply; the structural comparison catches
+              # signatures that differ in parameter names only.
+              my int $candidate-idx := -1;
               if nqp::existskey(%gated-candidates, $signature) {
-                my $candidate-idx := nqp::atkey(%gated-candidates, $signature);
+                $candidate-idx := nqp::atkey(%gated-candidates, $signature);
+              }
+              else {
+                for @gated-idxs {
+                  if signatures-equivalent($sig,
+                      nqp::atkey(nqp::atpos(@allowed-candidates, $_), 'signature')) {
+                    $candidate-idx := $_;
+                    last;
+                  }
+                }
+              }
+
+              if $candidate-idx >= 0 {
                 my $last-seen-revision := nqp::atkey(
                         nqp::atpos(@allowed-candidates, $candidate-idx),
                         'required_revision'
                                                                                       );
 
                 if $last-seen-revision < $required-revision {
-                  nqp::bindkey(%gated-candidates, $signature, $candidate-idx);
                   nqp::bindpos(@allowed-candidates, $candidate-idx, $candidate);
                   # Do *not* bump $allowed-idx here
                 }
+                nqp::bindkey(%gated-candidates, $signature, $candidate-idx);
               } else {
+                nqp::bindkey(%gated-candidates, $signature, $allowed-idx);
+                nqp::push(@gated-idxs, $allowed-idx);
                 nqp::push(@allowed-candidates, $candidate);
-                nqp::bindkey(%gated-candidates, $signature, $allowed-idx++);
+                $allowed-idx++;
               }
             } else {
               nqp::push(@allowed-candidates, $candidate);

--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -2477,40 +2477,48 @@ class RakuAST::Sub
         # at compile time, so a signature carrying either is left out of the check.
         return Nil unless self.IMPL-SIGNATURE-STATICALLY-COMPARABLE($signature);
 
-        # If there is a revision gated proto, we don't want to worry about throwing
-        # re-declaration exceptions. Otherwise, crawl the candidates and ensure that
-        # none of them double up.
-        #
-        # TODO: Make this handle the case of clashing revision gated candidates
-        # TODO: rather than simply ignore the check for revision gating as is
-        # TODO: currently done.
-        if !(nqp::can($proto, 'REQUIRED-REVISION') && $proto.REQUIRED-REVISION) {
-            my @seen-accepts;
-            for $proto.dispatchees {
-                last if $_.can("default");
-                next if $_ =:= $meta;
+        # Crawl the candidates and ensure that none of them double up. For a
+        # revision gated proto, equivalent signatures gated at different
+        # revisions are how a routine evolves per language version, so only
+        # candidates competing at the same effective revision are compared.
+        # A candidate without its own gate defaults to the proto's revision,
+        # as it does at dispatch time.
+        my $proto-revision := nqp::can($proto, 'REQUIRED-REVISION') && $proto.REQUIRED-REVISION;
+        my $self-revision := $proto-revision
+            ?? (nqp::can($meta, 'REQUIRED-REVISION') ?? $meta.REQUIRED-REVISION !! $proto-revision)
+            !! Nil;
+        my @seen-accepts;
+        for $proto.dispatchees {
+            last if $_.can("default");
+            next if $_ =:= $meta;
 
-                my $other-signature := $_.signature;
-                next unless $signature.arity == $other-signature.arity;
-                next unless self.IMPL-SIGNATURE-STATICALLY-COMPARABLE($other-signature);
+            if $proto-revision {
+                my $other-revision := nqp::can($_, 'REQUIRED-REVISION')
+                    ?? $_.REQUIRED-REVISION
+                    !! $proto-revision;
+                next unless $other-revision == $self-revision;
+            }
 
-                @seen-accepts.push($_)
-                    if try $other-signature.ACCEPTS($signature)
-                        && try $signature.ACCEPTS($other-signature);
+            my $other-signature := $_.signature;
+            next unless $signature.arity == $other-signature.arity;
+            next unless self.IMPL-SIGNATURE-STATICALLY-COMPARABLE($other-signature);
 
-                if @seen-accepts > 0 {
-                    my %args;
-                    if my $origin := self.origin {
-                        my $origin-match := self.origin.as-match;
-                        %args<filename>   := $origin-match.file;
-                        %args<line> := $origin-match.line
-                    }
-                    self.add-worry: $resolver.build-exception:
-                            'X::Redeclaration::Multi',
-                            :symbol(self.name.canonicalize),
-                            :ambiguous(@seen-accepts),
-                            |%args;
+            @seen-accepts.push($_)
+                if try $other-signature.ACCEPTS($signature)
+                    && try $signature.ACCEPTS($other-signature);
+
+            if @seen-accepts > 0 {
+                my %args;
+                if my $origin := self.origin {
+                    my $origin-match := self.origin.as-match;
+                    %args<filename>   := $origin-match.file;
+                    %args<line> := $origin-match.line
                 }
+                self.add-worry: $resolver.build-exception:
+                        'X::Redeclaration::Multi',
+                        :symbol(self.name.canonicalize),
+                        :ambiguous(@seen-accepts),
+                        |%args;
             }
         }
     }

--- a/src/vm/moar/dispatchers.nqp
+++ b/src/vm/moar/dispatchers.nqp
@@ -2839,6 +2839,48 @@ sub multi-ambiguous-handler($ambig-call, $target, $capture) {
     );
 }
 
+# Whether two signatures are interchangeable for revision gating: the
+# same parameter shapes and types in the same order, differing at most
+# in parameter names. Anything a name-blind comparison cannot vouch for
+# (named, slurpy, capture or sub-signature parameters, constraints,
+# type captures) makes them non-interchangeable, so such candidates
+# each stand on their own, as any two distinct signatures do.
+sub revision-gated-signatures-equivalent($sig-a, $sig-b) {
+    my @params-a := nqp::getattr($sig-a, Signature, '@!params');
+    my @params-b := nqp::getattr($sig-b, Signature, '@!params');
+    return 0 unless nqp::elems(@params-a) == nqp::elems(@params-b);
+
+    my int $n := nqp::elems(@params-a);
+    my int $i := -1;
+    while ++$i < $n {
+        my $a := nqp::atpos(@params-a, $i);
+        my $b := nqp::atpos(@params-b, $i);
+
+        my int $flags := nqp::getattr_i($a, Parameter, '$!flags');
+        return 0 unless $flags == nqp::getattr_i($b, Parameter, '$!flags');
+        return 0 if $flags +& (nqp::const::SIG_ELEM_SLURPY_POS
+                            +| nqp::const::SIG_ELEM_SLURPY_NAMED
+                            +| nqp::const::SIG_ELEM_SLURPY_LOL
+                            +| nqp::const::SIG_ELEM_SLURPY_ONEARG
+                            +| nqp::const::SIG_ELEM_IS_CAPTURE);
+        return 0 unless nqp::isnull(nqp::getattr($a, Parameter, '@!named_names'))
+                     && nqp::isnull(nqp::getattr($b, Parameter, '@!named_names'));
+        return 0 unless nqp::isnull(nqp::getattr($a, Parameter, '@!post_constraints'))
+                     && nqp::isnull(nqp::getattr($b, Parameter, '@!post_constraints'));
+        return 0 unless nqp::isnull(nqp::getattr($a, Parameter, '@!type_captures'))
+                     && nqp::isnull(nqp::getattr($b, Parameter, '@!type_captures'));
+        return 0 if nqp::getattr($a, Parameter, '$!sub_signature')
+                 || nqp::getattr($b, Parameter, '$!sub_signature');
+        return 0 if nqp::defined(nqp::getattr($a, Parameter, '$!signature_constraint'))
+                 || nqp::defined(nqp::getattr($b, Parameter, '$!signature_constraint'));
+
+        return 0 unless nqp::eqaddr(
+            nqp::getattr($a, Parameter, '$!type'),
+            nqp::getattr($b, Parameter, '$!type'));
+    }
+    1
+}
+
 # Helper sub to filter out revision-gated multi-candidates
 sub multi-filter-revision-gated-candidates($proto, $caller-revision) {
     my @candidates := $proto.dispatch_order;
@@ -2848,6 +2890,7 @@ sub multi-filter-revision-gated-candidates($proto, $caller-revision) {
     my int $allowed-idx := 0;
     my @allowed-candidates;
     my %gated-candidates;
+    my @gated-idxs;
     while $idx < nqp::elems(@candidates) {
         my $candidate := nqp::atpos(@candidates, $idx++);
 
@@ -2861,23 +2904,43 @@ sub multi-filter-revision-gated-candidates($proto, $caller-revision) {
         my $required-revision := nqp::atkey($candidate, 'required_revision') // $proto-revision;
         if $required-revision <= $caller-revision {
             if nqp::existskey($candidate, 'signature') {
-                my $signature := nqp::atkey($candidate, 'signature').gist;
+                my $sig := nqp::atkey($candidate, 'signature');
+                my $signature := $sig.gist;
 
+                # Find the admitted candidate this one supersedes or is
+                # superseded by. The rendered signature catches the exact
+                # same text cheaply; the structural comparison catches
+                # signatures that differ in parameter names only.
+                my int $candidate-idx := -1;
                 if nqp::existskey(%gated-candidates, $signature) {
-                    my $candidate-idx := nqp::atkey(%gated-candidates, $signature);
+                    $candidate-idx := nqp::atkey(%gated-candidates, $signature);
+                }
+                else {
+                    for @gated-idxs {
+                        if revision-gated-signatures-equivalent($sig,
+                            nqp::atkey(nqp::atpos(@allowed-candidates, $_), 'signature')) {
+                            $candidate-idx := $_;
+                            last;
+                        }
+                    }
+                }
+
+                if $candidate-idx >= 0 {
                     my $last-seen-revision := nqp::atkey(
                         nqp::atpos(@allowed-candidates, $candidate-idx),
                         'required_revision'
                     );
 
                     if $last-seen-revision < $required-revision {
-                        nqp::bindkey(%gated-candidates, $signature, $candidate-idx);
                         nqp::bindpos(@allowed-candidates, $candidate-idx, $candidate);
                         # Do *not* bump $allowed-idx here
                     }
+                    nqp::bindkey(%gated-candidates, $signature, $candidate-idx);
                 } else {
+                    nqp::bindkey(%gated-candidates, $signature, $allowed-idx);
+                    nqp::push(@gated-idxs, $allowed-idx);
                     nqp::push(@allowed-candidates, $candidate);
-                    nqp::bindkey(%gated-candidates, $signature, $allowed-idx++);
+                    $allowed-idx++;
                 }
             } else {
                 nqp::push(@allowed-candidates, $candidate);

--- a/t/02-rakudo/12-multi-revision-gated.t
+++ b/t/02-rakudo/12-multi-revision-gated.t
@@ -1,8 +1,9 @@
 use lib <t/packages/Test-Helpers>;
+use nqp;
 use Test;
 use Test::Helpers;
 
-plan 6;
+plan 8;
 
 my $to-eval = q:to/END/;
 
@@ -53,3 +54,16 @@ END
 
 is-run 'use v6.c;' ~ $clashing-to-eval, :err(*),
         :out("first (6)"), 'same-revision equivalent candidates dispatch to one candidate';
+
+# The compile time redeclaration worry is a RakuAST frontend check.
+if nqp::gethllsym('Raku', 'COMPILER-FRONTEND') eq 'rakuast' {
+    is-run 'use v6.c;' ~ $clashing-to-eval,
+            :err(/'equivalent signatures'/), :out(*),
+            'same-revision equivalent candidates get the redeclaration worry';
+    is-run 'use v6.c;' ~ $renamed-to-eval,
+            :err(''), :out(*),
+            'candidates gated at different revisions do not get the redeclaration worry';
+}
+else {
+    skip 'the redeclaration worry needs the RakuAST frontend', 2;
+}

--- a/t/02-rakudo/12-multi-revision-gated.t
+++ b/t/02-rakudo/12-multi-revision-gated.t
@@ -2,7 +2,7 @@ use lib <t/packages/Test-Helpers>;
 use Test;
 use Test::Helpers;
 
-plan 3;
+plan 6;
 
 my $to-eval = q:to/END/;
 
@@ -21,3 +21,35 @@ is-run 'use v6.d;' ~ $to-eval,
         :out("6.d (7)"), q|is revision-gated("6.d") candidate called for 'use v6.d;'|;
 is-run 'use v6.e.PREVIEW;' ~ $to-eval,
         :out("6.e (8)"), q|is revision-gated("6.e") candidate called for 'use v6.e;'|;
+
+# Superseding a candidate must not require copying its parameter names:
+# the filter compares signatures structurally, not by their rendering.
+my $renamed-to-eval = q:to/END/;
+
+proto sub gated(|) is revision-gated("6.c") {*}
+multi sub gated(Int $x) is revision-gated("6.c") { print "6.c ($x)" }
+multi sub gated(Int $y) is revision-gated("6.e") { print "6.e ({$y+2})" }
+
+gated(6);
+
+END
+
+is-run 'use v6.c;' ~ $renamed-to-eval,
+        :out("6.c (6)"), 'candidates differing in parameter name only supersede (6.c caller)';
+is-run 'use v6.e.PREVIEW;' ~ $renamed-to-eval,
+        :out("6.e (8)"), 'candidates differing in parameter name only supersede (6.e caller)';
+
+# Two candidates gated at the same revision cannot both be dispatched to;
+# one of them wins rather than every call dying as an ambiguous dispatch.
+my $clashing-to-eval = q:to/END/;
+
+proto sub gated(|) is revision-gated("6.c") {*}
+multi sub gated(Int $x) is revision-gated("6.c") { print "first ($x)" }
+multi sub gated(Int $y) is revision-gated("6.c") { print "second ($y)" }
+
+gated(6);
+
+END
+
+is-run 'use v6.c;' ~ $clashing-to-eval, :err(*),
+        :out("first (6)"), 'same-revision equivalent candidates dispatch to one candidate';


### PR DESCRIPTION
Previously the dispatch filter for revision gated protos grouped candidates by their rendered signature, so superseding a candidate at a later language revision only worked when the replacement copied the original's parameter names exactly. With different names both candidates were admitted, and every call from a revision that admits both died at runtime:

```raku
proto sub f(|) is revision-gated("6.c") {*}
multi sub f(Int $x) is revision-gated("6.c") { "old" }
multi sub f(Int $y) is revision-gated("6.e") { "new" }

# use v6.e.PREVIEW callers:
# Ambiguous call to 'f(Int)'; these signatures all match:
#   (Int $x)
#   (Int $y)
```

The first commit keeps the rendered signature as a cheap first comparison and falls back to a structural one: the same parameter shapes and types in the same order, ignoring parameter names. Signatures with named, slurpy, capture or sub-signature parameters, constraints or type captures still require identical text to supersede, since a name-blind comparison cannot vouch for those: a named parameter's name is its interface, and two `where` constraints with identical surroundings cannot be told apart statically. For those shapes the behavior is unchanged. Both filter copies (src/vm/moar/dispatchers.nqp and the BOOTSTRAP one used by other backends) get the same change.

The second commit resolves a TODO in the RakuAST frontend's duplicate multi check. Previously a revision gated proto turned off the equivalent-signature redeclaration worry entirely, because equivalent candidates gated at different revisions are how a routine evolves per language version. That also silenced the worry for candidates clashing within the same revision, which can never both be dispatched to. The check now compares only candidates competing at the same effective revision, with an ungated candidate defaulting to the proto's revision as it does at dispatch time:

```raku
proto sub f(|) is revision-gated("6.c") {*}
multi sub f(Int $x) is revision-gated("6.c") { "first" }
multi sub f(Int $y) is revision-gated("6.c") { "second" }
# now warns: Redeclaration of multi sub 'f' with equivalent signatures ...
```
