### PR TITLE
Add C99 hexadecimal float literals

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -8686,6 +8686,7 @@ Did you mean a call like '"
         if $<integer> {
             make $*W.add_numeric_constant($/, 'Int', $<integer>.ast);
         }
+        elsif $<hex_float>      { make $<hex_float>.ast; }
         elsif $<dec_number>     { make $<dec_number>.ast; }
         elsif $<rad_number>     { make $<rad_number>.ast; }
         elsif $<rat_number>     { make $<rat_number>.ast; }
@@ -8750,6 +8751,42 @@ Did you mean a call like '"
             $ast.node($/);
             make $ast;
         }
+    }
+
+    method hex_float($/) {
+        # The mantissa hex digits form an integer H with $f bits shifted
+        # into the fraction, so the value is H * 2 ** ($exp - $f).  H is
+        # exact in bigint arithmetic and the power-of-two scaling is
+        # applied in two steps so the intermediate product stays exact
+        # for any representable result: a single correctly rounded
+        # conversion in total.
+        my $Int := $*W.find_single_symbol_in_setting('Int');
+        my str $digits := ($<int> ?? $<int>.Str !! '') ~ ($<frac> ?? $<frac>.Str !! '');
+        my $H := nqp::radix_I(16, $digits, 0, 0, $Int)[0];
+
+        my int $f := 0;
+        if $<frac> {
+            my str $fs := $<frac>.Str;
+            my int $i  := 0;
+            my int $n  := nqp::chars($fs);
+            while $i < $n {
+                $f := $f + 4 unless nqp::eqat($fs, '_', $i);
+                $i := $i + 1;
+            }
+        }
+
+        my str $estr := nqp::join('', nqp::split('_', $<exp>.Str));
+        my int $k := nqp::chars($estr) > 6
+            ?? 999999   # any such exponent over/underflows anyway
+            !! nqp::radix(10, $estr, 0, 0)[0];
+        $k := -$k if $<sign> eq '-' || $<sign> eq '−';
+        $k := $k - $f;
+
+        my int $k1 := nqp::div_i($k, 2);
+        my num $value := nqp::mul_n(
+            nqp::mul_n(nqp::tonum_I($H), nqp::pow_n(2.0, $k1)),
+            nqp::pow_n(2.0, $k - $k1));
+        make $*W.add_numeric_constant($/, 'Num', $value);
     }
 
     method rad_number($/) {

--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -3320,6 +3320,7 @@ sub, perhaps you accidentally placed a semicolon after routine's definition?"
     token numish {
         [
         | 'NaN' >>
+        | <hex_float>
         | <integer>
         | <dec_number>
         | <rad_number>
@@ -3338,6 +3339,18 @@ sub, perhaps you accidentally placed a semicolon after routine's definition?"
         | $<coeff> = [ <int=.decint> '.' <frac=.decint> ] <escale>?
         | $<coeff> = [ <int=.decint>                    ] <escale>
         ]
+    }
+
+    # C99 hexadecimal floating point, e.g. 0x1.8p+1; the binary exponent
+    # is mandatory, which keeps 0x1.abs parsing as a method call
+    token hex_float {
+        :dba('hexadecimal float')
+        0x '_'?
+        [
+        | <int=.hexint> [ '.' <frac=.hexint> ]?
+        |               '.' <frac=.hexint>
+        ]
+        <[pP]> <sign> <exp=.decint>
     }
 
     token signed-integer { <sign> <integer> }

--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -3344,6 +3344,11 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
             $attachee := Nodify('IntLiteral').new($<integer>.ast);
         }
 
+        # 0x1.8p+1
+        elsif $<hex-float> {
+            $attachee := $<hex-float>.ast;
+        }
+
         # 42.137
         elsif $<decimal-number> {
             $attachee := $<decimal-number>.ast;
@@ -3465,6 +3470,45 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
             }
             self.attach: $/, Nodify('RatLiteral').new($rat);
         }
+    }
+
+    method hex-float($/) {
+        # The mantissa hex digits form an integer H with $f bits shifted
+        # into the fraction, so the value is H * 2 ** ($exp - $f).  H is
+        # exact in bigint arithmetic and the power-of-two scaling is
+        # applied in two steps so the intermediate product stays exact
+        # for any representable result: a single correctly rounded
+        # conversion in total.
+        my $LITERALS := $*LITERALS;
+        my str $digits := ($<int> ?? $<int>.Str !! '') ~ ($<frac> ?? $<frac>.Str !! '');
+        my $H := nqp::radix_I(16, $digits, 0, 0, $LITERALS.int-type)[0];
+
+        my int $f := 0;
+        if $<frac> {
+            my str $fs := $<frac>.Str;
+            my int $i  := 0;
+            my int $n  := nqp::chars($fs);
+            while $i < $n {
+                $f := $f + 4 unless nqp::eqat($fs, '_', $i);
+                $i := $i + 1;
+            }
+        }
+
+        my str $estr := nqp::join('', nqp::split('_', $<exp>.Str));
+        my int $k := nqp::chars($estr) > 6
+            ?? 999999   # any such exponent over/underflows anyway
+            !! nqp::radix(10, $estr, 0, 0)[0];
+        $k := -$k if $<sign> eq '-' || $<sign> eq '−';
+        $k := $k - $f;
+
+        my int $k1 := nqp::div_i($k, 2);
+        my num $value := nqp::mul_n(
+            nqp::mul_n(nqp::tonum_I($H), nqp::pow_n(2.0, $k1)),
+            nqp::pow_n(2.0, $k - $k1));
+        $value := nqp::neg_n($value) if $*NEGATE_VALUE;
+        self.attach: $/, Nodify('NumLiteral').new(
+          nqp::box_n($value, $LITERALS.num-type)
+        );
     }
 
     method radix-number($/) {

--- a/src/Raku/Grammar.nqp
+++ b/src/Raku/Grammar.nqp
@@ -4472,6 +4472,7 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
     token numish {
         [
           | 'NaN' »
+          | <hex-float>
           | <integer>
           | <decimal-number>
           | <radix-number>
@@ -4536,6 +4537,18 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
     }
 
     token escale { <[Ee]> <sign> <decint> }
+
+    # C99 hexadecimal floating point, e.g. 0x1.8p+1; the binary exponent
+    # is mandatory, which keeps 0x1.abs parsing as a method call
+    token hex-float {
+        :dba('hexadecimal float')
+        0x '_'?
+        [
+        | <int=.hexint> [ '.' <frac=.hexint> ]?
+        |               '.' <frac=.hexint>
+        ]
+        <[pP]> <sign> <exp=.decint>
+    }
 
     token sign { '+' | '-' | '−' | '' }
 

--- a/t/02-rakudo/hexfloat-literals.t
+++ b/t/02-rakudo/hexfloat-literals.t
@@ -1,0 +1,31 @@
+use v6;
+use Test;
+
+# C99 hexadecimal floating point literals, e.g. 0x1.8p+1
+
+plan 20;
+
+is-deeply 0x1.8p+1, 3e0,     'basic hexfloat with fraction';
+is-deeply 0x1p+0,   1e0,     'hexfloat without fraction';
+is-deeply 0x1p-2,   0.25e0,  'negative exponent';
+is-deeply 0x.8p+1,  1e0,     'hexfloat without integer part';
+is-deeply 0x1.8P4,  24e0,    'capital P exponent, no sign';
+is-deeply 0x1.999999999999ap-4, 0.1e0, 'full-precision mantissa';
+is-deeply 0xdead.beefp0, (0xdead + 0xbeef / 65536).Num, 'multi-digit parts';
+is-deeply -0x1.8p+1, -3e0,   'negated hexfloat';
+is-deeply 0x1.fffffffffffffp+1023, 1.7976931348623157e308, 'largest double';
+is-deeply 0x1p-1022,  2.2250738585072014e-308, 'smallest normal';
+is-deeply 0x1p-1074,  5e-324, 'smallest subnormal';
+is-deeply 0x1.8p-1074, 1e-323, 'subnormal tie rounds to even';
+is-deeply 0x1p+9999,  Inf,   'exponent overflow gives Inf';
+is-deeply 0x1p-9999,  0e0,   'exponent underflow gives 0';
+is-deeply 0xde_ad.be_efp+0, 0xdead.beefp0, 'underscores in mantissa';
+is-deeply 0x1p+1_0, 1024e0,  'underscore in exponent';
+ok (-0x0p+0) === -0e0,       'negative zero survives';
+
+# unchanged behaviors
+is-deeply 0x10, 16,     'plain hex integer literal is still an Int';
+is-deeply 0x1.abs, 1,   'method call on hex integer literal still works';
+throws-like { EVAL '0x1.8' }, Exception, 'hexfloat without p exponent is still an error';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Accept C99 hexadecimal floating point literals as Num literals, in both the legacy and the RakuAST frontends:

```raku
say 0x1.8p+1;                  # 3 (a Num)
say -0x1.999999999999ap-4;     # -0.1
say 0x.8p+0;                   # 0.5
```

The binary exponent (`p`/`P`, optionally signed) is mandatory, as in C99, which keeps existing syntax unambiguous: `0x1.abs` remains a method call, `0x10` remains an `Int`, `0x1.8` remains an error. Values are constructed exactly, with a single correctly rounded conversion.

The sprintf `%a`/`%A` counterpart for the 6.e Formatter is in #6525.

🤖 Generated with [Claude Code](https://claude.com/claude-code)