### PR TITLE
Call min/max key functions once per value

### DIFF
--- a/src/core.c/Order.rakumod
+++ b/src/core.c/Order.rakumod
@@ -173,11 +173,6 @@ proto sub infix:<coll>(  $, $, *% --> Order:D) {*}
 # integer value for comparison.
 augment class Any {
 
-    # Make sure given comparator has an arity of 2
-    my sub aritize22(&by) {
-        nqp::iseq_i(&by.arity,2) ?? &by !! { by($^a) cmp by($^b) }
-    }
-
     # Common logic for minpairs / maxpairs
     method !minmaxpairs(\order, &by) {
         nqp::iseq_i(&by.arity,2)
@@ -484,6 +479,28 @@ augment class Any {
           )
         );
     }
+    method !key-minmax-range-check(
+      $value, &by, $mi is rw, $mi-key is rw, $exmi is rw,
+                   $ma is rw, $ma-key is rw, $exma is rw
+    --> Nil) {
+        nqp::if(
+          nqp::eqaddr((my $min-key := by($value.min)) cmp $mi-key,Order::Less),
+          nqp::stmts(
+            ($mi     = $value.min),
+            ($mi-key = $min-key),
+            ($exmi   = $value.excludes-min)
+          )
+        );
+
+        nqp::if(
+          nqp::eqaddr((my $max-key := by($value.max)) cmp $ma-key,Order::More),
+          nqp::stmts(
+            ($ma     = $value.max),
+            ($ma-key = $max-key),
+            ($exma   = $value.excludes-max)
+          )
+        );
+    }
 
     proto method minmax (|) is nodal {*}
     multi method minmax(Any:D: ) {
@@ -534,17 +551,21 @@ augment class Any {
     }
     multi method minmax(Any:D: :&by!) { self.minmax(&by, |%_) }
     multi method minmax(Any:D: &by) {
+        nqp::iseq_i(&by.arity,2)
+          ?? self!cmp-minmax(&by)
+          !! self!key-minmax(&by)
+    }
+    method !cmp-minmax(&comparator) {
         nqp::if(
           (my $iter := self.iterator-and-first(".minmax",my $pulled)),
           nqp::stmts(
-            (my &comparator = aritize22(&by)),
             nqp::if(
               nqp::istype($pulled,Range),
               self!minmax-range-init($pulled,
                 my $min,my int $excludes-min,my $max,my int $excludes-max),
               nqp::if(
                 nqp::istype($pulled,Positional),
-                self!minmax-range-init($pulled.minmax(&by), # recurse min/max
+                self!minmax-range-init($pulled.minmax(&comparator), # recurse min/max
                   $min,$excludes-min,$max,$excludes-max),
                 ($min = $max = $pulled)
               )
@@ -559,7 +580,7 @@ augment class Any {
                      &comparator,$min,$excludes-min,$max,$excludes-max),
                   nqp::if(
                     nqp::istype($pulled,Positional),
-                    self!cmp-minmax-range-check($pulled.minmax(&by),
+                    self!cmp-minmax-range-check($pulled.minmax(&comparator),
                        &comparator,$min,$excludes-min,$max,$excludes-max),
                     nqp::if(
                       nqp::eqaddr(comparator($pulled,$min),Order::Less),
@@ -567,6 +588,75 @@ augment class Any {
                       nqp::if(
                         nqp::eqaddr(comparator($pulled,$max),Order::More),
                         ($max = $pulled)
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        );
+
+        nqp::defined($min)
+          ?? Range.new($min,$max,:$excludes-min,:$excludes-max)
+          !! Range.Inf-Inf
+    }
+    # A 1-arg &by maps a value to the key to compare it by, so call it
+    # once per value and cache the keys of the current minimum and
+    # maximum.  Ranges and Positionals contribute their two endpoints.
+    method !key-minmax(&by) {
+        nqp::if(
+          (my $iter := self.iterator-and-first(".minmax",my $pulled)),
+          nqp::stmts(
+            nqp::if(
+              nqp::istype($pulled,Range),
+              nqp::stmts(
+                self!minmax-range-init($pulled,
+                  my $min,my int $excludes-min,my $max,my int $excludes-max),
+                (my $min-key = by($min)),
+                (my $max-key = by($max))
+              ),
+              nqp::if(
+                nqp::istype($pulled,Positional),
+                nqp::stmts(
+                  self!minmax-range-init($pulled.minmax(&by), # recurse min/max
+                    $min,$excludes-min,$max,$excludes-max),
+                  ($min-key = by($min)),
+                  ($max-key = by($max))
+                ),
+                nqp::stmts(
+                  ($min = $max = $pulled),
+                  ($min-key = $max-key = by($pulled))
+                )
+              )
+            ),
+            nqp::until(
+              nqp::eqaddr(($pulled := $iter.pull-one),IterationEnd),
+              nqp::if(
+                nqp::isconcrete($pulled),
+                nqp::if(
+                  nqp::istype($pulled,Range),
+                  self!key-minmax-range-check($pulled,
+                     &by,$min,$min-key,$excludes-min,$max,$max-key,$excludes-max),
+                  nqp::if(
+                    nqp::istype($pulled,Positional),
+                    self!key-minmax-range-check($pulled.minmax(&by),
+                       &by,$min,$min-key,$excludes-min,$max,$max-key,$excludes-max),
+                    nqp::stmts(
+                      (my $key := by($pulled)),
+                      nqp::if(
+                        nqp::eqaddr($key cmp $min-key,Order::Less),
+                        nqp::stmts(
+                          ($min     = $pulled),
+                          ($min-key = $key)
+                        ),
+                        nqp::if(
+                          nqp::eqaddr($key cmp $max-key,Order::More),
+                          nqp::stmts(
+                            ($max     = $pulled),
+                            ($max-key = $key)
+                          )
+                        )
                       )
                     )
                   )

--- a/src/core.c/Order.rakumod
+++ b/src/core.c/Order.rakumod
@@ -248,8 +248,11 @@ augment class Any {
     }
     multi method min(Any:D: :&by!) { self.min(&by, |%_) }
     multi method min(Any:D: &by) {
-        my &comparator := aritize22(&by);
-
+        nqp::iseq_i(&by.arity,2)
+          ?? self!cmp-min(&by)
+          !! self!key-min(&by)
+    }
+    method !cmp-min(&comparator) {
         nqp::if(
           (my $iter := self.iterator-and-first(".min", my $min)),
           nqp::until(
@@ -258,6 +261,32 @@ augment class Any {
               (nqp::isconcrete($pulled)
                 && nqp::eqaddr(comparator($pulled,$min),Order::Less)),
               $min = $pulled
+            )
+          )
+        );
+
+        nqp::defined($min) ?? $min !! Inf
+    }
+    # A 1-arg &by maps a value to the key to compare it by, so call it
+    # once per value and cache the key of the current minimum.
+    method !key-min(&by) {
+        nqp::if(
+          (my $iter := self.iterator-and-first(".min", my $min)),
+          nqp::stmts(
+            (my $min-key = by($min)),
+            nqp::until(
+              nqp::eqaddr((my $pulled := $iter.pull-one),IterationEnd),
+              nqp::if(
+                (nqp::isconcrete($pulled)
+                  && nqp::eqaddr(
+                       (my $key := by($pulled)) cmp $min-key,
+                       Order::Less
+                     )),
+                nqp::stmts(
+                  ($min     = $pulled),
+                  ($min-key = $key)
+                )
+              )
             )
           )
         );
@@ -305,8 +334,11 @@ augment class Any {
     }
     multi method max(Any:D: :&by!) { self.max(&by, |%_) }
     multi method max(Any:D: &by) {
-        my &comparator := aritize22(&by);
-
+        nqp::iseq_i(&by.arity,2)
+          ?? self!cmp-max(&by)
+          !! self!key-max(&by)
+    }
+    method !cmp-max(&comparator) {
         nqp::if(
           (my $iter := self.iterator-and-first(".max", my $max)),
           nqp::until(
@@ -315,6 +347,32 @@ augment class Any {
               (nqp::isconcrete($pulled)
                 && nqp::eqaddr(comparator($pulled,$max),Order::More)),
               $max = $pulled
+            )
+          )
+        );
+
+        nqp::defined($max) ?? $max !! -Inf
+    }
+    # A 1-arg &by maps a value to the key to compare it by, so call it
+    # once per value and cache the key of the current maximum.
+    method !key-max(&by) {
+        nqp::if(
+          (my $iter := self.iterator-and-first(".max", my $max)),
+          nqp::stmts(
+            (my $max-key = by($max)),
+            nqp::until(
+              nqp::eqaddr((my $pulled := $iter.pull-one),IterationEnd),
+              nqp::if(
+                (nqp::isconcrete($pulled)
+                  && nqp::eqaddr(
+                       (my $key := by($pulled)) cmp $max-key,
+                       Order::More
+                     )),
+                nqp::stmts(
+                  ($max     = $pulled),
+                  ($max-key = $key)
+                )
+              )
             )
           )
         );

--- a/src/core.c/Order.rakumod
+++ b/src/core.c/Order.rakumod
@@ -180,7 +180,11 @@ augment class Any {
 
     # Common logic for minpairs / maxpairs
     method !minmaxpairs(\order, &by) {
-        my &comparator := aritize22(&by);
+        nqp::iseq_i(&by.arity,2)
+          ?? self!cmp-minmaxpairs(order, &by)
+          !! self!key-minmaxpairs(order, &by)
+    }
+    method !cmp-minmaxpairs(\order, &comparator) {
         my $iter   := self.pairs.iterator;
         my $result := nqp::create(IterationBuffer);
 
@@ -206,6 +210,48 @@ augment class Any {
                   nqp::stmts(                       # new best
                     nqp::push(nqp::setelems($result,0),$pair),
                     nqp::bind($target,$value)
+                  ),
+                  nqp::if(                          # additional best
+                    nqp::eqaddr($cmp-result,Order::Same),
+                    nqp::push($result,$pair)
+                  )
+                )
+              )
+            )
+          )
+        );
+
+        $result
+    }
+    # A 1-arg &by maps a value to the key to compare it by, so call it
+    # once per value and cache the key of the current best values.
+    method !key-minmaxpairs(\order, &by) {
+        my $iter   := self.pairs.iterator;
+        my $result := nqp::create(IterationBuffer);
+
+        nqp::until(
+          nqp::eqaddr((my $pair := $iter.pull-one),IterationEnd)
+            || nqp::isconcrete(my $target := $pair.value),
+          nqp::null
+        );
+
+        nqp::unless(
+          nqp::eqaddr($pair,IterationEnd),
+          nqp::stmts(                               # found at least one value
+            nqp::push($result,$pair),
+            (my $target-key = by($target)),
+            nqp::until(
+              nqp::eqaddr(nqp::bind($pair,$iter.pull-one),IterationEnd),
+              nqp::if(
+                nqp::isconcrete(my $value := $pair.value),
+                nqp::if(
+                  nqp::eqaddr(
+                    (my $cmp-result := (my $key := by($value)) cmp $target-key),
+                    order
+                  ),
+                  nqp::stmts(                       # new best
+                    nqp::push(nqp::setelems($result,0),$pair),
+                    ($target-key = $key)
                   ),
                   nqp::if(                          # additional best
                     nqp::eqaddr($cmp-result,Order::Same),

--- a/src/core.c/Supply-coercers.rakumod
+++ b/src/core.c/Supply-coercers.rakumod
@@ -669,51 +669,110 @@
     }
 
     method min(Supply:D: &by = &infix:<cmp>) {
-        my &cmp = &by.arity == 2 ?? &by !! { by($^a) cmp by($^b) }
-        supply {
-            my $min;
-            whenever self -> \val {
-                if val.defined and !$min.defined || cmp(val,$min) < 0 {
-                    emit( $min := val );
-                }
-            }
-        }
+        &by.arity == 2
+          ?? supply {
+                 my $min;
+                 whenever self -> \val {
+                     if val.defined and !$min.defined || by(val,$min) < 0 {
+                         emit( $min := val );
+                     }
+                 }
+             }
+          # a 1-arg &by maps a value to the key to compare it by, so
+          # call it once per value and cache the current minimum's key
+          !! supply {
+                 my $min;
+                 my $min-key;
+                 whenever self -> \val {
+                     if val.defined {
+                         my \key = by(val);
+                         if !$min.defined || (key cmp $min-key) < 0 {
+                             $min-key = key;
+                             emit( $min := val );
+                         }
+                     }
+                 }
+             }
     }
 
     method max(Supply:D: &by = &infix:<cmp>) {
-        my &cmp = &by.arity == 2 ?? &by !! { by($^a) cmp by($^b) }
-        supply {
-            my $max;
-            whenever self -> \val {
-                 if val.defined and !$max.defined || cmp(val,$max) > 0 {
-                     emit( $max = val );
+        &by.arity == 2
+          ?? supply {
+                 my $max;
+                 whenever self -> \val {
+                     if val.defined and !$max.defined || by(val,$max) > 0 {
+                         emit( $max = val );
+                     }
                  }
-            }
-        }
+             }
+          # a 1-arg &by maps a value to the key to compare it by, so
+          # call it once per value and cache the current maximum's key
+          !! supply {
+                 my $max;
+                 my $max-key;
+                 whenever self -> \val {
+                     if val.defined {
+                         my \key = by(val);
+                         if !$max.defined || (key cmp $max-key) > 0 {
+                             $max-key = key;
+                             emit( $max = val );
+                         }
+                     }
+                 }
+             }
     }
 
     method minmax(Supply:D: &by = &infix:<cmp>) {
-        my &cmp = &by.arity == 2 ?? &by !! { by($^a) cmp by($^b) }
-        supply {
-            my $min;
-            my $max;
-            whenever self -> \val {
-                if nqp::istype(val,Failure) {
-                    val.throw;  # XXX or just ignore ???
-                }
-                elsif val.defined {
-                    if !$min.defined {
-                        emit( Range.new($min = val, $max = val) );
-                    }
-                    elsif cmp(val,$min) < 0 {
-                        emit( Range.new( $min = val, $max ) );
-                    }
-                    elsif cmp(val,$max) > 0 {
-                        emit( Range.new( $min, $max = val ) );
-                    }
-                }
-            }
-        }
+        &by.arity == 2
+          ?? supply {
+                 my $min;
+                 my $max;
+                 whenever self -> \val {
+                     if nqp::istype(val,Failure) {
+                         val.throw;  # XXX or just ignore ???
+                     }
+                     elsif val.defined {
+                         if !$min.defined {
+                             emit( Range.new($min = val, $max = val) );
+                         }
+                         elsif by(val,$min) < 0 {
+                             emit( Range.new( $min = val, $max ) );
+                         }
+                         elsif by(val,$max) > 0 {
+                             emit( Range.new( $min, $max = val ) );
+                         }
+                     }
+                 }
+             }
+          # a 1-arg &by maps a value to the key to compare it by, so
+          # call it once per value and cache the keys of the current
+          # minimum and maximum
+          !! supply {
+                 my $min;
+                 my $max;
+                 my $min-key;
+                 my $max-key;
+                 whenever self -> \val {
+                     if nqp::istype(val,Failure) {
+                         val.throw;  # XXX or just ignore ???
+                     }
+                     elsif val.defined {
+                         my \key = by(val);
+                         if !$min.defined {
+                             $min-key = $max-key = key;
+                             emit( Range.new($min = val, $max = val) );
+                         }
+                         elsif (key cmp $min-key) < 0 {
+                             $min-key = key;
+                             emit( Range.new( $min = val, $max ) );
+                         }
+                         elsif (key cmp $max-key) > 0 {
+                             $max-key = key;
+                             emit( Range.new( $min, $max = val ) );
+                         }
+                     }
+                 }
+             }
     }
 
     method grab(Supply:D: &when_done) {

--- a/t/02-rakudo/25-min-max-by-key.t
+++ b/t/02-rakudo/25-min-max-by-key.t
@@ -1,0 +1,73 @@
+use Test;
+
+plan 15;
+
+# A 1-arg &by passed to .min / .max is a key function, not a comparator.
+# It must be called once per value rather than twice per comparison,
+# which matters when the key function is expensive or has side effects.
+
+{
+    my int $calls;
+    my sub chars-of($value) { ++$calls; $value.chars }
+
+    $calls = 0;
+    is-deeply (^100).Array.min(&chars-of), 0,
+        '.min with a key function finds the first minimal value';
+    is $calls, 100,
+        '.min called the key function once per value';
+
+    $calls = 0;
+    is-deeply (^100).Array.max(&chars-of), 10,
+        '.max with a key function finds the first maximal value';
+    is $calls, 100,
+        '.max called the key function once per value';
+
+    $calls = 0;
+    is-deeply (42,).min(&chars-of), 42,
+        '.min of a single value returns that value';
+    is $calls, 1,
+        '.min of a single value called the key function once';
+}
+
+{
+    my int $calls;
+    my sub abs-of($value) { ++$calls; $value.abs }
+
+    $calls = 0;
+    is-deeply (Int, 3, 1, -5).min(&abs-of), 1,
+        '.min with a key function skips type objects';
+    is $calls, 3,
+        '.min never called the key function on a type object';
+}
+
+{
+    my int $calls;
+
+    $calls = 0;
+    is-deeply (^100).Array.max({ ++$calls; .chars }), 10,
+        '.max with a block using the topic finds the maximum';
+    is $calls, 100,
+        '.max called the topic block once per value';
+}
+
+{
+    my int $calls;
+    my sub compare($a, $b) { ++$calls; $a <=> $b }
+
+    $calls = 0;
+    is-deeply (3, 1, 4, 1, 5).min(&compare), 1,
+        '.min with a 2-arg comparator finds the minimum';
+    is $calls, 4,
+        '.min called the comparator once per value after the first';
+
+    $calls = 0;
+    is-deeply (3, 1, 4, 1, 5).max(&compare), 5,
+        '.max with a 2-arg comparator finds the maximum';
+    is $calls, 4,
+        '.max called the comparator once per value after the first';
+}
+
+is-deeply <ab cd e>.max(*.chars), 'ab',
+    '.max with a key function keeps the first of tied values';
+
+# vim: expandtab shiftwidth=4

--- a/t/02-rakudo/25-min-max-by-key.t
+++ b/t/02-rakudo/25-min-max-by-key.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 32;
+plan 39;
 
 # A 1-arg &by passed to .min / .max is a key function, not a comparator.
 # It must be called once per value rather than twice per comparison,
@@ -140,5 +140,57 @@ is-deeply ((3, 9), 1).minmax(*.abs), 1..9,
 
 is-deeply (3, 1, 4, 5).minmax(-> $a, $b { $a <=> $b }), 1..5,
     '.minmax with a 2-arg comparator finds the minimal and maximal values';
+
+{
+    my int $calls;
+    my sub chars-of($value) { ++$calls; $value.chars }
+
+    $calls = 0;
+    my @minima;
+    react {
+        whenever Supply.from-list(10, 9, 100, 8).min(&chars-of) {
+            @minima.push($_);
+        }
+    }
+    is-deeply @minima, [10, 9],
+        'Supply.min with a key function emits each new minimum';
+    is $calls, 4,
+        'Supply.min called the key function once per value';
+
+    $calls = 0;
+    my @maxima;
+    react {
+        whenever Supply.from-list(9, 10, 8, 100).max(&chars-of) {
+            @maxima.push($_);
+        }
+    }
+    is-deeply @maxima, [9, 10, 100],
+        'Supply.max with a key function emits each new maximum';
+    is $calls, 4,
+        'Supply.max called the key function once per value';
+
+    $calls = 0;
+    my @ranges;
+    react {
+        whenever Supply.from-list(5, 1, 10).minmax(&chars-of) {
+            @ranges.push($_);
+        }
+    }
+    is-deeply @ranges, [5..5, 5..10],
+        'Supply.minmax with a key function emits each widened range';
+    is $calls, 3,
+        'Supply.minmax called the key function once per value';
+}
+
+{
+    my @minima;
+    react {
+        whenever Supply.from-list(3, 1, 2).min(-> $a, $b { $a <=> $b }) {
+            @minima.push($_);
+        }
+    }
+    is-deeply @minima, [3, 1],
+        'Supply.min with a 2-arg comparator emits each new minimum';
+}
 
 # vim: expandtab shiftwidth=4

--- a/t/02-rakudo/25-min-max-by-key.t
+++ b/t/02-rakudo/25-min-max-by-key.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 15;
+plan 25;
 
 # A 1-arg &by passed to .min / .max is a key function, not a comparator.
 # It must be called once per value rather than twice per comparison,
@@ -69,5 +69,45 @@ plan 15;
 
 is-deeply <ab cd e>.max(*.chars), 'ab',
     '.max with a key function keeps the first of tied values';
+
+{
+    my int $calls;
+    my sub chars-of($value) { ++$calls; $value.chars }
+
+    $calls = 0;
+    is-deeply (^10).Array.minpairs(&chars-of), ((^10).map({ $_ => $_ })).List,
+        '.minpairs with a key function keeps all tied values';
+    is $calls, 10,
+        '.minpairs called the key function once per value';
+
+    $calls = 0;
+    is-deeply (9, 10, 11, 8).maxpairs(&chars-of), (1 => 10, 2 => 11),
+        '.maxpairs with a key function keeps all maximal values';
+    is $calls, 4,
+        '.maxpairs called the key function once per value';
+
+    $calls = 0;
+    is-deeply (^100).Array.min(&chars-of, :k), (^10).List,
+        '.min(:k) with a key function returns the keys of the minimal values';
+    is $calls, 100,
+        '.min(:k) called the key function once per value';
+
+    $calls = 0;
+    is-deeply (^100).Array.max(&chars-of, :v), (10..99).List,
+        '.max(:v) with a key function returns the maximal values';
+    is $calls, 100,
+        '.max(:v) called the key function once per value';
+}
+
+{
+    my int $calls;
+    my sub compare($a, $b) { ++$calls; $a <=> $b }
+
+    $calls = 0;
+    is-deeply (3, 1, 4, 1).minpairs(&compare), (1 => 1, 3 => 1),
+        '.minpairs with a 2-arg comparator keeps all minimal values';
+    is $calls, 3,
+        '.minpairs called the comparator once per value after the first';
+}
 
 # vim: expandtab shiftwidth=4

--- a/t/02-rakudo/25-min-max-by-key.t
+++ b/t/02-rakudo/25-min-max-by-key.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 25;
+plan 32;
 
 # A 1-arg &by passed to .min / .max is a key function, not a comparator.
 # It must be called once per value rather than twice per comparison,
@@ -109,5 +109,36 @@ is-deeply <ab cd e>.max(*.chars), 'ab',
     is $calls, 3,
         '.minpairs called the comparator once per value after the first';
 }
+
+{
+    my int $calls;
+    my sub chars-of($value) { ++$calls; $value.chars }
+
+    $calls = 0;
+    is-deeply (^100).Array.minmax(&chars-of), 0..10,
+        '.minmax with a key function finds the minimal and maximal values';
+    is $calls, 100,
+        '.minmax called the key function once per value';
+}
+
+{
+    my int $calls;
+    my sub abs-of($value) { ++$calls; $value.abs }
+
+    $calls = 0;
+    is-deeply (1..3, 9, -7).minmax(&abs-of), 1..9,
+        '.minmax with a key function compares Range values by their endpoints';
+    is $calls, 4,
+        '.minmax called the key function once per endpoint and value';
+}
+
+is-deeply (1^..5, 7).minmax(*.self), 1^..7,
+    '.minmax with a key function preserves endpoint exclusions';
+
+is-deeply ((3, 9), 1).minmax(*.abs), 1..9,
+    '.minmax with a key function recurses into Positional values';
+
+is-deeply (3, 1, 4, 5).minmax(-> $a, $b { $a <=> $b }), 1..5,
+    '.minmax with a 2-arg comparator finds the minimal and maximal values';
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously a 1-arg &by passed to .min/.max was turned into a 2-arg comparator `{ by($^a) cmp by($^b) }`. That recomputes the key of the current best value on every comparison, giving nearly 2N calls for N values. This dispatches on the arity of &by up front. A 2-arg &by is used directly as a comparator like before. A 1-arg &by is treated as a key function and the key of the current best value is cached, so it gets called exactly once per value.

The same treatment is applied to .minpairs/.maxpairs (and the :k/:v/:kv/:p forms of .min/.max that share their logic), to .minmax (where Range and Positional values contribute one call per endpoint), and to Supply.min/.max/.minmax. The Supply commit can be dropped if it is considered out of scope.

```
# before
$ raku -e 'my int $c = 0; sub s($s) { $c++; $s.chars }; say (^100).Array.max(&s); say $c'
10
198

# after
$ raku -e 'my int $c = 0; sub s($s) { $c++; $s.chars }; say (^100).Array.max(&s); say $c'
10
100
```

Fixes #5871
