### PR TITLE
I rename RakuAST currying to priming

### DIFF
--- a/src/Raku/ast/begintime.rakumod
+++ b/src/Raku/ast/begintime.rakumod
@@ -139,9 +139,9 @@ class RakuAST::BeginTime
     ) {
         my $*IMPL-COMPILE-DYNAMICALLY := 1;
 
-        # A curried argument (a WhateverCode) may be interpreted here, as
+        # A primed argument (a WhateverCode) may be interpreted here, as
         # its static block compiles against a real QAST context.
-        my $*IMPL-INTERPRET-CURRIED := 1;
+        my $*IMPL-INTERPRET-PRIMED := 1;
 
         # Ready to call
         if $callee.is-resolved

--- a/src/Raku/ast/call.rakumod
+++ b/src/Raku/ast/call.rakumod
@@ -160,7 +160,7 @@ class RakuAST::ArgList
         nqp::istype($arg, RakuAST::ApplyPrefix) &&
             nqp::istype($arg.prefix, RakuAST::Prefix) &&
             $arg.prefix.operator eq '|' &&
-            !$arg.IMPL-CURRIED
+            !$arg.IMPL-PRIMED
     }
 
     method IMPL-CAN-INTERPRET() {
@@ -702,7 +702,7 @@ class RakuAST::Call::Methodish
         OperatorProperties.postfix(self.dispatch || $default)
     }
 
-    method IMPL-CURRIES() { 3 }
+    method IMPL-PRIMES() { 3 }
 }
 
 # A call to a method identified by a name. Some names (like WHAT and HOW) are
@@ -772,10 +772,10 @@ class RakuAST::Call::Method
 
     # Special-op postfixes (.WHAT, .HOW, .VAR, .DEFINITE, etc.) compile to
     # primitive nqp:: ops, not real method calls, so they sit outside the
-    # currying machinery. `(5 ~~ *).WHAT` must therefore evaluate `(5 ~~ *)`
+    # priming machinery. `(5 ~~ *).WHAT` must therefore evaluate `(5 ~~ *)`
     # to a WhateverCode and then take its WHAT, rather than being absorbed
-    # into a curried `{ (5 ~~ $_).WHAT }`.
-    method IMPL-CURRIES() {
+    # into a primed `{ (5 ~~ $_).WHAT }`.
+    method IMPL-PRIMES() {
         $!name.is-identifier && nqp::istrue(self.IMPL-SPECIAL-OP($!name.canonicalize))
             ?? 0
             !! 3

--- a/src/Raku/ast/circumfix.rakumod
+++ b/src/Raku/ast/circumfix.rakumod
@@ -24,27 +24,27 @@ class RakuAST::Circumfix::Parentheses
     }
 
     # Generally needs to be called before children are visited, which is when the Apply*
-    # expressions implement their currying. After that happens, any RakuAST::Term::Whatever
+    # expressions implement their priming. After that happens, any RakuAST::Term::Whatever
     # operands will have been converted to RakuAST::Var::Lexical. At that stage, the below
-    # IMPL-SINGLE-CURRIED-EXPRESSION is the appropriate check.
-    method IMPL-CONTAINS-SINGULAR-CURRYABLE-EXPRESSION() {
+    # IMPL-SINGLE-PRIMED-EXPRESSION is the appropriate check.
+    method IMPL-CONTAINS-SINGULAR-PRIMEABLE-EXPRESSION() {
         nqp::elems($!semilist.IMPL-UNWRAP-LIST($!semilist.statements)) == 1
             && (my $statement-expression := $!semilist.IMPL-UNWRAP-LIST($!semilist.statements)[0])
             && nqp::istype($statement-expression, RakuAST::Statement::Expression)
             && (my $expression := $statement-expression.expression)
             && nqp::istype($expression, RakuAST::WhateverApplicable)
-            && $expression.IMPL-SHOULD-CURRY-DIRECTLY
+            && $expression.IMPL-SHOULD-PRIME-DIRECTLY
                 ?? $expression
                 !! Nil
     }
 
-    method IMPL-SINGULAR-CURRIED-EXPRESSION() {
+    method IMPL-SINGULAR-PRIMED-EXPRESSION() {
         nqp::elems($!semilist.IMPL-UNWRAP-LIST($!semilist.statements)) == 1
             && (my $statement-expression := $!semilist.IMPL-UNWRAP-LIST($!semilist.statements)[0])
             && nqp::istype($statement-expression, RakuAST::Statement::Expression)
             && (my $expression := $statement-expression.expression)
             && nqp::istype($expression, RakuAST::WhateverApplicable)
-            && $expression.IMPL-CURRIED
+            && $expression.IMPL-PRIMED
                 ?? $expression
                 !! Nil
     }

--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -1691,7 +1691,7 @@ class RakuAST::Block
     method IMPL-CHECK-DOUBLE-CLOSURE(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
         my $stmts := self.body.statement-list;
         if $stmts.IMPL-IS-SINGLE-EXPRESSION
-            && $stmts.code-statements[0].expression.IMPL-CURRIED
+            && $stmts.code-statements[0].expression.IMPL-PRIMED
         {
             return $resolver.build-exception: 'X::Syntax::Malformed',
                 :what('double closure; WhateverCode is already a closure without curlies, so either remove the curlies or use valid parameter syntax instead of *');
@@ -3909,8 +3909,8 @@ class RakuAST::SubstitutionReplacementThunk
     }
 }
 
-# Thunk for a curried Whatever expression.
-class RakuAST::CurryThunk
+# Thunk for a primed Whatever expression.
+class RakuAST::PrimeThunk
   is RakuAST::ExpressionThunk
   is RakuAST::ImplicitLookups
 {
@@ -3920,7 +3920,7 @@ class RakuAST::CurryThunk
     method new(Str $original-expression, @args) {
         my $obj := nqp::create(self);
         my @params := [];
-        nqp::bindattr($obj, RakuAST::CurryThunk, '$!parameters', @params);
+        nqp::bindattr($obj, RakuAST::PrimeThunk, '$!parameters', @params);
         for @args {
             # $name will usually be undefined, but sometimes we re-use references to existing * targets
             my $target := RakuAST::ParameterTarget::Whatever.new($_.name);
@@ -3930,7 +3930,7 @@ class RakuAST::CurryThunk
             );
             nqp::push(@params, $param);
         }
-        nqp::bindattr($obj, RakuAST::CurryThunk, '$!original-expression', nqp::hllizefor($original-expression, 'Raku'));
+        nqp::bindattr($obj, RakuAST::PrimeThunk, '$!original-expression', nqp::hllizefor($original-expression, 'Raku'));
         $obj
     }
 
@@ -3965,8 +3965,8 @@ class RakuAST::CurryThunk
     }
 }
 
-class RakuAST::HyperCurryThunk
-  is RakuAST::CurryThunk
+class RakuAST::HyperPrimeThunk
+  is RakuAST::PrimeThunk
 {
     method IMPL-THUNK-VALUE-QAST(RakuAST::IMPL::QASTContext $context) {
         my $qast := self.IMPL-CLOSURE-QAST($context);

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -104,20 +104,20 @@ class RakuAST::Expression
         $!thunks
     }
 
-    method IMPL-CURRIED() {
+    method IMPL-PRIMED() {
         my $cur-thunk := $!thunks;
         while $cur-thunk {
-            return $cur-thunk if nqp::istype($cur-thunk, RakuAST::CurryThunk);
+            return $cur-thunk if nqp::istype($cur-thunk, RakuAST::PrimeThunk);
             $cur-thunk := $cur-thunk.next;
         }
         False
     }
 
-    method IMPL-UNCURRY() {
+    method IMPL-UNPRIME() {
         my $prev-thunk;
         my $cur-thunk := $!thunks;
         while $cur-thunk {
-            if nqp::istype($cur-thunk, RakuAST::CurryThunk) {
+            if nqp::istype($cur-thunk, RakuAST::PrimeThunk) {
                 if $prev-thunk {
                     $prev-thunk.set-next($cur-thunk.next);
                 }
@@ -129,7 +129,7 @@ class RakuAST::Expression
             $prev-thunk := $cur-thunk;
             $cur-thunk := $cur-thunk.next;
         }
-        nqp::die("UNCURRY didn't find a CurryThunk");
+        nqp::die("UNPRIME didn't find a PrimeThunk");
     }
 
     method IMPL-REMOVE-THUNK(RakuAST::ExpressionThunk $thunk) {
@@ -155,14 +155,14 @@ class RakuAST::Expression
         $qast
     }
 
-    # Strip grouping parens from around a single curried expression, so
+    # Strip grouping parens from around a single primed expression, so
     # `where (* > 0)` is used as the WhateverCode it is, like `where * > 0`.
-    # Otherwise a caller wraps it in an ACCEPTS block whose body re-curries and
+    # Otherwise a caller wraps it in an ACCEPTS block whose body re-primes and
     # trips the double-closure check.
     method IMPL-UNWRAP-WHERE-PARENS() {
         nqp::istype(self, RakuAST::Circumfix::Parentheses)
-          && (my $curried := self.IMPL-SINGULAR-CURRIED-EXPRESSION)
-            ?? $curried
+          && (my $primed := self.IMPL-SINGULAR-PRIMED-EXPRESSION)
+            ?? $primed
             !! self
     }
 }
@@ -240,11 +240,11 @@ class RakuAST::Infixish
                                 RakuAST::Expression *@operands, Bool :$meta) {
     }
 
-    # %curried == 0 means do not curry
-    # %curried == 1 means curry Whatever only
-    # %curried == 2 means curry WhateverCode only
-    # %curried == 3 means curry both Whatever and WhateverCode (default)
-    method IMPL-CURRIES() { 0 }
+    # %primed == 0 means do not prime
+    # %primed == 1 means prime Whatever only
+    # %primed == 2 means prime WhateverCode only
+    # %primed == 3 means prime both Whatever and WhateverCode (default)
+    method IMPL-PRIMES() { 0 }
 
     method IMPL-OPERATOR() {
         nqp::die('IMPL-OPERATOR not implemented on ' ~ self.HOW.name(self));
@@ -402,14 +402,14 @@ class RakuAST::Infix
         }
     }
 
-    method IMPL-CURRIES() {
+    method IMPL-PRIMES() {
         # Lookup of infix operators and whether either left / right side
-        # will curry:
-        #  0 = do not curry
-        #  1 = curry Whatever only
-        #  2 = curry WhateverCode only
-        #  3 = curry both Whatever and WhateverCode (default)
-        my constant CURRIED := nqp::hash(
+        # will prime:
+        #  0 = do not prime
+        #  1 = prime Whatever only
+        #  2 = prime WhateverCode only
+        #  3 = prime both Whatever and WhateverCode (default)
+        my constant PRIMED := nqp::hash(
             '...'        , 0,
             '…'          , 0,
             '...^'       , 0,
@@ -440,7 +440,7 @@ class RakuAST::Infix
             '^..^'       , 2,
             'xx'         , 2,
         );
-        CURRIED{$!operator} // 3
+        PRIMED{$!operator} // 3
     }
 
     method IMPL-INFIX-COMPILE(RakuAST::IMPL::QASTContext $context,
@@ -1038,7 +1038,7 @@ class RakuAST::FlipFlop
         $!state-var.to-begin-time($resolver, $context);
     }
 
-    method IMPL-CURRIES() { 0 }
+    method IMPL-PRIMES() { 0 }
 
     method IMPL-INFIX-COMPILE(RakuAST::IMPL::QASTContext $context,
                               RakuAST::Expression $left, RakuAST::Expression $right, RakuAST::ColonPairish :$adverb) {
@@ -1332,7 +1332,7 @@ class RakuAST::MetaInfix
           !! True
     }
 
-    method IMPL-CURRIES { self.infix.IMPL-CURRIES }
+    method IMPL-PRIMES { self.infix.IMPL-PRIMES }
 
     method IMPL-THUNK-ARGUMENTS(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context,
                                 RakuAST::Expression *@operands, Bool :$meta) {
@@ -2064,106 +2064,106 @@ class RakuAST::MetaInfix::Hyper
 # Application of operators
 
 # This role is used by the Apply* family of expressions. We group all of the logic here
-# as well as using the role as a generic marker during searches for "curryability".
+# as well as using the role as a generic marker during searches for "primeability".
 # The design uses find-nodes-exclusive to determine wheter a given WhateverApplicable
-# node has child nodes that it needs to curry across as it hands out parameters with
+# node has child nodes that it needs to prime across as it hands out parameters with
 # RakuAST::ParameterTarget::Whatever nodes as targets. These parameter target nodes
 # are added to the *origin* WhateverApplicable's signature and then bound to operands
 # that were previously storing RakuAST::Term::Whatever nodes.
 class RakuAST::WhateverApplicable
 {
-    has int $!must-not-curry;
+    has int $!must-not-prime;
     has int $!hyperwhatever;
 
-    method IMPL-MUST-NOT-CURRY() {
-        nqp::bindattr_i(self, RakuAST::WhateverApplicable, '$!must-not-curry', 1);
+    method IMPL-MUST-NOT-PRIME() {
+        nqp::bindattr_i(self, RakuAST::WhateverApplicable, '$!must-not-prime', 1);
     }
 
-    method IMPL-CURRY(@params) {
+    method IMPL-PRIME(@params) {
         my $expr := self.origin ?? self.origin.Str !! self.DEPARSE;
         my $thunk := $!hyperwhatever
-            ?? RakuAST::HyperCurryThunk.new($expr, @params)
-            !! RakuAST::CurryThunk.new($expr, @params);
+            ?? RakuAST::HyperPrimeThunk.new($expr, @params)
+            !! RakuAST::PrimeThunk.new($expr, @params);
         self.wrap-with-thunk($thunk);
         $thunk
     }
 
-    method IMPL-MAYBE-CURRY(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
-        if self.IMPL-SHOULD-CURRY {
-            my $args := self.IMPL-REPLACE-CURRY-OPERANDS;
+    method IMPL-MAYBE-PRIME(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
+        if self.IMPL-SHOULD-PRIME {
+            my $args := self.IMPL-REPLACE-PRIME-OPERANDS;
             if $!hyperwhatever && nqp::elems($args) > 1 {
                 self.add-sorry:
                     $resolver.build-exception: 'X::HyperWhatever::Multiple';
             }
-            self.IMPL-CURRY($args).to-begin-time($resolver, $context);
+            self.IMPL-PRIME($args).to-begin-time($resolver, $context);
         }
     }
 
-    # A curried expression's value is its WhateverCode, and a BEGIN-time
-    # call may interpret it: the curry compiles as a static block whose
+    # A primed expression's value is its WhateverCode, and a BEGIN-time
+    # call may interpret it: the prime compiles as a static block whose
     # outer is the compunit, so the closure survives serialization into
     # a precompiled unit. Building it by running a dynamically compiled
     # thunk instead gives it a throwaway outer frame that no longer
     # matches after precompilation. Other interpret consumers, such as
-    # constant folding, must not treat the curry as a constant and have
+    # constant folding, must not treat the prime as a constant and have
     # no QAST context to compile the block with, so this is gated by the
     # dynamic flag the BEGIN-time call paths set.
-    method IMPL-CURRIED-CAN-INTERPRET() {
-        ($*IMPL-INTERPRET-CURRIED // 0) && self.IMPL-CURRIED ?? True !! False
+    method IMPL-PRIMED-CAN-INTERPRET() {
+        ($*IMPL-INTERPRET-PRIMED // 0) && self.IMPL-PRIMED ?? True !! False
     }
 
-    method IMPL-CURRIED-INTERPRET(RakuAST::IMPL::InterpContext $ctx) {
-        my $curry := self.IMPL-CURRIED;
-        $curry.IMPL-QAST-BLOCK($ctx.context, :blocktype<declaration_static>, :expression(self));
-        $curry.meta-object
+    method IMPL-PRIMED-INTERPRET(RakuAST::IMPL::InterpContext $ctx) {
+        my $prime := self.IMPL-PRIMED;
+        $prime.IMPL-QAST-BLOCK($ctx.context, :blocktype<declaration_static>, :expression(self));
+        $prime.meta-object
     }
 
     method IMPL-IS-XX() {
         False
     }
 
-    method IMPL-SHOULD-CURRY() {
-        return False if $!must-not-curry;
-        return False unless self.operator.IMPL-CURRIES;
-        return False unless self.IMPL-CUSTOM-SHOULD-CURRY-CONDITIONS;
+    method IMPL-SHOULD-PRIME() {
+        return False if $!must-not-prime;
+        return False unless self.operator.IMPL-PRIMES;
+        return False unless self.IMPL-CUSTOM-SHOULD-PRIME-CONDITIONS;
 
-        if nqp::bitand_i(self.operator.IMPL-CURRIES, 1) {
+        if nqp::bitand_i(self.operator.IMPL-PRIMES, 1) {
             for self.IMPL-UNWRAP-LIST(self.operands) {
                 return True if nqp::istype($_, RakuAST::Term::Whatever)
                             || nqp::istype($_, RakuAST::Term::HyperWhatever)
             }
         }
-        if nqp::bitand_i(self.operator.IMPL-CURRIES, 2) {
+        if nqp::bitand_i(self.operator.IMPL-PRIMES, 2) {
             for self.IMPL-UNWRAP-LIST(self.operands) {
-                return True if nqp::istype($_, RakuAST::Expression) && $_.IMPL-CURRIED;
+                return True if nqp::istype($_, RakuAST::Expression) && $_.IMPL-PRIMED;
                 return True if nqp::istype($_, RakuAST::Circumfix::Parentheses)
-                                        && $_.IMPL-SINGULAR-CURRIED-EXPRESSION && !self.IMPL-IS-XX;
+                                        && $_.IMPL-SINGULAR-PRIMED-EXPRESSION && !self.IMPL-IS-XX;
             }
         }
         False
     }
 
-    method IMPL-REPLACE-CURRY-OPERANDS() {
+    method IMPL-REPLACE-PRIME-OPERANDS() {
         my int $index := 0;
         my @operands := self.IMPL-UNWRAP-LIST(self.operands);
         for @operands {
             my $operand := $_;
-            if nqp::bitand_i(self.operator.IMPL-CURRIES, 1)
+            if nqp::bitand_i(self.operator.IMPL-PRIMES, 1)
             && (nqp::istype($_, RakuAST::Term::Whatever) || nqp::istype($_, RakuAST::Term::HyperWhatever)) {
                 nqp::bindattr_i(self, RakuAST::WhateverApplicable, '$!hyperwhatever', 1)
                     if nqp::istype($_, RakuAST::Term::HyperWhatever);
                 @operands[$index] := RakuAST::WhateverCode::Argument.new;
             }
 
-            # If we can curry WhateverCodes, uncurry them first, i.e. move the thunk up to this node
-            if nqp::bitand_i(self.operator.IMPL-CURRIES, 2) {
-                if $_.IMPL-CURRIED {
-                    $_.IMPL-UNCURRY;
+            # If we can prime WhateverCodes, unprime them first, i.e. move the thunk up to this node
+            if nqp::bitand_i(self.operator.IMPL-PRIMES, 2) {
+                if $_.IMPL-PRIMED {
+                    $_.IMPL-UNPRIME;
                 }
                 elsif nqp::istype($_, RakuAST::Circumfix::Parentheses)
-                      && (my $expression := $_.IMPL-SINGULAR-CURRIED-EXPRESSION)
+                      && (my $expression := $_.IMPL-SINGULAR-PRIMED-EXPRESSION)
                 {
-                    $expression.IMPL-UNCURRY;
+                    $expression.IMPL-UNPRIME;
                 }
             }
 
@@ -2183,13 +2183,13 @@ class RakuAST::WhateverApplicable
                 nqp::push(@args, $n);
             }
 
-            # Continue traversal if node is not any of the currying boundaries
+            # Continue traversal if node is not any of the priming boundaries
             ! (nqp::istype($n, RakuAST::Block)
                 || nqp::istype($n, RakuAST::Postcircumfix::ArrayIndex)
                 || nqp::istype($n, RakuAST::Call)
                 || nqp::istype($n, RakuAST::VarDeclaration::Simple)
-                || (nqp::istype($n, RakuAST::WhateverApplicable) && !nqp::bitand_i(self.operator.IMPL-CURRIES, 2))
-                || ($self-is-xx && nqp::istype($n, RakuAST::ApplyInfix) && $n.IMPL-SHOULD-CURRY-DIRECTLY))
+                || (nqp::istype($n, RakuAST::WhateverApplicable) && !nqp::bitand_i(self.operator.IMPL-PRIMES, 2))
+                || ($self-is-xx && nqp::istype($n, RakuAST::ApplyInfix) && $n.IMPL-SHOULD-PRIME-DIRECTLY))
         };
         self.visit-dfs($visitor, :strict);
 
@@ -2197,9 +2197,9 @@ class RakuAST::WhateverApplicable
         @args
     }
 
-    method IMPL-SHOULD-CURRY-DIRECTLY() {
-        return False unless nqp::bitand_i(self.operator.IMPL-CURRIES, 1);
-        return False unless self.IMPL-CUSTOM-SHOULD-CURRY-CONDITIONS;
+    method IMPL-SHOULD-PRIME-DIRECTLY() {
+        return False unless nqp::bitand_i(self.operator.IMPL-PRIMES, 1);
+        return False unless self.IMPL-CUSTOM-SHOULD-PRIME-CONDITIONS;
         for self.IMPL-UNWRAP-LIST(self.operands) {
             return True if nqp::istype($_, RakuAST::Term::Whatever)
                         || nqp::istype($_, RakuAST::Term::HyperWhatever);
@@ -2208,17 +2208,17 @@ class RakuAST::WhateverApplicable
         False
     }
 
-    method IMPL-OPERANDS-SHOULD-CURRY-DIRECTLY() {
+    method IMPL-OPERANDS-SHOULD-PRIME-DIRECTLY() {
         my $should-so := False;
         for self.IMPL-UNWRAP-LIST(self.operands) {
-            $should-so := $should-so || (nqp::istype($_, RakuAST::WhateverApplicable) && $_.IMPL-SHOULD-CURRY-DIRECTLY)
-                                     || (nqp::istype($_, RakuAST::Circumfix::Parentheses) && $_.IMPL-CONTAINS-SINGULAR-CURRYABLE-EXPRESSION)
+            $should-so := $should-so || (nqp::istype($_, RakuAST::WhateverApplicable) && $_.IMPL-SHOULD-PRIME-DIRECTLY)
+                                     || (nqp::istype($_, RakuAST::Circumfix::Parentheses) && $_.IMPL-CONTAINS-SINGULAR-PRIMEABLE-EXPRESSION)
         }
         $should-so
     }
 
-    # Override this to ask questions about the self when it comes to the should-curry question
-    method IMPL-CUSTOM-SHOULD-CURRY-CONDITIONS { True }
+    # Override this to ask questions about the self when it comes to the should-prime question
+    method IMPL-CUSTOM-SHOULD-PRIME-CONDITIONS { True }
 }
 
 # Application of an infix operator.
@@ -2275,7 +2275,7 @@ class RakuAST::ApplyInfix
     method operator() { $!infix }
 
     method PERFORM-BEGIN(Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
-        self.IMPL-MAYBE-CURRY($resolver, $context);
+        self.IMPL-MAYBE-PRIME($resolver, $context);
 
         $!infix.IMPL-THUNK-ARGUMENTS($resolver, $context, self.left, self.right);
     }
@@ -2350,7 +2350,7 @@ class RakuAST::ApplyInfix
                 self.add-sorry: $left.build-bind-exception($resolver);
             }
 
-            if $infix-op eq '~~' && $left.IMPL-CURRIED {
+            if $infix-op eq '~~' && $left.IMPL-PRIMED {
                 self.add-worry:
                   $resolver.build-exception:
                     'X::WhateverCode::SmartMatch::LHS';
@@ -2445,13 +2445,13 @@ class RakuAST::ApplyInfix
     method needs-sink-call() { $!infix.is-pure || $!infix.IMPL-RESULT-NEEDS-ITERATION }
 
     method IMPL-CAN-INTERPRET() {
-        self.IMPL-CURRIED-CAN-INTERPRET
+        self.IMPL-PRIMED-CAN-INTERPRET
           || $!infix.IMPL-CAN-INTERPRET && $!args.IMPL-CAN-INTERPRET
     }
 
     method IMPL-INTERPRET(RakuAST::IMPL::InterpContext $ctx) {
-        self.IMPL-CURRIED-CAN-INTERPRET
-          ?? self.IMPL-CURRIED-INTERPRET($ctx)
+        self.IMPL-PRIMED-CAN-INTERPRET
+          ?? self.IMPL-PRIMED-INTERPRET($ctx)
           !! $!infix.IMPL-INTERPRET($ctx, self.IMPL-UNWRAP-LIST($!args.args) );
     }
 }
@@ -2535,13 +2535,13 @@ class RakuAST::ApplyListInfix
         True
     }
 
-    method IMPL-CUSTOM-SHOULD-CURRY-CONDITIONS() {
+    method IMPL-CUSTOM-SHOULD-PRIME-CONDITIONS() {
         # Anything but a ','
         !self.IMPL-IS-LIST-LITERAL
     }
 
     method PERFORM-BEGIN(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
-        self.IMPL-MAYBE-CURRY($resolver, $context);
+        self.IMPL-MAYBE-PRIME($resolver, $context);
 
         if nqp::istype($!infix, RakuAST::Feed) {
             for self.IMPL-FEED-STAGES {
@@ -2636,7 +2636,7 @@ class RakuAST::ApplyListInfix
     }
 
     method IMPL-CAN-INTERPRET() {
-        return True if self.IMPL-CURRIED-CAN-INTERPRET;
+        return True if self.IMPL-PRIMED-CAN-INTERPRET;
         if $!infix.IMPL-CAN-INTERPRET {
             for self.IMPL-UNWRAP-LIST($!operands) {
                 return False unless $_.IMPL-CAN-INTERPRET;
@@ -2649,8 +2649,8 @@ class RakuAST::ApplyListInfix
     }
 
     method IMPL-INTERPRET(RakuAST::IMPL::InterpContext $ctx) {
-        self.IMPL-CURRIED-CAN-INTERPRET
-          ?? self.IMPL-CURRIED-INTERPRET($ctx)
+        self.IMPL-PRIMED-CAN-INTERPRET
+          ?? self.IMPL-PRIMED-INTERPRET($ctx)
           !! $!infix.IMPL-INTERPRET($ctx, $!operands)
     }
 }
@@ -2665,7 +2665,7 @@ class RakuAST::DottyInfixish
 {
     method new() { nqp::create(self) }
 
-    method IMPL-CURRIES() { 0 }
+    method IMPL-PRIMES() { 0 }
 
     method IMPL-THUNK-ARGUMENTS(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context,
                                 RakuAST::Expression *@operands, Bool :$meta) {
@@ -2804,7 +2804,7 @@ class RakuAST::Prefixish
         }
     }
 
-    method IMPL-CURRIES() { 3 }
+    method IMPL-PRIMES() { 3 }
 }
 
 # A lookup of a simple (non-meta) prefix operator.
@@ -2992,7 +2992,7 @@ class RakuAST::ApplyPrefix
     }
 
     method PERFORM-BEGIN(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
-        self.IMPL-MAYBE-CURRY($resolver, $context);
+        self.IMPL-MAYBE-PRIME($resolver, $context);
     }
 
     method PERFORM-CHECK(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
@@ -3023,12 +3023,12 @@ class RakuAST::ApplyPrefix
     }
 
     method IMPL-CAN-INTERPRET() {
-        self.IMPL-CURRIED-CAN-INTERPRET
+        self.IMPL-PRIMED-CAN-INTERPRET
           || $!operand.IMPL-CAN-INTERPRET && $!prefix.IMPL-CAN-INTERPRET
     }
 
     method IMPL-INTERPRET(RakuAST::IMPL::InterpContext $ctx) {
-        return self.IMPL-CURRIED-INTERPRET($ctx) if self.IMPL-CURRIED-CAN-INTERPRET;
+        return self.IMPL-PRIMED-INTERPRET($ctx) if self.IMPL-PRIMED-CAN-INTERPRET;
         my $op := $!prefix.IMPL-INTERPRET($ctx);
         $op($!operand.IMPL-INTERPRET($ctx))
     }
@@ -3089,11 +3089,11 @@ class RakuAST::Postfixish
         }
     }
 
-    # %curried == 0 means do not curry
-    # %curried == 1 means curry Whatever only
-    # %curried == 2 means curry WhateverCode only
-    # %curried == 3 means curry both Whatever and WhateverCode (default)
-    method IMPL-CURRIES() { 0 }
+    # %primed == 0 means do not prime
+    # %primed == 1 means prime Whatever only
+    # %primed == 2 means prime WhateverCode only
+    # %primed == 3 means prime both Whatever and WhateverCode (default)
+    method IMPL-PRIMES() { 0 }
 
     method can-be-used-with-hyper() { False }
 }
@@ -3160,7 +3160,7 @@ class RakuAST::Postfix
             self.resolution.IMPL-LOOKUP-QAST($context)
     }
 
-    method IMPL-CURRIES() { 3 }
+    method IMPL-PRIMES() { 3 }
 }
 
 # Base class for literal postfixes
@@ -3190,7 +3190,7 @@ class RakuAST::Postfix::Literal
 
     method can-be-used-with-hyper() { False }
 
-    method IMPL-CURRIES() { 3 }
+    method IMPL-PRIMES() { 3 }
 }
 
 # The postfix exponentiation operator (2⁴⁵).
@@ -3349,7 +3349,7 @@ class RakuAST::Postcircumfix::ArrayIndex
         self.visit-colonpairs($visitor);
     }
 
-    method IMPL-CURRIES() { 3 }
+    method IMPL-PRIMES() { 3 }
 
     method PERFORM-CHECK(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
         # 2nd chance to resolve to avoid bootstrapping issue in the setting
@@ -3508,7 +3508,7 @@ class RakuAST::Postcircumfix::HashIndex
         OperatorProperties.postcircumfix('{ }')
     }
 
-    method IMPL-CURRIES() { 3 }
+    method IMPL-PRIMES() { 3 }
 
     method IMPL-POSTFIX-QAST(RakuAST::IMPL::QASTContext $context, Mu $operand-qast) {
         my $name := self.is-resolved ?? self.resolution.lexical-name !! self.IMPL-LEXICAL-NAME;
@@ -3604,7 +3604,7 @@ class RakuAST::Postcircumfix::LiteralHashIndex
         OperatorProperties.postcircumfix('< >')
     }
 
-    method IMPL-CURRIES() { 3 }
+    method IMPL-PRIMES() { 3 }
 
     method IMPL-POSTFIX-QAST(RakuAST::IMPL::QASTContext $context, Mu $operand-qast) {
         my $name := self.resolution.lexical-name;
@@ -3667,9 +3667,9 @@ class RakuAST::MetaPostfix::Hyper
         ]
     }
 
-    method IMPL-CURRIES { $!postfix.IMPL-CURRIES }
+    method IMPL-PRIMES { $!postfix.IMPL-PRIMES }
 
-    method IMPL-CUSTOM-SHOULD-CURRY-CONDITIONS { $!postfix.IMPL-CUSTOM-SHOULD-CURRY-CONDITIONS }
+    method IMPL-CUSTOM-SHOULD-PRIME-CONDITIONS { $!postfix.IMPL-CUSTOM-SHOULD-PRIME-CONDITIONS }
 
     method IMPL-HOP-INFIX() {
         self.IMPL-UNWRAP-LIST(self.get-implicit-lookups())[0].resolution.compile-time-value()(
@@ -3715,8 +3715,8 @@ class RakuAST::ApplyPostfix
             $operand := $statement.expression
                 unless $statement.condition-modifier || $statement.loop-modifier;
 
-            # Double parentheses act as a currying border.
-            $obj.IMPL-MUST-NOT-CURRY if nqp::istype($operand, RakuAST::Circumfix::Parentheses);
+            # Double parentheses act as a priming border.
+            $obj.IMPL-MUST-NOT-PRIME if nqp::istype($operand, RakuAST::Circumfix::Parentheses);
         }
         nqp::bindattr($obj, RakuAST::ApplyPostfix, '$!operand', $operand);
         $obj
@@ -3746,7 +3746,7 @@ class RakuAST::ApplyPostfix
     }
 
     method PERFORM-BEGIN(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
-        self.IMPL-MAYBE-CURRY($resolver, $context);
+        self.IMPL-MAYBE-PRIME($resolver, $context);
     }
 
     method PERFORM-CHECK(Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
@@ -3755,12 +3755,12 @@ class RakuAST::ApplyPostfix
         #      Blockoid 𝄞 -e:1 ⎡{*.{}}⎤
         #        StatementList 𝄞 -e:1 ⎡*.{}⎤
         #          Statement::Expression ▪𝄞 -e:1 ⎡*.{}⎤
-        #            ... [curried]
+        #            ... [primed]
         #    Call::Term  ⎡(...)⎤
         #      ArgList  ⎡...⎤
         if nqp::istype($!operand, RakuAST::Block) && nqp::istype($!postfix, RakuAST::Call::Term) {
             my $stmts := $!operand.body.statement-list;
-            if $stmts.IMPL-IS-SINGLE-EXPRESSION && $stmts.code-statements[0].expression.IMPL-CURRIED {
+            if $stmts.IMPL-IS-SINGLE-EXPRESSION && $stmts.code-statements[0].expression.IMPL-PRIMED {
                 self.add-sorry:
                     $resolver.build-exception: 'X::Syntax::Malformed',
                         :what('double closure; WhateverCode is already a closure without curlies, so either remove the curlies or use valid parameter syntax instead of *')
@@ -3814,13 +3814,13 @@ class RakuAST::ApplyPostfix
     }
 
     method IMPL-CAN-INTERPRET() {
-        self.IMPL-CURRIED-CAN-INTERPRET
+        self.IMPL-PRIMED-CAN-INTERPRET
           || $!operand.IMPL-CAN-INTERPRET && $!postfix.IMPL-CAN-INTERPRET
     }
 
     method IMPL-INTERPRET(RakuAST::IMPL::InterpContext $ctx) {
-        self.IMPL-CURRIED-CAN-INTERPRET
-          ?? self.IMPL-CURRIED-INTERPRET($ctx)
+        self.IMPL-PRIMED-CAN-INTERPRET
+          ?? self.IMPL-PRIMED-INTERPRET($ctx)
           !! $!postfix.IMPL-INTERPRET($ctx, -> { $!operand.IMPL-INTERPRET($ctx) })
     }
 }

--- a/src/Raku/ast/parsetime.rakumod
+++ b/src/Raku/ast/parsetime.rakumod
@@ -55,9 +55,9 @@ class RakuAST::ParseTime
     # with a set of arguments.
     method IMPL-BEGIN-TIME-CALL(RakuAST::Node $callee, RakuAST::ArgList $args,
             RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
-        # A curried argument (a WhateverCode) may be interpreted here, as
+        # A primed argument (a WhateverCode) may be interpreted here, as
         # its static block compiles against a real QAST context.
-        my $*IMPL-INTERPRET-CURRIED := 1;
+        my $*IMPL-INTERPRET-PRIMED := 1;
         if $callee.is-resolved && nqp::istype($callee.resolution, RakuAST::CompileTimeValue) &&
                 $args.IMPL-CAN-INTERPRET {
             my $resolved := $callee.resolution.compile-time-value;

--- a/src/Raku/ast/signature.rakumod
+++ b/src/Raku/ast/signature.rakumod
@@ -954,7 +954,7 @@ class RakuAST::Parameter
             }
         }
         if $!where {
-            nqp::push(@post_constraints, $!where.IMPL-CURRIED ?? $!where.IMPL-CURRIED.meta-object !! $!where.meta-object);
+            nqp::push(@post_constraints, $!where.IMPL-PRIMED ?? $!where.IMPL-PRIMED.meta-object !! $!where.meta-object);
         }
         if $!array-shape {
             nqp::push(@post_constraints, $!array-shape.meta-object);
@@ -1104,7 +1104,7 @@ class RakuAST::Parameter
             self.add-sorry: $sorry if $sorry;
         }
 
-        if $!where && (! nqp::istype($!where, RakuAST::Code) || nqp::istype($!where, RakuAST::RegexThunk)) && !$!where.IMPL-CURRIED {
+        if $!where && (! nqp::istype($!where, RakuAST::Code) || nqp::istype($!where, RakuAST::RegexThunk)) && !$!where.IMPL-PRIMED {
             my $block := RakuAST::Block.new(
                 body => RakuAST::Blockoid.new(
                     RakuAST::StatementList.new(

--- a/src/Raku/ast/type.rakumod
+++ b/src/Raku/ast/type.rakumod
@@ -603,14 +603,14 @@ class RakuAST::Type::Parameterized
                 if $expr.has-compile-time-value {
                     $value := $expr.maybe-compile-time-value;
                 }
-                elsif nqp::istype($expr, RakuAST::Expression) && $expr.IMPL-CURRIED {
-                    # A WhateverCode argument. Compile the curry as a static
+                elsif nqp::istype($expr, RakuAST::Expression) && $expr.IMPL-PRIMED {
+                    # A WhateverCode argument. Compile the prime as a static
                     # block so it is one code object with an outer frame the
                     # compunit can serialize, rather than one built by running a
                     # throwaway BEGIN-time thunk. Mirrors the subset `where` path.
-                    $expr.IMPL-CURRIED.IMPL-QAST-BLOCK(
+                    $expr.IMPL-PRIMED.IMPL-QAST-BLOCK(
                       $context, :blocktype<declaration_static>, :expression($expr));
-                    $value := $expr.IMPL-CURRIED.meta-object;
+                    $value := $expr.IMPL-PRIMED.meta-object;
                 }
                 elsif nqp::istype($expr, RakuAST::Expression) {
                     # IMPL-BEGIN-TIME-EVALUATE attaches a thunk to the
@@ -700,10 +700,10 @@ class RakuAST::Type::Parameterized
 
     method IMPL-CAN-INTERPRET() {
         nqp::istype(self.base-type, RakuAST::CompileTimeValue)
-        && ($!args.IMPL-CAN-INTERPRET || self.IMPL-ARGS-COMPILE-TIME-OR-CURRIED)
+        && ($!args.IMPL-CAN-INTERPRET || self.IMPL-ARGS-COMPILE-TIME-OR-PRIMED)
     }
 
-    # Whether every argument either has a compile-time value or is a curryable
+    # Whether every argument either has a compile-time value or is a primeable
     # WhateverCode, which PRODUCE-META-OBJECT can compile as a static block.
     # This lets a `does Role[* op *]` application interpret the parameterization
     # rather than run it through a BEGIN-time thunk, whose WhateverCode closure
@@ -711,12 +711,12 @@ class RakuAST::Type::Parameterized
     # expression, a flattening `|@a`, an unresolved variable) satisfies neither
     # branch, so the whole parameterization falls back to the thunk path
     # unchanged. Kept next to the PRODUCE-META-OBJECT loop it must agree with.
-    method IMPL-ARGS-COMPILE-TIME-OR-CURRIED() {
+    method IMPL-ARGS-COMPILE-TIME-OR-PRIMED() {
         for $!args.IMPL-UNWRAP-LIST($!args.args) -> $arg {
             my $expr := nqp::istype($arg, RakuAST::NamedArg) ?? $arg.named-arg-value !! $arg;
             return False
               unless $expr.has-compile-time-value
-                  || (nqp::istype($expr, RakuAST::Expression) && $expr.IMPL-CURRIED);
+                  || (nqp::istype($expr, RakuAST::Expression) && $expr.IMPL-PRIMED);
         }
         True
     }
@@ -1191,7 +1191,7 @@ class RakuAST::Type::Subset
             nqp::bindattr(self, RakuAST::Type::Subset, '$!block', $block);
         }
         if $block
-          && !$block.IMPL-CURRIED
+          && !$block.IMPL-PRIMED
           && (!nqp::istype($block, RakuAST::Code)
                || nqp::istype($block, RakuAST::RegexThunk
              )
@@ -1243,11 +1243,11 @@ class RakuAST::Type::Subset
         );
 
         self.meta-object; # Finish meta-object setup so compile time type-checks will be correct
-        if $block && $block.IMPL-CURRIED {
+        if $block && $block.IMPL-PRIMED {
             $block.IMPL-CHECK($resolver, $context);
             $resolver.panic(Any) if $resolver.all-sorries.elems;
             # Cache QAST with expression as the BEGIN time stub wont know how to get that
-            $block.IMPL-CURRIED.IMPL-QAST-BLOCK($context, :blocktype<declaration_static>, :expression($block));
+            $block.IMPL-PRIMED.IMPL-QAST-BLOCK($context, :blocktype<declaration_static>, :expression($block));
         }
     }
 
@@ -1272,8 +1272,8 @@ class RakuAST::Type::Subset
         my $block := $!block;
 
         $type.HOW.set_of($type, $!of.meta-object) if $!of;
-        $type.HOW.set_where($type, $block.IMPL-CURRIED
-            ?? $block.IMPL-CURRIED.meta-object
+        $type.HOW.set_where($type, $block.IMPL-PRIMED
+            ?? $block.IMPL-PRIMED.meta-object
             !! $block.compile-time-value
         ) if $block;
 

--- a/t/12-rakuast/TODO
+++ b/t/12-rakuast/TODO
@@ -10,7 +10,7 @@ a test for that class.
 RakuAST::BracketedInfix
 RakuAST::Categorical
 RakuAST::ContainerCreator
-RakuAST::CurryThunk
+RakuAST::PrimeThunk
 RakuAST::Declaration::External
 RakuAST::Declaration::External::Constant
 RakuAST::Declaration::Import


### PR DESCRIPTION
## Summary

- I rename the RakuAST WhateverCode internals from curry/currying to prime/priming.
- I update the related methods, thunk classes, fields, comments, and the RakuAST TODO entry.
- I leave legacy compiler and metamodel uses of `curry` unchanged because they are outside the RakuAST terminology change.

## Validation

- I completed `perl Configure.pl --gen-moar --gen-nqp --backends=moar`.
- I verified the generated `gen/moar/ast.nqp` contains the renamed classes and methods with no old RakuAST curry symbols.
- I ran a source-reference consistency check across all 37 `src/Raku/ast/*.rakumod` modules; it found both renamed thunk classes, all 16 prime-related methods, no undeclared prime-method calls, and no old curry terminology.
- I verified the complete diff is limited to the requested curry-to-prime terminology mapping.
- I ran `git diff --check`.
- I started `make -j2`; it generated and compiled the Rakudo/NQP stages and reached `blib/CORE.c.setting.moarvm`, but the full build did not complete within the local time limit. I defer the complete build and test suite to CI.

Fixes #6199
