### PR TITLE
Fix lookbehind for patterns that cannot be flipped

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -11964,9 +11964,16 @@ class Perl6::RegexActions is QRegex::P6Regex::Actions does STDActions {
                     for $<arglist>.ast.list { $qast[0].push(wanted($_, 'assertname')) }
                 }
                 elsif $<nibbler> {
-                    my $nibbled := $name eq 'after'
-                        ?? self.flip_ast($<nibbler>.ast)
-                        !! $<nibbler>.ast;
+                    my $nibbled := $<nibbler>.ast;
+                    if $name eq 'after' {
+                        if self.can_flip_ast($nibbled)
+                          || !nqp::istype($qast[0][0], QAST::SVal) {
+                            $nibbled := self.flip_ast($nibbled);
+                        }
+                        else {
+                            $qast[0][0].value('after_scan');
+                        }
+                    }
                     my $sub := $/.slang_actions('Regex').qbuildsub($nibbled, :anon(1), :addself(1));
                     $qast[0].push($sub);
                 }

--- a/src/Raku/ast/regex.rakumod
+++ b/src/Raku/ast/regex.rakumod
@@ -1464,18 +1464,55 @@ class RakuAST::Regex::Assertion::Named::RegexArg
     }
 
     method IMPL-REGEX-QAST(RakuAST::IMPL::QASTContext $context, %mods) {
+        my $call-qast := self.IMPL-REGEX-QAST-CALL($context);
         my $body-qast := $!regex-arg.IMPL-REGEX-QAST($context, %mods);
-        $body-qast := self.IMPL-FLIP-QAST($body-qast) if self.name.canonicalize eq 'after';
+        if self.name.canonicalize eq 'after' {
+            if self.IMPL-CAN-FLIP-QAST($body-qast)
+              || !nqp::istype($call-qast[0][0], QAST::SVal) {
+                $body-qast := self.IMPL-FLIP-QAST($body-qast);
+            }
+            else {
+                $call-qast[0][0].value('after_scan');
+            }
+        }
         $!regex-arg.IMPL-APPLY-ATOM-RATCHET($body-qast, %mods);
         nqp::bindattr(self, RakuAST::Regex::Assertion::Named::RegexArg, '$!body-qast', $body-qast);
-        my $qast := self.IMPL-REGEX-QAST-CALL($context);
         my str $name := self.IMPL-UNIQUE-NAME;
         my $arg-qast := QAST::Var.new( :$name, :scope('lexical') );
         # QRegex::NFA reads this annotation to inline a <before ...>
         # argument's regex into the caller's declarative prefix for LTM.
         $arg-qast.annotate('orig_qast', $body-qast);
-        $qast[0].push($arg-qast);
-        $qast
+        $call-qast[0].push($arg-qast);
+        $call-qast
+    }
+
+    # Whether IMPL-FLIP-QAST can turn this syntax tree into one that,
+    # matched against the flipped target, is equivalent to matching the
+    # original right-to-left.  Subrule calls and embedded code have
+    # compiled bodies that match left-to-right no matter what surrounds
+    # them, and zero-width checks other than anchors inspect the character
+    # at the current position, which is on the other side once the target
+    # is flipped.  Lookbehinds containing any of those must scan instead.
+    method IMPL-CAN-FLIP-QAST($qast) {
+        return 1 unless nqp::istype($qast, QAST::Regex);
+        return 0 if $qast.subtype eq 'zerowidth';
+        my $rxtype := $qast.rxtype;
+        if $rxtype eq 'literal' || $rxtype eq 'cclass' || $rxtype eq 'enumcharlist'
+          || $rxtype eq 'charrange' || $rxtype eq 'uniprop'
+          || $rxtype eq 'anchor' || $rxtype eq 'dba' {
+            1
+        }
+        elsif $rxtype eq 'concat' || $rxtype eq 'alt' || $rxtype eq 'altseq'
+          || $rxtype eq 'conj' || $rxtype eq 'conjseq'
+          || $rxtype eq 'quant' || $rxtype eq 'dynquant' {
+            for @($qast) {
+                return 0 unless self.IMPL-CAN-FLIP-QAST($_);
+            }
+            1
+        }
+        else {
+            0
+        }
     }
 
     method IMPL-FLIP-QAST($qast) {

--- a/t/02-rakudo/lookbehind-subrule.t
+++ b/t/02-rakudo/lookbehind-subrule.t
@@ -1,0 +1,80 @@
+use Test;
+
+plan 24;
+
+# A lookbehind is compiled by reversing its pattern and matching against the
+# reversed target string. That is only possible for pattern nodes the
+# compiler knows how to reverse: subrule calls and embedded code have
+# compiled bodies that always match left-to-right, and zero-width checks
+# other than anchors inspect the character on the wrong side of a reversed
+# position. Lookbehinds containing any of those instead scan for a match of
+# the unreversed pattern that ends at the current position.
+
+my regex ab { ab }
+
+is ('ab ba' ~~ / <?after ab > /).pos, 2,
+    'lookbehind on a plain literal matches where the literal ends';
+is ('ab ba' ~~ / <?after <ab> > /).pos, 2,
+    'lookbehind calling a named regex matches where that regex ends';
+is ('ab ba' ~~ / <?after <{'ab'}> > /).pos, 2,
+    'lookbehind with an interpolated pattern matches where it ends';
+is ('ab ba' ~~ / <?after <{'ba'}> > /).pos, 5,
+    'lookbehind with a different interpolated pattern matches where it ends';
+
+my token tab { ab }
+is ('ab ba' ~~ / <?after <tab> > /).pos, 2,
+    'lookbehind calling a ratcheted token matches where the token ends';
+
+my regex aab { a || ab }
+is ('zab' ~~ / <?after <aab>> /).pos, 2,
+    'lookbehind subrule with sequential alternation matches its first ending here';
+ok ?('zb ab' ~~ / <?after <aab>> $ /),
+    'lookbehind backtracks into a subrule whose preferred match ends elsewhere';
+ok ?('xab' ~~ / <?after <aab>> $ /),
+    'lookbehind finds the longer alternative ending at the current position';
+
+ok ?('(x)' ~~ / <?after [ '(' ~ ')' x ]> /),
+    'goal matching inside a lookbehind matches the text behind';
+
+ok ?('abc' ~~ / abc <?after a <?before b> bc> /),
+    'lookahead nested inside a lookbehind checks the text ahead of its position';
+
+ok ?('ab' ~~ / ab <?after a <?[b]> b> /),
+    'zero-width character peek inside a lookbehind checks the character ahead';
+nok ?('ab' ~~ / ab <?after a <?[a]> b> /),
+    'zero-width character peek inside a lookbehind does not check the character behind';
+
+ok ?('aq' ~~ / aq <?after <[a..z] - [f]>> /),
+    'character class subtraction inside a lookbehind matches an included character';
+nok ?('af' ~~ / af <?after <[a..z] - [f]>> /),
+    'character class subtraction inside a lookbehind rejects a subtracted character';
+
+ok ?('ab' ~~ / ab <?after ^ <ab>> /),
+    'start anchor inside a scanning lookbehind holds at the start of the string';
+nok ?('zab' ~~ / zab <?after ^ <ab>> /),
+    'start anchor inside a scanning lookbehind fails away from the start';
+
+is ('ab ba' ~~ / <!after <ab>> b /).pos, 2,
+    'negated lookbehind with a subrule matches where the subrule cannot end';
+
+'ab ba' ~~ / <after ab> /;
+is $<after>.from, 2,
+    'capturing lookbehind on the reversing path starts its capture at the current position';
+is $<after>.pos, 2,
+    'capturing lookbehind on the reversing path ends its capture at the current position';
+
+'ab ba' ~~ / <after <ab>> /;
+is $<after>.from, 2,
+    'capturing lookbehind on the scanning path starts its capture at the current position';
+is $<after>.pos, 2,
+    'capturing lookbehind on the scanning path ends its capture at the current position';
+
+my @origs;
+'aab' ~~ / <?after a { @origs.push(~$/.orig) } ab> /;
+is @origs.tail, 'aab',
+    'a code block inside a scanning lookbehind sees the unreversed target';
+
+ok ?(('x' x 1000 ~ 'ab') ~~ / <?after <ab>> $ /),
+    'scanning lookbehind succeeds at the end of a long string';
+nok ?(('x' x 1000) ~~ / <?after <ab>> $ /),
+    'scanning lookbehind fails at the end of a long string with no match';


### PR DESCRIPTION
The <?after ...> assertion compiles by reversing the pattern syntax tree and matching it against a reversed copy of the target string. That only works for nodes the compiler knows how to reverse. Subrule calls (named rules, interpolated patterns, backreferences), embedded code, and zero-width checks other than anchors were left matching left-to-right against the reversed target, giving wrong results:

    my regex ab { ab }
    say .pos given 'ab ba' ~~ / <?after    ab   > /;  # 2
    say .pos given 'ab ba' ~~ / <?after   <ab>  > /;  # 5, should be 2
    say .pos given 'ab ba' ~~ / <?after <{'ab'}>> /;  # 5, should be 2

Both frontends now only reverse when every node in the lookbehind pattern is reversible, and otherwise emit a call to the new NQP-side after_scan method, which matches the unmodified pattern forward from each position at or before the current one and succeeds if any match ends exactly at the current position.

This also fixes goal matching, character class subtraction, and zero-width peeks such as <?[x]> inside lookbehinds, and the capturing <after ...> form no longer produces a negative-width match object.

Needs the corresponding NQP change to provide after_scan.

Resolves #6087