### PR TITLE
RakuAST: dispatch native-typed constants as native

### DIFF
--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -610,7 +610,40 @@ class RakuAST::VarDeclaration::Constant
     method compile-time-value() { $!value }
 
     method IMPL-LOOKUP-QAST(RakuAST::IMPL::QASTContext $context) {
-        QAST::Var.new(:name($!name), :scope<lexical>)
+        nqp::isnull(my $native := self.IMPL-NATIVE-VALUE-QAST)
+          ?? QAST::Var.new(:name($!name), :scope<lexical>)
+          !! $native
+    }
+
+    # A native-typed constant references a compile-time-known value, so emit
+    # that value as a native primitive rather than a lexical lookup of the
+    # boxed object. A lexical lookup produces an object even for a native
+    # type, which passes the constant as its boxed type at call sites and so
+    # never selects a native candidate; the native primitive passes as native
+    # and auto-boxes wherever an object is wanted. Returns nqp::null when the
+    # value is not the plain native type, in which case the boxed value (which
+    # a native-typed constant keeps unchanged) has to be looked up as-is.
+    method IMPL-NATIVE-VALUE-QAST() {
+        return nqp::null unless $!type;
+        my $native-type := $!type.meta-object;
+        my int $primspec := nqp::objprimspec($native-type);
+        return nqp::null unless $primspec == nqp::const::BIND_VAL_INT
+          || $primspec == nqp::const::BIND_VAL_NUM
+          || $primspec == nqp::const::BIND_VAL_STR;
+        # The boxed companion of a native type sits directly above it in the
+        # MRO (int -> Int, num -> Num, str -> Str); only unbox a value that is
+        # actually one of those.
+        my $mro := $native-type.HOW.mro($native-type);
+        return nqp::null unless nqp::elems($mro) > 1;
+        my $value := nqp::decont($!value);
+        return nqp::null unless nqp::istype($value, nqp::atpos($mro, 1));
+        $primspec == nqp::const::BIND_VAL_INT
+          ?? (nqp::isbig_I($value)
+                ?? nqp::null
+                !! QAST::IVal.new(:value(nqp::unbox_i($value))))
+          !! $primspec == nqp::const::BIND_VAL_NUM
+            ?? QAST::NVal.new(:value(nqp::unbox_n($value)))
+            !! QAST::SVal.new(:value(nqp::unbox_s($value)))
     }
 
     method IMPL-EXPR-QAST(RakuAST::IMPL::QASTContext $context) {
@@ -618,7 +651,7 @@ class RakuAST::VarDeclaration::Constant
     }
 
     method IMPL-TO-QAST(RakuAST::IMPL::QASTContext $context) {
-        QAST::Var.new(:name($!name), :scope<lexical>);
+        self.IMPL-LOOKUP-QAST($context)
     }
 }
 

--- a/t/02-rakudo/constant-native-dispatch.t
+++ b/t/02-rakudo/constant-native-dispatch.t
@@ -1,0 +1,80 @@
+use lib <t/packages/02-rakudo/lib>;
+use nqp;
+use Test;
+
+# A native-typed constant must present its native type at a call site, so a
+# reference to it selects a native multi candidate the same way a native
+# variable does. Previously the reference was compiled as a lookup of the
+# boxed value, which only ever matched the boxed candidate. Selecting a
+# native candidate this way is implemented only on the RakuAST frontend.
+
+my $rakuast := nqp::gethllsym('Raku', 'COMPILER-FRONTEND') eq 'rakuast';
+
+plan 8;
+
+{
+    my int constant PICK = 0;
+    multi foo(int) { 'native' }
+    if $rakuast {
+        is foo(PICK), 'native',
+          'native int constant selects an int multi candidate';
+    }
+    else {
+        skip 'native-typed constant dispatch is NYI on the legacy frontend';
+    }
+}
+
+{
+    my int constant PICK = 5;
+    multi bar(int) { 'native' }
+    multi bar(Int) { 'boxed'  }
+    if $rakuast {
+        is bar(PICK), 'native',
+          'native int constant prefers the int candidate over the Int candidate';
+    }
+    else {
+        skip 'native-typed constant dispatch is NYI on the legacy frontend';
+    }
+}
+
+{
+    my num constant N = 1.5e0;
+    multi baz(num) { 'native' }
+    if $rakuast {
+        is baz(N), 'native',
+          'native num constant selects a num multi candidate';
+    }
+    else {
+        skip 'native-typed constant dispatch is NYI on the legacy frontend';
+    }
+}
+
+{
+    my str constant S = 'hi';
+    multi qux(str) { 'native' }
+    if $rakuast {
+        is qux(S), 'native',
+          'native str constant selects a str multi candidate';
+    }
+    else {
+        skip 'native-typed constant dispatch is NYI on the legacy frontend';
+    }
+}
+
+# The value and its boxed behaviour are unchanged in object context.
+{
+    my int constant I = 42;
+    is I, 42, 'a native int constant reads back its value';
+    is I.^name, 'Int', 'a native int constant boxes to Int in object context';
+    is I + 8, 50, 'a native int constant works in arithmetic';
+}
+
+# A non-native constant is unaffected and still matches its boxed candidate.
+{
+    constant C = 10;
+    multi quux(Int) { 'boxed' }
+    is quux(C), 'boxed',
+      'a non-native constant still selects the boxed candidate';
+}
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously a reference to a native-typed constant compiled to a lexical lookup of the boxed value, so `my int constant PICK = 0; foo PICK` passed an Int and could never select a `foo(int)` candidate. A native multi candidate is only chosen when the argument is intrinsically native at the call site, the way a `my int $x` read is; a boxed lookup never qualifies.

Emit the compile-time-known value of a native-typed constant as a native primitive instead. It passes as native at call sites and auto-boxes wherever an object is wanted. The emission is guarded to the plain native value (matching the type's boxed companion via its MRO, big integers excepted); anything else keeps the boxed lexical lookup, so cross-type initializers stay unchanged.

Fixes #1932