### PR TITLE
RakuAST: allow a $!attr parameter in a sub nested in a method

### DIFF
--- a/src/Raku/ast/signature.rakumod
+++ b/src/Raku/ast/signature.rakumod
@@ -1259,7 +1259,12 @@ class RakuAST::Parameter
                 $resolver.build-exception: 'X::Syntax::VirtualCall', call => $!target.name;
         }
 
-        if nqp::istype($!owner, RakuAST::Sub) && $!target && ($!target.twigil eq '.' || $!target.twigil eq '!') {
+        # A `!`-twigil attributive parameter is checked by its own
+        # RakuAST::Var::Attribute target, which allows it when `self` is
+        # lexically available (a sub nested in a method) and reports it
+        # otherwise. Only the `.`-twigil form, which has no such target, is
+        # handled here.
+        if nqp::istype($!owner, RakuAST::Sub) && $!target && $!target.twigil eq '.' {
             self.add-sorry:
                 $resolver.build-exception: 'X::Syntax::NoSelf', variable => $!target.name;
         }

--- a/t/02-rakudo/attributive-param-in-nested-sub.t
+++ b/t/02-rakudo/attributive-param-in-nested-sub.t
@@ -1,0 +1,54 @@
+use Test;
+
+plan 4;
+
+# A `!`-twigil attributive parameter in a `sub` binds into the attribute of
+# the object whose method lexically encloses the sub. RakuAST used to reject
+# it outright ("Variable $!x used where no 'self' is available"), because the
+# sub is not itself a method; legacy accepts it since `self` is lexically
+# available.
+{
+    my class C {
+        has $.x is rw;
+        method via-sub {
+            my $store = sub ($, $!x) { };
+            $store(self, 42);
+            $!x;
+        }
+    }
+    is C.new.via-sub, 42,
+        'a $!attr parameter in a sub nested in a method binds the attribute';
+}
+
+# The Proxy shape from PDF::Content::Text::Box: a method returns a Proxy whose
+# FETCH/STORE closures reach the attribute, and STORE takes it as a parameter.
+{
+    my class TB {
+        has $!text;
+        method text is rw {
+            Proxy.new(
+                FETCH => sub ($)      { $!text },
+                STORE => sub ($, $!text) { $!text .= uc },
+            );
+        }
+    }
+    my $tb = TB.new;
+    $tb.text = 'hi';
+    is $tb.text, 'HI',
+        'a $!attr parameter in a Proxy STORE sub binds and reads back';
+}
+
+# Plain attribute access (not as a parameter) in a nested sub already worked;
+# guard against regressing it.
+{
+    my class C {
+        has $.x = 7;
+        method via-sub { my $get = sub { $!x }; $get() }
+    }
+    is C.new.via-sub, 7,
+        'plain $!attr access in a sub nested in a method still works';
+}
+
+# With no enclosing method there is no self, so it is still an error.
+throws-like 'sub f($!x) { }', X::Syntax::NoSelf,
+    'a $!attr parameter in a sub with no enclosing method is rejected';


### PR DESCRIPTION
A `!`-twigil attributive parameter in a `sub` was rejected outright with "Variable $!x used where no 'self' is available", even when the sub was lexically nested in a method where `self` is available. Legacy accepts it and binds into the enclosing object's attribute (PDF::Content::Text::Box does this in a Proxy STORE closure).

The parameter's RakuAST::Var::Attribute target already runs the correct self-availability check: it allows the parameter when `self` resolves and reports it otherwise. The blanket rejection of any attributive parameter in a Sub was both wrong (it fired even with a lexical self) and redundant for the `!` twigil (it produced a second, duplicate sorry at the top level). Drop the `!` case here and leave it to the target; the `.` twigil, which has no such target, keeps its check.