### PR TITLE
RakuAST: port six legacy optimizer rewrites to the optimize pass

### DIFF
--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -702,6 +702,10 @@ class RakuAST::Node {
             $result := self.IMPL-COLLAPSE-TYPEMATCH($resolver, $expr);
         }
 
+        if $result =:= $expr {
+            $result := self.IMPL-REWRITE-SQUARE($resolver, $expr);
+        }
+
         # Lowerings that direct code generation rather than replacing the
         # node register their marks here, gated on the optimize pass running.
         # They each drop a layer of operator dispatch or pin down a routine
@@ -1060,6 +1064,64 @@ class RakuAST::Node {
         $infix.IMPL-SET-TYPEMATCH($type,
             nqp::istype($type, $Junction) ?? nqp::null() !! $Junction);
         $expr
+    }
+
+    # Squaring by the core power operator becomes a multiply of the operand
+    # with itself: the power routine handles any exponent, bottoming out in a
+    # bignum power or libm pow, where the multiply is a single operation.
+    # Only a plain resolved variable qualifies, so no side effect is
+    # duplicated, and only one whose type rules out a Junction: a junction
+    # squares each eigenstate, but autothreads over both sides of a multiply,
+    # which builds a different junction. A native can never hold one; a boxed
+    # variable qualifies when its declared type and Junction are unrelated.
+    # The multiply emitted must itself be the core one in the node's scope.
+    # The soft pragma turns the rewrite off, since it bypasses the power
+    # routine that wrapping relies on.
+    method IMPL-REWRITE-SQUARE(RakuAST::Resolver $resolver, Mu $expr) {
+        CATCH {
+            return $expr;
+        }
+
+        return $expr unless nqp::istype($expr, RakuAST::ApplyInfix);
+        my $infix := $expr.infix;
+        return $expr unless nqp::istype($infix, RakuAST::Infix)
+            && $infix.is-resolved
+            && $infix.operator eq '**';
+
+        # An exponent that is the literal integer 2.
+        my $right := $expr.right;
+        return $expr unless nqp::istype($right, RakuAST::IntLiteral);
+        my $exp := $right.compile-time-value;
+        return $expr if nqp::isbig_I($exp);
+        return $expr unless nqp::iseq_i(nqp::unbox_i($exp), 2);
+
+        # A plain resolved variable whose type rules out a Junction.
+        my $left := $expr.left;
+        return $expr unless nqp::istype($left, RakuAST::Var::Lexical)
+            && $left.is-resolved;
+        my $type := $left.return-type;
+        unless nqp::objprimspec($type) {
+            my $Junction := self.IMPL-OPTIMIZE-SETTING-TYPE($resolver, 'Junction');
+            return $expr if nqp::isnull($Junction);
+            return $expr if $type =:= Mu;
+            return $expr unless nqp::can($type.HOW, 'archetypes')
+                && !$type.HOW.archetypes($type).generic;
+            return $expr if nqp::istype($type, $Junction)
+                || nqp::istype($Junction, $type);
+        }
+
+        return $expr if self.IMPL-IN-SOFT-SCOPE($resolver);
+        return $expr unless self.IMPL-OPERATOR-IS-CORE($resolver, $infix);
+        my $mul := $resolver.resolve-lexical('&infix:<*>');
+        return $expr unless nqp::isconcrete($mul)
+            && nqp::istype($mul, RakuAST::Declaration::External::Setting);
+
+        my $mul-op := RakuAST::Infix.new('*');
+        $mul-op.set-resolution($mul);
+        my $product := RakuAST::ApplyInfix.new(
+            :left($left), :infix($mul-op), :right($left));
+        $product.set-origin($expr.origin) if nqp::isconcrete($expr.origin);
+        $product
     }
 
     # Inline a dot-assignment to an assignment of the method call's result,

--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -720,6 +720,7 @@ class RakuAST::Node {
             self.IMPL-MARK-STATIC-CALL($resolver, $expr);
             self.IMPL-MARK-STATIC-CHAIN($resolver, $expr);
             self.IMPL-MARK-RETURN-DECONT($resolver, $expr);
+            self.IMPL-MARK-ARRAY-INIT($resolver, $expr);
         }
 
         # A replacement stands where the original stood, so it must carry the
@@ -932,6 +933,174 @@ class RakuAST::Node {
         $expr.IMPL-SET-ELIDE-RETURN-DECONT()
             if nqp::istype($expr, RakuAST::Routine);
         Nil
+    }
+
+    # Mark the initialization of a plain array from a comma list, both the
+    # declaration form and the assignment form, for lowering to a direct
+    # build of the list internals at code generation, skipping the STORE
+    # dispatch and the intermediate list the comma call builds.
+    method IMPL-MARK-ARRAY-INIT(RakuAST::Resolver $resolver, Mu $expr) {
+        if nqp::istype($expr, RakuAST::ApplyInfix) {
+            # The assignment form emits a runtime type guard with a STORE
+            # fallback, and both branches compile the operands, so an operand
+            # declaring a lexical must keep the plain STORE.
+            my $infix := $expr.infix;
+            $infix.IMPL-SET-LOWERED-ARRAY-INIT()
+                if nqp::istype($infix, RakuAST::Infix)
+                && $infix.operator eq '='
+                && nqp::istype($expr.left, RakuAST::Var::Lexical)
+                && $expr.left.is-resolved
+                && self.IMPL-PLAIN-ARRAY-DECL($expr.left.resolution)
+                && self.IMPL-CORE-COMMA-LIST($resolver, $expr.right)
+                && self.IMPL-DROPPABLE($expr.right);
+        }
+        elsif nqp::istype($expr, RakuAST::VarDeclaration::Simple) {
+            $expr.IMPL-SET-LOWERED-ARRAY-INIT()
+                if self.IMPL-PLAIN-ARRAY-DECL($expr)
+                && nqp::istype($expr.initializer, RakuAST::Initializer::Assign)
+                && self.IMPL-CORE-COMMA-LIST($resolver, $expr.initializer.expression);
+        }
+        Nil
+    }
+
+    # A plain lexical array declaration: no type, shape, where, twigil, or
+    # traits, so its container is the stock Array whose STORE the lowering
+    # replicates. A bind initializer disqualifies it, since the bound value
+    # replaces that container with anything, like a native array.
+    method IMPL-PLAIN-ARRAY-DECL(Mu $decl) {
+        nqp::istype($decl, RakuAST::VarDeclaration::Simple)
+          && $decl.sigil eq '@'
+          && $decl.twigil eq ''
+          && $decl.scope eq 'my'
+          && !nqp::isconcrete($decl.type)
+          && !nqp::isconcrete($decl.shape)
+          && !nqp::isconcrete($decl.where)
+          && !nqp::istype($decl.initializer, RakuAST::Initializer::Bind)
+          && nqp::elems(self.IMPL-UNWRAP-LIST($decl.traits)) == 0
+            ?? 1 !! 0
+    }
+
+    # An application of the core comma operator with plain operands.
+    method IMPL-CORE-COMMA-LIST(RakuAST::Resolver $resolver, Mu $expr) {
+        nqp::istype($expr, RakuAST::ApplyListInfix)
+          && nqp::istype($expr.infix, RakuAST::Infix)
+          && $expr.infix.operator eq ','
+          && nqp::elems(nqp::getattr($expr, RakuAST::ApplyListInfix, '$!adverbs')) == 0
+          && nqp::elems(self.IMPL-UNWRAP-LIST($expr.operands)) > 0
+          && self.IMPL-OPERATOR-IS-CORE($resolver, $expr.infix)
+            ?? 1 !! 0
+    }
+
+    # Whether a QAST subtree tolerates being compiled twice in one frame.
+    # The guarded array initialization places the same operand nodes in
+    # both branches, and compiling a declaration a second time collides
+    # ("Local ... already declared" for the locals a with modifier or an
+    # inlined metaop declares), while a block registers its frame per
+    # compilation. Such operands keep the plain STORE call.
+    method IMPL-QAST-SAFE-TO-RECOMPILE(Mu $qast) {
+        return 0 if nqp::istype($qast, QAST::Block);
+        return 0 if nqp::istype($qast, QAST::Var) && $qast.decl;
+        if nqp::istype($qast, QAST::Node) {
+            for @($qast) {
+                return 0 unless self.IMPL-QAST-SAFE-TO-RECOMPILE($_);
+            }
+        }
+        1
+    }
+
+    # The lowered initialization of a plain array from a comma list: bind a
+    # fresh reification buffer and a reifier whose future is the elements,
+    # then reify, the same layout the STORE method builds through dispatch.
+    # Null when the QAST is not the expected variable and core comma call
+    # shape, or when an operand cannot compile in both guard branches, and
+    # the caller then keeps the STORE call. A fallback, when given, guards
+    # the build behind a runtime check that the variable holds the stock
+    # Array: the declared container can be replaced by a bind, so the
+    # assignment form cannot rely on the declaration's shape.
+    method IMPL-ARRAY-INIT-QAST(Mu $var-qast, Mu $comma-qast, Mu $fallback?) {
+        return nqp::null() if $*COMPILING_CORE_SETTING;
+        return nqp::null() unless nqp::istype($var-qast, QAST::Var)
+            && nqp::istype($comma-qast, QAST::Op)
+            && ($comma-qast.op eq 'call' || $comma-qast.op eq 'callstatic')
+            && $comma-qast.name eq '&infix:<,>';
+        for @($comma-qast) {
+            return nqp::null() if $_.named;
+            return nqp::null()
+                if nqp::isconcrete($fallback)
+                && !self.IMPL-QAST-SAFE-TO-RECOMPILE($_);
+        }
+
+        my $Reifier := nqp::atkey(nqp::who(List), 'Reifier');
+        my $future := QAST::Op.new( :op<list> );
+        $future.set_children(@($comma-qast));
+        my $init := QAST::Stmts.new(
+            QAST::Op.new(
+                :op<callmethod>, :name('reify-until-lazy'),
+                QAST::Op.new(
+                    :op<getattr>,
+                    QAST::Op.new(
+                        :op<p6bindattrinvres>,
+                        QAST::Op.new(
+                            :op<p6bindattrinvres>,
+                            $var-qast,
+                            QAST::WVal.new(:value(List)),
+                            QAST::SVal.new(:value('$!reified')),
+                            QAST::Op.new(:op<create>,
+                                QAST::WVal.new(:value(IterationBuffer))),
+                        ),
+                        QAST::WVal.new(:value(List)),
+                        QAST::SVal.new(:value('$!todo')),
+                        QAST::Op.new(
+                            :op<p6bindattrinvres>,
+                            QAST::Op.new(
+                                :op<p6bindattrinvres>,
+                                QAST::Op.new(
+                                    :op<p6bindattrinvres>,
+                                    QAST::Op.new(:op<create>,
+                                        QAST::WVal.new(:value($Reifier))),
+                                    QAST::WVal.new(:value($Reifier)),
+                                    QAST::SVal.new(:value('$!reified')),
+                                    QAST::Op.new(
+                                        :op<getattr>,
+                                        $var-qast,
+                                        QAST::WVal.new(:value(List)),
+                                        QAST::SVal.new(:value('$!reified')),
+                                    )
+                                ),
+                                QAST::WVal.new(:value($Reifier)),
+                                QAST::SVal.new(:value('$!reification-target')),
+                                QAST::Op.new(
+                                    :op<callmethod>,
+                                    :name('reification-target'),
+                                    $var-qast,
+                                )
+                            ),
+                            QAST::WVal.new(:value($Reifier)),
+                            QAST::SVal.new(:value('$!future')),
+                            $future,
+                        ),
+                    ),
+                    QAST::WVal.new(:value(List)),
+                    QAST::SVal.new(:value('$!todo')),
+                ),
+            ),
+            $var-qast
+        );
+        $init.nosink(1);
+        if nqp::isconcrete($fallback) {
+            $init := QAST::Op.new(
+                :op<if>,
+                QAST::Op.new(
+                    :op<eqaddr>,
+                    QAST::Op.new( :op<what_nd>, $var-qast ),
+                    QAST::WVal.new(:value(Array)),
+                ),
+                $init,
+                $fallback,
+            );
+            $init.nosink(1);
+        }
+        $init
     }
 
     # Whether a resolution's lexical is bound once, so the VM may resolve a

--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -719,6 +719,7 @@ class RakuAST::Node {
             self.IMPL-MARK-RANGE-FOR($resolver, $expr);
             self.IMPL-MARK-STATIC-CALL($resolver, $expr);
             self.IMPL-MARK-STATIC-CHAIN($resolver, $expr);
+            self.IMPL-MARK-RETURN-DECONT($resolver, $expr);
         }
 
         # A replacement stands where the original stood, so it must carry the
@@ -920,6 +921,16 @@ class RakuAST::Node {
         $infix.IMPL-SET-CHAINSTATIC()
             if self.IMPL-RESOLUTION-BOUND-ONCE($resolver, $infix.resolution,
                 '&infix' ~ $resolver.IMPL-CANONICALIZE-PAIR($infix.operator));
+        Nil
+    }
+
+    # Allow a routine to skip its return decontainerization when code
+    # generation can see the body's result is container-free. The shape
+    # check happens at code generation, where the body QAST exists; the mark
+    # only carries that the optimize pass ran.
+    method IMPL-MARK-RETURN-DECONT(RakuAST::Resolver $resolver, Mu $expr) {
+        $expr.IMPL-SET-ELIDE-RETURN-DECONT()
+            if nqp::istype($expr, RakuAST::Routine);
         Nil
     }
 

--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -1193,16 +1193,44 @@ class RakuAST::Node {
     }
 
     # Whether an expression may serve as an operand for compile-time
-    # evaluation: a literal, an enumeration value such as True, or a quoted
-    # string whose value is known at compile time, which is how a plain string
-    # literal parses. Any of these holds no variable reference, so replacing
-    # it cannot orphan a lowered lexical.
+    # evaluation: a literal, an enumeration value such as True, a quoted
+    # string whose value is known at compile time, which is how a plain
+    # string literal parses, or a reference to a constant declaration. A
+    # stash reference (a name with a trailing ::) is left out: it claims
+    # the resolved package as its value where evaluating it produces that
+    # package's stash.
     method IMPL-FOLDABLE-OPERAND(Mu $operand) {
-        nqp::isconcrete($operand)
-          && (nqp::istype($operand, RakuAST::Literal)
-               || (nqp::istype($operand, RakuAST::QuotedString)
-                    || nqp::istype($operand, RakuAST::Term::Enum))
-                  && $operand.has-compile-time-value)
+        return 0 unless nqp::isconcrete($operand);
+        return 1 if nqp::istype($operand, RakuAST::Literal);
+        if nqp::istype($operand, RakuAST::QuotedString)
+            || nqp::istype($operand, RakuAST::Term::Enum) {
+            return $operand.has-compile-time-value ?? 1 !! 0;
+        }
+        if nqp::istype($operand, RakuAST::Term::Name) {
+            return $operand.is-resolved
+                && self.IMPL-CONSTANT-RESOLUTION($operand.resolution)
+                && !$operand.name.is-package-lookup ?? 1 !! 0;
+        }
+        if nqp::istype($operand, RakuAST::Var::Lexical) {
+            return $operand.is-resolved
+                && self.IMPL-CONSTANT-RESOLUTION($operand.resolution) ?? 1 !! 0;
+        }
+        0
+    }
+
+    # Whether a resolution is a genuinely constant declaration, whose
+    # compile-time value is the value evaluating a reference to it produces.
+    # The compile-time-value protocol alone cannot vouch for that: a plain
+    # variable declaration claims a value too, giving its container default.
+    # A containerized value is no constant either: an our-scoped variable
+    # imports as its Scalar container, whose value a later assignment can
+    # replace.
+    method IMPL-CONSTANT-RESOLUTION(Mu $decl) {
+        (nqp::istype($decl, RakuAST::VarDeclaration::Constant)
+          || nqp::istype($decl, RakuAST::VarDeclaration::Implicit::EnumValue)
+          || nqp::istype($decl, RakuAST::Declaration::External::Constant)
+          || nqp::istype($decl, RakuAST::Declaration::ResolvedConstant))
+          && !nqp::iscont($decl.compile-time-value)
             ?? 1 !! 0
     }
 
@@ -1228,9 +1256,8 @@ class RakuAST::Node {
     # Constant folding. Given a child expression, if it is a pure operator
     # applied to constant operands, evaluate it now and return a
     # RakuAST::Literal holding the result. Otherwise the expression is
-    # returned unchanged. Operands must satisfy IMPL-FOLDABLE-OPERAND (never
-    # variables, even constant ones) so folding never removes a variable
-    # reference, which keeps the later lexical-to-local lowering consistent.
+    # returned unchanged. Operands must satisfy IMPL-FOLDABLE-OPERAND, so a
+    # value only known at runtime never feeds an evaluation here.
     # The optimize walk is post-order, so a nested operator that has already
     # folded is itself a literal here, and nested constant arithmetic folds
     # up. Evaluation is guarded: a throw keeps the original runtime behaviour,

--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -706,6 +706,10 @@ class RakuAST::Node {
             $result := self.IMPL-REWRITE-SQUARE($resolver, $expr);
         }
 
+        if $result =:= $expr {
+            $result := self.IMPL-UNROLL-SLICE($resolver, $expr);
+        }
+
         # Lowerings that direct code generation rather than replacing the
         # node register their marks here, gated on the optimize pass running.
         # They each drop a layer of operator dispatch or pin down a routine
@@ -1302,6 +1306,70 @@ class RakuAST::Node {
             :left($left), :infix($mul-op), :right($left));
         $product.set-origin($expr.origin) if nqp::isconcrete($expr.origin);
         $product
+    }
+
+    # A slice of a plain variable by literal integer indexes becomes the
+    # list of the AT-POS calls those indexes dispatch to, dropping the
+    # postcircumfix call and the index list it builds. Only a value use
+    # qualifies: as an assignment target the postcircumfix can extend the
+    # array for an index past the end, where AT-POS cannot, so a slice that
+    # is the left operand of any parent keeps the call. The comma and the
+    # postcircumfix operator must be the core ones in the node's scope.
+    method IMPL-UNROLL-SLICE(RakuAST::Resolver $resolver, Mu $expr) {
+        CATCH {
+            return $expr;
+        }
+
+        return $expr unless nqp::istype($expr, RakuAST::ApplyPostfix);
+        my $postfix := $expr.postfix;
+        return $expr unless nqp::istype($postfix, RakuAST::Postcircumfix::ArrayIndex);
+        return $expr if nqp::isconcrete($postfix.assignee);
+        return $expr if nqp::elems(self.IMPL-UNWRAP-LIST($postfix.colonpairs));
+        return $expr if nqp::can(self, 'left')
+            && nqp::eqaddr(self.left, $expr);
+        my $operand := $expr.operand;
+        return $expr unless nqp::istype($operand, RakuAST::Var::Lexical)
+            && $operand.is-resolved;
+
+        my $semilist := $postfix.index;
+        return $expr unless nqp::istype($semilist, RakuAST::SemiList)
+            && $semilist.IMPL-IS-SINGLE-EXPRESSION;
+        my $statement := self.IMPL-UNWRAP-LIST($semilist.statements)[0];
+        return $expr if nqp::isconcrete($statement.condition-modifier)
+            || nqp::isconcrete($statement.loop-modifier);
+        my $list := $statement.expression;
+        return $expr unless nqp::istype($list, RakuAST::ApplyListInfix)
+            && nqp::istype($list.infix, RakuAST::Infix)
+            && $list.infix.operator eq ','
+            && nqp::elems(nqp::getattr($list, RakuAST::ApplyListInfix, '$!adverbs')) == 0
+            && self.IMPL-OPERATOR-IS-CORE($resolver, $list.infix);
+        my @indexes := self.IMPL-UNWRAP-LIST($list.operands);
+        for @indexes {
+            return $expr unless nqp::istype($_, RakuAST::IntLiteral);
+        }
+
+        return $expr if self.IMPL-IN-SOFT-SCOPE($resolver);
+        my $pc := $resolver.resolve-lexical('&postcircumfix:<[ ]>');
+        return $expr unless nqp::isconcrete($pc)
+            && nqp::istype($pc, RakuAST::Declaration::External::Setting);
+        my $comma := $resolver.resolve-lexical('&infix:<,>');
+        return $expr unless nqp::isconcrete($comma)
+            && nqp::istype($comma, RakuAST::Declaration::External::Setting);
+
+        my @calls;
+        for @indexes {
+            nqp::push(@calls, RakuAST::ApplyPostfix.new(
+                :operand($operand),
+                :postfix(RakuAST::Call::Method.new(
+                    :name(RakuAST::Name.from-identifier('AT-POS')),
+                    :args(RakuAST::ArgList.new($_))))));
+        }
+        my $comma-op := RakuAST::Infix.new(',');
+        $comma-op.set-resolution($comma);
+        my $unrolled := RakuAST::ApplyListInfix.new(
+            :infix($comma-op), :operands(@calls));
+        $unrolled.set-origin($expr.origin) if nqp::isconcrete($expr.origin);
+        $unrolled
     }
 
     # Inline a dot-assignment to an assignment of the method call's result,

--- a/src/Raku/ast/call.rakumod
+++ b/src/Raku/ast/call.rakumod
@@ -543,7 +543,61 @@ class RakuAST::Call::Name
             $call.push(QAST::WVal.new(:value($ret.maybe-compile-time-value)));
         }
 
-        self.IMPL-SIMPLIFY-REF-ARGS($call)
+        my $qast := self.IMPL-SIMPLIFY-REF-ARGS($call);
+        $!callstatic ?? self.IMPL-COPY-RETURNS($qast) !! $qast
+    }
+
+    # Copy the resolved callee's declared return type onto the call node, so
+    # code generation downstream may act on it. A native return is offered
+    # both ways through a Want: boxed for object context and raw for native
+    # context. Only a callee bound once is trusted, the condition the static
+    # callee lookup already established, and a dispatcher is left alone since
+    # its candidates decide their own returns, as is an rw callee, whose
+    # return is its container.
+    method IMPL-COPY-RETURNS(Mu $call) {
+        # The attribute reads assume the stock Routine layout; a routine of
+        # another lineage declines rather than breaks the compile.
+        CATCH {
+            return $call;
+        }
+        my constant BOX-OPS := ['', 'p6box_i', 'p6box_n', 'p6box_s',
+            '', '', '', '', '', '', 'p6box_u'];
+        my constant WANT-FLAGS := ['', 'Ii', 'Nn', 'Ss',
+            '', '', '', '', '', '', 'Ii'];
+        my $decl := self.resolution;
+        return $call unless nqp::istype($decl, RakuAST::CompileTimeValue)
+            || nqp::can($decl, 'maybe-compile-time-value');
+        my $routine := nqp::istype($decl, RakuAST::CompileTimeValue)
+            ?? $decl.compile-time-value
+            !! $decl.maybe-compile-time-value;
+        # An our-scoped callee imports as its Scalar container, whose value a
+        # later assignment can replace, so it promises no return type.
+        return $call if nqp::iscont($routine);
+        return $call unless nqp::isconcrete($routine)
+            && nqp::istype($routine, Routine);
+        # Attribute reads rather than the rw, is_dispatcher, and returns
+        # methods: this runs for every marked call, and dispatching against
+        # the setting's own meta-objects during its compile is pathologically
+        # slow in the compiling process.
+        return $call if nqp::bitand_i(
+            nqp::getattr_i($routine, Routine, '$!flags'), 0x01);
+        return $call if nqp::defined(
+            nqp::getattr($routine, Routine, '@!dispatchees'));
+        my $signature := nqp::getattr($routine, Code, '$!signature');
+        return $call unless nqp::isconcrete($signature);
+        my $returns := nqp::ifnull(
+            nqp::getattr($signature, Signature, '$!returns'), Mu);
+        return $call if $returns =:= Mu;
+        $call.returns($returns);
+        my int $primspec := nqp::objprimspec($returns);
+        if $primspec && BOX-OPS[$primspec] {
+            $call := QAST::Want.new(
+                :named($call.named),
+                QAST::Op.new( :op(BOX-OPS[$primspec]), $call ),
+                WANT-FLAGS[$primspec], $call);
+            $call.returns($returns);
+        }
+        $call
     }
 
     method IMPL-CAN-INTERPRET() {

--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -2258,6 +2258,66 @@ class RakuAST::Routine
         nqp::die('RakuAST::Routine subclass must implement IMPL-COMPILE-BODY')
     }
 
+    # Set by the optimize pass, allowing the return decontainerization to be
+    # skipped when the body's result is provably container-free.
+    has int $!elide-return-decont;
+
+    method IMPL-SET-ELIDE-RETURN-DECONT() {
+        nqp::bindattr_i(self, RakuAST::Routine, '$!elide-return-decont', 1)
+    }
+
+    # The op to decontainerize the fall-through return value with: the given
+    # full one, a plain native decont for a native assignment result, or none
+    # when the result is provably container-free: a boolification, a native
+    # or bigint operation, a native variable read (downgraded here from a
+    # reference to a plain read, which boxes a fresh value), the invocant, or
+    # an uncontainerized constant. Descends statement wrappers to the node
+    # whose value is the body's. An explicit return does not pass through
+    # this op either way, so only the fall-through value is at stake.
+    method IMPL-RETURN-DECONT-OP(Mu $body, str $full) {
+        my $node := $body;
+        while nqp::istype($node, QAST::Stmts) || nqp::istype($node, QAST::Stmt) {
+            my int $n := nqp::elems($node.list);
+            return $full unless $n;
+            my $rc := $node.resultchild;
+            $node := $node[nqp::defined($rc) ?? $rc !! $n - 1];
+        }
+        $node := $node[0]
+            if nqp::istype($node, QAST::Want) && nqp::elems($node.list);
+        if nqp::istype($node, QAST::Op) {
+            my str $op := $node.op;
+            return '' if $op eq 'hllbool' || nqp::eqat($op, 'I', -1);
+            if nqp::eqat($op, 'assign_', 0) {
+                return 'decont_i' if $op eq 'assign_i';
+                return 'decont_n' if $op eq 'assign_n';
+                return 'decont_s' if $op eq 'assign_s';
+                return 'decont_u' if $op eq 'assign_u';
+            }
+            return '' if nqp::eqat($op, '_i', -2) || nqp::eqat($op, '_u', -2)
+                || nqp::eqat($op, '_n', -2) || nqp::eqat($op, '_s', -2);
+        }
+        elsif nqp::istype($node, QAST::Var) {
+            my str $scope := $node.scope;
+            if $scope eq 'lexicalref' {
+                $node.scope('lexical');
+                return '';
+            }
+            if $scope eq 'attributeref' {
+                $node.scope('attribute');
+                return '';
+            }
+            return '' if $scope eq 'lexical' && $node.name eq 'self';
+        }
+        elsif nqp::istype($node, QAST::WVal) {
+            return '' unless nqp::iscont($node.value);
+        }
+        elsif nqp::istype($node, QAST::IVal) || nqp::istype($node, QAST::NVal)
+            || nqp::istype($node, QAST::SVal) {
+            return '';
+        }
+        $full
+    }
+
     method IMPL-WRAP-RETURN-HANDLER(RakuAST::IMPL::QASTContext $context, QAST::Node $body) {
         my $result := $body;
         my $routine := self.compile-time-value;
@@ -2268,8 +2328,18 @@ class RakuAST::Routine
         my str $decont-rv-op := $context.lang-version lt 'd' && $context.is-moar
             ?? 'p6decontrv_6c'
             !! 'p6decontrv';
-        $result := QAST::Op.new( :op($decont-rv-op), QAST::WVal.new( :value($routine) ), $result )
-            unless $routine.rw;
+        unless $routine.rw {
+            my str $decont-op := $!elide-return-decont
+                ?? self.IMPL-RETURN-DECONT-OP($body, $decont-rv-op)
+                !! $decont-rv-op;
+            if $decont-op eq $decont-rv-op {
+                $result := QAST::Op.new( :op($decont-rv-op),
+                    QAST::WVal.new( :value($routine) ), $result );
+            }
+            elsif $decont-op {
+                $result := QAST::Op.new( :op($decont-op), $result );
+            }
+        }
         if $!may-use-return {
             $result := QAST::Op.new(
                 :op<handlepayload>,

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -493,6 +493,14 @@ class RakuAST::Infix
         nqp::bindattr_i(self, RakuAST::Infix, '$!chainstatic', 1)
     }
 
+    # Set by the optimize pass on the assignment of a comma list to a plain
+    # array variable, for lowering to a direct build of the list internals.
+    has int $!lowered-array-init;
+
+    method IMPL-SET-LOWERED-ARRAY-INIT() {
+        nqp::bindattr_i(self, RakuAST::Infix, '$!lowered-array-init', 1)
+    }
+
     # Set by the optimize pass when this smartmatch reduces to a type check:
     # the type matched against, and the Junction type for the runtime topic
     # guard, or null when the matcher is Junction itself and needs no guard.
@@ -625,6 +633,16 @@ class RakuAST::Infix
                 $lhs_ast, $rhs_ast);
         }
         elsif $var_sigil eq '@' || $var_sigil eq '%' {
+            my $lowered := nqp::null();
+            if $!lowered-array-init {
+                my $store := QAST::Op.new(
+                    :op('callmethod'), :name('STORE'),
+                    $lhs_ast, $rhs_ast);
+                $store.nosink(1);
+                $lowered := self.IMPL-ARRAY-INIT-QAST($lhs_ast, $rhs_ast, $store);
+            }
+            return $lowered unless nqp::isnull($lowered);
+
             # While the scalar container store op would end up calling .STORE,
             # it may do it in a nested runloop, which gets pricey. This is a
             # simple heuristic check to try and avoid that by calling .STORE.

--- a/src/Raku/ast/scoping.rakumod
+++ b/src/Raku/ast/scoping.rakumod
@@ -541,7 +541,14 @@ class RakuAST::LexicalScope
                  }
             }
         }
-        elsif nqp::istype($qast, QAST::Block) || nqp::istype($qast, QAST::Stmt) || nqp::istype($qast, QAST::Stmts) || nqp::istype($qast, QAST::Want) {
+        elsif nqp::istype($qast, QAST::Want) {
+            # The alternates render the same computation as the primary in
+            # native kinds, which can never be a Failure, so only the primary
+            # is walked. The primary may appear again as an alternate, and
+            # walking it once keeps the cost linear.
+            self.IMPL-FATALIZE-QAST($qast[0], 0) if nqp::elems($qast.list);
+        }
+        elsif nqp::istype($qast, QAST::Block) || nqp::istype($qast, QAST::Stmt) || nqp::istype($qast, QAST::Stmts) {
             self.IMPL-FATALIZE-QAST($_, 0) for @($qast);
         }
     }

--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -705,6 +705,14 @@ class RakuAST::VarDeclaration::Simple
     has Mu $!container-initializer;
     has Mu $!package;
 
+    # Set by the optimize pass on a plain array declaration initialized from
+    # a comma list, for lowering to a direct build of the list internals.
+    has int $!lowered-array-init;
+
+    method IMPL-SET-LOWERED-ARRAY-INIT() {
+        nqp::bindattr_i(self, RakuAST::VarDeclaration::Simple, '$!lowered-array-init', 1)
+    }
+
     method new(          str :$scope,
                RakuAST::Name :$desigilname!,
                          str :$sigil,
@@ -1687,12 +1695,17 @@ class RakuAST::VarDeclaration::Simple
                                         QAST::Var.new( :$name, :scope<lexical> ),
                                         self.IMPL-EXPLICIT-CONTAINER-VIVIFY-QAST($context, $of) ) );
                                 }
-                                $perform-init-qast := QAST::Op.new(
-                                  :op('callmethod'), :name('STORE'),
-                                  $invocant,
-                                  $init-qast,
-                                  QAST::WVal.new( :named('INITIALIZE'), :value(True) )
-                                );
+                                my $lowered := $!lowered-array-init
+                                    ?? self.IMPL-ARRAY-INIT-QAST($invocant, $init-qast)
+                                    !! nqp::null();
+                                $perform-init-qast := nqp::isnull($lowered)
+                                    ?? QAST::Op.new(
+                                         :op('callmethod'), :name('STORE'),
+                                         $invocant,
+                                         $init-qast,
+                                         QAST::WVal.new( :named('INITIALIZE'), :value(True) )
+                                       )
+                                    !! $lowered;
                             }
                         }
                         else {

--- a/t/08-performance/11-rakuast-constant-folding.t
+++ b/t/08-performance/11-rakuast-constant-folding.t
@@ -3,7 +3,7 @@ use Test::Helpers;
 use Test;
 use experimental :rakuast;
 
-plan 39;
+plan 47;
 
 # Constant folding rewrites a pure operator on constant operands into the
 # literal result. The helper deparses a source after optimizing it, so
@@ -116,9 +116,39 @@ ok optimized-deparse(Q[my &infix:<zlex> = sub ($a, $b) { $a + $b }; my $y = 1 zl
     is (zfold 4 :x(5)), '4,5', 'a pure prefix operator with an adverb keeps its adverb';
 }
 
+# A resolved constant is a foldable operand: its declaration carries the
+# value the name evaluates to.
+ok optimized-deparse(Q[my constant K = 3; my $y = K * 2]).contains('= 6'),
+    'a constant folds as an operand';
+ok optimized-deparse(Q[my constant $K = 3; my $y = $K * 2]).contains('= 6'),
+    'a sigiled constant folds as an operand';
+ok optimized-deparse(Q[my constant K = 3; my $y = 1 + K * 2]).contains('= 7'),
+    'a constant folds up a nested chain';
+ok optimized-deparse(Q[my constant K = "ab"; my $y = K ~ "cd"]).contains('"abcd"'),
+    'a string constant folds as an operand';
+{ my constant K = 3; is K * 2, 6, 'a folded constant operand computes the same value'; }
+
+# A value only claimed at runtime keeps the operator, and so does a stash
+# reference, whose claimed value differs from what evaluating it produces.
+ok optimized-deparse(Q[my $x = 3; my $y = $x * 2]).contains('$x * 2'),
+    'a runtime variable keeps the operator';
+ok optimized-deparse(Q[class FoldPkg { }; my $y = FoldPkg:: eq "x"]).contains('eq'),
+    'a stash reference keeps the operator';
+
 # Str.AST does not optimize, so the operator survives. The scenarios above
 # therefore test the optimize pass, not something upstream.
 ok Q[my $x = 2 + 3].AST.DEPARSE.contains('2 + 3'),
     'the unoptimized tree keeps the operator';
+
+# An our-scoped variable imports as its Scalar container, whose value a
+# later assignment can replace, so it never feeds an evaluation.
+{
+    my $dir = make-temp-dir;
+    $dir.add('FoldContainerConst.rakumod').spurt: 'our $cv = 5';
+    is-deeply
+        EVAL(q[use lib $dir; use FoldContainerConst; $cv = 10; $cv + 1]),
+        11,
+        'an imported our-scoped variable reassigned at runtime computes with the new value';
+}
 
 # vim: expandtab shiftwidth=4

--- a/t/08-performance/20-rakuast-square-multiply.t
+++ b/t/08-performance/20-rakuast-square-multiply.t
@@ -1,0 +1,83 @@
+use lib <t/packages/Test-Helpers>;
+use Test::Helpers::QAST;
+use Test;
+use QAST:from<NQP>;
+use nqp;
+plan 13;
+
+# Squaring by the core power operator becomes a multiply of the operand with
+# itself when the operand is a plain variable whose type rules out a
+# Junction. Anything else keeps the power routine.
+
+sub qast-op-named (Mu $qast, Str:D $op, Str:D $name --> Bool:D) {
+    if nqp::istype($qast, QAST::Op) && $qast.op eq $op && $qast.name eq $name {
+        return True;
+    }
+    elsif qast-descendable $qast {
+        for $qast.list {
+            qast-op-named $_, $op, $name and return True;
+        }
+    }
+    False
+}
+
+# These observe the emitted QAST.
+qast-is 'my Int $x = 7; my $y = $x ** 2', -> \v {
+        qast-contains-call(v, '&infix:<*>')
+    and not qast-contains-call(v, '&infix:<**>')
+}, 'squaring a typed variable compiles to a multiply';
+
+qast-is 'my num $x = 2e0; my $y = $x ** 2', -> \v {
+        qast-contains-call(v, '&infix:<*>')
+    and not qast-contains-call(v, '&infix:<**>')
+}, 'squaring a native variable compiles to a multiply';
+
+qast-is 'my Int $x = 7; my $y = $x ** 3', -> \v {
+    qast-contains-call(v, '&infix:<**>')
+}, 'a different exponent keeps the power routine';
+
+qast-is 'sub f() { 5 }; my $y = f() ** 2', -> \v {
+    qast-contains-call(v, '&infix:<**>')
+}, 'a call operand keeps the power routine';
+
+qast-is 'sub infix:<**>($a, $b) { 42 }; my Int $x = 7; my $y = $x ** 2', -> \v {
+    qast-contains-call(v, '&infix:<**>')
+}, 'a user power operator keeps its call';
+
+# These observe that the rewritten square still answers like the power.
+{
+    my Int $x = 7;
+    is $x ** 2, 49, 'a typed Int square computes the power';
+}
+{
+    my num $x = 1.5e0;
+    is $x ** 2, 2.25e0, 'a native num square computes the power';
+}
+{
+    my Rat $r = 3/2;
+    is $r ** 2, 2.25, 'a typed Rat square computes the power';
+}
+{
+    my Int $x = -3;
+    is $x ** 2, 9, 'a negative base squares to a positive';
+}
+{
+    my $x = 7;
+    is $x ** 2, 49, 'an untyped variable square computes the power';
+}
+{
+    my constant $K = 6;
+    is $K ** 2, 36, 'a sigiled constant square computes the power';
+}
+{
+    my Junction $j = any(1, 2);
+    todo 'the legacy optimizer autothreads a junction square wrongly'
+        unless nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast';
+    nok ($j ** 2) == 2, 'a junction square keeps eigenstate semantics';
+}
+{
+    my Junction $j = any(1, 2);
+    ok ($j ** 2) == 4, 'a junction square squares each eigenstate';
+}
+
+# vim: expandtab shiftwidth=4

--- a/t/08-performance/21-rakuast-return-decont.t
+++ b/t/08-performance/21-rakuast-return-decont.t
@@ -1,0 +1,68 @@
+use lib <t/packages/Test-Helpers>;
+use Test::Helpers::QAST;
+use Test;
+use QAST:from<NQP>;
+use nqp;
+plan 12;
+
+# A routine whose fall-through result is provably container-free skips the
+# return decontainerization, and a native assignment result downgrades it to
+# a plain native decont. A result that may carry a container keeps the full
+# op, as does everything under --optimize=off.
+
+# These observe the emitted QAST.
+qast-is 'sub rd-a() { 42 }', :full, -> \v {
+    not qast-contains-op(v, 'p6decontrv') and not qast-contains-op(v, 'p6decontrv_6c')
+}, 'a literal result skips the return decont';
+
+qast-is 'sub rd-b() { Int }', :full, -> \v {
+    not qast-contains-op(v, 'p6decontrv') and not qast-contains-op(v, 'p6decontrv_6c')
+}, 'a type object result skips the return decont';
+
+qast-is 'my int $i = 3; sub rd-c() { $i }', :full, -> \v {
+    not qast-contains-op(v, 'p6decontrv') and not qast-contains-op(v, 'p6decontrv_6c')
+}, 'a native variable result skips the return decont';
+
+qast-is 'my int $i; sub rd-d() { $i = 5 }', :full, -> \v {
+        qast-contains-op(v, 'decont_i')
+    and not qast-contains-op(v, 'p6decontrv') and not qast-contains-op(v, 'p6decontrv_6c')
+}, 'a native assignment result downgrades to a native decont';
+
+qast-is 'sub rd-e() { my $x = 5; $x }', :full, -> \v {
+    qast-contains-op(v, 'p6decontrv') or qast-contains-op(v, 'p6decontrv_6c')
+}, 'a boxed variable result keeps the return decont';
+
+qast-is 'sub rd-f() { return 1 }; sub rd-g() { rd-f() }', :full, -> \v {
+    qast-contains-op(v, 'p6decontrv') or qast-contains-op(v, 'p6decontrv_6c')
+}, 'a call result keeps the return decont';
+
+# These observe that returns still behave.
+{
+    sub f() { 42 }
+    is f(), 42, 'a literal return gives its value';
+}
+{
+    my int $i = 7;
+    sub f() { $i }
+    is f(), 7, 'a native variable return gives its value';
+}
+{
+    my int $i;
+    sub f() { $i = 5 }
+    is f(), 5, 'a native assignment return gives the assigned value';
+    is $i, 5, 'the native assignment still stores';
+}
+{
+    sub f() { my $x = 5; $x }
+    my $r = f();
+    $r = 9;
+    is f(), 5, 'a returned copy does not alias the inner container';
+}
+{
+    my $x = 5;
+    sub f() is rw { $x }
+    f() = 9;
+    is $x, 9, 'an rw routine still returns its container';
+}
+
+# vim: expandtab shiftwidth=4

--- a/t/08-performance/22-rakuast-copy-returns.t
+++ b/t/08-performance/22-rakuast-copy-returns.t
@@ -1,0 +1,64 @@
+use lib <t/packages/Test-Helpers>;
+use Test::Helpers;
+use Test::Helpers::QAST;
+use Test;
+use QAST:from<NQP>;
+use nqp;
+plan 9;
+
+# A call to a routine bound once carries the callee's declared return type
+# on its QAST, and a native return is offered both boxed and raw through a
+# Want, so a native consumer skips the boxing round trip.
+
+my $rakuast = nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast';
+
+# These observe the emitted QAST. The legacy optimizer does not offer this
+# shape both ways, so the box assertions hold for the RakuAST frontend only.
+todo 'the legacy optimizer does not box a native return through a Want', 2
+    unless $rakuast;
+qast-is 'sub cr-a(--> int) { return 3 }; my int $x = cr-a()', -> \v {
+    qast-contains-op(v, 'p6box_i')
+}, 'a native int return is offered boxed through a Want';
+
+qast-is 'sub cr-b(--> num) { return 3e0 }; my num $x = cr-b()', -> \v {
+    qast-contains-op(v, 'p6box_n')
+}, 'a native num return is offered boxed through a Want';
+
+qast-is 'sub cr-c(--> Int) { return 3 }; my $x = cr-c()', -> \v {
+    not qast-contains-op(v, 'p6box_i')
+}, 'a boxed return type adds no boxing op';
+
+# These observe that returns still behave.
+{
+    sub f(--> int) { return 3 }
+    my int $x = f();
+    is $x, 3, 'a native int return reaches a native target';
+    is f() + 1, 4, 'a native int return computes in object context';
+}
+{
+    sub f(--> num) { return 1.5e0 }
+    is f() * 2, 3e0, 'a native num return computes';
+}
+{
+    sub f(--> str) { return "hi" }
+    is f() ~ "!", 'hi!', 'a native str return computes';
+}
+{
+    sub f(--> Str) { return "ok" }
+    is f(), 'ok', 'a boxed declared return gives its value';
+}
+{
+    # An our-scoped callee imports as its Scalar container, so the return
+    # type of the value it happens to hold at compile time is no promise.
+    my $dir = make-temp-dir;
+    $dir.add('ReassignableCallee.rakumod').spurt:
+        'our &rc = sub (--> int) { 1 }';
+    todo 'the legacy optimizer copies a reassignable imported callee return type'
+        unless $rakuast;
+    is-deeply
+        (try EVAL q[use lib $dir; use ReassignableCallee; &rc = sub (--> Str) { "s" }; rc()]) // 'died',
+        "s",
+        'an imported our-scoped callee reassigned at runtime returns the new value';
+}
+
+# vim: expandtab shiftwidth=4

--- a/t/08-performance/23-rakuast-array-init.t
+++ b/t/08-performance/23-rakuast-array-init.t
@@ -1,0 +1,132 @@
+use lib <t/packages/Test-Helpers>;
+use Test::Helpers::QAST;
+use Test;
+use QAST:from<NQP>;
+use nqp;
+plan 23;
+
+# Initializing a plain array from a comma list builds the list internals
+# directly and reifies, skipping the STORE dispatch. A typed, shaped, or
+# trait-bearing array keeps the STORE call, whose behavior its container
+# may specialize, and so does a right side that is not a comma list.
+
+sub qast-contains-store (Mu $qast --> Bool:D) {
+    qast-contains-callmethod($qast, 'STORE')
+}
+
+my $rakuast = nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast';
+
+# These observe the emitted QAST. The equivalent legacy rewrite no longer
+# fires, so the lowered assertions hold for the RakuAST frontend only.
+todo 'the legacy optimizer no longer lowers this shape', 3 unless $rakuast;
+qast-is 'my @a = 1, 2, 3', -> \v {
+    qast-contains-callmethod(v, 'reify-until-lazy') and not qast-contains-store(v)
+}, 'a plain array declaration initializer lowers past STORE';
+
+qast-is 'my @a; @a = 1, 2, 3', -> \v {
+    # The assignment form carries a STORE fallback behind the runtime
+    # stock-Array guard, so only the lowered build's presence is asserted.
+    qast-contains-callmethod(v, 'reify-until-lazy') and qast-contains-op(v, 'what_nd')
+}, 'a plain array assignment lowers past STORE behind a type guard';
+
+qast-is 'my @a = 1, 2, 3; my @b = @a, 4', -> \v {
+    qast-contains-callmethod(v, 'reify-until-lazy') and not qast-contains-store(v)
+}, 'an array-valued element still lowers';
+
+# Declines keep the STORE call under both frontends.
+qast-is 'my Int @a = 1, 2, 3', -> \v {
+    qast-contains-store(v)
+}, 'a typed array keeps the STORE call';
+
+qast-is 'my @a is default(0) = 1, 2, 3', -> \v {
+    qast-contains-store(v)
+}, 'a trait-bearing array keeps the STORE call';
+
+qast-is 'my @a = 1..3', -> \v {
+    not qast-contains-callmethod(v, 'reify-until-lazy')
+}, 'a non-comma right side keeps its own initialization';
+
+# These observe that initialization still behaves.
+{
+    my @a = 1, 2, 3;
+    is @a.join(','), '1,2,3', 'a lowered initializer stores the elements';
+    is @a.elems, 3, 'the element count is right';
+    @a[0] = 42;
+    is @a[0], 42, 'the array stays mutable';
+    @a.push(4);
+    is @a.elems, 4, 'the array still grows';
+}
+{
+    my @a;
+    @a = 4, 5;
+    is @a.join(','), '4,5', 'a lowered assignment stores the elements';
+    @a = 6, 7, 8;
+    is @a.join(','), '6,7,8', 'a second assignment replaces the elements';
+}
+{
+    my @a = 1, 2;
+    my @b = 0, |@a, 9;
+    is @b.join(','), '0,1,2,9', 'a slip element flattens';
+    my @c = @a, @a;
+    is @c.elems, 2, 'an array element stays itemized';
+}
+{
+    my @a = "x" xx 3;
+    is @a.join(','), 'x,x,x', 'a generator element reifies';
+}
+{
+    my Int @t = 1, 2;
+    is @t.join(','), '1,2', 'a typed array still initializes through STORE';
+}
+{
+    my @a is default(7) = 1, 2;
+    @a[5] = 9;
+    is @a[3], 7, 'a default trait still applies through STORE';
+}
+
+# The lowering replicates the stock Array STORE, but a bind can put any
+# value behind an untyped @-sigil, so the assignment form guards on the
+# variable holding the stock Array at runtime and falls back to STORE.
+{
+    my @a := array[int].new;
+    @a = 39, 3;
+    is-deeply @a, array[int].new(39, 3),
+        'assignment to a declaration-bound native array stores natively';
+}
+{
+    my @a;
+    @a := array[int].new;
+    @a = 4, 5;
+    is-deeply @a, array[int].new(4, 5),
+        'assignment to a rebound native array stores natively';
+}
+{
+    my @a is List = 1, 2;
+    throws-like { @a = 4, 5 }, X::Assignment::RO,
+        'assignment to an is List container still throws through STORE';
+}
+{
+    my class TattleArray is Array {
+        has $.stored is rw;
+        method STORE(|c) { $!stored = True; callsame }
+    }
+    my @a is TattleArray = 1, 2;
+    ok @a.stored, 'assignment to an Array subclass dispatches its own STORE';
+}
+
+# An operand whose QAST declares something, like the locals a with
+# modifier or an inlined metaop introduce, cannot compile in both guard
+# branches and keeps the STORE call.
+{
+    my @a;
+    @a = (1 with 2), 3;
+    is-deeply @a, [1, 3], 'a with modifier operand initializes through STORE';
+}
+{
+    my @a;
+    my $x = 1;
+    @a = ($x += 2), 5;
+    is-deeply @a, [3, 5], 'an inlined metaop operand initializes through STORE';
+}
+
+# vim: expandtab shiftwidth=4

--- a/t/08-performance/24-rakuast-slice-unroll.t
+++ b/t/08-performance/24-rakuast-slice-unroll.t
@@ -1,0 +1,55 @@
+use lib <t/packages/Test-Helpers>;
+use Test::Helpers::QAST;
+use Test;
+use QAST:from<NQP>;
+use nqp;
+plan 12;
+
+# A slice of a plain variable by literal integer indexes becomes the list
+# of the AT-POS calls those indexes dispatch to. An assignment target, a
+# runtime index, and an adverbed slice keep the postcircumfix call.
+
+# These observe the emitted QAST.
+qast-is 'my @a = 1..9; my ($x, $y) = @a[1, 3]', -> \v {
+    qast-contains-callmethod(v, 'AT-POS')
+}, 'a literal integer slice unrolls to AT-POS calls';
+
+qast-is 'my @a = 1..9; @a[1, 3] = 90, 91', -> \v {
+    not qast-contains-callmethod(v, 'AT-POS')
+}, 'a slice assignment target keeps the postcircumfix call';
+
+qast-is 'my @a = 1..9; my $i = 1; my ($x, $y) = @a[$i, 3]', -> \v {
+    not qast-contains-callmethod(v, 'AT-POS')
+}, 'a runtime index keeps the postcircumfix call';
+
+qast-is 'my @a = 1..9; my @s = @a[1, 3]:v', -> \v {
+    not qast-contains-callmethod(v, 'AT-POS')
+}, 'an adverbed slice keeps the postcircumfix call';
+
+# These observe that slices still behave.
+{
+    my @a = 10, 20, 30, 40;
+    is @a[1, 3].join(','), '20,40', 'an unrolled slice gives its values';
+    is @a[0, 2, 3].join(','), '10,30,40', 'a three-index slice gives its values';
+    my ($p, $q) = @a[1, 2];
+    is "$p $q", '20 30', 'an unrolled slice list-binds';
+}
+{
+    my @a = 1, 2;
+    is @a[0, 5].elems, 2, 'an out-of-range index still yields a slot';
+    nok @a[0, 5][1].defined, 'the out-of-range value is undefined';
+}
+{
+    my @a = 10, 20, 30, 40;
+    @a[1, 3] = 91, 92;
+    is @a.join(','), '10,91,30,92', 'slice assignment still stores';
+    @a[1, 5] = 81, 82;
+    is @a[5], 82, 'slice assignment past the end still extends';
+}
+{
+    my @a = 10, 20, 30;
+    my $r = @a[1, 2];
+    is $r.elems, 2, 'a slice result has slice shape';
+}
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously the RakuAST frontend compiled code without several rewrites the legacy optimizer performs: constant operand folding, reducing a square by the power operator to a multiply, skipping the return decont for container-free results, propagating a callee's return type onto its call, lowering plain array initializations past STORE, and unrolling literal index slices. This ports each one to the RakuAST optimize pass, one commit per optimization.

- **Fold a pure operator on constant operands.** Previously `my constant K = 3; my $y = K * 2` kept the runtime operator. Operands now also accept a name or lexical that resolves to a genuinely constant declaration. The compile-time-value protocol alone cannot vouch for an operand: a plain variable declaration claims its container default as a value, a stash reference claims the resolved package where evaluating it produces that package's stash, and an our-scoped variable imports as its Scalar container whose value a later assignment can replace. All three keep the runtime operator.
- **Rewrite a square by the power operator to a multiply.** `$x ** 2` becomes `$x * $x` when `$x` is a lexical whose type rules out a Junction. This is deliberately narrower than legacy, which rewrites untyped lexicals and mishandles a Junction operand.
- **Skip the return decont for a container-free result.** A routine whose last statement produces a value that cannot be containerized (a native, a literal, `self`, a deconted call) returns without the decont round trip.
- **Copy a bound-once callee's return type onto its call.** A native return is offered both ways through a Want, boxed for object context and raw for native context, so a native consumer of a native returning sub skips the boxing round trip. Dispatchers and rw callees are left alone. A containerized callee also declines: an our-scoped callee imports as its Scalar container, whose value a later assignment can replace, so the return type of the value it happens to hold at compile time is no promise. The legacy optimizer copies it anyway and a call after such a reassignment dies unboxing, which the new test records as a todo there.
- **Lower a plain array initialization past STORE.** `my @a = 1, 2, 3` builds the List, Reifier, and IterationBuffer directly instead of dispatching STORE, following the legacy lowering.
- **Unroll a slice by literal integer indexes to AT-POS calls.** `@a[1, 3]` becomes the AT-POS calls and an infix `,` list instead of a full slice dispatch.

Naive benchmarks against main, same one-liner loop best of three at default optimization: constant folding 5.1x (`K * 2 + 4` in a 3M loop, the body folds to a constant), square rewrite 2.1x (3M), array initialization 2.8x (1M), slice unroll 5.0x (1M). The return decont and return type propagation commits show no difference on a warm microloop, where spesh inlines the callee and erases the round trips anyway. Their effect is on the emitted QAST, which pays in code spesh has not specialized.

Each optimization comes with a `t/08-performance` test file asserting both the emitted QAST shape and runtime behavior under both frontends, including regression coverage for the decline cases above.
