### PR TITLE
Remove return constraints from CompUnit::Repos

### DIFF
--- a/src/core.c/CompUnit/Repository/AbsolutePath.rakumod
+++ b/src/core.c/CompUnit/Repository/AbsolutePath.rakumod
@@ -10,7 +10,7 @@ class CompUnit::Repository::AbsolutePath does CompUnit::Repository {
     method need(CompUnit::Repository::AbsolutePath:D:
       CompUnit::DependencySpecification $spec,
       CompUnit::PrecompilationRepository $precomp = self.precomp-repository()
-    --> CompUnit:D) {
+    ) {
         (my $repo := self.next-repo)
           ?? $repo.need($spec, $precomp)
           !! X::CompUnit::UnsatisfiedDependency.new(:specification($spec)).throw

--- a/src/core.c/CompUnit/Repository/FileSystem.rakumod
+++ b/src/core.c/CompUnit/Repository/FileSystem.rakumod
@@ -95,9 +95,7 @@ class CompUnit::Repository::FileSystem
         CompUnit::DependencySpecification $spec,
         CompUnit::PrecompilationRepository $precomp = self.precomp-repository(),
         CompUnit::PrecompilationStore :@precomp-stores = self!precomp-stores(),
-
-        --> CompUnit:D)
-    {
+    ) {
         my $spec-key = ~$spec;
         my $spec-promise;
         my $loaded-cu;

--- a/src/core.c/CompUnit/Repository/Installation.rakumod
+++ b/src/core.c/CompUnit/Repository/Installation.rakumod
@@ -658,8 +658,7 @@ class CompUnit::Repository::Installation does CompUnit::Repository::Locally does
         CompUnit::DependencySpecification $spec,
         CompUnit::PrecompilationRepository $precomp = self.precomp-repository(),
         CompUnit::PrecompilationStore :@precomp-stores = self!precomp-stores(),
-        --> CompUnit:D)
-    {
+    ) {
 
         # found a distribution for this spec
         if self!matching-dist($spec) -> $distribution {

--- a/src/core.c/CompUnit/Repository/NQP.rakumod
+++ b/src/core.c/CompUnit/Repository/NQP.rakumod
@@ -4,7 +4,7 @@ class CompUnit::Repository::NQP does CompUnit::Repository {
     method need(CompUnit::Repository::NQP:D:
       CompUnit::DependencySpecification $spec,
       CompUnit::PrecompilationRepository $precomp?,
-    --> CompUnit:D) {
+    ) {
         if $spec.from eq 'NQP' {
             my $key := $spec.short-name;
             CompUnit.new:

--- a/src/core.c/CompUnit/Repository/Perl5.rakumod
+++ b/src/core.c/CompUnit/Repository/Perl5.rakumod
@@ -5,7 +5,7 @@ class CompUnit::Repository::Perl5 does CompUnit::Repository {
     method need(CompUnit::Repository::Perl5:D:
       CompUnit::DependencySpecification $spec,
       CompUnit::PrecompilationRepository $precomp?,
-    --> CompUnit:D) {
+    ) {
         if $spec.from eq 'Perl5' {
             CATCH {
                 when X::CompUnit::UnsatisfiedDependency {

--- a/src/core.c/CompUnit/Repository/Unknown.rakumod
+++ b/src/core.c/CompUnit/Repository/Unknown.rakumod
@@ -8,8 +8,7 @@ class CompUnit::Repository::Unknown does CompUnit::Repository {
         CompUnit::PrecompilationStore :@precomp-stores = Array[CompUnit::PrecompilationStore].new(
             self.repo-chain.map(*.precomp-store).grep(*.defined)
         ),
-        --> CompUnit:D)
-    {
+    ) {
         return $precomp
             ?? self.next-repo.need($spec, $precomp, :@precomp-stores)
             !! self.next-repo.need($spec, :@precomp-stores)


### PR DESCRIPTION
If a `require ::($foo)` failed, then the initial execution error would trigger additional execution errors if .resume was called on it.  One for each recursion level in $*REPO.

  my $s; require ::("Foo"); CATCH { ++$s; .resume }; say $s;  # 9

This commit reduces that to 2.  Not sure yet where the last additional execution error is coming from.