### PR TITLE
Explicitly mention the existence of the gdb python plugin

### DIFF
--- a/tools/templates/moar/rakudo-debug-notice.in
+++ b/tools/templates/moar/rakudo-debug-notice.in
@@ -8,6 +8,8 @@ unless $*VM.config<ccdebugflags> { say "The currently used MoarVM backend is not
 say "This Rakudo version is $*RAKU.compiler.version() built on MoarVM version $*VM.version(),";
 say "running on $*DISTRO.gist() / $*KERNEL.gist()\n";
 
+say "For GDB, there is a python plugin included with MoarVM and installed next to libmoar.so that you may\nhave to add to gdbs auto-loading safe path or load explicitly with\n   source /path/to/libmoar.so-gdb.py\n";
+
 say "Type `bt full` to generate a backtrace if applicable, type `q` to quit or `help` for help.";
 
 say "-" x 96;

--- a/tools/templates/moar/rakudo-debug-notice.in
+++ b/tools/templates/moar/rakudo-debug-notice.in
@@ -8,7 +8,7 @@ unless $*VM.config<ccdebugflags> { say "The currently used MoarVM backend is not
 say "This Rakudo version is $*RAKU.compiler.version() built on MoarVM version $*VM.version(),";
 say "running on $*DISTRO.gist() / $*KERNEL.gist()\n";
 
-say "For GDB, there is a python plugin included with MoarVM and installed next to libmoar.so that you may\nhave to add to gdbs auto-loading safe path or load explicitly with\n   source /path/to/libmoar.so-gdb.py\n";
+say "For GDB, there is a python plugin included with MoarVM and installed next to libmoar.so that you may\nhave to add to gdb\x27s auto-loading safe path or load explicitly with\n   source /path/to/libmoar.so-gdb.py\n";
 
 say "Type `bt full` to generate a backtrace if applicable, type `q` to quit or `help` for help.";
 


### PR DESCRIPTION
I've put some work into making the plugin work better and be more useful, so it could be good to point out that you may need to do one more thing to actually be able to use it when running rakudo-gdb-m on something:

Python plugins are only automatically loaded by gdb if they live in a path configured as "safe". Manually loading it from its full path can always be done with the `source` command which is also mentioned in the message.