### PR TITLE
RakuAST: keep a traited variable reachable by name

### DIFF
--- a/src/Raku/ast/var-lowering.rakumod
+++ b/src/Raku/ast/var-lowering.rakumod
@@ -614,10 +614,12 @@ class RakuAST::IMPL::VarLowering {
         elsif nqp::isconcrete($decl.shape) {
             $declined := 'shaped';
         }
-        elsif self.IMPL-HAS-WILL-TRAIT($decl) {
-            # A will phaser looks its variable up by name in the calling
-            # frame at run time (Variable.willdo).
-            $declined := 'will';
+        elsif nqp::elems($decl.IMPL-UNWRAP-LIST($decl.traits)) {
+            # A variable trait applies through a Variable meta-object
+            # whose phaser helper looks the variable up by name in the
+            # calling frame at run time (Variable.willdo), and a custom
+            # trait_mod can do the same with any variable it is handed.
+            $declined := 'trait';
         }
         elsif $scope-index != nqp::elems($!frames) - 1 || $decl.creates-block {
             # The declaration is emitted under a thunk of its scope, so
@@ -759,13 +761,6 @@ class RakuAST::IMPL::VarLowering {
             }
         }
         Nil
-    }
-
-    method IMPL-HAS-WILL-TRAIT(Mu $decl) {
-        for $decl.IMPL-UNWRAP-LIST($decl.traits) {
-            return 1 if nqp::istype($_, RakuAST::Trait::Will);
-        }
-        0
     }
 
     # A resolved lookup whose resolution is a tracked declaration marks

--- a/t/02-rakudo/22-traited-variable-by-name.t
+++ b/t/02-rakudo/22-traited-variable-by-name.t
@@ -1,0 +1,44 @@
+use Test;
+
+plan 3;
+
+# A variable trait applies through a Variable meta-object whose phaser
+# helper (Variable.willdo) walks calling frames by name at run time, and
+# a custom trait_mod can hold on to the variable's name and do the same.
+# A traited declaration therefore must stay reachable as a by-name
+# lexical rather than be lowered to a frame-local.
+
+my constant loop-observed = class {};
+my constant sub-observed = class {};
+my @loop-seen;
+my @sub-seen;
+multi sub trait_mod:<does>(Variable:D $v, loop-observed) {
+    $v.block.add_phaser: 'LEAVE', $v.willdo: -> \var { @loop-seen.push(var) };
+}
+multi sub trait_mod:<does>(Variable:D $v, sub-observed) {
+    $v.block.add_phaser: 'LEAVE', $v.willdo: -> \var { @sub-seen.push(var) };
+}
+
+sub loop-traited() {
+    for 1..3 {
+        my $fh does loop-observed = $_ * 10;
+    }
+}
+loop-traited();
+is-deeply @loop-seen, [10, 20, 30],
+    'the LEAVE phaser of each loop iteration receives that iteration value';
+
+sub sub-traited() {
+    my $fh does sub-observed = 42;
+}
+sub-traited();
+is-deeply @sub-seen, [42],
+    'a LEAVE phaser added by a custom does trait receives the traited variable';
+
+my @will-seen;
+sub will-traited() {
+    my $x will leave { @will-seen.push($_) } = 66;
+}
+will-traited();
+is-deeply @will-seen, [66],
+    'a will leave phaser receives its variable';


### PR DESCRIPTION
Previously the lexical-to-local lowering declined a declaration with a will trait, whose phaser looks its variable up by name in the calling frame at run time (Variable.willdo), but still lowered a declaration carrying any other variable trait. A custom trait_mod receives the same Variable meta-object and can capture the variable name and walk calling frames the same way. Trait::IO does exactly that in the LEAVE phaser its auto-close trait installs: under lowering the walk found only the lowered-away sentinel at the declaring frame, stepped past it, and died with "ctxcaller needs an MVMContext" after running out of callers.

This declines lowering for a declaration carrying any variable trait, matching the legacy frontend, which marks every late-traited variable as implicitly used.