### PR TITLE
Make coercions check subset refinements on every value

### DIFF
--- a/src/vm/moar/dispatchers.nqp
+++ b/src/vm/moar/dispatchers.nqp
@@ -4554,6 +4554,32 @@ my $coerce-via-container := nqp::getstaticcode(-> $coercion, $value {
     nqp::dispatch('raku-coercion', $coercion, nqp::decont($value))
 });
 
+# Perform the full coercion protocol on every call
+my $coerce-value-checked := nqp::getstaticcode(-> $coercion, $value {
+    nqp::istype($value, nqp::how_nd($coercion).target_type($coercion))
+      ?? $value
+      !! nqp::how_nd($coercion)."!coerce_TargetType"($coercion, $value)
+});
+
+# Whether a type check against this type inspects the value itself rather
+# than just its type, as a subset refinement does. Such a check must be
+# repeated on every call, since dispatch program guards only cover the
+# type and concreteness of the value.
+sub type-check-is-value-dependent($type) {
+    my $HOW := nqp::how_nd($type);
+    while $HOW.archetypes($type).nominalizable {
+        my $subset := $HOW.wrappee-lookup($type, :subset);
+        return 0 if nqp::isnull($subset);
+
+        my $subsetHOW := nqp::how_nd($subset);
+        return 1 if nqp::isconcrete($subsetHOW.refinement($subset));
+
+        $type := $subsetHOW.refinee($subset);
+        $HOW  := nqp::how_nd($type);
+    }
+    0
+}
+
 # Return a list with coercer, method object and nominal target for the
 # given coercion object, value and optional force :with-runtime flag
 sub select-coercer($coercion, $value, :$with-runtime = 0) {
@@ -4742,6 +4768,17 @@ nqp::register('raku-coercion', -> $capture {
     my $constraint    := $coercionHOW.constraint_type($coercion);
     my $constraintHOW := $constraint.HOW;
 
+    # Helper sub to delegate to the per-call coercion code
+    my sub value-checked-fallback() {
+        nqp::delegate('boot-code-constant',
+          nqp::syscall('dispatcher-insert-arg-literal-obj',
+            nqp::syscall('dispatcher-replace-arg-literal-obj',
+              $capture, 0, $coercion
+            ), 0, $coerce-value-checked
+          )
+        );
+    }
+
     # If despite our efforts the value is still a container then try
     # deconting it first and then re-dispatch.
     if nqp::iscont($value) {
@@ -4754,34 +4791,51 @@ nqp::register('raku-coercion', -> $capture {
         );
     }
 
-    # Just matches, use identity.
+    # Just matches, use identity when the match is decided by the type alone.
     elsif nqp::istype_nd($value, $target_type) {
-        nqp::delegate('boot-value',
-          nqp::syscall('dispatcher-drop-arg', $capture, 0)
-        );
+        if type-check-is-value-dependent($target_type) {
+            value-checked-fallback();
+        }
+        else {
+            nqp::delegate('boot-value',
+              nqp::syscall('dispatcher-drop-arg', $capture, 0)
+            );
+        }
     }
 
     # The value doesn't match constraint type, throw by calling the MOP
-    # error throwing method
+    # error throwing method, unless the mismatch is decided by the value
+    # rather than its type.
     elsif !nqp::eqaddr($constraint, Mu)
       && !nqp::istype_nd($value, $constraint) {
-        nqp::delegate('raku-meth-call',
-          nqp::syscall('dispatcher-insert-arg-literal-obj',
-            nqp::syscall('dispatcher-insert-arg-literal-str',
+        if type-check-is-value-dependent($constraint) {
+            value-checked-fallback();
+        }
+        else {
+            nqp::delegate('raku-meth-call',
               nqp::syscall('dispatcher-insert-arg-literal-obj',
-                nqp::syscall('dispatcher-drop-arg',
-                  $capture, 0
+                nqp::syscall('dispatcher-insert-arg-literal-str',
+                  nqp::syscall('dispatcher-insert-arg-literal-obj',
+                    nqp::syscall('dispatcher-drop-arg',
+                      $capture, 0
+                    ), 0, $coercionHOW
+                  ), 0, '!invalid_type'
                 ), 0, $coercionHOW
-              ), 0, '!invalid_type'
-            ), 0, $coercionHOW
-          )
-        );
+              )
+            );
+        }
     }
 
     # The constraint type is a coercion on its own. This is not a
     # dispatchable case. Fallback to the metamodel method.
     elsif $constraintHOW.archetypes($constraint).coercive {
         runtime-fallback();
+    }
+
+    # A constraint that inspects the value must be rechecked on every
+    # call, which the coercers selected below do not do.
+    elsif type-check-is-value-dependent($constraint) {
+        value-checked-fallback();
     }
 
     # Try finding one of the coercion methods.

--- a/t/02-rakudo/coercion-subset-value-check.t
+++ b/t/02-rakudo/coercion-subset-value-check.t
@@ -1,0 +1,60 @@
+use Test;
+
+plan 19;
+
+# A coercion involving a subset must run the subset's refinement on every
+# value. The dispatch program recorded for a coercion only guards on the
+# type and concreteness of the value, so the fate of an earlier value of
+# the same type must not decide the fate of later ones. The order of the
+# assertions below is what exercises this: accepted values are followed by
+# rejected values of the same type, and the other way around.
+
+subset Even of UInt where * %% 2;
+
+is Even(56), 56, 'a value satisfying the subset coerces to itself';
+throws-like { Even(-3) }, X::Coerce::Impossible,
+    'a value failing the refinement is rejected after one was accepted';
+is Even(58), 58, 'a value satisfying the subset is accepted after one was rejected';
+
+is-deeply
+    (56, -3, 58).map({ (try Even($_)) // 'rejected' }).List,
+    (56, 'rejected', 58),
+    'a single call site accepts and rejects by value, not by type';
+
+is UInt(5), 5, 'a natural number coerces to UInt';
+throws-like { UInt(-3) }, X::Coerce::Impossible,
+    'a negative Int is rejected by UInt after a natural number was accepted';
+
+is Even("56"), 56, 'a Str holding an even number coerces into the subset';
+throws-like { Even("57") }, X::Coerce::Impossible,
+    'a Str holding an odd number is rejected after an even one was accepted';
+is Even("58"), 58, 'a Str holding an even number is accepted after an odd one was rejected';
+
+sub with-subset-target(Even() $x) { $x }
+is with-subset-target(4), 4, 'a parameter coercing to a subset accepts a satisfying value';
+throws-like { with-subset-target(-3) }, X::Coerce::Impossible,
+    'a parameter coercing to a subset rejects a failing value after accepting one';
+is with-subset-target(8), 8,
+    'a parameter coercing to a subset accepts a satisfying value after rejecting one';
+
+sub with-subset-constraint(Str(Even) $x) { $x }
+is with-subset-constraint(4), "4", 'a subset constraint on a coercion accepts a satisfying value';
+dies-ok { with-subset-constraint(-3) },
+    'a subset constraint on a coercion rejects a failing value after accepting one';
+is with-subset-constraint(6), "6",
+    'a subset constraint on a coercion accepts a satisfying value after rejecting one';
+
+subset DoubleEven of Even;
+is DoubleEven(56), 56, 'a subset of a refined subset accepts a satisfying value';
+throws-like { DoubleEven(-3) }, X::Coerce::Impossible,
+    'a subset of a refined subset rejects a failing value after accepting one';
+
+class NoCoercer { }
+subset AnyNoCoercer of NoCoercer where { True };
+my $instance = NoCoercer.new;
+ok AnyNoCoercer($instance) === $instance,
+    'a matching value with no coercion method passes through unchanged';
+ok AnyNoCoercer($instance) === $instance,
+    'a matching value with no coercion method still passes through on a repeated call';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
The raku-coercion dispatcher chose between identity, a constraint mismatch error, and coercer selection while recording a dispatch program whose guards only cover the type and concreteness of the value. A subset target or constraint checks the value itself, so whichever outcome the recorded value produced was replayed for every later value of the same type. Previously

    subset Even of UInt where * %% 2;
    say Even(56) + Even(-3);

printed 53, and a successful UInt(56) let a later UInt(-3) through unchecked anywhere in the program, since all such coercions share one dispatch site in the raku-invoke coercion path.

This makes the dispatcher detect types whose type check inspects the value and delegates those cases to code that repeats the full coercion protocol on every call. Purely nominal coercions keep their existing dispatch programs.

Fixes https://github.com/rakudo/rakudo/issues/5965