### PR TITLE
RakuAST: sink when/default bodies whose succeed payload is unused

### DIFF
--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -1624,7 +1624,9 @@ class RakuAST::Block
     }
 
     method propagate-sink(Bool $is-sunk) {
-        $!body.apply-sink($is-sunk && !self.needs-result);
+        my $body-sunk := $is-sunk && !self.needs-result;
+        self.set-nil-on-succeed() if $body-sunk;
+        $!body.apply-sink($body-sunk);
     }
 
     method PRODUCE-IMPLICIT-DECLARATIONS() {
@@ -1929,7 +1931,9 @@ class RakuAST::PointyBlock
     method bare-block() { False }
 
     method propagate-sink(Bool $is-sunk) {
-        self.body.apply-sink($is-sunk && !self.needs-result);
+        my $body-sunk := $is-sunk && !self.needs-result;
+        self.set-nil-on-succeed() if $body-sunk;
+        self.body.apply-sink($body-sunk);
         $!signature.apply-sink(True);
     }
 

--- a/src/Raku/ast/scoping.rakumod
+++ b/src/Raku/ast/scoping.rakumod
@@ -291,13 +291,18 @@ class RakuAST::LexicalScope
         Nil
     }
 
-    # A QUIT phaser reports whether it handled the exception by what it
-    # returns: Nil after a when/default succeeds, the exception otherwise.
-    # Its block's succeed handler therefore produces Nil, with the payload
-    # sunk, rather than the payload a succeed normally evaluates to.
+    # Marks this scope as having no use for its succeed payload, either
+    # because the scope's own outcome is sunk or because it must produce
+    # Nil, as a QUIT phaser does to report the exception handled. The
+    # succeed handler then sinks the payload and produces Nil instead of
+    # evaluating to it, and when/default compile their bodies as sunk.
     method set-nil-on-succeed() {
         nqp::bindattr_i(self, RakuAST::LexicalScope, '$!nil-on-succeed', 1);
         Nil
+    }
+
+    method nil-on-succeed() {
+        $!nil-on-succeed ?? True !! False
     }
 
     method attach-catch-handler(RakuAST::Statement::Catch $catch) {

--- a/src/Raku/ast/sink.rakumod
+++ b/src/Raku/ast/sink.rakumod
@@ -10,6 +10,8 @@ class RakuAST::SinkBoundary
     # Calculates the sink for this bounded unit.
     method calculate-sink() {
         unless $!sink-calculated {
+            self.set-nil-on-succeed()
+                if self.is-boundary-sunk() && nqp::istype(self, RakuAST::LexicalScope);
             self.get-boundary-sink-propagator().propagate-sink(self.is-boundary-sunk(), :has-block-parent);
             nqp::bindattr_i(self, RakuAST::SinkBoundary, '$!sink-calculated', 1);
         }

--- a/src/Raku/ast/statements.rakumod
+++ b/src/Raku/ast/statements.rakumod
@@ -1950,6 +1950,7 @@ class RakuAST::Statement::When
 {
     has RakuAST::Expression $.condition;
     has RakuAST::Block $.body;
+    has RakuAST::LexicalScope $!succeed-scope;
 
     method new(RakuAST::Expression :$condition!, RakuAST::Block :$body!, List :$labels) {
         my $obj := nqp::create(self);
@@ -1965,7 +1966,10 @@ class RakuAST::Statement::When
 
     method propagate-sink(Bool $is-sunk) {
         $!condition.apply-sink(False);
-        $!body.apply-sink(False); # Used as enclosing block outcome
+        # The body's value is the succeed payload, so it is only sunk when
+        # the scope taking that payload discards it.
+        $!body.apply-sink(nqp::isconcrete($!succeed-scope)
+            && $!succeed-scope.nil-on-succeed);
     }
 
     method PERFORM-BEGIN(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
@@ -1973,6 +1977,7 @@ class RakuAST::Statement::When
             $resolver.find-attach-target('compunit');
         if $block {
             $block.require-succeed-handler();
+            nqp::bindattr(self, RakuAST::Statement::When, '$!succeed-scope', $block);
         }
         else {
             nqp::die('when found no enclosing block to attach to');
@@ -2125,6 +2130,7 @@ class RakuAST::Statement::Default
   is RakuAST::BeginTime
 {
     has RakuAST::Block $.body;
+    has RakuAST::LexicalScope $!succeed-scope;
 
     method new(RakuAST::Block :$body!, List :$labels) {
         my $obj := nqp::create(self);
@@ -2138,7 +2144,10 @@ class RakuAST::Statement::Default
     }
 
     method propagate-sink(Bool $is-sunk) {
-        $!body.apply-sink(False); # Used as enclosing block outcome
+        # The body's value is the succeed payload, so it is only sunk when
+        # the scope taking that payload discards it.
+        $!body.apply-sink(nqp::isconcrete($!succeed-scope)
+            && $!succeed-scope.nil-on-succeed);
     }
 
     method PERFORM-BEGIN(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
@@ -2146,6 +2155,7 @@ class RakuAST::Statement::Default
             $resolver.find-attach-target('compunit');
         if $block {
             $block.require-succeed-handler();
+            nqp::bindattr(self, RakuAST::Statement::Default, '$!succeed-scope', $block);
         }
         else {
             nqp::die('default found no enclosing block to attach to');

--- a/t/05-messages/10-warnings.t
+++ b/t/05-messages/10-warnings.t
@@ -3,7 +3,7 @@ use nqp;
 use Test;
 use Test::Helpers;
 
-plan 17;
+plan 18;
 
 subtest 'Supply.interval with negative value warns' => {
     plan 2;
@@ -130,5 +130,11 @@ is-run ｢package Foo::Bar { class Foo::Bar {} }; print "ran"｣,
 is-run ｢use fatal; package Foo::Bar { class Foo::Bar {} }; print "ran"｣,
     'use fatal promotes the same-named enclosing package worry to an error',
     :err(/'inside an enclosing package of the same name'/), :exitcode(1);
+
+# https://github.com/rakudo/rakudo/issues/6074
+is-run ｢print do given 5 { when 5 { 42; 43 } }｣,
+    'the last statement of a when block in value position stays wanted',
+    :out<43>,
+    :err{ .contains('constant integer 42') && !.contains('constant integer 43') };
 
 # vim: expandtab shiftwidth=4

--- a/t/12-rakuast/xx-fixed-in-rakuast.rakutest
+++ b/t/12-rakuast/xx-fixed-in-rakuast.rakutest
@@ -2,7 +2,7 @@ use Test;
 use lib <t/packages/Test-Helpers>;
 use Test::Helpers;
 
-plan 130;
+plan 131;
 
 # t/spec/S03-sequence/misc.t
 # https://github.com/rakudo/rakudo/issues/5520
@@ -932,6 +932,18 @@ subtest 'use of &?ROUTINE and &?BLOCK' => {
         'a plain signature literal inside a WhateverCode links its code';
     is Q| (* ~~ :($ where { $^n > 0 }))(\(42)) |.AST.EVAL, True,
         'a where-constrained signature literal inside a WhateverCode links its code';
+}
+
+# https://github.com/rakudo/rakudo/issues/6074
+# A when/default body was always compiled as wanted for being the succeed
+# payload, so the last statement of a CATCH handler escaped the useless-use
+# warning its earlier statements produced. The body is now sunk when the
+# scope taking the payload discards it.
+{
+    is-run ｢Q| sub f { CATCH { default { 42; 43 } }; die 'nope' }; print f.raku |.AST.EVAL｣,
+        :out<Nil>, :err(/'Useless use of constant integer 42'
+            .*? 'Useless use of constant integer 43'/),
+        'the last statement of a CATCH default block also warns as useless';
 }
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously the body of a when or default statement was always compiled as wanted, since its value escapes as the succeed payload and normally becomes the outcome of the block the statement attaches to. That left the last statement of a CATCH or CONTROL handler unwarned even though handlers discard their result, so `CATCH { default { 42; 43 } }` warned about 42 but stayed silent about 43.

The nil-on-succeed flag already marks a scope whose succeed handler sinks the payload and produces Nil, which QUIT phasers set explicitly. This sets it on any scope whose own outcome is discarded: blocks that fully sink their bodies, and sunk sink boundaries such as routines returning Nil and non-EVAL mainlines. when and default now remember the scope they attach to and fully sink their bodies when that scope has no use for the payload, so the trailing statement warns in sink context and gets the usual runtime sink treatment.

Fixes #6074