### PR TITLE
Make MAIN recognize enum values that are not in scope

### DIFF
--- a/src/core.c/Main.rakumod
+++ b/src/core.c/Main.rakumod
@@ -71,6 +71,23 @@ my sub RUN-MAIN(&main, $mainline, :$in-as-argsfiles) {
             }
         }
 
+        # Enum values can only be resolved by name if they are visible in
+        # the caller's scope, which they are not when MAIN was imported
+        # from a module that does not also export the enum.  The enum types
+        # in the signatures of the MAIN candidates are always available, so
+        # collect their values by name for direct lookup.  The first enum
+        # seen wins if candidates use different enums that share a key.
+        my %signature-enum-values;
+        for &main.candidates -> &candidate {
+            for &candidate.signature.params -> $param {
+                my \type := $param.type;
+                if Metamodel::EnumHOW.ACCEPTS(type.HOW) {
+                    %signature-enum-values{.key} //= $_
+                      for type.^enum_value_list;
+                }
+            }
+        }
+
         sub thevalue(\a) {
             my \core-a   := try CORE::(a);
             my \global-a := try GLOBAL::(a);
@@ -84,7 +101,7 @@ my sub RUN-MAIN(&main, $mainline, :$in-as-argsfiles) {
             Metamodel::EnumHOW.ACCEPTS(type.HOW)
               && type (elem) type.HOW.enum_value_list(type)
               ?? type
-              !! coercer(a);
+              !! %signature-enum-values{a} // coercer(a);
         }
 
         my %options-with-req-arg = Hash.new;

--- a/t/02-rakudo/25-run-main-enum.t
+++ b/t/02-rakudo/25-run-main-enum.t
@@ -1,0 +1,54 @@
+use Test;
+
+plan 4;
+
+# https://github.com/rakudo/rakudo/issues/5091
+# Enum values in the signature of a MAIN must be recognized on the command
+# line even when the enum is not visible in the scope that RUN-MAIN is
+# called from, which is the case when MAIN is imported from a module that
+# declares the enum inside its own package.
+
+my $positional;
+my $named;
+my $mixed-enum;
+my $mixed-note;
+my $wolves;
+my $butterflies;
+my &positional-main;
+my &named-main;
+my &mixed-main;
+
+my class Container {
+    enum Interesting <Wolves Butterflies>;
+    $wolves      = Wolves;
+    $butterflies = Butterflies;
+    &positional-main = anon sub MAIN(Interesting $chosen) {
+        $positional = $chosen
+    }
+    &named-main = anon sub MAIN(Interesting :$chosen!) {
+        $named = $chosen
+    }
+    &mixed-main = anon sub MAIN(Interesting $chosen, Str $note) {
+        $mixed-enum = $chosen;
+        $mixed-note = $note;
+    }
+}
+
+@*ARGS = "Wolves",;
+RUN-MAIN(&positional-main, Nil);
+is-deeply $positional, $wolves,
+  'positional enum argument dispatches when the enum is not in scope';
+
+@*ARGS = "--chosen=Butterflies",;
+RUN-MAIN(&named-main, Nil);
+is-deeply $named, $butterflies,
+  'named enum argument dispatches when the enum is not in scope';
+
+@*ARGS = "Wolves", "hello";
+RUN-MAIN(&mixed-main, Nil);
+is-deeply $mixed-enum, $wolves,
+  'enum argument dispatches alongside a Str argument';
+is-deeply $mixed-note, "hello",
+  'word that is not an enum key still arrives as a Str';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously the command line argument parsing in RUN-MAIN resolved a potential enum value by looking the word up in the caller's lexical scope, GLOBAL::, and CORE::. When MAIN is imported from a module that declares the enum inside its own package none of those lookups can see the enum values, so dispatch would fail and the usage message would be shown instead.

This makes the argument parsing also consult the enum types found in the signatures of the MAIN candidates, which are reachable no matter where the enum was declared. The by-name lookups still take precedence, so behavior for enums that are visible in the caller's scope is unchanged.

Fixes #5091