### PR TITLE
RakuAST: store an invokable attribute default as a value

### DIFF
--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -1208,6 +1208,11 @@ class RakuAST::VarDeclaration::Simple
                   && (my $expression := $initializer.expression).has-compile-time-value
                   && nqp::isconcrete($expression.maybe-compile-time-value)
                   && !nqp::istype($expression, RakuAST::Code)
+                  # BUILDALL calls an invokable build value with the object
+                  # and the attribute's value to compute the default, so a
+                  # default whose value is a code object takes the method
+                  # path below to be stored as a value.
+                  && !nqp::isinvokable($expression.maybe-compile-time-value)
                   # A heredoc's body is spliced in at the end of the line, after
                   # this attribute has begun. Reading its value now would capture
                   # the placeholder, so leave it to the method path, which compiles

--- a/t/02-rakudo/attr-default-code-value.t
+++ b/t/02-rakudo/attr-default-code-value.t
@@ -1,0 +1,45 @@
+use Test;
+
+plan 6;
+
+# BUILDALL calls an invokable build value to compute an attribute's
+# default, so a default expression whose compile-time value is a code
+# object must be stored as a value instead of being used as the build
+# directly. Humming-Bird declares `has @!advice = ( { $^a } );` and
+# construction died with "Too many positionals passed; expected 1
+# argument but got 2".
+
+my class ListOfBlock {
+    has @!advice = ( { $^a } );
+    method advice() { @!advice }
+}
+is ListOfBlock.new.advice.elems, 1,
+    'a list default holding a block constructs and keeps one element';
+is ListOfBlock.new.advice[0]('kept'), 'kept',
+    'the stored block is callable with its own arity';
+
+my class PublicListOfBlock {
+    has @.advice = ( { 42 } );
+}
+is PublicListOfBlock.new.advice[0](), 42,
+    'a public list attribute stores a zero-arity block as a value';
+
+my class ScalarSub {
+    has $!formatter = &uc;
+    method formatter() { $!formatter }
+}
+is ScalarSub.new.formatter.('abc'), 'ABC',
+    'a scalar default naming a setting sub stores the sub itself';
+
+my class BareBlock {
+    has $!cb = { $^x ~ '!' };
+    method cb() { $!cb }
+}
+is BareBlock.new.cb.('hi'), 'hi!',
+    'a bare block default still stores the block';
+
+my class PlainValue {
+    has $.n = 42;
+}
+is PlainValue.new.n, 42,
+    'a plain literal default still initializes directly';


### PR DESCRIPTION
Previously an attribute default whose compile-time value is a code object took the direct build path when the expression node itself was not a code node, so a block inside a parenthesized list, or a named routine like &uc, became the build value itself. BUILDALL calls an invokable build with the object and the attribute's value to compute the default, so construction died with "Too many positionals passed; expected 1 argument but got 2". Humming-Bird declares `has @!advice = ( { $^a } );` and every Router.new failed this way.

This routes any default with an invokable compile-time value through the initializer method path, whose generated method returns the code object as the attribute's value, as a bare block default already did.