### PR TITLE
RakuAST: report a public attribute call's own thunks

### DIFF
--- a/src/Raku/ast/variable-access.rakumod
+++ b/src/Raku/ast/variable-access.rakumod
@@ -436,7 +436,10 @@ class RakuAST::Var::Attribute::Public
     }
 
     method creates-block() {
-        $!expression.creates-block;
+        # Thunks wrap around this node itself, not the expression it
+        # delegates its compilation to, so both must be consulted.
+        nqp::findmethod(RakuAST::Expression, 'creates-block')(self)
+            || $!expression.creates-block
     }
 
     method PERFORM-CHECK(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {

--- a/t/02-rakudo/23-self-call-loop-modifier.t
+++ b/t/02-rakudo/23-self-call-loop-modifier.t
@@ -1,0 +1,25 @@
+use Test;
+
+plan 2;
+
+# A $.meth(...) call parses into a wrapper node that delegates its
+# compilation to an inner self.meth(...).item chain. A for statement
+# modifier thunks the wrapper itself, so a lexical used as an argument
+# crosses a frame boundary that the wrapper must report, or the lexical
+# gets lowered to a frame-local the thunk cannot reach.
+
+my class Collector {
+    has @.seen;
+    method add($value, $extra) { @!seen.push($value + $extra) }
+    method create() {
+        my $base = 10;
+        $.add($base, $_) for 1, 2;
+        $base
+    }
+}
+
+my $c = Collector.new;
+is $c.create, 10,
+    'the method returns its lexical after the modifier loop';
+is-deeply $c.seen, [11, 12],
+    'each iteration passed the lexical to the self-call';


### PR DESCRIPTION
Previously RakuAST::Var::Attribute::Public answered creates-block from the self.foo.item expression it delegates its compilation to, but a thunk wraps around the node itself, such as the thunk a for statement modifier adds. The node therefore reported no frame where emission would create one, and the lexical-to-local lowering treated every use inside the statement as same-frame. In Pop::Entities the statement $.add: $guid, $_ for @components lowered $guid that way, and compilation died with "Cannot reference undeclared local $__lowered_guid_2" when the thunk referenced it.

This consults the node's own thunks as well as the delegated expression's.