### PR TITLE
RakuAST: link the code for a signature literal in a WhateverCode

### DIFF
--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -809,6 +809,14 @@ class RakuAST::ExpressionThunk
                 if $anon-decl($node) {
                     nqp::push($stmts, $node.IMPL-QAST-DECL($context));
                 }
+                # A signature literal's block owns the compiled code its
+                # meta-object links as $!code; an enclosing statement scope
+                # emits that declaration itself but stops at this thunk's
+                # block boundary, so emit it here or the signature reaches
+                # runtime with no code to bind under.
+                if nqp::istype($node, RakuAST::FakeSignature) {
+                    nqp::push($stmts, $node.block.IMPL-QAST-DECL-CODE($context));
+                }
                 unless nqp::istype($node, RakuAST::LexicalScope) {
                     @code-todo.push($node);
                 }

--- a/t/12-rakuast/xx-fixed-in-rakuast.rakutest
+++ b/t/12-rakuast/xx-fixed-in-rakuast.rakutest
@@ -2,7 +2,7 @@ use Test;
 use lib <t/packages/Test-Helpers>;
 use Test::Helpers;
 
-plan 129;
+plan 131;
 
 # t/spec/S03-sequence/misc.t
 # https://github.com/rakudo/rakudo/issues/5520
@@ -936,6 +936,16 @@ subtest 'use of &?ROUTINE and &?BLOCK' => {
         'a custom postcircumfix parses an empty subscript';
     is-deeply ($decl ~ Q| 10⌊3⌋ |).AST.EVAL, 10 => [3],
         'a custom postcircumfix passes the operand as the first argument';
+}
+
+# src/Raku/ast/code.rakumod
+# A signature literal inside a WhateverCode reached runtime with no code
+# linked to it, so smart-matching against it died in the binder.
+{
+    is Q| (* ~~ :(Int))(\(42)) |.AST.EVAL, True,
+        'a plain signature literal inside a WhateverCode links its code';
+    is Q| (* ~~ :($ where { $^n > 0 }))(\(42)) |.AST.EVAL, True,
+        'a where-constrained signature literal inside a WhateverCode links its code';
 }
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
A signature literal produces a block, and the signature's meta-object links that block's compiled code as its $!code; the binder invokes under that code to run the bind and any where clause. An enclosing statement scope emits the block declaration itself but stops at a thunk's block boundary, so a signature literal primed into a WhateverCode reached runtime with no code to bind under, and smart-matching against it died in the binder. Emit the block declaration from the thunk that owns it.