### PR TITLE
RakuAST: stop reporting an orphaned declarator doc as a missing declarand

### DIFF
--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -787,19 +787,31 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
         else {
             my $from    := $/.from;
             my $worries := $*DECLARAND-WORRIES;
+            # A trailing `#=` that could not attach to a preceding declarand
+            # is dropped here rather than reported: legacy is silent about an
+            # orphaned trailing doc, so a following declarand must not turn
+            # one into a worry.
             for $worries {
-                $_.value.typed-worry:
-                  'X::Syntax::Doc::Declarator::MissingDeclarand'
-                  if $_.key < $from;
                 nqp::deletekey($worries, $_.key);
             }
 
             $*DECLARAND          := $it;
             $*LAST-TRAILING-LINE := +$*ORIGIN-SOURCE.original-line($from);
 
-            if $it.podifiable && @*LEADING-DOC -> @leading {
-                $it.set-leading(@leading);
-                @*LEADING-DOC := [];
+            if @*LEADING-DOC -> @leading {
+                if $it.podifiable {
+                    $it.set-leading(@leading);
+                    @*LEADING-DOC          := [];
+                    $*LEADING-DOC-FALLBACK := NQPMu;
+                }
+                # A non-podifiable declarand (a lexical) does not surface the
+                # doc anywhere, so leave the leading doc collected for a later
+                # podifiable target. Remember the first such lexical: if
+                # nothing else claims the doc it lands here and is dropped,
+                # rather than being reported as a missing declarand.
+                elsif !nqp::isconcrete($*LEADING-DOC-FALLBACK) {
+                    $*LEADING-DOC-FALLBACK := $it;
+                }
             }
             $*IGNORE-NEXT-DECLARAND := nqp::istype($it,Nodify('Package'));
         }

--- a/src/Raku/Grammar.nqp
+++ b/src/Raku/Grammar.nqp
@@ -1294,6 +1294,8 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
         :my $*ADVERB-AS-INFIX;  # fallback for fake infix handling
 
         :my @*LEADING-DOC := [];         # temp storage leading declarator doc
+        :my $*LEADING-DOC-FALLBACK;      # non-podifiable declarand to ground
+                                         # leading doc on if nothing else claims it
         :my $*DECLARAND;                 # target for trailing declarator doc
         :my $*LAST-TRAILING-LINE := -1;  # number of last line with trailing doc
         :my $*IGNORE-NEXT-DECLARAND;     # True if next declarand to be ignored

--- a/src/Raku/ast/compunit.rakumod
+++ b/src/Raku/ast/compunit.rakumod
@@ -193,10 +193,16 @@ class RakuAST::CompUnit
     # during optimization, though will not do any transforms in and of itself.
     method check(RakuAST::Resolver $resolver) {
         if @*LEADING-DOC {
-            self.add-worry:
-              $resolver.build-exception:
-                'X::Syntax::Doc::Declarator::MissingDeclarand',
-                :position<leading>;
+            # A leading declarator doc that reached a lexical (a non-podifiable
+            # declarand) is dropped, as legacy does: the lexical is a valid
+            # place for the doc to land even though it surfaces nowhere. Only a
+            # doc that never reached any declarand is a missing declarand.
+            unless nqp::isconcrete($*LEADING-DOC-FALLBACK) {
+                self.add-worry:
+                  $resolver.build-exception:
+                    'X::Syntax::Doc::Declarator::MissingDeclarand',
+                    :position<leading>;
+            }
         }
 
         $!mainline.IMPL-CHECK($resolver, $!context);

--- a/t/02-rakudo/declarator-doc-orphan.t
+++ b/t/02-rakudo/declarator-doc-orphan.t
@@ -1,0 +1,45 @@
+use lib <t/packages/Test-Helpers>;
+use Test;
+use Test::Helpers;
+
+plan 3;
+
+# Legacy never reports a missing declarand. RakuAST does, but only for a
+# leading declarator doc that reaches no declarand at all (that case lives in
+# t/05-messages/10-warnings.t). These check the cases RakuAST used to warn
+# about where legacy stays silent.
+
+# A trailing #= that cannot attach to the preceding declarand (it sits on its
+# own line, past the previous routine) used to become a "missing declarand"
+# worry once the following routine was seen. It should be dropped silently.
+is-run q:to/CODE/,
+        class C {
+            method a { 1 }
+
+            #= documents the wrong way round
+            method b { 2 }
+        }
+        print "ran";
+        CODE
+    'a trailing #= that reaches no declarand does not warn',
+    :out<ran>, :err(''), :exitcode(0);
+
+# A leading #| before a lexical, with nothing later to document, grounds on
+# the lexical rather than being reported as a missing declarand.
+is-run q:to/CODE/,
+        #| documents the counter
+        my $counter = 0;
+        print "ran";
+        CODE
+    'a leading #| before a lexical with no other target does not warn',
+    :out<ran>, :err(''), :exitcode(0);
+
+# The lexical must not swallow the doc when a documentable target follows: a
+# leading #| before a lexical whose initializer is a sub still documents the
+# sub.
+is EVAL(q:to/CODE/), 'inner',
+        #| inner
+        my $code = sub { 1 };
+        $code.WHY.contents.head
+        CODE
+    'a leading #| falls through a lexical to a sub in its initializer';


### PR DESCRIPTION
Legacy never reports a missing declarand. RakuAST did in two cases where legacy stays silent, producing spurious worries on real modules (seen across the PDF::* distributions):

  - A trailing `#=` that could not attach to its preceding declarand became a worry once the next declarand appeared. Such an orphan is now dropped, the way legacy drops it.

  - A leading `#|` before a lexical was reported as a missing declarand when no later documentable declarand claimed it. A lexical is a valid place for the doc to land, so remember the first non-podifiable declarand a leading doc falls through and, if nothing else claims it, ground the doc there instead of warning. A leading doc that reaches no declarand at all is still reported, and one that falls through to a documentable target still attaches there.