### PR TITLE
Make cmp compare collections by their values

### DIFF
--- a/src/core.c/Order.rakumod
+++ b/src/core.c/Order.rakumod
@@ -68,6 +68,31 @@ multi sub infix:<cmp>(\a, Code:D $b) {
      a.Stringy cmp $b.name
 }
 
+multi sub infix:<cmp>(Iterable:D \a, Iterable:D \b) {
+    nqp::eqaddr(nqp::decont(a),nqp::decont(b))
+      ?? Same
+      !! infix:<cmp>(
+           # a Seq can only be iterated once, but sorting compares an
+           # element many times, so compare through a cache when the
+           # type provides one
+           nqp::istype(a,PositionalBindFailover)
+             ?? a.cache.iterator
+             !! a.iterator,
+           nqp::istype(b,PositionalBindFailover)
+             ?? b.cache.iterator
+             !! b.iterator
+         )
+}
+
+# Maps have no meaningful iteration order, so compare sorted pairs
+multi sub infix:<cmp>(Map:D \a, Map:D \b) {
+    nqp::eqaddr(nqp::decont(a),nqp::decont(b))
+      ?? Same
+      !! a.sort cmp b.sort
+}
+multi sub infix:<cmp>(Map:D \a, Iterable:D \b) { a.sort cmp b      }
+multi sub infix:<cmp>(Iterable:D \a, Map:D \b) { a      cmp b.sort }
+
 multi sub infix:<cmp>(List:D \a, List:D \b) {
     nqp::if(
       a.is-lazy || b.is-lazy,

--- a/src/core.c/QuantHash.rakumod
+++ b/src/core.c/QuantHash.rakumod
@@ -104,4 +104,13 @@ my role QuantHash::KeyOf[::CONSTRAINT] {
     }
 }
 
+# QuantHashes have no meaningful iteration order, so compare sorted pairs
+multi sub infix:<cmp>(QuantHash:D \a, QuantHash:D \b) {
+    nqp::eqaddr(nqp::decont(a),nqp::decont(b))
+      ?? Same
+      !! a.sort cmp b.sort
+}
+multi sub infix:<cmp>(QuantHash:D \a, Iterable:D \b) { a.sort cmp b      }
+multi sub infix:<cmp>(Iterable:D \a, QuantHash:D \b) { a      cmp b.sort }
+
 # vim: expandtab shiftwidth=4

--- a/t/02-rakudo/cmp-collections.t
+++ b/t/02-rakudo/cmp-collections.t
@@ -1,0 +1,61 @@
+use Test;
+
+plan 28;
+
+# https://github.com/rakudo/rakudo/issues/6075
+# cmp on collections compares the values they contain, not their
+# stringifications
+
+# Seq involving comparisons compare element by element
+is (10, 5).Seq cmp (7, 6).Seq, More, 'Seq cmp Seq compares element by element';
+is (10, 5)     cmp (7, 6).Seq, More, 'List cmp Seq compares element by element';
+is (10, 5).Seq cmp (7, 6),     More, 'Seq cmp List compares element by element';
+is (1, "5 6")  cmp (1, 5, 6).Seq, More,
+    'Seq comparison no longer coincides with the stringification';
+is (1, 2, 3).Seq cmp (1, 2, 3).Seq, Same, 'equal Seqs compare Same';
+is (1, 2).Seq cmp (1, 2, 3).Seq, Less, 'shorter Seq with equal prefix is Less';
+
+# a Seq can be compared more than once and survives the comparison
+my $seq = (3, 1).Seq;
+is $seq cmp (3, 2), Less, 'first comparison of the same Seq';
+is $seq cmp (3, 0), More, 'second comparison of the same Seq';
+is-deeply $seq.List, (3, 1), 'Seq still has its values after comparisons';
+is $seq cmp $seq, Same, 'Seq cmp itself is Same';
+
+# sorting Seqs compares each Seq multiple times
+is-deeply ((3, 1).Seq, (2, 0).Seq, (1, 9).Seq, (2, 0).Seq).sort.head.List,
+    (1, 9), 'sorting a list of Seqs works';
+
+# laziness is preserved
+is (lazy (1, 2, 3)) cmp (1, 2, 3), Same, 'lazy Seq cmp List';
+is (1..Inf).Seq cmp (1, 2, 3), More, 'infinite Seq cmp finite List';
+
+# Map cmp is content based and deterministic
+my $h1 = {:path(['a']), :value('alpha')};
+my $h2 = {:path(['b']), :value('bravo')};
+my $h3 = {:path(['c']), :value('charlie')};
+is $h1 cmp $h2, Less, 'multi-key Hash cmp by content is Less';
+is $h2 cmp $h1, More, 'multi-key Hash cmp by content is More';
+is {:a(1), :b(2)} cmp {:a(1), :b(2)}, Same, 'equal Hashes compare Same';
+is {:a(10)} cmp {:a(9)}, More, 'Hash cmp compares values as values';
+is-deeply ($h3, $h1, $h2).sort.map(*.<path>[0]).list, ('a', 'b', 'c'),
+    'sort of multi-key Hashes orders them by content';
+is Map.new((:b(2), :a(1))) cmp Map.new((:a(1), :b(2))), Same,
+    'Map cmp ignores insertion order';
+
+# QuantHash cmp is content based and deterministic
+is set(<b a c d e f g>) cmp set(<b a c d e f h>), Less,
+    'Set cmp compares sorted elements';
+is set(<a b>) cmp set(<a b>), Same, 'equal Sets compare Same';
+is bag(<a a b>) cmp bag(<a b b>), More, 'Bag cmp compares sorted pairs';
+is mix(<a b>) cmp mix(<a>), More, 'Mix with more elements is More';
+is-deeply (set(<b c>), set(<a b>), set(<a>)).sort.map(*.keys.sort.join).list,
+    ('a', 'ab', 'bc'), 'sort of Sets orders them by content';
+
+# behavior that must not change
+is (10, 5) cmp (7, 6), More, 'List cmp List still compares element by element';
+is <a b> cmp "a b", Same, 'List cmp Str still compares stringifications';
+is (1..3) cmp (1..3), Same, 'Range cmp Range still works';
+is (1, 2) cmp any((1, 2), (3, 4)), any(Same, Less), 'Junctions still autothread';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously cmp on a Seq fell through to the default candidate and compared stringifications, so (10,5).Seq cmp (7,6).Seq gave Less while (10,5) cmp (7,6) gave More, and sorting a List of Seqs ordered them by their string form.

An earlier fix (ee30c34ff, reverted in 1c586eb25) added infix:<cmp>(Iterable:D, Iterable:D) comparing raw iterators. Because Map does Iterable it also caught Map cmp Map, comparing via hash iteration order, which is not deterministic. That broke Crane and Data::Reshapers, which sort Lists of Maps.

This adds element by element comparison for Iterables with two refinements that make it hold up across the collection types:

Types that do PositionalBindFailover are compared through their cache. A Seq can normally be iterated only once, but sorting compares an element many times, so raw iterators would throw X::Seq::Consumed on the second comparison of the same Seq.

Unordered collections compare by their pairs in sorted order. Map cmp Map was only stable before because Map.Str happens to sort its pairs. Setty/Baggy/Mixy .Str does not sort, so Set cmp Set has been nondeterministic all along. Both now compare their sorted pairs, which is deterministic and also compares values as values, so {:a(10)} cmp {:a(9)} is now More instead of Less.

Fixes #6075