### PR TITLE
RakuAST: reduce a when with a type-object matcher to a type check

### DIFF
--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -733,6 +733,7 @@ class RakuAST::Node {
             self.IMPL-MARK-ARRAY-INIT($resolver, $expr);
             self.IMPL-MARK-CT-DISPATCH($resolver, $expr);
             self.IMPL-MARK-NATIVE-CONDITION($resolver, $expr);
+            self.IMPL-MARK-WHEN-TYPEMATCH($resolver, $expr);
         }
 
         # A replacement stands where the original stood, so it must carry the
@@ -1433,6 +1434,97 @@ class RakuAST::Node {
     # match qualifies: a link of a longer comparison chain must stay a chain
     # op. The soft pragma turns the reduction off, since it bypasses the
     # operator and ACCEPTS routines that wrapping relies on.
+    # The compile-time type object a matcher node reduces to a type check
+    # against, or null when it is anything else: the matcher must carry a
+    # compile-time type-object value, non-generic, whose ACCEPTS no user
+    # candidate can intercept.
+    method IMPL-TYPEMATCH-MATCHER-TYPE(Mu $matcher) {
+        CATCH {
+            return nqp::null();
+        }
+        return nqp::null() unless $matcher.has-compile-time-value;
+        my $type := $matcher.maybe-compile-time-value;
+        return nqp::null() if nqp::isconcrete($type);
+        my $how := $type.HOW;
+        return nqp::null() unless nqp::can($how, 'archetypes');
+        return nqp::null() if $how.archetypes($type).generic;
+        my $accepts := nqp::tryfindmethod($type, 'ACCEPTS');
+        return nqp::null() unless nqp::isconcrete($accepts)
+            && nqp::can($accepts, 'IS-SETTING-ONLY')
+            && nqp::istrue($accepts.IS-SETTING-ONLY(
+                nqp::const::SIG_ELEM_DEFINED_ONLY));
+        $type
+    }
+
+    # Mark a when statement, or when statement modifier, whose matcher is
+    # a compile-time type object for reduction to a type check on the
+    # topic. A when only ever tests plain truth of its match, so the
+    # check feeds the branch directly, with the same runtime guard a
+    # reduced smartmatch takes for a topic that turns out to be a
+    # concrete Junction.
+    method IMPL-MARK-WHEN-TYPEMATCH(RakuAST::Resolver $resolver, Mu $expr) {
+        CATCH {
+            return Nil;
+        }
+        my $when;
+        if nqp::istype($expr, RakuAST::Statement::When) {
+            $when := $expr;
+        }
+        elsif nqp::istype($expr, RakuAST::Statement::Expression) {
+            my $cond := $expr.condition-modifier;
+            $when := $cond
+                if nqp::isconcrete($cond)
+                && nqp::istype($cond, RakuAST::StatementModifier::When);
+        }
+        return Nil unless nqp::isconcrete($when);
+        my $matcher := nqp::istype($when, RakuAST::Statement::When)
+            ?? $when.condition
+            !! $when.expression;
+        my $type := self.IMPL-TYPEMATCH-MATCHER-TYPE($matcher);
+        return Nil if nqp::isnull($type);
+        my $Junction := self.IMPL-OPTIMIZE-SETTING-TYPE($resolver, 'Junction');
+        return Nil if nqp::isnull($Junction);
+        $when.IMPL-SET-TYPEMATCH($type,
+            nqp::istype($type, $Junction) ?? nqp::null() !! $Junction);
+        Nil
+    }
+
+    # A when construct's reduced condition: the topic, bound to a local so
+    # the guard and the check evaluate it once, tested with a plain istype
+    # the branch reads directly. A topic that turns out to be a concrete
+    # Junction autothreads over the matcher's ACCEPTS instead, as the full
+    # match would.
+    method IMPL-WHEN-TYPEMATCH-QAST(RakuAST::IMPL::QASTContext $context, Mu $topic-qast, Mu $type, Mu $junction) {
+        $context.ensure-sc($type);
+        my str $tmp := QAST::Node.unique('when_topic');
+        my $topic := QAST::Var.new( :name($tmp), :scope<local> );
+        my $check := QAST::Op.new( :op<istype>, $topic,
+            QAST::WVal.new( :value($type) ) );
+        unless nqp::isnull($junction) {
+            $context.ensure-sc($junction);
+            my $negate-value := nqp::hllboolfor(0, 'Raku');
+            $context.ensure-sc($negate-value);
+            $check := QAST::Op.new(
+                :op<if>,
+                QAST::Op.new(
+                    :op<if>,
+                    QAST::Op.new( :op<istype>, $topic,
+                        QAST::WVal.new( :value($junction) ) ),
+                    QAST::Op.new( :op<isconcrete>, $topic )),
+                QAST::Op.new(
+                    :op<callmethod>, :name<BOOLIFY-ACCEPTS>,
+                    $topic,
+                    QAST::WVal.new( :value($type) ),
+                    QAST::WVal.new( :value($negate-value) )),
+                $check);
+        }
+        QAST::Stmts.new(
+            QAST::Op.new( :op<bind>,
+                QAST::Var.new( :name($tmp), :scope<local>, :decl<var> ),
+                $topic-qast),
+            $check)
+    }
+
     method IMPL-COLLAPSE-TYPEMATCH(RakuAST::Resolver $resolver, Mu $expr) {
         # The checks introspect meta-objects the walk has no say over, so a
         # surprise from an unusual one declines rather than breaks the build.
@@ -1457,15 +1549,12 @@ class RakuAST::Node {
             && self.infix.properties.chain
             && nqp::eqaddr(self.left, $expr);
 
-        # A compile-time-known, non-generic type object on the right.
+        # A matcher that reduces to a compile-time type check.
         my $right := $expr.right;
-        return $expr unless $right.has-compile-time-value;
-        my $type := $right.maybe-compile-time-value;
-        return $expr if nqp::isconcrete($type);
+        my $type := self.IMPL-TYPEMATCH-MATCHER-TYPE($right);
+        return $expr if nqp::isnull($type);
         my $how := $type.HOW;
-        return $expr unless nqp::can($how, 'archetypes');
         my $archetypes := $how.archetypes($type);
-        return $expr if $archetypes.generic;
 
         my $Junction := self.IMPL-OPTIMIZE-SETTING-TYPE($resolver, 'Junction');
         my $Bool     := self.IMPL-OPTIMIZE-SETTING-TYPE($resolver, 'Bool');
@@ -1473,13 +1562,6 @@ class RakuAST::Node {
 
         return $expr unless self.IMPL-OPERATOR-IS-CORE($resolver, $infix);
         return $expr if self.IMPL-IN-SOFT-SCOPE($resolver);
-
-        # No user ACCEPTS candidate may be able to dispatch for the matcher.
-        my $accepts := nqp::tryfindmethod($type, 'ACCEPTS');
-        return $expr unless nqp::isconcrete($accepts)
-            && nqp::can($accepts, 'IS-SETTING-ONLY')
-            && nqp::istrue($accepts.IS-SETTING-ONLY(
-                nqp::const::SIG_ELEM_DEFINED_ONLY));
 
         # A native topic would need boxing the plain call already provides.
         return $expr if nqp::objprimspec($left.return-type);

--- a/src/Raku/ast/statement-mods.rakumod
+++ b/src/Raku/ast/statement-mods.rakumod
@@ -89,14 +89,31 @@ class RakuAST::StatementModifier::Unless
 class RakuAST::StatementModifier::When
   is RakuAST::StatementModifier::Condition
 {
+    # Set by the optimize pass when the matcher reduces to a type check:
+    # the type matched against, and the Junction type for the runtime
+    # topic guard, or null when the matcher is Junction itself.
+    has int $!typematch;
+    has Mu $!typematch-type;
+    has Mu $!typematch-junction;
+
+    method IMPL-SET-TYPEMATCH(Mu $type, Mu $junction) {
+        nqp::bindattr_i(self, RakuAST::StatementModifier::When, '$!typematch', 1);
+        nqp::bindattr(self, RakuAST::StatementModifier::When, '$!typematch-type', $type);
+        nqp::bindattr(self, RakuAST::StatementModifier::When, '$!typematch-junction', $junction);
+    }
+
     method IMPL-WRAP-QAST(RakuAST::IMPL::QASTContext $context, Mu $statement-qast) {
         QAST::Op.new(
             :op('if'),
-            QAST::Op.new(
-                :op('callmethod'), :name('ACCEPTS'),
-                self.expression.IMPL-TO-QAST($context),
-                QAST::Var.new( :name('$_'), :scope('lexical') )
-            ),
+            $!typematch
+                ?? self.IMPL-WHEN-TYPEMATCH-QAST($context,
+                    QAST::Var.new( :name('$_'), :scope('lexical') ),
+                    $!typematch-type, $!typematch-junction)
+                !! QAST::Op.new(
+                    :op('callmethod'), :name('ACCEPTS'),
+                    self.expression.IMPL-TO-QAST($context),
+                    QAST::Var.new( :name('$_'), :scope('lexical') )
+                ),
             $statement-qast,
             self.IMPL-EMPTY($context)
         )

--- a/src/Raku/ast/statements.rakumod
+++ b/src/Raku/ast/statements.rakumod
@@ -1978,12 +1978,30 @@ class RakuAST::Statement::When
         ]
     }
 
+    # Set by the optimize pass when the matcher reduces to a type check:
+    # the type matched against, and the Junction type for the runtime
+    # topic guard, or null when the matcher is Junction itself.
+    has int $!typematch;
+    has Mu $!typematch-type;
+    has Mu $!typematch-junction;
+
+    method IMPL-SET-TYPEMATCH(Mu $type, Mu $junction) {
+        nqp::bindattr_i(self, RakuAST::Statement::When, '$!typematch', 1);
+        nqp::bindattr(self, RakuAST::Statement::When, '$!typematch-type', $type);
+        nqp::bindattr(self, RakuAST::Statement::When, '$!typematch-junction', $junction);
+    }
+
     method IMPL-TO-QAST(RakuAST::IMPL::QASTContext $context) {
-        my $sm-qast := QAST::Op.new(
-            :op('callmethod'), :name('ACCEPTS'),
-            $!condition.IMPL-TO-QAST($context),
-            self.IMPL-UNWRAP-LIST(self.get-implicit-lookups)[0].IMPL-TO-QAST($context)
-        );
+        my $topic-qast :=
+            self.IMPL-UNWRAP-LIST(self.get-implicit-lookups)[0].IMPL-TO-QAST($context);
+        my $sm-qast := $!typematch
+            ?? self.IMPL-WHEN-TYPEMATCH-QAST($context, $topic-qast,
+                $!typematch-type, $!typematch-junction)
+            !! QAST::Op.new(
+                :op('callmethod'), :name('ACCEPTS'),
+                $!condition.IMPL-TO-QAST($context),
+                $topic-qast
+            );
         QAST::Op.new(
             :op('if'),
             $sm-qast,

--- a/t/08-performance/24-rakuast-when-typematch.t
+++ b/t/08-performance/24-rakuast-when-typematch.t
@@ -1,0 +1,128 @@
+use lib <t/packages/Test-Helpers>;
+use Test::Helpers::QAST;
+use Test;
+use QAST:from<NQP>;
+use nqp;
+plan 15;
+
+# A when whose matcher is a compile-time type object tests the topic
+# with istype instead of dispatching the matcher's ACCEPTS, with the
+# same runtime guard a reduced smartmatch takes for a topic that turns
+# out to be a concrete Junction.
+
+# The legacy frontend reduces when statements through its own QAST
+# optimizer, so the shapes here are this frontend's.
+if nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' {
+    qast-is 'given 42 { when Int { say 1 } }', :full, -> \v {
+        qast-contains-op(v, 'istype')
+            and not qast-contains-callmethod(v, 'ACCEPTS')
+    }, 'a when with a type-object matcher tests istype and calls no ACCEPTS';
+
+    qast-is 'my class C { method ACCEPTS($x) { True } }; given 42 { when C { say 1 } }', :full, -> \v {
+        qast-contains-callmethod(v, 'ACCEPTS')
+    }, 'a matcher with a user ACCEPTS keeps the dispatch';
+
+    qast-is 'given 42 { when 5 { say 1 } }', :full, -> \v {
+        qast-contains-callmethod(v, 'ACCEPTS')
+    }, 'a literal matcher is not a type object and keeps the dispatch';
+
+    qast-is '$_ = 42; say "x" when Int', :full, -> \v {
+        qast-contains-op(v, 'istype')
+            and not qast-contains-callmethod(v, 'ACCEPTS')
+    }, 'a when statement modifier with a type-object matcher reduces the same way';
+}
+else {
+    skip 'the reduced when shapes are specific to the RakuAST frontend', 4;
+}
+
+# Behavior stays identical.
+
+{
+    my @r;
+    for 42, "x", 3.5e0 {
+        given $_ {
+            when Int { @r.push('int') }
+            when Str { @r.push('str') }
+            default  { @r.push('def') }
+        }
+    }
+    is @r.join(','), 'int,str,def', 'a reduced when chain dispatches each topic to the right arm';
+}
+
+{
+    my class C { method ACCEPTS($x) { $x == 42 } }
+    my @r;
+    given 42 { when C { @r.push('custom') }; default { @r.push('no') } }
+    given 43 { when C { @r.push('custom') }; default { @r.push('no') } }
+    is @r.join(','), 'custom,no', 'a user ACCEPTS matcher still runs its own logic';
+}
+
+{
+    my @r;
+    given any(1, "x") { when Int { @r.push('yes') }; default { @r.push('no') } }
+    given any("y", "x") { when Int { @r.push('yes') }; default { @r.push('no') } }
+    is @r.join(','), 'yes,no', 'a concrete Junction topic still autothreads the match';
+}
+
+{
+    subset Even of Int where * %% 2;
+    my @r;
+    given 4 { when Even { @r.push('even') }; default { @r.push('odd') } }
+    given 3 { when Even { @r.push('even') }; default { @r.push('odd') } }
+    is @r.join(','), 'even,odd', 'a subset matcher still runs its refinement';
+}
+
+{
+    my @r;
+    given Int { when Int { @r.push('type') }; default { @r.push('no') } }
+    is @r.join(','), 'type', 'a type-object topic matches its own type';
+}
+
+{
+    my @r;
+    given 5 {
+        when Int     { @r.push('int'); proceed }
+        when Numeric { @r.push('num') }
+        default      { @r.push('def') }
+    }
+    is @r.join(','), 'int,num', 'proceed still falls through a reduced when';
+}
+
+{
+    my @r;
+    given 5 {
+        when Str { @r.push('str') }
+        @r.push('between');
+        when Int { @r.push('int') }
+    }
+    is @r.join(','), 'between,int', 'statements between reduced whens still run';
+}
+
+{
+    $_ = 42;
+    my @r;
+    @r.push('mod') when Int;
+    @r.push('strmod') when Str;
+    is @r.join(','), 'mod', 'reduced when statement modifiers fire on the topic type';
+}
+
+{
+    my @r;
+    given Mu { when Mu { @r.push('mu') } }
+    given 1  { when Mu { @r.push('any-topic') } }
+    is @r.join(','), 'mu,any-topic', 'a Mu matcher accepts everything either way';
+}
+
+{
+    my @r;
+    for 1, "x" {
+        when Int { @r.push('int'); succeed }
+        when Str { @r.push('str') }
+    }
+    is @r.join(','), 'int,str', 'succeed leaves a reduced when arm cleanly';
+}
+
+{
+    my $out = do given 42 { when Int { 'val' }; default { 'no' } };
+    is $out, 'val', 'a given returning a reduced when arm value still returns it';
+}


### PR DESCRIPTION
Previously every when dispatched its matcher's ACCEPTS at run time, so a chain of type-object whens in a given paid a method dispatch per arm. The reduced smartmatch already showed the matcher-side analysis: a compile-time type object, non-generic, whose ACCEPTS no user candidate can intercept, comes down to nqp::istype.

That analysis now lives in one place and the optimize pass also marks when statements and when statement modifiers whose matcher passes it. Code generation tests the topic with a plain istype the branch reads directly, with no boolification, since a when only ever tests truth of its match. A topic that turns out to be a concrete Junction autothreads over the matcher's ACCEPTS through the same runtime guard the reduced smartmatch takes, a subset matcher runs its refinement inside istype, and a matcher with a user ACCEPTS keeps the dispatch.