### PR TITLE
RakuAST: literalize an unhandled node to the sentinel, not a die

### DIFF
--- a/src/core.c/RakuAST/Literalize.rakumod
+++ b/src/core.c/RakuAST/Literalize.rakumod
@@ -165,8 +165,10 @@ augment class RakuAST::Node {
 
 #- N ---------------------------------------------------------------------------
 
+    # A node with no more specific candidate is one we cannot turn into a
+    # literal, which is the not-literalizable outcome, not an error.
     multi method literalize(RakuAST::Node:D:) {
-        nqp::die('literalize on ' ~ self.HOW.name(self) ~ ' NYI');
+        alas;
     }
 
 #- Q ---------------------------------------------------------------------------

--- a/t/02-rakudo/literalize-fallback.t
+++ b/t/02-rakudo/literalize-fallback.t
@@ -1,0 +1,20 @@
+use Test;
+
+# An indirect package name built from an expression that is not known at
+# compile time must fail with a proper diagnostic. The literalize fallback
+# for an unhandled node must report "not literalizable", which surfaces here
+# as "not compile-time known", rather than leaking an internal NYI message.
+
+plan 2;
+
+throws-like 'my $*x; class ::($*x ?? "A" !! "B") { }', Exception,
+  message => /'not compile-time known'/,
+  'indirect package name from a runtime expression is reported as not compile-time known';
+
+# The fallback returns the CannotLiteralize sentinel (an undefined type
+# object) instead of throwing when no specific candidate matches.
+{
+    use experimental :rakuast;
+    nok RakuAST::Statement::Empty.new.literalize.defined,
+      'literalize of a node with no specific candidate returns an undefined sentinel';
+}


### PR DESCRIPTION
Previously the catch-all literalize candidate died with "literalize on <type> NYI". That die is not a CannotLiteralize, so the proto's CATCH could not turn it into the sentinel and it leaked out. Building an indirect package name from a runtime expression then reported "literalize on RakuAST::Ternary NYI" instead of that the name is not compile-time known, and RakuDoc config post-processing, which expects an undefined sentinel on failure, met a hard error instead.

A node with no more specific candidate is simply not literalizable, so alas() like every other not-literalizable case, letting the proto return the sentinel the callers already handle.