### PR TITLE
RakuAST: late-bind qualified sub calls through the package chain

### DIFF
--- a/src/Raku/ast/call.rakumod
+++ b/src/Raku/ast/call.rakumod
@@ -306,9 +306,15 @@ class RakuAST::Call::Name
 
     method PERFORM-BEGIN(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
         nqp::bindattr(self, RakuAST::Call::Name, '$!package', $resolver.current-package);
+        # A qualified callee is late-bound: the stash entry is a fresh
+        # closure clone after every mainline run, and binding it at
+        # compilation time would serialize a per-consumer copy of it and
+        # of the module state it closes over.
         my $resolved := $!name.is-identifier
             ?? $resolver.resolve-lexical('&' ~ $!name.canonicalize)
-            !! $resolver.resolve-name($!name, :sigil('&'));
+            !! $!name.is-multi-part && !$!name.is-pseudo-package
+                ?? Nil
+                !! $resolver.resolve-name($!name, :sigil('&'));
         if $resolved {
             self.set-resolution($resolved);
         }

--- a/t/02-rakudo/qualified-call-shared-module-state.t
+++ b/t/02-rakudo/qualified-call-shared-module-state.t
@@ -1,0 +1,18 @@
+use lib <t/02-rakudo/test-packages>;
+use Test;
+
+plan 2;
+
+# Qualified calls from two precompiled consumers must reach the same
+# routine and the same module state. Binding the callee at consumer
+# precompilation time serialized a private copy per consumer, which is
+# how Intl::CLDR's StrDecode string table read back empty.
+
+use QualifiedCallSetter;
+use QualifiedCallGetter;
+
+QualifiedCallSetter::set-it(42);
+is QualifiedCallGetter::get-it(), 42,
+    'module state set through one precompiled consumer is visible through another';
+is QualifiedCallSetter::whoami-via-call(), QualifiedCallGetter::whoami-via-call(),
+    'qualified calls from both consumers invoke the same routine instance';

--- a/t/02-rakudo/test-packages/QualifiedCallGetter.rakumod
+++ b/t/02-rakudo/test-packages/QualifiedCallGetter.rakumod
@@ -1,0 +1,5 @@
+unit module QualifiedCallGetter;
+use QualifiedCallState;
+
+our sub get-it()            { QualifiedCallState::get-state() }
+our sub whoami-via-call()   { QualifiedCallState::whoami()    }

--- a/t/02-rakudo/test-packages/QualifiedCallSetter.rakumod
+++ b/t/02-rakudo/test-packages/QualifiedCallSetter.rakumod
@@ -1,0 +1,5 @@
+unit module QualifiedCallSetter;
+use QualifiedCallState;
+
+our sub set-it($v)          { QualifiedCallState::set-state($v) }
+our sub whoami-via-call()   { QualifiedCallState::whoami()      }

--- a/t/02-rakudo/test-packages/QualifiedCallState.rakumod
+++ b/t/02-rakudo/test-packages/QualifiedCallState.rakumod
@@ -1,0 +1,6 @@
+unit module QualifiedCallState;
+
+my $state = 0;
+our sub set-state($v) { $state = $v }
+our sub get-state()   { $state      }
+our sub whoami()      { &?ROUTINE.WHERE }


### PR DESCRIPTION
Previously a call through a qualified name like Foo::bar() bound the callee at compilation time when the name resolved to a compile time value. A module's mainline rebinds its our-subs to fresh closure clones in the stash on every run, so the binding a consumer took during its own precompilation was to the clone made when the module loaded into the precompiling process. That clone belongs to no serialization context, so the consumer serialized a private copy of the routine and the lexical state it closes over. Two precompiled consumers of the same module then invoked different copies, and module state one consumer set through such a call was invisible to the other. Intl::CLDR hits this with its StrDecode string table, which one compunit fills and the reader compunits see as empty.

This resolves qualified call names only for pseudo-package forms and otherwise emits the runtime package chain lookup, matching the traditional grammar, which never binds a qualified call statically.