### PR TITLE
RakuAST: upgrade a shadowed single-part package name to GLOBALish

### DIFF
--- a/src/Raku/ast/resolver.rakumod
+++ b/src/Raku/ast/resolver.rakumod
@@ -1271,6 +1271,34 @@ class RakuAST::Resolver::EVAL
         Nil
     }
 
+    # Resolves a name to the lexical constant it refers to in the
+    # enclosing scope: the innermost scope is not searched. This finds
+    # the declaration that a same-named declaration in the current
+    # scope shadows. The fallback chain matches resolve-lexical-constant
+    # below.
+    method resolve-shadowed-lexical-constant(Str $name) {
+        if $name eq 'GLOBAL' {
+            return self.global-package;
+        }
+        my @scopes := $!scopes;
+        my int $i  := nqp::elems(@scopes);
+        if $i > 1 {
+            $i := $i - 1;
+            while $i-- {
+                my $found := @scopes[$i].find-lexical($name);
+                if nqp::isconcrete($found) {
+                    return nqp::istype($found, RakuAST::CompileTimeValue) ?? $found !! Nil;
+                }
+            }
+        }
+        my $found := self.resolve-lexical-constant-in-outer($name);
+        return $found if nqp::isconcrete($found);
+        my $setting := nqp::getattr(self, RakuAST::Resolver, '$!setting');
+        nqp::isnull($setting) || !$setting
+          ?? Nil
+          !! self.IMPL-RESOLVE-LEXICAL-IN-SETTING($setting, $name)
+    }
+
     # Resolves a name to its lexical declaration if that declaration has a
     # compile-time value, otherwise Nil. A name bound to a non-constant
     # (e.g. `my \t := $runtime`) is not a compile-time constant, so the
@@ -1528,6 +1556,29 @@ class RakuAST::Resolver::Compile
         }
 
         self.resolve-lexical-in-outer($name)
+    }
+
+    # Resolves a name to the lexical constant it refers to in the
+    # enclosing scope: the innermost scope is not searched. This finds
+    # the declaration that a same-named declaration in the current
+    # scope shadows. The fallback matches resolve-lexical-constant
+    # below.
+    method resolve-shadowed-lexical-constant(Str $name) {
+        if $name eq 'GLOBAL' {
+            return self.global-package;
+        }
+        my @scopes := $!scopes;
+        my int $i  := nqp::elems(@scopes);
+        if $i > 1 {
+            $i := $i - 1;
+            while $i-- {
+                my $found := @scopes[$i].find-lexical($name);
+                if nqp::isconcrete($found) {
+                    return nqp::istype($found, RakuAST::CompileTimeValue) ?? $found !! Nil;
+                }
+            }
+        }
+        self.resolve-lexical-constant-in-outer($name)
     }
 
     # Resolves a name to its lexical declaration if that declaration has a

--- a/src/Raku/ast/scoping.rakumod
+++ b/src/Raku/ast/scoping.rakumod
@@ -1386,6 +1386,34 @@ class RakuAST::PackageInstaller {
                               && !$existing.HOW.is_composed($existing));
                 }
             }
+            # Upgrade what the name resolved to before this declaration
+            # to a top level GLOBALish entry, as the multi-part branch
+            # below does for a resolved leading part. `use` merges
+            # GLOBALish into the consumer, which is the only route there
+            # to a symbol nested under a unit-scoped module. The shadowed
+            # lookup skips the whole current scope; a pre-existing symbol
+            # here is an import's generated lexical, preferred first. No
+            # upgrade while compiling the setting, whose lexicals all
+            # resolve without it. This runs after the collision check
+            # above: when the current package is the global one, the
+            # upgrade writes the very stash that check reads, and the
+            # install below overwrites the entry either way.
+            my $setting := $resolver.setting;
+            if !nqp::isnull($setting) && $setting {
+                my $pre-existing := $generated && nqp::istype($generated, RakuAST::CompileTimeValue)
+                    ?? $generated
+                    !! $lexical;
+                if nqp::isconcrete($pre-existing) && nqp::istype($pre-existing, RakuAST::CompileTimeValue) {
+                    $pre-existing := $resolver.resolve-shadowed-lexical-constant($final)
+                        if nqp::eqaddr($pre-existing.compile-time-value, $type-object);
+                    if nqp::isconcrete($pre-existing)
+                        && !nqp::eqaddr($pre-existing.compile-time-value, $type-object) {
+                        self.IMPL-STASH-BIND(
+                          $resolver.get-global, $final, $pre-existing.compile-time-value
+                        );
+                    }
+                }
+            }
         }
         else {
             my @parts := nqp::clone(self.IMPL-UNWRAP-LIST($name.parts));

--- a/t/02-rakudo/enum-nested-in-same-name-package.t
+++ b/t/02-rakudo/enum-nested-in-same-name-package.t
@@ -1,0 +1,24 @@
+use lib <t/02-rakudo/test-packages>;
+use Test;
+
+plan 4;
+
+# A single-part package-ish declaration whose name is already lexically
+# visible upgrades that pre-existing symbol to a top level entry in the
+# compunit's GLOBALish. A `use` merges the module's GLOBALish into the
+# consumer lexically, so the upgrade is what lets a consumer reach
+# Gender::Gender when the module declares `enum Gender` inside
+# `package Gender` under `unit module`, as Intl::CLDR does. Without it
+# the consumer gets "Type 'Gender::Gender' is not declared".
+
+use EnumNestedInSameNamePackage;
+
+my Gender::Gender $g;
+ok $g === Gender::Gender,
+    'the nested enum type is reachable as Gender::Gender in the consumer';
+is Gender::Gender::neuter.Int, 0,
+    'an enum value is reachable through the fully qualified name';
+ok Gender::Gender =:= EnumNestedInSameNamePackage::Gender::Gender,
+    'the short name resolves to the same type as the fully qualified name';
+ok Gender =:= EnumNestedInSameNamePackage::Gender,
+    'the upgraded top level name is the package nested under the module';

--- a/t/02-rakudo/inherit-same-name-setting-package.t
+++ b/t/02-rakudo/inherit-same-name-setting-package.t
@@ -1,0 +1,24 @@
+use lib <t/02-rakudo/test-packages>;
+use Test;
+
+plan 4;
+
+# The parent module declares `unit package Unicode`, a name a setting
+# class already uses, with `class PRECIS` nested in it. The child module
+# uses the parent, declares the same `unit package Unicode`, and inherits
+# from the qualified Unicode::PRECIS name. Resolving that parent at
+# compile time needs the declared package to adopt the WHO the import
+# reached, which the GLOBALish upgrade provides. Unicode::PRECIS (and
+# MongoDB through it) failed with "'Unicode::PRECIS::Identifier' cannot
+# inherit from 'Unicode::PRECIS' because it is unknown".
+
+use Unicode::PRECIS::Identifier;
+
+ok Unicode::PRECIS::Identifier ~~ Unicode::PRECIS,
+    'the class declared inside the same-named unit package inherits the qualified parent';
+is Unicode::PRECIS::Identifier.new.tag, 'parent',
+    'a method from the inherited parent works on the child';
+is Unicode::PRECIS::Identifier.new.sub-tag, 'child',
+    'a method of the child itself works';
+ok Unicode::.keys.sort.join(',').contains('PRECIS'),
+    'the used package namespace carries the nested class';

--- a/t/02-rakudo/test-packages/EnumNestedInSameNamePackage.rakumod
+++ b/t/02-rakudo/test-packages/EnumNestedInSameNamePackage.rakumod
@@ -1,0 +1,8 @@
+unit module EnumNestedInSameNamePackage;
+
+package Gender {
+    enum Gender (
+        neuter    => 0,
+        masculine => 1,
+    )
+}

--- a/t/02-rakudo/test-packages/Unicode/PRECIS.rakumod
+++ b/t/02-rakudo/test-packages/Unicode/PRECIS.rakumod
@@ -1,0 +1,5 @@
+unit package Unicode;
+
+class PRECIS {
+    method tag() { 'parent' }
+}

--- a/t/02-rakudo/test-packages/Unicode/PRECIS/Identifier.rakumod
+++ b/t/02-rakudo/test-packages/Unicode/PRECIS/Identifier.rakumod
@@ -1,0 +1,7 @@
+use Unicode::PRECIS;
+
+unit package Unicode;
+
+class PRECIS::Identifier is Unicode::PRECIS {
+    method sub-tag() { 'child' }
+}


### PR DESCRIPTION
Previously only a multi-part package declaration upgraded a lexically resolved leading name part to a top level GLOBALish entry, so a single-part declaration whose name was already lexically visible left that symbol reachable only through its own scope. A package nested under a unit-scoped module is not in the compunit's GLOBALish at the top level, and GLOBALish is what a consumer's use merges in lexically, so a module declaring enum Gender inside package Gender compiled fine while its consumer failed with "Type 'Gender::Gender' is not declared". Intl::CLDR has exactly this shape in its Enums compunit.

This upgrades the pre-existing symbol of the same single-part name to a top level GLOBALish entry when installing a package declaration, matching install_package in the traditional grammar, which resolves the name with :upgrade_to_global before installing the new lexical. When the name resolves to the declaration being installed, the resolution is retried skipping the current scope so it finds the symbol the declaration shadows. The upgrade is skipped while compiling the setting, whose lexicals all resolve without it, matching find_single_symbol's early return before its upgrade path when no setting is loaded.