### PR TITLE
RakuAST: reduce smartmatch, when, and where forms at compile time

### DIFF
--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -743,6 +743,7 @@ class RakuAST::Node {
             self.IMPL-MARK-NATIVE-CONDITION($resolver, $expr);
             self.IMPL-MARK-WHEN-TYPEMATCH($resolver, $expr);
             self.IMPL-MARK-JUNCTION-FOLD($resolver, $expr);
+            self.IMPL-MARK-CHAIN-LINKS($resolver, $expr);
             self.IMPL-MARK-PARAM-WHERE-JUNCTION($resolver, $expr);
         }
 
@@ -1537,7 +1538,7 @@ class RakuAST::Node {
                     $matched := $matcher-value.ACCEPTS($topic-value);
                     $matched := $negated ?? $matched.not !! $matched.Bool;
                 }
-                return RakuAST::Literal.from-value($matched)
+                return self.IMPL-SMARTMATCH-FOLD-RESULT($expr, $matched)
                     unless nqp::isnull($matched);
             }
         }
@@ -1854,13 +1855,12 @@ class RakuAST::Node {
         my $Junction := self.IMPL-OPTIMIZE-SETTING-TYPE($resolver, 'Junction');
         return Nil if nqp::isnull($Junction);
 
-        # A declared type a Junction argument could bind to means the
-        # constraint itself can see a junction.
-        my $param-type := $expr.type;
-        if nqp::isconcrete($param-type) {
-            my $nominal := $param-type.compile-time-value;
-            return Nil if nqp::istype($Junction, nqp::decont($nominal));
-        }
+        # A nominal type a Junction argument could bind to means the
+        # constraint itself can see a junction, and a block parameter's
+        # implicit Mu is such a type, so the meta-object's word is the
+        # one that counts.
+        my $nominal := nqp::getattr($expr.meta-object, Parameter, '$!type');
+        return Nil if nqp::istype($Junction, nqp::decont($nominal));
 
         # The written constraint is the invocant of the ACCEPTS call the
         # begin-time wrapping built around it.
@@ -2039,6 +2039,44 @@ class RakuAST::Node {
                 $fallback))
     }
 
+    # A decided smartmatch replaces the node with its answer, except in an
+    # argument position: there the offering parent is the argument list,
+    # which cannot tell a chain operand from any other argument, and a
+    # replaced chain link would no longer take part in the chain op
+    # protocol. In an argument position the answer is recorded on the
+    # operator instead, code generation emits it as the constant, and an
+    # enclosing chain can still withdraw it.
+    method IMPL-SMARTMATCH-FOLD-RESULT(Mu $expr, Mu $value) {
+        if nqp::istype(self, RakuAST::ArgList) {
+            $expr.infix.IMPL-SET-SMARTMATCH-FOLD($value);
+            return $expr;
+        }
+        RakuAST::Literal.from-value($value)
+    }
+
+    # The links of a longer chain take part in the chain op protocol, so
+    # none of them may compile to anything but a chain op. The reduced
+    # smartmatch marks decide per node and cannot see the enclosing
+    # chain, whose own offering comes only after its operands were
+    # visited, so the enclosing chain withdraws any decision its operand
+    # links took.
+    method IMPL-MARK-CHAIN-LINKS(RakuAST::Resolver $resolver, Mu $expr) {
+        return Nil unless nqp::istype($expr, RakuAST::ApplyInfix)
+            && nqp::istype($expr.infix, RakuAST::Infix)
+            && $expr.infix.properties.chain;
+        my $left := $expr.left;
+        $left.infix.IMPL-CLEAR-SMARTMATCH-MARKS()
+            if nqp::istype($left, RakuAST::ApplyInfix)
+            && nqp::istype($left.infix, RakuAST::Infix)
+            && $left.infix.properties.chain;
+        my $right := $expr.right;
+        $right.infix.IMPL-CLEAR-SMARTMATCH-MARKS()
+            if nqp::istype($right, RakuAST::ApplyInfix)
+            && nqp::istype($right.infix, RakuAST::Infix)
+            && $right.infix.properties.chain;
+        Nil
+    }
+
     # The compile-time type object a matcher node reduces to a type check
     # against, or null when it is anything else: the matcher must carry a
     # compile-time type-object value, non-generic, whose ACCEPTS no user
@@ -2206,7 +2244,8 @@ class RakuAST::Node {
             && self.IMPL-DROPPABLE($left) && self.IMPL-DROPPABLE($right) {
             my int $matches := nqp::istype($left-value, $type);
             $matches := nqp::not_i($matches) if $negated;
-            return RakuAST::Literal.from-value(nqp::hllboolfor($matches, 'Raku'));
+            return self.IMPL-SMARTMATCH-FOLD-RESULT($expr,
+                nqp::hllboolfor($matches, 'Raku'));
         }
 
         # A topic variable whose declared type already guarantees the match
@@ -2228,7 +2267,7 @@ class RakuAST::Node {
             try $guaranteed := nqp::can($topic-type.HOW, 'archetypes')
                 && !$topic-type.HOW.archetypes($topic-type).generic
                 && nqp::istype($topic-type, $type);
-            return RakuAST::Literal.from-value(
+            return self.IMPL-SMARTMATCH-FOLD-RESULT($expr,
                 nqp::hllboolfor($negated ?? 0 !! 1, 'Raku'))
                 if $guaranteed;
         }

--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -713,6 +713,10 @@ class RakuAST::Node {
         }
 
         if $result =:= $expr {
+            $result := self.IMPL-COLLAPSE-PAIRMATCH($resolver, $expr);
+        }
+
+        if $result =:= $expr {
             $result := self.IMPL-REWRITE-SQUARE($resolver, $expr);
         }
 
@@ -1606,6 +1610,115 @@ class RakuAST::Node {
                     QAST::WVal.new( :value($neg-bool) ))))
     }
 
+    # The pieces a compile-time Pair matcher's smartmatch reduces to, or
+    # null: the Pair, the method its key names, the Bool its value wants
+    # back, and the types the emission guards with. Only a Pair whose
+    # ACCEPTS no user candidate can intercept qualifies, and whose key
+    # and boolified value are decided at compile time.
+    method IMPL-PAIRMATCH-DATA(RakuAST::Resolver $resolver, Mu $matcher) {
+        CATCH {
+            return nqp::null();
+        }
+        return nqp::null() unless $matcher.has-compile-time-value;
+        my $pair := $matcher.maybe-compile-time-value;
+        my $Pair := self.IMPL-OPTIMIZE-SETTING-TYPE($resolver, 'Pair');
+        my $Assoc := self.IMPL-OPTIMIZE-SETTING-TYPE($resolver, 'Associative');
+        return nqp::null() if nqp::isnull($Pair) || nqp::isnull($Assoc);
+        return nqp::null() unless nqp::isconcrete($pair)
+            && nqp::istype($pair, $Pair)
+            && nqp::eqaddr($pair.WHAT, $Pair);
+        my $accepts := nqp::tryfindmethod($Pair, 'ACCEPTS');
+        return nqp::null() unless nqp::isconcrete($accepts)
+            && nqp::can($accepts, 'IS-SETTING-ONLY')
+            && nqp::istrue($accepts.IS-SETTING-ONLY(
+                nqp::const::SIG_ELEM_UNDEFINED_ONLY));
+        my str $method := $pair.key.Str;
+        my $expected := $pair.value.Bool;
+        return nqp::null() unless nqp::isconcrete($expected);
+        [$pair, $method, $expected, $Pair, $Assoc]
+    }
+
+    # A smartmatch against a compile-time Pair asks the topic the method
+    # the key names. Mark the reduced form for code generation.
+    method IMPL-COLLAPSE-PAIRMATCH(RakuAST::Resolver $resolver, Mu $expr) {
+        CATCH {
+            return $expr;
+        }
+
+        return $expr unless nqp::istype($expr, RakuAST::ApplyInfix);
+        my $infix := $expr.infix;
+        return $expr unless nqp::istype($infix, RakuAST::Infix)
+            && $infix.is-resolved;
+        my str $op := $infix.operator;
+        return $expr unless $op eq '~~' || $op eq '!~~';
+        my $left := $expr.left;
+        return $expr if nqp::istype($left, RakuAST::ApplyInfix)
+            && nqp::istype($left.infix, RakuAST::Infix)
+            && $left.infix.properties.chain;
+        return $expr if nqp::istype(self, RakuAST::ApplyInfix)
+            && nqp::istype(self.infix, RakuAST::Infix)
+            && self.infix.properties.chain
+            && nqp::eqaddr(self.left, $expr);
+        return $expr unless self.IMPL-OPERATOR-IS-CORE($resolver, $infix);
+        return $expr if self.IMPL-IN-SOFT-SCOPE($resolver);
+        return $expr if nqp::objprimspec($left.return-type);
+
+        my $data := self.IMPL-PAIRMATCH-DATA($resolver, $expr.right);
+        return $expr if nqp::isnull($data);
+        $infix.IMPL-SET-PAIRMATCH($data);
+        $expr
+    }
+
+    # A reduced Pair match: the topic, bound to a local, answers the
+    # method the Pair's key names, and matches when the boolified answer
+    # is the Pair's boolified value. The reduction holds only for the
+    # method-asking ACCEPTS candidate, so an Associative or Pair topic
+    # takes the full match, whose candidates mean something else, and so
+    # does a topic without the method, whose failure explains itself
+    # better than a dispatch error would. A Junction topic autothreads in
+    # the method dispatch just as it would in the ACCEPTS one.
+    method IMPL-PAIRMATCH-QAST(RakuAST::IMPL::QASTContext $context, Mu $topic-qast, Mu @data, int $negated) {
+        my $pair     := @data[0];
+        my str $meth := @data[1];
+        my $expected := @data[2];
+        my $Pair     := @data[3];
+        my $Assoc    := @data[4];
+        $context.ensure-sc($pair);
+        $context.ensure-sc($expected);
+        $context.ensure-sc($Pair);
+        $context.ensure-sc($Assoc);
+        my str $tmp := QAST::Node.unique('pairmatch_topic');
+        my $topic := QAST::Var.new( :name($tmp), :scope<local> );
+        my $eligible := QAST::Op.new(
+            :op<if>,
+            QAST::Op.new( :op<can>, $topic, QAST::SVal.new( :value($meth) ) ),
+            QAST::Op.new(
+                :op<if>,
+                QAST::Op.new( :op<istype>, $topic, QAST::WVal.new( :value($Assoc) ) ),
+                QAST::IVal.new( :value(0) ),
+                QAST::Op.new( :op<not_i>,
+                    QAST::Op.new( :op<istype>, $topic, QAST::WVal.new( :value($Pair) ) ))),
+            QAST::IVal.new( :value(0) ));
+        my $answer := QAST::Op.new( :op<eqaddr>,
+            QAST::Op.new( :op<decont>,
+                QAST::Op.new( :op<callmethod>, :name<Bool>,
+                    QAST::Op.new( :op<callmethod>, :name($meth), $topic ))),
+            QAST::WVal.new( :value($expected) ));
+        $answer := QAST::Op.new( :op<not_i>, $answer ) if $negated;
+        my $fallback := QAST::Op.new( :op<callmethod>, :name($negated ?? 'not' !! 'Bool'),
+            QAST::Op.new( :op<callmethod>, :name<ACCEPTS>,
+                QAST::WVal.new( :value($pair) ),
+                $topic ));
+        QAST::Stmts.new(
+            QAST::Op.new( :op<bind>,
+                QAST::Var.new( :name($tmp), :scope<local>, :decl<var> ),
+                $topic-qast),
+            QAST::Op.new( :op<if>,
+                $eligible,
+                QAST::Op.new( :op<hllbool>, $answer ),
+                $fallback))
+    }
+
     # The compile-time type object a matcher node reduces to a type check
     # against, or null when it is anything else: the matcher must carry a
     # compile-time type-object value, non-generic, whose ACCEPTS no user
@@ -1657,6 +1770,10 @@ class RakuAST::Node {
             if nqp::istype($matcher, RakuAST::Literal) {
                 my $data := self.IMPL-LITMATCH-DATA($resolver, $matcher);
                 $when.IMPL-SET-LITMATCH($data) unless nqp::isnull($data);
+            }
+            elsif nqp::istype($matcher, RakuAST::ColonPair) {
+                my $data := self.IMPL-PAIRMATCH-DATA($resolver, $matcher);
+                $when.IMPL-SET-PAIRMATCH($data) unless nqp::isnull($data);
             }
             return Nil;
         }

--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -743,6 +743,7 @@ class RakuAST::Node {
             self.IMPL-MARK-NATIVE-CONDITION($resolver, $expr);
             self.IMPL-MARK-WHEN-TYPEMATCH($resolver, $expr);
             self.IMPL-MARK-JUNCTION-FOLD($resolver, $expr);
+            self.IMPL-MARK-PARAM-WHERE-JUNCTION($resolver, $expr);
         }
 
         # A replacement stands where the original stood, so it must carry the
@@ -1833,6 +1834,100 @@ class RakuAST::Node {
                 QAST::Var.new( :name($tmp), :scope<local>, :decl<var> ),
                 $other-qast),
             $result)
+    }
+
+    # Mark a parameter whose where constraint is a junction of type
+    # objects for an inline type check per eigenstate: the constraint
+    # closure's ACCEPTS comes down to asking whether the argument is any,
+    # or all, of the types. Only a parameter whose declared type keeps a
+    # Junction argument autothreading qualifies, so the constraint never
+    # sees a junction itself.
+    method IMPL-MARK-PARAM-WHERE-JUNCTION(RakuAST::Resolver $resolver, Mu $expr) {
+        CATCH {
+            return Nil;
+        }
+        return Nil unless nqp::istype($expr, RakuAST::Parameter);
+        my $where := $expr.where;
+        return Nil unless nqp::isconcrete($where)
+            && nqp::istype($where, RakuAST::Block);
+        return Nil if self.IMPL-IN-SOFT-SCOPE($resolver);
+        my $Junction := self.IMPL-OPTIMIZE-SETTING-TYPE($resolver, 'Junction');
+        return Nil if nqp::isnull($Junction);
+
+        # A declared type a Junction argument could bind to means the
+        # constraint itself can see a junction.
+        my $param-type := $expr.type;
+        if nqp::isconcrete($param-type) {
+            my $nominal := $param-type.compile-time-value;
+            return Nil if nqp::istype($Junction, nqp::decont($nominal));
+        }
+
+        # The written constraint is the invocant of the ACCEPTS call the
+        # begin-time wrapping built around it.
+        my $statements := $where.body.statement-list.IMPL-UNWRAP-LIST(
+            $where.body.statement-list.statements);
+        return Nil unless nqp::elems($statements) == 1
+            && nqp::istype($statements[0], RakuAST::Statement::Expression);
+        my $bool-call := $statements[0].expression;
+        return Nil unless nqp::istype($bool-call, RakuAST::ApplyPostfix);
+        my $accepts-call := $bool-call.operand;
+        return Nil unless nqp::istype($accepts-call, RakuAST::ApplyPostfix);
+        my $written := $accepts-call.operand;
+
+        my @types;
+        my int $all := 0;
+        if $written.has-compile-time-value {
+            my $value := nqp::decont($written.maybe-compile-time-value);
+            return Nil unless nqp::isconcrete($value)
+                && nqp::eqaddr($value.WHAT, $Junction);
+            my str $jtype := nqp::getattr($value, $Junction, '$!type');
+            return Nil unless $jtype eq 'any' || $jtype eq 'all';
+            $all := $jtype eq 'all';
+            my $states := nqp::getattr($value, $Junction, '$!eigenstates');
+            my int $n := nqp::elems($states);
+            return Nil if $n < 2;
+            my int $i := -1;
+            while ++$i < $n {
+                my $state := nqp::atpos($states, $i);
+                return Nil if nqp::isconcrete($state);
+                my $how := $state.HOW;
+                return Nil unless nqp::can($how, 'archetypes')
+                    && !$how.archetypes($state).generic;
+                my $accepts := nqp::tryfindmethod($state, 'ACCEPTS');
+                return Nil unless nqp::isconcrete($accepts)
+                    && nqp::can($accepts, 'IS-SETTING-ONLY')
+                    && nqp::istrue($accepts.IS-SETTING-ONLY(
+                        nqp::const::SIG_ELEM_DEFINED_ONLY));
+                nqp::push(@types, $state);
+            }
+        }
+        else {
+            my $constructor;
+            my $operands;
+            if nqp::istype($written, RakuAST::ApplyListInfix) {
+                $constructor := $written.infix;
+                $operands := $written.IMPL-UNWRAP-LIST($written.operands);
+            }
+            elsif nqp::istype($written, RakuAST::ApplyInfix) {
+                $constructor := $written.infix;
+                $operands := [$written.left, $written.right];
+            }
+            else {
+                return Nil;
+            }
+            return Nil unless nqp::istype($constructor, RakuAST::Infix)
+                && ((my str $op := $constructor.operator) eq '|' || $op eq '&')
+                && nqp::elems($operands) >= 2
+                && self.IMPL-OPERATOR-IS-CORE($resolver, $constructor);
+            $all := $op eq '&';
+            for $operands {
+                my $type := self.IMPL-TYPEMATCH-MATCHER-TYPE($_);
+                return Nil if nqp::isnull($type);
+                nqp::push(@types, $type);
+            }
+        }
+        $expr.IMPL-SET-WHERE-JUNCTION(@types, $all);
+        Nil
     }
 
     # The pieces a compile-time Pair matcher's smartmatch reduces to, or

--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -742,6 +742,7 @@ class RakuAST::Node {
             self.IMPL-MARK-CT-DISPATCH($resolver, $expr);
             self.IMPL-MARK-NATIVE-CONDITION($resolver, $expr);
             self.IMPL-MARK-WHEN-TYPEMATCH($resolver, $expr);
+            self.IMPL-MARK-JUNCTION-FOLD($resolver, $expr);
         }
 
         # A replacement stands where the original stood, so it must carry the
@@ -1608,6 +1609,230 @@ class RakuAST::Node {
                     QAST::Op.new( :op<isconcrete>, $topic ),
                     $cmp,
                     QAST::WVal.new( :value($neg-bool) ))))
+    }
+
+    # Mark a chaining comparison in boolean position whose operand is a
+    # junction for unfolding into a short-circuit chain of comparisons:
+    # the boolean answer is the same, and the losing comparisons never
+    # run. Only an any or all junction qualifies, only in a context that
+    # wants plain truth, and only when every candidate of the comparison
+    # takes Any or narrower, so no candidate could have bound the
+    # junction itself in place of autothreading.
+    method IMPL-MARK-JUNCTION-FOLD(RakuAST::Resolver $resolver, Mu $expr) {
+        CATCH {
+            return Nil;
+        }
+        if nqp::istype($expr, RakuAST::Statement::Loop) {
+            self.IMPL-TRY-JUNCTION-FOLD($resolver, $expr.condition)
+                if nqp::isconcrete($expr.condition);
+        }
+        elsif nqp::istype($expr, RakuAST::Statement::IfWith) {
+            self.IMPL-TRY-JUNCTION-FOLD($resolver, $expr.condition)
+                if $expr.IMPL-QAST-TYPE eq 'if';
+            for $expr.IMPL-UNWRAP-LIST($expr.elsifs) {
+                self.IMPL-TRY-JUNCTION-FOLD($resolver, $_.condition)
+                    if $_.IMPL-QAST-TYPE eq 'if';
+            }
+        }
+        elsif nqp::istype($expr, RakuAST::Statement::Unless) {
+            self.IMPL-TRY-JUNCTION-FOLD($resolver, $expr.condition);
+        }
+        elsif nqp::istype($expr, RakuAST::Statement::Expression) {
+            my $loop := $expr.loop-modifier;
+            self.IMPL-TRY-JUNCTION-FOLD($resolver, $loop.expression)
+                if nqp::isconcrete($loop)
+                && nqp::istype($loop, RakuAST::StatementModifier::WhileUntil);
+            my $cond := $expr.condition-modifier;
+            self.IMPL-TRY-JUNCTION-FOLD($resolver, $cond.expression)
+                if nqp::isconcrete($cond)
+                && (nqp::istype($cond, RakuAST::StatementModifier::If)
+                    && !nqp::istype($cond, RakuAST::StatementModifier::When)
+                    || nqp::istype($cond, RakuAST::StatementModifier::Unless));
+        }
+        elsif nqp::istype($expr, RakuAST::ApplyPrefix) {
+            my $prefix := $expr.prefix;
+            if nqp::istype($prefix, RakuAST::Prefix) {
+                my str $op := $prefix.operator;
+                if ($op eq '?' || $op eq '!' || $op eq 'so' || $op eq 'not')
+                    && self.IMPL-OPERATOR-IS-CORE($resolver, $prefix) {
+                    self.IMPL-TRY-JUNCTION-FOLD($resolver, $expr.operand);
+                }
+            }
+        }
+        Nil
+    }
+
+    method IMPL-TRY-JUNCTION-FOLD(RakuAST::Resolver $resolver, Mu $cond) {
+        return Nil unless nqp::istype($cond, RakuAST::ApplyInfix);
+        my $infix := $cond.infix;
+        return Nil unless nqp::istype($infix, RakuAST::Infix)
+            && $infix.is-resolved
+            && $infix.properties.chain;
+        my $left := $cond.left;
+        my $right := $cond.right;
+        return Nil if nqp::istype($left, RakuAST::ApplyInfix)
+            && nqp::istype($left.infix, RakuAST::Infix)
+            && $left.infix.properties.chain;
+        return Nil if nqp::istype($right, RakuAST::ApplyInfix)
+            && nqp::istype($right.infix, RakuAST::Infix)
+            && $right.infix.properties.chain;
+        return Nil unless self.IMPL-OPERATOR-IS-CORE($resolver, $infix);
+        return Nil if self.IMPL-IN-SOFT-SCOPE($resolver);
+        my $Junction := self.IMPL-OPTIMIZE-SETTING-TYPE($resolver, 'Junction');
+        return Nil if nqp::isnull($Junction);
+        my int $side := 0;
+        $side := 1 if self.IMPL-JUNCTION-FOLD-OPERAND($resolver, $left, $Junction);
+        $side := 2 if !$side && self.IMPL-JUNCTION-FOLD-OPERAND($resolver, $right, $Junction);
+        return Nil unless $side;
+        # The other operand must not be junction-ish itself: two junctions
+        # thread into each other rather than short-circuiting.
+        my $other := $side == 1 ?? $right !! $left;
+        return Nil if self.IMPL-JUNCTION-FOLD-OPERAND($resolver, $other, $Junction);
+        return Nil if $other.has-compile-time-value
+            && nqp::istype(nqp::decont($other.maybe-compile-time-value), $Junction);
+        my $resolution := $infix.resolution;
+        my $routine;
+        if nqp::istype($resolution, RakuAST::CompileTimeValue) {
+            $routine := $resolution.compile-time-value;
+        }
+        elsif nqp::can($resolution, 'maybe-compile-time-value') {
+            $routine := $resolution.maybe-compile-time-value;
+        }
+        else {
+            return Nil;
+        }
+        return Nil unless nqp::isconcrete($routine)
+            && self.IMPL-JUNCTION-CHAIN-HANDLES-ANY($resolver, $routine);
+        $infix.IMPL-SET-JUNCTION-FOLD($side, $Junction);
+        Nil
+    }
+
+    # Whether a comparison operand is a junction the unfolding handles: a
+    # compile-time concrete any or all Junction of two or more
+    # eigenstates, or a call to the core | or & constructor.
+    method IMPL-JUNCTION-FOLD-OPERAND(RakuAST::Resolver $resolver, Mu $operand, Mu $Junction) {
+        if $operand.has-compile-time-value {
+            my $value := nqp::decont($operand.maybe-compile-time-value);
+            return 1 if nqp::isconcrete($value)
+                && nqp::eqaddr($value.WHAT, $Junction)
+                && ((my str $type := nqp::getattr($value, $Junction, '$!type')) eq 'any'
+                    || $type eq 'all')
+                && nqp::elems(nqp::getattr($value, $Junction, '$!eigenstates')) >= 2;
+            return 0;
+        }
+        my $constructor;
+        my $operands;
+        if nqp::istype($operand, RakuAST::ApplyListInfix) {
+            $constructor := $operand.infix;
+            $operands := $operand.IMPL-UNWRAP-LIST($operand.operands);
+        }
+        elsif nqp::istype($operand, RakuAST::ApplyInfix) {
+            $constructor := $operand.infix;
+            $operands := [$operand.left, $operand.right];
+        }
+        else {
+            return 0;
+        }
+        return 0 unless nqp::istype($constructor, RakuAST::Infix)
+            && ((my str $op := $constructor.operator) eq '|' || $op eq '&')
+            && nqp::elems($operands) >= 2
+            && self.IMPL-OPERATOR-IS-CORE($resolver, $constructor);
+        1
+    }
+
+    # Whether every candidate of the comparison takes Any or narrower for
+    # every parameter, so a junction argument always autothreads rather
+    # than binding to a candidate directly.
+    method IMPL-JUNCTION-CHAIN-HANDLES-ANY(RakuAST::Resolver $resolver, Mu $routine) {
+        CATCH {
+            return 0;
+        }
+        my $Any := self.IMPL-OPTIMIZE-SETTING-TYPE($resolver, 'Any');
+        return 0 if nqp::isnull($Any);
+        my @candidates;
+        if nqp::can($routine, 'is_dispatcher') && $routine.is_dispatcher {
+            return 0 unless nqp::can($routine, 'onlystar') && $routine.onlystar;
+            for nqp::getattr($routine, Routine, '@!dispatchees') {
+                nqp::push(@candidates, $_);
+            }
+        }
+        else {
+            nqp::push(@candidates, $routine);
+        }
+        for @candidates {
+            my $sig := nqp::getattr($_, Code, '$!signature');
+            return 0 unless nqp::isconcrete($sig);
+            for nqp::getattr($sig, Signature, '@!params') {
+                return 0 unless nqp::istype(
+                    nqp::getattr($_, Parameter, '$!type'), $Any);
+            }
+        }
+        1
+    }
+
+    # An unfolded junction comparison: the plain operand, bound to a
+    # local so it evaluates once, compared against each eigenstate in a
+    # short-circuit chain, disjunctive for an any junction, conjunctive
+    # for an all one. Or null when the operand's code is not one of the
+    # junction shapes after all, and the plain comparison stands.
+    method IMPL-JUNCTION-FOLD-QAST(RakuAST::IMPL::QASTContext $context, str $chain-op, str $chain-name, Mu $left-qast, Mu $right-qast, int $side, Mu $Junction) {
+        my $junction-qast := $side == 1 ?? $left-qast !! $right-qast;
+        my $other-qast    := $side == 1 ?? $right-qast !! $left-qast;
+        my @eigen;
+        my int $conjunctive := 0;
+        if nqp::istype($junction-qast, QAST::WVal) {
+            my $value := $junction-qast.value;
+            return nqp::null() unless nqp::isconcrete($value)
+                && nqp::eqaddr($value.WHAT, $Junction);
+            my str $type := nqp::getattr($value, $Junction, '$!type');
+            return nqp::null() unless $type eq 'any' || $type eq 'all';
+            $conjunctive := $type eq 'all';
+            my $states := nqp::getattr($value, $Junction, '$!eigenstates');
+            my int $n := nqp::elems($states);
+            return nqp::null() if $n < 2;
+            my int $i := -1;
+            while ++$i < $n {
+                my $state := nqp::atpos($states, $i);
+                $context.ensure-sc($state);
+                nqp::push(@eigen, QAST::WVal.new( :value($state) ));
+            }
+        }
+        elsif nqp::istype($junction-qast, QAST::Op)
+            && ($junction-qast.op eq 'call' || $junction-qast.op eq 'callstatic')
+            && ($junction-qast.name eq '&infix:<|>' || $junction-qast.name eq '&infix:<&>') {
+            $conjunctive := $junction-qast.name eq '&infix:<&>';
+            my int $n := nqp::elems($junction-qast.list);
+            return nqp::null() if $n < 2;
+            my int $i := -1;
+            while ++$i < $n {
+                my $child := nqp::atpos($junction-qast.list, $i);
+                return nqp::null() if $child.named || $child.flat;
+                nqp::push(@eigen, $child);
+            }
+        }
+        else {
+            return nqp::null();
+        }
+        my str $tmp := QAST::Node.unique('junction_unfold');
+        my str $joiner := $conjunctive ?? 'if' !! 'unless';
+        my $result := nqp::null();
+        my int $i := nqp::elems(@eigen);
+        while --$i >= 0 {
+            my $other := QAST::Var.new( :name($tmp), :scope<local> );
+            my $cmp := $side == 1
+                ?? QAST::Op.new( :op($chain-op), :name($chain-name),
+                    nqp::atpos(@eigen, $i), $other )
+                !! QAST::Op.new( :op($chain-op), :name($chain-name),
+                    $other, nqp::atpos(@eigen, $i) );
+            $result := nqp::isnull($result)
+                ?? $cmp
+                !! QAST::Op.new( :op($joiner), $cmp, $result );
+        }
+        QAST::Stmts.new(
+            QAST::Op.new( :op<bind>,
+                QAST::Var.new( :name($tmp), :scope<local>, :decl<var> ),
+                $other-qast),
+            $result)
     }
 
     # The pieces a compile-time Pair matcher's smartmatch reduces to, or

--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -1594,6 +1594,30 @@ class RakuAST::Node {
             return RakuAST::Literal.from-value(nqp::hllboolfor($matches, 'Raku'));
         }
 
+        # A topic variable whose declared type already guarantees the match
+        # decides it now: every value the container can hold passes the
+        # check, and a declared type a Junction cannot satisfy rules out
+        # autothreading, while a matcher wide enough to admit a Junction
+        # does not autothread over one either. A failed guarantee proves
+        # nothing about the runtime value, so only success folds, and a
+        # subset's refinement must still run.
+        if !$is-subset && nqp::istype($left, RakuAST::Var::Lexical) && $left.is-resolved {
+            my $topic-type := $left.return-type;
+            my $resolution := $left.resolution;
+            if $topic-type =:= Mu
+                && nqp::istype($resolution, RakuAST::ParameterTarget::Var)
+                && nqp::isconcrete($resolution.declaration) {
+                try $topic-type := $resolution.declaration.return-type;
+            }
+            my int $guaranteed := 0;
+            try $guaranteed := nqp::can($topic-type.HOW, 'archetypes')
+                && !$topic-type.HOW.archetypes($topic-type).generic
+                && nqp::istype($topic-type, $type);
+            return RakuAST::Literal.from-value(
+                nqp::hllboolfor($negated ?? 0 !! 1, 'Raku'))
+                if $guaranteed;
+        }
+
         # Mark for code generation; the matcher being a Junction needs no
         # runtime guard.
         $infix.IMPL-SET-TYPEMATCH($type,

--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -709,6 +709,10 @@ class RakuAST::Node {
         }
 
         if $result =:= $expr {
+            $result := self.IMPL-COLLAPSE-LITMATCH($resolver, $expr);
+        }
+
+        if $result =:= $expr {
             $result := self.IMPL-REWRITE-SQUARE($resolver, $expr);
         }
 
@@ -1434,6 +1438,174 @@ class RakuAST::Node {
     # match qualifies: a link of a longer comparison chain must stay a chain
     # op. The soft pragma turns the reduction off, since it bypasses the
     # operator and ACCEPTS routines that wrapping relies on.
+    # The pieces a literal matcher's smartmatch reduces to, or null when
+    # the matcher is anything else: the literal's value, the setting
+    # comparison the reduced match runs, the Junction and Nil types the
+    # emission guards with, and whether the comparison is by string. Only
+    # an int, num, or str literal qualifies, since the reduction leans on
+    # what the value's own ACCEPTS comes down to: numeric equality over
+    # the topic's Numeric, or string equality over its Stringy. A NaN or
+    # infinite literal compares by identity instead, and a user ACCEPTS
+    # candidate that could take a concrete matcher keeps the dispatch.
+    method IMPL-LITMATCH-DATA(RakuAST::Resolver $resolver, Mu $matcher) {
+        CATCH {
+            return nqp::null();
+        }
+        my int $string := 0;
+        if nqp::istype($matcher, RakuAST::StrLiteral) {
+            $string := 1;
+        }
+        elsif nqp::istype($matcher, RakuAST::IntLiteral) {
+        }
+        elsif nqp::istype($matcher, RakuAST::NumLiteral) {
+            return nqp::null()
+                if nqp::isnanorinf(nqp::unbox_n($matcher.value));
+        }
+        else {
+            return nqp::null();
+        }
+        my $value := $matcher.maybe-compile-time-value;
+        return nqp::null() unless nqp::isconcrete($value);
+        my $accepts := nqp::tryfindmethod($value.WHAT, 'ACCEPTS');
+        return nqp::null() unless nqp::isconcrete($accepts)
+            && nqp::can($accepts, 'IS-SETTING-ONLY')
+            && nqp::istrue($accepts.IS-SETTING-ONLY(
+                nqp::const::SIG_ELEM_UNDEFINED_ONLY));
+        my $eq-name := RakuAST::Name.from-identifier(
+            $string ?? '&infix:<eq>' !! '&infix:<==>');
+        my $eq-res := $resolver.resolve-name-constant-in-setting($eq-name);
+        return nqp::null() unless nqp::isconcrete($eq-res);
+        my $eq := $eq-res.compile-time-value;
+        return nqp::null() unless nqp::isconcrete($eq);
+        my $Junction := self.IMPL-OPTIMIZE-SETTING-TYPE($resolver, 'Junction');
+        my $Nil      := self.IMPL-OPTIMIZE-SETTING-TYPE($resolver, 'Nil');
+        return nqp::null() if nqp::isnull($Junction) || nqp::isnull($Nil);
+        [$value, $eq, $Junction, $Nil, $string]
+    }
+
+    # A smartmatch against a literal comes down to an equality check. A
+    # known topic decides the match now through the literal's own ACCEPTS.
+    # Otherwise the reduced comparison is marked for code generation.
+    method IMPL-COLLAPSE-LITMATCH(RakuAST::Resolver $resolver, Mu $expr) {
+        CATCH {
+            return $expr;
+        }
+
+        return $expr unless nqp::istype($expr, RakuAST::ApplyInfix);
+        my $infix := $expr.infix;
+        return $expr unless nqp::istype($infix, RakuAST::Infix)
+            && $infix.is-resolved;
+        my str $op := $infix.operator;
+        my int $negated := $op eq '!~~';
+        return $expr unless $negated || $op eq '~~';
+        my $left := $expr.left;
+        return $expr if nqp::istype($left, RakuAST::ApplyInfix)
+            && nqp::istype($left.infix, RakuAST::Infix)
+            && $left.infix.properties.chain;
+        return $expr if nqp::istype(self, RakuAST::ApplyInfix)
+            && nqp::istype(self.infix, RakuAST::Infix)
+            && self.infix.properties.chain
+            && nqp::eqaddr(self.left, $expr);
+        return $expr unless nqp::istype($expr.right, RakuAST::Literal);
+        return $expr unless self.IMPL-OPERATOR-IS-CORE($resolver, $infix);
+        return $expr if self.IMPL-IN-SOFT-SCOPE($resolver);
+        return $expr if nqp::objprimspec($left.return-type);
+
+        # Both sides known decides the match now, through the literal's
+        # own ACCEPTS in case the equality it comes down to throws.
+        my $right := $expr.right;
+        if $left.has-compile-time-value
+            && self.IMPL-FOLDABLE-OPERAND($left)
+            && self.IMPL-DROPPABLE($left) && self.IMPL-DROPPABLE($right) {
+            my $matcher-value := $right.maybe-compile-time-value;
+            my $topic-value := $left.maybe-compile-time-value;
+            my $accepts := nqp::tryfindmethod($matcher-value.WHAT, 'ACCEPTS');
+            if nqp::isconcrete($accepts)
+                && nqp::can($accepts, 'IS-SETTING-ONLY')
+                && nqp::istrue($accepts.IS-SETTING-ONLY(
+                    nqp::const::SIG_ELEM_UNDEFINED_ONLY))
+                && nqp::can($topic-value.HOW, 'archetypes')
+                && !$topic-value.HOW.archetypes($topic-value).generic {
+                my $matched := nqp::null();
+                try {
+                    $matched := $matcher-value.ACCEPTS($topic-value);
+                    $matched := $negated ?? $matched.not !! $matched.Bool;
+                }
+                return RakuAST::Literal.from-value($matched)
+                    unless nqp::isnull($matched);
+            }
+        }
+
+        my $data := self.IMPL-LITMATCH-DATA($resolver, $right);
+        return $expr if nqp::isnull($data);
+        $infix.IMPL-SET-LITMATCH($data);
+        $expr
+    }
+
+    # A reduced literal match: the topic, bound to a local so the guards
+    # and the comparison evaluate it once, compared against the literal.
+    # A numeric comparison coerces the topic the way the literal's ACCEPTS
+    # would, with a failed coercion becoming NaN, which no number equals.
+    # An undefined topic answers without comparing, since the coercions
+    # would warn on it, and a topic that turns out to be a concrete
+    # Junction autothreads over the literal's ACCEPTS instead.
+    method IMPL-LITMATCH-QAST(RakuAST::IMPL::QASTContext $context, Mu $topic-qast, Mu @data, int $negated) {
+        my $value    := @data[0];
+        my $eq       := @data[1];
+        my $junction := @data[2];
+        my $nil      := @data[3];
+        my int $string := @data[4];
+        $context.ensure-sc($value);
+        $context.ensure-sc($eq);
+        $context.ensure-sc($junction);
+        my $neg-bool := nqp::hllboolfor($negated ?? 1 !! 0, 'Raku');
+        $context.ensure-sc($neg-bool);
+        my str $tmp := QAST::Node.unique('litmatch_topic');
+        my $topic := QAST::Var.new( :name($tmp), :scope<local> );
+        my $coerced;
+        if $string {
+            $coerced := QAST::Op.new( :op<callmethod>, :name<Stringy>, $topic );
+        }
+        else {
+            $context.ensure-sc($nil);
+            my $fail-or-nil := QAST::Op.new( :op<hllbool>, QAST::IVal.new( :value(1) ) );
+            $fail-or-nil.named('fail-or-nil');
+            my str $ntmp := QAST::Node.unique('litmatch_numeric');
+            $coerced := QAST::Stmts.new(
+                QAST::Op.new( :op<bind>,
+                    QAST::Var.new( :name($ntmp), :scope<local>, :decl<var> ),
+                    QAST::Op.new( :op<callmethod>, :name<Numeric>, $topic, $fail-or-nil )),
+                QAST::Op.new( :op<if>,
+                    QAST::Op.new( :op<istype>,
+                        QAST::Var.new( :name($ntmp), :scope<local> ),
+                        QAST::WVal.new( :value($nil) )),
+                    QAST::NVal.new( :value(nqp::nan()) ),
+                    QAST::Var.new( :name($ntmp), :scope<local> )));
+        }
+        my $cmp := QAST::Op.new( :op<call>,
+            QAST::WVal.new( :value($eq) ),
+            QAST::WVal.new( :value($value) ),
+            $coerced);
+        $cmp := QAST::Op.new( :op<callmethod>, :name<not>, $cmp ) if $negated;
+        QAST::Stmts.new(
+            QAST::Op.new( :op<bind>,
+                QAST::Var.new( :name($tmp), :scope<local>, :decl<var> ),
+                $topic-qast),
+            QAST::Op.new( :op<if>,
+                QAST::Op.new( :op<if>,
+                    QAST::Op.new( :op<istype>, $topic,
+                        QAST::WVal.new( :value($junction) ) ),
+                    QAST::Op.new( :op<isconcrete>, $topic )),
+                QAST::Op.new( :op<callmethod>, :name<BOOLIFY-ACCEPTS>,
+                    $topic,
+                    QAST::WVal.new( :value($value) ),
+                    QAST::WVal.new( :value($neg-bool) )),
+                QAST::Op.new( :op<if>,
+                    QAST::Op.new( :op<isconcrete>, $topic ),
+                    $cmp,
+                    QAST::WVal.new( :value($neg-bool) ))))
+    }
+
     # The compile-time type object a matcher node reduces to a type check
     # against, or null when it is anything else: the matcher must carry a
     # compile-time type-object value, non-generic, whose ACCEPTS no user
@@ -1481,7 +1653,13 @@ class RakuAST::Node {
             ?? $when.condition
             !! $when.expression;
         my $type := self.IMPL-TYPEMATCH-MATCHER-TYPE($matcher);
-        return Nil if nqp::isnull($type);
+        if nqp::isnull($type) {
+            if nqp::istype($matcher, RakuAST::Literal) {
+                my $data := self.IMPL-LITMATCH-DATA($resolver, $matcher);
+                $when.IMPL-SET-LITMATCH($data) unless nqp::isnull($data);
+            }
+            return Nil;
+        }
         my $Junction := self.IMPL-OPTIMIZE-SETTING-TYPE($resolver, 'Junction');
         return Nil if nqp::isnull($Junction);
         $when.IMPL-SET-TYPEMATCH($type,

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -526,6 +526,17 @@ class RakuAST::Infix
         nqp::bindattr(self, RakuAST::Infix, '$!pairmatch-data', $data);
     }
 
+    # Set by the optimize pass when a junction operand of this comparison
+    # in boolean position unfolds to a short-circuit chain: which side
+    # holds the junction, and the Junction type for the shape checks.
+    has int $!junction-fold;
+    has Mu $!junction-fold-junction;
+
+    method IMPL-SET-JUNCTION-FOLD(int $side, Mu $junction) {
+        nqp::bindattr_i(self, RakuAST::Infix, '$!junction-fold', $side);
+        nqp::bindattr(self, RakuAST::Infix, '$!junction-fold-junction', $junction);
+    }
+
     # Set by the optimize pass on the assignment of a comma list to a plain
     # array variable, for lowering to a direct build of the list internals.
     has int $!lowered-array-init;
@@ -629,6 +640,18 @@ class RakuAST::Infix
             my $inlined := self.IMPL-CT-INLINE-QAST(
                 $context, $!ct-inline-candidate, [$left-qast, $right-qast]);
             return $inlined unless nqp::isnull($inlined);
+        }
+
+        # A comparison in boolean position with a junction operand
+        # unfolds to short-circuit comparisons per eigenstate.
+        if $!junction-fold {
+            my $folded := self.IMPL-JUNCTION-FOLD-QAST($context,
+                self.properties.chain
+                    ?? ($!chainstatic ?? 'chainstatic' !! 'chain')
+                    !! 'call',
+                $name, $left-qast, $right-qast,
+                $!junction-fold, $!junction-fold-junction);
+            return $folded unless nqp::isnull($folded);
         }
 
         # Otherwise, it's called by finding the lexical sub to call, and

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -506,6 +506,16 @@ class RakuAST::Infix
         nqp::bindattr(self, RakuAST::Infix, '$!ct-inline-candidate', nqp::null())
     }
 
+    # Set by the optimize pass when this smartmatch reduces to a literal
+    # comparison: the literal, the setting comparison, and the guard types.
+    has int $!litmatch;
+    has Mu $!litmatch-data;
+
+    method IMPL-SET-LITMATCH(Mu $data) {
+        nqp::bindattr_i(self, RakuAST::Infix, '$!litmatch', 1);
+        nqp::bindattr(self, RakuAST::Infix, '$!litmatch-data', $data);
+    }
+
     # Set by the optimize pass on the assignment of a comma list to a plain
     # array variable, for lowering to a direct build of the list internals.
     has int $!lowered-array-init;
@@ -572,6 +582,8 @@ class RakuAST::Infix
                               Mu $right-qast
     ) {
         return self.IMPL-TYPEMATCH-QAST($context, $left-qast) if $!typematch;
+        return self.IMPL-LITMATCH-QAST($context, $left-qast, $!litmatch-data,
+            $!operator eq '!~~' ?? 1 !! 0) if $!litmatch;
 
         # Operators that map directly into a QAST op
         my constant QAST-OP := nqp::hash(

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -516,6 +516,16 @@ class RakuAST::Infix
         nqp::bindattr(self, RakuAST::Infix, '$!litmatch-data', $data);
     }
 
+    # Set by the optimize pass when this smartmatch against a compile-time
+    # Pair reduces to asking the topic the method the key names.
+    has int $!pairmatch;
+    has Mu $!pairmatch-data;
+
+    method IMPL-SET-PAIRMATCH(Mu $data) {
+        nqp::bindattr_i(self, RakuAST::Infix, '$!pairmatch', 1);
+        nqp::bindattr(self, RakuAST::Infix, '$!pairmatch-data', $data);
+    }
+
     # Set by the optimize pass on the assignment of a comma list to a plain
     # array variable, for lowering to a direct build of the list internals.
     has int $!lowered-array-init;
@@ -584,6 +594,8 @@ class RakuAST::Infix
         return self.IMPL-TYPEMATCH-QAST($context, $left-qast) if $!typematch;
         return self.IMPL-LITMATCH-QAST($context, $left-qast, $!litmatch-data,
             $!operator eq '!~~' ?? 1 !! 0) if $!litmatch;
+        return self.IMPL-PAIRMATCH-QAST($context, $left-qast, $!pairmatch-data,
+            $!operator eq '!~~' ?? 1 !! 0) if $!pairmatch;
 
         # Operators that map directly into a QAST op
         my constant QAST-OP := nqp::hash(

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -537,6 +537,26 @@ class RakuAST::Infix
         nqp::bindattr(self, RakuAST::Infix, '$!junction-fold-junction', $junction);
     }
 
+    # An enclosing chain withdraws a link's reduced-smartmatch decisions:
+    # a link must stay a chain op for the chain protocol.
+    method IMPL-CLEAR-SMARTMATCH-MARKS() {
+        nqp::bindattr_i(self, RakuAST::Infix, '$!typematch', 0);
+        nqp::bindattr_i(self, RakuAST::Infix, '$!litmatch', 0);
+        nqp::bindattr_i(self, RakuAST::Infix, '$!pairmatch', 0);
+        nqp::bindattr_i(self, RakuAST::Infix, '$!junction-fold', 0);
+        nqp::bindattr_i(self, RakuAST::Infix, '$!smartmatch-folded', 0);
+    }
+
+    # Set by the optimize pass when the smartmatch is decided outright in
+    # an argument position, where the node cannot be replaced.
+    has int $!smartmatch-folded;
+    has Mu $!smartmatch-fold-value;
+
+    method IMPL-SET-SMARTMATCH-FOLD(Mu $value) {
+        nqp::bindattr_i(self, RakuAST::Infix, '$!smartmatch-folded', 1);
+        nqp::bindattr(self, RakuAST::Infix, '$!smartmatch-fold-value', $value);
+    }
+
     # Set by the optimize pass on the assignment of a comma list to a plain
     # array variable, for lowering to a direct build of the list internals.
     has int $!lowered-array-init;
@@ -602,6 +622,10 @@ class RakuAST::Infix
                               Mu $left-qast,
                               Mu $right-qast
     ) {
+        if $!smartmatch-folded {
+            $context.ensure-sc($!smartmatch-fold-value);
+            return QAST::WVal.new( :value($!smartmatch-fold-value) );
+        }
         return self.IMPL-TYPEMATCH-QAST($context, $left-qast) if $!typematch;
         return self.IMPL-LITMATCH-QAST($context, $left-qast, $!litmatch-data,
             $!operator eq '!~~' ?? 1 !! 0) if $!litmatch;

--- a/src/Raku/ast/signature.rakumod
+++ b/src/Raku/ast/signature.rakumod
@@ -548,6 +548,11 @@ class RakuAST::Parameter
     has RakuAST::Parameter::Slurpy $.slurpy;
     has RakuAST::Expression        $.default;
     has RakuAST::Expression        $.where;
+    # Set by the optimize pass when the where constraint is a junction of
+    # type objects: the types the argument is checked against inline, and
+    # whether it must be all of them rather than any.
+    has Mu $!where-junction-types;
+    has int $!where-junction-all;
     has RakuAST::Expression        $.array-shape;
     has RakuAST::Node              $.owner;
     has RakuAST::Package           $!package;
@@ -712,6 +717,11 @@ class RakuAST::Parameter
     method set-where(RakuAST::Expression $where) {
         nqp::bindattr(self, RakuAST::Parameter, '$!where', $where);
         Nil
+    }
+
+    method IMPL-SET-WHERE-JUNCTION(Mu @types, int $all) {
+        nqp::bindattr(self, RakuAST::Parameter, '$!where-junction-types', @types);
+        nqp::bindattr_i(self, RakuAST::Parameter, '$!where-junction-all', $all);
     }
 
     method set-target(RakuAST::ParameterTarget $target) {
@@ -1857,18 +1867,43 @@ class RakuAST::Parameter
         }
 
         if $!where {
-            $param-qast.push(
-                QAST::ParamTypeCheck.new(
-                    QAST::Op.new(
-                        :op<istrue>,
+            if nqp::islist($!where-junction-types) {
+                # The constraint is a junction of type objects: check the
+                # argument against each inline, short-circuiting the same
+                # way the junction's ACCEPTS would collapse.
+                my @types := $!where-junction-types;
+                my int $i := nqp::elems(@types);
+                my $check := nqp::null();
+                while --$i >= 0 {
+                    my $type := nqp::atpos(@types, $i);
+                    $context.ensure-sc($type);
+                    my $istype := QAST::Op.new(
+                        :op<istype>,
+                        $temp-qast-var,
+                        QAST::WVal.new( :value($type) ));
+                    $check := nqp::isnull($check)
+                        ?? $istype
+                        !! QAST::Op.new(
+                            :op($!where-junction-all ?? 'if' !! 'unless'),
+                            $istype,
+                            $check);
+                }
+                $param-qast.push(QAST::ParamTypeCheck.new($check));
+            }
+            else {
+                $param-qast.push(
+                    QAST::ParamTypeCheck.new(
                         QAST::Op.new(
-                            :op('callmethod'), :name('ACCEPTS'),
-                            $!where.IMPL-TO-QAST($context),
-                            $temp-qast-var
+                            :op<istrue>,
+                            QAST::Op.new(
+                                :op('callmethod'), :name('ACCEPTS'),
+                                $!where.IMPL-TO-QAST($context),
+                                $temp-qast-var
+                            )
                         )
                     )
-                )
-            );
+                );
+            }
         }
 
         if $!array-shape {

--- a/src/Raku/ast/statement-mods.rakumod
+++ b/src/Raku/ast/statement-mods.rakumod
@@ -102,6 +102,16 @@ class RakuAST::StatementModifier::When
         nqp::bindattr(self, RakuAST::StatementModifier::When, '$!typematch-junction', $junction);
     }
 
+    # Set by the optimize pass when the matcher reduces to a literal
+    # comparison against the topic.
+    has int $!litmatch;
+    has Mu $!litmatch-data;
+
+    method IMPL-SET-LITMATCH(Mu $data) {
+        nqp::bindattr_i(self, RakuAST::StatementModifier::When, '$!litmatch', 1);
+        nqp::bindattr(self, RakuAST::StatementModifier::When, '$!litmatch-data', $data);
+    }
+
     method IMPL-WRAP-QAST(RakuAST::IMPL::QASTContext $context, Mu $statement-qast) {
         QAST::Op.new(
             :op('if'),
@@ -109,11 +119,15 @@ class RakuAST::StatementModifier::When
                 ?? self.IMPL-WHEN-TYPEMATCH-QAST($context,
                     QAST::Var.new( :name('$_'), :scope('lexical') ),
                     $!typematch-type, $!typematch-junction)
-                !! QAST::Op.new(
-                    :op('callmethod'), :name('ACCEPTS'),
-                    self.expression.IMPL-TO-QAST($context),
-                    QAST::Var.new( :name('$_'), :scope('lexical') )
-                ),
+                !! $!litmatch
+                    ?? self.IMPL-LITMATCH-QAST($context,
+                        QAST::Var.new( :name('$_'), :scope('lexical') ),
+                        $!litmatch-data, 0)
+                    !! QAST::Op.new(
+                        :op('callmethod'), :name('ACCEPTS'),
+                        self.expression.IMPL-TO-QAST($context),
+                        QAST::Var.new( :name('$_'), :scope('lexical') )
+                    ),
             $statement-qast,
             self.IMPL-EMPTY($context)
         )

--- a/src/Raku/ast/statement-mods.rakumod
+++ b/src/Raku/ast/statement-mods.rakumod
@@ -112,6 +112,16 @@ class RakuAST::StatementModifier::When
         nqp::bindattr(self, RakuAST::StatementModifier::When, '$!litmatch-data', $data);
     }
 
+    # Set by the optimize pass when the matcher is a compile-time Pair
+    # that reduces to asking the topic the method its key names.
+    has int $!pairmatch;
+    has Mu $!pairmatch-data;
+
+    method IMPL-SET-PAIRMATCH(Mu $data) {
+        nqp::bindattr_i(self, RakuAST::StatementModifier::When, '$!pairmatch', 1);
+        nqp::bindattr(self, RakuAST::StatementModifier::When, '$!pairmatch-data', $data);
+    }
+
     method IMPL-WRAP-QAST(RakuAST::IMPL::QASTContext $context, Mu $statement-qast) {
         QAST::Op.new(
             :op('if'),
@@ -123,11 +133,15 @@ class RakuAST::StatementModifier::When
                     ?? self.IMPL-LITMATCH-QAST($context,
                         QAST::Var.new( :name('$_'), :scope('lexical') ),
                         $!litmatch-data, 0)
-                    !! QAST::Op.new(
-                        :op('callmethod'), :name('ACCEPTS'),
-                        self.expression.IMPL-TO-QAST($context),
-                        QAST::Var.new( :name('$_'), :scope('lexical') )
-                    ),
+                    !! $!pairmatch
+                        ?? self.IMPL-PAIRMATCH-QAST($context,
+                            QAST::Var.new( :name('$_'), :scope('lexical') ),
+                            $!pairmatch-data, 0)
+                        !! QAST::Op.new(
+                            :op('callmethod'), :name('ACCEPTS'),
+                            self.expression.IMPL-TO-QAST($context),
+                            QAST::Var.new( :name('$_'), :scope('lexical') )
+                        ),
             $statement-qast,
             self.IMPL-EMPTY($context)
         )

--- a/src/Raku/ast/statements.rakumod
+++ b/src/Raku/ast/statements.rakumod
@@ -1991,17 +1991,29 @@ class RakuAST::Statement::When
         nqp::bindattr(self, RakuAST::Statement::When, '$!typematch-junction', $junction);
     }
 
+    # Set by the optimize pass when the matcher reduces to a literal
+    # comparison against the topic.
+    has int $!litmatch;
+    has Mu $!litmatch-data;
+
+    method IMPL-SET-LITMATCH(Mu $data) {
+        nqp::bindattr_i(self, RakuAST::Statement::When, '$!litmatch', 1);
+        nqp::bindattr(self, RakuAST::Statement::When, '$!litmatch-data', $data);
+    }
+
     method IMPL-TO-QAST(RakuAST::IMPL::QASTContext $context) {
         my $topic-qast :=
             self.IMPL-UNWRAP-LIST(self.get-implicit-lookups)[0].IMPL-TO-QAST($context);
         my $sm-qast := $!typematch
             ?? self.IMPL-WHEN-TYPEMATCH-QAST($context, $topic-qast,
                 $!typematch-type, $!typematch-junction)
-            !! QAST::Op.new(
-                :op('callmethod'), :name('ACCEPTS'),
-                $!condition.IMPL-TO-QAST($context),
-                $topic-qast
-            );
+            !! $!litmatch
+                ?? self.IMPL-LITMATCH-QAST($context, $topic-qast, $!litmatch-data, 0)
+                !! QAST::Op.new(
+                    :op('callmethod'), :name('ACCEPTS'),
+                    $!condition.IMPL-TO-QAST($context),
+                    $topic-qast
+                );
         QAST::Op.new(
             :op('if'),
             $sm-qast,

--- a/src/Raku/ast/statements.rakumod
+++ b/src/Raku/ast/statements.rakumod
@@ -2001,6 +2001,16 @@ class RakuAST::Statement::When
         nqp::bindattr(self, RakuAST::Statement::When, '$!litmatch-data', $data);
     }
 
+    # Set by the optimize pass when the matcher is a compile-time Pair
+    # that reduces to asking the topic the method its key names.
+    has int $!pairmatch;
+    has Mu $!pairmatch-data;
+
+    method IMPL-SET-PAIRMATCH(Mu $data) {
+        nqp::bindattr_i(self, RakuAST::Statement::When, '$!pairmatch', 1);
+        nqp::bindattr(self, RakuAST::Statement::When, '$!pairmatch-data', $data);
+    }
+
     method IMPL-TO-QAST(RakuAST::IMPL::QASTContext $context) {
         my $topic-qast :=
             self.IMPL-UNWRAP-LIST(self.get-implicit-lookups)[0].IMPL-TO-QAST($context);
@@ -2009,11 +2019,13 @@ class RakuAST::Statement::When
                 $!typematch-type, $!typematch-junction)
             !! $!litmatch
                 ?? self.IMPL-LITMATCH-QAST($context, $topic-qast, $!litmatch-data, 0)
-                !! QAST::Op.new(
-                    :op('callmethod'), :name('ACCEPTS'),
-                    $!condition.IMPL-TO-QAST($context),
-                    $topic-qast
-                );
+                !! $!pairmatch
+                    ?? self.IMPL-PAIRMATCH-QAST($context, $topic-qast, $!pairmatch-data, 0)
+                    !! QAST::Op.new(
+                        :op('callmethod'), :name('ACCEPTS'),
+                        $!condition.IMPL-TO-QAST($context),
+                        $topic-qast
+                    );
         QAST::Op.new(
             :op('if'),
             $sm-qast,

--- a/t/08-performance/24-rakuast-when-typematch.t
+++ b/t/08-performance/24-rakuast-when-typematch.t
@@ -22,9 +22,9 @@ if nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' {
         qast-contains-callmethod(v, 'ACCEPTS')
     }, 'a matcher with a user ACCEPTS keeps the dispatch';
 
-    qast-is 'given 42 { when 5 { say 1 } }', :full, -> \v {
+    qast-is 'my $m = 5; given 42 { when $m { say 1 } }', :full, -> \v {
         qast-contains-callmethod(v, 'ACCEPTS')
-    }, 'a literal matcher is not a type object and keeps the dispatch';
+    }, 'a matcher that is not known at compile time keeps the dispatch';
 
     qast-is '$_ = 42; say "x" when Int', :full, -> \v {
         qast-contains-op(v, 'istype')

--- a/t/08-performance/25-rakuast-smartmatch-family.t
+++ b/t/08-performance/25-rakuast-smartmatch-family.t
@@ -3,7 +3,7 @@ use Test::Helpers::QAST;
 use Test;
 use QAST:from<NQP>;
 use nqp;
-plan 19;
+plan 28;
 
 # The helper's walk does not descend a ParamTypeCheck, and a local name
 # identifies the unfolded junction more precisely than any op, so these
@@ -52,9 +52,12 @@ if nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' {
         not qast-contains-unfold-local(v)
     }, 'a junction comparison whose value is used keeps the junction';
 
+    qast-is 'sub f($x where Int|Str) { 1 }; f(1)', :full, -> \v {
+        qast-deep-contains-op(v, 'istype')
+    }, 'a junction-of-types where constraint checks the types inline';
 }
 else {
-    skip 'the reduced shapes are specific to the RakuAST frontend', 5;
+    skip 'the reduced shapes are specific to the RakuAST frontend', 6;
 }
 
 # Behavior stays identical.
@@ -109,4 +112,21 @@ else {
     isa-ok $r, Junction, 'a junction comparison used as a value stays a Junction';
     my $j = 1|2;
     ok ?($x == $j), 'a junction in a variable is not unfolded and still autothreads';
+}
+
+{
+    sub f($x where Int|Str) { 'ok' }
+    is f(1), 'ok', 'an inline any-of-types constraint accepts a matching argument';
+    is f('a'), 'ok', 'the second type of the constraint accepts too';
+    dies-ok { f(1.5e0) }, 'a non-matching argument still rejects';
+    sub g($x where Int & Numeric) { 'ok' }
+    is g(1), 'ok', 'an all-of-types constraint accepts when every type matches';
+    dies-ok { g('a') }, 'an all-of-types constraint rejects a partial match';
+    subset SmallInt of Int where * < 10;
+    sub s($x where SmallInt|Str) { 'ok' }
+    is-deeply (s(3), s('z')), ('ok', 'ok'), 'a subset eigenstate accepts through its refinement';
+    dies-ok { s(50) }, 'a subset eigenstate rejects through its refinement';
+    multi w($x where Int|Str) { 'is' }
+    multi w($x) { 'other' }
+    is-deeply (w(1), w(3.5e0)), ('is', 'other'), 'multi dispatch over an inline constraint is unchanged';
 }

--- a/t/08-performance/25-rakuast-smartmatch-family.t
+++ b/t/08-performance/25-rakuast-smartmatch-family.t
@@ -3,7 +3,7 @@ use Test::Helpers::QAST;
 use Test;
 use QAST:from<NQP>;
 use nqp;
-plan 3;
+plan 9;
 
 # The legacy frontend reduces through its own QAST optimizer, so the
 # shapes here are this frontend's.
@@ -12,9 +12,13 @@ if nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' {
         not qast-contains-op(v, 'istype')
     }, 'a typematch guaranteed by the declared type folds away its check';
 
+    qast-is 'my $x = 5; my $r = $x ~~ 42', :full, -> \v {
+        not qast-contains-call(v, '&infix:<~~>')
+    }, 'a literal matcher compiles without the smartmatch dispatch';
+
 }
 else {
-    skip 'the reduced shapes are specific to the RakuAST frontend', 1;
+    skip 'the reduced shapes are specific to the RakuAST frontend', 2;
 }
 
 # Behavior stays identical.
@@ -25,4 +29,19 @@ else {
         'a declared-type topic still answers each typematch correctly';
     sub typed(Int $a) { $a ~~ Int }
     ok typed(3), 'a typed parameter topic folds to the same answer';
+}
+
+{
+    my $x = 42;
+    is-deeply ($x ~~ 42, $x ~~ 43, $x !~~ 43, $x ~~ "42"), (True, False, True, True),
+        'literal matches compare the way their ACCEPTS would';
+    is "abc" ~~ 5, False, 'a topic that fails numeric coercion matches no number and does not throw';
+    my Int $u;
+    todo 'the legacy optimizer answers False for a negated literal match on an undefined topic'
+        unless nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast';
+    is-deeply ($u ~~ 42, $u !~~ 42), (False, True),
+        'an undefined topic fails a literal match without warning';
+    my $j = any(1, 42);
+    ok $j ~~ 42, 'a concrete Junction topic still autothreads a literal match';
+    is 5 ~~ 5.0, True, 'both sides known folds through the literal ACCEPTS';
 }

--- a/t/08-performance/25-rakuast-smartmatch-family.t
+++ b/t/08-performance/25-rakuast-smartmatch-family.t
@@ -1,0 +1,28 @@
+use lib <t/packages/Test-Helpers>;
+use Test::Helpers::QAST;
+use Test;
+use QAST:from<NQP>;
+use nqp;
+plan 3;
+
+# The legacy frontend reduces through its own QAST optimizer, so the
+# shapes here are this frontend's.
+if nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' {
+    qast-is 'my Int $x; my $r = $x ~~ Int', :full, -> \v {
+        not qast-contains-op(v, 'istype')
+    }, 'a typematch guaranteed by the declared type folds away its check';
+
+}
+else {
+    skip 'the reduced shapes are specific to the RakuAST frontend', 1;
+}
+
+# Behavior stays identical.
+
+{
+    my Int $x = 5;
+    is-deeply ($x ~~ Int, $x ~~ Str, $x !~~ Int), (True, False, False),
+        'a declared-type topic still answers each typematch correctly';
+    sub typed(Int $a) { $a ~~ Int }
+    ok typed(3), 'a typed parameter topic folds to the same answer';
+}

--- a/t/08-performance/25-rakuast-smartmatch-family.t
+++ b/t/08-performance/25-rakuast-smartmatch-family.t
@@ -3,7 +3,31 @@ use Test::Helpers::QAST;
 use Test;
 use QAST:from<NQP>;
 use nqp;
-plan 13;
+plan 19;
+
+# The helper's walk does not descend a ParamTypeCheck, and a local name
+# identifies the unfolded junction more precisely than any op, so these
+# walk every child list themselves.
+
+sub qast-deep-contains-op (Mu $qast, Str:D $name --> Bool:D) {
+    if nqp::istype($qast, QAST::Op) && $qast.op eq $name {
+        return True;
+    }
+    for (try $qast.list) // () {
+        return True if nqp::istype($_, QAST::Node) && qast-deep-contains-op($_, $name);
+    }
+    False
+}
+
+sub qast-contains-unfold-local (Mu $qast --> Bool:D) {
+    if nqp::istype($qast, QAST::Var) && $qast.name.starts-with('junction_unfold') {
+        return True;
+    }
+    for (try $qast.list) // () {
+        return True if nqp::istype($_, QAST::Node) && qast-contains-unfold-local($_);
+    }
+    False
+}
 
 # The legacy frontend reduces through its own QAST optimizer, so the
 # shapes here are this frontend's.
@@ -20,9 +44,17 @@ if nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' {
         not qast-contains-call(v, '&infix:<~~>')
     }, 'a Pair matcher compiles without the smartmatch dispatch';
 
+    qast-is 'my $x = 2; if $x == 1|2|3 { say 1 }', :full, -> \v {
+        qast-contains-unfold-local(v)
+    }, 'a junction comparison in boolean position unfolds to a short-circuit chain';
+
+    qast-is 'my $x = 2; my $r = $x == 1|2', :full, -> \v {
+        not qast-contains-unfold-local(v)
+    }, 'a junction comparison whose value is used keeps the junction';
+
 }
 else {
-    skip 'the reduced shapes are specific to the RakuAST frontend', 3;
+    skip 'the reduced shapes are specific to the RakuAST frontend', 5;
 }
 
 # Behavior stays identical.
@@ -58,4 +90,23 @@ else {
         'an Associative topic takes the full Pair match';
     my $p = (is-prime => True);
     ok 7 ~~ $p, 'a Pair in a variable keeps the full match and still matches';
+}
+
+{
+    my $x = 2;
+    my @r;
+    @r.push('any') if $x == 1|2|3;
+    @r.push('none') if $x == 4|5;
+    @r.push('all') if $x == 2&2;
+    @r.push('not-all') unless $x == 2&3;
+    is @r.join(','), 'any,all,not-all', 'unfolded junction conditions branch correctly';
+    my $a = 1;
+    my $b = 2;
+    @r = ();
+    @r.push('vars') if $x == $a|$b;
+    is @r.join, 'vars', 'a junction built from variables unfolds and still matches';
+    my $r = ($x == 1|2);
+    isa-ok $r, Junction, 'a junction comparison used as a value stays a Junction';
+    my $j = 1|2;
+    ok ?($x == $j), 'a junction in a variable is not unfolded and still autothreads';
 }

--- a/t/08-performance/25-rakuast-smartmatch-family.t
+++ b/t/08-performance/25-rakuast-smartmatch-family.t
@@ -3,7 +3,7 @@ use Test::Helpers::QAST;
 use Test;
 use QAST:from<NQP>;
 use nqp;
-plan 28;
+plan 31;
 
 # The helper's walk does not descend a ParamTypeCheck, and a local name
 # identifies the unfolded junction more precisely than any op, so these
@@ -129,4 +129,24 @@ else {
     multi w($x where Int|Str) { 'is' }
     multi w($x) { 'other' }
     is-deeply (w(1), w(3.5e0)), ('is', 'other'), 'multi dispatch over an inline constraint is unchanged';
+}
+
+{
+    # `~~` is a chaining infix, so `0 ~~ 0 ~~ 0` is `(0 ~~ 0) && (0 ~~ 0)`. The
+    # legacy QAST optimizer miscompiles a chained smartmatch that appears in an
+    # argument list, inverting the result; it comes out right under
+    # --optimize=off and for a single `~~`, and the RakuAST frontend gets it
+    # right through the chain-link withdrawal above. Only exercise the chain
+    # protocol where it holds.
+    if nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' {
+        is-deeply (0 ~~ 0 ~~ 0, 0 ~~ 0 ~~ 1, 0 ~~ 0 !~~ 1), (True, False, True),
+            'chained smartmatches keep the chain protocol over reduced links';
+    }
+    else {
+        skip 'the legacy optimizer miscompiles a chained ~~ in an argument list', 1;
+    }
+    my Int $x = 1;
+    is ($x ~~ Int ~~ Bool), False,
+        'a fold withdrawn from a chain link passes the middle operand along';
+    is (0 ~~ 0 == 0), True, 'a reduced link mixed with a comparison chains correctly';
 }

--- a/t/08-performance/25-rakuast-smartmatch-family.t
+++ b/t/08-performance/25-rakuast-smartmatch-family.t
@@ -3,7 +3,7 @@ use Test::Helpers::QAST;
 use Test;
 use QAST:from<NQP>;
 use nqp;
-plan 9;
+plan 13;
 
 # The legacy frontend reduces through its own QAST optimizer, so the
 # shapes here are this frontend's.
@@ -16,9 +16,13 @@ if nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' {
         not qast-contains-call(v, '&infix:<~~>')
     }, 'a literal matcher compiles without the smartmatch dispatch';
 
+    qast-is 'my $x = 5; my $r = $x ~~ :is-prime', :full, -> \v {
+        not qast-contains-call(v, '&infix:<~~>')
+    }, 'a Pair matcher compiles without the smartmatch dispatch';
+
 }
 else {
-    skip 'the reduced shapes are specific to the RakuAST frontend', 2;
+    skip 'the reduced shapes are specific to the RakuAST frontend', 3;
 }
 
 # Behavior stays identical.
@@ -44,4 +48,14 @@ else {
     my $j = any(1, 42);
     ok $j ~~ 42, 'a concrete Junction topic still autothreads a literal match';
     is 5 ~~ 5.0, True, 'both sides known folds through the literal ACCEPTS';
+}
+
+{
+    is-deeply (4 ~~ :is-prime, 7 ~~ :is-prime, 4 ~~ :!is-prime), (False, True, True),
+        'Pair matchers ask the method the key names';
+    my %h = e => 42;
+    is-deeply (%h ~~ :e, %h ~~ :!missing), (True, False),
+        'an Associative topic takes the full Pair match';
+    my $p = (is-prime => True);
+    ok 7 ~~ $p, 'a Pair in a variable keeps the full match and still matches';
 }


### PR DESCRIPTION
A smartmatch, a `when`, or a `where` constraint runs the full `ACCEPTS` dispatch even when the matcher is known at compile time and what it comes down to is far simpler. This teaches the RakuAST optimize pass to recognize the common shapes and generate the simpler code directly, on the `~~` operator form, on `when` statements and their statement modifier, and in signature binding.

The reductions:

- **A typematch the topic's declared type already decides** folds to `True`. When a variable or parameter is typed so every value it can hold passes the matcher, the check is redundant.
- **A match against an `int`, `num`, or `str` literal** becomes the equality it stands for, numeric equality over the topic's `Numeric` or string equality over its `Stringy`.
- **A match against a compile-time `Pair`** (the file-test shapes such as `$path ~~ :e`) asks the topic the method the key names and compares the boolified answer to the value.
- **A comparison against a junction in boolean position** becomes a short-circuit chain of the plain comparisons. In the condition of an `if`, `unless`, `while`, or `until`, their statement modifiers, or under a boolifying prefix, only plain truth is wanted, so building and then collapsing the junction is wasted.
- **A `where` constraint that is a junction of type objects** (`$x where Int|Str`) checks the argument against each type inline, instead of cloning and invoking the constraint closure whose `ACCEPTS` autothreads a `Bool` junction just to collapse it again.

Every reduction is guarded so it cannot change behavior. A guarantee that only fails, a subset that must still run its refinement, a topic type with a user `ACCEPTS` a concrete matcher could reach, a `NaN` or infinite literal, an `Associative` or `Pair` topic under the Pair reduction, a comparison whose value is used or whose operands are both junctions, and a parameter typed to admit a `Junction` argument all keep the full path. A concrete `Junction` topic autothreads through the reduced code by the same guard the reductions share.

The links of a comparison chain take part in the chain op protocol, so none may compile to anything but a chain op. The reductions decide per node, so an enclosing chain withdraws any reduction its operand links took, and a match already settled outright is recorded on the operator and emitted as the constant.
