### PR TITLE
RakuAST: emit the resolution for a resolved pseudo-package name

### DIFF
--- a/src/Raku/ast/term.rakumod
+++ b/src/Raku/ast/term.rakumod
@@ -19,8 +19,14 @@ class RakuAST::Term::Name
         self.new(RakuAST::Name.from-identifier($name))
     }
 
+    # Folding must agree with IMPL-EXPR-QAST on which names may use their
+    # resolution: only a leading-:: package search, and not ::GLOBAL.
     method has-compile-time-value() {
-        self.is-resolved && self.resolution.has-compile-time-value
+        self.is-resolved
+          && self.resolution.has-compile-time-value
+          && (!$!name.is-pseudo-package
+               || $!name.is-package-search
+                    && !$!name.without-first-part.is-global-lookup)
     }
 
     # A name with a trailing :: is a stash reference: evaluating it produces
@@ -80,8 +86,16 @@ class RakuAST::Term::Name
 
     method IMPL-EXPR-QAST(RakuAST::IMPL::QASTContext $context) {
         if $!name.is-pseudo-package {
-            if self-is-resolved {
-                self.resolution.IMPL-LOOKUP-QAST($context);
+            if $!name.is-package-search && !$!name.is-indirect-lookup
+            && (my $stripped := $!name.without-first-part).is-global-lookup {
+                $stripped.IMPL-QAST-PACKAGE-LOOKUP($context, $!package);
+            }
+            elsif self.is-resolved && $!name.is-package-search
+            && !$!name.is-indirect-lookup {
+                my $lookup := self.resolution.IMPL-LOOKUP-QAST($context);
+                $!name.is-package-lookup
+                    ?? QAST::Op.new(:op<who>, $lookup)
+                    !! $lookup;
             }
             else {
                 $!name.IMPL-QAST-PSEUDO-PACKAGE-LOOKUP($context);

--- a/t/02-rakudo/indirect-package-trailing-empty.t
+++ b/t/02-rakudo/indirect-package-trailing-empty.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 5;
+plan 7;
 
 # A `$var::` designates the package that is the variable's value. The trailing
 # `::` is an empty final name part; it adds no lookup, so `$p::` is the package
@@ -23,5 +23,11 @@ is ::($n).^name, 'Int',
 module PkgTrailingEmpty { our $sym = 42 }
 is ::PkgTrailingEmpty::<$sym>, 42,
     'a leading :: qualified lookup still resolves';
+ok ::PkgTrailingEmpty === PkgTrailingEmpty,
+    'a leading :: package search designates the package';
+
+GLOBAL::<TrailingEmptyProbe> = 43;
+is ::GLOBAL::<TrailingEmptyProbe>, 43,
+    'a leading :: GLOBAL lookup sees the runtime GLOBAL';
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously the pseudo-package branch of Term::Name guarded on `self-is-resolved`, not `self.is-resolved`. That is an undeclared name which the bootstrap compiler for these files passes through as an always-false term, so the branch never ran and a resolved `::Foo` always took the runtime pseudo-stash lookup instead of its resolution.

The observable result is unchanged, since the runtime lookup finds the same symbol. This restores the intended compile-time path. It carries no test because the two paths differ only in generated code, not in output.