### PR TITLE
RakuAST: Make native scalars usable in BEGIN-time code

### DIFF
--- a/src/Raku/ast/begintime.rakumod
+++ b/src/Raku/ast/begintime.rakumod
@@ -97,14 +97,35 @@ class RakuAST::BeginTime
             nqp::die('BEGIN time evaluation only supported for simple constructs so far')
         }
 
-        # A native-typed expression evaluates to a bare VM-level box (for
-        # example a BOOTInt) where the same expression at run time would
-        # produce an Int. Such a box has no Raku method table and a null
-        # WHO, so letting it escape into a stash breaks stash consumers
-        # like the compunit GLOBAL merge. Box VM-level scalars into their
-        # Raku types; leave VM-level aggregates alone, as constants holding
-        # nqp hashes and lists rely on staying unboxed.
+        self.IMPL-BOX-VM-VALUE($result)
+    }
+
+    # A native-typed expression evaluates to a bare VM-level box (for
+    # example a BOOTInt) where the same expression at run time would
+    # produce an Int. Such a box has no Raku method table and a null
+    # WHO, so letting it escape into a stash breaks stash consumers
+    # like the compunit GLOBAL merge. Box VM-level scalars into their
+    # Raku types; leave VM-level aggregates alone, as constants holding
+    # nqp hashes and lists rely on staying unboxed.
+    method IMPL-BOX-VM-VALUE(Mu $result) {
         unless nqp::isnull($result) {
+            # A native reference must not escape either. The frame
+            # holding the referenced slot is gone once this evaluation
+            # returns, and a reference cannot be serialized. Snapshot
+            # the referenced value, leaving a VM-level box for the
+            # code below.
+            if nqp::iscont_i($result) {
+                $result := nqp::box_i(nqp::decont_i($result), nqp::bootint());
+            }
+            elsif nqp::iscont_u($result) {
+                $result := nqp::box_u(nqp::decont_u($result), nqp::bootint());
+            }
+            elsif nqp::iscont_n($result) {
+                $result := nqp::box_n(nqp::decont_n($result), nqp::bootnum());
+            }
+            elsif nqp::iscont_s($result) {
+                $result := nqp::box_s(nqp::decont_s($result), nqp::bootstr());
+            }
             my $type := nqp::what($result);
             $result := nqp::hllizefor($result, 'Raku')
               if nqp::eqaddr($type, nqp::bootint())

--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -375,7 +375,8 @@ class RakuAST::Code
                 }
             }
             else {
-                if $scope eq 'lexical' && ! $declared-in-cu($name) && !%seen{$name} {
+                if ($scope eq 'lexical' || $scope eq 'lexicalref')
+                  && ! $declared-in-cu($name) && !%seen{$name} {
                     my $value := $var.ann('compile-time-value');
                     if !($value =:= NQPMu) {
                         %seen{$name} := 1;
@@ -390,7 +391,33 @@ class RakuAST::Code
                     # the runtime lookup reaches the caller's container.
                     elsif $name ne '$_' && $name ne '$/' && $name ne '$!' && $name ne '$¢' {
                         my $lexical := $parse-time-resolver.resolve-lexical($name);
-                        if $lexical
+                        my $of := $lexical && nqp::istype($lexical, RakuAST::VarDeclaration::Simple)
+                            ?? $lexical.IMPL-OF-TYPE
+                            !! Mu;
+                        # A native scalar has no container to share, and a
+                        # native slot cannot hold a static value for runtime
+                        # frames to copy. Declare a fresh slot of the same
+                        # native type. A write to it stays local to this
+                        # compiled code.
+                        if $lexical && (my int $prim-spec := nqp::objprimspec($of)) && $lexical.sigil eq '$' {
+                            $context.ensure-sc($of);
+                            %seen{$name} := 1;
+                            my $slot := QAST::Var.new(
+                                :scope<lexical>, :decl<var>, :$name, :returns($of)
+                            );
+                            # An int or num slot starts out as 0, but a str
+                            # slot starts out as a VM-level null string, so
+                            # bind its empty-string default explicitly.
+                            $block[0].push($prim-spec == 3
+                                ?? QAST::Op.new(:op('bind'), $slot, QAST::SVal.new(:value('')))
+                                !! $slot
+                            );
+                        }
+                        # Any other by-reference use stays late-bound for
+                        # the runtime lookup to satisfy.
+                        elsif $scope eq 'lexicalref' {
+                        }
+                        elsif $lexical
                           && !nqp::istype($lexical, RakuAST::Declaration::External)
                           && !nqp::istype($lexical, RakuAST::CompileTimeValue)
                           && !nqp::eqat($name, '!__REGEX_CAPTURE_', 0)

--- a/src/Raku/ast/statementprefixes.rakumod
+++ b/src/Raku/ast/statementprefixes.rakumod
@@ -727,7 +727,7 @@ class RakuAST::StatementPrefix::Phaser::Begin
                 $ex.rethrow;
             }
             nqp::bindattr(self, RakuAST::StatementPrefix::Phaser::Begin,
-              '$!value', $producer());
+              '$!value', self.IMPL-BOX-VM-VALUE($producer()));
             nqp::bindattr_i(self, RakuAST::StatementPrefix::Phaser::Begin,
               '$!has-value', 1);
         }

--- a/src/Raku/ast/variable-access.rakumod
+++ b/src/Raku/ast/variable-access.rakumod
@@ -127,7 +127,14 @@ class RakuAST::Var::Lexical
     }
 
     method IMPL-CAN-INTERPRET() {
-        self.is-resolved && nqp::istype(self.resolution, RakuAST::CompileTimeValue)
+        self.is-resolved
+          && nqp::istype(self.resolution, RakuAST::CompileTimeValue)
+          # A native scalar declaration has no container, so its
+          # meta-object is a VM null rather than a usable value.
+          # Decline, and the lookup is compiled instead.
+          && !(nqp::istype(self.resolution, RakuAST::VarDeclaration::Simple)
+                && self.resolution.sigil eq '$'
+                && nqp::objprimspec(self.resolution.IMPL-OF-TYPE))
     }
 
     method IMPL-INTERPRET(RakuAST::IMPL::InterpContext $ctx) {

--- a/t/02-rakudo/begin-native-var.t
+++ b/t/02-rakudo/begin-native-var.t
@@ -1,0 +1,51 @@
+use nqp;
+use Test;
+
+# A native-typed scalar used in BEGIN-time code refers to a slot in the
+# declaring frame, which does not exist at BEGIN time and has no container
+# the BEGIN-time code could share. The dynamically compiled BEGIN code
+# declares a fresh slot of the declared native type instead, so reads see
+# the type default and a write stays local to the BEGIN. The legacy
+# frontend does not compile these forms, so they are skipped there.
+
+my $rakuast := nqp::gethllsym('Raku', 'COMPILER-FRONTEND') eq 'rakuast';
+
+plan 10;
+
+if $rakuast {
+    lives-ok { EVAL 'BEGIN my int $foo' },
+      'a BEGIN whose statement declares a native int compiles';
+
+    is EVAL('BEGIN my int $foo = 5'), 5,
+      'a BEGIN produces the value assigned to a native int it declares';
+
+    is EVAL('BEGIN my num $foo = 2.5e0'), 2.5e0,
+      'a BEGIN produces the value assigned to a native num it declares';
+
+    is EVAL('BEGIN my str $foo = "hi"'), 'hi',
+      'a BEGIN produces the value assigned to a native str it declares';
+
+    is EVAL('my int $foo; my $x = BEGIN $foo; $x'), 0,
+      'a BEGIN reading an outer native int sees the type default';
+
+    is EVAL('my int $foo; BEGIN $foo = 5; $foo'), 0,
+      'a BEGIN-time write to an outer native int stays local to the BEGIN';
+
+    is-deeply EVAL('BEGIN my uint $foo = 7'), 7,
+      'a BEGIN produces the boxed value assigned to a native uint it declares';
+
+    is EVAL('my int $x; constant y = $x + 1; y'), 1,
+      'a constant initializer reading a native int sees the type default';
+
+    is EVAL('my str $x; constant y = $x ~ "!"; y'), '!',
+      'a constant initializer reading a native str sees the type default';
+}
+else {
+    skip 'native scalars in BEGIN-time code are NYI on the legacy frontend', 9;
+}
+
+# Native aggregates have containers, which BEGIN-time code shares.
+is do { my int @a; BEGIN @a.push(3); @a[0] }, 3,
+  'a BEGIN-time push to a native int array is visible at runtime';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously any BEGIN-time use of a native-typed scalar died while compiling the BEGIN with "No lexical found with name", e.g.

    BEGIN my int $foo;

A native scalar declaration has no container to share with dynamically compiled BEGIN-time code, and a native slot cannot hold a static value for runtime frames to copy, so unlike object variables the declaration cannot be reproduced in the compiled unit by binding a compile-time value.

This makes such code compile and run by:

- Declaring a fresh slot of the declared native type in the dynamically compiled unit. Reads see the type default and a write stays local to the BEGIN-time code. A str slot is explicitly initialized to the empty string, as a bare str lexical starts out as a VM-level null string.

- Declining constant-folding interpretation of a lookup that resolves to a native scalar declaration. Its meta-object slot holds a VM null, which previously escaped into the folded value, so for example `my int $x; constant y = $x + 1` died with a VMNull dispatch error. Such a lookup now falls back to the compiled path above.

- Snapshotting a native reference produced as the value of a BEGIN into its boxed type. The frame holding the referenced slot is gone once the evaluation returns, and a NativeRef cannot be serialized, so `BEGIN my int $foo = 5` in a precompiled module died with "Missing serialize REPR function for REPR NativeRef".

Fixes #5043 for RakuAST