### PR TITLE
RakuAST: don't run LAST in a loop that never runs its body

### DIFF
--- a/src/Raku/ast/statements.rakumod
+++ b/src/Raku/ast/statements.rakumod
@@ -1677,6 +1677,35 @@ class RakuAST::Statement::Loop
         QAST::WVal.new(:value($run-phasers))
     }
 
+    # A pre-test loop (while/until, or a C-style loop with a condition) that
+    # never runs its body must not fire LAST; FIRST already behaves this way. A
+    # repeat loop always runs its body once, so it keeps firing LAST. This is
+    # only for the eager (statement-level) loop; a lazy from-loop fires LAST
+    # from its iterator instead.
+    method IMPL-GUARD-LAST() {
+        my $phasers := nqp::getattr($!body.meta-object, Block, '$!phasers');
+        my @last := nqp::ishash($phasers) && nqp::existskey($phasers, 'LAST')
+          ?? $phasers<LAST> !! [];
+        nqp::elems(@last) && $!condition && !self.repeat
+    }
+
+    # Fold a did-run flag into a pre-test loop condition so LAST can tell
+    # whether the body ran. Binds the flag lexical when an iteration is about to
+    # run (before the body, so an immediate `last` still counts). $while is true
+    # for a while-style loop (body runs on a true condition), false for until.
+    method IMPL-LAST-GUARD-CONDITION(Mu $cond-qast, int $while, str $ran) {
+        my $set := QAST::Op.new(:op<bind>,
+          QAST::Var.new(:name($ran), :scope<lexical>, :returns(int)),
+          QAST::IVal.new(:value(1)));
+        $while
+          ?? QAST::Op.new(:op<if>, $cond-qast,
+               QAST::Stmts.new($set, QAST::IVal.new(:value(1))),
+               QAST::IVal.new(:value(0)))
+          !! QAST::Op.new(:op<if>, $cond-qast,
+               QAST::IVal.new(:value(1)),
+               QAST::Stmts.new($set, QAST::IVal.new(:value(0))))
+    }
+
     method IMPL-TO-QAST(RakuAST::IMPL::QASTContext $context) {
         my $phasers := nqp::getattr($!body.meta-object, Block, '$!phasers');
         my @next-phasers := nqp::ishash($phasers) && nqp::existskey($phasers, 'NEXT') ?? $phasers<NEXT> !! [];
@@ -1693,6 +1722,12 @@ class RakuAST::Statement::Loop
                 !! QAST::IVal.new( :value(1) );
             $cond-qast := self.IMPL-NATIVE-CONDITION-QAST($cond-qast)
                 if $!native-condition && $!condition;
+            my int $guard-last := self.IMPL-GUARD-LAST;
+            my str $ran;
+            if $guard-last {
+                $ran := QAST::Node.unique('LOOP_LAST_RAN');
+                $cond-qast := self.IMPL-LAST-GUARD-CONDITION($cond-qast, !self.negate, $ran);
+            }
             my $loop-qast := QAST::Op.new(
                 :$op,
                 $cond-qast,
@@ -1726,10 +1761,22 @@ class RakuAST::Statement::Loop
             if $!setup {
                 $wrapper.push($!setup.IMPL-TO-QAST($context));
             }
+            if $guard-last {
+                $wrapper.push(QAST::Op.new(:op<bind>,
+                  QAST::Var.new(:name($ran), :scope<lexical>, :decl<var>, :returns(int)),
+                  QAST::IVal.new(:value(0))));
+            }
             $wrapper.push($loop-qast);
-            for @last-phasers {
-                $context.ensure-sc($_);
-                $wrapper.push(QAST::Op.new(:op('call'), QAST::WVal.new(:value($_))));
+            if @last-phasers {
+                my $last-qast := QAST::Stmts.new;
+                for @last-phasers {
+                    $context.ensure-sc($_);
+                    $last-qast.push(QAST::Op.new(:op('call'), QAST::WVal.new(:value($_))));
+                }
+                $wrapper.push($guard-last
+                  ?? QAST::Op.new(:op<if>,
+                       QAST::Var.new(:name($ran), :scope<lexical>, :returns(int)), $last-qast)
+                  !! $last-qast);
             }
             unless self.sunk {
                 $wrapper.push(
@@ -1759,6 +1806,9 @@ class RakuAST::Statement::Loop
                     $label-qast.named('label');
                     $loop-qast.push($label-qast);
                 }
+                # Have the iterator run the body's LAST phaser at exhaustion.
+                $loop-qast.push(QAST::IVal.new(:value(1), :named('fire-last')))
+                  if @last-phasers;
                 $qast.push: $loop-qast;
                 $qast
             }
@@ -1783,13 +1833,10 @@ class RakuAST::Statement::Loop
                     $label-qast.named('label');
                     $qast.push($label-qast);
                 }
-                if @last-phasers {
-                    $qast := QAST::Stmts.new(:resultchild(0), $qast);
-                    for @last-phasers {
-                        $context.ensure-sc($_);
-                        $qast.push(QAST::Op.new(:op('call'), QAST::WVal.new(:value($_))));
-                    }
-                }
+                # No LAST call here: this loop is lazy, so its from-loop iterator
+                # runs the body's LAST phaser at exhaustion (only if the body ran).
+                $qast.push(QAST::IVal.new(:value(1), :named('fire-last')))
+                  if @last-phasers;
                 if self.IMPL-DISCARD-RESULT { # In case we're here because of UNDO phasers
                     $qast := QAST::Op.new(:op('p6sink'), $qast);
                 }
@@ -1822,13 +1869,10 @@ class RakuAST::Statement::Loop
             if @next-phasers {
                 $qast.push(self.IMPL-NEXT-PHASER-AFTERWARDS-QAST($context, @next-phasers));
             }
-            if @last-phasers {
-                $qast := QAST::Stmts.new(:resultchild(0), $qast);
-                for @last-phasers {
-                    $context.ensure-sc($_);
-                    $qast.push(QAST::Op.new(:op('call'), QAST::WVal.new(:value($_))));
-                }
-            }
+            # No LAST call here: this loop is lazy, so its from-loop iterator
+            # runs the body's LAST phaser at exhaustion (only if the body ran).
+            $qast.push(QAST::IVal.new(:value(1), :named('fire-last')))
+              if @last-phasers;
             $qast
         }
     }

--- a/src/Raku/ast/statements.rakumod
+++ b/src/Raku/ast/statements.rakumod
@@ -1715,6 +1715,35 @@ class RakuAST::Statement::Loop
         QAST::WVal.new(:value($run-phasers))
     }
 
+    # A pre-test loop (while/until, or a C-style loop with a condition) that
+    # never runs its body must not fire LAST; FIRST already behaves this way. A
+    # repeat loop always runs its body once, so it keeps firing LAST. This is
+    # only for the eager (statement-level) loop; a lazy from-loop fires LAST
+    # from its iterator instead.
+    method IMPL-GUARD-LAST() {
+        my $phasers := nqp::getattr($!body.meta-object, Block, '$!phasers');
+        my @last := nqp::ishash($phasers) && nqp::existskey($phasers, 'LAST')
+          ?? $phasers<LAST> !! [];
+        nqp::elems(@last) && $!condition && !self.repeat
+    }
+
+    # Fold a did-run flag into a pre-test loop condition so LAST can tell
+    # whether the body ran. Binds the flag lexical when an iteration is about to
+    # run (before the body, so an immediate `last` still counts). $while is true
+    # for a while-style loop (body runs on a true condition), false for until.
+    method IMPL-LAST-GUARD-CONDITION(Mu $cond-qast, int $while, str $ran) {
+        my $set := QAST::Op.new(:op<bind>,
+          QAST::Var.new(:name($ran), :scope<lexical>, :returns(int)),
+          QAST::IVal.new(:value(1)));
+        $while
+          ?? QAST::Op.new(:op<if>, $cond-qast,
+               QAST::Stmts.new($set, QAST::IVal.new(:value(1))),
+               QAST::IVal.new(:value(0)))
+          !! QAST::Op.new(:op<if>, $cond-qast,
+               QAST::IVal.new(:value(1)),
+               QAST::Stmts.new($set, QAST::IVal.new(:value(0))))
+    }
+
     method IMPL-TO-QAST(RakuAST::IMPL::QASTContext $context) {
         my $phasers := nqp::getattr($!body.meta-object, Block, '$!phasers');
         my @next-phasers := nqp::ishash($phasers) && nqp::existskey($phasers, 'NEXT') ?? $phasers<NEXT> !! [];
@@ -1731,6 +1760,12 @@ class RakuAST::Statement::Loop
                 !! QAST::IVal.new( :value(1) );
             $cond-qast := self.IMPL-NATIVE-CONDITION-QAST($cond-qast)
                 if $!native-condition && $!condition;
+            my int $guard-last := self.IMPL-GUARD-LAST;
+            my str $ran;
+            if $guard-last {
+                $ran := QAST::Node.unique('LOOP_LAST_RAN');
+                $cond-qast := self.IMPL-LAST-GUARD-CONDITION($cond-qast, !self.negate, $ran);
+            }
             my $loop-qast := QAST::Op.new(
                 :$op,
                 $cond-qast,
@@ -1764,10 +1799,22 @@ class RakuAST::Statement::Loop
             if $!setup {
                 $wrapper.push($!setup.IMPL-TO-QAST($context));
             }
+            if $guard-last {
+                $wrapper.push(QAST::Op.new(:op<bind>,
+                  QAST::Var.new(:name($ran), :scope<lexical>, :decl<var>, :returns(int)),
+                  QAST::IVal.new(:value(0))));
+            }
             $wrapper.push($loop-qast);
-            for @last-phasers {
-                $context.ensure-sc($_);
-                $wrapper.push(QAST::Op.new(:op('call'), QAST::WVal.new(:value($_))));
+            if @last-phasers {
+                my $last-qast := QAST::Stmts.new;
+                for @last-phasers {
+                    $context.ensure-sc($_);
+                    $last-qast.push(QAST::Op.new(:op('call'), QAST::WVal.new(:value($_))));
+                }
+                $wrapper.push($guard-last
+                  ?? QAST::Op.new(:op<if>,
+                       QAST::Var.new(:name($ran), :scope<lexical>, :returns(int)), $last-qast)
+                  !! $last-qast);
             }
             unless self.sunk {
                 $wrapper.push(
@@ -1797,6 +1844,9 @@ class RakuAST::Statement::Loop
                     $label-qast.named('label');
                     $loop-qast.push($label-qast);
                 }
+                # Have the iterator run the body's LAST phaser at exhaustion.
+                $loop-qast.push(QAST::IVal.new(:value(1), :named('fire-last')))
+                  if @last-phasers;
                 $qast.push: $loop-qast;
                 $qast
             }
@@ -1821,13 +1871,10 @@ class RakuAST::Statement::Loop
                     $label-qast.named('label');
                     $qast.push($label-qast);
                 }
-                if @last-phasers {
-                    $qast := QAST::Stmts.new(:resultchild(0), $qast);
-                    for @last-phasers {
-                        $context.ensure-sc($_);
-                        $qast.push(QAST::Op.new(:op('call'), QAST::WVal.new(:value($_))));
-                    }
-                }
+                # No LAST call here: this loop is lazy, so its from-loop iterator
+                # runs the body's LAST phaser at exhaustion (only if the body ran).
+                $qast.push(QAST::IVal.new(:value(1), :named('fire-last')))
+                  if @last-phasers;
                 if self.IMPL-DISCARD-RESULT { # In case we're here because of UNDO phasers
                     $qast := QAST::Op.new(:op('p6sink'), $qast);
                 }
@@ -1860,13 +1907,10 @@ class RakuAST::Statement::Loop
             if @next-phasers {
                 $qast.push(self.IMPL-NEXT-PHASER-AFTERWARDS-QAST($context, @next-phasers));
             }
-            if @last-phasers {
-                $qast := QAST::Stmts.new(:resultchild(0), $qast);
-                for @last-phasers {
-                    $context.ensure-sc($_);
-                    $qast.push(QAST::Op.new(:op('call'), QAST::WVal.new(:value($_))));
-                }
-            }
+            # No LAST call here: this loop is lazy, so its from-loop iterator
+            # runs the body's LAST phaser at exhaustion (only if the body ran).
+            $qast.push(QAST::IVal.new(:value(1), :named('fire-last')))
+              if @last-phasers;
             $qast
         }
     }

--- a/src/core.c/Rakudo/Iterator.rakumod
+++ b/src/core.c/Rakudo/Iterator.rakumod
@@ -1420,17 +1420,24 @@ class Rakudo::Iterator {
         has &!afterwards;
         has $!label;
         has int $!seen-first;
+        has $!LAST;      # combined LAST phaser of the body, or Nil
+        has int $!body-ran; # set once the loop body has run
 
-        method !SET-SELF(\body,\cond,\afterwards,\label) {
+        method !SET-SELF(\body,\cond,\afterwards,\label,\fire-last) {
             nqp::bindattr(self,self.WHAT,'$!slipper',nqp::null);
             &!body := body;
             &!cond := cond;
             &!afterwards := afterwards;
             $!label := nqp::decont(label);
+            # The frontend asks the iterator to run the body's LAST phaser by
+            # passing fire-last (the RakuAST frontend does; the legacy frontend
+            # keeps emitting the LAST call after the loop and leaves this off).
+            nqp::bindattr(self,self.WHAT,'$!LAST',
+              nqp::if(fire-last, body.callable_for_phaser('LAST'), Nil));
             self
         }
-        method new(\body,\cond,\afterwards,\label) {
-            nqp::create(self)!SET-SELF(body,cond,afterwards,label)
+        method new(\body,\cond,\afterwards,\label,\fire-last) {
+            nqp::create(self)!SET-SELF(body,cond,afterwards,label,fire-last)
         }
 
         method pull-one() {
@@ -1451,6 +1458,7 @@ class Rakudo::Iterator {
                       (my int $stopped),
                       nqp::stmts(
                         ($stopped = 1),
+                        ($!body-ran = 1),
                         nqp::handle(
                           nqp::if(
                             nqp::istype(($result := &!body()),Slip),
@@ -1489,15 +1497,31 @@ class Rakudo::Iterator {
                       ),
                       :nohandler
                     ),
-                    $result
+                    nqp::if(nqp::eqaddr($result,IterationEnd),self!last-done,$result)
                   ),
-                  IterationEnd
+                  self!last-done
                 )
             }
         }
+
+        # Run the body's LAST phaser once at exhaustion, if the body ran.
+        method !last-done() {
+            nqp::if(
+              $!body-ran,
+              nqp::if(
+                nqp::isconcrete($!LAST),
+                nqp::stmts(
+                  (my &the-last := $!LAST),
+                  ($!LAST := nqp::null),
+                  the-last()
+                )
+              )
+            );
+            IterationEnd
+        }
     }
-    method CStyleLoop(&body, &cond, &afterwards, $label) {
-        CStyleLoop.new(&body, &cond, &afterwards, $label)
+    method CStyleLoop(&body, &cond, &afterwards, $label, $fire-last = 0) {
+        CStyleLoop.new(&body, &cond, &afterwards, $label, $fire-last)
     }
 
     # Returns an iterator for iterating file system directories, producing
@@ -2502,16 +2526,23 @@ class Rakudo::Iterator {
     my class Loop does Rakudo::SlippyIterator {
         has &!body;
         has $!label;
+        has $!LAST;      # combined LAST phaser of the body, or Nil
+        has int $!body-ran; # set once the loop body has run
 
-        method !SET-SELF(\body,\label) {
+        method !SET-SELF(\body,\label,\fire-last) {
             nqp::bindattr(self,self.WHAT,'$!slipper',nqp::null);
             &!body := body;
             $!label := nqp::decont(label);
+            # The frontend asks the iterator to run the body's LAST phaser by
+            # passing fire-last (the RakuAST frontend does; the legacy frontend
+            # keeps emitting the LAST call after the loop and leaves this off).
+            nqp::bindattr(self,self.WHAT,'$!LAST',
+              nqp::if(fire-last, body.callable_for_phaser('LAST'), Nil));
             self
         }
 
-        method new(\body,\label) {
-            nqp::create(self)!SET-SELF(body,label)
+        method new(\body,\label,\fire-last) {
+            nqp::create(self)!SET-SELF(body,label,fire-last)
         }
 
         method pull-one() {
@@ -2527,6 +2558,7 @@ class Rakudo::Iterator {
                   $stopped,
                   nqp::stmts(
                     ($stopped = 1),
+                    ($!body-ran = 1),
                     nqp::handle(
                       nqp::if(
                         nqp::istype(($result := &!body()),Slip),
@@ -2555,14 +2587,31 @@ class Rakudo::Iterator {
                   ),
                   :nohandler
                 ),
-                $result
+                nqp::if(nqp::eqaddr($result,IterationEnd),self!last-done,$result)
               )
             )
         }
 
+        # A bare loop always runs its body, so its LAST fires whenever the loop
+        # ends (via `last`); the ran flag keeps it firing just once.
+        method !last-done() {
+            nqp::if(
+              $!body-ran,
+              nqp::if(
+                nqp::isconcrete($!LAST),
+                nqp::stmts(
+                  (my &the-last := $!LAST),
+                  ($!LAST := nqp::null),
+                  the-last()
+                )
+              )
+            );
+            IterationEnd
+        }
+
         method is-lazy(--> True) { }
     }
-    method Loop(&body, $label) { Loop.new(&body, $label) }
+    method Loop(&body, $label, $fire-last = 0) { Loop.new(&body, $label, $fire-last) }
 
     # An often occurring use of the Mappy role to generate all of the
     # keys of a Map / Hash.  Takes a Map / Hash as the only parameter.
@@ -4117,17 +4166,24 @@ class Rakudo::Iterator {
         has &!cond;
         has $!label;
         has int $!skip;
+        has $!LAST;      # combined LAST phaser of the body, or Nil
+        has int $!body-ran; # set once the loop body has run
 
-        method !SET-SELF(\body,\cond,\label) {
+        method !SET-SELF(\body,\cond,\label,\fire-last) {
             nqp::bindattr(self,self.WHAT,'$!slipper',nqp::null);
             &!body  := body;
             &!cond  := cond;
             $!label := nqp::decont(label);
             $!skip   = 1;
+            # The frontend asks the iterator to run the body's LAST phaser by
+            # passing fire-last (the RakuAST frontend does; the legacy frontend
+            # keeps emitting the LAST call after the loop and leaves this off).
+            nqp::bindattr(self,self.WHAT,'$!LAST',
+              nqp::if(fire-last, body.callable_for_phaser('LAST'), Nil));
             self
         }
-        method new(\body,\cond,\label) {
-            nqp::create(self)!SET-SELF(body,cond,label)
+        method new(\body,\cond,\label,\fire-last) {
+            nqp::create(self)!SET-SELF(body,cond,label,fire-last)
         }
 
         method pull-one() {
@@ -4144,6 +4200,7 @@ class Rakudo::Iterator {
                     nqp::until(   # XXX perhaps repeat_until?
                       (my int $stopped),
                       nqp::stmts(
+                        ($!body-ran = 1),
                         ($stopped = 1),
                         nqp::handle(
                           nqp::if(
@@ -4173,15 +4230,32 @@ class Rakudo::Iterator {
                       ),
                       :nohandler
                     ),
-                    $result
+                    nqp::if(nqp::eqaddr($result,IterationEnd),self!last-done,$result)
                   ),
-                  IterationEnd
+                  self!last-done
                 )
             }
         }
+
+        # A repeat loop always runs its body once, so its LAST always fires; the
+        # ran flag keeps it firing just once.
+        method !last-done() {
+            nqp::if(
+              $!body-ran,
+              nqp::if(
+                nqp::isconcrete($!LAST),
+                nqp::stmts(
+                  (my &the-last := $!LAST),
+                  ($!LAST := nqp::null),
+                  the-last()
+                )
+              )
+            );
+            IterationEnd
+        }
     }
-    method RepeatLoop(&body, &cond, $label) {
-        RepeatLoop.new(&body, &cond, $label)
+    method RepeatLoop(&body, &cond, $label, $fire-last = 0) {
+        RepeatLoop.new(&body, &cond, $label, $fire-last)
     }
 
     # Return an iterator for a non-lazy iterator that rotates values for a
@@ -5218,16 +5292,23 @@ class Rakudo::Iterator {
         has &!body;
         has &!cond;
         has $!label;
+        has $!LAST;      # combined LAST phaser of the body, or Nil
+        has int $!body-ran; # set once the loop body has run
 
-        method !SET-SELF(\body,\cond,\label) {
+        method !SET-SELF(\body,\cond,\label,\fire-last) {
             nqp::bindattr(self,self.WHAT,'$!slipper',nqp::null);
             &!body := body;
             &!cond := cond;
             $!label := nqp::decont(label);
+            # The frontend asks the iterator to run the body's LAST phaser by
+            # passing fire-last (the RakuAST frontend does; the legacy frontend
+            # keeps emitting the LAST call after the loop and leaves this off).
+            nqp::bindattr(self,self.WHAT,'$!LAST',
+              nqp::if(fire-last, body.callable_for_phaser('LAST'), Nil));
             self
         }
-        method new(\body,\cond,\label) {
-            nqp::create(self)!SET-SELF(body,cond,label)
+        method new(\body,\cond,\label,\fire-last) {
+            nqp::create(self)!SET-SELF(body,cond,label,fire-last)
         }
 
         method pull-one() {
@@ -5244,6 +5325,7 @@ class Rakudo::Iterator {
                       (my int $stopped),
                       nqp::stmts(
                         ($stopped = 1),
+                        ($!body-ran = 1),
                         nqp::handle(
                           nqp::if(
                             nqp::istype(($result := &!body()),Slip),
@@ -5272,16 +5354,34 @@ class Rakudo::Iterator {
                       ),
                       :nohandler
                     ),
-                    $result
+                    nqp::if(nqp::eqaddr($result,IterationEnd),self!last-done,$result)
                   ),
-                  IterationEnd
+                  self!last-done
                 )
             }
         }
 
+        # Run the body's LAST phaser once at exhaustion, if the body ran, then
+        # report exhaustion. This is what makes a lazy while/until loop fire
+        # LAST after its last iteration the way a `for` loop does, and skip it
+        # entirely when the body never ran.
+        method !last-done() {
+            nqp::if(
+              $!body-ran,
+              nqp::if(
+                nqp::isconcrete($!LAST),
+                nqp::stmts(
+                  (my &the-last := $!LAST),
+                  ($!LAST := nqp::null),
+                  the-last()
+                )
+              )
+            );
+            IterationEnd
+        }
     }
-    method WhileLoop(&body, &cond, $label) {
-        WhileLoop.new(&body, &cond, $label)
+    method WhileLoop(&body, &cond, $label, $fire-last = 0) {
+        WhileLoop.new(&body, &cond, $label, $fire-last)
     }
 
     # Return an iterator that will zip the given iterables (with &[,])

--- a/src/core.c/Rakudo/Iterator.rakumod
+++ b/src/core.c/Rakudo/Iterator.rakumod
@@ -1420,17 +1420,24 @@ class Rakudo::Iterator is implementation-detail {
         has &!afterwards;
         has $!label;
         has int $!seen-first;
+        has $!LAST;      # combined LAST phaser of the body, or Nil
+        has int $!body-ran; # set once the loop body has run
 
-        method !SET-SELF(\body,\cond,\afterwards,\label) {
+        method !SET-SELF(\body,\cond,\afterwards,\label,\fire-last) {
             nqp::bindattr(self,self.WHAT,'$!slipper',nqp::null);
             &!body := body;
             &!cond := cond;
             &!afterwards := afterwards;
             $!label := nqp::decont(label);
+            # The frontend asks the iterator to run the body's LAST phaser by
+            # passing fire-last (the RakuAST frontend does; the legacy frontend
+            # keeps emitting the LAST call after the loop and leaves this off).
+            nqp::bindattr(self,self.WHAT,'$!LAST',
+              nqp::if(fire-last, body.callable_for_phaser('LAST'), Nil));
             self
         }
-        method new(\body,\cond,\afterwards,\label) {
-            nqp::create(self)!SET-SELF(body,cond,afterwards,label)
+        method new(\body,\cond,\afterwards,\label,\fire-last) {
+            nqp::create(self)!SET-SELF(body,cond,afterwards,label,fire-last)
         }
 
         method pull-one() {
@@ -1451,6 +1458,7 @@ class Rakudo::Iterator is implementation-detail {
                       (my int $stopped),
                       nqp::stmts(
                         ($stopped = 1),
+                        ($!body-ran = 1),
                         nqp::handle(
                           nqp::if(
                             nqp::istype(($result := &!body()),Slip),
@@ -1489,15 +1497,31 @@ class Rakudo::Iterator is implementation-detail {
                       ),
                       :nohandler
                     ),
-                    $result
+                    nqp::if(nqp::eqaddr($result,IterationEnd),self!last-done,$result)
                   ),
-                  IterationEnd
+                  self!last-done
                 )
             }
         }
+
+        # Run the body's LAST phaser once at exhaustion, if the body ran.
+        method !last-done() {
+            nqp::if(
+              $!body-ran,
+              nqp::if(
+                nqp::isconcrete($!LAST),
+                nqp::stmts(
+                  (my &the-last := $!LAST),
+                  ($!LAST := nqp::null),
+                  the-last()
+                )
+              )
+            );
+            IterationEnd
+        }
     }
-    method CStyleLoop(&body, &cond, &afterwards, $label) {
-        CStyleLoop.new(&body, &cond, &afterwards, $label)
+    method CStyleLoop(&body, &cond, &afterwards, $label, $fire-last = 0) {
+        CStyleLoop.new(&body, &cond, &afterwards, $label, $fire-last)
     }
 
     # Returns an iterator for iterating file system directories, producing
@@ -2502,16 +2526,23 @@ class Rakudo::Iterator is implementation-detail {
     my class Loop does Rakudo::SlippyIterator {
         has &!body;
         has $!label;
+        has $!LAST;      # combined LAST phaser of the body, or Nil
+        has int $!body-ran; # set once the loop body has run
 
-        method !SET-SELF(\body,\label) {
+        method !SET-SELF(\body,\label,\fire-last) {
             nqp::bindattr(self,self.WHAT,'$!slipper',nqp::null);
             &!body := body;
             $!label := nqp::decont(label);
+            # The frontend asks the iterator to run the body's LAST phaser by
+            # passing fire-last (the RakuAST frontend does; the legacy frontend
+            # keeps emitting the LAST call after the loop and leaves this off).
+            nqp::bindattr(self,self.WHAT,'$!LAST',
+              nqp::if(fire-last, body.callable_for_phaser('LAST'), Nil));
             self
         }
 
-        method new(\body,\label) {
-            nqp::create(self)!SET-SELF(body,label)
+        method new(\body,\label,\fire-last) {
+            nqp::create(self)!SET-SELF(body,label,fire-last)
         }
 
         method pull-one() {
@@ -2527,6 +2558,7 @@ class Rakudo::Iterator is implementation-detail {
                   $stopped,
                   nqp::stmts(
                     ($stopped = 1),
+                    ($!body-ran = 1),
                     nqp::handle(
                       nqp::if(
                         nqp::istype(($result := &!body()),Slip),
@@ -2555,14 +2587,31 @@ class Rakudo::Iterator is implementation-detail {
                   ),
                   :nohandler
                 ),
-                $result
+                nqp::if(nqp::eqaddr($result,IterationEnd),self!last-done,$result)
               )
             )
         }
 
+        # A bare loop always runs its body, so its LAST fires whenever the loop
+        # ends (via `last`); the ran flag keeps it firing just once.
+        method !last-done() {
+            nqp::if(
+              $!body-ran,
+              nqp::if(
+                nqp::isconcrete($!LAST),
+                nqp::stmts(
+                  (my &the-last := $!LAST),
+                  ($!LAST := nqp::null),
+                  the-last()
+                )
+              )
+            );
+            IterationEnd
+        }
+
         method is-lazy(--> True) { }
     }
-    method Loop(&body, $label) { Loop.new(&body, $label) }
+    method Loop(&body, $label, $fire-last = 0) { Loop.new(&body, $label, $fire-last) }
 
     # An often occurring use of the Mappy role to generate all of the
     # keys of a Map / Hash.  Takes a Map / Hash as the only parameter.
@@ -4117,17 +4166,24 @@ class Rakudo::Iterator is implementation-detail {
         has &!cond;
         has $!label;
         has int $!skip;
+        has $!LAST;      # combined LAST phaser of the body, or Nil
+        has int $!body-ran; # set once the loop body has run
 
-        method !SET-SELF(\body,\cond,\label) {
+        method !SET-SELF(\body,\cond,\label,\fire-last) {
             nqp::bindattr(self,self.WHAT,'$!slipper',nqp::null);
             &!body  := body;
             &!cond  := cond;
             $!label := nqp::decont(label);
             $!skip   = 1;
+            # The frontend asks the iterator to run the body's LAST phaser by
+            # passing fire-last (the RakuAST frontend does; the legacy frontend
+            # keeps emitting the LAST call after the loop and leaves this off).
+            nqp::bindattr(self,self.WHAT,'$!LAST',
+              nqp::if(fire-last, body.callable_for_phaser('LAST'), Nil));
             self
         }
-        method new(\body,\cond,\label) {
-            nqp::create(self)!SET-SELF(body,cond,label)
+        method new(\body,\cond,\label,\fire-last) {
+            nqp::create(self)!SET-SELF(body,cond,label,fire-last)
         }
 
         method pull-one() {
@@ -4144,6 +4200,7 @@ class Rakudo::Iterator is implementation-detail {
                     nqp::until(   # XXX perhaps repeat_until?
                       (my int $stopped),
                       nqp::stmts(
+                        ($!body-ran = 1),
                         ($stopped = 1),
                         nqp::handle(
                           nqp::if(
@@ -4173,15 +4230,32 @@ class Rakudo::Iterator is implementation-detail {
                       ),
                       :nohandler
                     ),
-                    $result
+                    nqp::if(nqp::eqaddr($result,IterationEnd),self!last-done,$result)
                   ),
-                  IterationEnd
+                  self!last-done
                 )
             }
         }
+
+        # A repeat loop always runs its body once, so its LAST always fires; the
+        # ran flag keeps it firing just once.
+        method !last-done() {
+            nqp::if(
+              $!body-ran,
+              nqp::if(
+                nqp::isconcrete($!LAST),
+                nqp::stmts(
+                  (my &the-last := $!LAST),
+                  ($!LAST := nqp::null),
+                  the-last()
+                )
+              )
+            );
+            IterationEnd
+        }
     }
-    method RepeatLoop(&body, &cond, $label) {
-        RepeatLoop.new(&body, &cond, $label)
+    method RepeatLoop(&body, &cond, $label, $fire-last = 0) {
+        RepeatLoop.new(&body, &cond, $label, $fire-last)
     }
 
     # Return an iterator for a non-lazy iterator that rotates values for a
@@ -5218,16 +5292,23 @@ class Rakudo::Iterator is implementation-detail {
         has &!body;
         has &!cond;
         has $!label;
+        has $!LAST;      # combined LAST phaser of the body, or Nil
+        has int $!body-ran; # set once the loop body has run
 
-        method !SET-SELF(\body,\cond,\label) {
+        method !SET-SELF(\body,\cond,\label,\fire-last) {
             nqp::bindattr(self,self.WHAT,'$!slipper',nqp::null);
             &!body := body;
             &!cond := cond;
             $!label := nqp::decont(label);
+            # The frontend asks the iterator to run the body's LAST phaser by
+            # passing fire-last (the RakuAST frontend does; the legacy frontend
+            # keeps emitting the LAST call after the loop and leaves this off).
+            nqp::bindattr(self,self.WHAT,'$!LAST',
+              nqp::if(fire-last, body.callable_for_phaser('LAST'), Nil));
             self
         }
-        method new(\body,\cond,\label) {
-            nqp::create(self)!SET-SELF(body,cond,label)
+        method new(\body,\cond,\label,\fire-last) {
+            nqp::create(self)!SET-SELF(body,cond,label,fire-last)
         }
 
         method pull-one() {
@@ -5244,6 +5325,7 @@ class Rakudo::Iterator is implementation-detail {
                       (my int $stopped),
                       nqp::stmts(
                         ($stopped = 1),
+                        ($!body-ran = 1),
                         nqp::handle(
                           nqp::if(
                             nqp::istype(($result := &!body()),Slip),
@@ -5272,16 +5354,34 @@ class Rakudo::Iterator is implementation-detail {
                       ),
                       :nohandler
                     ),
-                    $result
+                    nqp::if(nqp::eqaddr($result,IterationEnd),self!last-done,$result)
                   ),
-                  IterationEnd
+                  self!last-done
                 )
             }
         }
 
+        # Run the body's LAST phaser once at exhaustion, if the body ran, then
+        # report exhaustion. This is what makes a lazy while/until loop fire
+        # LAST after its last iteration the way a `for` loop does, and skip it
+        # entirely when the body never ran.
+        method !last-done() {
+            nqp::if(
+              $!body-ran,
+              nqp::if(
+                nqp::isconcrete($!LAST),
+                nqp::stmts(
+                  (my &the-last := $!LAST),
+                  ($!LAST := nqp::null),
+                  the-last()
+                )
+              )
+            );
+            IterationEnd
+        }
     }
-    method WhileLoop(&body, &cond, $label) {
-        WhileLoop.new(&body, &cond, $label)
+    method WhileLoop(&body, &cond, $label, $fire-last = 0) {
+        WhileLoop.new(&body, &cond, $label, $fire-last)
     }
 
     # Return an iterator that will zip the given iterables (with &[,])

--- a/src/core.c/Seq.rakumod
+++ b/src/core.c/Seq.rakumod
@@ -169,21 +169,24 @@ my class Seq is Cool does Iterable does Sequence {
         )
     }
 
-    # This method is mainly called from Actions.nqp
+    # This method is mainly called from Actions.nqp. $fire-last asks the loop
+    # iterator to run the body's LAST phaser at exhaustion (only if the body
+    # ran), the way a `for` loop does; the RakuAST frontend passes it, the
+    # legacy frontend still emits the LAST call after the loop instead.
     proto method from-loop(|) {*}
-    multi method from-loop(&body, :$label) {
-        Seq.new: Rakudo::Iterator.Loop(&body, $label)
+    multi method from-loop(&body, :$label, :$fire-last = 0) {
+        Seq.new: Rakudo::Iterator.Loop(&body, $label, $fire-last)
     }
-    multi method from-loop(&body, &cond, :$repeat!, :$label) {
+    multi method from-loop(&body, &cond, :$repeat!, :$label, :$fire-last = 0) {
         Seq.new: $repeat
-          ?? Rakudo::Iterator.RepeatLoop(&body, &cond // -> { 1 }, $label)
-          !! Rakudo::Iterator.WhileLoop(&body, &cond // -> { 1 }, $label)
+          ?? Rakudo::Iterator.RepeatLoop(&body, &cond // -> { 1 }, $label, $fire-last)
+          !! Rakudo::Iterator.WhileLoop(&body, &cond // -> { 1 }, $label, $fire-last)
     }
-    multi method from-loop(&body, &cond, :$label) {
-        Seq.new: Rakudo::Iterator.WhileLoop(&body, &cond // -> { 1 }, $label)
+    multi method from-loop(&body, &cond, :$label, :$fire-last = 0) {
+        Seq.new: Rakudo::Iterator.WhileLoop(&body, &cond // -> { 1 }, $label, $fire-last)
     }
-    multi method from-loop(&body, &cond, &afterwards, :$label) {
-        Seq.new: Rakudo::Iterator.CStyleLoop(&body, &cond // -> { 1 }, &afterwards, $label)
+    multi method from-loop(&body, &cond, &afterwards, :$label, :$fire-last = 0) {
+        Seq.new: Rakudo::Iterator.CStyleLoop(&body, &cond // -> { 1 }, &afterwards, $label, $fire-last)
     }
 
     multi method ACCEPTS(Seq:D: Iterable:D \iterable --> Bool:D) {

--- a/t/12-rakuast/xx-fixed-in-rakuast.rakutest
+++ b/t/12-rakuast/xx-fixed-in-rakuast.rakutest
@@ -2,7 +2,7 @@ use Test;
 use lib <t/packages/Test-Helpers>;
 use Test::Helpers;
 
-plan 145;
+plan 153;
 
 # t/spec/S03-sequence/misc.t
 # https://github.com/rakudo/rakudo/issues/5520
@@ -25,6 +25,51 @@ plan 145;
     my @a;
     Q| for () { FIRST @a.push: 'first'; ENTER @a.push: 'enter'; NEXT @a.push: 'next'; LEAVE @a.push: 'leave'; LAST @a.push: 'last'; } |.AST.EVAL;
     is-deeply @a, [], "phasers do not fire for loop that did not run";
+}
+
+# src/Raku/ast/statements.rakumod
+# A pre-test loop (while/until, or a C-style loop with a condition) fired its
+# LAST phaser even when the condition was false at once and the body never ran,
+# unlike FIRST. LAST now only runs when the body ran at least once.
+{
+    my @a;
+    Q| while 0 { FIRST @a.push: 'first'; LAST @a.push: 'last' } |.AST.EVAL;
+    is-deeply @a, [], "while whose body never runs fires neither FIRST nor LAST";
+}
+{
+    my @a;
+    Q| until 1 { LAST @a.push: 'last' } |.AST.EVAL;
+    is-deeply @a, [], "until whose body never runs does not fire LAST";
+}
+{
+    my @a;
+    Q| loop (my $i = 0; $i > 5; $i++) { LAST @a.push: 'last' } |.AST.EVAL;
+    is-deeply @a, [], "C-style loop whose body never runs does not fire LAST";
+}
+{
+    my @a;
+    Q| my $i = 0; while $i++ < 3 { LAST @a.push: 'last' } |.AST.EVAL;
+    is-deeply @a, ['last'], "while that runs fires LAST exactly once";
+}
+{
+    my @a;
+    Q| while 1 { LAST @a.push: 'last'; last } |.AST.EVAL;
+    is-deeply @a, ['last'], "an immediate last on the first iteration still fires LAST";
+}
+{
+    my @a;
+    Q| repeat { LAST @a.push: 'last' } while 0 |.AST.EVAL;
+    is-deeply @a, ['last'], "repeat runs its body once and fires LAST";
+}
+{
+    my @a;
+    Q| my @x = (while 0 { LAST @a.push: 'last' }); @x.elems |.AST.EVAL;
+    is-deeply @a, [], "an empty while used for its value does not fire LAST";
+}
+{
+    my @a;
+    Q| my $i = 0; my @x = (while $i++ < 2 { LAST @a.push: 'last'; $i }); @x.elems |.AST.EVAL;
+    is-deeply @a, ['last'], "a while used for its value fires LAST once when it runs";
 }
 
 # t/spec/S05-match/basics.t

--- a/t/12-rakuast/xx-fixed-in-rakuast.rakutest
+++ b/t/12-rakuast/xx-fixed-in-rakuast.rakutest
@@ -2,7 +2,7 @@ use Test;
 use lib <t/packages/Test-Helpers>;
 use Test::Helpers;
 
-plan 131;
+plan 139;
 
 # t/spec/S03-sequence/misc.t
 # https://github.com/rakudo/rakudo/issues/5520
@@ -25,6 +25,51 @@ plan 131;
     my @a;
     Q| for () { FIRST @a.push: 'first'; ENTER @a.push: 'enter'; NEXT @a.push: 'next'; LEAVE @a.push: 'leave'; LAST @a.push: 'last'; } |.AST.EVAL;
     is-deeply @a, [], "phasers do not fire for loop that did not run";
+}
+
+# src/Raku/ast/statements.rakumod
+# A pre-test loop (while/until, or a C-style loop with a condition) fired its
+# LAST phaser even when the condition was false at once and the body never ran,
+# unlike FIRST. LAST now only runs when the body ran at least once.
+{
+    my @a;
+    Q| while 0 { FIRST @a.push: 'first'; LAST @a.push: 'last' } |.AST.EVAL;
+    is-deeply @a, [], "while whose body never runs fires neither FIRST nor LAST";
+}
+{
+    my @a;
+    Q| until 1 { LAST @a.push: 'last' } |.AST.EVAL;
+    is-deeply @a, [], "until whose body never runs does not fire LAST";
+}
+{
+    my @a;
+    Q| loop (my $i = 0; $i > 5; $i++) { LAST @a.push: 'last' } |.AST.EVAL;
+    is-deeply @a, [], "C-style loop whose body never runs does not fire LAST";
+}
+{
+    my @a;
+    Q| my $i = 0; while $i++ < 3 { LAST @a.push: 'last' } |.AST.EVAL;
+    is-deeply @a, ['last'], "while that runs fires LAST exactly once";
+}
+{
+    my @a;
+    Q| while 1 { LAST @a.push: 'last'; last } |.AST.EVAL;
+    is-deeply @a, ['last'], "an immediate last on the first iteration still fires LAST";
+}
+{
+    my @a;
+    Q| repeat { LAST @a.push: 'last' } while 0 |.AST.EVAL;
+    is-deeply @a, ['last'], "repeat runs its body once and fires LAST";
+}
+{
+    my @a;
+    Q| my @x = (while 0 { LAST @a.push: 'last' }); @x.elems |.AST.EVAL;
+    is-deeply @a, [], "an empty while used for its value does not fire LAST";
+}
+{
+    my @a;
+    Q| my $i = 0; my @x = (while $i++ < 2 { LAST @a.push: 'last'; $i }); @x.elems |.AST.EVAL;
+    is-deeply @a, ['last'], "a while used for its value fires LAST once when it runs";
 }
 
 # t/spec/S05-match/basics.t


### PR DESCRIPTION
Previously a pre-test loop (while/until, or a C-style loop with a condition) fired its LAST phaser even when the condition was false at once and the body never ran, though FIRST already did not. Gate LAST on the body having run at least once.

An eager (statement-level) while/until loop folds a did-run flag into its condition, set as an iteration starts so an immediate `last` still counts, and runs LAST only when the flag is set. A value-context loop lowers to a lazy from-loop, whose iterator now runs the body's LAST phaser at exhaustion, only if the body ran, gated by a fire-last flag threaded through from-loop.

This is the RakuAST frontend only; the legacy frontend is unchanged.