### PR TITLE
RakuAST: install lowered array init after its operands evaluate

### DIFF
--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -1037,9 +1037,13 @@ class RakuAST::Node {
         1
     }
 
-    # The lowered initialization of a plain array from a comma list: bind a
-    # fresh reification buffer and a reifier whose future is the elements,
-    # then reify, the same layout the STORE method builds through dispatch.
+    # The lowered initialization of a plain array from a comma list: fill a
+    # fresh reification buffer from a reifier whose future is the elements,
+    # then install the buffer and reifier, the same layout and order the
+    # STORE method builds through dispatch. The order matters for the
+    # assignment form: an operand may read the target (@a = |@a, 1), so
+    # nothing binds into the variable until the eager part of the
+    # reification has run.
     # Null when the QAST is not the expected variable and core comma call
     # shape, or when an operand cannot compile in both guard branches, and
     # the caller then keeps the STORE call. A fallback, when given, guards
@@ -1062,58 +1066,97 @@ class RakuAST::Node {
         my $Reifier := nqp::atkey(nqp::who(List), 'Reifier');
         my $future := QAST::Op.new( :op<list> );
         $future.set_children(@($comma-qast));
+        my $buf    := QAST::Node.unique('array_init_buf');
+        my $old    := QAST::Node.unique('array_init_old');
+        my $target := QAST::Node.unique('array_init_target');
+        my $todo   := QAST::Node.unique('array_init_todo');
         my $init := QAST::Stmts.new(
             QAST::Op.new(
-                :op<callmethod>, :name('reify-until-lazy'),
+                :op<bind>,
+                QAST::Var.new(:name($buf), :scope<local>, :decl<var>),
+                QAST::Op.new(:op<create>,
+                    QAST::WVal.new(:value(IterationBuffer))),
+            ),
+            # The reification target wraps whatever buffer the variable
+            # holds, so the fresh buffer goes in just to mint it and the
+            # old one comes right back.
+            QAST::Op.new(
+                :op<bind>,
+                QAST::Var.new(:name($old), :scope<local>, :decl<var>),
                 QAST::Op.new(
                     :op<getattr>,
+                    $var-qast,
+                    QAST::WVal.new(:value(List)),
+                    QAST::SVal.new(:value('$!reified')),
+                ),
+            ),
+            QAST::Op.new(
+                :op<bindattr>,
+                $var-qast,
+                QAST::WVal.new(:value(List)),
+                QAST::SVal.new(:value('$!reified')),
+                QAST::Var.new(:name($buf), :scope<local>),
+            ),
+            QAST::Op.new(
+                :op<bind>,
+                QAST::Var.new(:name($target), :scope<local>, :decl<var>),
+                QAST::Op.new(
+                    :op<callmethod>, :name('reification-target'),
+                    $var-qast,
+                ),
+            ),
+            QAST::Op.new(
+                :op<bindattr>,
+                $var-qast,
+                QAST::WVal.new(:value(List)),
+                QAST::SVal.new(:value('$!reified')),
+                QAST::Var.new(:name($old), :scope<local>),
+            ),
+            # The operands evaluate here, inside the future list, and the
+            # eager part of the reification runs right after, both against
+            # the variable's old content.
+            QAST::Op.new(
+                :op<bind>,
+                QAST::Var.new(:name($todo), :scope<local>, :decl<var>),
+                QAST::Op.new(
+                    :op<p6bindattrinvres>,
                     QAST::Op.new(
                         :op<p6bindattrinvres>,
                         QAST::Op.new(
                             :op<p6bindattrinvres>,
-                            $var-qast,
-                            QAST::WVal.new(:value(List)),
-                            QAST::SVal.new(:value('$!reified')),
                             QAST::Op.new(:op<create>,
-                                QAST::WVal.new(:value(IterationBuffer))),
-                        ),
-                        QAST::WVal.new(:value(List)),
-                        QAST::SVal.new(:value('$!todo')),
-                        QAST::Op.new(
-                            :op<p6bindattrinvres>,
-                            QAST::Op.new(
-                                :op<p6bindattrinvres>,
-                                QAST::Op.new(
-                                    :op<p6bindattrinvres>,
-                                    QAST::Op.new(:op<create>,
-                                        QAST::WVal.new(:value($Reifier))),
-                                    QAST::WVal.new(:value($Reifier)),
-                                    QAST::SVal.new(:value('$!reified')),
-                                    QAST::Op.new(
-                                        :op<getattr>,
-                                        $var-qast,
-                                        QAST::WVal.new(:value(List)),
-                                        QAST::SVal.new(:value('$!reified')),
-                                    )
-                                ),
-                                QAST::WVal.new(:value($Reifier)),
-                                QAST::SVal.new(:value('$!reification-target')),
-                                QAST::Op.new(
-                                    :op<callmethod>,
-                                    :name('reification-target'),
-                                    $var-qast,
-                                )
-                            ),
+                                QAST::WVal.new(:value($Reifier))),
                             QAST::WVal.new(:value($Reifier)),
-                            QAST::SVal.new(:value('$!future')),
-                            $future,
+                            QAST::SVal.new(:value('$!reified')),
+                            QAST::Var.new(:name($buf), :scope<local>),
                         ),
+                        QAST::WVal.new(:value($Reifier)),
+                        QAST::SVal.new(:value('$!reification-target')),
+                        QAST::Var.new(:name($target), :scope<local>),
                     ),
-                    QAST::WVal.new(:value(List)),
-                    QAST::SVal.new(:value('$!todo')),
+                    QAST::WVal.new(:value($Reifier)),
+                    QAST::SVal.new(:value('$!future')),
+                    $future,
                 ),
             ),
-            $var-qast
+            QAST::Op.new(
+                :op<callmethod>, :name('reify-until-lazy'),
+                QAST::Var.new(:name($todo), :scope<local>),
+            ),
+            QAST::Op.new(
+                :op<bindattr>,
+                $var-qast,
+                QAST::WVal.new(:value(List)),
+                QAST::SVal.new(:value('$!todo')),
+                QAST::Var.new(:name($todo), :scope<local>),
+            ),
+            QAST::Op.new(
+                :op<p6bindattrinvres>,
+                $var-qast,
+                QAST::WVal.new(:value(List)),
+                QAST::SVal.new(:value('$!reified')),
+                QAST::Var.new(:name($buf), :scope<local>),
+            ),
         );
         $init.nosink(1);
         if nqp::isconcrete($fallback) {

--- a/t/08-performance/23-rakuast-array-init.t
+++ b/t/08-performance/23-rakuast-array-init.t
@@ -3,7 +3,7 @@ use Test::Helpers::QAST;
 use Test;
 use QAST:from<NQP>;
 use nqp;
-plan 23;
+plan 27;
 
 # Initializing a plain array from a comma list builds the list internals
 # directly and reifies, skipping the STORE dispatch. A typed, shaped, or
@@ -82,6 +82,31 @@ qast-is 'my @a = 1..3', -> \v {
     my @a is default(7) = 1, 2;
     @a[5] = 9;
     is @a[3], 7, 'a default trait still applies through STORE';
+}
+
+# The lowered build installs nothing into the variable until the eager
+# part of the reification has run, so an operand that reads the target
+# sees its old content, as it does through STORE.
+{
+    my @a = 1, 2;
+    @a = |@a, 3;
+    is @a.join(','), '1,2,3', 'a slip of the target appends to its old content';
+}
+{
+    my @a = 1, 2;
+    @a = @a[1], @a[0];
+    is @a.join(','), '2,1', 'indexing the target reads its old content';
+}
+{
+    my @a = 1, 2;
+    my sub f() { @a[0] + 10 }
+    @a = f(), 3;
+    is @a.join(','), '11,3', 'a call reading the target sees its old content';
+}
+{
+    my @a = 1, 2;
+    @a = (gather take @a[0]).Slip, 5;
+    is @a.join(','), '1,5', 'an eager gather reading the target sees its old content';
 }
 
 # The lowering replicates the stock Array STORE, but a bind can put any


### PR DESCRIPTION
Previously the lowered initialization of a plain array from a comma list bound the fresh reification buffer into the variable before the operand expressions evaluated and reified. For the declaration form that order cannot be observed, but the assignment form covers an operand that reads the target, and @a = |@a, 3 slipped the already-emptied array.

This makes the lowered build follow the STORE method's order: fill the detached buffer from the operands while the variable still holds its old content, then install the buffer and reifier. The reification target wraps whatever buffer the variable holds, so the fresh buffer is swapped in just to mint it and the old one put right back.