### PR TITLE
RakuAST: give a stash reference its stash as compile-time value

### DIFF
--- a/src/Raku/ast/term.rakumod
+++ b/src/Raku/ast/term.rakumod
@@ -23,8 +23,12 @@ class RakuAST::Term::Name
         self.is-resolved && self.resolution.has-compile-time-value
     }
 
+    # A name with a trailing :: is a stash reference: evaluating it produces
+    # the .WHO of the resolved package, so the compile-time value is that
+    # stash, not the package itself.
     method maybe-compile-time-value() {
-        self.resolution.compile-time-value
+        my $value := self.resolution.compile-time-value;
+        $!name.is-package-lookup ?? nqp::who($value) !! $value
     }
 
     method PERFORM-PARSE(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {

--- a/t/02-rakudo/99-misc.t
+++ b/t/02-rakudo/99-misc.t
@@ -2,7 +2,7 @@ use lib <t/packages/Test-Helpers>;
 use Test;
 use Test::Helpers;
 
-plan 13;
+plan 14;
 
 subtest 'IO::Handle.raku.EVAL roundtrips' => {
     plan 7;
@@ -172,5 +172,17 @@ subtest 'trailing paren declarator doc directly after a block', {
 &f.WHY｣),
         'attached',
         'the doc attaches without a separating semicolon';
+}
+
+subtest 'a stash reference used as a compile-time value is the stash', {
+    plan 4;
+    my class Misc99 { class Inner { } }
+    my constant S = Misc99::;
+    ok S ~~ Stash, 'a trailing :: on a class name gives its stash';
+    ok S<Inner>:exists, 'the stash holds the nested package';
+    my constant G = GLOBAL::;
+    ok G ~~ Stash, 'a trailing :: on GLOBAL gives a stash';
+    my constant T = Int;
+    ok T =:= Int, 'a name without a trailing :: keeps its own value';
 }
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously a name with a trailing :: claimed the resolved package as its compile-time value, where evaluating the name produces the .WHO of that package. A consumer of the compile-time value then saw the wrong object: my constant S = Foo::Bar:: bound S to the package where the legacy frontend binds the stash, and a compile-time consumer like the smartmatch type check reduction judged EXPORT::ALL:: ~~ Stash False.

This applies nqp::who to the resolution's value in Term::Name's maybe-compile-time-value when the name is a package lookup, matching what its code generation emits.