### PR TITLE
RakuAST: extend lexical lowering to anonymous variables and BEGIN-compiled routines

### DIFF
--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -181,6 +181,11 @@ class RakuAST::Code
         my $precomp;
         my $compiler-thunk := {
             my $*IMPL-COMPILE-DYNAMICALLY := 1;
+            # This emission caches the QAST block before the unit's
+            # optimize phase has decided which lexicals become locals,
+            # and the unit's own emission reuses the cache. Decide for
+            # this code object now so both compilations agree.
+            RakuAST::IMPL::VarLowering.analyze-routine(self, $resolver);
             my $block := self.IMPL-QAST-BLOCK($context, :blocktype<declaration_static>);
             $precomp := self.IMPL-COMPILE-DYNAMICALLY($resolver, $context, $block);
         };

--- a/src/Raku/ast/var-lowering.rakumod
+++ b/src/Raku/ast/var-lowering.rakumod
@@ -129,12 +129,9 @@ class RakuAST::IMPL::VarLowering {
     has int $!debug;
     has int $!begin-context;
     has int $!topic-not-dynamic;
+    has int $!declarations-only;
 
-    method analyze-compunit(RakuAST::CompUnit $compunit, RakuAST::Resolver $resolver, :$interactive?) {
-        # Escape hatch while the lowering is young: skip the analysis
-        # entirely, leaving every lexical emitted by name.
-        return Nil if nqp::atkey(nqp::getenvhash(), 'RAKUDO_NO_LEX2LOCAL');
-
+    method IMPL-MAKE-ANALYZER(RakuAST::Resolver $resolver) {
         my $analyzer := nqp::create(self);
         nqp::bindattr($analyzer, RakuAST::IMPL::VarLowering, '$!frames', []);
         nqp::bindattr_i($analyzer, RakuAST::IMPL::VarLowering, '$!debug',
@@ -156,6 +153,30 @@ class RakuAST::IMPL::VarLowering {
         $sentinel := $found.compile-time-value
             if nqp::isconcrete($found) && nqp::can($found, 'compile-time-value');
         nqp::bindattr($analyzer, RakuAST::IMPL::VarLowering, '$!sentinel', $sentinel);
+        $analyzer
+    }
+
+    # Scoped analysis for one code object compiled ahead of the unit's
+    # optimize phase for BEGIN-time use: its QAST is emitted and cached
+    # right away, so the unit-wide analysis comes too late to affect it.
+    method analyze-routine(RakuAST::Code $routine, RakuAST::Resolver $resolver) {
+        return Nil if nqp::atkey(nqp::getenvhash(), 'RAKUDO_NO_LEX2LOCAL');
+        my $analyzer := self.IMPL-MAKE-ANALYZER($resolver);
+        # Only declarations: the flatten and unused-implicit rewrites
+        # change block shapes in ways the dynamic compilation's by-name
+        # fixup is not prepared for.
+        nqp::bindattr_i($analyzer, RakuAST::IMPL::VarLowering,
+            '$!declarations-only', 1);
+        $analyzer.IMPL-WALK($routine);
+        Nil
+    }
+
+    method analyze-compunit(RakuAST::CompUnit $compunit, RakuAST::Resolver $resolver, :$interactive?) {
+        # Escape hatch while the lowering is young: skip the analysis
+        # entirely, leaving every lexical emitted by name.
+        return Nil if nqp::atkey(nqp::getenvhash(), 'RAKUDO_NO_LEX2LOCAL');
+
+        my $analyzer := self.IMPL-MAKE-ANALYZER($resolver);
 
         # The mainline Block is an empty shell for the mainline code
         # object; the compilation unit's statements live in the statement
@@ -435,7 +456,9 @@ class RakuAST::IMPL::VarLowering {
             self.IMPL-DECIDE($frame);
             my int $flattened;
             if $frame.is-flatten-candidate {
-                my int $approved := self.IMPL-FLATTEN-VERDICT($frame);
+                my int $approved := $!declarations-only
+                    ?? 0
+                    !! self.IMPL-FLATTEN-VERDICT($frame);
                 $flattened := $approved;
                 if $approved {
                     $frame.node.IMPL-SET-FLATTEN-APPROVED();
@@ -461,7 +484,8 @@ class RakuAST::IMPL::VarLowering {
                         !! self.IMPL-MARK-CAPTURED-ID($id);
                 }
             }
-            self.IMPL-DECIDE-IMPLICITS($frame) unless $flattened;
+            self.IMPL-DECIDE-IMPLICITS($frame)
+                unless $flattened || $!declarations-only;
         }
         Nil
     }

--- a/src/Raku/ast/var-lowering.rakumod
+++ b/src/Raku/ast/var-lowering.rakumod
@@ -571,9 +571,6 @@ class RakuAST::IMPL::VarLowering {
     # the declaration alone.
     method IMPL-REGISTER-DECL(RakuAST::VarDeclaration::Simple $decl, str $alias-id?) {
         return Nil unless $decl.scope eq 'my';
-        # An anonymous declaration has no name to look up, and nothing to
-        # gain from this analysis until lowering handles it directly.
-        return Nil if nqp::istype($decl, RakuAST::VarDeclaration::Anonymous);
 
         my int $i := nqp::elems($!frames);
         my $scope-frame;
@@ -607,8 +604,13 @@ class RakuAST::IMPL::VarLowering {
             # call ops, so a `&`-sigiled lexical must keep its symbol.
             $declined := 'callable';
         }
-        elsif !nqp::iscclass(nqp::const::CCLASS_ALPHABETIC,
+        elsif !nqp::istype($decl, RakuAST::VarDeclaration::Anonymous)
+            && !nqp::iscclass(nqp::const::CCLASS_ALPHABETIC,
                 $decl.desigilname.canonicalize, 0) {
+            # This keeps punctuation variables such as $/ addressable
+            # by name. An anonymous variable reports an empty
+            # desigilname, but nothing can look one up, so it is
+            # exempt.
             $declined := 'name';
         }
         elsif nqp::isconcrete($decl.shape) {

--- a/t/02-rakudo/rakuast-anon-container-freshness.t
+++ b/t/02-rakudo/rakuast-anon-container-freshness.t
@@ -1,0 +1,83 @@
+use v6;
+use nqp;
+use Test;
+
+plan 3;
+
+# An anonymous container declaration must yield a fresh object on every
+# call. When the declaration stays a clone-vivified lexical, the MoarVM
+# spesh inliner vivifies it once per caller frame instead of once per
+# call, so a hot loop starts receiving the same object every iteration.
+# Lowering the declaration to a local avoids that shape. These loops run
+# long enough for specialization and inlining to have happened.
+
+sub read-ident(Str $source --> Str) { 'id' }
+
+sub parse-group(Str $source, $pos is rw --> Array) {
+    my @nodes;
+    while $pos < $source.chars {
+        my $char = $source.substr($pos, 1);
+        if $char eq ':' {
+            $pos = $source.chars;
+            @nodes.push: { type => 'param', name => read-ident($source) };
+        }
+        else {
+            @nodes.push: { type => 'literal', text => $char };
+            $pos++;
+        }
+    }
+    @nodes
+}
+
+my $literal-divergence = -1;
+for 1..2000 -> $i {
+    my $pos = 0;
+    my @ast = parse-group('/widgets/:id', $pos);
+    my $literals = @ast.grep({ .<type> eq 'literal' }).map({ .<text> }).join;
+    unless $literals eq '/widgets/' {
+        $literal-divergence = $i;
+        last;
+    }
+}
+is $literal-divergence, -1,
+    'a hash composer in a hot loop keeps per-iteration literal values';
+
+my $identity-divergence = -1;
+for 1..2000 -> $i {
+    my $pos = 0;
+    my @ast = parse-group('/widgets/:id', $pos);
+    my @wheres = @ast.grep({ .<type> eq 'literal' }).map({ .WHERE });
+    unless @wheres.unique.elems == @wheres.elems {
+        $identity-divergence = $i;
+        last;
+    }
+}
+is $identity-divergence, -1,
+    'a hash composer in a hot loop allocates a distinct hash per iteration';
+
+sub begin-used-composer(*@elems) { my % = @elems }
+BEGIN begin-used-composer('warm', 1);
+
+sub collect-three($i) {
+    my @seen;
+    for ^3 -> $j {
+        @seen.push: begin-used-composer('n', $i + $j);
+    }
+    @seen
+}
+
+my $begin-divergence = -1;
+for 1..2000 -> $i {
+    my @seen = collect-three($i);
+    unless @seen.map({ .WHERE }).unique.elems == 3 {
+        $begin-divergence = $i;
+        last;
+    }
+}
+# The legacy frontend compiles a BEGIN-invoked sub dynamically with the
+# optimizer skipped, so its anonymous hash stays a clone-vivified lexical
+# and the spesh inliner serves the same object to every loop iteration.
+todo 'BEGIN-compiled routines keep unlowered containers under the legacy frontend'
+    unless nqp::gethllsym('Raku', 'COMPILER-FRONTEND') eq 'rakuast';
+is $begin-divergence, -1,
+    'a BEGIN-invoked sub returns a fresh anonymous hash per call in a hot loop';


### PR DESCRIPTION
Previously two kinds of declarations never went through the lex2local analysis. Anonymous declarations such as the `my % = @elems` in `circumfix:<{ }>` were skipped entirely, and any routine invoked at BEGIN time was compiled and cached before the analysis ran, so nothing inside it was lowered either. In both cases the container declaration is emitted as a clone vivified lexical, i.e. the fresh copy each invocation observes comes from lazy vivification rather than from instructions in the frame body.

That shape is mishandled by the MoarVM spesh inliner. Vivification caches the clone in the frame environment, and once the callee is inlined that environment belongs to the caller, so a hot loop calling such a routine starts receiving the same object on every iteration instead of a fresh one per call:

```raku
sub composer(*@elems) { my % = @elems }
BEGIN composer(0);
sub collect($i) { my @seen; @seen.push(composer($i + $_)) for ^3; @seen }
# once collect gets hot enough for composer to be inlined,
# all three elements of @seen are the same hash
```

This is what blin flagged for CSS::Grammar (every node of a built AST aliased to the last one) and MVC::Keayl (every literal node of a route pattern was the same hash, so `/widgets` rendered as `ssssssss`). The legacy frontend avoids the shape for ordinary code because its optimizer lowers these declarations to explicitly cloned locals. However its BEGIN-compiled routines skip the optimizer and are reachable the same way, the example above aliases on released rakudo with the legacy frontend as well, so the underlying inliner behavior likely warrants a MoarVM issue of its own.

This lowers anonymous declarations (they have no lookup path at all, as such they are the safest candidates) and has the BEGIN-time compiler thunk run a scoped, declarations-only pass over the code object before its QAST is emitted and cached. make test passes on both frontends. The included test covers both shapes, with the BEGIN case marked todo on the legacy frontend.
