### PR TITLE
RakuAST: carry a dynamic regex's capture closures in its own frame

### DIFF
--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -278,6 +278,10 @@ class RakuAST::Node {
                         # would re-emit them referencing locals of the
                         # frame it flattened into.
                     }
+                    elsif nqp::istype($node, RakuAST::RegexThunk) && $node.IMPL-DECLS-PLACED-INLINE {
+                        # Its declaration already lives in the containing
+                        # regex's own block.
+                    }
                     else {
                         my $code := $node.IMPL-QAST-DECL-CODE($context);
                         $stmts.push($code);

--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -3478,6 +3478,39 @@ class RakuAST::RegexThunk
   is RakuAST::Meta
   is RakuAST::BeginTime
 {
+    has int $!decls-placed-inline;
+
+    method IMPL-PLACE-DECLS-INLINE() {
+        nqp::bindattr_i(self, RakuAST::RegexThunk, '$!decls-placed-inline', 1);
+        Nil
+    }
+    method IMPL-DECLS-PLACED-INLINE() { $!decls-placed-inline }
+
+    # Gather the regex-thunk declarations of this regex's subtree so the
+    # regex carries them in its own frame. A dynamically compiled regex
+    # serializes as a value, and a declaration left to an enclosing frame
+    # is only ever bound in the compile-time frame instance, which does
+    # not survive precompilation.
+    method IMPL-NESTED-REGEX-THUNK-DECLS(RakuAST::IMPL::QASTContext $context) {
+        my $stmts := QAST::Stmts.new;
+        my @todo := [self];
+        while @todo {
+            my $visit := @todo.shift;
+            $visit.visit-children: -> $node {
+                if nqp::istype($node, RakuAST::RegexThunk) {
+                    $node.IMPL-PLACE-DECLS-INLINE();
+                    $stmts.push($node.IMPL-QAST-DECL-CODE($context));
+                }
+                elsif nqp::istype($node, RakuAST::Code) {
+                    # A plain code block keeps its usual placement.
+                }
+                else {
+                    nqp::push(@todo, $node);
+                }
+            }
+        }
+        $stmts
+    }
 
     method PRODUCE-META-OBJECT(:$resolver, :$context) {
         # Create default signature, receiving invocant only.
@@ -3500,6 +3533,9 @@ class RakuAST::RegexThunk
             RakuAST::Expression :$expression) {
         my $slash := RakuAST::VarDeclaration::Implicit::Special.new(:name('$/'));
         my $thunk := self.IMPL-THUNKED-REGEX-QAST($context); # must be before nested blocks
+        my $nested-decls := $*IMPL-COMPILE-DYNAMICALLY
+            ?? self.IMPL-NESTED-REGEX-THUNK-DECLS($context)
+            !! QAST::Stmts.new;
         QAST::Block.new(
             :blocktype('declaration_static'),
             QAST::Var.new( :decl('var'), :scope('local'), :name('self') ),
@@ -3524,6 +3560,7 @@ class RakuAST::RegexThunk
                     )
                 )
             ),
+            $nested-decls,
             $thunk
         )
     }

--- a/src/Raku/ast/regex.rakumod
+++ b/src/Raku/ast/regex.rakumod
@@ -530,10 +530,17 @@ class RakuAST::Regex::CapturingGroup
         # quantified.
         my $block := self.IMPL-QAST-FORM-BLOCK($context, :blocktype('declaration_static'));
         self.IMPL-LINK-META-OBJECT($context, $block);
+        my $decl := self.IMPL-UNWRAP-LIST(self.get-implicit-declarations())[0];
         QAST::Stmts.new(
             $block,
-            self.IMPL-UNWRAP-LIST(self.get-implicit-declarations())[0].IMPL-BIND-QAST($context,
-                self.IMPL-CLOSURE-QAST($context) ),
+            self.IMPL-DECLS-PLACED-INLINE
+                # Placed in the containing regex's block, whose frame does
+                # not carry the implicit declaration, so declare here.
+                ?? QAST::Op.new(
+                     :op('bind'),
+                     QAST::Var.new( :decl('var'), :scope('lexical'), :name($decl.name) ),
+                     self.IMPL-CLOSURE-QAST($context))
+                !! $decl.IMPL-BIND-QAST($context, self.IMPL-CLOSURE-QAST($context)),
         )
     }
 

--- a/t/02-rakudo/begin-regex-precomp.t
+++ b/t/02-rakudo/begin-regex-precomp.t
@@ -1,0 +1,16 @@
+use lib <t/02-rakudo/test-packages>;
+use Test;
+use BeginTimeRegex;
+
+plan 3;
+
+# Loading the module precompiles it, so these BEGIN-created regexes come
+# back through serialization and must still reach their capture-group
+# and code-block closures at match time.
+
+is BeginTimeRegex::parse-capture('abc-12'), 'abc|12',
+    'the capture groups of a precompiled BEGIN regex match';
+is BeginTimeRegex::parse-make('x'), 'made:x',
+    'a code block of a precompiled BEGIN regex runs and makes';
+is BeginTimeRegex::parse-nested('ab'), 'ab|b',
+    'a nested capture group of a precompiled BEGIN regex matches';

--- a/t/02-rakudo/test-packages/BeginTimeRegex.rakumod
+++ b/t/02-rakudo/test-packages/BeginTimeRegex.rakumod
@@ -1,0 +1,20 @@
+unit module BeginTimeRegex;
+
+# A regex created at BEGIN time reaches the precompilation as a
+# serialized value, so everything it invokes at match time must live in
+# its own frame; a compile-time frame instance does not survive.
+
+my $capture-rx = BEGIN / (\w+) '-' (\d+) /;
+our sub parse-capture($s) {
+    $s ~~ $capture-rx ?? "$0|$1" !! "no-match"
+}
+
+my $block-rx = BEGIN / (\w) { make "made:" ~ $/ } /;
+our sub parse-make($s) {
+    $block-rx.ACCEPTS($s).made
+}
+
+my $nested-rx = BEGIN / ( a (b) ) /;
+our sub parse-nested($s) {
+    $s ~~ $nested-rx ?? "$0|$0[0]" !! "no-match"
+}


### PR DESCRIPTION
Previously the block a capture group or regex-argument assertion compiles to was declared in the frame enclosing the regex, with its closure bound into a lexical there that the regex looks up through its outer chain at match time. A regex compiled at BEGIN time serializes into a precompilation as a value though, and its enclosing frame is a compile-time frame instance whose lexical bindings do not survive. The deserialized regex found a null where its capture closure should be and matching died with "lang-call cannot invoke object of type 'VMNull'". Uni63's BEGIN-constructed encoding regexes failed that way whenever the module loaded from precompilation.

Under dynamic compilation a regex thunk now gathers the regex-thunk declarations of its subtree into its own block, so a serialized regex value is self-contained. The nested-declaration walk skips a thunk placed that way, and an inline-placed capture group declares its lexical itself since the implicit declaration belongs to the enclosing scope. An ordinary regex keeps the enclosing-frame placement and its saving of a closure clone per regex entry.