### PR TITLE
RakuAST: access an attribute the open class declares later untyped

### DIFF
--- a/src/Raku/ast/variable-access.rakumod
+++ b/src/Raku/ast/variable-access.rakumod
@@ -355,7 +355,16 @@ class RakuAST::Var::Attribute
                 self.IMPL-QAST-PACKAGE-LOOKUP($context)
             )
         }
-        QAST::Op.new(:op<null>)
+        # Code generated inside a BEGIN block can reference an attribute the
+        # still-open class declares further down its body. The attribute is
+        # not on the stub yet, but the access only needs the name and package
+        # at runtime, so emit it untyped. A genuinely undeclared attribute is
+        # rejected at check or compose time and never runs this code.
+        QAST::Var.new(
+            :scope('attribute'), :name($!name), :returns(Mu),
+            self.IMPL-UNWRAP-LIST(self.get-implicit-lookups)[0].IMPL-TO-QAST($context),
+            self.IMPL-QAST-PACKAGE-LOOKUP($context)
+        )
     }
 
     method IMPL-BIND-QAST(RakuAST::IMPL::QASTContext $context, QAST::Node $source-qast) {
@@ -381,7 +390,17 @@ class RakuAST::Var::Attribute
                 $source-qast
             )
         }
-        QAST::Op.new(:op<null>)
+        # As in IMPL-EXPR-QAST: the attribute may be declared further down
+        # the still-open class body, so bind untyped rather than emit null.
+        QAST::Op.new(
+            :op('bind'),
+            QAST::Var.new(
+                :scope('attribute'), :name($!name), :returns(Mu),
+                self.IMPL-UNWRAP-LIST(self.get-implicit-lookups)[0].IMPL-TO-QAST($context),
+                self.IMPL-QAST-PACKAGE-LOOKUP($context)
+            ),
+            $source-qast
+        )
     }
 }
 

--- a/t/02-rakudo/begin-attr-before-declaration.t
+++ b/t/02-rakudo/begin-attr-before-declaration.t
@@ -1,0 +1,46 @@
+use Test;
+
+plan 4;
+
+# A method literal built inside a BEGIN block generates its code before the
+# class finishes parsing, so an attribute declared further down the body is
+# not on the class yet at that point. The access used to compile to a null,
+# so touching the attribute at runtime failed on a VMNull invocant.
+
+{
+    my class C {
+        my $m = BEGIN method () { @!later.push('pushed'); @!later };
+        has @.later;
+        method run() { $m(self) }
+    }
+    is-deeply C.new.run, ['pushed'],
+        'a BEGIN-built method can read an attribute declared after the BEGIN';
+}
+
+{
+    my class C {
+        my $m = BEGIN method () { $!scalar };
+        has $.scalar = 'default';
+        method run() { $m(self) }
+    }
+    is C.new.run, 'default',
+        'a BEGIN-built method reads a later scalar attribute default';
+}
+
+{
+    my class C {
+        my $m = BEGIN method ($value) { $!scalar = $value; $!scalar };
+        has $.scalar is rw;
+        method run($value) { $m(self, $value) }
+    }
+    is C.new.run(42), 42,
+        'a BEGIN-built method can assign a later scalar attribute';
+}
+
+# The undeclared-attribute error still fires for an attribute the class
+# never declares.
+throws-like 'class C { my $m = BEGIN method () { $!nope }; }',
+    X::Attribute::Undeclared,
+    'an attribute never declared in the class is still rejected';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously an attribute access compiled inside a BEGIN block emitted a null op when the attribute was not yet on the still-open class, which happens when the class declares the attribute further down its body. The code compiled cleanly, since the undeclared-attribute check runs against the finished class, but touching the attribute at runtime produced VMNull, so something like @!gsaves.push died with "No such method 'push' for invocant of type 'VMNull'".

An attribute access only needs the attribute name and the package object at runtime, so emit an untyped access when the attribute is not yet known. A genuinely undeclared attribute is still rejected at check or compose time and never reaches that code.