### PR TITLE
Do not apply unspace to whitespace inside regexes

### DIFF
--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -705,6 +705,17 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         ]*
     }
 
+    # Whitespace between regex atoms.  Like ws, but without unspace:
+    # in a regex a backslash always starts an escape such as \# or \s.
+    token regex-ws {
+        :dba('whitespace')
+        [
+        | [\r\n || \v] <.heredoc>
+        | <.unv>
+        | <.vcs-conflict>
+        ]*
+    }
+
     token vws {
         :dba('vertical whitespace')
         [
@@ -2925,8 +2936,7 @@ sub, perhaps you accidentally placed a semicolon after routine's definition?"
           { $*IN_DECL := '' }
            <.newpad>
           [ [ ':'?'(' <signature('sig', 1)> ')' ] | <trait> ]*
-          '{'
-          [
+          '{'<.regex-ws>[
           | ['*'|'<...>'|'<*>'] <?{ $*MULTINESS eq 'proto' }> $<onlystar>={1}
           | <nibble(self.quote_lang(%*RX<P5> ?? self.slang_grammar('P5Regex') !! self.slang_grammar('Regex'), '{', '}'))>
           ]
@@ -5819,7 +5829,7 @@ grammar Perl6::RegexGrammar is QRegex::P6Regex::Grammar does STD does MatchPacka
     method throw_solitary_quantifier() { self.typed_panic('X::Syntax::Regex::SolitaryQuantifier') }
     method throw_solitary_backtrack_control() { self.typed_sorry('X::Syntax::Regex::SolitaryBacktrackControl') }
 
-    token normspace { <?before \s | '#'> <.LANG('MAIN', 'ws')> }
+    token normspace { <?before \s | '#'> <.LANG('MAIN', 'regex-ws')> }
 
     token rxstopper { <stopper> }
 

--- a/src/Raku/Grammar.nqp
+++ b/src/Raku/Grammar.nqp
@@ -4318,8 +4318,7 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
           { $*IN-DECL := '' }
           [ '(' <signature> ')' ]?
           <trait($*BLOCK)>*
-          '{' <.regex-whitespace>
-          [
+          '{'<.regex-whitespace>[
             | ['*'|'<...>'|'<*>'] <?{ $*MULTINESS eq 'proto' }> $<onlystar>={1}
             | <nibble(self.quote-lang(self.Regex(%*RX<P5>), '{', '}'))>
           ]

--- a/src/Raku/Grammar.nqp
+++ b/src/Raku/Grammar.nqp
@@ -4318,7 +4318,8 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
           { $*IN-DECL := '' }
           [ '(' <signature> ')' ]?
           <trait($*BLOCK)>*
-          '{'<.regex-whitespace>[
+          '{' <.regex-whitespace>
+          [
             | ['*'|'<...>'|'<*>'] <?{ $*MULTINESS eq 'proto' }> $<onlystar>={1}
             | <nibble(self.quote-lang(self.Regex(%*RX<P5>), '{', '}'))>
           ]

--- a/src/Raku/Grammar.nqp
+++ b/src/Raku/Grammar.nqp
@@ -4318,8 +4318,7 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
           { $*IN-DECL := '' }
           [ '(' <signature> ')' ]?
           <trait($*BLOCK)>*
-          '{'
-          [
+          '{'<.regex-whitespace>[
             | ['*'|'<...>'|'<*>'] <?{ $*MULTINESS eq 'proto' }> $<onlystar>={1}
             | <nibble(self.quote-lang(self.Regex(%*RX<P5>), '{', '}'))>
           ]
@@ -5712,6 +5711,17 @@ Rakudo significantly on *every* run."
         ]*
     }
 
+    # Whitespace between regex atoms.  Like ws, but without unspace:
+    # in a regex a backslash always starts an escape such as \# or \s.
+    token regex-whitespace {
+        :dba('whitespace')
+        [
+          | [ \r\n || \v ] <.heredoc>
+          | <.horizontal-whitespace>
+          | <.vcs-conflict>
+        ]*
+    }
+
     # Handle vertical whitespace including version control markers
     token vertical-whitespace {
         :dba('vertical whitespace')
@@ -6558,7 +6568,7 @@ grammar Raku::RegexGrammar is QRegex::P6Regex::Grammar does Raku::Common {
         self.typed-sorry: 'X::Syntax::Regex::SolitaryBacktrackControl';
     }
 
-    token normspace { <?before \s | '#'> <.LANG('MAIN', 'ws')> }
+    token normspace { <?before \s | '#'> <.LANG('MAIN', 'regex-whitespace')> }
 
     token rxstopper { <stopper> }
 

--- a/t/02-rakudo/25-regex-unspace.t
+++ b/t/02-rakudo/25-regex-unspace.t
@@ -1,0 +1,49 @@
+use Test;
+
+plan 12;
+
+# https://github.com/rakudo/rakudo/issues/4387
+# Whitespace inside a regex must not apply unspace: a backslash there
+# always starts an escape like \# or \s, so `regex { \# }` matches a
+# literal hash instead of commenting out the rest of the line.
+
+is ("#" ~~ regex { \# }), "#",
+    'regex {} with a leading escaped hash matches a literal hash';
+is ("#" ~~ token { \# }), "#",
+    'token {} with a leading escaped hash matches a literal hash';
+is ("#" ~~ rule { \# }), "#",
+    'rule {} with a leading escaped hash matches a literal hash';
+
+my regex hash { \# }
+is ("#" ~~ &hash), "#",
+    'a named regex with a leading escaped hash matches a literal hash';
+
+is ("a#b" ~~ rx/ a \# b /), "a#b",
+    'an escaped hash after whitespace mid-regex stays an escape';
+is ("a #" ~~ rx:s/ a \# /), "a #",
+    'an escaped hash after sigspace stays an escape';
+
+my regex spread { \#
+    x }
+is ("#x" ~~ &spread), "#x",
+    'an escaped hash does not comment out the rest of its line';
+
+my regex commented { # a comment
+    a }
+is ("a" ~~ &commented), "a",
+    'a line comment at the start of a regex body still works';
+
+my regex embedded { #`(one
+two) ab }
+is ("ab" ~~ &embedded), "ab",
+    'a multi-line embedded comment at the start of a regex body still works';
+
+is ("a b" ~~ rule { a b }), "a b",
+    'rule {} sigspace still applies between atoms';
+
+throws-like q| rx/ a \ b / |, X::Syntax::Regex::Unspace,
+    'a backslash before whitespace mid-regex reports the no-unspace error';
+throws-like q| my regex r { \ } |, X::Syntax::Regex::Unspace,
+    'a backslash before whitespace in a regex body reports the no-unspace error';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously `regex { \# }` failed to parse with "Regex not terminated", while the equivalent `/ \# /` and `rx{ \# }` parsed fine. An escaped hash preceded by whitespace, e.g. `/ a \# b /`, failed the same way in every regex form. Worse, when the rest of the line could be discarded without losing the terminator the regex silently compiled to something else entirely:

    my regex r { \#
        x }    # compiled to bare `x`, matching without the hash

This happened because whitespace inside a regex was parsed with the main language ws, which performs unspace: a backslash before whitespace or a comment marker is eaten as a line continuation. The regex grammars normspace token delegated to it for the whitespace between atoms, and regex_def, being a rule, applied it directly after the opening curly of a regex/token/rule body. In a regex a backslash always starts an escape such as \# or \x20, and unspace is explicitly rejected there with X::Syntax::Regex::Unspace, so it must never apply.

This adds a regex-ws token (regex-whitespace in the RakuAST grammar) that matches everything the main language ws does except unspace, and uses it both in the normspace overrides of the regex grammars and after the opening curly in regex_def. A backslash before whitespace inside a regex now also consistently reports X::Syntax::Regex::Unspace instead of sometimes being silently eaten as a line continuation.

Fixes #4387