### PR TITLE
RakuAST: anchor a qualified our-declaration at its leading package

### DIFF
--- a/src/Raku/ast/name.rakumod
+++ b/src/Raku/ast/name.rakumod
@@ -344,7 +344,7 @@ class RakuAST::Name
         $result
     }
 
-    method IMPL-QAST-PACKAGE-LOOKUP(RakuAST::IMPL::QASTContext $context, Mu $start-package, RakuAST::Declaration :$lexical, str :$sigil, str :$twigil, Bool :$global-fallback) {
+    method IMPL-QAST-PACKAGE-LOOKUP(RakuAST::IMPL::QASTContext $context, Mu $start-package, RakuAST::Declaration :$lexical, str :$sigil, str :$twigil, Bool :$global-fallback, Bool :$global-root) {
         my $result;
         my $final := $!parts[nqp::elems($!parts) - 1];
         my int $first;
@@ -357,6 +357,11 @@ class RakuAST::Name
                 unless $lexical.lexical-name eq $!parts[0].name;
             $first := 1;
             $result := $lexical.IMPL-LOOKUP-QAST($context);
+        }
+        elsif $global-root {
+            # Walk every part starting from the merged run-time GLOBAL
+            # rather than a package fixed at compile time.
+            $result := QAST::Op.new(:op<getcurhllsym>, QAST::SVal.new(:value<GLOBAL>));
         }
         else {
             $result := QAST::WVal.new(:value($start-package));

--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -705,6 +705,11 @@ class RakuAST::VarDeclaration::Simple
     has Mu $!container-initializer;
     has Mu $!package;
 
+    # For a qualified name, the resolution of its leading package when
+    # one is lexically visible; the name then anchors there rather than
+    # at GLOBAL.
+    has RakuAST::Declaration $!qualified-root;
+
     # Set by the optimize pass on a plain array declaration initialized from
     # a comma list, for lowering to a direct build of the list internals.
     has int $!lowered-array-init;
@@ -1105,6 +1110,17 @@ class RakuAST::VarDeclaration::Simple
             # There is always a package, even if it's just GLOBALish
             nqp::bindattr(self, RakuAST::VarDeclaration::Simple, '$!package',
                 $package);
+            if $!desigilname.is-multi-part
+                && !nqp::istype($!desigilname.root-part, RakuAST::Name::Part::Empty) {
+                # A qualified name anchors at its leading package: the
+                # lexically visible one when there is one, GLOBAL
+                # otherwise, never the package of the enclosing scope.
+                my $rooted := $resolver.resolve-name(
+                    RakuAST::Name.new($!desigilname.root-part));
+                nqp::bindattr(self, RakuAST::VarDeclaration::Simple,
+                    '$!qualified-root', $rooted)
+                    if $rooted;
+            }
         }
         nqp::bindattr(self, RakuAST::VarDeclaration::Simple, '$!generics-package',
             $resolver.find-attach-target('generics-pad'));
@@ -1665,7 +1681,16 @@ class RakuAST::VarDeclaration::Simple
             # both, as self.name and the meta-object installation use. Without
             # the twigil the lookup would miss the slot and global-fallback would
             # vivify an orphan under the twigil-less name.
-            my $lookup := $!desigilname.IMPL-QAST-PACKAGE-LOOKUP($context, $!package, :sigil($!sigil), :twigil(self.twigil), :global-fallback);
+            my $lookup := $!desigilname.is-multi-part
+                ?? nqp::isconcrete($!qualified-root)
+                    ?? $!desigilname.IMPL-QAST-PACKAGE-LOOKUP($context, $!package,
+                        :lexical($!qualified-root), :sigil($!sigil),
+                        :twigil(self.twigil), :global-fallback)
+                    !! $!desigilname.IMPL-QAST-PACKAGE-LOOKUP($context, $!package,
+                        :global-root, :sigil($!sigil),
+                        :twigil(self.twigil), :global-fallback)
+                !! $!desigilname.IMPL-QAST-PACKAGE-LOOKUP($context, $!package,
+                    :sigil($!sigil), :twigil(self.twigil), :global-fallback);
             $lookup.name('VIVIFY-KEY');
             QAST::Op.new(
               :op('bind'),

--- a/t/02-rakudo/24-qualified-our-anchor.t
+++ b/t/02-rakudo/24-qualified-our-anchor.t
@@ -1,0 +1,29 @@
+use lib <t/02-rakudo/test-packages>;
+use Test;
+use QualifiedOurAnchor;
+
+plan 6;
+
+# A qualified our-scoped declaration anchors at its leading package:
+# the lexically visible one when there is one, GLOBAL otherwise, never
+# the package of the enclosing scope.
+
+class C { our $Foo::Bar::x = 42; our &Foo::Bar::f = sub { "hi" } }
+
+is $Foo::Bar::x, 42,
+    'a qualified our variable declared in a class body anchors at GLOBAL';
+is Foo::Bar::f(), 'hi',
+    'a qualified our sub declared in a class body anchors at GLOBAL';
+
+my class M { }
+class C2 { our $M::z = 3 }
+is $M::z, 3,
+    'a qualified our variable anchors at a lexically visible package';
+ok M::.EXISTS-KEY('$z'),
+    'the lexically visible package stash holds the variable';
+
+is $QOA::Target::flag, False,
+    'a qualified our variable from a used module is visible';
+QOA::Target::set-flag();
+is $QOA::Target::flag, True,
+    'a qualified our sub from a used module updates the shared variable';

--- a/t/02-rakudo/test-packages/QualifiedOurAnchor.rakumod
+++ b/t/02-rakudo/test-packages/QualifiedOurAnchor.rakumod
@@ -1,0 +1,10 @@
+unit class QualifiedOurAnchor;
+
+# Qualified our-scoped declarations anchor at their leading package,
+# not at this class, so a user of this module reaches them through
+# the merged GLOBAL.
+
+our $QOA::Target::flag = False;
+our &QOA::Target::set-flag = sub () {
+    $QOA::Target::flag = True;
+}


### PR DESCRIPTION
Previously the package slot for a declaration like our $Foo::Bar::x was vivified by walking from the package of the enclosing scope, so inside a class body the symbols ended up nested under that class, while references to the name resolve their leading package lexically and fall back to GLOBAL. Gnome::N declares our &Gnome::N::debug from inside another class that way, and calling Gnome::N::debug() died with "Could not find symbol '&debug'".

This resolves the leading package at BEGIN time the way a reference does and roots the run-time vivification at that resolution, or at the merged run-time GLOBAL when nothing lexical matches.