### PR TITLE
RakuAST: compile an .AST tree's own unit when EVALing it

### DIFF
--- a/src/Raku/ast/compunit.rakumod
+++ b/src/Raku/ast/compunit.rakumod
@@ -307,6 +307,15 @@ class RakuAST::CompUnit
     # does not declare its own GLOBAL and so forth.
     method is-eval() { $!is-eval ?? True !! False }
 
+    # Put this unit's SC back on the compiling-SC stack before compiling it
+    # again. Creating the unit pushed the SC, but the backend pops it after
+    # every non-nested compile, so a reused unit (an .AST tree EVALed a
+    # second time) would otherwise compile with no compiling SC. A nested
+    # unit shares the enclosing compilation's SC, which is already current.
+    method IMPL-PUSH-COMPILING-SC() {
+        nqp::pushcompsc($!sc) unless $!is-eval == 2;
+    }
+
     # The resolver used to compile this CompUnit, exposed so a later pipeline
     # stage (the optimize stage) can run an AST pass that resolves names.
     method resolver() { $!resolver }

--- a/src/Raku/ast/statements.rakumod
+++ b/src/Raku/ast/statements.rakumod
@@ -533,6 +533,19 @@ class RakuAST::StatementList
     has List $!statements;
     has int $!is-sunk;
     has Mu   $.code-statements;  # internal only: actual code statements
+    has Mu   $!origin-comp-unit; # internal only: set by Cool.AST, see below
+
+    # A statement list handed out by Cool.AST was already begun as part of
+    # its parse's compilation unit, so begin-time state that lives on that
+    # unit's mainline scope (an implicit proto, require's symbol captures)
+    # is not part of the statement list itself. Cool.AST records the unit
+    # here so EVAL can compile it rather than wrap the statement list in a
+    # fresh unit whose mainline lacks that state.
+    method IMPL-SET-ORIGIN-COMP-UNIT(Mu $comp-unit) {
+        nqp::bindattr(self, RakuAST::StatementList, '$!origin-comp-unit',
+          $comp-unit);
+    }
+    method IMPL-ORIGIN-COMP-UNIT() { nqp::ifnull($!origin-comp-unit, Mu) }
 
     method new(*@statements, Bool :$trace) {
         my $obj := nqp::create(self);

--- a/src/core.c/ForeignCode.rakumod
+++ b/src/core.c/ForeignCode.rakumod
@@ -74,9 +74,27 @@ $lang = 'Raku' if $lang eq 'perl6';
     }
 
     if nqp::istype($code, RakuAST::Node) {
-        # Wrap as required to get compilation unit.
+        # Wrap as required to get compilation unit. A unit that already
+        # exists (rather than the wrapper created below, whose creation
+        # pushes its fresh SC) needs its SC put back on the compiling-SC
+        # stack, which the backend pops after each non-nested compile.
+        my $reused-comp-unit := False;
         my $comp-unit := do if nqp::istype($code, RakuAST::CompUnit) {
+            $reused-comp-unit := True;
             $code
+        }
+        # A statement list from Cool.AST was already begun as part of its
+        # parse's compilation unit; begin-time state such as an implicit
+        # proto or require's symbol captures lives on that unit's mainline
+        # scope, not in the statement list. Compile that unit, as wrapping
+        # the (begun, so begin cannot run again) statements in a fresh one
+        # would lose the state. Only when the statement list is still the
+        # unit's own: one transplanted into a user-built tree is theirs.
+        elsif nqp::istype($code, RakuAST::StatementList)
+          && nqp::isconcrete(my $origin := $code.IMPL-ORIGIN-COMP-UNIT)
+          && nqp::eqaddr(nqp::decont($origin.statement-list), nqp::decont($code)) {
+            $reused-comp-unit := True;
+            $origin
         }
         else {
             my $statement-list := do if nqp::istype($code, RakuAST::StatementList) {
@@ -123,6 +141,7 @@ $lang = 'Raku' if $lang eq 'perl6';
         my $optimize-option = nqp::getcomp('Raku').cli-options<optimize> // '';
         $comp-unit.optimize($resolver)
             unless $optimize-option eq 'off' || $optimize-option eq '0';
+        $comp-unit.IMPL-PUSH-COMPILING-SC if $reused-comp-unit;
         $compiled := compile-rakuast-comp-unit($comp-unit);
     }
     else {

--- a/src/core.c/core_epilogue.rakumod
+++ b/src/core.c/core_epilogue.rakumod
@@ -817,11 +817,20 @@ augment class Cool {
           |(:optimize($_) with $compiler.cli-options<optimize>),
           :target<ast>, :compunit_ok(1), :$grammar, :$actions;
 
-        $expression
-          ?? $ast.statement-list.statements.head.expression
-          !! $compunit
-            ?? $ast
-            !! $ast.statement-list
+        if $expression {
+            $ast.statement-list.statements.head.expression
+        }
+        elsif $compunit {
+            $ast
+        }
+        else {
+            # The statements were already begun as part of $ast; record it
+            # so EVAL can compile the unit that holds their begin-time
+            # scope state instead of wrapping them in a fresh one.
+            my $statement-list := $ast.statement-list;
+            $statement-list.IMPL-SET-ORIGIN-COMP-UNIT($ast);
+            $statement-list
+        }
     }
 }
 

--- a/t/12-rakuast/eval.rakutest
+++ b/t/12-rakuast/eval.rakutest
@@ -6,7 +6,7 @@ use lib <t/packages/Test-Helpers>;
 use Test;
 use Test::Helpers;
 
-plan 1;
+plan 7;
 
 # A tree parsed by Str.AST has its code objects stubbed in the parse's
 # abandoned context, so EVALing it at BEGIN time used to leak compiler
@@ -18,6 +18,40 @@ plan 1;
       :out("42\n"),
       :err(""),
       'precompiling a module returning a Str.AST.EVAL Sub from BEGIN works';
+}
+
+# Declaring a multi inside a Str.AST tree used to die at the call site with
+# "lang-call cannot invoke object of type 'VMNull'": the implicit proto's
+# generated declaration lives on the parse unit's mainline scope, which the
+# fresh unit EVAL wrapped the (already begun) statements in did not have.
+# EVAL now compiles the unit the tree was parsed as.
+{
+    is Q| multi keep(Int \v) { v }; multi keep(Str \v) { "s" ~ v }; keep(5) ~ keep("x") |.AST.EVAL,
+      "5sx", 'multis declared inside .AST.EVAL dispatch';
+
+    my $ast = Q| multi keep(Int \v) { v * 2 }; keep(21) |.AST;
+    is $ast.EVAL, 42, 'an .AST tree declaring a multi EVALs';
+    is $ast.EVAL, 42, 'the same .AST tree EVALs a second time';
+}
+
+# require inside a Str.AST tree used to die for the same lost-mainline
+# reason: bare require with "bindkey_o requires a concrete object",
+# require-with-import with "Lexical '&ok' does not exist in this frame".
+{
+    is Q| require Test; 1 |.AST.EVAL, 1,
+      'require inside .AST.EVAL works';
+    is Q| require Test <&ok>; &ok.name |.AST.EVAL, 'ok',
+      'require with import inside .AST.EVAL works';
+}
+
+# The same lost state broke precompilation when the EVAL happened at BEGIN
+# time, since the multi's compiled unit is part of the module's output.
+{
+    (temp %*ENV)<RAKUDO_RAKUAST> = 1;
+    is-run 'use lib <t/packages/12-rakuast/lib>; use ParsedMultiAtBegin; say ParsedMultiAtBegin::bump(41);',
+      :out("42\n"),
+      :err(""),
+      'precompiling a module returning a Str.AST.EVAL multi from BEGIN works';
 }
 
 # vim: expandtab shiftwidth=4

--- a/t/packages/12-rakuast/lib/ParsedMultiAtBegin.rakumod
+++ b/t/packages/12-rakuast/lib/ParsedMultiAtBegin.rakumod
@@ -1,0 +1,7 @@
+# Precompiling this module used to fail: the multi's implicit proto is a
+# generated declaration on the Str.AST parse unit's mainline scope, which
+# was lost when EVAL wrapped the already-begun statements in a fresh unit.
+use MONKEY-SEE-NO-EVAL;
+unit module ParsedMultiAtBegin;
+my $c = BEGIN 'multi keep(Int \v) { v + 1 }; &keep'.AST.EVAL;
+our sub bump($n) { $c($n) }


### PR DESCRIPTION
Previously declaring a multi inside a Str.AST tree died at the call site with "lang-call cannot invoke object of type 'VMNull'", and any require died with "bindkey_o requires a concrete object" or "Lexical '&sym' does not exist in this frame". Cool.AST returns the parsed unit's statement list, whose statements were already begun as part of that unit, so begin-time state living on its mainline scope (the implicit proto's generated declaration, require's symbol captures) was lost when EVAL wrapped the statements in a fresh unit, where begin cannot run again.

Cool.AST now records the parsed unit on the statement list it hands out, and EVAL compiles that unit when the statement list is still the unit's own. A statement list transplanted into a user-built tree is unaffected. Since the backend pops the compiling SC after every non-nested compile, a reused unit pushes its SC back beforehand, which also fixes EVALing the same tree, or an .AST(:compunit) result, more than once.