### PR TITLE
Carry a declared native return without settled arguments

### DIFF
--- a/src/Perl6/Optimizer.nqp
+++ b/src/Perl6/Optimizer.nqp
@@ -3445,6 +3445,15 @@ class Perl6::Optimizer {
             if $scopes == 0 || $scopes == 1 && nqp::can($obj, 'soft') && !$obj.soft {
                 $op.op('callstatic');
             }
+            # A callee that is not a dispatcher promises its declared
+            # return type however the arguments bind, and a closure clone
+            # shares its signature, so the promise holds even when the
+            # trial bind settled nothing. A callee compiled under the
+            # soft pragma can be wrapped at run time, so it promises
+            # nothing.
+            unless $dispatcher || nqp::can($obj, 'soft') && $obj.soft {
+                return copy_returns($op, $obj);
+            }
         }
         else {
             # We really should find routines; failure to do so is a CHECK

--- a/src/Raku/ast/call.rakumod
+++ b/src/Raku/ast/call.rakumod
@@ -470,6 +470,22 @@ class RakuAST::Call::Name
                             '$!native-return-type', $ret) unless nqp::isnull($ret);
                     }
                 }
+
+                # A callee that is not a dispatcher promises its declared
+                # return type however the arguments bind, and a closure
+                # clone shares its signature, so the promise holds even
+                # when the analysis settled nothing. A callee compiled
+                # under the soft pragma can be wrapped at run time, so it
+                # promises nothing.
+                if !nqp::objprimspec($!native-return-type)
+                    && !(nqp::can($routine, 'is_dispatcher') && $routine.is_dispatcher)
+                    && !(nqp::can($routine, 'rw') && $routine.rw)
+                    && !(nqp::can($routine, 'soft') && $routine.soft)
+                    && nqp::can($routine, 'returns')
+                    && nqp::objprimspec($routine.returns) {
+                    nqp::bindattr(self, RakuAST::Call::Name,
+                        '$!native-return-type', $routine.returns);
+                }
             }
         }
     }

--- a/t/02-rakudo/native-return-coercion.t
+++ b/t/02-rakudo/native-return-coercion.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 22;
+plan 23;
 
 # Assigning the result of a call to a native-typed container coerces with
 # the unbox that matches the callee's declared native return type. A routine
@@ -155,4 +155,15 @@ plan 22;
     sub sfail(--> int) { fail "boom" }
     my $r = sfail();
     is-deeply $r.defined, False, 'Failure from a native-return sub stays soft in object context';
+}
+
+# A named argument keeps the dispatch analysis from settling, but a sub
+# that is not a dispatcher promises its declared return type however the
+# arguments bind, so the native return is still carried.
+{
+    sub named-ret(int $a, :$k --> int) { $a * 2 }
+    my int $i = 3;
+    my num $y;
+    $y = named-ret($i, :k);
+    is $y, 6e0, 'a named argument still lets the declared native return widen';
 }


### PR DESCRIPTION
Previously a call the dispatch analysis could not settle, one with a named argument for instance, only carried its native return type when the optimize pass marked the call static. The result then changed with the optimization level:

    sub f(int $a, :$k --> int) { $a * 2 }
    my int $i = 3;
    my num $y = f($i, :k); # 6 by default, unbox error at --optimize=off

A callee that is not a dispatcher promises its declared return type however the arguments bind. A closure clone shares its signature, so the promise holds for a routine declared in any scope. Both frontends now carry such a return whether or not the analysis settled, at check time on the RakuAST frontend and at the end of the call optimization on the legacy one. A callee compiled under the soft pragma can be wrapped at run time, so it still promises nothing.