### PR TITLE
RakuAST: put "use if" functionality in core

### DIFF
--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -1008,7 +1008,11 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
                     my @cp   := $module-name.IMPL-UNWRAP-LIST($colonpairs);
                     my $last := @cp.pop;
                     if $last.key eq 'if' {
-                        my $value := $last.value.literalize;
+                        my $value := Nodify(
+                          "BeginTime"
+                        ).IMPL-BEGIN-TIME-EVALUATE(
+                          $last.value, $*R, $*CU.context
+                        );
                         if nqp::isconcrete($value) {
 
                             # Module should be loaded

--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -1000,16 +1000,44 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
 
         # proper module loading
         else {
-            my $LANG := $*LANG;
-            $ast := Nodify('Statement::Use').new(
-              :module-name($<module-name>.ast), :$argument
-            );
+            my $LANG        := $*LANG;
+            my $module-name := $<module-name>.ast;
+
+            if $LANG.pragma("if") {
+                if $module-name.colonpairs -> $colonpairs {
+                    my @cp   := $module-name.IMPL-UNWRAP-LIST($colonpairs);
+                    my $last := @cp.pop;
+                    if $last.key eq 'if' {
+                        my $value := $last.value.literalize;
+                        if nqp::isconcrete($value) {
+
+                            # Module should be loaded
+                            if $value {
+                                # make sure the :if adverb disappears
+                                $module-name.set-colonpairs(@cp);
+                            }
+
+                            # Not to be loaded, so make it an empty statement
+                            else {
+                                self.attach: $/, Nodify('Statement::Empty').new;
+                                return;
+                            }
+                        }
+                        else {
+                            $/.panic("Did not provide compile-time-value for :if adverb in use statement");
+                        }
+                    }
+                }
+            }
+
+            $ast := Nodify('Statement::Use').new(:$module-name, :$argument);
             self.SET-NODE-ORIGIN($/, $ast); # Ensure we have line numbers for errors
             $ast.ensure-begin-performed($*R, $*CU.context);
             for $ast.IMPL-UNWRAP-LIST($ast.categoricals) {
                 $/.add-categorical(
                   $_.category, $_.opname, $_.canname, $_.subname, $_.declarand, :current-scope);
             }
+
             for $ast.superseded-declarators {
                 my $pdecl := $_.key;
                 my $meta := $_.value;

--- a/src/Raku/ast/pragma.rakumod
+++ b/src/Raku/ast/pragma.rakumod
@@ -33,6 +33,7 @@ class RakuAST::Pragma
           'attributes',         0,
           'dynamic-scope',      0,
           'fatal',              0,
+          'if',                 1,
           'internals',          1,
           'invocant',           0,
           'isms',               0,


### PR DESCRIPTION
The "if" module https://raku.land/zef:raku-community-modules/if is not really easily portable to RakuAST.  But it *is* quite easy to implement the functionality into RakuAST.  Which is what this commit does:

1. make "if" a pragma
2. in the module loading action, check if the "if" pragma is set
3. if so, check if there are any adverbs
4. if there are, check if the last one is "if"
5. if it is, check if there is a compile time value
6. if there is, and the value is truish, remove that adverb and continue as if nothing has happend
7. if the value is not trueish, codegen an empty statement
8. if there is no compile time value, panic

This leaves the question on what to do if an ":if" adverb is specified, and the "if" pragma is not: currently all unknown adverbs are ignored.  OTOH, *always* checking for adverbs also feel icky from a performance point of view.

With this change, the "if" module can become a no-op for RakuAST.

  use if;
  use Test:if(1);
  ok 1;   # works

  use if;
  use Test:if(0);
  ok 1;   # compilation error, "ok" not known