### PR TITLE
RakuAST: resolve &?BLOCK past inlined control-flow branches

### DIFF
--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -102,8 +102,35 @@ class RakuAST::Code
     has Mu $!qast-block;
     has str $!cuid;
 
+    # A control-flow statement (if/unless/with/without/while/until/loop) runs
+    # its branch inline, so `&?BLOCK` inside it means the enclosing real block,
+    # not the branch. Such branches are marked here to be skipped when locating
+    # the block `&?BLOCK` refers to.
+    has int $!immediate-block-user-body;
+
+    # Set once this block has grown the implicit `&?BLOCK` lexical, so a second
+    # reference does not add a duplicate declaration.
+    has int $!has-block-variable;
+
     method PERFORM-PARSE(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
         Nil
+    }
+
+    method set-immediate-block-user-body() {
+        nqp::bindattr_i(self, RakuAST::Code, '$!immediate-block-user-body', 1);
+    }
+    method is-immediate-block-user-body() { $!immediate-block-user-body }
+
+    # Ensure this block declares the implicit `&?BLOCK` lexical, bound to its
+    # own code object. A reference to `&?BLOCK` requests this on the innermost
+    # enclosing real block, so inner control-flow branches resolve `&?BLOCK`
+    # lexically to it regardless of whether they end up as their own frame.
+    method IMPL-ENSURE-BLOCK-VARIABLE() {
+        unless $!has-block-variable {
+            nqp::bindattr_i(self, RakuAST::Code, '$!has-block-variable', 1);
+            self.add-generated-lexical-declaration(
+                RakuAST::VarDeclaration::Implicit::CurrentBlock.new);
+        }
     }
 
     method IMPL-EXTRA-BEGIN-TIME-DECLS(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {

--- a/src/Raku/ast/resolver.rakumod
+++ b/src/Raku/ast/resolver.rakumod
@@ -135,6 +135,21 @@ class RakuAST::Resolver {
         Nil
     }
 
+    # Find the innermost enclosing block that `&?BLOCK` refers to: the nearest
+    # pushed 'block' target that is not an inlined control-flow branch. Returns
+    # Nil if there is none (for example at compilation-unit top level).
+    method find-block-variable-target() {
+        my @stack := $!attach-targets<block>;
+        if nqp::isconcrete(@stack) {
+            my int $i := nqp::elems(@stack);
+            while $i-- {
+                my $target := @stack[$i];
+                return $target unless $target.is-immediate-block-user-body;
+            }
+        }
+        Nil
+    }
+
     # Find the current (most recently pushed) attachment target with the
     # specified name, or return Nil if there is no target by the given name,
     # or no targets left for the given name.

--- a/src/Raku/ast/statements.rakumod
+++ b/src/Raku/ast/statements.rakumod
@@ -1224,6 +1224,7 @@ class RakuAST::Statement::IfWith
         else {
             $!then.set-implicit-topic(False, :local);
         }
+        $!then.set-immediate-block-user-body();
         for $!elsifs {
             $_.apply-implicit-block-semantics();
             $last-was-with := $_.IMPL-QAST-TYPE eq 'with';
@@ -1235,6 +1236,7 @@ class RakuAST::Statement::IfWith
             else {
                 $!else.set-implicit-topic(False, :local);
             }
+            $!else.set-immediate-block-user-body();
         }
     }
 
@@ -1345,6 +1347,7 @@ class RakuAST::Statement::Elsif {
 
     method apply-implicit-block-semantics(:$resolver, :$context) {
         $!then.set-implicit-topic(False, :local);
+        $!then.set-immediate-block-user-body();
     }
 
     method IMPL-QAST-TYPE() { 'if' }
@@ -1359,6 +1362,7 @@ class RakuAST::Statement::Orwith
 
     method apply-implicit-block-semantics(:$resolver, :$context) {
         self.then.set-implicit-topic(True, :required);
+        self.then.set-immediate-block-user-body();
     }
 }
 
@@ -1383,6 +1387,7 @@ class RakuAST::Statement::Unless
 
     method apply-implicit-block-semantics(:$resolver, :$context) {
         $!body.set-implicit-topic(False, :local);
+        $!body.set-immediate-block-user-body();
     }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
@@ -1439,6 +1444,7 @@ class RakuAST::Statement::Without
 
     method apply-implicit-block-semantics(:$resolver, :$context) {
         $!body.set-implicit-topic(True, :required);
+        $!body.set-immediate-block-user-body();
     }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {
@@ -1519,6 +1525,7 @@ class RakuAST::Statement::Loop
 
     method apply-implicit-block-semantics(:$resolver, :$context) {
         $!body.set-implicit-topic(False, :local);
+        $!body.set-immediate-block-user-body();
     }
 
     method mark-block-statement() {

--- a/src/Raku/ast/variable-access.rakumod
+++ b/src/Raku/ast/variable-access.rakumod
@@ -538,9 +538,29 @@ class RakuAST::Var::Compiler::Line
 
 class RakuAST::Var::Compiler::Block
   is RakuAST::Var::Compiler
+  is RakuAST::CheckTime
 {
+    has int $!lexical;
+
+    # Resolved at CHECK time, not parse time: the enclosing control-flow
+    # branches are only marked as inlined once their statement is assembled,
+    # which for the compiler happens after this node is parsed but before the
+    # check pass walks it.
+    method PERFORM-CHECK(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
+        my $block := $resolver.find-block-variable-target();
+        if $block {
+            $block.IMPL-ENSURE-BLOCK-VARIABLE();
+            nqp::bindattr_i(self, RakuAST::Var::Compiler::Block, '$!lexical', 1);
+        }
+    }
+
     method IMPL-EXPR-QAST(RakuAST::IMPL::QASTContext $context) {
-        QAST::Op.new( :op('getcodeobj'), QAST::Op.new( :op('curcode') ) )
+        # Resolve to the innermost enclosing real block's `&?BLOCK` lexical.
+        # Falling back to the running frame's code object covers the case where
+        # no such block was found (for example at compilation-unit top level).
+        $!lexical
+          ?? QAST::Var.new( :name<&?BLOCK>, :scope<lexical> )
+          !! QAST::Op.new( :op('getcodeobj'), QAST::Op.new( :op('curcode') ) )
     }
 }
 

--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -2829,6 +2829,20 @@ class RakuAST::VarDeclaration::Implicit::Routine
     }
 }
 
+# The implicit `&?BLOCK` term declaration for a block. Bound to the block's own
+# code object, so a lexical reference to `&?BLOCK` from an inlined control-flow
+# branch inside the block resolves to it.
+class RakuAST::VarDeclaration::Implicit::CurrentBlock
+  is RakuAST::VarDeclaration::Implicit::Routine
+{
+    method new() {
+        my $obj := nqp::create(self);
+        nqp::bindattr_s($obj, RakuAST::VarDeclaration::Implicit, '$!name', '&?BLOCK');
+        nqp::bindattr_s($obj, RakuAST::Declaration, '$!scope', 'my');
+        $obj
+    }
+}
+
 # Used for constructs that generate state variables
 class RakuAST::VarDeclaration::Implicit::State
   is RakuAST::VarDeclaration::Implicit

--- a/t/12-rakuast/block-var.rakutest
+++ b/t/12-rakuast/block-var.rakutest
@@ -1,0 +1,80 @@
+use v6.e.PREVIEW;
+use Test;
+
+# &?BLOCK names the innermost enclosing real block, and a control-flow branch
+# (if/unless/with/without/while/until/loop) is transparent: `&?BLOCK` written
+# in one refers to the block the branch runs in, not the branch itself. This
+# must hold whether or not the branch is compiled as its own frame, so each
+# case pairs the reference with a smartmatch, which forces a branch frame.
+
+plan 8;
+
+{
+    sub s($p) { if $p { &?BLOCK } else { Nil } }
+    is s(1).signature.gist, '($p)',
+      '&?BLOCK in an if branch is the enclosing routine';
+}
+
+{
+    sub s($p) { if $p { my $x = $p ~~ Int; &?BLOCK } else { Nil } }
+    is s(1).signature.gist, '($p)',
+      '&?BLOCK in an if branch with a branch-frame-forcing smartmatch is the routine';
+}
+
+{
+    sub s($p) { my $n = 2; while $n-- { return &?BLOCK } }
+    is s(1).signature.gist, '($p)',
+      '&?BLOCK in a while body is the enclosing routine';
+}
+
+{
+    my $fac = -> Int $n { $n > 1 ?? $n * &?BLOCK($n - 1) !! 1 };
+    is $fac(5), 120, '&?BLOCK recurses the pointy block it is written in';
+}
+
+{
+    my $fac = -> Int $n { if $n > 1 { $n * &?BLOCK($n - 1) } else { 1 } };
+    is $fac(5), 120, '&?BLOCK recurses the enclosing block from inside an if branch';
+}
+
+{
+    sub outer($p) {
+        if $p { my $b = { &?BLOCK }; $b() === $b } else { Nil }
+    }
+    ok outer(1),
+      '&?BLOCK in a bare block inside an if branch is the bare block itself';
+}
+
+# A self-continuing decoder: the returned sub feeds itself back through &?BLOCK
+# until it has collected $count values, then returns the collected list. This
+# is the pattern Data::MessagePack's streaming unpacker relies on.
+{
+    sub collector(Int $count) {
+        my @acc;
+        my $n = $count;
+        return sub ($value) {
+            @acc.push($value);
+            if $value !~~ Int {
+                return @acc;
+            }
+            return @acc unless --$n;
+            return &?BLOCK;
+        }
+    }
+
+    my $next = collector(3);
+    my @emitted;
+    for 10, 20, 30, 40, 50, 60 -> $v {
+        $next = $next.($v);
+        unless $next ~~ Sub {
+            @emitted.push($next.List);
+            $next = collector(3);
+        }
+    }
+    is-deeply @emitted, [(10, 20, 30), (40, 50, 60)],
+      'a &?BLOCK self-continuation inside an if branch accumulates per group';
+    is @emitted.elems, 2,
+      'the self-continuation emits one result per group, not one per value';
+}
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously &?BLOCK compiled to getcodeobj(curcode()), the code object of the running frame. Inside an if/unless/with/without/while/until/loop branch that the backend gave its own frame (because it holds a smartmatch or a nested closure, say) that returned the branch itself instead of the block the branch runs in. A &?BLOCK self-continuation written in such a branch then yielded the wrong code object. Data::MessagePack's streaming unpacker relies on that pattern and fragmented its decoded arrays and maps under RakuAST.

&?BLOCK now resolves lexically, the way &?ROUTINE does. The innermost enclosing real block declares an implicit &?BLOCK bound to its own code object, and a reference emits a lexical lookup of it. Control-flow branches are marked so they are skipped when choosing that block, so a reference in a branch resolves to the block the branch runs in whether or not the branch became its own frame. The reference is resolved at CHECK time, since a branch is only marked as inlined once its statement is assembled, which happens after the reference is parsed.

A statement-modifier for wraps its statement in a thunk rather than a block, so &?BLOCK there now refers to the enclosing block instead of the thunk.