### PR TITLE
RakuAST: lower non-escaping lexicals to locals and flatten frame-independent bodies

### DIFF
--- a/src/Perl6/Compiler.nqp
+++ b/src/Perl6/Compiler.nqp
@@ -253,7 +253,8 @@ class Perl6::Compiler is HLL::Compiler {
             my $optimize := %adverbs<optimize>;
             unless nqp::defined($optimize)
               && ($optimize eq 'off' || $optimize eq '0') {
-                $past.optimize($past.resolver);
+                $past.optimize($past.resolver,
+                    :interactive(%adverbs<interactive> ?? 1 !! 0));
             }
             return $past;
         }

--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -272,6 +272,12 @@ class RakuAST::Node {
                     if nqp::istype($visit, RakuAST::IMPL::ImmediateBlockUser) &&
                             $visit.IMPL-IMMEDIATELY-USES($node) {
                     }
+                    elsif nqp::istype($node, RakuAST::Block) && $node.IMPL-FLATTEN-APPROVED {
+                        # A flattened loop body's statements are emitted
+                        # inline by its loop; a block declaration for it
+                        # would re-emit them referencing locals of the
+                        # frame it flattened into.
+                    }
                     else {
                         my $code := $node.IMPL-QAST-DECL-CODE($context);
                         $stmts.push($code);

--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -1456,6 +1456,40 @@ class RakuAST::Block
     has int $!is-in-method;
     has int $!may-have-signature;
 
+    # Set by the lexical-to-local lowering analysis on the sunk body of a
+    # loop statement when everything the block does is provably
+    # frame-independent: every declaration it makes is a lowered local or
+    # an unused implicit, nothing reaches its lexicals by name, and it
+    # has no phasers or handlers. The loop then emits the body's
+    # statements inline instead of calling the block each iteration.
+    has int $!flatten-approved;
+
+    method IMPL-SET-FLATTEN-APPROVED() {
+        nqp::bindattr_i(self, RakuAST::Block, '$!flatten-approved', 1)
+    }
+
+    method IMPL-FLATTEN-APPROVED() { $!flatten-approved }
+
+    # The body emitted for inlining into the frame of the block's user:
+    # declarations of nested code objects, the lowered locals with a
+    # fresh container clone on every entry (a per-iteration frame would
+    # have provided a fresh container the same way), and the statement
+    # list. The by-name sentinel lexicals are deliberately absent, since
+    # the enclosing frame's symbols are not this block's to declare.
+    method IMPL-QAST-FLATTENED(RakuAST::IMPL::QASTContext $context) {
+        my $stmts := QAST::Stmts.new();
+        for self.IMPL-UNWRAP-LIST(self.ast-lexical-declarations()) {
+            if nqp::istype($_, RakuAST::VarDeclaration::Simple)
+                && $_.IMPL-LOWERED-LOCAL-NAME {
+                $stmts.push($_.IMPL-QAST-DECL-FLATTENED($context));
+            }
+        }
+        my $nested-blocks := self.IMPL-QAST-NESTED-BLOCK-DECLS($context);
+        $stmts.push($nested-blocks) if nqp::elems($nested-blocks.list);
+        $stmts.push($!body.IMPL-TO-QAST($context));
+        $stmts
+    }
+
     method new(RakuAST::Blockoid :$body,
                             Bool :$implicit-topic,
                             Bool :$required-topic,

--- a/src/Raku/ast/compunit.rakumod
+++ b/src/Raku/ast/compunit.rakumod
@@ -218,13 +218,13 @@ class RakuAST::CompUnit
     # QAST generation. It pushes the unit scope itself in batch resolve mode
     # (the tree is already checked, nothing is being declared), so a caller just
     # hands over a resolver.
-    method optimize(RakuAST::Resolver $resolver) {
+    method optimize(RakuAST::Resolver $resolver, :$interactive?) {
         $resolver.push-scope(self);
         $!mainline.IMPL-OPTIMIZE($resolver);
         self.IMPL-OPTIMIZE($resolver);
         # With the tree in its final shape, decide which lexicals can be
         # emitted as frame-locals.
-        RakuAST::IMPL::VarLowering.analyze-compunit(self);
+        RakuAST::IMPL::VarLowering.analyze-compunit(self, $resolver, :$interactive);
         $resolver.pop-scope;
     }
 

--- a/src/Raku/ast/compunit.rakumod
+++ b/src/Raku/ast/compunit.rakumod
@@ -222,6 +222,9 @@ class RakuAST::CompUnit
         $resolver.push-scope(self);
         $!mainline.IMPL-OPTIMIZE($resolver);
         self.IMPL-OPTIMIZE($resolver);
+        # With the tree in its final shape, decide which lexicals can be
+        # emitted as frame-locals.
+        RakuAST::IMPL::VarLowering.analyze-compunit(self);
         $resolver.pop-scope;
     }
 

--- a/src/Raku/ast/statements.rakumod
+++ b/src/Raku/ast/statements.rakumod
@@ -1630,7 +1630,9 @@ class RakuAST::Statement::Loop
             my $loop-qast := QAST::Op.new(
                 :$op,
                 $!condition ?? $!condition.IMPL-TO-QAST($context) !! QAST::IVal.new( :value(1) ),
-                $!body.IMPL-TO-QAST($context, :immediate),
+                $!body.IMPL-FLATTEN-APPROVED
+                    ?? $!body.IMPL-QAST-FLATTENED($context)
+                    !! $!body.IMPL-TO-QAST($context, :immediate),
             );
             my @post;
             if @next-phasers {

--- a/src/Raku/ast/statements.rakumod
+++ b/src/Raku/ast/statements.rakumod
@@ -1244,11 +1244,17 @@ class RakuAST::Statement::IfWith
             !! [RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('Empty'))]
     }
 
+    method IMPL-BRANCH-QAST(RakuAST::IMPL::QASTContext $context, Mu $body) {
+        nqp::istype($body, RakuAST::Block) && $body.IMPL-FLATTEN-APPROVED
+            ?? $body.IMPL-QAST-FLATTENED($context)
+            !! $body.IMPL-TO-QAST($context, :immediate)
+    }
+
     method IMPL-TO-QAST(RakuAST::IMPL::QASTContext $context) {
         # Start with the else (or Empty).
         my $cur-end;
         if $!else {
-            $cur-end := $!else.IMPL-TO-QAST($context, :immediate);
+            $cur-end := self.IMPL-BRANCH-QAST($context, $!else);
         }
         else {
             $cur-end :=
@@ -1262,7 +1268,7 @@ class RakuAST::Statement::IfWith
             $cur-end := QAST::Op.new(
                 :op($branch.IMPL-QAST-TYPE),
                 $branch.condition.IMPL-TO-QAST($context),
-                $branch.then.IMPL-TO-QAST($context, :immediate),
+                self.IMPL-BRANCH-QAST($context, $branch.then),
                 $cur-end
             );
         }
@@ -1271,7 +1277,7 @@ class RakuAST::Statement::IfWith
         QAST::Op.new(
             :op(self.IMPL-QAST-TYPE),
             $!condition.IMPL-TO-QAST($context),
-            $!then.IMPL-TO-QAST($context, :immediate),
+            self.IMPL-BRANCH-QAST($context, $!then),
             $cur-end
         )
     }
@@ -1389,7 +1395,9 @@ class RakuAST::Statement::Unless
         QAST::Op.new(
             :op('unless'),
             $!condition.IMPL-TO-QAST($context),
-            $!body.IMPL-TO-QAST($context, :immediate),
+            $!body.IMPL-FLATTEN-APPROVED
+                ?? $!body.IMPL-QAST-FLATTENED($context)
+                !! $!body.IMPL-TO-QAST($context, :immediate),
             self.IMPL-UNWRAP-LIST(self.get-implicit-lookups)[0].IMPL-TO-QAST($context)
         )
     }

--- a/src/Raku/ast/var-lowering.rakumod
+++ b/src/Raku/ast/var-lowering.rakumod
@@ -1,0 +1,282 @@
+# Escape analysis for lexical-to-local lowering. Walks a checked and
+# optimized compilation unit and decides, per `my` declaration, whether
+# every access is confined to the frame that declares it. A confined
+# declaration is marked so QAST emission can use a frame-local register
+# slot instead of a by-name lexical entry. The walk mirrors the frame
+# structure QAST emission produces: every node that creates a block (a
+# lexical scope, or an expression carrying thunks) is a frame boundary.
+
+# Per-frame bookkeeping made while the walk is inside that frame.
+class RakuAST::IMPL::VarLoweringFrame {
+    has RakuAST::Node $!node;
+    has int $!is-scope;
+    has int $!poisoned;
+    has Mu $!candidates;
+    has Mu $!candidate-ids;
+
+    method new(RakuAST::Node $node, int $is-scope) {
+        my $obj := nqp::create(self);
+        nqp::bindattr($obj, RakuAST::IMPL::VarLoweringFrame, '$!node', $node);
+        nqp::bindattr_i($obj, RakuAST::IMPL::VarLoweringFrame, '$!is-scope', $is-scope);
+        nqp::bindattr($obj, RakuAST::IMPL::VarLoweringFrame, '$!candidates', []);
+        nqp::bindattr($obj, RakuAST::IMPL::VarLoweringFrame, '$!candidate-ids', nqp::hash());
+        $obj
+    }
+
+    method node() { $!node }
+    method is-scope() { $!is-scope }
+    method poison() {
+        nqp::bindattr_i(self, RakuAST::IMPL::VarLoweringFrame, '$!poisoned', 1);
+        Nil
+    }
+    method is-poisoned() { $!poisoned }
+
+    method register(Mu $decl, str $declined) {
+        my $record := nqp::hash('decl', $decl, 'declined', $declined);
+        nqp::push($!candidates, $record);
+        nqp::bindkey($!candidate-ids, ~nqp::objectid($decl), $record);
+        Nil
+    }
+
+    method record-for-id(str $id) {
+        nqp::atkey($!candidate-ids, $id)
+    }
+
+    method candidates() { $!candidates }
+}
+
+# Drives the analysis. One instance analyzes one compilation unit.
+class RakuAST::IMPL::VarLowering {
+    has Mu $!frames;
+    has int $!debug;
+
+    method analyze-compunit(RakuAST::CompUnit $compunit) {
+        my $analyzer := nqp::create(self);
+        nqp::bindattr($analyzer, RakuAST::IMPL::VarLowering, '$!frames', []);
+        nqp::bindattr_i($analyzer, RakuAST::IMPL::VarLowering, '$!debug',
+            nqp::atkey(nqp::getenvhash(), 'RAKUDO_LOWERING_DEBUG') ?? 1 !! 0);
+
+        # The mainline Block is an empty shell for the mainline code
+        # object; the compilation unit's statements live in the statement
+        # list, which QAST emission places directly in the mainline frame.
+        # So the compilation unit and the mainline share one frame here,
+        # and the shell is skipped to visit each node exactly once.
+        my $mainline := $compunit.mainline;
+        $analyzer.IMPL-ENTER($compunit, 1);
+        $compunit.visit-children(-> $child {
+            $analyzer.IMPL-WALK($child) unless nqp::eqaddr($child, $mainline);
+        });
+        $analyzer.IMPL-LEAVE();
+        Nil
+    }
+
+    method IMPL-WALK(RakuAST::Node $node) {
+        # A variable declaration belongs to the enclosing scope's frame,
+        # not to any frame the node itself creates.
+        self.IMPL-REGISTER-DECL($node)
+            if nqp::istype($node, RakuAST::VarDeclaration::Simple);
+
+        my int $pushed;
+        if nqp::istype($node, RakuAST::MayCreateBlock) && $node.creates-block {
+            self.IMPL-ENTER($node, nqp::istype($node, RakuAST::LexicalScope) ?? 1 !! 0);
+            $pushed := 1;
+        }
+
+        self.IMPL-REGISTER-USE($node)
+            if nqp::istype($node, RakuAST::Lookup) && $node.is-resolved;
+        self.IMPL-CHECK-POISON($node);
+
+        $node.visit-children(-> $child { self.IMPL-WALK($child) });
+
+        self.IMPL-LEAVE() if $pushed;
+        Nil
+    }
+
+    method IMPL-ENTER(RakuAST::Node $node, int $is-scope) {
+        nqp::push($!frames, RakuAST::IMPL::VarLoweringFrame.new($node, $is-scope));
+        Nil
+    }
+
+    method IMPL-LEAVE() {
+        my $frame := nqp::pop($!frames);
+        self.IMPL-DECIDE($frame) if $frame.is-scope;
+        Nil
+    }
+
+    # Register a `my` declaration with the frame of its declaring scope,
+    # along with any reason it must stay a lexical that is knowable from
+    # the declaration alone.
+    method IMPL-REGISTER-DECL(RakuAST::VarDeclaration::Simple $decl) {
+        return Nil unless $decl.scope eq 'my';
+        # An anonymous declaration has no name to look up, and nothing to
+        # gain from this analysis until lowering handles it directly.
+        return Nil if nqp::istype($decl, RakuAST::VarDeclaration::Anonymous);
+
+        my int $i := nqp::elems($!frames);
+        my $scope-frame;
+        my int $scope-index := -1;
+        while --$i >= 0 {
+            my $frame := nqp::atpos($!frames, $i);
+            if $frame.is-scope {
+                $scope-frame := $frame;
+                $scope-index := $i;
+                last;
+            }
+        }
+        return Nil if $scope-index < 0;
+
+        my str $declined := '';
+        my str $sigil := $decl.sigil;
+        if $decl.twigil ne '' {
+            $declined := 'twigil';
+        }
+        elsif $decl.forced-dynamic {
+            $declined := 'dynamic';
+        }
+        elsif nqp::isconcrete($decl.container-descriptor)
+            && $decl.container-descriptor.dynamic {
+            # An `is dynamic` trait reaches the descriptor by mutation,
+            # not through the declaration's own attributes.
+            $declined := 'dynamic';
+        }
+        elsif $sigil ne '$' && $sigil ne '@' && $sigil ne '%' {
+            # A callable is looked up by name as the callee of emitted
+            # call ops, so a `&`-sigiled lexical must keep its symbol.
+            $declined := 'callable';
+        }
+        elsif !nqp::iscclass(nqp::const::CCLASS_ALPHABETIC,
+                $decl.desigilname.canonicalize, 0) {
+            $declined := 'name';
+        }
+        elsif nqp::isconcrete($decl.shape) {
+            $declined := 'shaped';
+        }
+        elsif $scope-index != nqp::elems($!frames) - 1 || $decl.creates-block {
+            # The declaration is emitted under a thunk of its scope, so
+            # its accesses cross a frame boundary the scope nesting does
+            # not show.
+            $declined := 'thunked';
+        }
+        $scope-frame.register($decl, $declined);
+        Nil
+    }
+
+    # A resolved lookup whose resolution is a tracked declaration marks
+    # that declaration as captured when the lookup lives in any frame
+    # other than the declaring one.
+    method IMPL-REGISTER-USE(RakuAST::Node $node) {
+        my str $id := ~nqp::objectid($node.resolution);
+        my int $top := nqp::elems($!frames) - 1;
+        my int $i := $top + 1;
+        while --$i >= 0 {
+            my $record := nqp::atpos($!frames, $i).record-for-id($id);
+            unless nqp::isnull($record) {
+                nqp::bindkey($record, 'captured', 1) if $i != $top;
+                return Nil;
+            }
+        }
+        Nil
+    }
+
+    # Constructs that can reach lexicals by name at runtime. Any of them
+    # poisons every frame the walk is currently inside: the lexicals of
+    # those frames must stay addressable by name.
+    method IMPL-CHECK-POISON(RakuAST::Node $node) {
+        my constant POISON-CALLS := nqp::hash(
+            'EVAL', 1, 'EVALFILE', 1,
+            'callwith', 1, 'callsame', 1,
+            'nextwith', 1, 'nextsame', 1,
+            'samewith', 1,
+            'throws-like', 1, 'repl', 1,
+        );
+        my constant POISON-VARS := nqp::hash(
+            '&EVAL', 1, '&EVALFILE', 1,
+            '&callwith', 1, '&callsame', 1,
+            '&nextwith', 1, '&nextsame', 1,
+            '&samewith', 1,
+            '&throws-like', 1, '&repl', 1,
+        );
+
+        if nqp::istype($node, RakuAST::Call::Name) {
+            my $name := $node.name;
+            if $name.is-pseudo-package || $name.is-indirect-lookup
+                || nqp::existskey(POISON-CALLS, $name.canonicalize) {
+                self.IMPL-POISON-ALL();
+            }
+        }
+        elsif nqp::istype($node, RakuAST::Var::Lexical) {
+            if $node.desigilname.is-indirect-lookup
+                || nqp::existskey(POISON-VARS, $node.name) {
+                self.IMPL-POISON-ALL();
+            }
+        }
+        elsif nqp::istype($node, RakuAST::Var::Package)
+            || nqp::istype($node, RakuAST::Term::Name)
+            || nqp::istype($node, RakuAST::Type::Simple) {
+            my $name := $node.name;
+            if nqp::istype($name, RakuAST::Name)
+                && ($name.is-pseudo-package || $name.is-indirect-lookup) {
+                self.IMPL-POISON-ALL();
+            }
+        }
+        elsif nqp::istype($node, RakuAST::QuotedRegex)
+            || nqp::istype($node, RakuAST::RegexDeclaration)
+            || nqp::istype($node, RakuAST::Substitution)
+            || nqp::istype($node, RakuAST::Transliteration) {
+            # Regex code reaches lexicals of its enclosing frames late,
+            # through the cursor, not through resolved lookups this walk
+            # can see. Substitutions and transliterations carry regex
+            # and replacement code the same way.
+            self.IMPL-POISON-ALL();
+        }
+        Nil
+    }
+
+    # This code runs where the NQP setting's IO subs are not reachable,
+    # so stderr output is spelled out in ops, including the byte buffer
+    # type to encode into.
+    method IMPL-NOTE(str $message) {
+        my $u8 := nqp::newtype(nqp::knowhow(), 'P6int');
+        nqp::composetype($u8, nqp::hash('integer', nqp::hash('unsigned', 1, 'bits', 8)));
+        my $buf-type := nqp::newtype(nqp::knowhow(), 'VMArray');
+        nqp::composetype($buf-type, nqp::hash('array', nqp::hash('type', $u8)));
+        nqp::writefh(nqp::getstderr(),
+            nqp::encode($message ~ "\n", 'utf8', nqp::create($buf-type)));
+        Nil
+    }
+
+    method IMPL-POISON-ALL() {
+        my int $i := nqp::elems($!frames);
+        while --$i >= 0 {
+            nqp::atpos($!frames, $i).poison();
+        }
+        Nil
+    }
+
+    method IMPL-DECIDE(Mu $frame) {
+        my $candidates := $frame.candidates;
+        return Nil unless nqp::elems($candidates);
+        my int $poisoned := $frame.is-poisoned;
+        for $candidates -> $record {
+            my $decl := nqp::atkey($record, 'decl');
+            my str $declined := nqp::atkey($record, 'declined');
+            if $declined eq '' && $poisoned {
+                $declined := 'poisoned';
+            }
+            if $declined eq '' && nqp::existskey($record, 'captured') {
+                $declined := 'captured';
+            }
+            if $declined eq '' {
+                $decl.IMPL-SET-LOWERED-TO-LOCAL();
+            }
+            if $!debug {
+                my str $where := $frame.node.HOW.name($frame.node);
+                self.IMPL-NOTE($declined eq ''
+                    ?? "lex2local: lower '" ~ $decl.lexical-name ~ "' in " ~ $where
+                    !! "lex2local: keep '" ~ $decl.lexical-name ~ "' in "
+                        ~ $where ~ " (" ~ $declined ~ ")");
+            }
+        }
+        Nil
+    }
+}

--- a/src/Raku/ast/var-lowering.rakumod
+++ b/src/Raku/ast/var-lowering.rakumod
@@ -192,6 +192,32 @@ class RakuAST::IMPL::VarLowering {
             }
         }
 
+        # A conditional statement's branch bodies flatten the same way,
+        # sunk or value-producing: an inlined branch evaluates to its
+        # last statement just as the immediate block call did. A branch
+        # that topicalizes, as with and orwith do, keeps its frame,
+        # which its required topic enforces in the verdict.
+        if nqp::istype($node, RakuAST::Statement::IfWith) {
+            self.IMPL-REGISTER-IMPLICIT-LOOKUPS($node);
+            self.IMPL-WALK($node.condition);
+            self.IMPL-WALK-FLATTEN-CANDIDATE($node.then);
+            for $node.IMPL-UNWRAP-LIST($node.elsifs) {
+                self.IMPL-WALK($_.condition);
+                self.IMPL-WALK-FLATTEN-CANDIDATE($_.then);
+            }
+            my $else := $node.else;
+            self.IMPL-WALK-FLATTEN-CANDIDATE($else) if nqp::isconcrete($else);
+            $node.visit-labels(-> $label { self.IMPL-WALK($label) });
+            return Nil;
+        }
+        if nqp::istype($node, RakuAST::Statement::Unless) {
+            self.IMPL-REGISTER-IMPLICIT-LOOKUPS($node);
+            self.IMPL-WALK($node.condition);
+            self.IMPL-WALK-FLATTEN-CANDIDATE($node.body);
+            $node.visit-labels(-> $label { self.IMPL-WALK($label) });
+            return Nil;
+        }
+
         # A variable declaration belongs to the enclosing scope's frame,
         # not to any frame the node itself creates. A parameter's uses
         # resolve to the target node while emission delegates to the
@@ -518,6 +544,26 @@ class RakuAST::IMPL::VarLowering {
                 my str $op := $prefix.operator;
                 $top.block-flatten() if $op eq 'temp' || $op eq 'let';
             }
+        }
+        elsif nqp::istype($node, RakuAST::Nqp) {
+            # Ops that observe the identity of the running frame, or of
+            # its caller or outer, mean something else once the frame is
+            # gone.
+            my constant FRAME-OPS := nqp::hash(
+                'ctx', 1, 'ctxcaller', 1, 'ctxcallerskipthunks', 1,
+                'ctxouter', 1, 'ctxouterskipthunks', 1,
+                'curcode', 1, 'callercode', 1,
+                'getlexouter', 1, 'getlexcaller', 1, 'getlexdyn', 1,
+                'getlexrel', 1, 'getlexreldyn', 1, 'getlexrelcaller', 1,
+                'savecapture', 1, 'usecapture', 1, 'takedispatcher', 1,
+            );
+            $top.block-flatten() if nqp::existskey(FRAME-OPS, $node.op);
+        }
+        elsif nqp::istype($node, RakuAST::Var::Dynamic) {
+            # A dynamic lookup that did not resolve lexically walks the
+            # caller chain at run time, and that walk starts at the
+            # frame's caller, so removing the frame skips one link.
+            $top.block-flatten();
         }
         elsif nqp::istype($node, RakuAST::Var::Lexical) {
             # A magical is emitted as a by-name lexical, so at run time

--- a/src/Raku/ast/var-lowering.rakumod
+++ b/src/Raku/ast/var-lowering.rakumod
@@ -14,6 +14,11 @@ class RakuAST::IMPL::VarLoweringFrame {
     has Mu $!candidates;
     has Mu $!candidate-ids;
     has Mu $!candidate-names;
+    has Mu $!implicit-ids;
+    has int $!implicit-used;
+    has int $!flatten-candidate;
+    has int $!flatten-blocked;
+    has Mu $!deferred-uses;
 
     method new(RakuAST::Node $node, int $is-scope) {
         my $obj := nqp::create(self);
@@ -22,6 +27,8 @@ class RakuAST::IMPL::VarLoweringFrame {
         nqp::bindattr($obj, RakuAST::IMPL::VarLoweringFrame, '$!candidates', []);
         nqp::bindattr($obj, RakuAST::IMPL::VarLoweringFrame, '$!candidate-ids', nqp::hash());
         nqp::bindattr($obj, RakuAST::IMPL::VarLoweringFrame, '$!candidate-names', nqp::hash());
+        nqp::bindattr($obj, RakuAST::IMPL::VarLoweringFrame, '$!implicit-ids', nqp::hash());
+        nqp::bindattr($obj, RakuAST::IMPL::VarLoweringFrame, '$!deferred-uses', []);
         $obj
     }
 
@@ -32,6 +39,34 @@ class RakuAST::IMPL::VarLoweringFrame {
         Nil
     }
     method is-poisoned() { $!poisoned }
+
+    method register-implicit(str $id) {
+        nqp::bindkey($!implicit-ids, $id, 1);
+        Nil
+    }
+    method is-implicit(str $id) { nqp::existskey($!implicit-ids, $id) }
+    method mark-implicit-used() {
+        nqp::bindattr_i(self, RakuAST::IMPL::VarLoweringFrame, '$!implicit-used', 1);
+        Nil
+    }
+    method implicit-used() { $!implicit-used }
+
+    method mark-flatten-candidate() {
+        nqp::bindattr_i(self, RakuAST::IMPL::VarLoweringFrame, '$!flatten-candidate', 1);
+        Nil
+    }
+    method is-flatten-candidate() { $!flatten-candidate }
+    method block-flatten() {
+        nqp::bindattr_i(self, RakuAST::IMPL::VarLoweringFrame, '$!flatten-blocked', 1);
+        Nil
+    }
+    method flatten-blocked() { $!flatten-blocked }
+
+    method add-deferred(str $id) {
+        nqp::push($!deferred-uses, $id);
+        Nil
+    }
+    method deferred-uses() { $!deferred-uses }
 
     method register(Mu $decl, str $declined) {
         my $record := nqp::hash('decl', $decl, 'declined', $declined);
@@ -115,6 +150,8 @@ class RakuAST::IMPL::VarLowering {
     }
 
     method IMPL-WALK(RakuAST::Node $node) {
+        self.IMPL-CHECK-FLATTEN-BLOCKERS($node);
+
         # Trait arguments, type parameterizations, and constant
         # initializers are evaluated at BEGIN time by dynamically
         # compiled code that reaches lexicals by name, which neither the
@@ -138,6 +175,23 @@ class RakuAST::IMPL::VarLowering {
     }
 
     method IMPL-WALK-INNER(RakuAST::Node $node) {
+
+        # The sunk body of a loop statement is a flatten candidate: if
+        # everything it does proves frame-independent, the loop emits its
+        # statements inline and uses of enclosing lexicals from it do not
+        # count as captures.
+        if nqp::istype($node, RakuAST::Statement::Loop) && $node.IMPL-DISCARD-RESULT {
+            my $body := $node.body;
+            if nqp::isconcrete($body) {
+                self.IMPL-REGISTER-IMPLICIT-LOOKUPS($node);
+                $node.visit-children(-> $child {
+                    self.IMPL-WALK($child) unless nqp::eqaddr($child, $body);
+                });
+                self.IMPL-WALK-FLATTEN-CANDIDATE($body);
+                return Nil;
+            }
+        }
+
         # A variable declaration belongs to the enclosing scope's frame,
         # not to any frame the node itself creates. A parameter's uses
         # resolve to the target node while emission delegates to the
@@ -229,6 +283,7 @@ class RakuAST::IMPL::VarLowering {
 
         self.IMPL-REGISTER-USE($node)
             if nqp::istype($node, RakuAST::Lookup) && $node.is-resolved;
+        self.IMPL-REGISTER-IMPLICIT-LOOKUPS($node);
         self.IMPL-CHECK-POISON($node);
 
         $node.visit-children(-> $child { self.IMPL-WALK($child) });
@@ -238,13 +293,91 @@ class RakuAST::IMPL::VarLowering {
     }
 
     method IMPL-ENTER(RakuAST::Node $node, int $is-scope) {
-        nqp::push($!frames, RakuAST::IMPL::VarLoweringFrame.new($node, $is-scope));
-        Nil
+        my $frame := RakuAST::IMPL::VarLoweringFrame.new($node, $is-scope);
+        nqp::push($!frames, $frame);
+        # Uses can resolve to a scope's implicit declarations, whose
+        # identities decide whether the implicits go unused.
+        if $is-scope && nqp::istype($node, RakuAST::ImplicitDeclarations) {
+            for $node.IMPL-UNWRAP-LIST($node.get-implicit-declarations()) {
+                $frame.register-implicit(~nqp::objectid($_));
+            }
+        }
+        $frame
     }
 
     method IMPL-LEAVE() {
         my $frame := nqp::pop($!frames);
-        self.IMPL-DECIDE($frame) if $frame.is-scope;
+        if $frame.is-scope {
+            self.IMPL-DECIDE($frame);
+            if $frame.is-flatten-candidate {
+                my int $approved := self.IMPL-FLATTEN-VERDICT($frame);
+                if $approved {
+                    $frame.node.IMPL-SET-FLATTEN-APPROVED();
+                    if $!debug {
+                        my str $where := '';
+                        my $origin := $frame.node.origin;
+                        if nqp::isconcrete($origin) {
+                            my $source := $origin.source;
+                            $where := ' at ' ~ $source.original-file
+                                ~ ':' ~ $source.original-line($origin.from);
+                        }
+                        self.IMPL-NOTE('lex2local: flatten '
+                            ~ $frame.node.HOW.name($frame.node) ~ $where);
+                    }
+                }
+                # A use that crossed only this pending body settles now:
+                # an approved body is part of its parent's frame, so the
+                # use re-evaluates from the parent's viewpoint, while a
+                # declined body was a real frame boundary after all.
+                for $frame.deferred-uses -> $id {
+                    $approved
+                        ?? self.IMPL-REGISTER-USE-ID($id)
+                        !! self.IMPL-MARK-CAPTURED-ID($id);
+                }
+            }
+        }
+        Nil
+    }
+
+    # Whether a flatten-candidate body proved frame-independent: not
+    # poisoned, no construct that reaches lexicals by name, no handlers,
+    # unused implicit topic only, and every declaration of its own a
+    # lowered local.
+    method IMPL-FLATTEN-VERDICT(Mu $frame) {
+        return 0 if $frame.is-poisoned
+            || $frame.flatten-blocked
+            || $frame.implicit-used;
+        my $block := $frame.node;
+        return 0 if nqp::getattr($block, RakuAST::LexicalScope, '$!catch-handlers')
+            || nqp::getattr($block, RakuAST::LexicalScope, '$!control-handlers');
+        return 0 if nqp::elems($block.IMPL-UNWRAP-LIST(
+            $block.generated-lexical-declarations()));
+        for $block.IMPL-UNWRAP-LIST($block.ast-lexical-declarations()) {
+            # The emission's own predicate is the deciding one: the
+            # analysis mark alone is not enough, since emission declines
+            # some marked declarations, natives among them, and such a
+            # declaration still needs the frame.
+            if nqp::istype($_, RakuAST::VarDeclaration::Simple)
+                && $_.IMPL-LOWERED-LOCAL-NAME {
+            }
+            else {
+                return 0 unless $frame.is-implicit(~nqp::objectid($_))
+                    && nqp::istype($_, RakuAST::VarDeclaration::Implicit::BlockTopic)
+                    && !$_.required && !$_.exception;
+            }
+        }
+        1
+    }
+
+    method IMPL-MARK-CAPTURED-ID(str $id) {
+        my int $i := nqp::elems($!frames);
+        while --$i >= 0 {
+            my $record := nqp::atpos($!frames, $i).record-for-id($id);
+            unless nqp::isnull($record) {
+                nqp::bindkey($record, 'captured', 1);
+                return Nil;
+            }
+        }
         Nil
     }
 
@@ -312,6 +445,93 @@ class RakuAST::IMPL::VarLowering {
         Nil
     }
 
+    # Some nodes reach lexicals through implicit lookups that
+    # visit-children does not hand out, such as the topic a bare method
+    # call resolves. They count as uses like any other.
+    method IMPL-REGISTER-IMPLICIT-LOOKUPS(RakuAST::Node $node) {
+        if nqp::istype($node, RakuAST::ImplicitLookups) {
+            for $node.IMPL-UNWRAP-LIST($node.get-implicit-lookups()) {
+                self.IMPL-CHECK-FLATTEN-BLOCKERS($_);
+                self.IMPL-REGISTER-USE($_)
+                    if nqp::istype($_, RakuAST::Lookup) && $_.is-resolved;
+            }
+        }
+        Nil
+    }
+
+    # Walk the body of a sunk loop statement as a flatten candidate when
+    # its shape allows flattening at all: a plain block, no signature or
+    # placeholders, no phasers. Everything else about eligibility is
+    # decided from what the walk observes, when the frame pops.
+    method IMPL-WALK-FLATTEN-CANDIDATE(RakuAST::Node $body) {
+        unless nqp::eqaddr($body.WHAT, RakuAST::Block)
+            && !nqp::isconcrete($body.placeholder-signature)
+            && !$body.has-any-phasers {
+            self.IMPL-WALK($body);
+            return Nil;
+        }
+        my $frame := self.IMPL-ENTER($body, 1);
+        $frame.mark-flatten-candidate();
+        self.IMPL-REGISTER-IMPLICIT-LOOKUPS($body);
+        $body.visit-children(-> $child { self.IMPL-WALK($child) });
+        self.IMPL-LEAVE();
+        Nil
+    }
+
+    # Constructs that reach the topic, or other lexicals, by name at run
+    # time without a resolved lookup this walk could see. Any of them in
+    # a candidate body's flat extent keeps the body a real frame.
+    method IMPL-CHECK-FLATTEN-BLOCKERS(RakuAST::Node $node) {
+        my int $n := nqp::elems($!frames);
+        return Nil unless $n;
+        my $top := nqp::atpos($!frames, $n - 1);
+        return Nil unless $top.is-flatten-candidate && !$top.flatten-blocked;
+        if nqp::istype($node, RakuAST::Statement::When)
+            || nqp::istype($node, RakuAST::Statement::Default) {
+            $top.block-flatten();
+        }
+        elsif nqp::istype($node, RakuAST::Statement::Expression) {
+            my $cond := $node.condition-modifier;
+            my $loop := $node.loop-modifier;
+            $top.block-flatten()
+                if (nqp::isconcrete($cond)
+                    && !nqp::istype($cond, RakuAST::StatementModifier::If)
+                    && !nqp::istype($cond, RakuAST::StatementModifier::Unless))
+                || (nqp::isconcrete($loop)
+                    && !nqp::istype($loop, RakuAST::StatementModifier::WhileUntil));
+        }
+        elsif nqp::istype($node, RakuAST::ApplyInfix)
+            || nqp::istype($node, RakuAST::ApplyListInfix) {
+            my $infix := $node.infix;
+            if nqp::istype($infix, RakuAST::Infix) {
+                my str $op := $infix.operator;
+                $top.block-flatten()
+                    if $op eq '~~' || $op eq '!~~'
+                    || $op eq 'andthen' || $op eq 'orelse' || $op eq 'notandthen';
+            }
+        }
+        elsif nqp::istype($node, RakuAST::ApplyPrefix) {
+            # temp and let register their restore on the frame of the
+            # code that runs them.
+            my $prefix := $node.prefix;
+            if nqp::istype($prefix, RakuAST::Prefix) {
+                my str $op := $prefix.operator;
+                $top.block-flatten() if $op eq 'temp' || $op eq 'let';
+            }
+        }
+        elsif nqp::istype($node, RakuAST::Var::Lexical) {
+            # A magical is emitted as a by-name lexical, so at run time
+            # it binds to the innermost declaration of that name even
+            # when its compile-time resolution points at an outer one.
+            # Using one in the body means the body's own magical, whose
+            # declaration flattening would remove.
+            my str $name := $node.name;
+            $top.block-flatten()
+                if $name eq '$_' || $name eq '$/' || $name eq '$!' || $name eq '$¢';
+        }
+        Nil
+    }
+
     method IMPL-HAS-WILL-TRAIT(Mu $decl) {
         for $decl.IMPL-UNWRAP-LIST($decl.traits) {
             return 1 if nqp::istype($_, RakuAST::Trait::Will);
@@ -321,20 +541,41 @@ class RakuAST::IMPL::VarLowering {
 
     # A resolved lookup whose resolution is a tracked declaration marks
     # that declaration as captured when the lookup lives in any frame
-    # other than the declaring one.
+    # other than the declaring one. A use separated from its declaration
+    # only by pending flatten-candidate bodies is deferred instead, since
+    # an approved body dissolves into its parent's frame.
     method IMPL-REGISTER-USE(RakuAST::Node $node) {
-        my str $id := ~nqp::objectid($node.resolution);
+        self.IMPL-REGISTER-USE-ID(~nqp::objectid($node.resolution));
+    }
+
+    method IMPL-REGISTER-USE-ID(str $id) {
         my int $top := nqp::elems($!frames) - 1;
         my int $i := $top + 1;
         while --$i >= 0 {
-            my $record := nqp::atpos($!frames, $i).record-for-id($id);
+            my $frame := nqp::atpos($!frames, $i);
+            my $record := $frame.record-for-id($id);
             unless nqp::isnull($record) {
                 if $!begin-context {
                     nqp::bindkey($record, 'captured', 1);
                 }
                 elsif $i != $top {
-                    nqp::bindkey($record, 'captured', 1);
+                    my int $j := $top;
+                    my int $only-candidates := 1;
+                    while $j > $i {
+                        unless nqp::atpos($!frames, $j).is-flatten-candidate {
+                            $only-candidates := 0;
+                            last;
+                        }
+                        $j--;
+                    }
+                    $only-candidates
+                        ?? nqp::atpos($!frames, $top).add-deferred($id)
+                        !! nqp::bindkey($record, 'captured', 1);
                 }
+                return Nil;
+            }
+            if $frame.is-implicit($id) {
+                $frame.mark-implicit-used();
                 return Nil;
             }
         }
@@ -451,6 +692,7 @@ class RakuAST::IMPL::VarLowering {
             if $declined eq '' && nqp::existskey($record, 'captured') {
                 $declined := 'captured';
             }
+            nqp::bindkey($record, 'final', $declined);
             if $declined eq '' {
                 $decl.IMPL-SET-LOWERED-TO-LOCAL($!sentinel);
             }

--- a/src/Raku/ast/var-lowering.rakumod
+++ b/src/Raku/ast/var-lowering.rakumod
@@ -13,6 +13,7 @@ class RakuAST::IMPL::VarLoweringFrame {
     has int $!poisoned;
     has Mu $!candidates;
     has Mu $!candidate-ids;
+    has Mu $!candidate-names;
 
     method new(RakuAST::Node $node, int $is-scope) {
         my $obj := nqp::create(self);
@@ -20,6 +21,7 @@ class RakuAST::IMPL::VarLoweringFrame {
         nqp::bindattr_i($obj, RakuAST::IMPL::VarLoweringFrame, '$!is-scope', $is-scope);
         nqp::bindattr($obj, RakuAST::IMPL::VarLoweringFrame, '$!candidates', []);
         nqp::bindattr($obj, RakuAST::IMPL::VarLoweringFrame, '$!candidate-ids', nqp::hash());
+        nqp::bindattr($obj, RakuAST::IMPL::VarLoweringFrame, '$!candidate-names', nqp::hash());
         $obj
     }
 
@@ -33,8 +35,28 @@ class RakuAST::IMPL::VarLoweringFrame {
 
     method register(Mu $decl, str $declined) {
         my $record := nqp::hash('decl', $decl, 'declined', $declined);
+        # Redeclarations of one name in one scope share a runtime symbol,
+        # so neither copy can own a private register slot.
+        my str $name := $decl.lexical-name;
+        my $clash := nqp::atkey($!candidate-names, $name);
+        if nqp::isnull($clash) {
+            nqp::bindkey($!candidate-names, $name, $record);
+        }
+        else {
+            nqp::bindkey($clash, 'declined', 'duplicate')
+                unless nqp::atkey($clash, 'declined');
+            nqp::bindkey($record, 'declined', 'duplicate')
+                unless $declined;
+        }
         nqp::push($!candidates, $record);
         nqp::bindkey($!candidate-ids, ~nqp::objectid($decl), $record);
+        $record
+    }
+
+    # An extra identity a use-site's resolution may carry for this
+    # candidate, such as the parameter target wrapping a declaration.
+    method alias(str $id, Mu $record) {
+        nqp::bindkey($!candidate-ids, $id, $record);
         Nil
     }
 
@@ -48,13 +70,32 @@ class RakuAST::IMPL::VarLoweringFrame {
 # Drives the analysis. One instance analyzes one compilation unit.
 class RakuAST::IMPL::VarLowering {
     has Mu $!frames;
+    has Mu $!sentinel;
     has int $!debug;
+    has int $!begin-context;
 
-    method analyze-compunit(RakuAST::CompUnit $compunit) {
+    method analyze-compunit(RakuAST::CompUnit $compunit, RakuAST::Resolver $resolver, :$interactive?) {
+        # Escape hatch while the lowering is young: skip the analysis
+        # entirely, leaving every lexical emitted by name.
+        return Nil if nqp::atkey(nqp::getenvhash(), 'RAKUDO_NO_LEX2LOCAL');
+
         my $analyzer := nqp::create(self);
         nqp::bindattr($analyzer, RakuAST::IMPL::VarLowering, '$!frames', []);
         nqp::bindattr_i($analyzer, RakuAST::IMPL::VarLowering, '$!debug',
             nqp::atkey(nqp::getenvhash(), 'RAKUDO_LOWERING_DEBUG') ?? 1 !! 0);
+
+        # The sentinel type that stands in for a lowered lexical's
+        # by-name symbol. Without it (very early bootstrap) nothing is
+        # marked, since the emitted placeholder could not be produced.
+        my $sentinel := nqp::null;
+        my $sentinel-name := RakuAST::Name.from-identifier-parts(
+            'Rakudo', 'Internals', 'LoweredAwayLexical');
+        my $found := $resolver.resolve-name-constant-in-setting($sentinel-name);
+        $found := $resolver.resolve-name-constant($sentinel-name)
+            unless nqp::isconcrete($found);
+        $sentinel := $found.compile-time-value
+            if nqp::isconcrete($found) && nqp::can($found, 'compile-time-value');
+        nqp::bindattr($analyzer, RakuAST::IMPL::VarLowering, '$!sentinel', $sentinel);
 
         # The mainline Block is an empty shell for the mainline code
         # object; the compilation unit's statements live in the statement
@@ -63,6 +104,9 @@ class RakuAST::IMPL::VarLowering {
         # and the shell is skipped to visit each node exactly once.
         my $mainline := $compunit.mainline;
         $analyzer.IMPL-ENTER($compunit, 1);
+        # Each interactive (REPL) line must leave its lexicals reachable
+        # by name for the lines compiled after it.
+        $analyzer.IMPL-POISON-ALL() if $interactive;
         $compunit.visit-children(-> $child {
             $analyzer.IMPL-WALK($child) unless nqp::eqaddr($child, $mainline);
         });
@@ -71,15 +115,116 @@ class RakuAST::IMPL::VarLowering {
     }
 
     method IMPL-WALK(RakuAST::Node $node) {
+        # Trait arguments, type parameterizations, and constant
+        # initializers are evaluated at BEGIN time by dynamically
+        # compiled code that reaches lexicals by name, which neither the
+        # frame nesting nor the resolutions here can show. Every use in
+        # such a subtree escapes.
+        my int $begin-entered;
+        if nqp::istype($node, RakuAST::Trait)
+            || nqp::istype($node, RakuAST::Type::Parameterized)
+            || nqp::istype($node, RakuAST::VarDeclaration::Constant) {
+            nqp::bindattr_i(self, RakuAST::IMPL::VarLowering, '$!begin-context',
+                $!begin-context + 1);
+            $begin-entered := 1;
+        }
+        if $begin-entered {
+            self.IMPL-WALK-INNER($node);
+            nqp::bindattr_i(self, RakuAST::IMPL::VarLowering, '$!begin-context',
+                $!begin-context - 1);
+            return Nil;
+        }
+        self.IMPL-WALK-INNER($node)
+    }
+
+    method IMPL-WALK-INNER(RakuAST::Node $node) {
         # A variable declaration belongs to the enclosing scope's frame,
-        # not to any frame the node itself creates.
-        self.IMPL-REGISTER-DECL($node)
-            if nqp::istype($node, RakuAST::VarDeclaration::Simple);
+        # not to any frame the node itself creates. A parameter's uses
+        # resolve to the target node while emission delegates to the
+        # declaration it wraps, so the target registers the declaration
+        # under both identities, and the wrapped declaration itself is
+        # skipped when the walk reaches it as a child.
+        if nqp::istype($node, RakuAST::ParameterTarget::Var) {
+            my $decl := $node.declaration;
+            self.IMPL-REGISTER-DECL($decl, ~nqp::objectid($node))
+                if nqp::isconcrete($decl)
+                && nqp::istype($decl, RakuAST::VarDeclaration::Simple);
+        }
+        elsif nqp::istype($node, RakuAST::VarDeclaration::Simple) {
+            self.IMPL-REGISTER-DECL($node)
+                unless nqp::getattr($node, RakuAST::VarDeclaration::Simple, '$!is-parameter');
+        }
+
+        # A list declaration bound with := goes through the runtime
+        # signature binder, which writes into the frame's lexicals by
+        # name.
+        if nqp::istype($node, RakuAST::VarDeclaration::Signature)
+            && nqp::isconcrete($node.initializer)
+            && $node.initializer.is-binding {
+            self.IMPL-POISON-CURRENT-SCOPE();
+        }
+
+        # Feed stages are emitted inside blocks the tree does not show,
+        # so anything a stage references stays a by-name lexical.
+        if nqp::istype($node, RakuAST::ApplyListInfix)
+            && nqp::istype($node.infix, RakuAST::Feed) {
+            $node.visit-children(-> $child {
+                self.IMPL-ENTER($child, 0);
+                self.IMPL-WALK($child);
+                self.IMPL-LEAVE();
+            });
+            return Nil;
+        }
+
+        # An nqp::handle handler is code-generated in an implicit block
+        # of its own, so a lexical referenced from a handler must stay
+        # addressable by name. The protected expression, the first
+        # argument, runs in the current frame.
+        if nqp::istype($node, RakuAST::Nqp)
+            && ($node.op eq 'handle' || $node.op eq 'handlepayload') {
+            my int $first := 1;
+            $node.visit-children(-> $child {
+                if $first {
+                    $first := 0;
+                    self.IMPL-WALK($child);
+                }
+                else {
+                    self.IMPL-ENTER($child, 0);
+                    self.IMPL-WALK($child);
+                    self.IMPL-LEAVE();
+                }
+            });
+            return Nil;
+        }
+
+        # A loop statement modifier's thunk wraps the statement
+        # expression, and a condition modifier's test is compiled inside
+        # that same thunk, while the loop source stays outside. Mirror
+        # that frame placement rather than walking the modifiers in the
+        # statement's own frame.
+        if nqp::istype($node, RakuAST::Statement::Expression)
+            && nqp::isconcrete($node.loop-modifier) {
+            my $expression := $node.expression;
+            if nqp::istype($expression, RakuAST::Expression) && $expression.creates-block {
+                self.IMPL-ENTER($node, 0);
+                self.IMPL-WALK($expression);
+                self.IMPL-WALK($node.condition-modifier)
+                    if nqp::isconcrete($node.condition-modifier);
+                self.IMPL-LEAVE();
+                self.IMPL-WALK($node.loop-modifier);
+                $node.visit-labels(-> $label { self.IMPL-WALK($label) });
+                return Nil;
+            }
+        }
 
         my int $pushed;
         if nqp::istype($node, RakuAST::MayCreateBlock) && $node.creates-block {
             self.IMPL-ENTER($node, nqp::istype($node, RakuAST::LexicalScope) ?? 1 !! 0);
             $pushed := 1;
+            # A signature that needs the runtime binder binds by name
+            # into the frame, so its lexicals must stay addressable.
+            nqp::atpos($!frames, nqp::elems($!frames) - 1).poison()
+                if nqp::istype($node, RakuAST::Code) && $node.custom-args;
         }
 
         self.IMPL-REGISTER-USE($node)
@@ -106,7 +251,7 @@ class RakuAST::IMPL::VarLowering {
     # Register a `my` declaration with the frame of its declaring scope,
     # along with any reason it must stay a lexical that is knowable from
     # the declaration alone.
-    method IMPL-REGISTER-DECL(RakuAST::VarDeclaration::Simple $decl) {
+    method IMPL-REGISTER-DECL(RakuAST::VarDeclaration::Simple $decl, str $alias-id?) {
         return Nil unless $decl.scope eq 'my';
         # An anonymous declaration has no name to look up, and nothing to
         # gain from this analysis until lowering handles it directly.
@@ -151,14 +296,27 @@ class RakuAST::IMPL::VarLowering {
         elsif nqp::isconcrete($decl.shape) {
             $declined := 'shaped';
         }
+        elsif self.IMPL-HAS-WILL-TRAIT($decl) {
+            # A will phaser looks its variable up by name in the calling
+            # frame at run time (Variable.willdo).
+            $declined := 'will';
+        }
         elsif $scope-index != nqp::elems($!frames) - 1 || $decl.creates-block {
             # The declaration is emitted under a thunk of its scope, so
             # its accesses cross a frame boundary the scope nesting does
             # not show.
             $declined := 'thunked';
         }
-        $scope-frame.register($decl, $declined);
+        my $record := $scope-frame.register($decl, $declined);
+        $scope-frame.alias($alias-id, $record) if $alias-id;
         Nil
+    }
+
+    method IMPL-HAS-WILL-TRAIT(Mu $decl) {
+        for $decl.IMPL-UNWRAP-LIST($decl.traits) {
+            return 1 if nqp::istype($_, RakuAST::Trait::Will);
+        }
+        0
     }
 
     # A resolved lookup whose resolution is a tracked declaration marks
@@ -171,7 +329,12 @@ class RakuAST::IMPL::VarLowering {
         while --$i >= 0 {
             my $record := nqp::atpos($!frames, $i).record-for-id($id);
             unless nqp::isnull($record) {
-                nqp::bindkey($record, 'captured', 1) if $i != $top;
+                if $!begin-context {
+                    nqp::bindkey($record, 'captured', 1);
+                }
+                elsif $i != $top {
+                    nqp::bindkey($record, 'captured', 1);
+                }
                 return Nil;
             }
         }
@@ -207,6 +370,16 @@ class RakuAST::IMPL::VarLowering {
         elsif nqp::istype($node, RakuAST::Var::Lexical) {
             if $node.desigilname.is-indirect-lookup
                 || nqp::existskey(POISON-VARS, $node.name) {
+                self.IMPL-POISON-ALL();
+            }
+        }
+        elsif nqp::istype($node, RakuAST::Call::Method) {
+            # A method named EVAL reaches enclosing lexicals the same way
+            # the sub form does, for example a string or AST's .EVAL.
+            my $name := $node.name;
+            if nqp::istype($name, RakuAST::Name)
+                && !$name.is-indirect-lookup
+                && nqp::existskey(POISON-CALLS, $name.canonicalize) {
                 self.IMPL-POISON-ALL();
             }
         }
@@ -253,6 +426,18 @@ class RakuAST::IMPL::VarLowering {
         Nil
     }
 
+    method IMPL-POISON-CURRENT-SCOPE() {
+        my int $i := nqp::elems($!frames);
+        while --$i >= 0 {
+            my $frame := nqp::atpos($!frames, $i);
+            if $frame.is-scope {
+                $frame.poison();
+                last;
+            }
+        }
+        Nil
+    }
+
     method IMPL-DECIDE(Mu $frame) {
         my $candidates := $frame.candidates;
         return Nil unless nqp::elems($candidates);
@@ -267,7 +452,7 @@ class RakuAST::IMPL::VarLowering {
                 $declined := 'captured';
             }
             if $declined eq '' {
-                $decl.IMPL-SET-LOWERED-TO-LOCAL();
+                $decl.IMPL-SET-LOWERED-TO-LOCAL($!sentinel);
             }
             if $!debug {
                 my str $where := $frame.node.HOW.name($frame.node);

--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -709,9 +709,20 @@ class RakuAST::VarDeclaration::Simple
     # a comma list, for lowering to a direct build of the list internals.
     has int $!lowered-array-init;
 
+    # Set by the lexical-to-local lowering analysis when every access to
+    # this declaration is confined to the declaring frame, so it can be
+    # emitted as a frame-local rather than a by-name lexical.
+    has int $!lowered-to-local;
+
     method IMPL-SET-LOWERED-ARRAY-INIT() {
         nqp::bindattr_i(self, RakuAST::VarDeclaration::Simple, '$!lowered-array-init', 1)
     }
+
+    method IMPL-SET-LOWERED-TO-LOCAL() {
+        nqp::bindattr_i(self, RakuAST::VarDeclaration::Simple, '$!lowered-to-local', 1)
+    }
+
+    method IMPL-LOWERED-TO-LOCAL() { $!lowered-to-local }
 
     method new(          str :$scope,
                RakuAST::Name :$desigilname!,

--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -711,18 +711,63 @@ class RakuAST::VarDeclaration::Simple
 
     # Set by the lexical-to-local lowering analysis when every access to
     # this declaration is confined to the declaring frame, so it can be
-    # emitted as a frame-local rather than a by-name lexical.
+    # emitted as a frame-local rather than a by-name lexical. The
+    # sentinel is installed as a static lexical under the declared name,
+    # so by-name access from another frame (CALLER::, the binder's
+    # error-reporting failover) still finds a symbol and fails the same
+    # way it does for any lowered lexical.
     has int $!lowered-to-local;
+    has str $!lowered-local-name;
+    has Mu $!lowered-away-sentinel;
 
     method IMPL-SET-LOWERED-ARRAY-INIT() {
         nqp::bindattr_i(self, RakuAST::VarDeclaration::Simple, '$!lowered-array-init', 1)
     }
 
-    method IMPL-SET-LOWERED-TO-LOCAL() {
-        nqp::bindattr_i(self, RakuAST::VarDeclaration::Simple, '$!lowered-to-local', 1)
+    method IMPL-SET-LOWERED-TO-LOCAL(Mu $sentinel) {
+        nqp::bindattr_i(self, RakuAST::VarDeclaration::Simple, '$!lowered-to-local', 1);
+        nqp::bindattr(self, RakuAST::VarDeclaration::Simple, '$!lowered-away-sentinel', $sentinel);
     }
 
     method IMPL-LOWERED-TO-LOCAL() { $!lowered-to-local }
+
+    # The frame-local name for a lowered declaration, minted on first
+    # request so the declaration and every lookup agree regardless of
+    # emission order, or the empty string when this declaration stays a
+    # by-name lexical. Native scalars decline: their l-value accesses
+    # need a lexicalref, and QAST has no local equivalent. Declarations
+    # with an explicit container base type decline: their initialization
+    # emits by-name vivification lookups.
+    method IMPL-LOWERED-LOCAL-NAME() {
+        return $!lowered-local-name if $!lowered-local-name;
+        return '' unless $!lowered-to-local;
+        return '' if nqp::isnull($!lowered-away-sentinel);
+        return '' if $!already-declared
+            || self.scope ne 'my'
+            || $!desigilname.is-multi-part
+            || self.IMPL-HAS-EXPLICIT-CONTAINER-BASE-TYPE;
+        my $of := $!where ?? $!type.meta-object !! self.IMPL-OF-TYPE;
+        return '' if self.sigil eq '$' && nqp::objprimspec($of);
+        # The assignment emit paths choose their strategy from the QAST
+        # name's leading sigil, so the local keeps it. The declared name
+        # rides along for debuggability.
+        nqp::bindattr_s(self, RakuAST::VarDeclaration::Simple,
+            '$!lowered-local-name',
+            QAST::Node.unique(self.sigil ~ '__lowered_' ~ $!desigilname.canonicalize));
+        if nqp::atkey(nqp::getenvhash(), 'RAKUDO_LOWERING_DEBUG') {
+            my str $where := '';
+            my $origin := self.origin;
+            if nqp::isconcrete($origin) {
+                my $source := $origin.source;
+                $where := ' at ' ~ $source.original-file
+                    ~ ':' ~ $source.original-line($origin.from);
+            }
+            RakuAST::IMPL::VarLowering.IMPL-NOTE(
+                'lex2local: minted ' ~ $!lowered-local-name ~ ' for '
+                    ~ self.name ~ $where);
+        }
+        $!lowered-local-name
+    }
 
     method new(          str :$scope,
                RakuAST::Name :$desigilname!,
@@ -1522,22 +1567,45 @@ class RakuAST::VarDeclaration::Simple
             }
             elsif $!initializer && $!initializer.is-binding {
                 # Will be bound on first use, so just a declaration.
-                QAST::Var.new( :scope('lexical'), :decl('var'), :name(self.name) )
+                my str $local-name := self.IMPL-LOWERED-LOCAL-NAME;
+                if $local-name {
+                    $context.ensure-sc($!lowered-away-sentinel);
+                    QAST::Stmts.new(
+                        QAST::Var.new( :scope('lexical'), :decl('static'), :name(self.name),
+                            :value($!lowered-away-sentinel) ),
+                        QAST::Var.new( :scope('local'), :decl('var'), :name($local-name) )
+                    )
+                }
+                else {
+                    QAST::Var.new( :scope('lexical'), :decl('var'), :name(self.name) )
+                }
             }
             else {
                 # Need to vivify the object. Note: maybe we want to drop the
                 # contvar, though we'll need an alternative for BEGIN.
                 my $container := self.meta-object;
                 $context.ensure-sc($container);
-                my $qast := QAST::Var.new(
-                    :scope('lexical'), :decl('contvar'), :name(self.name),
-                    :value($container)
-                );
-                if self.IMPL-HAS-EXPLICIT-CONTAINER-BASE-TYPE {
-                    $qast := QAST::Op.new( :op('bind'), $qast,
-                      self.IMPL-EXPLICIT-CONTAINER-VIVIFY-QAST($context, $of) );
+                my str $local-name := self.IMPL-LOWERED-LOCAL-NAME;
+                if $local-name {
+                    $context.ensure-sc($!lowered-away-sentinel);
+                    QAST::Stmts.new(
+                        QAST::Var.new( :scope('lexical'), :decl('static'), :name(self.name),
+                            :value($!lowered-away-sentinel) ),
+                        QAST::Var.new( :scope('local'), :decl('contvar'), :name($local-name),
+                            :value($container) )
+                    )
                 }
-                $qast
+                else {
+                    my $qast := QAST::Var.new(
+                        :scope('lexical'), :decl('contvar'), :name(self.name),
+                        :value($container)
+                    );
+                    if self.IMPL-HAS-EXPLICIT-CONTAINER-BASE-TYPE {
+                        $qast := QAST::Op.new( :op('bind'), $qast,
+                          self.IMPL-EXPLICIT-CONTAINER-VIVIFY-QAST($context, $of) );
+                    }
+                    $qast
+                }
             }
         }
         elsif $scope eq 'our' || $!desigilname.is-multi-part {
@@ -1593,7 +1661,10 @@ class RakuAST::VarDeclaration::Simple
         my $qast;
         if $scope eq 'my' || $scope eq 'state' || $scope eq 'our' {
             my str $sigil := self.sigil;
-            my $var-access := QAST::Var.new( :$name, :scope<lexical> );
+            my str $local-name := self.IMPL-LOWERED-LOCAL-NAME;
+            my $var-access := $local-name
+                ?? QAST::Var.new( :name($local-name), :scope<local> )
+                !! QAST::Var.new( :$name, :scope<lexical> );
             my $of := self.IMPL-OF-TYPE;
 
             if $sigil eq '$' && (my int $prim-spec := nqp::objprimspec($of)) {
@@ -1769,18 +1840,25 @@ class RakuAST::VarDeclaration::Simple
     method IMPL-LOOKUP-QAST(RakuAST::IMPL::QASTContext $context, Mu :$rvalue) {
         my str $scope := self.scope;
         if $scope eq 'my' || $scope eq 'state' || $scope eq 'our' {
+            my str $local-name := self.IMPL-LOWERED-LOCAL-NAME;
             my str $scope := 'lexical';
             unless $rvalue {
                 # Potentially l-value native lookups need a lexicalref.
+                # A lowered declaration is never native, so its scope
+                # stays a plain local.
                 if self.sigil eq '$' && self.scope ne 'our' {
                     my $of := self.IMPL-OF-TYPE;
                     if nqp::objprimspec($of) && (!$!is-parameter || !$!is-ro) {
                         $scope := 'lexicalref';
                     }
-                    return QAST::Var.new( :name(self.name), :$scope, :returns($of) );
+                    return $local-name
+                        ?? QAST::Var.new( :name($local-name), :scope('local'), :returns($of) )
+                        !! QAST::Var.new( :name(self.name), :$scope, :returns($of) );
                 }
             }
-            QAST::Var.new( :name(self.name), :$scope )
+            $local-name
+                ?? QAST::Var.new( :name($local-name), :scope('local') )
+                !! QAST::Var.new( :name(self.name), :$scope )
         }
         elsif self.is-attribute {
             my $package := $!attribute-package.meta-object;
@@ -1806,9 +1884,12 @@ class RakuAST::VarDeclaration::Simple
         my str $scope := self.scope;
         my $native := nqp::objprimspec(self.IMPL-OF-TYPE);
         nqp::die('Can only compile bind to my-scoped variables') unless $scope eq 'my' || $scope eq 'state' || $scope eq 'our';
+        my str $local-name := self.IMPL-LOWERED-LOCAL-NAME;
         QAST::Op.new(
             :op('bind'),
-            QAST::Var.new( :name(self.name), :scope($native && $!is-rw ?? 'lexicalref' !! 'lexical') ),
+            $local-name
+                ?? QAST::Var.new( :name($local-name), :scope('local') )
+                !! QAST::Var.new( :name(self.name), :scope($native && $!is-rw ?? 'lexicalref' !! 'lexical') ),
             $source-qast
         )
     }

--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -769,6 +769,36 @@ class RakuAST::VarDeclaration::Simple
         $!lowered-local-name
     }
 
+    # The declaration form for a scope flattened into its user's frame:
+    # the local, refreshed with a clone of the container prototype on
+    # every entry, so each iteration of a flattened loop body gets its
+    # own container the way a per-iteration frame would have. A bound
+    # declaration has no container and needs no refresh.
+    method IMPL-QAST-DECL-FLATTENED(RakuAST::IMPL::QASTContext $context) {
+        my str $local-name := self.IMPL-LOWERED-LOCAL-NAME;
+        nqp::die('Cannot emit a flattened declaration that is not lowered')
+            unless $local-name;
+        my $decl := QAST::Var.new( :scope('local'), :decl('var'), :name($local-name) );
+        if $!initializer && $!initializer.is-binding {
+            $decl
+        }
+        else {
+            my $container := self.meta-object;
+            $context.ensure-sc($container);
+            QAST::Stmts.new(
+                $decl,
+                QAST::Op.new(
+                    :op('bind'),
+                    QAST::Var.new( :name($local-name), :scope('local') ),
+                    # clone_nd, since a plain clone would decontainerize
+                    # and clone the prototype's default value instead of
+                    # the container.
+                    QAST::Op.new( :op('clone_nd'), QAST::WVal.new( :value($container) ) )
+                )
+            )
+        }
+    }
+
     method new(          str :$scope,
                RakuAST::Name :$desigilname!,
                          str :$sigil,

--- a/t/08-performance/19-rakuast-lex2local.t
+++ b/t/08-performance/19-rakuast-lex2local.t
@@ -1,0 +1,155 @@
+use lib <t/packages/Test-Helpers>;
+use Test::Helpers;
+use Test::Helpers::QAST;
+use Test;
+use QAST:from<NQP>;
+use nqp;
+plan 26;
+
+# A `my` declaration whose every access stays inside its declaring frame
+# is emitted as a frame-local register slot instead of a by-name lexical.
+# A static sentinel lexical remains under the declared name, so by-name
+# access from another frame still finds a symbol and fails over the same
+# way as before. A declaration that escapes, or that a construct can
+# reach by name at runtime, keeps its ordinary lexical declaration. Both
+# frontends lower, so these assertions hold for either.
+
+sub qast-var-decl (Mu $qast, Str:D $name, Str:D $decl --> Bool:D) {
+    if nqp::istype($qast, QAST::Var) && $qast.name eq $name && $qast.decl eq $decl {
+        return True;
+    }
+    if qast-descendable $qast {
+        for $qast.list {
+            qast-var-decl $_, $name, $decl and return True;
+        }
+    }
+    False
+}
+
+# The sentinel that replaces a lowered declaration's by-name symbol.
+sub lowered-away (Mu $qast, Str:D $name --> Bool:D) {
+    qast-var-decl($qast, $name, 'static')
+}
+
+# An ordinary containerized lexical declaration.
+sub kept-lexical (Mu $qast, Str:D $name --> Bool:D) {
+    qast-var-decl($qast, $name, 'contvar')
+}
+
+qast-is 'my $x = 1; say $x', :full, -> \v {
+    lowered-away(v, '$x') and not kept-lexical(v, '$x')
+}, 'a non-escaping scalar is lowered to a local';
+
+qast-is 'my $x := [1,2]; say $x.elems', :full, -> \v {
+    lowered-away(v, '$x')
+}, 'a non-escaping bound declaration is lowered to a local';
+
+qast-is 'my @a = 1,2; say @a.sum', :full, -> \v {
+    lowered-away(v, '@a')
+}, 'a non-escaping array is lowered to a local';
+
+qast-is 'my %h = a => 1; say %h.elems', :full, -> \v {
+    lowered-away(v, '%h')
+}, 'a non-escaping hash is lowered to a local';
+
+qast-is 'sub f($a) { $a + 1 }; say f(1)', :full, -> \v {
+    lowered-away(v, '$a')
+}, 'a non-escaping parameter is lowered to a local';
+
+qast-is 'my $x = 1; my $c = { $x }; say $c()', :full, -> \v {
+    kept-lexical(v, '$x') and not lowered-away(v, '$x')
+}, 'a block-captured scalar keeps its lexical';
+
+qast-is 'use MONKEY-SEE-NO-EVAL; my $x = 1; say EVAL "1"', :full, -> \v {
+    kept-lexical(v, '$x')
+}, 'EVAL in scope keeps every lexical addressable by name';
+
+qast-is 'use MONKEY-SEE-NO-EVAL; my $x = 1; say "1".EVAL', :full, -> \v {
+    kept-lexical(v, '$x')
+}, 'the EVAL method in scope keeps every lexical addressable by name';
+
+qast-is 'my $x is dynamic = 1; say $x', :full, -> \v {
+    kept-lexical(v, '$x')
+}, 'an is-dynamic declaration keeps its lexical';
+
+qast-is 'my $*d = 1; say $*d', :full, -> \v {
+    kept-lexical(v, '$*d')
+}, 'a dynamic-twigil declaration keeps its lexical';
+
+qast-is 'my &g = { 42 }; say g()', :full, -> \v {
+    kept-lexical(v, '&g')
+}, 'a callable declaration keeps its lexical for by-name callee lookup';
+
+qast-is 'my int $i = 5; say $i', :full, -> \v {
+    qast-var-decl(v, '$i', 'var')
+}, 'a native scalar keeps a declaration under its own name';
+
+qast-is 'my $x = 1; say MY::<$x>', :full, -> \v {
+    kept-lexical(v, '$x')
+}, 'a pseudo-package access in scope keeps every lexical';
+
+qast-is 'multi f(Int $i) { my $t = 1; callsame; $t }; multi f(Any $a) { 2 }; say f(1)', :full, -> \v {
+    kept-lexical(v, '$t')
+}, 'callsame in scope keeps the enclosing lexicals';
+
+qast-is 'my $x = "a"; say "a" ~~ /a/; say $x', :full, -> \v {
+    kept-lexical(v, '$x')
+}, 'a regex in scope keeps the enclosing lexicals';
+
+qast-is 'my $x will leave { 1 } = 5; say $x', :full, -> \v {
+    kept-lexical(v, '$x')
+}, 'a will phaser keeps its variable addressable by name';
+
+qast-is 'my ($a, $b) := (3, 4); say $a', :full, -> \v {
+    kept-lexical(v, '$a')
+}, 'a signature binding keeps its targets addressable for the binder';
+
+qast-is 'my $x = 2..4; my @r; $x ==> map(* + 1) ==> @r; say @r', :full, -> \v {
+    kept-lexical(v, '$x')
+}, 'a feed keeps the lexicals its stages reference';
+
+# Behavior stays identical under lowering.
+
+is (1..3).map(-> $i { sub { $i * 10 } }).map({ .() }).join(','), '10,20,30',
+    'closures capture distinct per-iteration variables';
+
+{
+    my ($a, $b) = (3, 4);
+    is "$a $b", '3 4', 'list assignment reaches the declared targets';
+}
+
+{
+    my ($a, $b) := (3, 4);
+    is "$a $b", '3 4', 'list binding reaches the declared targets';
+}
+
+{
+    sub lex2local-callee() { CALLER::<$x> }
+    sub lex2local-caller() { my $x = 1; lex2local-callee() }
+    throws-like { lex2local-caller() }, X::Caller::NotDynamic,
+        'CALLER:: access to a lowered lexical dies the same way';
+}
+
+{
+    sub with-copy($a is copy) { $a = 5; $a }
+    is with-copy(1), 5, 'an is-copy parameter assigns inside its frame';
+}
+
+{
+    sub counting() { state $n = 0; ++$n }
+    counting();
+    is counting(), 2, 'a state variable keeps its per-code storage';
+}
+
+# The transform obeys the optimizer switch.
+
+my $stage = nqp::getcomp('Raku').qast-stage;
+is-run 'my $x = 1; say $x',
+    'no declaration is lowered under --optimize=off',
+    :compiler-args['--optimize=off', "--target=$stage"],
+    :out({ $_ !~~ / '__lowered' / });
+
+is-run 'my $x = 1; say $x',
+    'the QAST of an optimized compilation shows the lowered local',
+    :compiler-args["--target=$stage"],
+    :out({ $_ ~~ / '__lowered' / });

--- a/t/08-performance/20-rakuast-lex2local-flatten.t
+++ b/t/08-performance/20-rakuast-lex2local-flatten.t
@@ -3,7 +3,7 @@ use Test::Helpers::QAST;
 use Test;
 use QAST:from<NQP>;
 use nqp;
-plan 12;
+plan 18;
 
 # The sunk body of a loop statement whose every piece is provably
 # frame-independent is emitted inline rather than called as a block each
@@ -109,4 +109,44 @@ else {
         die 'boom' if $i == 2;
     }
     is $caught, 'c', 'a CATCH in the loop body keeps the body a frame and fires';
+}
+
+# Conditional statement branch bodies flatten the same way.
+
+qast-is 'my $sum = 0; my int $i = 0; while $i < 9 { if $i % 2 { $sum = $sum + $i } else { $sum = $sum - 1 }; $i = $i + 1 }; say $sum',
+    :full, -> \v {
+    qast-var-decl(v, '$sum', 'static')
+}, 'an accumulator used from branch bodies inside a loop body is lowered';
+
+{
+    my $sum = 0;
+    my int $i = 0;
+    while $i < 9 { if $i % 2 { $sum = $sum + $i } else { $sum = $sum - 1 }; $i = $i + 1 }
+    is $sum, 11, 'flattened branch bodies inside a flattened loop accumulate correctly';
+}
+
+{
+    my $x = 5;
+    my $r = do if $x > 3 { 'big' } else { 'small' };
+    is $r, 'big', 'a value-producing if with flattened branches evaluates to the branch value';
+}
+
+{
+    my $r = '';
+    for 1..3 -> $n { if $n == 1 { $r ~= 'a' } elsif $n == 2 { $r ~= 'b' } else { $r ~= 'c' } }
+    is $r, 'abc', 'an elsif chain with flattened branches selects correctly';
+}
+
+{
+    my $c = 0;
+    my int $i = 0;
+    while $i < 4 { unless $i == 2 { $c = $c + 1 }; $i = $i + 1 }
+    is $c, 3, 'a flattened unless body runs when its condition is false';
+}
+
+{
+    sub with-dynamic() { my $*D = 5; read-dynamic() }
+    sub read-dynamic() { my $r; if 1 { $r = $*D }; $r }
+    is with-dynamic(), 5,
+        'a dynamic lookup in a branch body still walks the caller chain';
 }

--- a/t/08-performance/20-rakuast-lex2local-flatten.t
+++ b/t/08-performance/20-rakuast-lex2local-flatten.t
@@ -1,0 +1,112 @@
+use lib <t/packages/Test-Helpers>;
+use Test::Helpers::QAST;
+use Test;
+use QAST:from<NQP>;
+use nqp;
+plan 12;
+
+# The sunk body of a loop statement whose every piece is provably
+# frame-independent is emitted inline rather than called as a block each
+# iteration. An enclosing lexical used only from such a body then counts
+# as frame-confined and is lowered to a local. Both frontends flatten
+# and lower, so the shape assertions hold for either.
+
+sub qast-var-decl (Mu $qast, Str:D $name, Str:D $decl --> Bool:D) {
+    if nqp::istype($qast, QAST::Var) && $qast.name eq $name && $qast.decl eq $decl {
+        return True;
+    }
+    if qast-descendable $qast {
+        for $qast.list {
+            qast-var-decl $_, $name, $decl and return True;
+        }
+    }
+    False
+}
+
+qast-is 'my $sum = 0; my int $i = 0; while $i < 3 { $sum = $sum + 1; $i = $i + 1 }; say $sum',
+    :full, -> \v {
+    qast-var-decl(v, '$sum', 'static')
+}, 'an accumulator used only from a flattenable loop body is lowered';
+
+qast-is 'my $x = 0; my int $i = 0; while $i < 3 { my $c = { $x }; $c(); $i = $i + 1 }; say $x',
+    :full, -> \v {
+    qast-var-decl(v, '$x', 'contvar')
+}, 'a lexical captured by a closure inside the loop body keeps its lexical';
+
+# The smartmatch guard is this frontend's own conservatism: it reaches
+# the topic by name at emit time, which the analysis cannot see through.
+# The legacy frontend analyzes the emitted QAST instead and can lower
+# here, so this shape is only asserted on the RakuAST frontend.
+if nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' {
+    qast-is 'my $x = 0; my int $i = 0; while $i < 3 { $x = $x ~~ Int ?? 1 !! 2; $i = $i + 1 }; say $x',
+        :full, -> \v {
+        qast-var-decl(v, '$x', 'contvar')
+    }, 'a smartmatch in the loop body keeps the body a real frame';
+}
+else {
+    skip 'smartmatch conservatism is specific to the RakuAST frontend';
+}
+
+# Behavior stays identical under flattening.
+
+{
+    my $sum = 0;
+    my int $i = 0;
+    while $i < 3 { my $t = 2; $sum = $sum + $t; $i = $i + 1 }
+    is $sum, 6, 'a flattened body accumulates into the enclosing lexical';
+}
+
+{
+    my @r;
+    my int $i = 0;
+    while $i < 3 { my $t = $i + 10; @r.push($t.VAR); $i = $i + 1 }
+    is @r.map({ .self }).join(','), '10,11,12',
+        'each iteration of a flattened body sees its own value';
+    nok @r[0].VAR =:= @r[1].VAR,
+        'each iteration of a flattened body gets a fresh container';
+}
+
+{
+    my $s = 0;
+    my int $i = 0;
+    while $i < 10 { $i = $i + 1; next if $i % 2; last if $i > 6; $s = $s + $i }
+    is $s, 12, 'next and last control a loop with a flattened body';
+}
+
+{
+    my @c;
+    my int $i = 0;
+    while $i < 2 { my $t = $i * 5; @c.push({ $t }); $i = $i + 1 }
+    is @c.map({ .() }).join(','), '0,5',
+        'closures in a loop body capture per-iteration variables';
+}
+
+{
+    my $n = 0;
+    loop { $n = $n + 1; last if $n > 4 }
+    is $n, 5, 'a conditionless loop statement flattens and terminates';
+}
+
+{
+    my $n = 10;
+    repeat { $n = $n + 1 } while $n < 3;
+    is $n, 11, 'a repeat loop runs its flattened body once before the test';
+}
+
+{
+    my $r = '';
+    my int $i = 0;
+    while $i < 3 { $i = $i + 1; given $i { when 2 { $r ~= 'two' }; default { $r ~= 'n' } } }
+    is $r, 'ntwon', 'given and when inside a loop body behave unchanged';
+}
+
+{
+    my $caught = '';
+    my int $i = 0;
+    while $i < 3 {
+        $i = $i + 1;
+        CATCH { default { $caught ~= 'c' } }
+        die 'boom' if $i == 2;
+    }
+    is $caught, 'c', 'a CATCH in the loop body keeps the body a frame and fires';
+}

--- a/tools/templates/raku_ast_sources
+++ b/tools/templates/raku_ast_sources
@@ -27,6 +27,7 @@ src/Raku/ast/variable-declaration.rakumod
 src/Raku/ast/variable-access.rakumod
 src/Raku/ast/contextualizer.rakumod
 src/Raku/ast/code.rakumod
+src/Raku/ast/var-lowering.rakumod
 src/Raku/ast/compunit.rakumod
 src/Raku/ast/statementprefixes.rakumod
 src/Raku/ast/statement-mods.rakumod


### PR DESCRIPTION
Previously the RakuAST frontend emitted every user lexical with lexical scope, so every variable access is a by-name frame entry, and every loop iteration called its body block. The legacy frontend lowers non-escaping lexicals to frame-local register slots and inlines immediate blocks in `lexical_vars_to_locals` and `inline_immediate_block`, and much of the pre-spesh hot loop gap between the frontends lives there.

This implements the equivalent as an AST-level pass, in four commits:

* An escape analysis (`RakuAST::IMPL::VarLowering`) runs from `CompUnit.optimize` once the tree is in its final shape. It walks the program mirroring the frame structure QAST emission will produce and marks each `my`-scoped declaration whose every access stays inside its declaring frame.
* QAST emission acts on the mark: a lowered declaration emits a local register slot, plus a static lexical carrying `Rakudo::Internals::LoweredAwayLexical` under the declared name so by-name access from another frame (`CALLER::`, the binder's error reporting failover) still finds a symbol and fails as before. Native scalars keep their lexical, since their l-value accesses need a lexicalref and QAST has no local equivalent.
* The sunk body of a loop statement flattens when everything it does is provably frame-independent, so the loop emits the body's statements inline instead of calling the block each iteration. Loop control is unchanged, since the QAST while op owns the `last`/`next`/`redo` handlers.
* Conditional branch bodies (`then`/`elsif`/`else`/`unless`) flatten under the same rules, sunk or value-producing, so a loop whose body holds conditionals still lowers its accumulator.

The analysis is conservative about everything that reaches lexicals by name at run time rather than through a resolved lookup: `EVAL` in sub and method form, the `callsame` family, pseudo-packages, indirect names, regexes (including `s///` and `tr///`), `will` phasers, the full runtime binder, `temp`/`let`, dynamic variable lookups, frame-identity nqp ops, magicals, BEGIN-evaluated trait arguments and type parameterizations, and interactive compilation. Any of these keeps the affected declarations as ordinary lexicals or keeps the body a real frame.

On `my $sum = 0; my int $i = 0; while $i < 1000000 { $sum = $sum + $p.x; $i = $i + 1 }` this is 20 percent faster with spesh and 9 percent faster without. With an `if`/`else` in the loop body it is 23 percent faster with spesh. The gap to the legacy frontend on these loops narrows from 3.0x to 1.7x-2.4x.

`--optimize=off` disables the pass, `RAKUDO_NO_LEX2LOCAL=1` skips the analysis while the transform is young, and `RAKUDO_LOWERING_DEBUG=1` reports each decision and minted local. Tests in t/08-performance/19-rakuast-lex2local.t and 20-rakuast-lex2local-flatten.t assert the lowered and kept shapes and unchanged behavior on both frontends, using shapes both frontends agree on (lowered means a static sentinel under the original name, kept means a contvar). `make test` and the spectest suite pass on both frontends.
