### PR TITLE
RakuAST: don't fatalize the // left side of a dynamic-variable read

### DIFF
--- a/src/Raku/ast/scoping.rakumod
+++ b/src/Raku/ast/scoping.rakumod
@@ -515,7 +515,15 @@ class RakuAST::LexicalScope
                     }
                 }
             }
-            elsif $op eq 'hllize' {
+            elsif $op eq 'hllize' || $op eq 'ifnull' {
+                # Identity wrappers codegen puts around a single leaf value: the
+                # result is exactly one operand, so a boolified context reaches
+                # through unchanged. Only such internal wrappers belong here (a
+                # dynamic-var read lowers to ifnull(getlexdyn, &DYNAMIC-FALLBACK),
+                # whose fallback Failure a surrounding `//` defuses). A user-level
+                # transparent construct like the right of `//` or a ternary branch
+                # is deliberately absent: fatal throws a Failure there, as on the
+                # legacy frontend.
                 self.IMPL-FATALIZE-QAST($_, $bool-context) for @($qast);
             }
             else {


### PR DESCRIPTION
Under `use fatal`, `%*FOO // {}` on an undeclared dynamic variable threw "Dynamic variable %*FOO not found" instead of defusing to the right side.

A dynamic-variable read lowers to `ifnull(getlexdyn, &DYNAMIC-FALLBACK(...))`, and the fallback returns a Failure that `//` is meant to defuse. The runtime `use fatal` walk marks the left operand of `//` (a `defor` op) as boolified so its calls are not wrapped with FATALIZE. That marking stopped at the `ifnull`: the general branch reset the boolified context to 0 before recursing, so the `&DYNAMIC-FALLBACK` call was wrapped and its Failure thrown before `//` ever saw it. `ifnull` is value-transparent, like `hllize`, so it now passes the boolified context through to both operands.

Fixes the Getopt::Long test failure where `call-with-getopt`, whose default `%options = %*SUB-MAIN-OPTS // {}` runs under `use fatal`, died looking up an undeclared %*SUB-MAIN-OPTS.