### PR TITLE
RakuAST: implement =begin/end ignore

### DIFF
--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -4455,6 +4455,13 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
         }
     }
 
+    method doc-block:sym<ignore-block>($/) {
+        unless $*FROM-SEEN{$/.from}++ {
+            self.doc-origin: $/, Nodify('Doc::Block').from-paragraphs:
+              :margin(~$<margin>), :type<ignore>, :paragraphs([~$<ignored>]);
+        }
+    }
+
     method doc-block:sym<begin>($/) {
         unless $*FROM-SEEN{$/.from}++ {
             if ~$<level> -> $level {

--- a/src/Raku/Grammar.nqp
+++ b/src/Raku/Grammar.nqp
@@ -5797,6 +5797,16 @@ Rakudo significantly on *every* run."
         ^^ \h* '=finish' $<level>=\d* <doc-newline> $<finish> = .*
     }
 
+    # handle =begin ignore
+    token doc-block:sym<ignore-block> {
+
+        ^^ $<margin>=[ \h* ] '=begin' \h+ ignore <.doc-newline>
+
+        $<ignored>=[ [ <.ignore-block>+ | .  ]*? ]
+
+        [ ^^ \h* '=end' \h+ ignore <.doc-newline> | $ ]
+    }
+
     # handle =alias
     token doc-block:sym<alias> {
         :my $width;


### PR DESCRIPTION
As discussed in https://github.com/Raku/RakuDoc-v2/issues/103, implemented with a little help by thoughtstream!

In short: anything between `=begin ignore` and the nearest `=end ignore` will be ignored by rakudoc parsing.  This allows for a quick way to "comment out" parts of a RakuDoc document (or Raku program, for that matter) without needing valid RakuDoc inbetween.