### PR TITLE
Make .split and .trans honor capture markers

### DIFF
--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -5059,6 +5059,18 @@ BEGIN {
               || nqp::elems(@!pos-capture-counts)
         }
 
+        # Are there any capture markers?  '<(' and ')>' compile into
+        # named captures called '$!from' and '$!to'.
+        method has-capture-markers() {
+            my int $i := nqp::elems(@!named-capture-names);
+            my int $found := 0;
+            while --$i >= 0 {
+                my str $name := nqp::atpos_s(@!named-capture-names, $i);
+                $found := 1 if $name eq '$!from' || $name eq '$!to';
+            }
+            $found
+        }
+
         ## Raku Match object building
         ## (for use in standard Raku regexes)
 

--- a/src/core.c/Match.rakumod
+++ b/src/core.c/Match.rakumod
@@ -219,6 +219,33 @@ my class Match is Capture is Cool does NQPMatchRole {
         $!regexsub($new)
     }
 
+    # Transfer capture marker positions from the capture stack into
+    # $!from / $!to.  This is the part of .MATCH that determines the
+    # match extent, without reifying any captures.
+    method CURSOR_CAPTURE_MARKERS(--> Nil) is implementation-detail {
+        my $cstack := nqp::getattr(self,Match,'$!cstack');
+        nqp::if(
+          $cstack,
+          nqp::stmts(
+            (my int $i = -1),
+            nqp::while(
+              nqp::islt_i(++$i,nqp::elems($cstack)),
+              nqp::stmts(
+                (my $cursor := nqp::atpos($cstack,$i)),
+                (my str $name = nqp::getattr_s($cursor,Match,'$!name')),
+                nqp::if(
+                  nqp::not_i(nqp::isnull_s($name))
+                    && (nqp::iseq_s($name,'$!from')
+                         || nqp::iseq_s($name,'$!to')),
+                  nqp::bindattr_i(self,Match,$name,
+                    nqp::getattr_i($cursor,Match,'$!from'))
+                )
+              )
+            )
+          )
+        )
+    }
+
     ##### / <:General_Category{$property}> /
     my $general-category-property-lookup := nqp::hash(
         "Uppercase_Letter", "Lu",

--- a/src/core.c/Rakudo/Iterator.rakumod
+++ b/src/core.c/Rakudo/Iterator.rakumod
@@ -2613,6 +2613,8 @@ class Rakudo::Iterator {
 
     my &POPULATE := Match.^lookup("MATCH" );  # fully populate Match object
 
+    my &CAPTURE-MARKERS := Match.^lookup("CURSOR_CAPTURE_MARKERS");
+
     my $movers := nqp::list(
       Match.^lookup("CURSOR_MORE"),     # :g
       Match.^lookup("CURSOR_OVERLAP"),  # :ov
@@ -2689,6 +2691,104 @@ class Rakudo::Iterator {
     }
     method MatchCursorLimit(\regex, \string, \limit, \mover) {
         MatchCursorLimit.new(regex, string, limit, mover)
+    }
+
+    # Cursor iterators for regexes with capture markers.  These bind
+    # the marker positions of each produced cursor into $!from and
+    # $!pos, so consumers read the match extent as with any cursor.
+    # The mover has already run at that point, so rebinding $!pos does
+    # not change where the next match is attempted.
+    my class MatchCursorMarkers does Iterator {
+        has Mu $!cursor;
+        has Mu $!mover;
+        method !SET-SELF(&regex, \string, int $mover) {
+            $!cursor := regex($initialize-cursor(Match, string, :0c));
+            $!mover  := nqp::atpos($movers,$mover);
+            self
+        }
+        method new(\regex, \string, \mover) {
+            nqp::create(self)!SET-SELF(regex, string, mover)
+        }
+        method pull-one() is raw {
+            nqp::if(
+              nqp::isge_i(nqp::getattr_i($!cursor,Match,'$!pos'),0),
+              nqp::stmts(
+                (my $current := $!cursor),
+                ($!cursor := $!mover($!cursor)),
+                CAPTURE-MARKERS($current),
+                nqp::if(
+                  nqp::isge_i(
+                    (my int $to = nqp::getattr_i($current,Match,'$!to')),
+                    0
+                  ),
+                  nqp::bindattr_i($current,Match,'$!pos',$to)
+                ),
+                $current
+              ),
+              IterationEnd
+            )
+        }
+        method skip-one() is raw {
+            nqp::if(
+              nqp::isge_i(nqp::getattr_i($!cursor,Match,'$!pos'),0),
+              ($!cursor := $!mover($!cursor)),
+            )
+        }
+    }
+
+    my class MatchCursorLimitMarkers does Iterator {
+        has Mu $!cursor;
+        has Mu $!mover;
+        has int $!todo;
+        method !SET-SELF(&regex, \string, int $todo, int $mover) {
+            $!cursor := regex($initialize-cursor(Match, string, :0c));
+            $!mover  := nqp::atpos($movers,$mover);
+            $!todo    = $todo + 1;
+            self
+        }
+        method new(\regex, \string, \todo, \mover) {
+            nqp::create(self)!SET-SELF(regex, string, todo, mover)
+        }
+        method pull-one() is raw {
+            nqp::if(
+              --$!todo
+                && nqp::isge_i(nqp::getattr_i($!cursor,Match,'$!pos'),0),
+              nqp::stmts(
+                (my $current := $!cursor),
+                ($!cursor := $!mover($!cursor)),
+                CAPTURE-MARKERS($current),
+                nqp::if(
+                  nqp::isge_i(
+                    (my int $to = nqp::getattr_i($current,Match,'$!to')),
+                    0
+                  ),
+                  nqp::bindattr_i($current,Match,'$!pos',$to)
+                ),
+                $current
+              ),
+              IterationEnd
+            )
+        }
+        method skip-one() is raw {
+            nqp::if(
+              --$!todo
+                && nqp::isge_i(nqp::getattr_i($!cursor,Match,'$!pos'),0),
+              ($!cursor := $!mover($!cursor)),
+            )
+        }
+    }
+
+    # Select a cursor iterator according to whether the regex
+    # contains capture markers
+    my sub match-cursor(\regex, \string, int $mover) {
+        nqp::istype(regex,Regex) && regex.HAS-CAPTURE-MARKERS
+          ?? MatchCursorMarkers.new(regex, string, $mover)
+          !! MatchCursor.new(regex, string, $mover)
+    }
+    my sub match-cursor-limit(\regex, \string, \todo, int $mover) {
+        nqp::istype(regex,Regex) && regex.HAS-CAPTURE-MARKERS
+          ?? MatchCursorLimitMarkers.new(regex, string, todo, $mover)
+          !! MatchCursorLimit.new(regex, string, todo, $mover)
     }
 
     # generate full blown Match objects for given regex, string and limit
@@ -2775,12 +2875,12 @@ class Rakudo::Iterator {
         }
         method new(\regex, \string, \limit) {
             my \iterator := nqp::istype(limit,Whatever) || limit == Inf
-              ?? MatchCursor.new(regex, string, 0)
+              ?? match-cursor(regex, string, 0)
               !! limit < 1
                 ?? (return Rakudo::Iterator.Empty)
                 !! limit == 1
                   ?? (return Rakudo::Iterator.OneValue(string))
-                  !! MatchCursorLimit.new(regex, string, limit.Int - 1, 0);
+                  !! match-cursor-limit(regex, string, limit.Int - 1, 0);
 
             nqp::create(self)!SET-SELF(iterator, string)
         }
@@ -2859,12 +2959,12 @@ class Rakudo::Iterator {
         }
         method new(\regex, \string, \mapper, \limit, \skip-empty) {
             my \iterator := nqp::istype(limit,Whatever) || limit == Inf
-              ?? MatchCursor.new(regex, string, 0)
+              ?? match-cursor(regex, string, 0)
               !! limit < 1 || (skip-empty && nqp::not_i(nqp::chars(string)))
                 ?? (return Rakudo::Iterator.Empty)
                 !! limit == 1
                   ?? (return Rakudo::Iterator.OneValue(string))
-                  !! MatchCursorLimit.new(regex, string, limit.Int - 1, 0);
+                  !! match-cursor-limit(regex, string, limit.Int - 1, 0);
 
             nqp::create(self)!SET-SELF(
               iterator, string, mapper, nqp::istrue(skip-empty))

--- a/src/core.c/Regex.rakumod
+++ b/src/core.c/Regex.rakumod
@@ -86,6 +86,15 @@ my class Regex { # declared in BOOTSTRAP
         )
     }
 
+    # Whether this regex contains the capture markers '<(' or ')>'
+    method HAS-CAPTURE-MARKERS(Regex:D:) is implementation-detail {
+        nqp::hllbool(
+          nqp::not_i(nqp::isnull($!caps))
+            && nqp::isconcrete($!caps)
+            && $!caps.has-capture-markers
+        )
+    }
+
     multi method Bool(Regex:D:) {
         my Mu \topic = $!topic;
         nqp::istype_nd(topic, Rakudo::Internals::RegexBoolification6cMarker)

--- a/src/core.c/Str.rakumod
+++ b/src/core.c/Str.rakumod
@@ -28,6 +28,8 @@ my class Str does Stringy { # declared in BOOTSTRAP
     my \CURSOR-OVERLAP    := Match.^lookup("CURSOR_OVERLAP");  # :ov
     my \CURSOR-EXHAUSTIVE := Match.^lookup("CURSOR_NEXT"   );  # :ex
 
+    my &CAPTURE-MARKERS := Match.^lookup("CURSOR_CAPTURE_MARKERS");
+
     my &POST-MATCH  := Match.^lookup("MATCH" );  # Match object
     my &POST-STR    := Match.^lookup("STR"   );  # Str object
 
@@ -2410,6 +2412,7 @@ my class Str does Stringy { # declared in BOOTSTRAP
                 unless nqp::existskey($needles-seen,$gist) {
                     nqp::bindkey($needles-seen,$gist,1);
 
+                    my int $markers = $needle.HAS-CAPTURE-MARKERS;
                     my $cursor;
                     my int $pos;
                     my int $c;
@@ -2427,11 +2430,12 @@ my class Str does Stringy { # declared in BOOTSTRAP
                                  -1
                                ),
                           nqp::stmts(
+                            nqp::if($markers,CAPTURE-MARKERS($cursor)),
                             nqp::push(
                               $pins,
                               nqp::list_i(
                                 $cursor.from,
-                                $pos - $cursor.from,
+                                ($markers ?? $cursor.to !! $pos) - $cursor.from,
                                 $index
                               )
                             ),
@@ -2448,11 +2452,12 @@ my class Str does Stringy { # declared in BOOTSTRAP
                             -1
                           ),
                           nqp::stmts(
+                            nqp::if($markers,CAPTURE-MARKERS($cursor)),
                             nqp::push(
                               $pins,
                               nqp::list_i(
                                 $cursor.from,
-                                $pos - $cursor.from,
+                                ($markers ?? $cursor.to !! $pos) - $cursor.from,
                                 $index
                               )
                             ),

--- a/t/02-rakudo/split-trans-capture-markers.t
+++ b/t/02-rakudo/split-trans-capture-markers.t
@@ -1,0 +1,62 @@
+use Test;
+
+plan 16;
+
+# https://github.com/rakudo/rakudo/issues/5761
+# The separator that .split and .trans act on is the marked part of each
+# match: text outside the capture markers stays in the surrounding parts.
+
+is-deeply "foobar".split(/ o <( o )> b /).List, ("fo", "bar"),
+  '.split honors both capture markers';
+
+is-deeply "foobar".split(/ o <( ob /).List, ("fo", "ar"),
+  '.split honors a <( marker without )>';
+
+is-deeply "foobar".split(/ oo )> b /).List, ("f", "bar"),
+  '.split honors a )> marker without <(';
+
+is-deeply "foobar".split(/ oob /).List, ("f", "ar"),
+  '.split without capture markers is unaffected';
+
+is-deeply "foobarfoobar".split(/ o <( o )> b /).List, ("fo", "barfo", "bar"),
+  '.split honors capture markers on repeated matches';
+
+is-deeply "foobaroob".split(/ o <( o )> b /, 2).List, ("fo", "baroob"),
+  '.split with a limit honors capture markers';
+
+is-deeply "oobfoob".split(/ o <( o )> b /, :skip-empty).List, ("o", "bfo", "b"),
+  '.split with :skip-empty honors capture markers';
+
+is-deeply "foobar".split([/ o <( o )> b /]).List, ("fo", "bar"),
+  '.split with a needle list honors capture markers';
+
+my $v = "foobar".split(/ o <( o )> b /, :v).List;
+is-deeply ($v[0], $v[2]), ("fo", "bar"),
+  '.split with :v produces parts according to capture markers';
+is $v[1].Str, "o",
+  '.split with :v produces the marked extent as the separator Match';
+is-deeply ($v[1].from, $v[1].to), (2, 3),
+  '.split with :v produces a Match with the marked extent';
+
+is "foobar".trans(/ o <( o )> b / => "z"), "fozbar",
+  '.trans with a string replacement honors capture markers';
+
+is "foobar".trans(/ o <( o )> b / => { "[$_]" }), "fo[o]bar",
+  '.trans with a callable replacement honors capture markers';
+
+is "foobarfoobar".trans([/ o <( o )> b /] => ["Z"]), "foZbarfoZbar",
+  '.trans with needle and replacement lists honors capture markers';
+
+# The extent a marker regex splits on is the same extent that .subst
+# replaces.
+my $string = "xxabcxxabc";
+my $rx     = / a <( b )> c /;
+is $string.split($rx).join("|"), $string.subst($rx, "|", :g),
+  '.split and .subst agree on the extent of a marker regex';
+
+# Markers inside an interpolated regex apply to the inner match only.
+my $inner = / o <( o )> b /;
+is-deeply "foobar".split(/ $inner /).List, ("f", "ar"),
+  '.split does not apply capture markers of an interpolated regex';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously .split and .trans read the match extent directly from the `$!from` and `$!pos` attributes of each cursor. Capture markers are compiled as named captures called `$!from` and `$!to`, and their positions only get transferred out of the capture stack when a full Match object is reified with .MATCH. Since the split iterators never reify, the markers were ignored:

    say "foobar".split(/ o <( o )> b /);         # (f ar)
    say "foobar".trans(/ o <( o )> b / => "z");  # fzar

These now produce ("fo", "bar") and "fozbar", agreeing with .match, .subst and .comb.

Calling .MATCH on every cursor would also fix this, but slows down all .split and .trans calls by about 40% whether they use markers or not. Instead the new RegexCaptures.has-capture-markers method determines from the capture names whether a regex contains markers at all, exposed as Regex.HAS-CAPTURE-MARKERS. Only when it does, the split iterators select cursor iterators that transfer the marker positions of each produced cursor with the new Match.CURSOR_CAPTURE_MARKERS method, which scans the capture stack without reifying anything. The marker end position is folded into `$!pos` after the mover has advanced, so consumers can keep reading `$!from` and `$!pos` unchanged. The multiple needle .split candidate applies the same treatment in its regex needle loop.

Regexes without capture markers take exactly the same code path as before.

Fixes #5761