### PR TITLE
RakuAST: emit callstatic and chainstatic for bound-once callees

### DIFF
--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -700,14 +700,16 @@ class RakuAST::Node {
 
         # Lowerings that direct code generation rather than replacing the
         # node register their marks here, gated on the optimize pass running.
-        # They each drop a layer of operator dispatch, so the `soft` pragma,
-        # which keeps routines wrappable, turns them off.
+        # They each drop a layer of operator dispatch or pin down a routine
+        # lookup, so the `soft` pragma, which keeps routines wrappable, turns
+        # them off.
         if $result =:= $expr && !self.IMPL-IN-SOFT-SCOPE($resolver) {
             self.IMPL-MARK-NATIVE-INCDEC($resolver, $expr);
             self.IMPL-MARK-NATIVE-METAOP($resolver, $expr);
             self.IMPL-MARK-SCALAR-METAOP($resolver, $expr);
             self.IMPL-MARK-DOT-ASSIGN($resolver, $expr);
             self.IMPL-MARK-RANGE-FOR($resolver, $expr);
+            self.IMPL-MARK-STATIC-CALL($resolver, $expr);
         }
 
         # A replacement stands where the original stood, so it must carry the
@@ -883,6 +885,21 @@ class RakuAST::Node {
         $for.IMPL-SET-CAN-LOWER-RANGE()
             if nqp::isconcrete($operator)
             && self.IMPL-OPERATOR-IS-CORE($resolver, $operator);
+        Nil
+    }
+
+    # Mark a call to a named sub that resolved to a setting routine for a
+    # static callee lookup at code generation. The setting binds each routine
+    # name once and user code cannot rebind it, so the VM may resolve the
+    # lookup a single time and treat the result as a constant. A name declared
+    # in user code stays a plain lookup even when it resolves at compile time,
+    # since its binding may be a fresh clone per scope entry.
+    method IMPL-MARK-STATIC-CALL(RakuAST::Resolver $resolver, Mu $expr) {
+        $expr.IMPL-SET-CALLSTATIC()
+            if nqp::istype($expr, RakuAST::Call::Name)
+            && $expr.name.is-identifier
+            && $expr.is-resolved
+            && nqp::istype($expr.resolution, RakuAST::Declaration::External::Setting);
         Nil
     }
 

--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -710,6 +710,7 @@ class RakuAST::Node {
             self.IMPL-MARK-DOT-ASSIGN($resolver, $expr);
             self.IMPL-MARK-RANGE-FOR($resolver, $expr);
             self.IMPL-MARK-STATIC-CALL($resolver, $expr);
+            self.IMPL-MARK-STATIC-CHAIN($resolver, $expr);
         }
 
         # A replacement stands where the original stood, so it must carry the
@@ -889,41 +890,58 @@ class RakuAST::Node {
     }
 
     # Mark a call to a named sub whose callee lexical is bound once for a
-    # static callee lookup at code generation, so the VM may resolve the
-    # lookup a single time and treat the result as a constant. Two kinds of
-    # callee qualify. A setting routine: the setting binds each routine name
-    # once and user code cannot rebind it. And a compile-time-valued binding
-    # in the outermost scope of the compilation unit (a sub declaration or an
-    # import), since that scope's frame is entered once per load and a sub
-    # declaration cannot be rebound. A declaration without a compile-time
-    # value, like `my &foo`, stays a plain lookup: its binding is free to be
-    # rebound at runtime. A routine declared in a nested scope also stays a
-    # plain lookup, since its enclosing frame is entered many times and each
-    # entry may bind a fresh clone. A callee compiled under the soft pragma
-    # keeps the plain lookup so it stays wrappable.
+    # static callee lookup at code generation.
     method IMPL-MARK-STATIC-CALL(RakuAST::Resolver $resolver, Mu $expr) {
         return Nil unless nqp::istype($expr, RakuAST::Call::Name)
             && $expr.name.is-identifier
             && $expr.is-resolved;
-        my $decl := $expr.resolution;
-        if nqp::istype($decl, RakuAST::Declaration::External::Setting) {
-            $expr.IMPL-SET-CALLSTATIC();
-            return Nil;
-        }
+        $expr.IMPL-SET-CALLSTATIC()
+            if self.IMPL-RESOLUTION-BOUND-ONCE($resolver, $expr.resolution,
+                '&' ~ $expr.name.canonicalize);
+        Nil
+    }
 
-        return Nil unless nqp::istype($decl, RakuAST::CompileTimeValue)
+    # Mark a chaining comparison whose operator's lexical is bound once for a
+    # static callee lookup at code generation.
+    method IMPL-MARK-STATIC-CHAIN(RakuAST::Resolver $resolver, Mu $expr) {
+        return Nil unless nqp::istype($expr, RakuAST::ApplyInfix);
+        my $infix := $expr.infix;
+        return Nil unless nqp::istype($infix, RakuAST::Infix)
+            && $infix.is-resolved
+            && $infix.properties.chain;
+        $infix.IMPL-SET-CHAINSTATIC()
+            if self.IMPL-RESOLUTION-BOUND-ONCE($resolver, $infix.resolution,
+                '&infix' ~ $resolver.IMPL-CANONICALIZE-PAIR($infix.operator));
+        Nil
+    }
+
+    # Whether a resolution's lexical is bound once, so the VM may resolve a
+    # lookup of $name a single time and treat the result as a constant. Two
+    # kinds of binding qualify. A setting routine: the setting binds each
+    # routine name once and user code cannot rebind it. And a
+    # compile-time-valued binding in the outermost scope of the compilation
+    # unit (a sub declaration or an import), since that scope's frame is
+    # entered once per load and a sub declaration cannot be rebound. A
+    # declaration without a compile-time value, like `my &foo`, does not
+    # qualify: its binding is free to be rebound at runtime. Nor does a
+    # routine declared in a nested scope, since its enclosing frame is
+    # entered many times and each entry may bind a fresh clone. Nor does a
+    # callee compiled under the soft pragma, so it stays wrappable.
+    method IMPL-RESOLUTION-BOUND-ONCE(RakuAST::Resolver $resolver, Mu $decl, str $name) {
+        return 1 if nqp::istype($decl, RakuAST::Declaration::External::Setting);
+
+        return 0 unless nqp::istype($decl, RakuAST::CompileTimeValue)
             || nqp::can($decl, 'maybe-compile-time-value');
         my $routine := nqp::istype($decl, RakuAST::CompileTimeValue)
             ?? $decl.compile-time-value
             !! $decl.maybe-compile-time-value;
-        return Nil unless nqp::isconcrete($routine)
+        return 0 unless nqp::isconcrete($routine)
             && nqp::istype($routine, Code)
             && nqp::can($routine, 'soft') && !$routine.soft;
 
         # The nearest scope declaring the name must be the outermost one, and
         # the declaration found there must be the resolution itself, so a
         # shadowing declaration the resolution predates turns the mark off.
-        my str $name := '&' ~ $expr.name.canonicalize;
         my $nearest := nqp::null();
         my $outermost := nqp::null();
         $resolver.find-scope-property(-> $scope {
@@ -933,11 +951,9 @@ class RakuAST::Node {
                 && nqp::isconcrete($scope.find-lexical($name));
             Nil
         });
-        $expr.IMPL-SET-CALLSTATIC()
-            if !nqp::isnull($nearest)
+        !nqp::isnull($nearest)
             && nqp::eqaddr($nearest, $outermost)
-            && nqp::eqaddr($outermost.find-lexical($name), $decl);
-        Nil
+            && nqp::eqaddr($outermost.find-lexical($name), $decl)
     }
 
     # Inline a dot-assignment to an assignment of the method call's result,

--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -888,18 +888,55 @@ class RakuAST::Node {
         Nil
     }
 
-    # Mark a call to a named sub that resolved to a setting routine for a
-    # static callee lookup at code generation. The setting binds each routine
-    # name once and user code cannot rebind it, so the VM may resolve the
-    # lookup a single time and treat the result as a constant. A name declared
-    # in user code stays a plain lookup even when it resolves at compile time,
-    # since its binding may be a fresh clone per scope entry.
+    # Mark a call to a named sub whose callee lexical is bound once for a
+    # static callee lookup at code generation, so the VM may resolve the
+    # lookup a single time and treat the result as a constant. Two kinds of
+    # callee qualify. A setting routine: the setting binds each routine name
+    # once and user code cannot rebind it. And a compile-time-valued binding
+    # in the outermost scope of the compilation unit (a sub declaration or an
+    # import), since that scope's frame is entered once per load and a sub
+    # declaration cannot be rebound. A declaration without a compile-time
+    # value, like `my &foo`, stays a plain lookup: its binding is free to be
+    # rebound at runtime. A routine declared in a nested scope also stays a
+    # plain lookup, since its enclosing frame is entered many times and each
+    # entry may bind a fresh clone. A callee compiled under the soft pragma
+    # keeps the plain lookup so it stays wrappable.
     method IMPL-MARK-STATIC-CALL(RakuAST::Resolver $resolver, Mu $expr) {
-        $expr.IMPL-SET-CALLSTATIC()
-            if nqp::istype($expr, RakuAST::Call::Name)
+        return Nil unless nqp::istype($expr, RakuAST::Call::Name)
             && $expr.name.is-identifier
-            && $expr.is-resolved
-            && nqp::istype($expr.resolution, RakuAST::Declaration::External::Setting);
+            && $expr.is-resolved;
+        my $decl := $expr.resolution;
+        if nqp::istype($decl, RakuAST::Declaration::External::Setting) {
+            $expr.IMPL-SET-CALLSTATIC();
+            return Nil;
+        }
+
+        return Nil unless nqp::istype($decl, RakuAST::CompileTimeValue)
+            || nqp::can($decl, 'maybe-compile-time-value');
+        my $routine := nqp::istype($decl, RakuAST::CompileTimeValue)
+            ?? $decl.compile-time-value
+            !! $decl.maybe-compile-time-value;
+        return Nil unless nqp::isconcrete($routine)
+            && nqp::istype($routine, Code)
+            && nqp::can($routine, 'soft') && !$routine.soft;
+
+        # The nearest scope declaring the name must be the outermost one, and
+        # the declaration found there must be the resolution itself, so a
+        # shadowing declaration the resolution predates turns the mark off.
+        my str $name := '&' ~ $expr.name.canonicalize;
+        my $nearest := nqp::null();
+        my $outermost := nqp::null();
+        $resolver.find-scope-property(-> $scope {
+            $outermost := $scope;
+            $nearest := $scope
+                if nqp::isnull($nearest)
+                && nqp::isconcrete($scope.find-lexical($name));
+            Nil
+        });
+        $expr.IMPL-SET-CALLSTATIC()
+            if !nqp::isnull($nearest)
+            && nqp::eqaddr($nearest, $outermost)
+            && nqp::eqaddr($outermost.find-lexical($name), $decl);
         Nil
     }
 

--- a/src/Raku/ast/call.rakumod
+++ b/src/Raku/ast/call.rakumod
@@ -468,9 +468,9 @@ class RakuAST::Call::Name
         @sigs
     }
 
-    # Set by the optimize pass when the resolved callee is a setting routine,
-    # whose lexical is bound once, so the callee lookup can be compiled as a
-    # static one the VM resolves a single time.
+    # Set by the optimize pass when the resolved callee's lexical is bound
+    # once, so the callee lookup can be compiled as a static one the VM
+    # resolves a single time.
     has int $!callstatic;
 
     method IMPL-SET-CALLSTATIC() {

--- a/src/Raku/ast/call.rakumod
+++ b/src/Raku/ast/call.rakumod
@@ -468,6 +468,15 @@ class RakuAST::Call::Name
         @sigs
     }
 
+    # Set by the optimize pass when the resolved callee is a setting routine,
+    # whose lexical is bound once, so the callee lookup can be compiled as a
+    # static one the VM resolves a single time.
+    has int $!callstatic;
+
+    method IMPL-SET-CALLSTATIC() {
+        nqp::bindattr_i(self, RakuAST::Call::Name, '$!callstatic', 1)
+    }
+
     method IMPL-EXPR-QAST(RakuAST::IMPL::QASTContext $context) {
         my $call := QAST::Op.new( :op('call') );
         if $!name.is-identifier {
@@ -483,6 +492,7 @@ class RakuAST::Call::Name
                     $name := '&' ~ $!name.canonicalize;
                 }
                 $call.name($name);
+                $call.op('callstatic') if $!callstatic;
             }
         }
         else {

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -858,7 +858,7 @@ class RakuAST::Feed
             # for @(*) since if we find that it overrides all other things.
             # But that's todo...soon. :-)
             if nqp::istype($stage, QAST::Op) {
-                if $stage.op eq 'call' {
+                if $stage.op eq 'call' || $stage.op eq 'callstatic' {
                     # It's a call. Stick a call to the current supplier in
                     # as its last argument.
                     $stage.push(QAST::Op.new( :op('call'), $result ));

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -484,6 +484,15 @@ class RakuAST::Infix
         }
     }
 
+    # Set by the optimize pass when the resolved operator's lexical is bound
+    # once, so a chaining operator's callee lookup can be compiled as a
+    # static one the VM resolves a single time.
+    has int $!chainstatic;
+
+    method IMPL-SET-CHAINSTATIC() {
+        nqp::bindattr_i(self, RakuAST::Infix, '$!chainstatic', 1)
+    }
+
     method IMPL-INFIX-QAST(
       RakuAST::IMPL::QASTContext $context,
                               Mu $left-qast,
@@ -514,7 +523,9 @@ class RakuAST::Infix
           # Otherwise, it's called by finding the lexical sub to call, and
           # compiling it as chaining if required.
           !! self.IMPL-SIMPLIFY-REF-ARGS(QAST::Op.new(
-               :op(self.properties.chain ?? 'chain' !! 'call'),
+               :op(self.properties.chain
+                     ?? ($!chainstatic ?? 'chainstatic' !! 'chain')
+                     !! 'call'),
                :$name,
                $left-qast,
                $right-qast

--- a/src/Raku/ast/scoping.rakumod
+++ b/src/Raku/ast/scoping.rakumod
@@ -502,7 +502,8 @@ class RakuAST::LexicalScope
                 # We've been here before (tree with shared bits, presumably).
             }
             elsif nqp::existskey(BOOLIFY_FIRST_CHILD_OPS, $op) ||
-                    $op eq 'call' && nqp::existskey(BOOLIFY_FIRST_CHILD_CALLS, $qast.name) {
+                    ($op eq 'call' || $op eq 'callstatic')
+                    && nqp::existskey(BOOLIFY_FIRST_CHILD_CALLS, $qast.name) {
                 my int $first := 1;
                 for @($qast) {
                     if $first {
@@ -522,7 +523,9 @@ class RakuAST::LexicalScope
                  # Don't wrap a flattening arg (the synthetic FLATTENABLE_LIST/
                  # HASH calls): :flat must stay on the real result, not on a
                  # FATALIZE wrapper. The operand is still fatalized above.
-                 if !$bool-context && ($op eq 'call' || $op eq 'callmethod') && !$qast.flat {
+                 if !$bool-context
+                    && ($op eq 'call' || $op eq 'callstatic' || $op eq 'callmethod')
+                    && !$qast.flat {
                     if $qast.name eq '&fail' {
                         $qast.name('&die');
                     }

--- a/t/08-performance/18-rakuast-callstatic.t
+++ b/t/08-performance/18-rakuast-callstatic.t
@@ -1,0 +1,67 @@
+use lib <t/packages/Test-Helpers>;
+use Test::Helpers::QAST;
+use Test;
+use QAST:from<NQP>;
+use nqp;
+plan 9;
+
+# A call to a named setting routine compiles its callee lookup as a static
+# one, which the VM may resolve a single time. A routine declared in user
+# code keeps the plain lookup, since its binding may be a fresh clone per
+# scope entry.
+
+sub qast-op-named (Mu $qast, Str:D $op, Str:D $name --> Bool:D) {
+    if nqp::istype($qast, QAST::Op) && $qast.op eq $op && $qast.name eq $name {
+        return True;
+    }
+    elsif qast-descendable $qast {
+        for $qast.list {
+            qast-op-named $_, $op, $name and return True;
+        }
+    }
+    False
+}
+
+# These observe the emitted QAST.
+qast-is 'my $x = 1; say $x', -> \v {
+        qast-op-named(v, 'callstatic', '&say')
+    and not qast-op-named(v, 'call', '&say')
+}, 'a call to a setting routine compiles to a static callee lookup';
+
+qast-is 'my $s = "hi"; chars $s', -> \v {
+        qast-op-named(v, 'callstatic', '&chars')
+    and not qast-op-named(v, 'call', '&chars')
+}, 'a setting routine whose value is used compiles to a static callee lookup';
+
+qast-is '{ my sub f($x) { return $x + 1 }; f(1) }', :full, -> \v {
+        qast-op-named(v, 'call', '&f')
+    and not qast-op-named(v, 'callstatic', '&f')
+}, 'a call to a nested user routine keeps the plain callee lookup';
+
+# These observe that statically looked up callees still behave.
+{
+    my $s = "HI";
+    is chars($s), 2, 'a setting routine called by name returns its value';
+}
+{
+    sub f { return 42; 99 }
+    is f(), 42, 'return unwinds through a static callee lookup';
+}
+{
+    is (gather { take 1; take 2 }).join(','), '1,2',
+        'take reaches the enclosing gather through a static callee lookup';
+}
+{
+    sub g { fail "nope" }
+    ok g() ~~ Failure, 'fail produces a Failure through a static callee lookup';
+}
+{
+    my @a = 1, 2, 3;
+    is elems(@a), 3, 'a multi setting routine called by name returns its value';
+}
+{
+    my $out = do { use soft; my $s = "hi"; uc $s };
+    is $out, 'HI', 'a setting routine still runs under the soft pragma';
+}
+
+# vim: expandtab shiftwidth=4

--- a/t/08-performance/18-rakuast-callstatic.t
+++ b/t/08-performance/18-rakuast-callstatic.t
@@ -3,7 +3,7 @@ use Test::Helpers::QAST;
 use Test;
 use QAST:from<NQP>;
 use nqp;
-plan 18;
+plan 28;
 
 # A call to a named setting routine compiles its callee lookup as a static
 # one, which the VM may resolve a single time. So does a call to a routine
@@ -67,6 +67,25 @@ qast-is 'my &foo = sub { 1 }; foo()', -> \v {
     and not qast-op-named(v, 'callstatic', '&foo')
 }, 'a call through a routine variable keeps the plain callee lookup';
 
+# A single comparison is a static lookup under both frontends, though they
+# differ in shape: the legacy optimizer first rewrites the one-link chain
+# to a plain call.
+qast-is 'my $a = 1; my $b = 2; $a == $b', -> \v {
+    (qast-op-named(v, 'chainstatic', '&infix:<==>')
+        or qast-op-named(v, 'callstatic', '&infix:<==>'))
+    and not qast-op-named(v, 'chain', '&infix:<==>')
+    and not qast-op-named(v, 'call', '&infix:<==>')
+}, 'a comparison against a setting operator compiles to a static callee lookup';
+
+qast-is 'my $a = 1; my $b = 2; my $c = 3; $a == $b == $c', -> \v {
+        qast-op-named(v, 'chainstatic', '&infix:<==>')
+    and not qast-op-named(v, 'chain', '&infix:<==>')
+}, 'a chained comparison against a setting operator compiles to static chain links';
+
+qast-is '{ my multi sub infix:<==>(\a, \b) { return 3 }; my $x = "a"; my $y = "b"; $x == $y }', :full, -> \v {
+    not qast-op-named(v, 'chainstatic', '&infix:<==>')
+}, 'a comparison against a nested user operator keeps the plain lookup';
+
 # These observe that statically looked up callees still behave.
 {
     my $s = "HI";
@@ -82,7 +101,9 @@ qast-is 'my &foo = sub { 1 }; foo()', -> \v {
 }
 {
     sub g { fail "nope" }
-    ok g() ~~ Failure, 'fail produces a Failure through a static callee lookup';
+    my $f = g();
+    ok $f ~~ Failure, 'fail produces a Failure through a static callee lookup';
+    $f.so;
 }
 {
     my @a = 1, 2, 3;
@@ -105,5 +126,29 @@ is rt-fact(5), 120, 'a recursive outermost-scope sub computes through static loo
 is rt-mf(1), 1, 'a multi called with an Int picks the Int candidate';
 is rt-mf("x"), 2, 'a multi called with a Str picks the Str candidate';
 is rt-add(5), 15, 'an outermost-scope sub closing over a mainline lexical reads it';
+
+# Chained comparisons still follow the chaining protocol through static
+# operator lookups.
+my $lo = 1;
+my $mid = 2;
+my $hi = 3;
+ok $lo < $mid < $hi, 'a true chained comparison holds through static links';
+nok $lo < $hi < $mid, 'a false chained comparison fails through static links';
+my $rt-mid-calls = 0;
+sub rt-mid { $rt-mid-calls++; 2 }
+ok 1 < rt-mid() < 3, 'a chained comparison with a call in the middle holds';
+is $rt-mid-calls, 1, 'the middle operand of a chained comparison runs once';
+ok ?(any(1, 2) < 3), 'a Junction autothreads through a static comparison';
+
+# The fatalize pass recognizes a static callee lookup both as a call whose
+# Failure it promotes and as a boolifying consumer that disarms its argument.
+sub rt-will-fail() { fail 'nope' }
+{
+    sub rt-nested-fail() { fail 'nope' }
+    lives-ok { use fatal; my $x = defined rt-nested-fail(); 1 },
+        'use fatal respects defined through a static callee lookup';
+}
+dies-ok { use fatal; my $x = rt-will-fail(); 1 },
+    'use fatal promotes a Failure from a static callee lookup';
 
 # vim: expandtab shiftwidth=4

--- a/t/08-performance/18-rakuast-callstatic.t
+++ b/t/08-performance/18-rakuast-callstatic.t
@@ -3,12 +3,15 @@ use Test::Helpers::QAST;
 use Test;
 use QAST:from<NQP>;
 use nqp;
-plan 9;
+plan 18;
 
 # A call to a named setting routine compiles its callee lookup as a static
-# one, which the VM may resolve a single time. A routine declared in user
-# code keeps the plain lookup, since its binding may be a fresh clone per
-# scope entry.
+# one, which the VM may resolve a single time. So does a call to a routine
+# bound once in the outermost scope of the compilation unit: a sub
+# declaration, which cannot be rebound, or an import, which is installed
+# once at load. A `my &f` variable keeps the plain lookup since it can be
+# rebound at runtime, and so does a routine declared in a nested scope,
+# whose enclosing frame may bind a fresh clone per entry.
 
 sub qast-op-named (Mu $qast, Str:D $op, Str:D $name --> Bool:D) {
     if nqp::istype($qast, QAST::Op) && $qast.op eq $op && $qast.name eq $name {
@@ -38,6 +41,32 @@ qast-is '{ my sub f($x) { return $x + 1 }; f(1) }', :full, -> \v {
     and not qast-op-named(v, 'callstatic', '&f')
 }, 'a call to a nested user routine keeps the plain callee lookup';
 
+qast-is 'sub foo($x) { return $x }; foo(1)', -> \v {
+        qast-op-named(v, 'callstatic', '&foo')
+    and not qast-op-named(v, 'call', '&foo')
+}, 'a call to a sub declared in the outermost scope compiles to a static callee lookup';
+
+qast-is 'multi sub mf(Int $x) { return 1 }; multi sub mf(Str $x) { return 2 }; mf(1)', -> \v {
+        qast-op-named(v, 'callstatic', '&mf')
+    and not qast-op-named(v, 'call', '&mf')
+}, 'a call to a multi declared in the outermost scope compiles to a static callee lookup';
+
+# The recursive call inside the sub is not asserted on: the sub's own name
+# is visible in its own scope, so the mark declines it there.
+qast-is 'sub fact($n) { return 1 if $n < 2; fact($n - 1) * $n }; fact(5)', -> \v {
+    qast-op-named(v, 'callstatic', '&fact')
+}, 'the outer call to a recursive sub compiles to a static callee lookup';
+
+qast-is 'use Test; plan 1', -> \v {
+        qast-op-named(v, 'callstatic', '&plan')
+    and not qast-op-named(v, 'call', '&plan')
+}, 'a call to an imported routine compiles to a static callee lookup';
+
+qast-is 'my &foo = sub { 1 }; foo()', -> \v {
+        qast-op-named(v, 'call', '&foo')
+    and not qast-op-named(v, 'callstatic', '&foo')
+}, 'a call through a routine variable keeps the plain callee lookup';
+
 # These observe that statically looked up callees still behave.
 {
     my $s = "HI";
@@ -63,5 +92,18 @@ qast-is '{ my sub f($x) { return $x + 1 }; f(1) }', :full, -> \v {
     my $out = do { use soft; my $s = "hi"; uc $s };
     is $out, 'HI', 'a setting routine still runs under the soft pragma';
 }
+# These subs live in the test file's outermost scope so the calls below
+# exercise the static lookup path at runtime. Their names are distinct from
+# the ones in the compiled snippets above, which share this file's context.
+my $base = 10;
+sub rt-fact($n) { return 1 if $n < 2; rt-fact($n - 1) * $n }
+multi sub rt-mf(Int $x) { return 1 }
+multi sub rt-mf(Str $x) { return 2 }
+sub rt-add($x) { $base + $x }
+
+is rt-fact(5), 120, 'a recursive outermost-scope sub computes through static lookups';
+is rt-mf(1), 1, 'a multi called with an Int picks the Int candidate';
+is rt-mf("x"), 2, 'a multi called with a Str picks the Str candidate';
+is rt-add(5), 15, 'an outermost-scope sub closing over a mainline lexical reads it';
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously the RakuAST frontend always emitted plain `call` and `chain` ops for named sub calls and chained comparisons, which look up the callee lexical on every call. The legacy optimizer instead emits `callstatic` and `chainstatic` when the callee binding cannot change, which on MoarVM compiles the lookup as `getlexstatic_o` so the VM may resolve it a single time and treat the callee as a constant.

This adds optimize pass marks (`IMPL-MARK-STATIC-CALL`, `IMPL-MARK-STATIC-CHAIN`) that flag a resolved `RakuAST::Call::Name` or a chaining `RakuAST::Infix`, and code generation then emits the static op. Both share one bound-once test, `IMPL-RESOLUTION-BOUND-ONCE`. Two kinds of callee qualify, matching the legacy optimizer's conditions:

* A setting routine. The setting binds each routine name once and user code cannot rebind it.
* A compile-time valued binding in the outermost scope of the compilation unit, which covers sub declarations, multis, and imports. That scope's frame is entered once per load and a sub declaration cannot be rebound. The nearest scope declaring the name must be the outermost one and the declaration found there must be the resolution itself, so a shadowing declaration or a nested routine declines the mark.

A `my &foo` variable keeps the plain lookup since its declaration has no compile-time value and it can be rebound at runtime. A callee compiled under the `soft` pragma keeps the plain lookup so it stays wrappable, as does everything under `--optimize=off`. Two divergences from the legacy optimizer are deliberate: a recursive call keeps the plain lookup since the routine's own name is visible in its own scope, and a one-link chain compiles to `chainstatic` where legacy first rewrites it to a plain call and emits `callstatic`.

The feed operator appends the fed value to a stage call by matching the stage call's op, so it now accepts `callstatic` alongside `call`. Without that a feed stage like `==> map(&flip)` silently lost its input.