### PR TITLE
RakuAST: rewrite a square by the power operator to a multiply

### DIFF
--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -702,6 +702,10 @@ class RakuAST::Node {
             $result := self.IMPL-COLLAPSE-TYPEMATCH($resolver, $expr);
         }
 
+        if $result =:= $expr {
+            $result := self.IMPL-REWRITE-SQUARE($resolver, $expr);
+        }
+
         # Lowerings that direct code generation rather than replacing the
         # node register their marks here, gated on the optimize pass running.
         # They each drop a layer of operator dispatch or pin down a routine
@@ -1060,6 +1064,64 @@ class RakuAST::Node {
         $infix.IMPL-SET-TYPEMATCH($type,
             nqp::istype($type, $Junction) ?? nqp::null() !! $Junction);
         $expr
+    }
+
+    # Squaring by the core power operator becomes a multiply of the operand
+    # with itself: the power routine handles any exponent, bottoming out in a
+    # bignum power or libm pow, where the multiply is a single operation.
+    # Only a plain resolved variable qualifies, so no side effect is
+    # duplicated, and only one whose type rules out a Junction: a junction
+    # squares each eigenstate, but autothreads over both sides of a multiply,
+    # which builds a different junction. A native can never hold one; a boxed
+    # variable qualifies when its declared type and Junction are unrelated.
+    # The multiply emitted must itself be the core one in the node's scope.
+    # The soft pragma turns the rewrite off, since it bypasses the power
+    # routine that wrapping relies on.
+    method IMPL-REWRITE-SQUARE(RakuAST::Resolver $resolver, Mu $expr) {
+        CATCH {
+            return $expr;
+        }
+
+        return $expr unless nqp::istype($expr, RakuAST::ApplyInfix);
+        my $infix := $expr.infix;
+        return $expr unless nqp::istype($infix, RakuAST::Infix)
+            && $infix.is-resolved
+            && $infix.operator eq '**';
+
+        # An exponent that is the literal integer 2.
+        my $right := $expr.right;
+        return $expr unless nqp::istype($right, RakuAST::IntLiteral);
+        my $exp := $right.compile-time-value;
+        return $expr if nqp::isbig_I($exp);
+        return $expr unless nqp::iseq_i(nqp::unbox_i($exp), 2);
+
+        # A plain resolved variable whose type rules out a Junction.
+        my $left := $expr.left;
+        return $expr unless nqp::istype($left, RakuAST::Var::Lexical)
+            && $left.is-resolved;
+        my $type := $left.return-type;
+        unless nqp::objprimspec($type) {
+            my $Junction := self.IMPL-OPTIMIZE-SETTING-TYPE($resolver, 'Junction');
+            return $expr if nqp::isnull($Junction);
+            return $expr if $type =:= Mu;
+            return $expr unless nqp::can($type.HOW, 'archetypes')
+                && !$type.HOW.archetypes($type).generic;
+            return $expr if nqp::istype($type, $Junction)
+                || nqp::istype($Junction, $type);
+        }
+
+        return $expr if self.IMPL-IN-SOFT-SCOPE($resolver);
+        return $expr unless self.IMPL-OPERATOR-IS-CORE($resolver, $infix);
+        my $mul := $resolver.resolve-lexical('&infix:<*>');
+        return $expr unless nqp::isconcrete($mul)
+            && nqp::istype($mul, RakuAST::Declaration::External::Setting);
+
+        my $mul-op := RakuAST::Infix.new('*');
+        $mul-op.set-resolution($mul);
+        my $product := RakuAST::ApplyInfix.new(
+            :left($left), :infix($mul-op), :right($left));
+        $product.set-origin($expr.origin) if nqp::isconcrete($expr.origin);
+        $product
     }
 
     # Inline a dot-assignment to an assignment of the method call's result,

--- a/t/08-performance/20-rakuast-square-multiply.t
+++ b/t/08-performance/20-rakuast-square-multiply.t
@@ -1,0 +1,83 @@
+use lib <t/packages/Test-Helpers>;
+use Test::Helpers::QAST;
+use Test;
+use QAST:from<NQP>;
+use nqp;
+plan 13;
+
+# Squaring by the core power operator becomes a multiply of the operand with
+# itself when the operand is a plain variable whose type rules out a
+# Junction. Anything else keeps the power routine.
+
+sub qast-op-named (Mu $qast, Str:D $op, Str:D $name --> Bool:D) {
+    if nqp::istype($qast, QAST::Op) && $qast.op eq $op && $qast.name eq $name {
+        return True;
+    }
+    elsif qast-descendable $qast {
+        for $qast.list {
+            qast-op-named $_, $op, $name and return True;
+        }
+    }
+    False
+}
+
+# These observe the emitted QAST.
+qast-is 'my Int $x = 7; my $y = $x ** 2', -> \v {
+        qast-contains-call(v, '&infix:<*>')
+    and not qast-contains-call(v, '&infix:<**>')
+}, 'squaring a typed variable compiles to a multiply';
+
+qast-is 'my num $x = 2e0; my $y = $x ** 2', -> \v {
+        qast-contains-call(v, '&infix:<*>')
+    and not qast-contains-call(v, '&infix:<**>')
+}, 'squaring a native variable compiles to a multiply';
+
+qast-is 'my Int $x = 7; my $y = $x ** 3', -> \v {
+    qast-contains-call(v, '&infix:<**>')
+}, 'a different exponent keeps the power routine';
+
+qast-is 'sub f() { 5 }; my $y = f() ** 2', -> \v {
+    qast-contains-call(v, '&infix:<**>')
+}, 'a call operand keeps the power routine';
+
+qast-is 'sub infix:<**>($a, $b) { 42 }; my Int $x = 7; my $y = $x ** 2', -> \v {
+    qast-contains-call(v, '&infix:<**>')
+}, 'a user power operator keeps its call';
+
+# These observe that the rewritten square still answers like the power.
+{
+    my Int $x = 7;
+    is $x ** 2, 49, 'a typed Int square computes the power';
+}
+{
+    my num $x = 1.5e0;
+    is $x ** 2, 2.25e0, 'a native num square computes the power';
+}
+{
+    my Rat $r = 3/2;
+    is $r ** 2, 2.25, 'a typed Rat square computes the power';
+}
+{
+    my Int $x = -3;
+    is $x ** 2, 9, 'a negative base squares to a positive';
+}
+{
+    my $x = 7;
+    is $x ** 2, 49, 'an untyped variable square computes the power';
+}
+{
+    my constant $K = 6;
+    is $K ** 2, 36, 'a sigiled constant square computes the power';
+}
+{
+    my Junction $j = any(1, 2);
+    todo 'the legacy optimizer autothreads a junction square wrongly'
+        unless nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast';
+    nok ($j ** 2) == 2, 'a junction square keeps eigenstate semantics';
+}
+{
+    my Junction $j = any(1, 2);
+    ok ($j ** 2) == 4, 'a junction square squares each eigenstate';
+}
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously $x ** 2 always called the power routine, which handles any exponent and bottoms out in a bignum power for Int and libm pow for Num, where a multiply is a single operation. Measured at 1.4x to 1.7x per operation across Int, Num, and native num operands.

This rewrites a square in the optimize pass when the operand is a plain resolved variable, so no side effect is duplicated, and its type rules out a Junction: a junction squares each eigenstate, but autothreads over both sides of a multiply, which builds a different junction. A native operand can never hold one; a boxed operand qualifies when its declared type and Junction are unrelated. An untyped variable therefore keeps the power routine. The legacy optimizer rewrites any plain variable and autothreads a junction square wrongly, which the type condition avoids rather than inherits.