### PR TITLE
RakuAST: don't compose a class to resolve an attributive parameter

### DIFF
--- a/src/Raku/ast/signature.rakumod
+++ b/src/Raku/ast/signature.rakumod
@@ -2130,7 +2130,10 @@ class RakuAST::ParameterTarget::Var
 
         if $twigil eq '!' {
             if $!attribute-package {
-                my $package := $!attribute-package.meta-object;
+                # stubbed-meta-object avoids composing the package: an
+                # attributive parameter checked from inside a BEGIN block
+                # would otherwise compose the enclosing class mid-body.
+                my $package := $!attribute-package.stubbed-meta-object;
                 unless $package.HOW.has_attribute($package, $!name) {
                     self.add-sorry:
                       $resolver.build-exception: 'X::Attribute::Undeclared',

--- a/src/Raku/ast/variable-access.rakumod
+++ b/src/Raku/ast/variable-access.rakumod
@@ -340,7 +340,12 @@ class RakuAST::Var::Attribute
     }
 
     method IMPL-EXPR-QAST(RakuAST::IMPL::QASTContext $context) {
-        my $package := $!package.meta-object;
+        # stubbed-meta-object avoids composing the package. By codegen time
+        # the class is normally already composed, so this is the same object;
+        # but for a method built inside a BEGIN block it is not yet composed,
+        # and forcing it here would finalize the class before its remaining
+        # members are added.
+        my $package := $!package.stubbed-meta-object;
         if $package.HOW.has_attribute($package, $!name) {
             my $attr-type := $package.HOW.get_attribute_for_usage($package, $!name).type;
             return QAST::Var.new(
@@ -354,7 +359,8 @@ class RakuAST::Var::Attribute
     }
 
     method IMPL-BIND-QAST(RakuAST::IMPL::QASTContext $context, QAST::Node $source-qast) {
-        my $package := $!package.meta-object;
+        # stubbed-meta-object avoids composing the package (see IMPL-EXPR-QAST).
+        my $package := $!package.stubbed-meta-object;
         if $package.HOW.has_attribute($package, $!name) {
             my $attr-type := $package.HOW.get_attribute_for_usage($package, $!name).type;
             unless nqp::eqaddr($attr-type, Mu) {

--- a/t/02-rakudo/begin-time-attributive-param-method.t
+++ b/t/02-rakudo/begin-time-attributive-param-method.t
@@ -1,0 +1,65 @@
+use Test;
+
+plan 5;
+
+# A `method` with an attributive parameter, built inside a BEGIN block in a
+# class body, must not force the enclosing class to compose. Composing it
+# mid-body would finalize the class before its remaining members are added,
+# so any method declared after the BEGIN block would go missing.
+{
+    my class C {
+        has $!x;
+        BEGIN my $m = method ($!x) { $!x };
+        method later { 'installed' }
+    }
+    is C.new.later, 'installed',
+        'a method after a BEGIN-built attributive-param method is still installed';
+}
+
+# The attribute the parameter binds into must still work at runtime.
+{
+    my class C {
+        has $.v;
+        BEGIN my $store = method ($!v) { $!v };
+        method run { $store(self, 42) }
+    }
+    is C.new.run, 42,
+        'a BEGIN-built attributive-param method binds its attribute';
+}
+
+# The shape from PDF::Content::Ops: a table of anonymous methods built in a
+# BEGIN block, whose signatures carry a slurpy attributive parameter and a
+# `where` clause that calls a private method declared later in the class.
+{
+    my class C {
+        has @!colors;
+        my Method %store;
+        BEGIN %store = (
+            fill => method (*@!colors where self!ok($_)) { @!colors.join(',') },
+        );
+        method run { %store<fill>(self, 1, 2, 3) }
+        method !ok(@c) { True }
+    }
+    is C.new.run, '1,2,3',
+        'a BEGIN-built method with a where-clause private call composes and runs';
+}
+
+# The normal (non-BEGIN) path is unchanged.
+{
+    my class C {
+        has @!colors;
+        my $m = method (*@!colors) { @!colors.elems };
+        method run { $m(self, 1, 2) }
+    }
+    is C.new.run, 2,
+        'the non-BEGIN attributive-param method path still works';
+}
+
+# An attributive parameter naming an attribute the class does not have must
+# still be a compile error, not a silent pass.
+{
+    throws-like
+        'class C { has $!x; BEGIN my $m = method ($!nope) { } }',
+        X::Attribute::Undeclared,
+        'an undeclared attribute in a BEGIN-built method is still rejected';
+}


### PR DESCRIPTION
A `method` carrying an attributive parameter (`$!x`, `*@!colors`), built inside a BEGIN block in a class body, forced the enclosing class to compose while resolving the attribute. Composing mid-body finalized the class before its remaining members were added, so every method declared after the BEGIN block went missing and calling one reported "No such method".

Look the attribute up through the stubbed meta-object, the way RakuAST::Var::Attribute already does for its own undeclared-attribute check. The attribute's type and primspec are present on the stub, and when these paths run at ordinary code-gen the class is already composed, so the stubbed meta-object is the same object as the composed one.

This surfaced from PDF::Content::Ops, whose operator table is a BEGIN-built hash of anonymous methods with slurpy attributive parameters.