### PR TITLE
RakuAST: deparse and raku a "will" trait via .phase and .block

### DIFF
--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -2705,10 +2705,10 @@ CODE
         self.syn-trait($ast.IMPL-TRAIT-NAME) ~ ' ' ~ self.deparse($ast.type)
     }
 
-    multi method raku(RakuAST::Trait::Will:D $ast --> Str:D) {
+    multi method deparse(RakuAST::Trait::Will:D $ast --> Str:D) {
         self.syn-trait("will")
-          ~ ' ' ~ self.deparse($ast.type)
-          ~ ' ' ~ self.deparse($ast.expr)
+          ~ ' ' ~ $ast.phase
+          ~ ' ' ~ self.deparse($ast.block)
     }
 
     multi method deparse(RakuAST::Trait::WillBuild:D $ast --> Str:D) {

--- a/src/core.c/RakuAST/Raku.rakumod
+++ b/src/core.c/RakuAST/Raku.rakumod
@@ -1184,7 +1184,7 @@ augment class RakuAST::Node {
     }
 
     multi method raku(RakuAST::Trait::Will:D: --> Str:D) {
-        self!nameds: <type expr>
+        self!nameds: <phase block>
     }
 
     multi method raku(RakuAST::Trait::WillBuild:D: --> Str:D) {

--- a/t/02-rakudo/deparse-will-trait.t
+++ b/t/02-rakudo/deparse-will-trait.t
@@ -1,0 +1,23 @@
+use Test;
+
+# A "will" trait (my $x will begin { }) parses to a RakuAST::Trait::Will,
+# whose attributes are .phase and .block. Both .DEPARSE and .raku used to
+# reference non-existent .type / .expr and threw; check they round-trip.
+
+plan 4;
+
+my $ast := Q/my $x will begin { 42 }/.AST;
+
+my $deparsed := $ast.DEPARSE;
+like $deparsed, /'will begin'/,
+  'a will trait deparses with its phase';
+
+is $deparsed.AST.DEPARSE, $deparsed,
+  'the deparsed source reparses to the same deparse';
+
+my $raku;
+lives-ok { $raku := $ast.raku },
+  'a will trait produces .raku without referencing missing attributes';
+
+like $raku, / 'RakuAST::Trait::Will.new' \s* '(' \s* 'phase' /,
+  'the .raku reconstruction names the trait with its phase';


### PR DESCRIPTION
RakuAST::Trait::Will holds .phase and .block, but both handlers reached for .type and .expr, which it does not have. .raku threw "No such method 'type'", and .DEPARSE had no candidate at all: the deparse method was mistakenly named "raku", so it both shadowed the real .raku and left "will" traits to fall through to the base "Deparsing ... not yet implemented" catcher. So `my $x will begin { }` could be neither deparsed nor reconstructed.

Rename the deparse method and read .phase and .block in both handlers.