### PR TITLE
RakuAST: make the require adverb constraint tests self-contained

### DIFF
--- a/t/12-rakuast/xx-fixed-in-rakuast.rakutest
+++ b/t/12-rakuast/xx-fixed-in-rakuast.rakutest
@@ -868,22 +868,36 @@ subtest 'use of &?ROUTINE and &?BLOCK' => {
 # The legacy grammar instead silently drops the adverbs and loads by base
 # name, so an unsatisfiable constraint is only enforced under RakuAST.
 {
-    lives-ok { require Test:ver<6.0.0+> },
-        'require loads a module through a satisfiable :ver constraint';
-    lives-ok { require Test:api },
-        'require loads a module with a bare boolean adverb';
-    is (do { require Test:ver<6.0.0+> }).^name, 'Test',
-        'a require with an adverb used as a block value returns the module';
+    # The constraints are tested against a fixture distribution whose
+    # META6.json declares a version, auth, and api, prepended to the
+    # repository chain. A repository only enforces a constraint the
+    # distribution declares something for, so requiring an installed
+    # module here would depend on what the environment happens to
+    # provide: the harness resolves Test to rakudo's own lib/, a bare
+    # source that satisfies any constraint.
+    my $fixture-repo = CompUnit::Repository::FileSystem.new(
+        :prefix($*PROGRAM.parent.parent.add('packages/12-rakuast/require-fixture').absolute),
+        :next-repo($*REPO),
+    );
     {
-        require Test:ver<6.0.0+> <&pass>;
-        ok &pass ~~ Sub, 'a require with an adverb still imports the requested symbol';
+        my $*REPO = $fixture-repo;
+        lives-ok { require Require::Fixture:ver<1.0+> },
+            'require loads a module through a satisfiable :ver constraint';
+        lives-ok { require Require::Fixture:api },
+            'require loads a module with a bare boolean adverb';
+        is (do { require Require::Fixture:ver<1.0+> }).^name, 'Require::Fixture',
+            'a require with an adverb used as a block value returns the module';
+        {
+            require Require::Fixture:ver<1.0+> <&fixture-sub>;
+            ok &fixture-sub ~~ Sub, 'a require with an adverb still imports the requested symbol';
+        }
+        todo "the legacy grammar ignores an unsatisfiable :ver on require" unless %*ENV<RAKUDO_RAKUAST>;
+        dies-ok { require Require::Fixture:ver<999999.1> },
+            'require fails on an unsatisfiable :ver constraint';
+        todo "the legacy grammar ignores an unsatisfiable :auth on require" unless %*ENV<RAKUDO_RAKUAST>;
+        dies-ok { require Require::Fixture:auth<nobody> },
+            'require fails on an unsatisfiable :auth constraint';
     }
-    todo "the legacy grammar ignores an unsatisfiable :ver on require" unless %*ENV<RAKUDO_RAKUAST>;
-    dies-ok { require Test:ver<999999.1> },
-        'require fails on an unsatisfiable :ver constraint';
-    todo "the legacy grammar ignores an unsatisfiable :auth on require" unless %*ENV<RAKUDO_RAKUAST>;
-    dies-ok { require Test:auth<nobody> },
-        'require fails on an unsatisfiable :auth constraint';
 }
 
 # src/Raku/ast/regex.rakumod

--- a/t/12-rakuast/xx-fixed-in-rakuast.rakutest
+++ b/t/12-rakuast/xx-fixed-in-rakuast.rakutest
@@ -447,7 +447,7 @@ subtest 'use of &?ROUTINE and &?BLOCK' => {
 
 # https://github.com/rakudo/rakudo/issues/3786
 {
-    todo "dispatch error"; # unless %*ENV<RAKUDO_RAKUAST>;
+    todo "dispatch error" unless %*ENV<RAKUDO_RAKUAST>;
     is-deeply
       (try 'my class C { has $.sig = :(); }; C.new.sig'.EVAL),
       :(), 'can have a signature as a default for an attribute';

--- a/t/packages/12-rakuast/require-fixture/META6.json
+++ b/t/packages/12-rakuast/require-fixture/META6.json
@@ -1,0 +1,10 @@
+{
+    "name": "Require::Fixture",
+    "ver": "1.5",
+    "auth": "test:fixture",
+    "api": "2",
+    "description": "Fixture distribution for require adverb constraint tests",
+    "provides": {
+        "Require::Fixture": "lib/Require/Fixture.rakumod"
+    }
+}

--- a/t/packages/12-rakuast/require-fixture/lib/Require/Fixture.rakumod
+++ b/t/packages/12-rakuast/require-fixture/lib/Require/Fixture.rakumod
@@ -1,0 +1,3 @@
+unit module Require::Fixture;
+
+sub fixture-sub is export { 'fixture' }


### PR DESCRIPTION
Previously the require adverb tests constrained requires of the installed Test module. What those constraints exercise then depends on the environment: which repository in the chain resolves the name, and whether the distribution it resolves to declares a version or auth at all. A repository only enforces the fields a distribution declares, so a bare source resolved from a lib directory satisfies any constraint, and an installed Test is not guaranteed to be present in the first place.

The tests now prepend a fixture distribution whose META6.json declares a version, auth, and api, and constrain requires of that. Resolution goes through the fixture in every environment, so the satisfiable constraints load, the import form imports, and the unsatisfiable constraints fail deterministically regardless of what the surrounding installation provides.

Also scopes the todo on the attribute-signature-default test to the legacy frontend. The test passes under RakuAST, so the todo now covers only the frontend where the dispatch error remains.
