### PR TITLE
RakuAST: look up an indirect ::("EXPORT") at run time

### DIFF
--- a/src/Raku/ast/resolver.rakumod
+++ b/src/Raku/ast/resolver.rakumod
@@ -354,6 +354,14 @@ class RakuAST::Resolver {
 
         # Resolve the root part.
         my $name     := $root.name;
+
+        # EXPORT resolves to this unit's own export-package. That suits a
+        # written EXPORT::<...> reference, but an indirect lookup is a runtime
+        # symbolic lookup and must not fold to a compile-time package. A
+        # constant-string indirect lookup still arrives as an Expression part.
+        return Nil
+          if $name eq 'EXPORT'
+          && nqp::istype($root, RakuAST::Name::Part::Expression);
         my str $setting-rev;
         if ($name eq 'CORE') {
             return Nil unless @parts;  # bare CORE has nothing to resolve
@@ -585,6 +593,11 @@ class RakuAST::Resolver {
 
     # Check if a name is a known type.
     method is-name-type(RakuAST::Name $Rname) {
+        # An indirect lookup is a term, not a type name, even when its constant
+        # string resolves. Term::Name folds a resolved one and looks the rest
+        # up at run time.
+        return False if $Rname.is-indirect-lookup;
+
         my $constant := self.resolve-name($Rname);
         if nqp::istype($constant, RakuAST::CompileTimeValue) {
             # Name resolves, but is it an instance or a type object?

--- a/src/Raku/ast/term.rakumod
+++ b/src/Raku/ast/term.rakumod
@@ -83,6 +83,12 @@ class RakuAST::Term::Name
             if self-is-resolved {
                 self.resolution.IMPL-LOOKUP-QAST($context);
             }
+            elsif $!name.is-indirect-lookup {
+                # An unresolved indirect lookup is a runtime symbolic lookup.
+                # Its lookup consults %?REQUIRE-SYMBOLS, which the pseudo-stash
+                # lookup below does not.
+                $!name.IMPL-QAST-INDIRECT-LOOKUP($context);
+            }
             else {
                 $!name.IMPL-QAST-PSEUDO-PACKAGE-LOOKUP($context);
             }

--- a/t/02-rakudo/require-export-package-indirect.t
+++ b/t/02-rakudo/require-export-package-indirect.t
@@ -1,0 +1,24 @@
+use lib <t/02-rakudo/test-packages>;
+use Test;
+
+plan 3;
+
+# `require` loads a module and merges its EXPORT package into the caller's
+# %?REQUIRE-SYMBOLS. Reading it back through an indirect lookup `::("EXPORT")`
+# must run at run time so it sees those merged symbols; folding the constant
+# string to this compilation unit's own (empty) export-package would report no
+# exports. A direct `EXPORT::<...>` reference still resolves at compile time.
+
+require ::("BundleExport");
+
+ok ::("EXPORT").WHO<DEFAULT>:exists,
+    'the required module EXPORT::DEFAULT is visible through ::("EXPORT")';
+
+my @pairs = ::("EXPORT").WHO<DEFAULT>.WHO.pairs;
+is @pairs.map(*.key).sort, ('&bundle-export',),
+    'the required module exports are read from ::("EXPORT")';
+
+is ::("EXPORT").WHO<DEFAULT>.WHO<&bundle-export>('x'), 'bundled x',
+    'the re-read exported sub is callable';
+
+# vim: expandtab shiftwidth=4

--- a/t/02-rakudo/test-packages/BundleExport.rakumod
+++ b/t/02-rakudo/test-packages/BundleExport.rakumod
@@ -1,0 +1,8 @@
+unit module BundleExport;
+
+# A module whose exports are declared through an explicit EXPORT::DEFAULT
+# package (the older idiom, as Test::Async bundles use), rather than the
+# `is export` trait.
+package EXPORT::DEFAULT {
+    our sub bundle-export($v) { "bundled " ~ $v }
+}


### PR DESCRIPTION
Reading a required module's exports through an indirect lookup, as in `require ::($bundle); ::("EXPORT").WHO<DEFAULT>`, returned nothing under the RakuAST frontend. The constant string "EXPORT" resolved at compile time to this compilation unit's own export-package, which is empty, instead of running the symbolic lookup that would see the exports a `require` merged into the caller's %?REQUIRE-SYMBOLS.

An indirect lookup is a run-time symbolic lookup, so three places now treat it as one rather than folding the constant string:

- The resolver no longer applies the EXPORT special-case to an indirect root, so `::("EXPORT")` stays unresolved and reaches code generation as a runtime lookup. A direct EXPORT::<...> reference is unaffected.
- is-name-type reports an indirect lookup as a term, not a type, so an unresolved one is not routed into the undeclared-type check.
- Code generation for an unresolved indirect pseudo-package lookup uses the lookup that consults %?REQUIRE-SYMBOLS instead of the pseudo-stash lookup.

A constant indirect lookup that resolves to a stable symbol (a type, a setting sub) still folds, so `my constant T = ::("Int")` and the reduce metaops are unchanged.

This surfaced from Test::Async, whose bundles declare exports through an explicit EXPORT::DEFAULT package that its aggregator re-exports.