### PR TITLE
RakuAST: reduce a smartmatch against a type object to a type check

### DIFF
--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -698,6 +698,10 @@ class RakuAST::Node {
             $result := self.IMPL-FOLD-CONSTANT($resolver, $expr);
         }
 
+        if $result =:= $expr {
+            $result := self.IMPL-COLLAPSE-TYPEMATCH($resolver, $expr);
+        }
+
         # Lowerings that direct code generation rather than replacing the
         # node register their marks here, gated on the optimize pass running.
         # They each drop a layer of operator dispatch or pin down a routine
@@ -954,6 +958,108 @@ class RakuAST::Node {
         !nqp::isnull($nearest)
             && nqp::eqaddr($nearest, $outermost)
             && nqp::eqaddr($outermost.find-lexical($name), $decl)
+    }
+
+    # A smartmatch against a compile-time-known type object reduces to a type
+    # check. The setting's ACCEPTS for a type object is nqp::istype of the
+    # topic against it, and istype itself runs a subset's refinement and
+    # honors definite and coercion types, so the reduction preserves the
+    # match. It is only valid when no user ACCEPTS candidate could dispatch
+    # instead, which the setting's own IS-SETTING-ONLY answers, ignoring
+    # candidates that need a defined invocant since the matcher here is a
+    # type object. A concrete Junction topic autothreads over ACCEPTS, so
+    # code generation guards the fast path with a runtime Junction test,
+    # unless the matcher is Junction itself, which istype answers directly.
+    # A topic that is itself a compile-time value decides the match here and
+    # the whole expression becomes that constant; a subset is excluded from
+    # that, since its refinement may depend on runtime state. Only a lone
+    # match qualifies: a link of a longer comparison chain must stay a chain
+    # op. The soft pragma turns the reduction off, since it bypasses the
+    # operator and ACCEPTS routines that wrapping relies on.
+    method IMPL-COLLAPSE-TYPEMATCH(RakuAST::Resolver $resolver, Mu $expr) {
+        # The checks introspect meta-objects the walk has no say over, so a
+        # surprise from an unusual one declines rather than breaks the build.
+        CATCH {
+            return $expr;
+        }
+
+        # A lone application of the smartmatch operator.
+        return $expr unless nqp::istype($expr, RakuAST::ApplyInfix);
+        my $infix := $expr.infix;
+        return $expr unless nqp::istype($infix, RakuAST::Infix)
+            && $infix.is-resolved;
+        my str $op := $infix.operator;
+        my int $negated := $op eq '!~~';
+        return $expr unless $negated || $op eq '~~';
+        my $left := $expr.left;
+        return $expr if nqp::istype($left, RakuAST::ApplyInfix)
+            && nqp::istype($left.infix, RakuAST::Infix)
+            && $left.infix.properties.chain;
+        return $expr if nqp::istype(self, RakuAST::ApplyInfix)
+            && nqp::istype(self.infix, RakuAST::Infix)
+            && self.infix.properties.chain
+            && nqp::eqaddr(self.left, $expr);
+
+        # A compile-time-known, non-generic type object on the right.
+        my $right := $expr.right;
+        return $expr unless $right.has-compile-time-value;
+        my $type := $right.maybe-compile-time-value;
+        return $expr if nqp::isconcrete($type);
+        my $how := $type.HOW;
+        return $expr unless nqp::can($how, 'archetypes');
+        my $archetypes := $how.archetypes($type);
+        return $expr if $archetypes.generic;
+
+        my $Junction := self.IMPL-OPTIMIZE-SETTING-TYPE($resolver, 'Junction');
+        my $Bool     := self.IMPL-OPTIMIZE-SETTING-TYPE($resolver, 'Bool');
+        return $expr if nqp::isnull($Junction) || nqp::isnull($Bool);
+
+        return $expr unless self.IMPL-OPERATOR-IS-CORE($resolver, $infix);
+        return $expr if self.IMPL-IN-SOFT-SCOPE($resolver);
+
+        # No user ACCEPTS candidate may be able to dispatch for the matcher.
+        my $accepts := nqp::tryfindmethod($type, 'ACCEPTS');
+        return $expr unless nqp::isconcrete($accepts)
+            && nqp::can($accepts, 'IS-SETTING-ONLY')
+            && nqp::istrue($accepts.IS-SETTING-ONLY(
+                nqp::const::SIG_ELEM_DEFINED_ONLY));
+
+        # A native topic would need boxing the plain call already provides.
+        return $expr if nqp::objprimspec($left.return-type);
+
+        # A topic known to be a concrete Junction keeps the full smartmatch.
+        my int $left-known := $left.has-compile-time-value;
+        my $left-value;
+        if $left-known {
+            $left-value := $left.maybe-compile-time-value;
+            return $expr if nqp::isconcrete($left-value)
+                && nqp::istype($left-value, $Junction);
+        }
+
+        my int $is-subset := $archetypes.nominalizable
+            && nqp::can($how, 'wrappee-lookup')
+            && !nqp::isnull($how.wrappee-lookup($type, :subset));
+
+        # A known topic decides the match now, unless a subset's refinement
+        # would need to run. The topic must be a foldable operand, the same
+        # bound constant folding uses: a name lookup may claim a compile-time
+        # value that differs from what evaluating it produces, so only a
+        # literal-like topic is trusted.
+        if $left-known && !$is-subset
+            && self.IMPL-FOLDABLE-OPERAND($left)
+            && nqp::can($left-value.HOW, 'archetypes')
+            && !$left-value.HOW.archetypes($left-value).generic
+            && self.IMPL-DROPPABLE($left) && self.IMPL-DROPPABLE($right) {
+            my int $matches := nqp::istype($left-value, $type);
+            $matches := nqp::not_i($matches) if $negated;
+            return RakuAST::Literal.from-value(nqp::hllboolfor($matches, 'Raku'));
+        }
+
+        # Mark for code generation; the matcher being a Junction needs no
+        # runtime guard.
+        $infix.IMPL-SET-TYPEMATCH($type,
+            nqp::istype($type, $Junction) ?? nqp::null() !! $Junction);
+        $expr
     }
 
     # Inline a dot-assignment to an assignment of the method call's result,

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -493,11 +493,65 @@ class RakuAST::Infix
         nqp::bindattr_i(self, RakuAST::Infix, '$!chainstatic', 1)
     }
 
+    # Set by the optimize pass when this smartmatch reduces to a type check:
+    # the type matched against, and the Junction type for the runtime topic
+    # guard, or null when the matcher is Junction itself and needs no guard.
+    has int $!typematch;
+    has Mu $!typematch-type;
+    has Mu $!typematch-junction;
+
+    method IMPL-SET-TYPEMATCH(Mu $type, Mu $junction) {
+        nqp::bindattr_i(self, RakuAST::Infix, '$!typematch', 1);
+        nqp::bindattr(self, RakuAST::Infix, '$!typematch-type', $type);
+        nqp::bindattr(self, RakuAST::Infix, '$!typematch-junction', $junction);
+    }
+
+    # A smartmatch the optimize pass reduced to a type check. The topic is
+    # bound to a local so the Junction guard and the check evaluate it once.
+    # A concrete Junction topic autothreads over the matcher's ACCEPTS, so it
+    # takes BOOLIFY-ACCEPTS, as the setting's smartmatch does for that case;
+    # any other topic takes the plain type check.
+    method IMPL-TYPEMATCH-QAST(RakuAST::IMPL::QASTContext $context, Mu $left-qast) {
+        my int $negated := $!operator eq '!~~';
+        $context.ensure-sc($!typematch-type);
+        my str $tmp := QAST::Node.unique('typematch_topic');
+        my $topic := QAST::Var.new( :name($tmp), :scope<local> );
+        my $istype := QAST::Op.new( :op<istype>, $topic,
+            QAST::WVal.new( :value($!typematch-type) ) );
+        $istype := QAST::Op.new( :op<not_i>, $istype ) if $negated;
+        my $check := QAST::Op.new( :op<hllbool>, $istype );
+        unless nqp::isnull($!typematch-junction) {
+            $context.ensure-sc($!typematch-junction);
+            my $negate-value := nqp::hllboolfor($negated, 'Raku');
+            $context.ensure-sc($negate-value);
+            $check := QAST::Op.new(
+                :op<if>,
+                QAST::Op.new(
+                    :op<if>,
+                    QAST::Op.new( :op<istype>, $topic,
+                        QAST::WVal.new( :value($!typematch-junction) ) ),
+                    QAST::Op.new( :op<isconcrete>, $topic )),
+                QAST::Op.new(
+                    :op<callmethod>, :name<BOOLIFY-ACCEPTS>,
+                    $topic,
+                    QAST::WVal.new( :value($!typematch-type) ),
+                    QAST::WVal.new( :value($negate-value) )),
+                $check);
+        }
+        QAST::Stmts.new(
+            QAST::Op.new( :op<bind>,
+                QAST::Var.new( :name($tmp), :scope<local>, :decl<var> ),
+                $left-qast),
+            $check)
+    }
+
     method IMPL-INFIX-QAST(
       RakuAST::IMPL::QASTContext $context,
                               Mu $left-qast,
                               Mu $right-qast
     ) {
+        return self.IMPL-TYPEMATCH-QAST($context, $left-qast) if $!typematch;
+
         # Operators that map directly into a QAST op
         my constant QAST-OP := nqp::hash(
           '||',  'unless',

--- a/t/08-performance/19-rakuast-typematch.t
+++ b/t/08-performance/19-rakuast-typematch.t
@@ -1,0 +1,95 @@
+use lib <t/packages/Test-Helpers>;
+use Test::Helpers::QAST;
+use Test;
+use QAST:from<NQP>;
+use nqp;
+plan 22;
+
+# A smartmatch against a compile-time-known type object reduces to a type
+# check guarded by a runtime Junction test on the topic. A matcher with a
+# user ACCEPTS candidate, a matcher only known at runtime, and a link of a
+# longer comparison chain all keep the full smartmatch.
+
+sub qast-op-named (Mu $qast, Str:D $op, Str:D $name --> Bool:D) {
+    if nqp::istype($qast, QAST::Op) && $qast.op eq $op && $qast.name eq $name {
+        return True;
+    }
+    elsif qast-descendable $qast {
+        for $qast.list {
+            qast-op-named $_, $op, $name and return True;
+        }
+    }
+    False
+}
+
+# These observe the emitted QAST.
+qast-is 'my $x = 5; my $r = $x ~~ Int', -> \v {
+        qast-contains-op(v, 'istype')
+    and not qast-op-named(v, 'chain', '&infix:<~~>')
+    and not qast-op-named(v, 'chainstatic', '&infix:<~~>')
+    and not qast-op-named(v, 'call', '&infix:<~~>')
+    and not qast-op-named(v, 'callstatic', '&infix:<~~>')
+}, 'a smartmatch against a type object compiles to a type check';
+
+qast-is 'my $x = 5; my $r = $x !~~ Int', -> \v {
+    qast-contains-op(v, 'istype') and qast-contains-op(v, 'not_i')
+}, 'a negated smartmatch against a type object compiles to a negated type check';
+
+qast-is 'my $x = 5; my $r = $x ~~ Int', -> \v {
+    qast-contains-callmethod(v, 'BOOLIFY-ACCEPTS')
+}, 'the type check carries a Junction fallback for the topic';
+
+qast-is 'my $x = 5; my $r = $x ~~ Junction', -> \v {
+        qast-contains-op(v, 'istype')
+    and not qast-contains-callmethod(v, 'BOOLIFY-ACCEPTS')
+}, 'a match against Junction itself needs no fallback';
+
+qast-is 'my $r = 42 ~~ Int', -> \v {
+        not qast-contains-op(v, 'istype')
+    and not qast-op-named(v, 'chain', '&infix:<~~>')
+    and not qast-op-named(v, 'chainstatic', '&infix:<~~>')
+    and not qast-op-named(v, 'call', '&infix:<~~>')
+    and not qast-op-named(v, 'callstatic', '&infix:<~~>')
+}, 'a smartmatch of two compile-time values folds to a constant';
+
+qast-is 'subset TmEven of Int where * %% 2; my $x = 5; my $r = $x ~~ TmEven', -> \v {
+    qast-contains-op(v, 'istype')
+}, 'a smartmatch against a subset compiles to a type check';
+
+qast-is 'class TmW { method ACCEPTS($x) { True } }; my $x = 5; my $r = $x ~~ TmW', -> \v {
+    not qast-contains-op(v, 'istype')
+}, 'a matcher with its own ACCEPTS keeps the full smartmatch';
+
+qast-is 'my $x = 5; my $y = Int; my $r = $x ~~ $y', -> \v {
+    not qast-contains-op(v, 'istype')
+}, 'a matcher only known at runtime keeps the full smartmatch';
+
+# These observe that the reduced match still answers like the full one.
+my $x = 5;
+my Int $u;
+subset RtEven of Int where * %% 2;
+class RtW { method ACCEPTS($x) { True } }
+
+is ($x ~~ Int), True, 'a variable topic matches its type';
+is ($x !~~ Str), True, 'a negated match against a foreign type holds';
+is ($x ~~ Int:D), True, 'a definite type matches a concrete topic';
+is ($u ~~ Int:D), False, 'a definite type rejects an undefined topic';
+is ("5" ~~ Int(Str)), True, 'a coercion type accepts a coercible topic';
+is ($x ~~ RtEven), False, 'a subset runs its refinement';
+is (4 ~~ RtEven), True, 'a subset accepts a refined value';
+is ($x ~~ RtW), True, 'a user ACCEPTS candidate still runs';
+is (any(1, "x") ~~ Int), True, 'an any Junction topic autothreads';
+is (all(1, "x") ~~ Int), False, 'an all Junction topic autothreads';
+is (any(1, "x") !~~ Int), False, 'a negated Junction match negates the whole match';
+is (any(3, 4) ~~ RtEven), True, 'a Junction topic autothreads over a subset';
+{
+    my $calls = 0;
+    sub topic { $calls++; 5 }
+    is "{topic() ~~ Int} $calls", 'True 1', 'the topic is evaluated once';
+}
+# A name lookup may claim a compile-time value that differs from what
+# evaluating it produces, so it must match at runtime rather than fold.
+sub tm-marker() is export { }
+is (EXPORT::ALL:: ~~ Stash), True, 'a package stash topic matches its type at runtime';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously a smartmatch always compiled to a call of the setting's infix:<~~>, which dispatches ACCEPTS and boolifies its result. When the matcher is a compile-time known type object the legacy optimizer instead emits a plain nqp::istype of the topic, which answers identically: istype runs a subset's refinement and honors definite and coercion types.

This adds an optimize pass rewrite for a lone application of the core smartmatch operator whose right side is a compile-time known, non-generic type object with no user ACCEPTS candidate that could dispatch, which the setting's IS-SETTING-ONLY answers. Code generation binds the topic to a local and guards the type check with a runtime Junction test, sending a concrete Junction topic to BOOLIFY-ACCEPTS as the setting's smartmatch does. A topic that is itself a compile-time value decides the match at compile time and the expression folds to that constant, with subsets excluded since their refinement may depend on runtime state. A link of a longer comparison chain, a native topic, and the soft pragma keep the full smartmatch.