### PR TITLE
Refactor error X::Syntax::InfixInTermPosition

### DIFF
--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -2596,7 +2596,7 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
             );
             $ast := nqp::existskey(PODNAMES,$name)
               ?? Nodify('Var::Doc').new(nqp::substr($name,2))
-              !! nqp::die("Pod variable $name NYI");
+              !! nqp::die("RakuDoc variable $name NYI");
         }
         elsif $twigil eq '~' {
             my $name := $desigilname.canonicalize;

--- a/src/core.c/Exception.rakumod
+++ b/src/core.c/Exception.rakumod
@@ -2412,15 +2412,36 @@ my class X::Syntax::Extension::SpecialForm does X::Syntax {
 my class X::Syntax::InfixInTermPosition does X::Syntax {
     has $.infix;
     method message() {
-        my $infix := $!infix.trim;
-        my $type  := Raku.legacy ?? 'Pod' !! 'RakuDoc';
-        "Preceding context expects a term, but found infix $infix instead."
-        ~ (
-            $.post && $.post.starts-with('end ')
-                ?? "\nDid you forget '=begin $.post.substr(4)' $type marker?"
-                !! "\nDid you make a mistake in $type syntax?"
-            if $infix eq '='
-        )
+        my $post := $.post // "";
+
+        # Looks like a rakudoc error
+        if $!infix eq '='
+          && $post.contains(/^ [ begin | end | for <!before \w> ] /) {
+            my   $type := Raku.legacy ?? 'Pod' !! 'RakuDoc';
+            my str $tag = $post.starts-with('end ')
+              ?? "a '=begin $post.substr(4)'"
+              !! $post.starts-with('begin ')
+                ?? "an '=end $post.substr(6)'"
+                !! "";
+
+            my str @parts = "An error in $type syntax is suspected.";
+            @parts.push($tag
+              ?? "Perhaps $tag marker was forgotten or was improperly nested?"
+              !! "Perhaps the name on a '=for' marker was forgotten?"
+            );
+            @parts.push(
+              "Or such a marker was absorbed by an unclosed '=begin ignore' marker?"
+            ) if $type eq 'RakuDoc' && $post.starts-with('begin ');
+            @parts.push(
+              "Alternately, an infix '=' was seen where a term was expected."
+            );
+            @parts.join(" ").naive-word-wrapper
+        }
+
+        # Probably not a rakudoc error
+        else {
+            "Preceding context expects a term, but found infix $!infix.trim() instead."
+        }
     }
 }
 

--- a/src/core.c/Exception.rakumod
+++ b/src/core.c/Exception.rakumod
@@ -2413,11 +2413,12 @@ my class X::Syntax::InfixInTermPosition does X::Syntax {
     has $.infix;
     method message() {
         my $infix := $!infix.trim;
+        my $type  := Raku.legacy ?? 'Pod' !! 'RakuDoc';
         "Preceding context expects a term, but found infix $infix instead."
         ~ (
             $.post && $.post.starts-with('end ')
-                ?? "\nDid you forget '=begin $.post.substr(4)' Pod marker?"
-                !! "\nDid you make a mistake in Pod syntax?"
+                ?? "\nDid you forget '=begin $.post.substr(4)' $type marker?"
+                !! "\nDid you make a mistake in $type syntax?"
             if $infix eq '='
         )
     }

--- a/t/05-messages/02-errors.t
+++ b/t/05-messages/02-errors.t
@@ -78,12 +78,14 @@ is-run ｢my %h = <a 1 b 2>; enum Bits (%h)｣, :err{
 
 # https://github.com/Raku/old-issue-tracker/issues/4285
 {
-    is-run ｢=end MEOWS｣, :err{ /«Pod»/ && .contains: '=begin MEOWS' },
-        :exitcode(*),
-        'error with `=end FOO` suggests Pod mistake and offers `=begin FOO`';
+    my $type := Raku.legacy ?? 'Pod' !! 'RakuDoc';
 
-    is-run ｢=for｣, :err(/«Pod»/), :exitcode(*),
-        'error for `=for` suggests it might be a Pod mistake';
+    is-run ｢=end MEOWS｣, :err{ .contains($type) && .contains('=begin MEOWS') },
+        :exitcode(*),
+        'error with `=end MEOWS` suggests mistake and offers `=begin MEOWS`';
+
+    is-run ｢=for｣, :err{ .contains($type) }, :exitcode(*),
+        'error for `=for` suggests it might be a mistake';
 }
 
 # https://github.com/Raku/old-issue-tracker/issues/4392


### PR DESCRIPTION
This error is most often called if there is an error in Pod/RakuDoc
syntax.  So make those types of cases much more elaborate, and
mention the fact that a term was expected as a last option.
    
So a "=begin FOO" without "=end FOO" will now (in RakUAST) be reported as:
```    
An error in RakuDoc syntax is suspected. Perhaps an '=end FOO' marker
was forgotten or was improperly nested? Or such a marker was absorbed by
an unclosed '=begin ignore' marker? Alternately, an infix '=' was seen
where a term was expected.
```
Also some tests needed to be adapted to still be passing in RakuAST.