### PR TITLE
Make explicitly-manage return the managed string

### DIFF
--- a/lib/NativeCall.rakumod
+++ b/lib/NativeCall.rakumod
@@ -510,7 +510,8 @@ our sub explicitly-manage(
     }
 
     $x does ExplicitlyManagedString;
-    $x.cstr = nqp::box_s(nqp::unbox_s($x), CStr)
+    $x.cstr = nqp::box_s(nqp::unbox_s($x), CStr);
+    $x
 }
 
 our sub refresh($obj --> 1) is export(:DEFAULT, :utils) {

--- a/t/04-nativecall/02-simple-args.c
+++ b/t/04-nativecall/02-simple-args.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <math.h>
 
@@ -137,4 +138,9 @@ DLLEXPORT int TakeSSizeT(ssize_t x)
     if (x == -42)
         return 14;
     return 0;
+}
+
+DLLEXPORT void FreeString(char *str)
+{
+    free(str);
 }

--- a/t/04-nativecall/02-simple-args.t
+++ b/t/04-nativecall/02-simple-args.t
@@ -3,7 +3,7 @@ use CompileTestLib;
 use NativeCall;
 use Test;
 
-plan 21;
+plan 24;
 
 compile_test_lib('02-simple-args');
 
@@ -41,6 +41,16 @@ my $str = 'ok 7 - checked previously passed string';
 explicitly-manage($str);
 SetString($str);
 is CheckString(), 7, 'checked previously passed string';
+
+# https://github.com/rakudo/rakudo/issues/5955
+sub FreeString(Str) is native('./02-simple-args') { * }
+my $managed = explicitly-manage('will be freed by the callee');
+does-ok $managed, NativeCall::Types::ExplicitlyManagedString,
+    'explicitly-manage returns the managed string';
+FreeString($managed);
+pass 'callee freed an explicitly-managed string variable';
+FreeString(explicitly-manage('will also be freed by the callee'));
+pass 'callee freed the result of explicitly-manage passed directly';
 
 # Make sure wrapped subs work
 sub wrapped(int32) returns int32 is native('./02-simple-args') { * }


### PR DESCRIPTION
Previously explicitly-manage returned the internal CStr box produced by its final assignment. Passing that return value directly to a native sub skipped the ExplicitlyManagedString handling in the dispatcher, so the argument was marshalled as a plain Str and MoarVM freed the temporary buffer after the call. A C function that takes ownership of the string then freed it a second time and the process aborted.

This returns the mixed-in string itself so the documented usage free2(explicitly-manage('Foo')) marshals through the manually managed CStr path.

Fixes https://github.com/rakudo/rakudo/issues/5955