### PR TITLE
RakuAST: branch on a native-int condition directly

### DIFF
--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -732,6 +732,7 @@ class RakuAST::Node {
             self.IMPL-MARK-RETURN-DECONT($resolver, $expr);
             self.IMPL-MARK-ARRAY-INIT($resolver, $expr);
             self.IMPL-MARK-CT-DISPATCH($resolver, $expr);
+            self.IMPL-MARK-NATIVE-CONDITION($resolver, $expr);
         }
 
         # A replacement stands where the original stood, so it must carry the
@@ -1112,6 +1113,92 @@ class RakuAST::Node {
             $init.nosink(1);
         }
         $init
+    }
+
+    # Mark a conditional or loop statement so code generation may test a
+    # native-int condition directly: the boolification over a native-int
+    # computation is dropped, and a bare native-int variable is compared
+    # against zero. Registering the mark here gates the rewrite on the
+    # optimize pass running. A with or when part tests something other
+    # than truth, so code generation only rewrites plain if parts.
+    method IMPL-MARK-NATIVE-CONDITION(RakuAST::Resolver $resolver, Mu $expr) {
+        if nqp::istype($expr, RakuAST::Statement::Loop)
+            || nqp::istype($expr, RakuAST::Statement::IfWith)
+            || nqp::istype($expr, RakuAST::Statement::Unless) {
+            $expr.IMPL-SET-NATIVE-CONDITION();
+        }
+        elsif nqp::istype($expr, RakuAST::Statement::Expression) {
+            my $loop := $expr.loop-modifier;
+            $loop.IMPL-SET-NATIVE-CONDITION()
+                if nqp::isconcrete($loop)
+                && nqp::istype($loop, RakuAST::StatementModifier::WhileUntil);
+            my $cond := $expr.condition-modifier;
+            $cond.IMPL-SET-NATIVE-CONDITION()
+                if nqp::isconcrete($cond)
+                && (nqp::istype($cond, RakuAST::StatementModifier::If)
+                    || nqp::istype($cond, RakuAST::StatementModifier::Unless));
+        }
+        Nil
+    }
+
+    # A condition rewritten to branch on the native int it computes. A
+    # boolified native-int computation loses the boolification, and with
+    # it a return-type check the boolification satisfied statically. A
+    # bare native-int variable reference is read as a value and compared
+    # against zero, which is what its boolification comes down to.
+    method IMPL-NATIVE-CONDITION-QAST(Mu $cond) {
+        my $stripped := self.IMPL-STRIP-BOOL-CONDITION($cond);
+        return $stripped unless nqp::isnull($stripped);
+        if nqp::istype($cond, QAST::Var)
+            && nqp::objprimspec($cond.returns) == 1 {
+            my str $scope := $cond.scope;
+            if $scope eq 'lexicalref' {
+                $cond.scope('lexical');
+            }
+            elsif $scope eq 'attributeref' {
+                $cond.scope('attribute');
+            }
+            else {
+                return $cond unless $scope eq 'lexical' || $scope eq 'local';
+            }
+            return QAST::Op.new( :op('isne_i'), $cond, QAST::IVal.new( :value(0) ) );
+        }
+        $cond
+    }
+
+    # Descend a condition's value path through statement wrappers, and
+    # through a return-type check, to a boolification of a provably
+    # native-int child, and return the condition with the boolification
+    # dropped, or null when the shape is anything else. Only a child the
+    # compiler already treats as a native int qualifies: the
+    # boolification coerces any other operand itself, and dropping it
+    # would change what the branch tests.
+    method IMPL-STRIP-BOOL-CONDITION(Mu $node) {
+        if nqp::istype($node, QAST::Op) {
+            my str $op := $node.op;
+            if $op eq 'hllbool' {
+                my $child := nqp::atpos($node.list, 0);
+                return $child
+                    if nqp::istype($child, QAST::IVal)
+                    || nqp::istype($child, QAST::Op) && nqp::eqat($child.op, '_i', -2);
+            }
+            elsif $op eq 'p6typecheckrv' {
+                return self.IMPL-STRIP-BOOL-CONDITION(nqp::atpos($node.list, 0));
+            }
+        }
+        elsif nqp::istype($node, QAST::Stmts) || nqp::istype($node, QAST::Stmt) {
+            my int $n := nqp::elems($node.list);
+            if $n {
+                my $rc := $node.resultchild;
+                my int $idx := nqp::defined($rc) ?? $rc !! $n - 1;
+                my $inner := self.IMPL-STRIP-BOOL-CONDITION(nqp::atpos($node.list, $idx));
+                unless nqp::isnull($inner) {
+                    nqp::bindpos($node.list, $idx, $inner);
+                    return $node;
+                }
+            }
+        }
+        nqp::null()
     }
 
     # Mark a call whose argument types decide the dispatch at compile time.

--- a/src/Raku/ast/statement-mods.rakumod
+++ b/src/Raku/ast/statement-mods.rakumod
@@ -26,6 +26,16 @@ class RakuAST::StatementModifier::Condition
   is RakuAST::StatementModifier
   is RakuAST::ImplicitLookups
 {
+    # Set by the optimize pass, allowing a native-int condition to be
+    # tested directly.
+    has int $!native-condition;
+
+    method IMPL-SET-NATIVE-CONDITION() {
+        nqp::bindattr_i(self, RakuAST::StatementModifier::Condition, '$!native-condition', 1)
+    }
+
+    method IMPL-NATIVE-CONDITION() { $!native-condition }
+
     method PRODUCE-IMPLICIT-LOOKUPS() {
         [
             RakuAST::Type::Setting.new(RakuAST::Name.from-identifier('Empty'))
@@ -46,9 +56,12 @@ class RakuAST::StatementModifier::If
   is RakuAST::StatementModifier::Condition
 {
     method IMPL-WRAP-QAST(RakuAST::IMPL::QASTContext $context, Mu $statement-qast) {
+        my $cond-qast := self.expression.IMPL-TO-QAST($context);
+        $cond-qast := self.IMPL-NATIVE-CONDITION-QAST($cond-qast)
+            if self.IMPL-NATIVE-CONDITION;
         QAST::Op.new(
             :op('if'),
-            self.expression.IMPL-TO-QAST($context),
+            $cond-qast,
             $statement-qast,
             self.IMPL-EMPTY($context)
         )
@@ -60,9 +73,12 @@ class RakuAST::StatementModifier::Unless
   is RakuAST::StatementModifier::Condition
 {
     method IMPL-WRAP-QAST(RakuAST::IMPL::QASTContext $context, Mu $statement-qast) {
+        my $cond-qast := self.expression.IMPL-TO-QAST($context);
+        $cond-qast := self.IMPL-NATIVE-CONDITION-QAST($cond-qast)
+            if self.IMPL-NATIVE-CONDITION;
         QAST::Op.new(
             :op('unless'),
-            self.expression.IMPL-TO-QAST($context),
+            $cond-qast,
             $statement-qast,
             self.IMPL-EMPTY($context)
         )
@@ -222,11 +238,22 @@ class RakuAST::StatementModifier::WhileUntil
         ]
     }
 
+    # Set by the optimize pass, allowing a native-int condition to be
+    # tested directly.
+    has int $!native-condition;
+
+    method IMPL-SET-NATIVE-CONDITION() {
+        nqp::bindattr_i(self, RakuAST::StatementModifier::WhileUntil, '$!native-condition', 1)
+    }
+
     method IMPL-WRAP-QAST(RakuAST::IMPL::QASTContext $context, Mu $statement-qast, Bool :$sink, Bool :$block, Mu :$expression) {
         if $sink {
+            my $cond-qast := self.expression.IMPL-TO-QAST($context);
+            $cond-qast := self.IMPL-NATIVE-CONDITION-QAST($cond-qast)
+                if $!native-condition;
             QAST::Op.new(
                 :op(self.negate ?? 'until' !! 'while'),
-                self.expression.IMPL-TO-QAST($context),
+                $cond-qast,
                 $statement-qast
             )
         }

--- a/src/Raku/ast/statements.rakumod
+++ b/src/Raku/ast/statements.rakumod
@@ -1262,6 +1262,21 @@ class RakuAST::Statement::IfWith
             !! $body.IMPL-TO-QAST($context, :immediate)
     }
 
+    # Set by the optimize pass, allowing a native-int condition of a
+    # plain if part to be tested directly.
+    has int $!native-condition;
+
+    method IMPL-SET-NATIVE-CONDITION() {
+        nqp::bindattr_i(self, RakuAST::Statement::IfWith, '$!native-condition', 1)
+    }
+
+    method IMPL-CONDITION-QAST(RakuAST::IMPL::QASTContext $context, Mu $condition, str $type) {
+        my $qast := $condition.IMPL-TO-QAST($context);
+        $qast := self.IMPL-NATIVE-CONDITION-QAST($qast)
+            if $!native-condition && $type eq 'if';
+        $qast
+    }
+
     method IMPL-TO-QAST(RakuAST::IMPL::QASTContext $context) {
         # Start with the else (or Empty).
         my $cur-end;
@@ -1279,7 +1294,7 @@ class RakuAST::Statement::IfWith
             my $branch := $!elsifs[$i];
             $cur-end := QAST::Op.new(
                 :op($branch.IMPL-QAST-TYPE),
-                $branch.condition.IMPL-TO-QAST($context),
+                self.IMPL-CONDITION-QAST($context, $branch.condition, $branch.IMPL-QAST-TYPE),
                 self.IMPL-BRANCH-QAST($context, $branch.then),
                 $cur-end
             );
@@ -1288,7 +1303,7 @@ class RakuAST::Statement::IfWith
         # Finally, the initial condition.
         QAST::Op.new(
             :op(self.IMPL-QAST-TYPE),
-            $!condition.IMPL-TO-QAST($context),
+            self.IMPL-CONDITION-QAST($context, $!condition, self.IMPL-QAST-TYPE),
             self.IMPL-BRANCH-QAST($context, $!then),
             $cur-end
         )
@@ -1403,10 +1418,21 @@ class RakuAST::Statement::Unless
         ]
     }
 
+    # Set by the optimize pass, allowing a native-int condition to be
+    # tested directly.
+    has int $!native-condition;
+
+    method IMPL-SET-NATIVE-CONDITION() {
+        nqp::bindattr_i(self, RakuAST::Statement::Unless, '$!native-condition', 1)
+    }
+
     method IMPL-TO-QAST(RakuAST::IMPL::QASTContext $context) {
+        my $cond-qast := $!condition.IMPL-TO-QAST($context);
+        $cond-qast := self.IMPL-NATIVE-CONDITION-QAST($cond-qast)
+            if $!native-condition;
         QAST::Op.new(
             :op('unless'),
-            $!condition.IMPL-TO-QAST($context),
+            $cond-qast,
             $!body.IMPL-FLATTEN-APPROVED
                 ?? $!body.IMPL-QAST-FLATTENED($context)
                 !! $!body.IMPL-TO-QAST($context, :immediate),
@@ -1496,6 +1522,14 @@ class RakuAST::Statement::Loop
   is RakuAST::IMPL::ImmediateBlockUser
   is RakuAST::ImplicitBlockSemanticsProvider
 {
+    # Set by the optimize pass, allowing a native-int condition to be
+    # tested directly.
+    has int $!native-condition;
+
+    method IMPL-SET-NATIVE-CONDITION() {
+        nqp::bindattr_i(self, RakuAST::Statement::Loop, '$!native-condition', 1)
+    }
+
     # The setup expression for the loop.
     has RakuAST::Expression $.setup;
 
@@ -1647,9 +1681,14 @@ class RakuAST::Statement::Loop
             my str $op := self.repeat
                 ?? (self.negate ?? 'repeat_until' !! 'repeat_while')
                 !! (self.negate ?? 'until' !! 'while');
+            my $cond-qast := $!condition
+                ?? $!condition.IMPL-TO-QAST($context)
+                !! QAST::IVal.new( :value(1) );
+            $cond-qast := self.IMPL-NATIVE-CONDITION-QAST($cond-qast)
+                if $!native-condition && $!condition;
             my $loop-qast := QAST::Op.new(
                 :$op,
-                $!condition ?? $!condition.IMPL-TO-QAST($context) !! QAST::IVal.new( :value(1) ),
+                $cond-qast,
                 $!body.IMPL-FLATTEN-APPROVED
                     ?? $!body.IMPL-QAST-FLATTENED($context)
                     !! $!body.IMPL-TO-QAST($context, :immediate),

--- a/t/08-performance/23-rakuast-native-condition.t
+++ b/t/08-performance/23-rakuast-native-condition.t
@@ -1,0 +1,92 @@
+use lib <t/packages/Test-Helpers>;
+use Test::Helpers::QAST;
+use Test;
+use QAST:from<NQP>;
+use nqp;
+plan 14;
+
+# A conditional or loop whose condition computes a native int branches
+# on that int directly: the boolification over an inlined native
+# comparison is dropped, and a bare native-int variable is compared
+# against zero instead of boxing a Bool every time around.
+
+# The comparison shapes depend on this frontend's compile-time dispatch
+# inlining putting the boolified native comparison in condition position.
+if nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' {
+    qast-is 'my int $i; while $i < 5 { $i++ }', :full, -> \v {
+        qast-contains-op(v, 'islt_i') and not qast-contains-op(v, 'hllbool')
+    }, 'a native comparison while condition branches on islt_i with no boolification';
+
+    qast-is 'my int $i = 3; if $i < 5 { say 1 }', :full, -> \v {
+        qast-contains-op(v, 'islt_i') and not qast-contains-op(v, 'hllbool')
+    }, 'a native comparison if condition branches on islt_i with no boolification';
+
+    qast-is 'my int $i = 3; unless $i > 5 { say 1 }', :full, -> \v {
+        qast-contains-op(v, 'isgt_i') and not qast-contains-op(v, 'hllbool')
+    }, 'a native comparison unless condition branches on isgt_i with no boolification';
+
+    qast-is 'my int $i = 3; my int $k = 0; $k++ while $i-- > 0; say $k', :full, -> \v {
+        not qast-contains-op(v, 'hllbool')
+    }, 'a while statement modifier condition loses its boolification';
+}
+else {
+    skip 'the stripped comparison shapes are specific to the RakuAST frontend', 4;
+}
+
+qast-is 'my int $i = 3; while $i { $i-- }', :full, -> \v {
+    qast-contains-op(v, 'isne_i')
+}, 'a bare native-int while condition compares against zero';
+
+qast-is 'my $x = 3; while $x { $x-- }', :full, -> \v {
+    not qast-contains-op(v, 'isne_i')
+}, 'a boxed variable condition stays as it was';
+
+# Behavior stays identical.
+
+{
+    my int $i = 0;
+    my int $n = 0;
+    while $i < 5 { $n = $n + $i; $i++ }
+    is $n, 10, 'a stripped while comparison loops the right number of times';
+}
+
+{
+    my int $i = 3;
+    while $i { $i-- }
+    is $i, 0, 'a bare native-int condition counts down to zero';
+}
+
+{
+    my int $i = -1;
+    my $r = $i ?? 'true' !! 'false';
+    while $i { $i++ }
+    is $i, 0, 'a negative native int is true and increments up to zero';
+}
+
+{
+    my int $i = 3;
+    is ($i < 5 ?? 'lt' !! 'ge'), 'lt', 'ternaries are untouched and correct';
+    my @r;
+    if $i < 2 { @r.push('a') } elsif $i < 5 { @r.push('b') } else { @r.push('c') }
+    is @r.join, 'b', 'a stripped elsif chain picks the right branch';
+}
+
+{
+    my int $i = 5;
+    my @r;
+    @r.push('if') if $i < 9;
+    @r.push('unless') unless $i < 2;
+    is @r.join(','), 'if,unless', 'stripped condition modifiers still fire correctly';
+}
+
+{
+    my int $j = 0;
+    repeat { $j++ } while $j < 3;
+    is $j, 3, 'a stripped repeat-while runs its body first';
+}
+
+{
+    my $seen;
+    with 42 { $seen = $_ }
+    is $seen, 42, 'a with part still topicalizes its condition value';
+}


### PR DESCRIPTION
Previously a condition that computed a native int still boxed a Bool for the branch to test. With compile-time dispatch inlining putting the native comparison in condition position, every iteration of a native-typed loop paid a boolification, a return-type check on the inlined operator, and the unboxing of the result. A bare native-int variable condition read through a reference and boxed the same way.

The optimize pass now marks conditional and loop statements, and the if, unless, while, and until statement modifiers, and code generation rewrites a marked condition: the boolification over a provably native-int computation is dropped, along with the return-type check it satisfied statically, and a bare native-int variable is read as a value and compared against zero. Only plain if parts rewrite: a with part tests definedness and topicalizes the condition value, so its condition is left as it was.

    my int $i; my int $n;
    while $i < 10000000 { $n = $n + $i; $i++ }

runs 14 percent faster on top of the inlining, at parity with the legacy frontend on the same build.