### PR TITLE
Bind generic class parameter types via the full binder

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -9716,6 +9716,14 @@ Did you mean a call like '"
                         return 0;
                     }
 
+                    # A generic class such as Array[T] is generic and
+                    # nominal, unlike a type capture. No typevar binding
+                    # exists under its name, so only the full binder can
+                    # instantiate and check it.
+                    if $ptype_archetypes.nominal {
+                        return 0;
+                    }
+
                     $var.push(QAST::ParamTypeCheck.new(QAST::Op.new(
                         :op('istype_nd'),
                         QAST::Var.new( :name(get_decont_name()), :scope('local') ),

--- a/src/Raku/ast/signature.rakumod
+++ b/src/Raku/ast/signature.rakumod
@@ -1203,16 +1203,34 @@ class RakuAST::Parameter
             && !($meta-object.optional || $meta-object.slurpy || $meta-object.capture);
 
         # Parameters needing the full binder force custom-args on
-        # their owning routine. Conditions decidable from AST state
-        # set the flag here at BEGIN time. The flag must be True by
-        # the time the owning routine compiles, which can happen
-        # during BEGIN (for example, a trait_mod multi applied to
-        # an attribute).
+        # their owning routine. The flag must be True by the time the
+        # owning routine compiles, which can happen during BEGIN (for
+        # example, a trait_mod multi applied to an attribute, or a
+        # method in a role body).
         $!owner.set-custom-args
             if nqp::isconcrete($!owner)
             && ($!sub-signature || nqp::elems($!names) > 2);
+        self.IMPL-SET-CUSTOM-ARGS-FOR-GENERIC;
 
         $!target.to-begin-time($resolver, $context) if $!target;
+    }
+
+    # Type captures are the only generic parameter types the lowered
+    # typecheck can handle. Generic classes such as Array[T], which are
+    # generic and nominal, and parametric generics such as Positional[T]
+    # need the full binder to instantiate them from the type environment.
+    # Also called at CHECK time for types whose archetypes are not final
+    # at the parameter's begin time, such as a class stub completed later.
+    method IMPL-SET-CUSTOM-ARGS-FOR-GENERIC() {
+        my $param-type := nqp::getattr(self.meta-object, Parameter, '$!type');
+        my $archetypes := $param-type.HOW.archetypes($param-type);
+        $!owner.set-custom-args
+            if nqp::isconcrete($!owner)
+            && $archetypes.generic
+            && !$archetypes.coercive
+            && ($archetypes.nominal
+                 || nqp::can($archetypes, "parametric")
+                      && $archetypes.parametric);
     }
 
     method PERFORM-CHECK(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
@@ -1292,15 +1310,7 @@ class RakuAST::Parameter
         my int $is-generic  := $ptype-archetypes.generic;
         my int $is-coercive := $ptype-archetypes.coercive;
 
-        # Generic parametric parameter types need the full binder.
-        # This branch depends on archetype data so it runs at CHECK
-        # time. Parameter shape conditions are handled in PERFORM-BEGIN.
-        if $is-generic
-          && !$is-coercive
-          && nqp::can($ptype-archetypes, "parametric")
-          && $ptype-archetypes.parametric {
-            $!owner.set-custom-args;
-        }
+        self.IMPL-SET-CUSTOM-ARGS-FOR-GENERIC;
 
         if $!type {
             my $param-type := $!type.compile-time-value;

--- a/src/core.c/TypeEnv.rakumod
+++ b/src/core.c/TypeEnv.rakumod
@@ -28,7 +28,11 @@ my class TypeEnv { # declared in BOOTSTRAP
                 my Mu \pair = nqp::shift(iter);
                 my $sym := nqp::iterkey_s(pair);
                 unless nqp::existskey(ctx-hash, $sym) {
-                    nqp::bindkey(ctx-hash, $sym, (my \v = nqp::iterval(pair)));
+                    # A lexical can hold an unhandled Failure, which throws
+                    # when sunk, so the copied value must not be this
+                    # block's value.
+                    nqp::bindkey(ctx-hash, $sym, nqp::iterval(pair));
+                    Nil
                 }
             }
 

--- a/t/02-rakudo/generic-class-parameter-type.t
+++ b/t/02-rakudo/generic-class-parameter-type.t
@@ -1,0 +1,103 @@
+use Test;
+
+plan 19;
+
+# https://github.com/rakudo/rakudo/issues/5805
+# Parameterizing Array or Hash with a still-generic T produces a generic
+# class rather than a type capture or a parametric role curry. Binding a
+# parameter of such a type must instantiate it from the type environment.
+
+sub array-taker(::T $a, Array[T] $b) { $b }
+{
+    my Int @a = 666;
+    my $bound = array-taker(42, @a);
+    ok $bound.WHAT =:= Array[Int], 'Array[T] parameter instantiates to Array[Int] for an Int argument pair';
+    is-deeply $bound.List, (666,), 'Array[T] parameter binds the passed array contents';
+}
+{
+    my Str @a = 'x';
+    ok array-taker('s', @a).WHAT =:= Array[Str], 'Array[T] parameter instantiates to Array[Str] for a Str argument pair';
+}
+{
+    my Str @a = 'x';
+    throws-like { array-taker(42, @a) }, X::TypeCheck::Binding::Parameter,
+        'Array[T] parameter rejects an array whose type does not match the instantiated T';
+}
+
+sub hash-taker(::T $a, Hash[T] $b) { $b }
+{
+    my Int %h = a => 666;
+    my $bound = hash-taker(42, %h);
+    ok $bound.WHAT =:= Hash[Int], 'Hash[T] parameter instantiates to Hash[Int] for an Int argument pair';
+    is-deeply $bound<a>, 666, 'Hash[T] parameter binds the passed hash contents';
+}
+{
+    my Int %h = a => 666;
+    throws-like { hash-taker('s', %h) }, X::TypeCheck::Binding::Parameter,
+        'Hash[T] parameter rejects a hash whose type does not match the instantiated T';
+}
+
+sub positional-taker(::T $a, Positional[T] $b) { $b }
+{
+    my Int @a = 666;
+    ok positional-taker(42, @a).WHAT =:= Array[Int], 'Positional[T] parameter still binds an Array[Int] argument';
+}
+
+sub capture-taker(::T $a, T $b) { $b }
+is capture-taker(42, 43), 43, 'plain T parameter still binds a value of the captured type';
+throws-like { capture-taker(42, 'str') }, X::TypeCheck::Binding::Parameter,
+    'plain T parameter still rejects a value outside the captured type';
+
+{
+    role ArrayMethod[::T] { method m(Array[T] $x) { $x } }
+    my class WithInt does ArrayMethod[Int] { }
+    my Int @a = 1;
+    ok WithInt.m(@a).WHAT =:= Array[Int], 'Array[T] parameter on a role method binds after concretization';
+    my Str @b = 'x';
+    throws-like { WithInt.m(@b) }, X::TypeCheck::Binding::Parameter,
+        'Array[T] parameter on a role method rejects a mismatched array after concretization';
+}
+
+{
+    role PositionalMethod[::T] { method m(Positional[T] $x) { $x } }
+    my class PosWithInt does PositionalMethod[Int] { }
+    my Int @a = 1;
+    ok PosWithInt.m(@a).WHAT =:= Array[Int], 'Positional[T] parameter on a role method binds after concretization';
+}
+
+{
+    role CaptureMethod[::T] { method m(T $x) { $x } }
+    my class CapWithInt does CaptureMethod[Int] { }
+    is CapWithInt.m(5), 5, 'plain T parameter on a role method still binds after concretization';
+}
+
+# Multi dispatch trial-binds a generic candidate, so it must also
+# instantiate generic class parameter types to decide a match.
+multi multi-taker(::T $a, Array[T] $b) { 'generic' }
+multi multi-taker($a, $b) { 'fallback' }
+{
+    my Int @a = 666;
+    is multi-taker(42, @a), 'generic', 'multi dispatch picks the Array[T] candidate for a matching argument pair';
+    my Str @b = 'x';
+    is multi-taker(42, @b), 'fallback', 'multi dispatch falls back when the array type does not match T';
+}
+
+multi lone-taker(::T $a, Array[T] $b) { 'generic' }
+{
+    my Str @a = 'x';
+    throws-like { lone-taker(42, @a) }, X::Multi::NoMatch,
+        'multi dispatch reports no match when the only candidate has a mismatched Array[T] parameter';
+}
+
+{
+    role MultiMethod[::T] {
+        multi method m(Array[T] $x) { 'typed' }
+        multi method m($x) { 'other' }
+    }
+    my class MultiWithInt does MultiMethod[Int] { }
+    my Int @a = 1;
+    is MultiWithInt.m(@a), 'typed', 'multi method on a role picks the Array[T] candidate after concretization';
+    is MultiWithInt.m('s'), 'other', 'multi method on a role falls back for a non-array argument';
+}
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously a parameter typed with a generic class, such as Array[T] in a signature like (::T $a, Array[T] $b), failed to bind with "Internal error: inconsistent bind result". Both frontends lowered the parameter to an inline type check that cannot succeed. The legacy frontend emitted a typevar lookup under the name "Array[T]", which no frame ever binds, and the RakuAST frontend checked against the uninstantiated generic type. The full binder that runs afterwards to report the failure then bound successfully, which is the inconsistency the error message refers to.

A generic class is generic and nominal, while a type capture is generic only and a role curry such as Positional[T] is generic and parametric. Signature lowering only knows how to check type captures, so this bails out to the full binder for nominal generics the same way it already does for parametric ones. The full binder instantiates the type from the type environment, so (::T $a, Array[T] $b) now binds Array[Int] for an Int argument pair and rejects a mismatch with a normal type check error. The same applies to Hash[T].

The RakuAST frontend set custom-args for parametric generics at CHECK time, which is too late for routines compiled during BEGIN, such as methods in role bodies. The archetype condition now also runs at the end of PERFORM-BEGIN. That additionally fixes Positional[T] parameters on role methods under the RakuAST frontend, which previously died with "Method T.ACCEPTS not found".

The same change covers multi dispatch, which previously died with "Cannot resolve caller" for a matching argument pair. The dispatcher trial binds a generic candidate to decide whether it matches, and the trial runs the compiled binding that emitted the broken inline check. Generic class candidates now match when the instantiated type accepts the argument and are skipped otherwise.

Fixes #5805