### PR TITLE
Remove undocumented and deprecated "gethostname"

### DIFF
--- a/src/core.c/core_epilogue.rakumod
+++ b/src/core.c/core_epilogue.rakumod
@@ -187,11 +187,6 @@ sub from-json($text)
     Rakudo::Internals::JSON.from-json($text);
 }
 
-proto sub gethostname(*%) is implementation-detail {*}
-multi sub gethostname(--> Str:D) is DEPRECATED('$*KERNEL.hostname') {
-    $*KERNEL.hostname
-}
-
 augment class Mu {
     proto method perl(|) {*}
     multi method perl(Mu \SELF: |c) is DEPRECATED("raku") { SELF.raku(|c) }

--- a/t/02-rakudo/03-corekeys-6c.t
+++ b/t/02-rakudo/03-corekeys-6c.t
@@ -172,7 +172,6 @@ my @expected = (
   Q{&full-barrier},
   Q{&get},
   Q{&getc},
-  Q{&gethostname},
   Q{&gist},
   Q{&goto},
   Q{&grep},

--- a/t/02-rakudo/03-corekeys-6d.t
+++ b/t/02-rakudo/03-corekeys-6d.t
@@ -172,7 +172,6 @@ my @expected = (
     Q{&full-barrier},
     Q{&get},
     Q{&getc},
-    Q{&gethostname},
     Q{&gist},
     Q{&goto},
     Q{&grep},

--- a/t/02-rakudo/03-corekeys-6e.t
+++ b/t/02-rakudo/03-corekeys-6e.t
@@ -174,7 +174,6 @@ my @expected = (
     Q{&full-barrier},
     Q{&get},
     Q{&getc},
-    Q{&gethostname},
     Q{&gist},
     Q{&goto},
     Q{&grep},

--- a/t/02-rakudo/03-corekeys.t
+++ b/t/02-rakudo/03-corekeys.t
@@ -175,7 +175,6 @@ my @allowed =
       Q{&full-barrier},
       Q{&get},
       Q{&getc},
-      Q{&gethostname},
       Q{&gist},
       Q{&goto},
       Q{&grep},

--- a/t/02-rakudo/04-settingkeys-6c.t
+++ b/t/02-rakudo/04-settingkeys-6c.t
@@ -171,7 +171,6 @@ my %allowed = (
     Q{&full-barrier},
     Q{&get},
     Q{&getc},
-    Q{&gethostname},
     Q{&gist},
     Q{&goto},
     Q{&grep},

--- a/t/02-rakudo/04-settingkeys-6e.t
+++ b/t/02-rakudo/04-settingkeys-6e.t
@@ -171,7 +171,6 @@ my %allowed = (
     Q{&full-barrier},
     Q{&get},
     Q{&getc},
-    Q{&gethostname},
     Q{&gist},
     Q{&goto},
     Q{&grep},

--- a/t/02-rakudo/12-proto-arity-count.t
+++ b/t/02-rakudo/12-proto-arity-count.t
@@ -144,7 +144,6 @@ sub all-the-protos {
     &full-barrier,
     &get,
     &getc,
-    &gethostname,
     &gist,
     &goto,
     &grep,


### PR DESCRIPTION
The canonical way nowadays is Kernel.hostname.  The deprecation message is about 6 years old  :-)