### PR TITLE
RakuAST: skip unused implicits, flatten more statement forms, and inline compile-time decided dispatches

### DIFF
--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -731,6 +731,7 @@ class RakuAST::Node {
             self.IMPL-MARK-STATIC-CHAIN($resolver, $expr);
             self.IMPL-MARK-RETURN-DECONT($resolver, $expr);
             self.IMPL-MARK-ARRAY-INIT($resolver, $expr);
+            self.IMPL-MARK-CT-DISPATCH($resolver, $expr);
         }
 
         # A replacement stands where the original stood, so it must carry the
@@ -1111,6 +1112,181 @@ class RakuAST::Node {
             $init.nosink(1);
         }
         $init
+    }
+
+    # Mark a call whose argument types decide the dispatch at compile time.
+    # A named sub call and an infix operator application both qualify when
+    # the callee resolves to a compile-time routine whose lexical is bound
+    # once, and every argument is a plain positional with a known nominal
+    # type. For an onlystar multi, the proto must trial-bind and the
+    # candidate analysis must land on exactly one candidate; for a plain
+    # sub, its own signature must trial-bind. The chosen routine is recorded
+    # on the node, and code generation splices its inline info, when it has
+    # any, in place of the call. A chaining operator only qualifies standing
+    # alone: a link inside a longer chain takes part in the chain op
+    # protocol, which an inlined body no longer would.
+    method IMPL-MARK-CT-DISPATCH(RakuAST::Resolver $resolver, Mu $expr) {
+        return Nil if nqp::istrue(nqp::ifnull(nqp::getlexdyn('$*NO-CT-DISPATCH'), 0));
+        my $target;
+        my @args;
+        my str $lexname;
+        if nqp::istype($expr, RakuAST::Call::Name) {
+            return Nil unless $expr.name.is-identifier
+                && $expr.is-resolved
+                && !$expr.feed-stage;
+            return Nil if nqp::isconcrete($expr.args.invocant);
+            my $arg-list := $expr.args;
+            for self.IMPL-UNWRAP-LIST($arg-list.args) {
+                return Nil if nqp::istype($_, RakuAST::NamedArg)
+                    || $arg-list.IMPL-IS-FLATTENING($_);
+                nqp::push(@args, $_);
+            }
+            $target := $expr;
+            $lexname := '&' ~ $expr.name.canonicalize;
+        }
+        elsif nqp::istype($expr, RakuAST::ApplyInfix) {
+            my $infix := $expr.infix;
+            return Nil unless nqp::istype($infix, RakuAST::Infix) && $infix.is-resolved;
+            return Nil if nqp::elems($expr.colonpairs);
+            my $left := $expr.left;
+            my $right := $expr.right;
+            if $infix.properties.chain {
+                # An operand that is itself a chain link makes this a longer
+                # chain. Its links take part in the chain op protocol, so
+                # none of them may be inlined. The operands were visited,
+                # and possibly marked, before this node was offered, so the
+                # decision they took is withdrawn here.
+                my int $linked := 0;
+                if nqp::istype($left, RakuAST::ApplyInfix)
+                    && nqp::istype($left.infix, RakuAST::Infix)
+                    && $left.infix.properties.chain {
+                    $left.infix.IMPL-CLEAR-CT-INLINE-CANDIDATE();
+                    $linked := 1;
+                }
+                if nqp::istype($right, RakuAST::ApplyInfix)
+                    && nqp::istype($right.infix, RakuAST::Infix)
+                    && $right.infix.properties.chain {
+                    $right.infix.IMPL-CLEAR-CT-INLINE-CANDIDATE();
+                    $linked := 1;
+                }
+                return Nil if $linked;
+            }
+            nqp::push(@args, $left);
+            nqp::push(@args, $right);
+            $target := $infix;
+            $lexname := '&infix' ~ $resolver.IMPL-CANONICALIZE-PAIR($infix.operator);
+        }
+        else {
+            return Nil;
+        }
+
+        my $resolution := $target.resolution;
+        return Nil unless self.IMPL-RESOLUTION-BOUND-ONCE($resolver, $resolution, $lexname);
+        my $routine := nqp::istype($resolution, RakuAST::CompileTimeValue)
+            ?? $resolution.compile-time-value
+            !! $resolution.maybe-compile-time-value;
+        return Nil unless nqp::isconcrete($routine)
+            && nqp::istype($routine, Code)
+            && nqp::can($routine, 'signature');
+
+        my @info := self.IMPL-CT-ARG-TYPES($resolver, @args);
+        return Nil unless nqp::elems(@info);
+        my @types := @info[0];
+        my @flags := @info[1];
+
+        my $chosen;
+        if nqp::can($routine, 'is_dispatcher') && $routine.is_dispatcher {
+            return Nil unless nqp::can($routine, 'onlystar') && $routine.onlystar;
+            my int $proto-ok := 0;
+            my @multi-result;
+            try {
+                $proto-ok := nqp::p6trialbind($routine.signature, @types, @flags);
+                @multi-result := $routine.analyze_dispatch(@types, @flags);
+            }
+            return Nil unless $proto-ok == 1
+                && nqp::elems(@multi-result)
+                && nqp::atpos(@multi-result, 0) == 1;
+            $chosen := nqp::atpos(@multi-result, 1);
+        }
+        else {
+            my int $ct-result := 0;
+            try $ct-result := nqp::p6trialbind($routine.signature, @types, @flags);
+            return Nil unless $ct-result == 1;
+            $chosen := $routine;
+        }
+        return Nil if nqp::can($chosen, 'soft') && $chosen.soft;
+        $target.IMPL-SET-CT-INLINE-CANDIDATE($chosen);
+        Nil
+    }
+
+    # The nominal types and native flags of the given arguments, as trial
+    # binding and candidate analysis expect them, or an empty list when any
+    # argument's type is not known well enough for the answer to be final.
+    # A native type is passed as its boxed counterpart carrying the native
+    # flag. A literal of a boxed type prefers a native candidate when it is
+    # alone or paired with a native argument of matching kind, as the same
+    # allomorphic argument would at run time.
+    method IMPL-CT-ARG-TYPES(RakuAST::Resolver $resolver, Mu @args) {
+        my int $ARG_IS_LITERAL := 32;
+        my @types;
+        my @flags;
+        my @allo;
+        my int $num-prim := 0;
+        my int $num-allo := 0;
+        for @args {
+            my $type := $_.return-type;
+            # A parameter read reports no type of its own; the declared type
+            # of the parameter's variable is the read's type. Kept local to
+            # this analysis so the trial-bind diagnostic's coverage does not
+            # change underneath existing code.
+            if $type =:= Mu
+                && nqp::istype($_, RakuAST::Var::Lexical)
+                && $_.is-resolved
+                && nqp::istype($_.resolution, RakuAST::ParameterTarget::Var)
+                && nqp::isconcrete($_.resolution.declaration) {
+                try $type := $_.resolution.declaration.return-type;
+            }
+            return [] if $type =:= Mu;
+            my int $ok := 0;
+            try $ok := $type.HOW.archetypes.nominal && !$type.HOW.archetypes.generic;
+            return [] unless $ok;
+            return [] if nqp::istype($type.HOW, Perl6::Metamodel::SubsetHOW);
+            my int $ps := nqp::objprimspec($type);
+            if $ps == 1 || $ps == 2 || $ps == 3 {
+                $type := self.IMPL-OPTIMIZE-SETTING-TYPE($resolver,
+                    $ps == 1 ?? 'Int' !! $ps == 2 ?? 'Num' !! 'Str');
+                return [] if nqp::isnull($type);
+                $num-prim++;
+            }
+            elsif $ps {
+                return [];
+            }
+            nqp::push(@types, $type);
+            nqp::push(@flags, $ps);
+            my int $allo-flag := 0;
+            if nqp::istype($_, RakuAST::Literal) {
+                my $native := $_.native-type-flag;
+                # An integer too wide for the native representation is not
+                # allomorphic: only its boxed form holds the value.
+                if nqp::defined($native)
+                    && !($native == 1
+                        && nqp::isbig_I(nqp::decont($_.compile-time-value))) {
+                    $allo-flag := $native;
+                    $num-allo++;
+                }
+            }
+            nqp::push(@allo, $allo-flag);
+        }
+        if nqp::elems(@types) == 2 && $num-prim == 1 && $num-allo == 1 {
+            my int $prim := nqp::atpos(@flags, 0) || nqp::atpos(@flags, 1);
+            my int $allo-idx := nqp::atpos(@allo, 0) ?? 0 !! 1;
+            nqp::bindpos(@flags, $allo-idx, $prim +| $ARG_IS_LITERAL)
+                if nqp::atpos(@allo, $allo-idx) == $prim;
+        }
+        elsif nqp::elems(@types) == 1 && $num-allo == 1 {
+            nqp::bindpos(@flags, 0, nqp::atpos(@allo, 0) +| $ARG_IS_LITERAL);
+        }
+        [@types, @flags]
     }
 
     # Whether a resolution's lexical is bound once, so the VM may resolve a

--- a/src/Raku/ast/call.rakumod
+++ b/src/Raku/ast/call.rakumod
@@ -477,7 +477,27 @@ class RakuAST::Call::Name
         nqp::bindattr_i(self, RakuAST::Call::Name, '$!callstatic', 1)
     }
 
+    # Set by the optimize pass when the argument types decide the dispatch
+    # at compile time: the routine, for a multi the chosen candidate, whose
+    # inline info, when it has any, is spliced in place of the call.
+    has Mu $!ct-inline-candidate;
+
+    method IMPL-SET-CT-INLINE-CANDIDATE(Mu $routine) {
+        nqp::bindattr(self, RakuAST::Call::Name, '$!ct-inline-candidate', $routine)
+    }
+
     method IMPL-EXPR-QAST(RakuAST::IMPL::QASTContext $context) {
+        if nqp::isconcrete($!ct-inline-candidate) {
+            my $info := nqp::getattr($!ct-inline-candidate, Routine, '$!inline_info');
+            if nqp::isconcrete($info) && nqp::istype($info, QAST::Node) {
+                my @args-qast;
+                for self.IMPL-UNWRAP-LIST(self.args.args) {
+                    nqp::push(@args-qast, $_.IMPL-TO-QAST($context));
+                }
+                my $inlined := self.IMPL-CT-INLINE-QAST($context, $!ct-inline-candidate, @args-qast);
+                return $inlined unless nqp::isnull($inlined);
+            }
+        }
         my $call := QAST::Op.new( :op('call') );
         if $!name.is-identifier {
             if !self.is-resolved && $!name.canonicalize eq 'die' {

--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -2022,6 +2022,13 @@ class RakuAST::Routine
     has Bool $!replace-stub;
     has Bool $!may-use-return;
 
+    # Set when the `soft` pragma is in effect where the routine is declared.
+    # The pragma promises the routine stays wrappable at run time, so no
+    # inline info may be recorded for it. Captured at begin time because the
+    # pragma is a scope property, and code generation, where the info is
+    # recorded, no longer has the scope stack.
+    has int $!in-soft-scope;
+
     method multiness() {
         my $multiness := $!multiness;
         nqp::isnull_s($multiness) ?? '' !! $multiness
@@ -2155,6 +2162,8 @@ class RakuAST::Routine
     }
 
     method PERFORM-BEGIN(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
+        nqp::bindattr_i(self, RakuAST::Routine, '$!in-soft-scope', 1)
+            if self.IMPL-IN-SOFT-SCOPE($resolver);
         self.body.to-begin-time($resolver, $context); # In case it's the default created in the ctor.
 
         # Make sure that our placeholder signature has resolutions performed.
@@ -2358,7 +2367,175 @@ class RakuAST::Routine
         $block.annotate('count', $signature.count);
         $block.push($body);
         self.add-phasers-handling-code($context, $block);
-        self.IMPL-MAYBE-FATALIZE-QAST($block)
+        my $formed := self.IMPL-MAYBE-FATALIZE-QAST($block);
+        self.IMPL-MAYBE-SET-INLINE-INFO($formed);
+        $formed
+    }
+
+    # A named sub whose body reduces to a tree of inlinable ops over its
+    # parameters records that tree on its code object, with each parameter
+    # use replaced by a positional placeholder. A caller that decides the
+    # dispatch at compile time splices the tree in place of the call, with
+    # the argument code standing in for the placeholders. Substituting
+    # argument code for a parameter is only identity-preserving when the
+    # binding is: every parameter must be native, required, positional, and
+    # by-value, with no constraints beyond its type. The routine itself must
+    # be a plain one: a custom invocation protocol, phasers, or the `soft`
+    # pragma's wrappability promise all keep the call.
+    method IMPL-MAYBE-SET-INLINE-INFO(Mu $block) {
+        return Nil unless nqp::istype(self, RakuAST::Sub)
+            && self.name
+            && !$!in-soft-scope;
+        my $code := self.meta-object;
+        return Nil unless nqp::isconcrete($code);
+        return Nil if nqp::can($code, 'CALL-ME');
+        return Nil if nqp::can($code, 'soft') && $code.soft;
+        return Nil if nqp::isconcrete(nqp::getattr($code, Block, '$!phasers'));
+        return Nil unless nqp::elems($block.list) == 3;
+
+        my $signature := nqp::getattr($code, Code, '$!signature');
+        my @params := nqp::getattr($signature, Signature, '@!params');
+        my int $n := nqp::elems(@params);
+        return Nil unless $n;
+        my %placeholders;
+        my int $i := -1;
+        while ++$i < $n {
+            my $param := nqp::atpos(@params, $i);
+            # Only a full-width signed int, full-width num, or str parameter
+            # binds any argument the trial bind accepts unchanged. An
+            # unsigned or narrower native wraps or truncates on binding,
+            # which argument code standing in for the parameter would skip.
+            my $param-type := nqp::getattr($param, Parameter, '$!type');
+            my int $ps := nqp::objprimspec($param-type);
+            return Nil unless $ps == 3
+                || ($ps == 1 || $ps == 2) && nqp::objprimbits($param-type) == 64;
+            my int $flags := nqp::getattr_i($param, Parameter, '$!flags');
+            return Nil if $flags +& (nqp::const::SIG_ELEM_IS_OPTIONAL
+                +| nqp::const::SIG_ELEM_IS_COPY
+                +| nqp::const::SIG_ELEM_BIND_PRIVATE_ATTR
+                +| nqp::const::SIG_ELEM_BIND_PUBLIC_ATTR);
+            return Nil if nqp::isconcrete(nqp::getattr($param, Parameter, '@!named_names'))
+                || nqp::isconcrete(nqp::getattr($param, Parameter, '@!type_captures'))
+                || nqp::isconcrete(nqp::getattr($param, Parameter, '@!post_constraints'))
+                || nqp::isconcrete(nqp::getattr($param, Parameter, '$!sub_signature'))
+                || nqp::isconcrete(nqp::getattr($param, Parameter, '$!default_value'))
+                || nqp::isconcrete(nqp::getattr($param, Parameter, '$!signature_constraint'));
+            my str $name := nqp::getattr_s($param, Parameter, '$!variable_name');
+            %placeholders{$name} := QAST::InlinePlaceholder.new(:position($i))
+                unless nqp::isnull_s($name) || $name eq '';
+        }
+
+        # The block's declarations may hold only the implicits a routine
+        # always gets and the parameters themselves. Anything else, and in
+        # particular any nested block, means the body depends on its frame.
+        for $block.list[0].list {
+            if nqp::istype($_, QAST::Var) && $_.scope eq 'lexical' {
+                my str $name := $_.name;
+                return Nil unless $name eq '$_' || $name eq '$/' || $name eq '$!'
+                    || $name eq '$¢' || $name eq '$*DISPATCHER'
+                    || nqp::existskey(%placeholders, $name);
+            }
+            elsif nqp::istype($_, QAST::Block) {
+                return Nil;
+            }
+            elsif (nqp::istype($_, QAST::Stmt) || nqp::istype($_, QAST::Stmts))
+                && nqp::elems($_.list) && nqp::istype($_.list[0], QAST::Block) {
+                return Nil;
+            }
+        }
+
+        # A body that spliced other routines' inline info is itself a
+        # candidate, so trees can compound through chains of small helpers.
+        # The node budget bounds that growth: a routine whose body walk
+        # exceeds it keeps the call, and the amount of code any single
+        # call site can splice stays small.
+        my $info;
+        my int $walked := 0;
+        my @budget := [64];
+        try {
+            $info := self.IMPL-INLINE-INFO-NODE($block.list[2], %placeholders, @budget);
+            $walked := 1;
+        }
+        if $walked && nqp::istype($info, QAST::Node) {
+            RakuAST::IMPL::VarLowering.IMPL-NOTE("INLINE-INFO " ~ self.name.canonicalize)
+                if nqp::existskey(nqp::getenvhash(), 'RAKUDO_INLINE_DEBUG');
+            nqp::bindattr($code, Routine, '$!inline_info', $info);
+        }
+        Nil
+    }
+
+    method IMPL-INLINE-INFO-CLEAR(Mu $node) {
+        $node.node(nqp::null());
+        $node.clear_annotations();
+        $node
+    }
+
+    # Rebuild a body node as inline info, dying when the body is not
+    # expressible independent of its frame: only literal values, object
+    # references other than pseudo-stashes, inlinable ops, statement and
+    # want wrappers, and parameter reads, which become placeholders, can
+    # appear. Source locations and annotations are stripped from the
+    # copies, as they describe the routine, not the call site the tree
+    # will be spliced into.
+    method IMPL-INLINE-INFO-NODE(Mu $node, %placeholders, @budget) {
+        nqp::bindpos(@budget, 0, nqp::atpos(@budget, 0) - 1);
+        nqp::die('Body too large to inline') if nqp::atpos(@budget, 0) < 0;
+        if nqp::istype($node, QAST::IVal) || nqp::istype($node, QAST::SVal)
+            || nqp::istype($node, QAST::NVal) {
+            $node.node ?? self.IMPL-INLINE-INFO-CLEAR($node.shallow_clone) !! $node
+        }
+        elsif nqp::istype($node, QAST::WVal) {
+            nqp::die('Routines using pseudo-stashes are not inlinable')
+                if $node.value.HOW.name($node.value) eq 'PseudoStash';
+            $node.node ?? self.IMPL-INLINE-INFO-CLEAR($node.shallow_clone) !! $node
+        }
+        elsif nqp::istype($node, QAST::Op) {
+            nqp::die('Non-inlinable op encountered')
+                unless nqp::getcomp('QAST').operations.is_inlinable('Raku', $node.op);
+            my $replacement := $node.shallow_clone;
+            my int $n := nqp::elems($node.list);
+            my int $i := -1;
+            while ++$i < $n {
+                nqp::bindpos($replacement.list, $i,
+                    self.IMPL-INLINE-INFO-NODE($node.list[$i], %placeholders, @budget));
+            }
+            self.IMPL-INLINE-INFO-CLEAR($replacement)
+        }
+        elsif nqp::istype($node, QAST::Var) && ($node.scope eq 'lexical' || $node.scope eq '') {
+            nqp::die('Cannot inline with non-argument variables')
+                unless nqp::existskey(%placeholders, $node.name);
+            my $replacement := %placeholders{$node.name};
+            if $node.named || $node.flat {
+                $replacement := $replacement.shallow_clone;
+                $replacement.named($node.named) if $node.named;
+                $replacement.flat($node.flat) if $node.flat;
+            }
+            $replacement
+        }
+        elsif nqp::istype($node, QAST::Stmt) || nqp::istype($node, QAST::Stmts) {
+            my $replacement := $node.shallow_clone;
+            my int $n := nqp::elems($node.list);
+            my int $i := -1;
+            while ++$i < $n {
+                nqp::bindpos($replacement.list, $i,
+                    self.IMPL-INLINE-INFO-NODE($node.list[$i], %placeholders, @budget));
+            }
+            self.IMPL-INLINE-INFO-CLEAR($replacement)
+        }
+        elsif nqp::istype($node, QAST::Want) {
+            my $replacement := $node.shallow_clone;
+            my int $n := nqp::elems($node.list);
+            my int $i := 0;
+            while $i < $n {
+                nqp::bindpos($replacement.list, $i,
+                    self.IMPL-INLINE-INFO-NODE($node.list[$i], %placeholders, @budget));
+                $i := $i + 2;
+            }
+            self.IMPL-INLINE-INFO-CLEAR($replacement)
+        }
+        else {
+            nqp::die('Unhandled node type; will not inline')
+        }
     }
 
     method IMPL-COMPILE-BODY(RakuAST::IMPL::QASTContext $context) {

--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -1756,6 +1756,11 @@ class RakuAST::Block
             $block
         }
         else {
+            # A frame-independent bare block statement runs inline, with
+            # no closure clone and no call.
+            return self.IMPL-QAST-FLATTENED($context)
+                if self.bare-block && self.IMPL-FLATTEN-APPROVED;
+
             # Not immediate, so already produced as a declaration above; just
             # closure clone it. Only invoke if it's a bare block.
             # Ensure the block is linked when our outer block gets cloned before

--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -1470,6 +1470,45 @@ class RakuAST::Block
 
     method IMPL-FLATTEN-APPROVED() { $!flatten-approved }
 
+    # The declaration receiving a flattened invocation's argument. A
+    # plain block has none: its topic is only eligible for flattening
+    # when unused, so the argument is discarded.
+    method IMPL-FLATTEN-ARG-DECLARATION() { nqp::null }
+
+    # As IMPL-QAST-FLATTENED, but binding the given argument QAST into
+    # the block's argument declaration, the way calling the block with
+    # one positional would have.
+    method IMPL-QAST-FLATTENED-WITH-ARG(RakuAST::IMPL::QASTContext $context, Mu $arg-qast) {
+        my $arg-decl := self.IMPL-FLATTEN-ARG-DECLARATION;
+        my $stmts := QAST::Stmts.new();
+        for self.IMPL-UNWRAP-LIST(self.ast-lexical-declarations()) {
+            if nqp::istype($_, RakuAST::VarDeclaration::Simple)
+                && $_.IMPL-LOWERED-LOCAL-NAME {
+                if !nqp::isnull($arg-decl) && nqp::eqaddr($_, $arg-decl) {
+                    my str $local-name := $_.IMPL-LOWERED-LOCAL-NAME;
+                    $stmts.push(QAST::Var.new(
+                        :scope('local'), :decl('var'), :name($local-name) ));
+                    # hllize as the parameter binder would have, since
+                    # an iterator driven from nqp-side code can hand out
+                    # unboxed values.
+                    $stmts.push(QAST::Op.new(
+                        :op('bind'),
+                        QAST::Var.new( :name($local-name), :scope('local') ),
+                        QAST::Op.new( :op('hllize'),
+                            QAST::Op.new( :op('decont'), $arg-qast ) )
+                    ));
+                }
+                else {
+                    $stmts.push($_.IMPL-QAST-DECL-FLATTENED($context));
+                }
+            }
+        }
+        my $nested-blocks := self.IMPL-QAST-NESTED-BLOCK-DECLS($context);
+        $stmts.push($nested-blocks) if nqp::elems($nested-blocks.list);
+        $stmts.push($!body.IMPL-TO-QAST($context));
+        $stmts
+    }
+
     # The body emitted for inlining into the frame of the block's user:
     # declarations of nested code objects, the lowered locals with a
     # fresh container clone on every entry (a per-iteration frame would
@@ -1713,6 +1752,7 @@ class RakuAST::Block
             :$blocktype,
             self.IMPL-QAST-DECLS($context)
         );
+        self.IMPL-ADD-LOWERED-DEBUG-MAPPINGS($block);
 
         # Compile body and, if needed, a signature, and set up arity and any
         # exception rethrow logic.
@@ -1802,6 +1842,33 @@ class RakuAST::PointyBlock
   is RakuAST::Doc::DeclaratorTarget
 {
     has RakuAST::Signature $.signature;
+
+    # The single plain positional parameter, when the signature is
+    # simple enough that binding a flattened invocation's argument to
+    # the parameter's local matches what the call would have done: no
+    # type to check, no default, no where, no adverbs, no traits.
+    method IMPL-FLATTEN-ARG-DECLARATION() {
+        my @params := self.IMPL-UNWRAP-LIST($!signature.parameters);
+        return nqp::null unless nqp::elems(@params) == 1;
+        my $param := @params[0];
+        return nqp::null if nqp::isconcrete($param.type)
+            || nqp::isconcrete($param.default)
+            || nqp::isconcrete($param.where)
+            || nqp::isconcrete($param.array-shape)
+            || nqp::isconcrete($param.sub-signature)
+            || $param.optional
+            || $param.invocant
+            || $param.default-rw
+            || $param.default-raw
+            || !($param.slurpy =:= RakuAST::Parameter::Slurpy)
+            || nqp::elems($param.IMPL-UNWRAP-LIST($param.names))
+            || nqp::elems($param.IMPL-UNWRAP-LIST($param.traits));
+        my $target := $param.target;
+        return nqp::null unless nqp::istype($target, RakuAST::ParameterTarget::Var)
+            && nqp::isconcrete($target.declaration)
+            && !nqp::elems($target.declaration.IMPL-UNWRAP-LIST($target.declaration.traits));
+        $target.declaration
+    }
 
     method new(RakuAST::Signature :$signature,
                 RakuAST::Blockoid :$body,
@@ -2283,6 +2350,7 @@ class RakuAST::Routine
                     :blocktype('declaration_static'),
                     self.IMPL-QAST-DECLS($context)
                 ), :key);
+        self.IMPL-ADD-LOWERED-DEBUG-MAPPINGS($block);
         my $signature := self.placeholder-signature || $!signature;
         $block.push($signature.IMPL-QAST-BINDINGS($context, :needs-full-binder(self.custom-args), :multi(self.multiness eq 'multi')));
         $block.custom_args(1) if self.custom-args;

--- a/src/Raku/ast/compunit.rakumod
+++ b/src/Raku/ast/compunit.rakumod
@@ -219,6 +219,9 @@ class RakuAST::CompUnit
     # (the tree is already checked, nothing is being declared), so a caller just
     # hands over a resolver.
     method optimize(RakuAST::Resolver $resolver, :$interactive?) {
+        # Diagnostic switch: turns compile-time dispatch decisions off so a
+        # suspect inlining can be ruled in or out without a rebuild.
+        my $*NO-CT-DISPATCH := nqp::existskey(nqp::getenvhash(), 'RAKUDO_NO_CT_DISPATCH');
         $resolver.push-scope(self);
         $!mainline.IMPL-OPTIMIZE($resolver);
         self.IMPL-OPTIMIZE($resolver);

--- a/src/Raku/ast/compunit.rakumod
+++ b/src/Raku/ast/compunit.rakumod
@@ -591,6 +591,9 @@ class RakuAST::CompUnit
                 $!mainline.IMPL-QAST-FORM-BLOCK($context, :blocktype<declaration_static>);
         $top-level.name('<unit>');
         $top-level.annotate('IN_DECL', $!is-eval ?? 'eval' !! 'mainline');
+        # The compilation unit's own lowered declarations live in the
+        # mainline frame the shell block forms.
+        self.IMPL-ADD-LOWERED-DEBUG-MAPPINGS($top-level);
         my @pre-deserialize;
         # When compiling a CORE.<spec>.setting (setting-name shaped like
         # 'NULL.<spec>'), emit a pre-deserialize task that calls

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -3981,7 +3981,9 @@ class RakuAST::Statement::For
             && self.IMPL-CAN-USE-STATEMENT-FORM($!body) {
             my @lookups := self.IMPL-UNWRAP-LIST(self.get-implicit-lookups);
             my $Nil := @lookups[1].resolution.compile-time-value;
-            my $body-qast := $!body.IMPL-TO-QAST($context);
+            my int $flatten := $!body.IMPL-FLATTEN-APPROVED;
+            my $flatten-body := $flatten ?? $!body !! Mu;
+            my $body-qast := $flatten ?? Mu !! $!body.IMPL-TO-QAST($context);
 
             # An integer-range source the optimize pass approved becomes a
             # native counting loop, unless a bound turns out not to be a
@@ -3990,7 +3992,7 @@ class RakuAST::Statement::For
                 && nqp::elems(@labels) == 0
                 && !$!body.has-any-phasers {
                 my $range-qast := self.IMPL-TO-QAST-RANGE(
-                    $context, $!source, $body-qast, $Nil);
+                    $context, $!source, $body-qast, $Nil, :flatten-body($flatten-body));
                 return $range-qast unless $range-qast =:= Mu;
             }
 
@@ -4000,7 +4002,8 @@ class RakuAST::Statement::For
               $body-qast,
               @labels ?? @labels[0] !! RakuAST::Label,
               @lookups[0].resolution.compile-time-value,
-              $Nil
+              $Nil,
+              :flatten-body($flatten-body)
             );
         }
 

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -493,6 +493,19 @@ class RakuAST::Infix
         nqp::bindattr_i(self, RakuAST::Infix, '$!chainstatic', 1)
     }
 
+    # Set by the optimize pass when the operand types decide the dispatch at
+    # compile time: the routine, for a multi the chosen candidate, whose
+    # inline info, when it has any, is spliced in place of the operator call.
+    has Mu $!ct-inline-candidate;
+
+    method IMPL-SET-CT-INLINE-CANDIDATE(Mu $routine) {
+        nqp::bindattr(self, RakuAST::Infix, '$!ct-inline-candidate', $routine)
+    }
+
+    method IMPL-CLEAR-CT-INLINE-CANDIDATE() {
+        nqp::bindattr(self, RakuAST::Infix, '$!ct-inline-candidate', nqp::null())
+    }
+
     # Set by the optimize pass on the assignment of a comma list to a plain
     # array variable, for lowering to a direct build of the list internals.
     has int $!lowered-array-init;
@@ -579,19 +592,31 @@ class RakuAST::Infix
             $name := '&infix' ~ RakuAST::Resolver.IMPL-CANONICALIZE-PAIR($!operator);
         }
 
-        (my str $op := QAST-OP{$!operator})
-          # Directly mapping
-          ?? QAST::Op.new(:$op, $left-qast, $right-qast)
-          # Otherwise, it's called by finding the lexical sub to call, and
-          # compiling it as chaining if required.
-          !! self.IMPL-SIMPLIFY-REF-ARGS(QAST::Op.new(
-               :op(self.properties.chain
-                     ?? ($!chainstatic ?? 'chainstatic' !! 'chain')
-                     !! 'call'),
-               :$name,
-               $left-qast,
-               $right-qast
-             ))
+        # Directly mapping
+        my str $op := QAST-OP{$!operator};
+        if $op {
+            return QAST::Op.new(:$op, $left-qast, $right-qast);
+        }
+
+        # A compile-time-decided dispatch to a routine with inline info
+        # stands in for the call. A single-link chain compiles the same as
+        # a call, so the inlined body serves either form.
+        if nqp::isconcrete($!ct-inline-candidate) {
+            my $inlined := self.IMPL-CT-INLINE-QAST(
+                $context, $!ct-inline-candidate, [$left-qast, $right-qast]);
+            return $inlined unless nqp::isnull($inlined);
+        }
+
+        # Otherwise, it's called by finding the lexical sub to call, and
+        # compiling it as chaining if required.
+        self.IMPL-SIMPLIFY-REF-ARGS(QAST::Op.new(
+            :op(self.properties.chain
+                  ?? ($!chainstatic ?? 'chainstatic' !! 'chain')
+                  !! 'call'),
+            :$name,
+            $left-qast,
+            $right-qast
+        ))
     }
 
     method IMPL-ASSIGN-OP(QAST::Node $lhs_ast, QAST::Node $rhs_ast) {

--- a/src/Raku/ast/scoping.rakumod
+++ b/src/Raku/ast/scoping.rakumod
@@ -1125,6 +1125,87 @@ class RakuAST::Lookup
         }
         1
     }
+
+    # Splice the given routine's inline info in place of a call to it, with
+    # the argument code standing in for the parameter placeholders, or null
+    # when the routine carries no inline info. An argument used other than
+    # exactly once in the body is bound to a temporary first, so its code
+    # runs once regardless. A native reference argument bound to a
+    # never-rw parameter is downgraded to a value read, as the reference
+    # would only re-box on every use in the spliced body.
+    method IMPL-CT-INLINE-QAST(RakuAST::IMPL::QASTContext $context, Mu $routine, Mu @args-qast) {
+        my $info := nqp::getattr($routine, Routine, '$!inline_info');
+        return nqp::null() unless nqp::isconcrete($info) && nqp::istype($info, QAST::Node);
+        return nqp::null() if nqp::can($routine, 'soft') && $routine.soft;
+        RakuAST::IMPL::VarLowering.IMPL-NOTE("SPLICE " ~ $routine.name)
+            if nqp::existskey(nqp::getenvhash(), 'RAKUDO_INLINE_DEBUG');
+        my $sig := nqp::getattr($routine, Code, '$!signature');
+        my @params := nqp::isconcrete($sig)
+            ?? nqp::getattr($sig, Signature, '@!params')
+            !! nqp::list();
+        my @usages;
+        $info.count_inline_placeholder_usages(@usages);
+        my $inlined := QAST::Stmts.new();
+        my @fillers;
+        my int $n := nqp::elems(@args-qast);
+        my int $i := -1;
+        while ++$i < $n {
+            my $arg := nqp::atpos(@args-qast, $i);
+            # Every parameter of a routine with inline info is native. A
+            # native variable argument already carries its native type,
+            # but a literal's code offers the native form only where that
+            # form is wanted, and falls back to the boxed value anywhere
+            # else. The bound parameter would have been the native value
+            # throughout, so its native form stands in.
+            if $i < nqp::elems(@params) && nqp::istype($arg, QAST::Want) {
+                my int $ps := nqp::objprimspec(nqp::getattr(
+                    nqp::atpos(@params, $i), Parameter, '$!type'));
+                if $ps {
+                    my str $want := $ps == 1 ?? 'Ii' !! $ps == 2 ?? 'Nn' !! 'Ss';
+                    my int $j := 1;
+                    my int $alts := nqp::elems($arg.list);
+                    while $j < $alts {
+                        if nqp::atpos($arg.list, $j) eq $want {
+                            $arg := nqp::atpos($arg.list, $j + 1);
+                            last;
+                        }
+                        $j := $j + 2;
+                    }
+                }
+            }
+            unless $*COMPILING_CORE_SETTING {
+                if nqp::istype($arg, QAST::Var) && nqp::objprimspec($arg.returns) {
+                    my str $scope := $arg.scope;
+                    if ($scope eq 'lexicalref' || $scope eq 'attributeref')
+                        && self.IMPL-PARAM-NEVER-RW($routine, $i) {
+                        $arg.scope($scope eq 'lexicalref' ?? 'lexical' !! 'attribute');
+                    }
+                }
+            }
+            my $usage := nqp::atpos(@usages, $i);
+            if !nqp::isnull($usage) && $usage == 1 {
+                nqp::push(@fillers, $arg);
+            }
+            else {
+                my str $name := QAST::Node.unique('_inline_arg_');
+                $inlined.push(QAST::Op.new(
+                    :op('bind'),
+                    QAST::Var.new( :name($name), :scope('local'), :returns($arg.returns), :decl('var') ),
+                    $arg));
+                nqp::push(@fillers, QAST::Var.new( :name($name), :scope('local'), :returns($arg.returns) ));
+            }
+        }
+        $inlined.push($info.substitute_inline_placeholders(@fillers));
+        # The routine's return type, read raw: a method dispatch on the
+        # routine can not be made while the setting holding it is still
+        # being compiled.
+        if nqp::isconcrete($sig) {
+            my $returns := nqp::getattr($sig, Signature, '$!returns');
+            $inlined.returns($returns)
+                unless nqp::isnull($returns) || nqp::isconcrete($returns);
+        }
+        $inlined
+    }
 }
 
 # Details about an undeclared symbol.

--- a/src/Raku/ast/scoping.rakumod
+++ b/src/Raku/ast/scoping.rakumod
@@ -55,6 +55,19 @@ class RakuAST::LexicalScope
         Nil
     }
 
+    # Register the original names of this scope's lowered declarations
+    # on the block, so backtraces and debuggers can still name them.
+    method IMPL-ADD-LOWERED-DEBUG-MAPPINGS(Mu $block) {
+        for self.IMPL-UNWRAP-LIST(self.ast-lexical-declarations()) {
+            if nqp::istype($_, RakuAST::VarDeclaration::Simple)
+                && $_.IMPL-LOWERED-LOCAL-NAME {
+                $block.add_local_debug_mapping(
+                    $_.IMPL-LOWERED-LOCAL-NAME, $_.lexical-name);
+            }
+        }
+        Nil
+    }
+
     method IMPL-QAST-DECLS(RakuAST::IMPL::QASTContext $context) {
         my $stmts := QAST::Stmts.new();
 

--- a/src/Raku/ast/signature.rakumod
+++ b/src/Raku/ast/signature.rakumod
@@ -1365,7 +1365,12 @@ class RakuAST::Parameter
         my $param-qast := QAST::Var.new( :decl('param'), :scope('local'), :$name );
         my $temp-qast-var := QAST::Var.new( :name($name), :scope('local') );
 
-        # Deal with nameds and slurpies.
+        # Deal with nameds and slurpies. An unused implicit slurpy hash
+        # still accepts and discards stray nameds, but builds no hash.
+        my int $discard := nqp::isconcrete($!target)
+            && nqp::istype($!target, RakuAST::ParameterTarget::Var)
+            && nqp::isconcrete($!target.declaration)
+            && $!target.declaration.IMPL-UNUSED-SLURPY;
         my int $was-slurpy;
         my @prepend;
         if $!names {
@@ -1373,7 +1378,7 @@ class RakuAST::Parameter
         }
         elsif !($!slurpy =:= RakuAST::Parameter::Slurpy) {
             $!slurpy.IMPL-TRANSFORM-PARAM-QAST($context, $param-qast, $temp-qast-var,
-                $!target.sigil, $flags, @prepend);
+                $!target.sigil, $flags, @prepend, :discard($discard));
             $was-slurpy := 1;
         }
 
@@ -1713,7 +1718,7 @@ class RakuAST::Parameter
                         $temp-qast-var,
                     )));
         }
-        if nqp::isconcrete($!target) {
+        if nqp::isconcrete($!target) && !$discard {
             if $flags +& (
               nqp::const::SIG_ELEM_IS_RW +| nqp::const::SIG_ELEM_IS_RAW
             ) {
@@ -2345,7 +2350,7 @@ class RakuAST::Parameter::Slurpy {
     }
 
     method IMPL-TRANSFORM-PARAM-QAST(RakuAST::IMPL::QASTContext $context,
-            Mu $param-qast, Mu $temp-qast, str $sigil, int $flags, @prepend) {
+            Mu $param-qast, Mu $temp-qast, str $sigil, int $flags, @prepend, :$discard) {
         # Not slurply, so nothing to do
         $param-qast
     }
@@ -2375,7 +2380,7 @@ class RakuAST::Parameter::Slurpy::Flattened
     }
 
     method IMPL-TRANSFORM-PARAM-QAST(RakuAST::IMPL::QASTContext $context,
-            Mu $param-qast, Mu $temp-qast, str $sigil, int $flags, @prepend) {
+            Mu $param-qast, Mu $temp-qast, str $sigil, int $flags, @prepend, :$discard) {
         my int $is-rw := $flags +& nqp::const::SIG_ELEM_IS_RW;
         my int $is-raw := $flags +& nqp::const::SIG_ELEM_IS_RAW;
 
@@ -2398,7 +2403,7 @@ class RakuAST::Parameter::Slurpy::Flattened
                     QAST::SVal.new( :value('$!storage') ),
                     $temp-qast
                 )
-            ));
+            )) unless $discard;
         }
         elsif $sigil eq '$' || $sigil eq '&' {
             # Slurpiness on scalar and callable parameters does not actually have
@@ -2421,7 +2426,7 @@ class RakuAST::Parameter::Slurpy::Unflattened
     }
 
     method IMPL-TRANSFORM-PARAM-QAST(RakuAST::IMPL::QASTContext $context,
-            Mu $param-qast, Mu $temp-qast, str $sigil, int $flags, @prepend) {
+            Mu $param-qast, Mu $temp-qast, str $sigil, int $flags, @prepend, :$discard) {
         my int $is-rw := $flags +& nqp::const::SIG_ELEM_IS_RW;
         my int $is-raw := $flags +& nqp::const::SIG_ELEM_IS_RAW;
         if $sigil eq '@' {
@@ -2444,7 +2449,7 @@ class RakuAST::Parameter::Slurpy::SingleArgument
     }
 
     method IMPL-TRANSFORM-PARAM-QAST(RakuAST::IMPL::QASTContext $context,
-            Mu $param-qast, Mu $temp-qast, str $sigil, int $flags, @prepend) {
+            Mu $param-qast, Mu $temp-qast, str $sigil, int $flags, @prepend, :$discard) {
         my int $is-rw := $flags +& nqp::const::SIG_ELEM_IS_RW;
         my int $is-raw := $flags +& nqp::const::SIG_ELEM_IS_RAW;
         if $sigil eq '@' || $sigil eq '' {
@@ -2465,7 +2470,7 @@ class RakuAST::Parameter::Slurpy::Capture
     }
 
     method IMPL-TRANSFORM-PARAM-QAST(RakuAST::IMPL::QASTContext $context,
-            Mu $param-qast, Mu $temp-qast, str $sigil, int $flags, @prepend) {
+            Mu $param-qast, Mu $temp-qast, str $sigil, int $flags, @prepend, :$discard) {
         # Sneak in a slurpy hash parameter too.
         $param-qast.slurpy(1);
         my $hash-param-name := $temp-qast.name ~ '_hash';

--- a/src/Raku/ast/statements.rakumod
+++ b/src/Raku/ast/statements.rakumod
@@ -252,7 +252,7 @@ class RakuAST::ForLoopImplementation
     # via the optimize pass and that the body is a simple one-argument
     # block with no phasers.
     method IMPL-TO-QAST-RANGE(RakuAST::IMPL::QASTContext $context,
-            Mu $source, Mu $body-qast, Mu $Nil) {
+            Mu $source, Mu $body-qast, Mu $Nil, :$flatten-body) {
         my $expr := self.IMPL-UNWRAP-RANGE-EXPRESSION($source);
         my int $reverse := 0;
         if nqp::istype($expr, RakuAST::ApplyPostfix)
@@ -321,13 +321,25 @@ class RakuAST::ForLoopImplementation
                 :name($last-name), :scope<local>, :decl<var>, :returns(int) ),
             $end-qast
         );
-        my $bind-callee := QAST::Op.new( :op<bind>,
-            QAST::Var.new( :name($callee-name), :scope<local>, :decl<var> ),
-            $body-qast
-        );
+        my int $flatten := nqp::isconcrete($flatten-body);
+        my $bind-callee;
+        unless $flatten {
+            $bind-callee := QAST::Op.new( :op<bind>,
+                QAST::Var.new( :name($callee-name), :scope<local>, :decl<var> ),
+                $body-qast
+            );
+        }
 
-        # Step the iteration value and call the body with it while it is
-        # on the start side of the end value.
+        # Step the iteration value and run the body with it while it is
+        # on the start side of the end value: inline when the body
+        # flattens, as a call otherwise.
+        my $body-run := $flatten
+            ?? $flatten-body.IMPL-QAST-FLATTENED-WITH-ARG($context,
+                QAST::Var.new( :name($it-name), :scope<local>, :returns(int) ))
+            !! QAST::Op.new( :op<call>,
+                QAST::Var.new( :name($callee-name), :scope<local> ),
+                QAST::Var.new( :name($it-name), :scope<local>, :returns(int) )
+            );
         my $loop := QAST::Op.new( :op<while>,
             QAST::Op.new(
                 :op($step < 0 ?? 'isge_i' !! 'isle_i'),
@@ -340,21 +352,15 @@ class RakuAST::ForLoopImplementation
                 ),
                 QAST::Var.new( :name($last-name), :scope<local>, :returns(int) )
             ),
-            QAST::Op.new( :op<call>,
-                QAST::Var.new( :name($callee-name), :scope<local> ),
-                QAST::Var.new( :name($it-name), :scope<local>, :returns(int) )
-            )
+            $body-run
         );
 
         $context.ensure-sc($Nil);
-        self.IMPL-SET-NODE(
-            QAST::Stmts.new(
-                $bind-it,
-                $bind-last,
-                $bind-callee,
-                $loop,
-                QAST::WVal.new( :value($Nil) )
-            ), :key)
+        my $stmts := QAST::Stmts.new( $bind-it, $bind-last );
+        $stmts.push($bind-callee) unless $flatten;
+        $stmts.push($loop);
+        $stmts.push(QAST::WVal.new( :value($Nil) ));
+        self.IMPL-SET-NODE($stmts, :key)
     }
 
     # Whether a sunk statement-level for loop with the given body can
@@ -375,7 +381,7 @@ class RakuAST::ForLoopImplementation
     # has no loop phasers, matching the legacy p6forstmt op.
     method IMPL-TO-QAST-STATEMENT(RakuAST::IMPL::QASTContext $context,
             Mu $source-qast, Mu $body-qast, RakuAST::Label $label,
-            Mu $IterationEnd, Mu $Nil) {
+            Mu $IterationEnd, Mu $Nil, :$flatten-body) {
         # Bind the source into a temporary.
         my $for-target-name := QAST::Node.unique('for_target');
         my $bind-target := QAST::Op.new(
@@ -417,21 +423,35 @@ class RakuAST::ForLoopImplementation
         );
 
         # Bind the underlying VM code ref of the body so each iteration
-        # invokes it without going through the code object.
+        # invokes it without going through the code object. A flattened
+        # body runs inline instead, with the pulled value bound to its
+        # argument declaration.
+        my int $flatten := nqp::isconcrete($flatten-body);
         my $block-name := QAST::Node.unique('for_block');
-        my $bind-block := QAST::Op.new(
-            :op('bind'),
-            QAST::Var.new( :name($block-name), :scope('local'), :decl('var') ),
-            QAST::Op.new(
-                :op('getattr'),
-                $body-qast,
-                QAST::WVal.new( :value(Code) ),
-                QAST::SVal.new( :value('$!do') )
-            )
-        );
+        my $bind-block;
+        unless $flatten {
+            $bind-block := QAST::Op.new(
+                :op('bind'),
+                QAST::Var.new( :name($block-name), :scope('local'), :decl('var') ),
+                QAST::Op.new(
+                    :op('getattr'),
+                    $body-qast,
+                    QAST::WVal.new( :value(Code) ),
+                    QAST::SVal.new( :value('$!do') )
+                )
+            );
+        }
 
-        # Pull values until IterationEnd, calling the body with each one.
+        # Pull values until IterationEnd, running the body with each one.
         my $iter-val-name := QAST::Node.unique('for_iterval');
+        my $body-run := $flatten
+            ?? $flatten-body.IMPL-QAST-FLATTENED-WITH-ARG($context,
+                QAST::Var.new( :name($iter-val-name), :scope('local') ))
+            !! QAST::Op.new(
+                :op('call'),
+                QAST::Var.new( :name($block-name), :scope('local') ),
+                QAST::Var.new( :name($iter-val-name), :scope('local') )
+            );
         my $loop := QAST::Op.new(
             :op('until'),
             QAST::Op.new(
@@ -449,11 +469,7 @@ class RakuAST::ForLoopImplementation
                 ),
                 QAST::Var.new( :name($iteration-end-name), :scope('local') )
             ),
-            QAST::Op.new(
-                :op('call'),
-                QAST::Var.new( :name($block-name), :scope('local') ),
-                QAST::Var.new( :name($iter-val-name), :scope('local') )
-            )
+            $body-run
         );
         if $label {
             my $label-qast := $label.IMPL-LOOKUP-QAST($context);
@@ -462,15 +478,11 @@ class RakuAST::ForLoopImplementation
         }
 
         $context.ensure-sc($Nil);
-        self.IMPL-SET-NODE(
-            QAST::Stmts.new(
-                $bind-target,
-                $bind-iterator,
-                $bind-iteration-end,
-                $bind-block,
-                $loop,
-                QAST::WVal.new( :value($Nil) )
-            ), :key)
+        my $stmts := QAST::Stmts.new( $bind-target, $bind-iterator, $bind-iteration-end );
+        $stmts.push($bind-block) unless $flatten;
+        $stmts.push($loop);
+        $stmts.push(QAST::WVal.new( :value($Nil) ));
+        self.IMPL-SET-NODE($stmts, :key)
     }
 
     # The most general, least optimized, form for a `for` loop, which
@@ -1855,6 +1867,18 @@ class RakuAST::Statement::Given
     }
 
     method IMPL-TO-QAST(RakuAST::IMPL::QASTContext $context) {
+        if $!body.IMPL-FLATTEN-APPROVED {
+            my $source-name := QAST::Node.unique('given_source');
+            return QAST::Stmts.new(
+                QAST::Op.new(
+                    :op('bind'),
+                    QAST::Var.new( :name($source-name), :scope('local'), :decl('var') ),
+                    $!source.IMPL-TO-QAST($context)
+                ),
+                $!body.IMPL-QAST-FLATTENED-WITH-ARG($context,
+                    QAST::Var.new( :name($source-name), :scope('local') ))
+            );
+        }
         QAST::Op.new(
             :op('call'),
             $!body.IMPL-TO-QAST($context),

--- a/src/Raku/ast/var-lowering.rakumod
+++ b/src/Raku/ast/var-lowering.rakumod
@@ -238,6 +238,27 @@ class RakuAST::IMPL::VarLowering {
             return Nil;
         }
 
+        # A bare block statement is called where it stands, so it
+        # flattens under the same rules as a loop body. A loop modifier
+        # keeps the block a per-iteration frame, and a topicalizing
+        # condition modifier passes the block an argument.
+        if nqp::istype($node, RakuAST::Statement::Expression)
+            && !nqp::isconcrete($node.loop-modifier) {
+            my $expression := $node.expression;
+            my $cond := $node.condition-modifier;
+            if nqp::eqaddr($expression.WHAT, RakuAST::Block)
+                && $expression.bare-block
+                && (!nqp::isconcrete($cond)
+                    || nqp::istype($cond, RakuAST::StatementModifier::If)
+                    || nqp::istype($cond, RakuAST::StatementModifier::Unless)) {
+                self.IMPL-REGISTER-IMPLICIT-LOOKUPS($node);
+                self.IMPL-WALK($cond) if nqp::isconcrete($cond);
+                self.IMPL-WALK-FLATTEN-CANDIDATE($expression);
+                $node.visit-labels(-> $label { self.IMPL-WALK($label) });
+                return Nil;
+            }
+        }
+
         # A variable declaration belongs to the enclosing scope's frame,
         # not to any frame the node itself creates. A parameter's uses
         # resolve to the target node while emission delegates to the

--- a/src/Raku/ast/var-lowering.rakumod
+++ b/src/Raku/ast/var-lowering.rakumod
@@ -20,6 +20,7 @@ class RakuAST::IMPL::VarLoweringFrame {
     has int $!flatten-candidate;
     has int $!flatten-blocked;
     has Mu $!deferred-uses;
+    has str $!implicit-slurpy-id;
 
     method new(RakuAST::Node $node, int $is-scope) {
         my $obj := nqp::create(self);
@@ -68,6 +69,12 @@ class RakuAST::IMPL::VarLoweringFrame {
         Nil
     }
     method flatten-blocked() { $!flatten-blocked }
+
+    method set-implicit-slurpy-id(str $id) {
+        nqp::bindattr_s(self, RakuAST::IMPL::VarLoweringFrame, '$!implicit-slurpy-id', $id);
+        Nil
+    }
+    method implicit-slurpy-id() { $!implicit-slurpy-id }
 
     method add-deferred(str $id) {
         nqp::push($!deferred-uses, $id);
@@ -237,6 +244,21 @@ class RakuAST::IMPL::VarLowering {
         # declaration it wraps, so the target registers the declaration
         # under both identities, and the wrapped declaration itself is
         # skipped when the walk reaches it as a child.
+        # A %_ appearing in a method body is a slurpy hash placeholder
+        # node rather than a variable lookup, and it is what makes the
+        # signature's implicit slurpy hash matter.
+        if nqp::istype($node, RakuAST::VarDeclaration::Placeholder::SlurpyHash) {
+            my int $i := nqp::elems($!frames);
+            while --$i >= 0 {
+                my $frame := nqp::atpos($!frames, $i);
+                if $frame.implicit-slurpy-id {
+                    my $record := $frame.record-for-id($frame.implicit-slurpy-id);
+                    nqp::bindkey($record, 'used', 1) unless nqp::isnull($record);
+                    last;
+                }
+            }
+        }
+
         if nqp::istype($node, RakuAST::ParameterTarget::Var) {
             my $decl := $node.declaration;
             self.IMPL-REGISTER-DECL($decl, ~nqp::objectid($node))
@@ -342,6 +364,16 @@ class RakuAST::IMPL::VarLowering {
                     if nqp::istype($_, RakuAST::VarDeclaration::Implicit);
             }
         }
+        if $is-scope && nqp::istype($node, RakuAST::Routine)
+            && nqp::isconcrete($node.signature) {
+            my $slurpy := nqp::getattr($node.signature, RakuAST::Signature,
+                '$!implicit-slurpy-hash');
+            $frame.set-implicit-slurpy-id(
+                ~nqp::objectid($slurpy.target.declaration))
+                if nqp::isconcrete($slurpy)
+                && nqp::isconcrete($slurpy.target)
+                && nqp::isconcrete($slurpy.target.declaration);
+        }
         $frame
     }
 
@@ -390,6 +422,12 @@ class RakuAST::IMPL::VarLowering {
     # outward only through scopes whose own topic went unused.
     method IMPL-DECIDE-IMPLICITS(Mu $frame) {
         my int $poisoned := $frame.is-poisoned;
+        my str $slurpy-id := $frame.implicit-slurpy-id;
+        if $slurpy-id && !$poisoned {
+            my $record := $frame.record-for-id($slurpy-id);
+            nqp::atkey($record, 'decl').IMPL-SET-UNUSED-SLURPY()
+                unless nqp::isnull($record) || nqp::existskey($record, 'used');
+        }
         my $it := nqp::iterator($frame.implicit-records);
         while $it {
             my $record := nqp::iterval(nqp::shift($it));
@@ -684,6 +722,7 @@ class RakuAST::IMPL::VarLowering {
             my $frame := nqp::atpos($!frames, $i);
             my $record := $frame.record-for-id($id);
             unless nqp::isnull($record) {
+                nqp::bindkey($record, 'used', 1);
                 if $!begin-context {
                     nqp::bindkey($record, 'captured', 1);
                 }

--- a/src/Raku/ast/var-lowering.rakumod
+++ b/src/Raku/ast/var-lowering.rakumod
@@ -15,6 +15,7 @@ class RakuAST::IMPL::VarLoweringFrame {
     has Mu $!candidate-ids;
     has Mu $!candidate-names;
     has Mu $!implicit-ids;
+    has Mu $!implicit-names;
     has int $!implicit-used;
     has int $!flatten-candidate;
     has int $!flatten-blocked;
@@ -28,6 +29,7 @@ class RakuAST::IMPL::VarLoweringFrame {
         nqp::bindattr($obj, RakuAST::IMPL::VarLoweringFrame, '$!candidate-ids', nqp::hash());
         nqp::bindattr($obj, RakuAST::IMPL::VarLoweringFrame, '$!candidate-names', nqp::hash());
         nqp::bindattr($obj, RakuAST::IMPL::VarLoweringFrame, '$!implicit-ids', nqp::hash());
+        nqp::bindattr($obj, RakuAST::IMPL::VarLoweringFrame, '$!implicit-names', nqp::hash());
         nqp::bindattr($obj, RakuAST::IMPL::VarLoweringFrame, '$!deferred-uses', []);
         $obj
     }
@@ -40,12 +42,17 @@ class RakuAST::IMPL::VarLoweringFrame {
     }
     method is-poisoned() { $!poisoned }
 
-    method register-implicit(str $id) {
-        nqp::bindkey($!implicit-ids, $id, 1);
+    method register-implicit(str $id, Mu $decl) {
+        my $record := nqp::hash('decl', $decl);
+        nqp::bindkey($!implicit-ids, $id, $record);
+        nqp::bindkey($!implicit-names, $decl.lexical-name, $record);
         Nil
     }
-    method is-implicit(str $id) { nqp::existskey($!implicit-ids, $id) }
-    method mark-implicit-used() {
+    method implicit-record-for-id(str $id) { nqp::atkey($!implicit-ids, $id) }
+    method implicit-record-for-name(str $name) { nqp::atkey($!implicit-names, $name) }
+    method implicit-records() { $!implicit-ids }
+    method mark-implicit-used(Mu $record) {
+        nqp::bindkey($record, 'used', 1);
         nqp::bindattr_i(self, RakuAST::IMPL::VarLoweringFrame, '$!implicit-used', 1);
         Nil
     }
@@ -108,6 +115,7 @@ class RakuAST::IMPL::VarLowering {
     has Mu $!sentinel;
     has int $!debug;
     has int $!begin-context;
+    has int $!topic-not-dynamic;
 
     method analyze-compunit(RakuAST::CompUnit $compunit, RakuAST::Resolver $resolver, :$interactive?) {
         # Escape hatch while the lowering is young: skip the analysis
@@ -118,6 +126,10 @@ class RakuAST::IMPL::VarLowering {
         nqp::bindattr($analyzer, RakuAST::IMPL::VarLowering, '$!frames', []);
         nqp::bindattr_i($analyzer, RakuAST::IMPL::VarLowering, '$!debug',
             nqp::atkey(nqp::getenvhash(), 'RAKUDO_LOWERING_DEBUG') ?? 1 !! 0);
+        # From 6.d the topic is not a dynamic variable, so a callee
+        # cannot reach an unused one and its declaration can go.
+        nqp::bindattr_i($analyzer, RakuAST::IMPL::VarLowering, '$!topic-not-dynamic',
+            nqp::getcomp('Raku').language_revision >= 2 ?? 1 !! 0);
 
         # The sentinel type that stands in for a lowered lexical's
         # by-name symbol. Without it (very early bootstrap) nothing is
@@ -150,6 +162,7 @@ class RakuAST::IMPL::VarLowering {
     }
 
     method IMPL-WALK(RakuAST::Node $node) {
+        self.IMPL-CHECK-NAME-REACHERS($node);
         self.IMPL-CHECK-FLATTEN-BLOCKERS($node);
 
         # Trait arguments, type parameterizations, and constant
@@ -325,7 +338,8 @@ class RakuAST::IMPL::VarLowering {
         # identities decide whether the implicits go unused.
         if $is-scope && nqp::istype($node, RakuAST::ImplicitDeclarations) {
             for $node.IMPL-UNWRAP-LIST($node.get-implicit-declarations()) {
-                $frame.register-implicit(~nqp::objectid($_));
+                $frame.register-implicit(~nqp::objectid($_), $_)
+                    if nqp::istype($_, RakuAST::VarDeclaration::Implicit);
             }
         }
         $frame
@@ -335,8 +349,10 @@ class RakuAST::IMPL::VarLowering {
         my $frame := nqp::pop($!frames);
         if $frame.is-scope {
             self.IMPL-DECIDE($frame);
+            my int $flattened;
             if $frame.is-flatten-candidate {
                 my int $approved := self.IMPL-FLATTEN-VERDICT($frame);
+                $flattened := $approved;
                 if $approved {
                     $frame.node.IMPL-SET-FLATTEN-APPROVED();
                     if $!debug {
@@ -360,6 +376,54 @@ class RakuAST::IMPL::VarLowering {
                         ?? self.IMPL-REGISTER-USE-ID($id)
                         !! self.IMPL-MARK-CAPTURED-ID($id);
                 }
+            }
+            self.IMPL-DECIDE-IMPLICITS($frame) unless $flattened;
+        }
+        Nil
+    }
+
+    # An unused implicit whose declaring scope nothing reaches by name
+    # need not be set up at all. The topic only goes from 6.d, where it
+    # is not dynamic, so a callee cannot reach it either. A kept topic
+    # that aliases the enclosing one still emits its getlexouter, which
+    # is a by-name use of the enclosing topic, so elimination cascades
+    # outward only through scopes whose own topic went unused.
+    method IMPL-DECIDE-IMPLICITS(Mu $frame) {
+        my int $poisoned := $frame.is-poisoned;
+        my $it := nqp::iterator($frame.implicit-records);
+        while $it {
+            my $record := nqp::iterval(nqp::shift($it));
+            my $decl := nqp::atkey($record, 'decl');
+            my int $used := nqp::existskey($record, 'used');
+            if nqp::istype($decl, RakuAST::VarDeclaration::Implicit::BlockTopic) {
+                if $decl.exception {
+                    self.IMPL-MARK-MAGICAL-USED('$!');
+                }
+                elsif $decl.parameter {
+                    # A parameter-form topic cannot go: without its param
+                    # declaration the block would no longer accept the
+                    # argument its callers pass. Only a non-required
+                    # parameter defaults from the enclosing topic.
+                    self.IMPL-MARK-MAGICAL-USED('$_') unless $decl.required;
+                }
+                elsif !$used && !$poisoned && $!topic-not-dynamic {
+                    # A non-parameter topic binds from the enclosing one
+                    # whether or not it is marked required, so an unused
+                    # one is dropped whole.
+                    $decl.IMPL-SET-UNUSED();
+                }
+                else {
+                    # And a kept one reads the enclosing topic by name.
+                    self.IMPL-MARK-MAGICAL-USED('$_');
+                }
+            }
+            elsif nqp::istype($decl, RakuAST::VarDeclaration::Implicit::Special) {
+                $decl.IMPL-SET-UNUSED()
+                    if $decl.name eq '$_'
+                    && !$used && !$poisoned && $!topic-not-dynamic;
+            }
+            elsif nqp::istype($decl, RakuAST::VarDeclaration::Implicit::Cursor) {
+                $decl.IMPL-SET-UNUSED() if !$used && !$poisoned;
             }
         }
         Nil
@@ -387,9 +451,9 @@ class RakuAST::IMPL::VarLowering {
                 && $_.IMPL-LOWERED-LOCAL-NAME {
             }
             else {
-                return 0 unless $frame.is-implicit(~nqp::objectid($_))
-                    && nqp::istype($_, RakuAST::VarDeclaration::Implicit::BlockTopic)
-                    && !$_.required && !$_.exception;
+                return 0 if nqp::isnull($frame.implicit-record-for-id(~nqp::objectid($_)))
+                    || !nqp::istype($_, RakuAST::VarDeclaration::Implicit::BlockTopic)
+                    || $_.required || $_.exception;
             }
         }
         1
@@ -477,7 +541,7 @@ class RakuAST::IMPL::VarLowering {
     method IMPL-REGISTER-IMPLICIT-LOOKUPS(RakuAST::Node $node) {
         if nqp::istype($node, RakuAST::ImplicitLookups) {
             for $node.IMPL-UNWRAP-LIST($node.get-implicit-lookups()) {
-                self.IMPL-CHECK-FLATTEN-BLOCKERS($_);
+                self.IMPL-CHECK-NAME-REACHERS($_);
                 self.IMPL-REGISTER-USE($_)
                     if nqp::istype($_, RakuAST::Lookup) && $_.is-resolved;
             }
@@ -512,31 +576,7 @@ class RakuAST::IMPL::VarLowering {
         return Nil unless $n;
         my $top := nqp::atpos($!frames, $n - 1);
         return Nil unless $top.is-flatten-candidate && !$top.flatten-blocked;
-        if nqp::istype($node, RakuAST::Statement::When)
-            || nqp::istype($node, RakuAST::Statement::Default) {
-            $top.block-flatten();
-        }
-        elsif nqp::istype($node, RakuAST::Statement::Expression) {
-            my $cond := $node.condition-modifier;
-            my $loop := $node.loop-modifier;
-            $top.block-flatten()
-                if (nqp::isconcrete($cond)
-                    && !nqp::istype($cond, RakuAST::StatementModifier::If)
-                    && !nqp::istype($cond, RakuAST::StatementModifier::Unless))
-                || (nqp::isconcrete($loop)
-                    && !nqp::istype($loop, RakuAST::StatementModifier::WhileUntil));
-        }
-        elsif nqp::istype($node, RakuAST::ApplyInfix)
-            || nqp::istype($node, RakuAST::ApplyListInfix) {
-            my $infix := $node.infix;
-            if nqp::istype($infix, RakuAST::Infix) {
-                my str $op := $infix.operator;
-                $top.block-flatten()
-                    if $op eq '~~' || $op eq '!~~'
-                    || $op eq 'andthen' || $op eq 'orelse' || $op eq 'notandthen';
-            }
-        }
-        elsif nqp::istype($node, RakuAST::ApplyPrefix) {
+        if nqp::istype($node, RakuAST::ApplyPrefix) {
             # temp and let register their restore on the frame of the
             # code that runs them.
             my $prefix := $node.prefix;
@@ -565,15 +605,58 @@ class RakuAST::IMPL::VarLowering {
             # frame's caller, so removing the frame skips one link.
             $top.block-flatten();
         }
-        elsif nqp::istype($node, RakuAST::Var::Lexical) {
-            # A magical is emitted as a by-name lexical, so at run time
-            # it binds to the innermost declaration of that name even
-            # when its compile-time resolution points at an outer one.
-            # Using one in the body means the body's own magical, whose
-            # declaration flattening would remove.
+        Nil
+    }
+
+    # Reaching a magical by name, or running a construct that reads and
+    # writes the topic by name, counts as a use of the innermost
+    # declaration of that name: magicals are emitted as by-name
+    # lexicals, so at run time they bind innermost even when their
+    # compile-time resolution points at an outer declaration.
+    method IMPL-CHECK-NAME-REACHERS(RakuAST::Node $node) {
+        if nqp::istype($node, RakuAST::Var::Lexical) {
             my str $name := $node.name;
-            $top.block-flatten()
+            self.IMPL-MARK-MAGICAL-USED($name)
                 if $name eq '$_' || $name eq '$/' || $name eq '$!' || $name eq '$¢';
+        }
+        elsif nqp::istype($node, RakuAST::Statement::When)
+            || nqp::istype($node, RakuAST::Statement::Default) {
+            self.IMPL-MARK-MAGICAL-USED('$_');
+        }
+        elsif nqp::istype($node, RakuAST::Statement::Expression) {
+            my $cond := $node.condition-modifier;
+            my $loop := $node.loop-modifier;
+            self.IMPL-MARK-MAGICAL-USED('$_')
+                if (nqp::isconcrete($cond)
+                    && !nqp::istype($cond, RakuAST::StatementModifier::If)
+                    && !nqp::istype($cond, RakuAST::StatementModifier::Unless))
+                || (nqp::isconcrete($loop)
+                    && !nqp::istype($loop, RakuAST::StatementModifier::WhileUntil));
+        }
+        elsif nqp::istype($node, RakuAST::ApplyInfix)
+            || nqp::istype($node, RakuAST::ApplyListInfix) {
+            my $infix := $node.infix;
+            if nqp::istype($infix, RakuAST::Infix) {
+                my str $op := $infix.operator;
+                self.IMPL-MARK-MAGICAL-USED('$_')
+                    if $op eq '~~' || $op eq '!~~'
+                    || $op eq 'andthen' || $op eq 'orelse' || $op eq 'notandthen';
+            }
+        }
+        Nil
+    }
+
+    method IMPL-MARK-MAGICAL-USED(str $name) {
+        my int $i := nqp::elems($!frames);
+        while --$i >= 0 {
+            my $frame := nqp::atpos($!frames, $i);
+            if $frame.is-scope {
+                my $record := $frame.implicit-record-for-name($name);
+                unless nqp::isnull($record) {
+                    $frame.mark-implicit-used($record);
+                    return Nil;
+                }
+            }
         }
         Nil
     }
@@ -620,8 +703,9 @@ class RakuAST::IMPL::VarLowering {
                 }
                 return Nil;
             }
-            if $frame.is-implicit($id) {
-                $frame.mark-implicit-used();
+            my $implicit := $frame.implicit-record-for-id($id);
+            unless nqp::isnull($implicit) {
+                $frame.mark-implicit-used($implicit);
                 return Nil;
             }
         }

--- a/src/Raku/ast/var-lowering.rakumod
+++ b/src/Raku/ast/var-lowering.rakumod
@@ -18,6 +18,7 @@ class RakuAST::IMPL::VarLoweringFrame {
     has Mu $!implicit-names;
     has int $!implicit-used;
     has int $!flatten-candidate;
+    has int $!flatten-arg;
     has int $!flatten-blocked;
     has Mu $!deferred-uses;
     has str $!implicit-slurpy-id;
@@ -63,6 +64,11 @@ class RakuAST::IMPL::VarLoweringFrame {
         nqp::bindattr_i(self, RakuAST::IMPL::VarLoweringFrame, '$!flatten-candidate', 1);
         Nil
     }
+    method mark-flatten-arg() {
+        nqp::bindattr_i(self, RakuAST::IMPL::VarLoweringFrame, '$!flatten-arg', 1);
+        Nil
+    }
+    method flatten-arg() { $!flatten-arg }
     method is-flatten-candidate() { $!flatten-candidate }
     method block-flatten() {
         nqp::bindattr_i(self, RakuAST::IMPL::VarLoweringFrame, '$!flatten-blocked', 1);
@@ -234,6 +240,31 @@ class RakuAST::IMPL::VarLowering {
             self.IMPL-REGISTER-IMPLICIT-LOOKUPS($node);
             self.IMPL-WALK($node.condition);
             self.IMPL-WALK-FLATTEN-CANDIDATE($node.body);
+            $node.visit-labels(-> $label { self.IMPL-WALK($label) });
+            return Nil;
+        }
+
+        # A sunk serial for statement drives its body directly, and a
+        # given calls its body with the topicalized value, so both walk
+        # their bodies as argument-taking flatten candidates: a plain
+        # body flattens when its topic goes unused, and a pointy body
+        # with one plain parameter has the iteration value bound to the
+        # parameter's local instead.
+        if nqp::istype($node, RakuAST::Statement::For)
+            && $node.mode eq 'serial'
+            && $node.IMPL-DISCARD-RESULT
+            && !nqp::isconcrete($node.otherwise)
+            && $node.IMPL-CAN-USE-STATEMENT-FORM($node.body) {
+            self.IMPL-REGISTER-IMPLICIT-LOOKUPS($node);
+            self.IMPL-WALK($node.source);
+            self.IMPL-WALK-FLATTEN-CANDIDATE($node.body, :arg);
+            $node.visit-labels(-> $label { self.IMPL-WALK($label) });
+            return Nil;
+        }
+        if nqp::istype($node, RakuAST::Statement::Given) {
+            self.IMPL-REGISTER-IMPLICIT-LOOKUPS($node);
+            self.IMPL-WALK($node.source);
+            self.IMPL-WALK-FLATTEN-CANDIDATE($node.body, :arg);
             $node.visit-labels(-> $label { self.IMPL-WALK($label) });
             return Nil;
         }
@@ -510,9 +541,14 @@ class RakuAST::IMPL::VarLowering {
                 && $_.IMPL-LOWERED-LOCAL-NAME {
             }
             else {
+                # Before 6.d the topic is dynamic, so a called routine can
+                # reach it by name with no use this analysis could see,
+                # and a body declaring one must stay a frame.
                 return 0 if nqp::isnull($frame.implicit-record-for-id(~nqp::objectid($_)))
                     || !nqp::istype($_, RakuAST::VarDeclaration::Implicit::BlockTopic)
-                    || $_.required || $_.exception;
+                    || ($_.required && !$frame.flatten-arg)
+                    || !$!topic-not-dynamic
+                    || $_.exception;
             }
         }
         1
@@ -612,8 +648,12 @@ class RakuAST::IMPL::VarLowering {
     # its shape allows flattening at all: a plain block, no signature or
     # placeholders, no phasers. Everything else about eligibility is
     # decided from what the walk observes, when the frame pops.
-    method IMPL-WALK-FLATTEN-CANDIDATE(RakuAST::Node $body) {
-        unless nqp::eqaddr($body.WHAT, RakuAST::Block)
+    method IMPL-WALK-FLATTEN-CANDIDATE(RakuAST::Node $body, :$arg?) {
+        my int $shape-ok := nqp::eqaddr($body.WHAT, RakuAST::Block);
+        $shape-ok := 1 if $arg
+            && nqp::eqaddr($body.WHAT, RakuAST::PointyBlock)
+            && !nqp::isnull($body.IMPL-FLATTEN-ARG-DECLARATION);
+        unless $shape-ok
             && !nqp::isconcrete($body.placeholder-signature)
             && !$body.has-any-phasers {
             self.IMPL-WALK($body);
@@ -621,6 +661,7 @@ class RakuAST::IMPL::VarLowering {
         }
         my $frame := self.IMPL-ENTER($body, 1);
         $frame.mark-flatten-candidate();
+        $frame.mark-flatten-arg() if $arg;
         self.IMPL-REGISTER-IMPLICIT-LOOKUPS($body);
         $body.visit-children(-> $child { self.IMPL-WALK($child) });
         self.IMPL-LEAVE();

--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -2468,6 +2468,17 @@ class RakuAST::VarDeclaration::Implicit
 {
     has str $.name;
 
+    # Set by the lexical-to-local lowering analysis when nothing in the
+    # declaring scope, and nothing reaching lexicals by name at run
+    # time, uses this implicit, so the scope can skip setting it up.
+    has int $!unused;
+
+    method IMPL-SET-UNUSED() {
+        nqp::bindattr_i(self, RakuAST::VarDeclaration::Implicit, '$!unused', 1)
+    }
+
+    method IMPL-UNUSED() { $!unused }
+
     method new(str :$name!, str :$scope) {
         my $obj := nqp::create(self);
         nqp::bindattr_s($obj, RakuAST::VarDeclaration::Implicit, '$!name', $name);
@@ -2538,6 +2549,7 @@ class RakuAST::VarDeclaration::Implicit::Special
     }
 
     method IMPL-QAST-DECL(RakuAST::IMPL::QASTContext $context) {
+        return QAST::Op.new( :op('null') ) if self.IMPL-UNUSED;
         my $container := self.meta-object;
         $context.ensure-sc($container);
         QAST::Var.new(
@@ -2595,6 +2607,7 @@ class RakuAST::VarDeclaration::Implicit::BlockTopic
     }
 
     method IMPL-QAST-DECL(RakuAST::IMPL::QASTContext $context) {
+        return QAST::Op.new( :op('null') ) if self.IMPL-UNUSED;
         if $!exception {
             QAST::Stmts.new(
                 QAST::Var.new( :decl('param'), :scope('local'), :name('EXCEPTION') ),
@@ -2747,6 +2760,7 @@ class RakuAST::VarDeclaration::Implicit::Cursor
     }
 
     method IMPL-QAST-DECL(RakuAST::IMPL::QASTContext $context) {
+        return QAST::Op.new( :op('null') ) if self.IMPL-UNUSED;
         my $container := self.meta-object;
         $context.ensure-sc($container);
         QAST::Var.new(

--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -724,6 +724,17 @@ class RakuAST::VarDeclaration::Simple
         nqp::bindattr_i(self, RakuAST::VarDeclaration::Simple, '$!lowered-array-init', 1)
     }
 
+    # Set by the lexical-to-local lowering analysis on a method's unused
+    # implicit %_ target: the slurpy parameter still accepts and
+    # discards stray nameds, but no hash is wrapped, declared, or bound.
+    has int $!unused-slurpy;
+
+    method IMPL-SET-UNUSED-SLURPY() {
+        nqp::bindattr_i(self, RakuAST::VarDeclaration::Simple, '$!unused-slurpy', 1)
+    }
+
+    method IMPL-UNUSED-SLURPY() { $!unused-slurpy }
+
     method IMPL-SET-LOWERED-TO-LOCAL(Mu $sentinel) {
         nqp::bindattr_i(self, RakuAST::VarDeclaration::Simple, '$!lowered-to-local', 1);
         nqp::bindattr(self, RakuAST::VarDeclaration::Simple, '$!lowered-away-sentinel', $sentinel);
@@ -1564,6 +1575,13 @@ class RakuAST::VarDeclaration::Simple
         my $of := $!where ?? $!type.meta-object !! self.IMPL-OF-TYPE;
 
         return QAST::Op.new(:op<null>) if $!already-declared;
+
+        # An unused implicit slurpy hash builds and binds no hash, but its
+        # lexical slot must still exist: the full binder, as run by
+        # is_bindable and capture binding, binds the parameter into the
+        # lexpad by name.
+        return QAST::Var.new( :scope('lexical'), :decl('var'), :name(self.name) )
+            if $!unused-slurpy;
 
         if $scope eq 'my' && !$!desigilname.is-multi-part {
             # Lexically scoped

--- a/t/08-performance/20-rakuast-lex2local-flatten.t
+++ b/t/08-performance/20-rakuast-lex2local-flatten.t
@@ -3,7 +3,7 @@ use Test::Helpers::QAST;
 use Test;
 use QAST:from<NQP>;
 use nqp;
-plan 18;
+plan 21;
 
 # The sunk body of a loop statement whose every piece is provably
 # frame-independent is emitted inline rather than called as a block each
@@ -109,6 +109,31 @@ else {
         die 'boom' if $i == 2;
     }
     is $caught, 'c', 'a CATCH in the loop body keeps the body a frame and fires';
+}
+
+# A bare block statement flattens under the same rules. The legacy
+# optimizer cannot flatten these, since their optional topic parameter
+# defeats its arity check, so the shape is only asserted here.
+
+if nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' {
+    qast-is 'my $x = 0; { $x = 5 }; say $x', :full, -> \v {
+        qast-var-decl(v, '$x', 'static')
+    }, 'a lexical used only from a flattenable bare block statement is lowered';
+}
+else {
+    skip 'bare block flattening is specific to the RakuAST frontend';
+}
+
+{
+    my $x = 0;
+    { my $t = 3; $x = $t }
+    is $x, 3, 'a flattened bare block statement runs its statements';
+}
+
+{
+    $_ = 42;
+    { $_ := 43 }
+    is $_, 42, 'a bare block that rebinds the topic keeps its frame and alias';
 }
 
 # Conditional statement branch bodies flatten the same way.

--- a/t/08-performance/20-rakuast-lex2local-flatten.t
+++ b/t/08-performance/20-rakuast-lex2local-flatten.t
@@ -3,7 +3,7 @@ use Test::Helpers::QAST;
 use Test;
 use QAST:from<NQP>;
 use nqp;
-plan 21;
+plan 30;
 
 # The sunk body of a loop statement whose every piece is provably
 # frame-independent is emitted inline rather than called as a block each
@@ -175,3 +175,65 @@ qast-is 'my $sum = 0; my int $i = 0; while $i < 9 { if $i % 2 { $sum = $sum + $i
     is with-dynamic(), 5,
         'a dynamic lookup in a branch body still walks the caller chain';
 }
+
+# Statement for and given bodies flatten as argument-taking candidates:
+# a pointy body with one plain parameter has the iteration value bound
+# to the parameter's local, and a plain body flattens when its topic
+# goes unused. The legacy optimizer flattens neither.
+
+if nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' {
+    qast-is 'my $sum = 0; for ^9 -> $x { $sum = $sum + $x }; say $sum', :full, -> \v {
+        qast-var-decl(v, '$sum', 'static')
+            and not qast-var-decl(v, '$x', 'contvar')
+            and not qast-var-decl(v, '$x', 'var')
+    }, 'a pointy for body flattens, lowering the accumulator and dissolving the parameter';
+
+    qast-is 'my $n = 0; for ^5 { $n = $n + 1 }; say $n', :full, -> \v {
+        qast-var-decl(v, '$n', 'static')
+    }, 'a topic-free for body flattens and lowers the accumulator';
+
+    qast-is 'my $x = 0; given 42 { $x = 1 }; say $x', :full, -> \v {
+        qast-var-decl(v, '$x', 'static')
+    }, 'a topic-free given body flattens';
+}
+else {
+    skip 'for and given body flattening is specific to the RakuAST frontend', 3;
+}
+
+{
+    my $sum = 0;
+    for ^10 -> $x { $sum = $sum + $x }
+    is $sum, 45, 'a flattened pointy for body accumulates correctly';
+}
+
+{
+    my $s = 0;
+    for ^20 -> $i { next if $i % 2; last if $i > 8; $s = $s + $i }
+    is $s, 20, 'next and last control a flattened pointy for';
+}
+
+{
+    my @r;
+    for 1..3 { @r.push($_) }
+    is @r.join(','), '1,2,3', 'a for body using its topic behaves unchanged';
+}
+
+{
+    my @a = 1, 2, 3;
+    for @a <-> $e { $e++ }
+    is @a.join(','), '2,3,4', 'an rw pointy parameter keeps its frame and mutates';
+}
+
+{
+    my @a = 0, 1, 2;
+    for @a -> $v is rw { $v++ }
+    is @a.join(','), '1,2,3', 'an is-rw parameter keeps its frame and mutates';
+}
+
+{
+    my @c;
+    for 1..2 -> $x { @c.push({ $x }) }
+    is @c.map({ .() }).join(','), '1,2',
+        'closures over the parameter keep the body a frame per iteration';
+}
+

--- a/t/08-performance/21-rakuast-unused-implicits.t
+++ b/t/08-performance/21-rakuast-unused-implicits.t
@@ -3,7 +3,7 @@ use Test::Helpers::QAST;
 use Test;
 use QAST:from<NQP>;
 use nqp;
-plan 11;
+plan 15;
 
 # A routine declares fresh $_ and $¢ containers it usually never uses,
 # and a block binds its topic from the enclosing one. When nothing in
@@ -83,4 +83,36 @@ else {
     sub capturer() { my $c = { $seen = $_ }; $c(7) }
     capturer();
     is $seen, 7, 'a closure taking the topic as its argument still receives it';
+}
+
+# A method's implicit %_ goes the same way when unused, while the
+# slurpy parameter itself stays, so stray nameds are still accepted
+# and discarded.
+
+if nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' {
+    qast-is 'my class C { method m() { 42 } }; say C.m', :full, -> \v {
+        not qast-var-decl(v, '%_', 'contvar')
+    }, 'a method that never touches %_ declares no hash for it';
+
+    qast-is 'my class C { method m() { %_.elems } }; say C.m', :full, -> \v {
+        qast-var-decl(v, '%_', 'contvar')
+    }, 'a method using the %_ placeholder keeps its hash';
+}
+else {
+    skip 'the %_ shapes are specific to the RakuAST frontend', 2;
+}
+
+{
+    my class C { method m() { 'ok' } }
+    is C.m(:stray, :other(2)), 'ok',
+        'a method with an unused %_ still accepts and discards stray nameds';
+}
+
+{
+    my class C {
+        has @.handles;
+        method new(*@handles) { self.bless(:@handles, |%_) }
+    }
+    is C.new(1, 2).handles.join(','), '1,2',
+        'flattening %_ into another call still works';
 }

--- a/t/08-performance/21-rakuast-unused-implicits.t
+++ b/t/08-performance/21-rakuast-unused-implicits.t
@@ -1,0 +1,86 @@
+use lib <t/packages/Test-Helpers>;
+use Test::Helpers::QAST;
+use Test;
+use QAST:from<NQP>;
+use nqp;
+plan 11;
+
+# A routine declares fresh $_ and $¢ containers it usually never uses,
+# and a block binds its topic from the enclosing one. When nothing in
+# the scope, and nothing reaching lexicals by name at run time, uses
+# such an implicit, its declaration is not emitted, which saves a
+# container clone per call.
+
+sub qast-var-decl (Mu $qast, Str:D $name, Str:D $decl --> Bool:D) {
+    if nqp::istype($qast, QAST::Var) && $qast.name eq $name && $qast.decl eq $decl {
+        return True;
+    }
+    if qast-descendable $qast {
+        for $qast.list {
+            qast-var-decl $_, $name, $decl and return True;
+        }
+    }
+    False
+}
+
+qast-is 'sub f($a) { $a + $a }; say f(1)', :full, -> \v {
+    not qast-var-decl(v, '$_', 'contvar')
+}, 'a sub that never touches the topic declares no fresh $_';
+
+# The kept-shape and cursor assertions are this frontend's: the legacy
+# optimizer lowers a used topic to a local rather than keeping the
+# contvar, and gates $¢ on the scope making no calls at all, which an
+# operator call already defeats.
+if nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' {
+    qast-is 'sub f($a) { $_ = $a; $_ + 1 }; say f(1)', :full, -> \v {
+        qast-var-decl(v, '$_', 'contvar')
+    }, 'a sub that assigns the topic keeps its fresh $_';
+
+    qast-is 'sub f($a) { $a ~~ Int }; say f(1)', :full, -> \v {
+        qast-var-decl(v, '$_', 'contvar')
+    }, 'a smartmatch reaches the topic by name, so the fresh $_ stays';
+
+    qast-is 'sub f($a) { $a + $a }; say f(1)', :full, -> \v {
+        not qast-var-decl(v, '$¢', 'contvar')
+    }, 'a sub with no regex declares no fresh $¢';
+}
+else {
+    skip 'shapes specific to the RakuAST frontend', 3;
+}
+
+# Behavior stays identical.
+
+{
+    sub topical() { $_ = 5; $_ + 1 }
+    is topical(), 6, 'assigning and reading the topic in a sub behaves unchanged';
+}
+
+{
+    $_ = 42;
+    sub fresh() { $_ }
+    ok !fresh().defined, 'a sub sees its own fresh topic, not the enclosing one';
+}
+
+{
+    $_ = 1;
+    given 2 { is $_, 2, 'given topicalizes' }
+    is $_, 1, 'the enclosing topic survives a given';
+}
+
+{
+    my @r;
+    for 1..3 { @r.push($_) }
+    is @r.join(','), '1,2,3', 'a for loop binds its topic per iteration';
+}
+
+{
+    sub matcher($x) { $x ~~ Int ?? 'int' !! 'other' }
+    is matcher(1), 'int', 'smartmatch in a sub with a kept topic works';
+}
+
+{
+    my $seen;
+    sub capturer() { my $c = { $seen = $_ }; $c(7) }
+    capturer();
+    is $seen, 7, 'a closure taking the topic as its argument still receives it';
+}

--- a/t/08-performance/22-rakuast-ct-dispatch.t
+++ b/t/08-performance/22-rakuast-ct-dispatch.t
@@ -1,0 +1,105 @@
+use lib <t/packages/Test-Helpers>;
+use Test::Helpers::QAST;
+use Test;
+use QAST:from<NQP>;
+use nqp;
+plan 17;
+
+# A call whose argument types decide the dispatch at compile time is
+# replaced by the chosen routine's recorded body, with the argument
+# code standing in for the parameters. The recording happens for named
+# subs whose parameters are all plain natives and whose body reduces
+# to inlinable ops, which covers the native operator candidates the
+# setting provides.
+
+qast-is 'my int $i = 3; my int $j = $i + 1; say $j', :full, -> \v {
+    qast-contains-op(v, 'add_i') and not qast-contains-call(v, '&infix:<+>')
+}, 'native int addition compiles to add_i with no operator call';
+
+qast-is 'my int $i = 3; my $b = $i < 5; say $b', :full, -> \v {
+    qast-contains-op(v, 'islt_i') and not qast-contains-call(v, '&infix:«<»')
+}, 'a standalone comparison compiles to islt_i with no chain call';
+
+qast-is 'my int $i = 3; my $b = 1 < $i < 5; say $b', :full, -> \v {
+    qast-contains-call(v, '&infix:«<»')
+}, 'a multi-link chain keeps its chain calls, whose protocol inlining would break';
+
+qast-is 'my num $n = 2e0; my num $m = $n * 3e0; say $m', :full, -> \v {
+    qast-contains-op(v, 'mul_n') and not qast-contains-call(v, '&infix:<*>')
+}, 'native num multiplication compiles to mul_n with no operator call';
+
+# The recording extends to user subs: a body that itself inlined its
+# operator calls reduces to inlinable ops, so its own callers splice it.
+# The legacy frontend records inline info before optimizing, so its
+# user subs keep the call.
+if nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' {
+    qast-is 'sub twice(int $a) { $a + $a }; my int $i = 2; say twice($i)', :full, -> \v {
+        not qast-contains-call(v, '&twice')
+    }, 'a call to a native-parameter user sub splices the body in place of the call';
+}
+else {
+    skip 'user-sub inlining through inlined operators is specific to the RakuAST frontend', 1;
+}
+
+qast-is 'use soft; sub g(int $a) { $a + 1 }; my int $i = 2; say g($i)', :full, -> \v {
+    qast-contains-call(v, '&g')
+}, 'the soft pragma keeps the call so the routine stays wrappable';
+
+# Behavior stays identical where the splice applies.
+
+{
+    my int $i = 3;
+    is $i + 1, 4, 'inlined native addition computes the right value';
+}
+
+{
+    my int $i = 3;
+    is $i + 170141183460469231731687303715884105727,
+        170141183460469231731687303715884105730,
+        'an integer literal too wide for a native stays a boxed dispatch';
+}
+
+{
+    my int $i = 3;
+    is-deeply (so any(1, 5) < $i, so all(1, 5) < $i), (True, False),
+        'junction arguments still autothread rather than taking a decided dispatch';
+}
+
+{
+    my int $i = 3;
+    is (1 < $i < 5), True, 'a true multi-link chain still short-circuits correctly';
+    is (5 < $i < 9), False, 'a false first link stops a multi-link chain';
+}
+
+{
+    sub bump(int $a is rw) { $a = $a + 1 }
+    my int $i = 5;
+    bump($i);
+    is $i, 6, 'an rw native parameter keeps the call and writes through';
+}
+
+{
+    use soft;
+    sub g(int $a) { $a + 1 }
+    g(1);
+    &g.wrap(-> |c { 'wrapped' });
+    is g(5), 'wrapped', 'wrapping a routine compiled under soft still intercepts calls';
+}
+
+{
+    multi sub m(int $a) { 'int' }
+    multi sub m(str $a) { 'str' }
+    my int $i = 1;
+    my str $s = 'x';
+    is m($i), 'int', 'a decided multi call still lands on the int candidate';
+    is m($s), 'str', 'a decided multi call still lands on the str candidate';
+}
+
+{
+    my int $i = 4;
+    is &infix:<+>($i, 2), 6, 'calling the operator through its code object still works';
+}
+
+{
+    is ([+] 1..5), 15, 'the reduce metaop over an inlinable operator still works';
+}


### PR DESCRIPTION
Follow-up to #6461, building on its lexical-to-local analysis. Previously the analysis only relocated variables and flattened loop and branch bodies. This extends it in three directions: implicit declarations that go unused are no longer emitted at all, more statement forms flatten, and a call whose dispatch the argument types already decide is inlined at compile time.

- Every routine cloned fresh `$_` and `$¢` containers at entry and every block bound its topic from the enclosing one, whether or not anything used them. When nothing in the scope uses one and nothing can reach it by name at run time, the declaration is not emitted. The topic only goes from 6.d onward, where it is not a dynamic variable. Around 10 percent on call-heavy code.
- A method that never uses `%_` skips the hash wrap, the container declaration, and the bind. The slurpy param slot stays, so stray nameds are still accepted and discarded.
- A frame-independent bare block statement flattens under the same rules as a loop body, running its statements inline instead of closure-cloning and calling its code object. The legacy optimizer cannot flatten these at all, since the block's optional topic parameter defeats its arity check. A loop whose body runs a bare block each iteration is twice as fast.
- Statement `for` and `given` bodies flatten as argument-taking candidates. A plain block body flattens when its topic goes unused, and a pointy body with one plain parameter binds the iteration value to the parameter's lowered local. `for ^1000000 -> $i { $sum = $sum + $i }` runs 36 percent faster. Every lowered declaration now also registers its original name through `add_local_debug_mapping`, so backtraces and debuggers name lowered variables the way the legacy optimizer's lowering does.
- A named sub call or infix application whose dispatch the argument types decide splices the chosen candidate's recorded body in place of the call, when that body reduces to inlinable ops over plain full-width native parameters. The recorded inline info also restores legacy-optimizer compile-time inlining on a RakuAST-built setting. A native `while` accumulator loop runs ten times faster and now matches the legacy frontend on the same build.

`--optimize=off` disables the transforms. `RAKUDO_NO_LEX2LOCAL=1` and `RAKUDO_NO_CT_DISPATCH=1` turn off the analysis and the dispatch decisions for triage. `RAKUDO_LOWERING_DEBUG=1` and `RAKUDO_INLINE_DEBUG=1` report each decision.

One divergence, noted in its commit: assigning to a flattened readonly parameter reports the immutable-value error rather than the readonly-variable one, since the value sits in a register rather than a bound lexical.
