### PR TITLE
RakuAST: fold constant conditions and drop the code they make dead

### DIFF
--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -748,6 +748,7 @@ class RakuAST::Node {
             self.IMPL-MARK-WHEN-TYPEMATCH($resolver, $expr);
             self.IMPL-MARK-JUNCTION-FOLD($resolver, $expr);
             self.IMPL-MARK-CHAIN-LINKS($resolver, $expr);
+            self.IMPL-DROP-UNREACHABLE($resolver, $expr);
             self.IMPL-MARK-PARAM-WHERE-JUNCTION($resolver, $expr);
         }
 
@@ -2056,6 +2057,81 @@ class RakuAST::Node {
             return $expr;
         }
         RakuAST::Literal.from-value($value)
+    }
+
+    # Whether a statement unconditionally leaves the surrounding code, so
+    # nothing after it in its statement list can run. Only the setting's
+    # return, return-rw, and exit qualify: their control transfer cannot
+    # be resumed into the following statements. A thrown exception can,
+    # since a handler's resume continues right after the throw, so die
+    # and its relatives do not qualify, and neither do the loop controls,
+    # whose control exceptions a CONTROL block can resume the same way.
+    method IMPL-STATEMENT-TERMINATES(RakuAST::Resolver $resolver, Mu $stmt) {
+        return 0 unless nqp::istype($stmt, RakuAST::Statement::Expression);
+        return 0 if nqp::isconcrete($stmt.condition-modifier)
+            || nqp::isconcrete($stmt.loop-modifier);
+        my $expr := $stmt.expression;
+        return 0 unless nqp::istype($expr, RakuAST::Call::Name)
+            && $expr.is-resolved
+            && $expr.name.is-identifier
+            && nqp::istype($expr.resolution, RakuAST::Declaration::External::Setting);
+        my str $name := $expr.name.canonicalize;
+        $name eq 'return' || $name eq 'return-rw' || $name eq 'exit'
+    }
+
+    # Statements following one that unconditionally leaves never run, so
+    # they are dropped from the list, each on its own: one that declares
+    # stays, since its lexical is visible regardless, and so does a
+    # phaser statement, whose begin-time registration outlives its
+    # position but whose spot in the list is left alone all the same.
+    method IMPL-DROP-UNREACHABLE(RakuAST::Resolver $resolver, Mu $expr) {
+        CATCH {
+            return Nil;
+        }
+        return Nil unless nqp::istype(self, RakuAST::StatementList);
+        return Nil unless self.IMPL-STATEMENT-TERMINATES($resolver, $expr);
+        self.IMPL-DROP-UNREACHABLE-IN(self.IMPL-UNWRAP-LIST(self.statements), $expr);
+        self.IMPL-DROP-UNREACHABLE-IN(self.code-statements, $expr);
+        Nil
+    }
+
+    method IMPL-DROP-UNREACHABLE-IN(Mu $statements, Mu $expr) {
+        my int $n := nqp::elems($statements);
+        my int $found := -1;
+        my int $i := -1;
+        while ++$i < $n {
+            if nqp::eqaddr(nqp::atpos($statements, $i), $expr) {
+                $found := $i;
+                last;
+            }
+        }
+        return Nil if $found < 0;
+        my @kept;
+        my int $dropped := 0;
+        $i := $found;
+        while ++$i < $n {
+            my $following := nqp::atpos($statements, $i);
+            # A phaser's registration, and a CATCH or CONTROL block's
+            # installation as the scope's handler, hold wherever the
+            # statement sits, so they stay.
+            my int $declarative := nqp::istype($following, RakuAST::Statement::Catch)
+                || nqp::istype($following, RakuAST::Statement::Control)
+                || nqp::istype($following, RakuAST::Statement::Expression)
+                && nqp::istype($following.expression, RakuAST::StatementPrefix::Phaser);
+            if !$declarative && self.IMPL-DROPPABLE($following) {
+                $dropped := 1;
+            }
+            else {
+                nqp::push(@kept, $following);
+            }
+        }
+        if $dropped {
+            nqp::setelems($statements, $found + 1);
+            for @kept {
+                nqp::push($statements, $_);
+            }
+        }
+        Nil
     }
 
     # A conditional whose condition's truth is known at compile time

--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -717,6 +717,10 @@ class RakuAST::Node {
         }
 
         if $result =:= $expr {
+            $result := self.IMPL-COLLAPSE-DEAD-BRANCH($resolver, $expr);
+        }
+
+        if $result =:= $expr {
             $result := self.IMPL-REWRITE-SQUARE($resolver, $expr);
         }
 
@@ -2052,6 +2056,111 @@ class RakuAST::Node {
             return $expr;
         }
         RakuAST::Literal.from-value($value)
+    }
+
+    # A conditional whose condition's truth is known at compile time
+    # keeps only the code that could run. The taken branch, a block with
+    # a scope of its own, stands as a bare block statement, which the
+    # later analysis may flatten into the enclosing frame, and a false
+    # condition with no other branch leaves the statement's Empty value.
+    # The dropped branches are code the running program could never
+    # reach, and a dropped block confines its declarations, but a
+    # dropped condition is evaluated code, so every dropped condition
+    # must be droppable. A with part tests definedness and topicalizes
+    # its value, so only plain if parts collapse.
+    method IMPL-COLLAPSE-DEAD-BRANCH(RakuAST::Resolver $resolver, Mu $expr) {
+        CATCH {
+            return $expr;
+        }
+        if nqp::istype($expr, RakuAST::Statement::IfWith) {
+            return $expr if nqp::elems(self.IMPL-UNWRAP-LIST($expr.labels));
+            return $expr unless $expr.IMPL-QAST-TYPE eq 'if';
+            my int $truth := self.IMPL-CONSTANT-TRUTH($resolver, $expr.condition);
+            return $expr if $truth < 0
+                || !self.IMPL-DROPPABLE($expr.condition);
+            if $truth {
+                return $expr unless self.IMPL-BRANCH-COLLAPSIBLE($expr.then);
+                for $expr.IMPL-UNWRAP-LIST($expr.elsifs) {
+                    return $expr unless self.IMPL-DROPPABLE($_.condition);
+                }
+                return self.IMPL-BRANCH-STATEMENT($expr.then);
+            }
+            return $expr if nqp::elems($expr.IMPL-UNWRAP-LIST($expr.elsifs));
+            my $else := $expr.else;
+            if nqp::isconcrete($else) {
+                return $expr unless self.IMPL-BRANCH-COLLAPSIBLE($else);
+                return self.IMPL-BRANCH-STATEMENT($else);
+            }
+            return self.IMPL-EMPTY-STATEMENT($resolver, $expr);
+        }
+        elsif nqp::istype($expr, RakuAST::Statement::Unless) {
+            return $expr if nqp::elems(self.IMPL-UNWRAP-LIST($expr.labels));
+            my int $truth := self.IMPL-CONSTANT-TRUTH($resolver, $expr.condition);
+            return $expr if $truth < 0
+                || !self.IMPL-DROPPABLE($expr.condition);
+            unless $truth {
+                return $expr unless self.IMPL-BRANCH-COLLAPSIBLE($expr.body);
+                return self.IMPL-BRANCH-STATEMENT($expr.body);
+            }
+            return self.IMPL-EMPTY-STATEMENT($resolver, $expr);
+        }
+        elsif nqp::istype($expr, RakuAST::Statement::Expression) {
+            return $expr if nqp::isconcrete($expr.loop-modifier)
+                || nqp::elems(self.IMPL-UNWRAP-LIST($expr.labels));
+            # A block statement under a condition modifier is invoked with
+            # the condition's value, so the modifier stays.
+            return $expr if nqp::istype($expr.expression, RakuAST::Block);
+            my $cond := $expr.condition-modifier;
+            return $expr unless nqp::isconcrete($cond);
+            my int $negated := nqp::istype($cond, RakuAST::StatementModifier::Unless);
+            return $expr unless $negated
+                || nqp::istype($cond, RakuAST::StatementModifier::If)
+                && !nqp::istype($cond, RakuAST::StatementModifier::When);
+            my int $truth := self.IMPL-CONSTANT-TRUTH($resolver, $cond.expression);
+            return $expr if $truth < 0
+                || !self.IMPL-DROPPABLE($cond.expression);
+            $truth := nqp::not_i($truth) if $negated;
+            if $truth {
+                # The statement runs unconditionally; only the test goes.
+                $expr.replace-condition-modifier(
+                    RakuAST::StatementModifier::Condition);
+                return $expr;
+            }
+            return $expr unless self.IMPL-DROPPABLE($expr.expression);
+            return self.IMPL-EMPTY-STATEMENT($resolver, $expr);
+        }
+        $expr
+    }
+
+    # Whether a surviving branch may stand alone: the if and unless
+    # statements invoke a branch that takes arguments, a pointy or one
+    # with placeholders, with the condition's value, so only a plain
+    # parameterless block runs the same on its own.
+    method IMPL-BRANCH-COLLAPSIBLE(Mu $block) {
+        nqp::eqaddr($block.WHAT, RakuAST::Block)
+            && !nqp::isconcrete($block.placeholder-signature)
+            && (!nqp::isconcrete($block.signature)
+                || nqp::elems($block.IMPL-UNWRAP-LIST(
+                    $block.signature.parameters)) == 0)
+    }
+
+    # The taken branch as a statement of its own: a bare block statement
+    # runs where it stands and yields its last statement's value, the
+    # same way the branch would have.
+    method IMPL-BRANCH-STATEMENT(Mu $block) {
+        my $statement := RakuAST::Statement::Expression.new(:expression($block));
+        $statement.mark-block-statement();
+        $statement
+    }
+
+    # A statement standing where dropped code stood, evaluating to the
+    # Empty a branchless conditional evaluates to.
+    method IMPL-EMPTY-STATEMENT(RakuAST::Resolver $resolver, Mu $expr) {
+        my $empty := $resolver.resolve-name-constant-in-setting(
+            RakuAST::Name.from-identifier('Empty'));
+        return $expr unless nqp::isconcrete($empty);
+        RakuAST::Statement::Expression.new(
+            :expression(RakuAST::Literal.from-value($empty.compile-time-value)))
     }
 
     # The links of a longer chain take part in the chain op protocol, so

--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -2618,10 +2618,15 @@ class RakuAST::Node {
             # nesting suggests. Folding the inner comparison to a literal would
             # drop that operand and change the result, so chaining infixes are
             # left for runtime.
+            # A chaining comparison folds too: the foldable-operand bound
+            # already rules out a nested chain link as an operand, and when
+            # this application is itself the link of a longer chain, the
+            # argument-position delivery below leaves the node in place, so
+            # the enclosing chain can withdraw the answer and keep its
+            # middle-operand sharing.
             $foldable := nqp::istype($infix, RakuAST::Infix)
                 && $infix.is-resolved
                 && self.IMPL-PURE-ROUTINE($infix)
-                && !$infix.properties.chain
                 && !nqp::isconcrete($expr.args.arg-at-pos(2))
                 && self.IMPL-FOLDABLE-OPERAND($expr.left)
                 && self.IMPL-FOLDABLE-OPERAND($expr.right);
@@ -2670,6 +2675,12 @@ class RakuAST::Node {
         return $expr unless @result[0];
         my $value := @result[1];
         return $expr unless self.IMPL-FOLDABLE-VALUE($resolver, $value);
+
+        if nqp::istype($expr, RakuAST::ApplyInfix)
+            && nqp::istype($expr.infix, RakuAST::Infix)
+            && $expr.infix.properties.chain {
+            return self.IMPL-SMARTMATCH-FOLD-RESULT($expr, $value);
+        }
 
         my $literal := RakuAST::Literal.from-value($value);
         $literal.set-origin($expr.origin) if nqp::isconcrete($expr.origin);

--- a/t/08-performance/11-rakuast-constant-folding.t
+++ b/t/08-performance/11-rakuast-constant-folding.t
@@ -37,7 +37,7 @@ ok optimized-deparse(Q[my $y = 3 / 4]).contains('= 0.75'),       'integer divisi
 ok optimized-deparse(Q[my $s = (2 ** 10).Str]).contains('1024.Str'),         'a method call invocant folds';
 ok optimized-deparse(Q[my $p = (status => 6 * 7)]).contains('status => 42'), 'a pair value folds';
 ok optimized-deparse(Q[my $x = do { 100 - 1 }]).contains('99'),              'a block final value folds';
-ok optimized-deparse(Q[say "x" if 2 ** 3]).contains('if 8'),                 'a statement modifier condition folds';
+ok optimized-deparse(Q[{ say "x" } if 2 ** 3]).contains('if 8'),             'a statement modifier condition folds';
 ok optimized-deparse(Q[my @a = [2 + 3, 4 * 5]]).contains('[5, 20]'),         'array composer elements fold';
 ok optimized-deparse(Q[my @a; @a[2 + 3]]).contains('[5]'),                   'an index expression folds';
 ok optimized-deparse(Q[sub f($x = 2 + 3) { }]).contains('= 5'),              'a parameter default folds';

--- a/t/08-performance/26-rakuast-dead-branch.t
+++ b/t/08-performance/26-rakuast-dead-branch.t
@@ -1,0 +1,26 @@
+use lib <t/packages/Test-Helpers>;
+use Test::Helpers::QAST;
+use Test;
+use QAST:from<NQP>;
+use nqp;
+plan 3;
+
+# A chaining comparison on constant operands folds to its answer. As a
+# link of a longer chain the answer is recorded on the operator rather
+# than replacing the link, so the chain protocol holds.
+
+if nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' {
+    qast-is 'my $r = 2 > 4', :full, -> \v {
+        not qast-contains-call(v, '&infix:«>»')
+    }, 'a constant chained comparison compiles without the comparison call';
+}
+else {
+    skip 'the folded shape is specific to the RakuAST frontend', 1;
+}
+
+{
+    is-deeply (2 > 4, 1 < 2 < 3, 3 < 2 < 10), (False, True, False),
+        'chained comparisons on constants fold to the runtime answers';
+    my $x = 5;
+    is (1 < 2 < $x), True, 'a folded link inside a live chain still chains';
+}

--- a/t/08-performance/26-rakuast-dead-branch.t
+++ b/t/08-performance/26-rakuast-dead-branch.t
@@ -3,19 +3,112 @@ use Test::Helpers::QAST;
 use Test;
 use QAST:from<NQP>;
 use nqp;
-plan 3;
+plan 22;
 
-# A chaining comparison on constant operands folds to its answer. As a
-# link of a longer chain the answer is recorded on the operator rather
-# than replacing the link, so the chain protocol holds.
+# A conditional whose condition's truth is known at compile time keeps
+# only the code that could run, and a chaining comparison on constant
+# operands folds to its answer so such conditions become decidable.
 
+sub qast-contains-sval (Mu $qast, Str:D $value --> Bool:D) {
+    if nqp::istype($qast, QAST::SVal) && $qast.value eq $value {
+        return True;
+    }
+    for (try $qast.list) // () {
+        return True if nqp::istype($_, QAST::Node) && qast-contains-sval($_, $value);
+    }
+    False
+}
+
+# The legacy frontend has no dead-branch elimination, so the shapes
+# here are this frontend's.
 if nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' {
-    qast-is 'my $r = 2 > 4', :full, -> \v {
-        not qast-contains-call(v, '&infix:«>»')
-    }, 'a constant chained comparison compiles without the comparison call';
+    qast-is 'if 2 > 4 { say "deadstr" } else { say "alivestr" }', :full, -> \v {
+        qast-contains-sval(v, 'alivestr') and not qast-contains-sval(v, 'deadstr')
+    }, 'a false constant comparison keeps only the else branch';
+
+    qast-is 'my constant DEBUG = False; if DEBUG { say "deadstr" }', :full, -> \v {
+        not qast-contains-sval(v, 'deadstr')
+    }, 'a constant-gated branch is dropped whole';
+
+    qast-is 'if 1 < 2 { say "alivestr" }', :full, -> \v {
+        qast-contains-sval(v, 'alivestr')
+            and not qast-contains-call(v, '&infix:«<»')
+            and not qast-contains-op(v, 'islt_i')
+    }, 'a true constant condition leaves the branch with no test at all';
+
+    qast-is 'say "deadstr" if 2 > 4', :full, -> \v {
+        not qast-contains-sval(v, 'deadstr')
+    }, 'a false condition modifier drops its statement';
+
+    # Not :full, so the walk sees only this statement's QAST and the absence
+    # of an if op means the modifier itself is gone, not just the folded
+    # comparison inside it.
+    qast-is 'say "alivestr" if 2 > 1', -> \v {
+        qast-contains-sval(v, 'alivestr')
+            and not qast-contains-op(v, 'if')
+    }, 'a true condition modifier is eliminated whole';
+
+    qast-is 'my $x = 3; if $x > 4 { say "maybestr" }', :full, -> \v {
+        qast-contains-sval(v, 'maybestr')
+    }, 'a runtime condition keeps its conditional';
 }
 else {
-    skip 'the folded shape is specific to the RakuAST frontend', 1;
+    skip 'the dead-branch shapes are specific to the RakuAST frontend', 6;
+}
+
+# Behavior stays identical.
+
+{
+    my @r;
+    if 2 > 4 { @r.push('dead') } else { @r.push('alive') }
+    is @r.join, 'alive', 'the surviving else branch runs';
+}
+
+{
+    my constant DEBUG = False;
+    my @r;
+    if DEBUG { @r.push('dead') }
+    @r.push('after');
+    is @r.join, 'after', 'code after a dropped constant-gated branch runs';
+}
+
+{
+    is-deeply (do if 0 { 5 }), Empty, 'a false conditional with no else is Empty';
+    is (do if 1 { 5 } else { 6 }), 5, 'a true conditional yields its then value';
+    is (do if 0 { 5 } else { 6 }), 6, 'a false conditional yields its else value';
+    is (do unless 0 { 7 }), 7, 'a false unless condition yields its body value';
+    is-deeply (do unless 1 { 7 }), Empty, 'a true unless condition is Empty';
+}
+
+{
+    my @r;
+    @r.push('if') if 1;
+    @r.push('dead') if 0;
+    @r.push('unless') unless 0;
+    is @r.join(','), 'if,unless', 'condition modifiers with known truth keep the right statements';
+}
+
+{
+    my $x = 5 if 0;
+    ok !$x.defined, 'a dropped-condition declaration is still declared and undefined';
+}
+
+{
+    my @r;
+    if 1 { @r.push('a') } elsif 1 { @r.push('b') } else { @r.push('c') }
+    if 0 { @r.push('x') } elsif 1 { @r.push('q') }
+    is @r.join(','), 'a,q', 'elsif chains pick the same arms as at runtime';
+}
+
+{
+    if 0 { } elsif (my $k = 5) { }
+    is $k, 5, 'a declaration in a kept elsif condition still binds';
+}
+
+{
+    my $seen;
+    with 42 { $seen = $_ }
+    is $seen, 42, 'a with part is untouched and still topicalizes';
 }
 
 {
@@ -23,4 +116,16 @@ else {
         'chained comparisons on constants fold to the runtime answers';
     my $x = 5;
     is (1 < 2 < $x), True, 'a folded link inside a live chain still chains';
+}
+
+{
+    my int $n = 0;
+    if 1 { my $a = 1; $n = $n + $a }
+    is $n, 1, 'a collapsed branch that then flattens still runs its code';
+}
+
+{
+    my class Boomy { method Bool() { die "boom" } }
+    my \b = Boomy.new;
+    dies-ok { if b { } }, 'a constant whose Bool throws keeps the throw at runtime';
 }

--- a/t/08-performance/26-rakuast-dead-branch.t
+++ b/t/08-performance/26-rakuast-dead-branch.t
@@ -3,7 +3,7 @@ use Test::Helpers::QAST;
 use Test;
 use QAST:from<NQP>;
 use nqp;
-plan 22;
+plan 34;
 
 # A conditional whose condition's truth is known at compile time keeps
 # only the code that could run, and a chaining comparison on constant
@@ -128,4 +128,66 @@ else {
     my class Boomy { method Bool() { die "boom" } }
     my \b = Boomy.new;
     dies-ok { if b { } }, 'a constant whose Bool throws keeps the throw at runtime';
+}
+
+# Statements after one that unconditionally leaves the surrounding code
+# never run, and are dropped unless they declare something or register
+# a phaser.
+
+if nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' {
+    qast-is 'sub f() { return 5; say "deadstr" }; say f()', :full, -> \v {
+        not qast-contains-sval(v, 'deadstr')
+    }, 'statements after a return are dropped';
+
+    qast-is 'sub f() { return 5; my $k = 1; say "deadstr" }; say f()', :full, -> \v {
+        not qast-contains-sval(v, 'deadstr')
+    }, 'a declaring unreachable statement stays while its droppable neighbors go';
+
+    qast-is 'sub f() { die "x"; say "livestr" }; try f()', :full, -> \v {
+        qast-contains-sval(v, 'livestr')
+    }, 'statements after a die stay, since a handler can resume into them';
+
+    qast-is 'sub f() { return 5; say "deadstr"; CATCH { default { say "handlerstr" } } }; say f()', :full, -> \v {
+        qast-contains-sval(v, 'handlerstr') and not qast-contains-sval(v, 'deadstr')
+    }, 'a CATCH after a return stays while its droppable neighbors go';
+}
+else {
+    skip 'the unreachable-code shapes are specific to the RakuAST frontend', 4;
+}
+
+{
+    sub f() { return 5; say "dead" }
+    is f(), 5, 'a routine still returns its value with trailing code dropped';
+}
+
+{
+    sub f() { return 1; sub g() { 9 } }
+    is f(), 1, 'a routine declared after a return is kept, since its name hoists';
+    sub caller-test() { return 2; my $x = 3 }
+    is caller-test(), 2, 'an unreachable declaration is kept without running its initializer';
+}
+
+{
+    my $l;
+    sub f() { return 7; LEAVE $l = 'leave-ran' }
+    is f(), 7, 'a phaser after a return still registers';
+    is $l, 'leave-ran', 'and fires when the routine is left';
+}
+
+{
+    my @r;
+    sub f() { die "x"; @r.push('resumed') }
+    { f(); CATCH { default { .resume } } }
+    @r.push('end');
+    is @r.join(','), 'resumed,end', 'resuming after a die still reaches the following statements';
+}
+
+{
+    sub f() { return 5 if 1 > 2; 'fell-through' }
+    is f(), 'fell-through', 'a conditional return does not drop what follows';
+}
+
+{
+    lives-ok { EVAL 'return 1; CATCH { default { } }' },
+        'a CATCH after a mainline return still catches the control exception';
 }


### PR DESCRIPTION
Previously the RakuAST optimize pass compiled code that can never run. A conditional with a compile-time condition still emitted both branches and tested the constant at runtime, and statements after an unconditional `return` were compiled though nothing reaches them. This teaches the pass to drop such code, and extends constant folding to the chaining comparisons that make many conditions decidable in the first place.

**Fold a chaining comparison on constant operands.** Chaining infixes were excluded from constant folding, because replacing a link of a longer chain with its answer would hand the next comparison a boolean in place of the shared middle operand. A decided comparison in an argument position now records its answer on the operator, where an enclosing chain withdraws it, rather than replacing the node. So a constant comparison folds like any other pure operator, and `2 > 4` becomes decidable at compile time.

**Keep only the branch a constant condition selects.** An `if` or `unless`, statement or statement modifier, whose condition is known at compile time now keeps only the code that could run. The taken branch stands as a bare block, which the lowering analysis may flatten into the enclosing frame, and a false conditional with no other branch leaves its `Empty`. A branch that takes arguments, a pointy or one with placeholders, receives the condition's value, so it keeps its conditional, as does a block statement under a condition modifier. A `with` tests definedness and topicalizes, so only plain `if` and `unless` collapse, and a constant whose `Bool` throws keeps the throw at runtime. A dropped branch confines its declarations, so no name is lost.

**Drop statements nothing after a return can reach.** Statements following an unconditional `return`, `return-rw`, or `exit` are now dropped. Only those three end reachability. A thrown exception does not, since a handler can `.resume` into the statements right after the throw, so `die` and the loop controls leave their followers alone, and the call must carry no condition or loop modifier. Statements that still register something are kept: anything that declares a name, since a routine declared after a return is callable through its hoisted name, plus phasers and `CATCH` and `CONTROL` blocks, which attach to the scope wherever they sit.
