### PR TITLE
RakuAST: keep declarand nodes out of a precompiled $=rakudoc

### DIFF
--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -3012,8 +3012,16 @@ class RakuAST::VarDeclaration::Implicit::Doc::Rakudoc
             }
             elsif nqp::istype($_,RakuAST::Statement::Expression) {
                 my $expression := $_.expression;
+                # A declarand node must not go into a precompilation's SC.
+                # Its backlinks (a routine's $!outer, a BEGIN prefix's cached
+                # thunk) reach live compile-time frames, and serializing those
+                # snapshots leaves deserialized BEGIN closures with an outer
+                # chain that dead-ends before the setting. Declarator docs on
+                # a precompiled unit stay reachable via .WHY on the meta
+                # objects and via $=pod.
                 if nqp::istype($expression,RakuAST::Doc::DeclaratorTarget)
-                  && $expression.WHY {
+                  && $expression.WHY
+                  && !$*RAKUDOC-SKIP-DECLARANDS {
                     nqp::push($RAKUDOC,$expression);
                 }
                 # Descend into a package or routine/block body so docs declared
@@ -3035,10 +3043,10 @@ class RakuAST::VarDeclaration::Implicit::Doc::Rakudoc
       RakuAST::Resolver $resolver,
       RakuAST::IMPL::QASTContext $context
     ) {
+        my $compunit := $resolver.find-attach-target('compunit');
         my $*RAKUDOC := [];
-        self.fetch-blocks(
-          $resolver.find-attach-target('compunit').statement-list
-        );
+        my $*RAKUDOC-SKIP-DECLARANDS := $compunit.precompilation-mode;
+        self.fetch-blocks($compunit.statement-list);
 
         nqp::bindattr(self, RakuAST::VarDeclaration::Implicit::Doc, '$!value',
           self.IMPL-WRAP-LIST($*RAKUDOC)

--- a/t/02-rakudo/begin-closure-doc-precomp.t
+++ b/t/02-rakudo/begin-closure-doc-precomp.t
@@ -1,0 +1,22 @@
+use lib <t/02-rakudo/test-packages>;
+use Test;
+use BeginClosureDoc;
+
+plan 3;
+
+# Loading the module precompiles it, so the BEGIN-built closures come back
+# through serialization. A declarator doc in the same compunit used to put
+# the declarand node into $=rakudoc, whose serialization snapshotted live
+# compile-time frames; the closures then deserialized with an outer chain
+# that dead-ended before the setting, and calling any setting routine from
+# their bodies died with a VMNull invocation.
+
+is BeginClosureDoc.call-sub('q'), 'Q',
+    'a precompiled BEGIN-built closure can call a setting sub';
+is-deeply BeginClosureDoc.call-table('q'), ['q'],
+    'a precompiled BEGIN-built table closure can use the array composer';
+is BeginClosureDoc.^find_method('documented').WHY.leading,
+    'documented after the BEGIN closures',
+    'the declarator doc is still reachable through .WHY after precompilation';
+
+# vim: expandtab shiftwidth=4

--- a/t/02-rakudo/test-packages/BeginClosureDoc.rakumod
+++ b/t/02-rakudo/test-packages/BeginClosureDoc.rakumod
@@ -1,0 +1,13 @@
+unit class BeginClosureDoc;
+
+my $s = BEGIN sub ($op) { uc($op) };
+
+my Routine %Ops = BEGIN %(
+    'q' => sub ($op) { [$op] },
+);
+
+method call-sub($op)   { $s($op) }
+method call-table($op) { %Ops{$op}($op) }
+
+#| documented after the BEGIN closures
+method documented() { }


### PR DESCRIPTION
Previously `$=rakudoc` collected the declarand node of every documented declaration, and a precompilation serialized those nodes into its serialization context. A declarand node carries backlinks into the whole compilation: a routine node references its outer code node, and a BEGIN statement prefix caches the thunk that ran at compile time. Serializing that thunk closure snapshots live compile-time frames, and the snapshot chain dead-ends before the setting. A closure created at BEGIN time then deserialized with the dead chain as its outer, so calling any setting routine from its body died with "lang-call cannot invoke object of type 'VMNull'".

This keeps declarand nodes out of `$=rakudoc` when precompiling. Standalone doc blocks are pure data and are still collected, and declarator docs on a precompiled unit stay reachable through .WHY on the meta-objects and through `$=pod`. A direct compile, as --rakudoc uses, still collects the declarand nodes.
