### PR TITLE
Give a literal the native representation of its context

### DIFF
--- a/src/Perl6/Optimizer.nqp
+++ b/src/Perl6/Optimizer.nqp
@@ -3000,6 +3000,9 @@ class Perl6::Optimizer {
         # Calls are especially interesting as we may wish to do some
         # kind of inlining.
         elsif $optype eq 'call' {
+            # A nameless call carries its callee as the first child, so its
+            # positional arguments start one later.
+            self.rewrite_paired_literal_args($op, $opname eq '' ?? 1 !! 0);
             my $opt_result := $opname eq ''
                 ?? self.optimize_nameless_call($op)
                 !! self.optimize_call($op);
@@ -3379,11 +3382,17 @@ class Perl6::Optimizer {
             my $dispatcher := nqp::can($obj, "is_dispatcher") && $obj.is_dispatcher;
             if $dispatcher && $obj.onlystar {
                 # Try to do compile-time multi-dispatch. Need to consider
-                # both the proto and the multi candidates.
+                # both the proto and the multi candidates. The dispatch
+                # decision reads the arguments as the call site passes them,
+                # while an impossible dispatch is diagnosed with the reading
+                # that also counts a lone literal as native, so a candidate
+                # taking a native `is rw` parameter is still ruled out at
+                # compile time.
                 my @ct_arg_info := self.analyze_args_for_ct_call($op);
                 if +@ct_arg_info {
                     my @types := @ct_arg_info[0];
                     my @flags := @ct_arg_info[1];
+                    my @diag_flags := @ct_arg_info[2];
                     my $ct_result_proto := nqp::p6trialbind($obj.signature, @types, @flags);
                     my @ct_result_multi := $obj.analyze_dispatch(@types, @flags);
                     if $ct_result_proto == 1 && @ct_result_multi[0] == 1 {
@@ -3395,11 +3404,15 @@ class Perl6::Optimizer {
                                 !! self.call_ct_chosen_multi($op, $obj, $chosen);
                         }
                     }
-                    elsif $ct_result_proto == -1 || @ct_result_multi[0] == -1 {
-                        self.report_inevitable_dispatch_failure(
-                            $op, @types, @flags, $obj,
-                            :protoguilt($ct_result_proto == -1)
-                        ) unless $*NO-COMPILE-TIME-THROWAGE;
+                    else {
+                        my $diag_proto := nqp::p6trialbind($obj.signature, @types, @diag_flags);
+                        my @diag_multi := $obj.analyze_dispatch(@types, @diag_flags);
+                        if $diag_proto == -1 || @diag_multi[0] == -1 {
+                            self.report_inevitable_dispatch_failure(
+                                $op, @types, @diag_flags, $obj,
+                                :protoguilt($diag_proto == -1)
+                            ) unless $*NO-COMPILE-TIME-THROWAGE;
+                        }
                     }
                 }
                 if $op.op eq 'chain' { $!chain_depth := $!chain_depth - 1 }
@@ -3410,6 +3423,7 @@ class Perl6::Optimizer {
                 if +@ct_arg_info {
                     my @types := @ct_arg_info[0];
                     my @flags := @ct_arg_info[1];
+                    my @diag_flags := @ct_arg_info[2];
                     my $sig := $obj.signature;
                     my $ct_result := nqp::p6trialbind($sig, @types, @flags);
                     if $ct_result == 1 {
@@ -3430,10 +3444,13 @@ class Perl6::Optimizer {
                             return copy_returns($op, $obj);
                         }
                     }
-                    elsif $ct_result == -1 {
-                        self.report_inevitable_dispatch_failure(
-                            $op, @types, @flags, $obj
-                        ) unless $*NO-COMPILE-TIME-THROWAGE;
+                    else {
+                        my $diag_result := nqp::p6trialbind($sig, @types, @diag_flags);
+                        if $diag_result == -1 {
+                            self.report_inevitable_dispatch_failure(
+                                $op, @types, @diag_flags, $obj
+                            ) unless $*NO-COMPILE-TIME-THROWAGE;
+                        }
                     }
                 }
             }
@@ -4132,8 +4149,13 @@ class Perl6::Optimizer {
                 my $prim := nqp::objprimspec($type);
                 my str $allo := $_.has_compile_time_value && nqp::istype($_, QAST::Want)
                     ?? $_[1] !! '';
+                # A literal is a value, never a container, whether it still
+                # wears its allomorphic Want or was already rewritten to its
+                # native form by rewrite_paired_literal_args.
+                my int $literal := $allo ne '' || $_.ann('native_literal_arg')
+                    ?? $ARG_IS_LITERAL !! 0;
                 @types.push($type);
-                @flags.push($prim);
+                @flags.push($prim +| $literal);
                 @allomorphs.push($allo);
                 $num_prim := $num_prim + 1 if $prim;
                 $num_allo := $num_allo + 1 if $allo;
@@ -4143,25 +4165,72 @@ class Perl6::Optimizer {
             }
         }
 
-        # See if we have an allomorphic constant that may allow us to do
-        # a native dispatch with it; takes at least one declaratively
-        # native argument to make this happen.
-        if nqp::elems(@types) == 2 && $num_prim == 1 && $num_allo == 1 {
-            my int $prim_flag := @flags[0] || @flags[1];
-            my int $allo_idx := @allomorphs[0] ?? 0 !! 1;
-            if @allomorphs[$allo_idx] eq @allo_map[$prim_flag] {
-                @flags[$allo_idx] := $prim_flag +| $ARG_IS_LITERAL;
-            }
-        }
-
-        # Alternatively, a single arg that is allomorphic will prefer
-        # the literal too.
+        # A lone literal has no native context to adapt to, so it dispatches
+        # as the boxed value it is, and rewrite_paired_literal_args already
+        # gave a paired literal its native reading. Ruling out a candidate
+        # that takes a native `is rw` parameter still needs the native
+        # reading of a lone literal, so that is reported separately. Only
+        # the plain flags decide what runs.
+        my @diag_flags := nqp::clone(@flags);
         if nqp::elems(@types) == 1 && $num_allo == 1 {
             my $rev := %allo_rev{@allomorphs[0]};
-            @flags[0] := nqp::defined($rev) ?? $rev +| $ARG_IS_LITERAL !! 0;
+            @flags[0] := $ARG_IS_LITERAL;
+            @diag_flags[0] := nqp::defined($rev)
+                ?? $rev +| $ARG_IS_LITERAL
+                !! $ARG_IS_LITERAL;
         }
 
-        [@types, @flags]
+        [@types, @flags, @diag_flags]
+    }
+
+    # The native-paired-literal rule: a literal argument beside an argument
+    # of a native kind the literal can hold is passed in that kind, so
+    # runtime dispatch reaches the same candidate the compile time analysis
+    # counts on at any level that runs this optimizer. The literal's Want is
+    # replaced with its native alternative, marked so the argument analysis
+    # keeps reading it as a literal value. Exactly two positional arguments
+    # qualify, since with more there is no single native context for a
+    # literal to adopt.
+    method rewrite_paired_literal_args($op, int $first-arg) {
+        return 0 unless nqp::elems($op) == $first-arg + 2;
+        my int $i := $first-arg;
+        my int $literal-idx := -1;
+        my int $other-idx := -1;
+        while $i < $first-arg + 2 {
+            my $arg := $op[$i];
+            return 0 unless nqp::can($arg, 'flat');
+            return 0 if $arg.flat || $arg.named ne '';
+            if nqp::istype($arg, QAST::Want) && $arg.has_compile_time_value
+                && nqp::elems($arg.list) == 3 {
+                if $literal-idx == -1 {
+                    $literal-idx := $i;
+                }
+                else {
+                    # Two literals pair with each other no more than one
+                    # does with nothing.
+                    return 0;
+                }
+            }
+            else {
+                $other-idx := $i;
+            }
+            $i := $i + 1;
+        }
+        return 0 if $literal-idx == -1 || $other-idx == -1;
+
+        my $literal := $op[$literal-idx];
+        my int $kind := %allo_rev{$literal[1]} // 0;
+        return 0 unless $kind;
+        return 0 unless nqp::objprimspec($op[$other-idx].returns) == $kind;
+
+        my $native-type := try $!symbols.find_lexical(@prim_names[$kind]);
+        return 0 unless nqp::objprimspec($native-type) == $kind;
+
+        my $native := $literal[2];
+        $native.returns($native-type);
+        $native.annotate('native_literal_arg', 1);
+        $op[$literal-idx] := $native;
+        1
     }
 
     method report_inevitable_dispatch_failure($op, @types, @flags, $obj, :$protoguilt) {
@@ -4531,17 +4600,13 @@ class Perl6::Optimizer {
         # wanting the boxed object never unboxes and escape values like a
         # Failure still flow through. The scope test is looser than the
         # callstatic one above, since a closure clone still runs the same
-        # candidates. A soft proto can be wrapped at run time, and a literal
-        # argument reaches the callee boxed, so either one leaves run-time
-        # dispatch free to answer with a different candidate.
+        # candidates. A soft proto can be wrapped at run time, which leaves
+        # run-time dispatch free to answer with a different candidate. A
+        # literal argument is trusted: the analysis read it exactly as the
+        # call site passes it, native when rewrite_paired_literal_args gave
+        # it its native form and the boxed value otherwise.
         if $scopes == 0 || nqp::can($proto, 'soft') && !$proto.soft {
-            my int $literal-args := 0;
-            for @($call) {
-                $literal-args := 1
-                    if nqp::istype($_, QAST::Want) && $_.has_compile_time_value;
-            }
-            if !$literal-args
-            && nqp::can($chosen, 'returns') && !(nqp::can($chosen, 'rw') && $chosen.rw) {
+            if nqp::can($chosen, 'returns') && !(nqp::can($chosen, 'rw') && $chosen.rw) {
                 if nqp::objprimspec($chosen.returns) {
                     my $native := $call.shallow_clone;
                     $native.returns($chosen.returns);

--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -3211,7 +3211,16 @@ class Perl6::World is HLL::World {
     method add_numeric_constant($/, $type, $value) {
         my $node := $/;
         if $type eq 'Int' && (try $value.HOW.name($value)) eq 'Int' {
+            # Whether the value is exactly representable as a native int.
+            # How the Int is stored answers a different question, since the
+            # small-value slot is narrower than a native int.
+            my int $fits := 1;
             if nqp::isbig_I($value) {
+                $fits := 0;
+                try $fits := nqp::iseq_I(
+                    nqp::box_i(nqp::unbox_i($value), nqp::what($value)), $value);
+            }
+            unless $fits {
                 # cannot unbox to int without loss of information
                 my $const := self.add_constant('Int', 'bigint', $value);
                 $const.node: $node;

--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -1370,33 +1370,89 @@ class RakuAST::Node {
         Nil
     }
 
+    # The statically known type of this node in argument position: its
+    # return-type, falling back to the declared type of the variable a
+    # resolved parameter read refers to, since a parameter read reports no
+    # type of its own.
+    method IMPL-STATIC-ARG-TYPE() {
+        my $type := self.return-type;
+        if $type =:= Mu
+            && nqp::istype(self, RakuAST::Var::Lexical)
+            && self.is-resolved
+            && nqp::istype(self.resolution, RakuAST::ParameterTarget::Var)
+            && nqp::isconcrete(self.resolution.declaration) {
+            try $type := self.resolution.declaration.return-type;
+        }
+        $type
+    }
+
+    # The native kind this node's constant value compiles a native
+    # alternative for, or Nil. A node that answers a kind emits a QAST::Want
+    # whose native alternative IMPL-TO-QAST-ARG can select.
+    method IMPL-NATIVE-LITERAL-KIND() { Nil }
+
+    # The native-paired-literal rule: given two argument nodes, the literal
+    # that adopts the other argument's native representation, or null. A
+    # literal carries no declared type, so beside an argument whose static
+    # type is a native kind the literal can hold, it takes that kind. It
+    # stays the boxed value it literally is otherwise. This single predicate
+    # decides both the candidate analysis and the emitted representation, so
+    # the two cannot disagree.
+    method IMPL-NATIVE-PAIRED-LITERAL-OF(Mu $a, Mu $b) {
+        # A synthesized call may carry raw values rather than nodes in its
+        # argument list, and those have no representation to decide.
+        return nqp::null() unless nqp::isconcrete($a) && nqp::istype($a, RakuAST::Node)
+            && nqp::isconcrete($b) && nqp::istype($b, RakuAST::Node);
+        my $a-kind := $a.IMPL-NATIVE-LITERAL-KIND;
+        my $b-kind := $b.IMPL-NATIVE-LITERAL-KIND;
+        my $literal;
+        my $other;
+        my int $kind;
+        if nqp::defined($a-kind) && !nqp::defined($b-kind) {
+            $literal := $a;
+            $other := $b;
+            $kind := $a-kind;
+        }
+        elsif nqp::defined($b-kind) && !nqp::defined($a-kind) {
+            $literal := $b;
+            $other := $a;
+            $kind := $b-kind;
+        }
+        else {
+            return nqp::null();
+        }
+        nqp::objprimspec($other.IMPL-STATIC-ARG-TYPE) == $kind
+            ?? $literal
+            !! nqp::null()
+    }
+
+    # The QAST for this node in argument position: the native alternative of
+    # the node's own Want when the node is a literal taking part in a native
+    # pairing, and the ordinary QAST otherwise.
+    method IMPL-TO-QAST-ARG(RakuAST::IMPL::QASTContext $context) {
+        my $qast := self.IMPL-TO-QAST($context);
+        nqp::defined(self.IMPL-NATIVE-LITERAL-KIND)
+          && nqp::istype($qast, QAST::Want)
+          && nqp::elems($qast.list) >= 3
+            ?? $qast.list[2]
+            !! $qast
+    }
+
     # The nominal types and native flags of the given arguments, as trial
     # binding and candidate analysis expect them, or an empty list when any
     # argument's type is not known well enough for the answer to be final.
     # A native type is passed as its boxed counterpart carrying the native
-    # flag. A literal of a boxed type prefers a native candidate when it is
-    # alone or paired with a native argument of matching kind, as the same
-    # allomorphic argument would at run time.
+    # flag. A literal is flagged as the value it is: native when it is
+    # paired with a native argument of matching kind, which is exactly when
+    # the call site passes its native form, and the boxed value otherwise.
     method IMPL-CT-ARG-TYPES(RakuAST::Resolver $resolver, Mu @args) {
         my int $ARG_IS_LITERAL := 32;
         my @types;
         my @flags;
-        my @allo;
-        my int $num-prim := 0;
-        my int $num-allo := 0;
         for @args {
-            my $type := $_.return-type;
-            # A parameter read reports no type of its own; the declared type
-            # of the parameter's variable is the read's type. Kept local to
-            # this analysis so the trial-bind diagnostic's coverage does not
-            # change underneath existing code.
-            if $type =:= Mu
-                && nqp::istype($_, RakuAST::Var::Lexical)
-                && $_.is-resolved
-                && nqp::istype($_.resolution, RakuAST::ParameterTarget::Var)
-                && nqp::isconcrete($_.resolution.declaration) {
-                try $type := $_.resolution.declaration.return-type;
-            }
+            # A synthesized call may carry raw values rather than nodes.
+            return [] unless nqp::isconcrete($_) && nqp::istype($_, RakuAST::Node);
+            my $type := $_.IMPL-STATIC-ARG-TYPE;
             return [] if $type =:= Mu;
             my int $ok := 0;
             try $ok := $type.HOW.archetypes.nominal && !$type.HOW.archetypes.generic;
@@ -1407,35 +1463,27 @@ class RakuAST::Node {
                 $type := self.IMPL-OPTIMIZE-SETTING-TYPE($resolver,
                     $ps == 1 ?? 'Int' !! $ps == 2 ?? 'Num' !! 'Str');
                 return [] if nqp::isnull($type);
-                $num-prim++;
             }
             elsif $ps {
                 return [];
             }
             nqp::push(@types, $type);
-            nqp::push(@flags, $ps);
-            my int $allo-flag := 0;
-            if nqp::istype($_, RakuAST::Literal) {
-                my $native := $_.native-type-flag;
-                # An integer too wide for the native representation is not
-                # allomorphic: only its boxed form holds the value.
-                if nqp::defined($native)
-                    && !($native == 1
-                        && nqp::isbig_I(nqp::decont($_.compile-time-value))) {
-                    $allo-flag := $native;
-                    $num-allo++;
-                }
+            # A literal with a native form is a value, never a container.
+            # This mirrors what the legacy frontend knows of a literal
+            # through its allomorphic Want, so the frontends rule out an
+            # `is rw` candidate for the same arguments.
+            nqp::push(@flags, nqp::defined($_.IMPL-NATIVE-LITERAL-KIND)
+                ?? $ps +| $ARG_IS_LITERAL
+                !! $ps);
+        }
+        if nqp::elems(@types) == 2 {
+            my $literal := self.IMPL-NATIVE-PAIRED-LITERAL-OF(
+                nqp::atpos(@args, 0), nqp::atpos(@args, 1));
+            unless nqp::isnull($literal) {
+                my int $idx := nqp::eqaddr(nqp::atpos(@args, 0), $literal) ?? 0 !! 1;
+                my int $prim := nqp::atpos(@flags, $idx == 0 ?? 1 !! 0) +& 0xF;
+                nqp::bindpos(@flags, $idx, $prim +| $ARG_IS_LITERAL);
             }
-            nqp::push(@allo, $allo-flag);
-        }
-        if nqp::elems(@types) == 2 && $num-prim == 1 && $num-allo == 1 {
-            my int $prim := nqp::atpos(@flags, 0) || nqp::atpos(@flags, 1);
-            my int $allo-idx := nqp::atpos(@allo, 0) ?? 0 !! 1;
-            nqp::bindpos(@flags, $allo-idx, $prim +| $ARG_IS_LITERAL)
-                if nqp::atpos(@allo, $allo-idx) == $prim;
-        }
-        elsif nqp::elems(@types) == 1 && $num-allo == 1 {
-            nqp::bindpos(@flags, 0, nqp::atpos(@allo, 0) +| $ARG_IS_LITERAL);
         }
         [@types, @flags]
     }

--- a/src/Raku/ast/call.rakumod
+++ b/src/Raku/ast/call.rakumod
@@ -89,7 +89,30 @@ class RakuAST::ArgList
         }
     }
 
-    method IMPL-ADD-QAST-ARGS(RakuAST::IMPL::QASTContext $context, QAST::Op $call) {
+    # The literal of a native-paired pair of positional arguments, which the
+    # emission passes in its native form and the candidate analysis counts
+    # as native. Exactly two positional arguments qualify, since with more
+    # there is no single native context for a literal to adopt.
+    method IMPL-NATIVE-PAIRED-LITERAL() {
+        return nqp::null() unless nqp::elems($!args) == 2 && !nqp::isconcrete($!invocant);
+        my $first  := nqp::atpos($!args, 0);
+        my $second := nqp::atpos($!args, 1);
+        return nqp::null() if nqp::istype($first, RakuAST::NamedArg)
+            || nqp::istype($second, RakuAST::NamedArg)
+            || self.IMPL-IS-FLATTENING($first)
+            || self.IMPL-IS-FLATTENING($second);
+        self.IMPL-NATIVE-PAIRED-LITERAL-OF($first, $second)
+    }
+
+    # Only a sub call opts into native pairing. A method call resolves its
+    # callee at runtime from an open set of candidates, and no compile time
+    # analysis commits a choice for it, so its literal arguments stay the
+    # boxed values they always were.
+    method IMPL-ADD-QAST-ARGS(RakuAST::IMPL::QASTContext $context, QAST::Op $call, Bool :$native-pairing) {
+        my $native-literal := $native-pairing
+            ?? self.IMPL-NATIVE-PAIRED-LITERAL
+            !! nqp::null();
+
         # We need to remove duplicate named args, so make a first pass through to
         # collect those.
         my %named-counts;
@@ -145,7 +168,9 @@ class RakuAST::ArgList
             }
             else {
                 # Positional argument.
-                $call.push($arg.IMPL-TO-QAST($context))
+                $call.push(nqp::eqaddr($arg, $native-literal)
+                    ?? $arg.IMPL-TO-QAST-ARG($context)
+                    !! $arg.IMPL-TO-QAST($context))
             }
         }
     }
@@ -431,6 +456,17 @@ class RakuAST::Call::Name
                         my $rev := @args[0].native-type-flag;
                         @flags[0] := nqp::defined($rev) ?? $rev +| $ARG_IS_LITERAL !! 0;
                     }
+                    elsif nqp::elems(@types) == 2 {
+                        # A native-paired literal is passed in its native
+                        # form, so it is diagnosed with the native reading,
+                        # which also rules out a candidate that takes a
+                        # native `is rw` parameter.
+                        my $paired := self.args.IMPL-NATIVE-PAIRED-LITERAL;
+                        if !nqp::isnull($paired) && nqp::defined($paired.IMPL-NATIVE-LITERAL-KIND) {
+                            my int $idx := nqp::eqaddr(@args[0], $paired) ?? 0 !! 1;
+                            @flags[$idx] := $paired.IMPL-NATIVE-LITERAL-KIND +| $ARG_IS_LITERAL;
+                        }
+                    }
                     my $ct_result := nqp::p6trialbind($sig, @types, @flags);
                     my @ct_result_multi;
                     if nqp::can($routine, 'is_dispatcher') && $routine.is_dispatcher && $routine.onlystar {
@@ -465,9 +501,18 @@ class RakuAST::Call::Name
                     else {
                         # The call is settled at compile time, so the chosen
                         # candidate's native return type describes the result.
-                        my $ret := self.IMPL-NATIVE-RETURN-TYPE($routine, @types, @flags);
-                        nqp::bindattr(self, RakuAST::Call::Name,
-                            '$!native-return-type', $ret) unless nqp::isnull($ret);
+                        # The flags above read a lone literal as native to
+                        # diagnose an impossible dispatch, so the recording
+                        # re-reads the arguments as the call site passes
+                        # them, through the same analysis the inline pass
+                        # and the argument emission use.
+                        my @info := self.IMPL-CT-ARG-TYPES($resolver, @args);
+                        if nqp::elems(@info) {
+                            my $ret := self.IMPL-NATIVE-RETURN-TYPE($routine,
+                                @info[0], @info[1]);
+                            nqp::bindattr(self, RakuAST::Call::Name,
+                                '$!native-return-type', $ret) unless nqp::isnull($ret);
+                        }
                     }
                 }
             }
@@ -565,7 +610,7 @@ class RakuAST::Call::Name
                 );
             }
         }
-        self.args.IMPL-ADD-QAST-ARGS($context, $call);
+        self.args.IMPL-ADD-QAST-ARGS($context, $call, :native-pairing);
 
         # Add return value from signature if this is a return without args
         my $block := $!block;
@@ -686,7 +731,7 @@ class RakuAST::Call::Term
 
     method IMPL-POSTFIX-QAST(RakuAST::IMPL::QASTContext $context, Mu $callee-qast) {
         my $call := QAST::Op.new( :op('call'), $callee-qast );
-        self.args.IMPL-ADD-QAST-ARGS($context, $call);
+        self.args.IMPL-ADD-QAST-ARGS($context, $call, :native-pairing);
         $call
     }
 

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -483,12 +483,25 @@ class RakuAST::Infix
             self.IMPL-SMARTMATCH-QAST($context, $left, $right, nqp::atkey(OP-SMARTMATCH, $op));
         }
         else {
+            # A literal operand beside a native one is passed in its native
+            # form, so runtime dispatch reaches the candidate the analysis
+            # counts on. A short-circuit operator yields an operand rather
+            # than dispatching on the pair, and an adverb turns into a named
+            # argument the analysis declines, so both keep the boxed form.
+            my $native-literal := NQPMu;
+            unless $adverb || self.short-circuit {
+                $native-literal := self.IMPL-NATIVE-PAIRED-LITERAL-OF($left, $right);
+            }
             my $qast := self.IMPL-INFIX-QAST:
                 $context,
                 $op eq '='
                     ?? $left.IMPL-ADJUST-QAST-FOR-LVALUE($left.IMPL-TO-QAST($context))
-                    !! $left.IMPL-TO-QAST($context),
-                $right.IMPL-TO-QAST($context);
+                    !! nqp::eqaddr($left, $native-literal)
+                        ?? $left.IMPL-TO-QAST-ARG($context)
+                        !! $left.IMPL-TO-QAST($context),
+                nqp::eqaddr($right, $native-literal)
+                    ?? $right.IMPL-TO-QAST-ARG($context)
+                    !! $right.IMPL-TO-QAST($context);
             if $adverb {
                 my $val-ast := $adverb.named-arg-value.IMPL-TO-QAST($context);
                 $val-ast.named($adverb.named-arg-name);
@@ -2552,15 +2565,18 @@ class RakuAST::ApplyInfix
             && !self.infix.short-circuit
             && self.IMPL-SUNK-OPERATOR-PURE(self.infix);
 
-        self.IMPL-RECORD-NATIVE-RETURN-TYPE;
+        self.IMPL-RECORD-NATIVE-RETURN-TYPE($resolver);
 
         True
     }
 
     # Record the native return type when the operator settles on a single
     # candidate, so a native-typed target coerces with the matching unbox
-    # and an enclosing operator sees this result as native.
-    method IMPL-RECORD-NATIVE-RETURN-TYPE() {
+    # and an enclosing operator sees this result as native. The operands
+    # are read through the same analysis the inline pass and the operand
+    # emission use, so a literal counts as native exactly when its native
+    # form is what gets passed.
+    method IMPL-RECORD-NATIVE-RETURN-TYPE(RakuAST::Resolver $resolver) {
         my $infix := $!infix;
         return Nil unless nqp::istype($infix, RakuAST::Infix) && $infix.is-resolved;
 
@@ -2571,8 +2587,11 @@ class RakuAST::ApplyInfix
         return Nil if $infix.properties.chain;
 
         # An adverb reaches the callee as a named argument the trial bind
-        # below never saw, so run-time dispatch may answer differently.
+        # below never saw, and a short-circuit operator yields an operand
+        # rather than dispatching, so run-time dispatch may answer
+        # differently for either.
         return Nil if nqp::elems(self.colonpairs);
+        return Nil if $infix.short-circuit;
 
         return Nil unless nqp::can($infix.resolution, 'compile-time-value');
         my $routine := $infix.resolution.compile-time-value;
@@ -2581,18 +2600,10 @@ class RakuAST::ApplyInfix
         my $left := self.left;
         my $right := self.right;
         return Nil unless nqp::isconcrete($left) && nqp::isconcrete($right);
-        my $left-type := $left.return-type;
-        return Nil if $left-type =:= Mu
-          || nqp::istype($left-type.HOW, Perl6::Metamodel::SubsetHOW)
-          || nqp::istype($left-type.HOW, Perl6::Metamodel::GenericHOW);
-        my $right-type := $right.return-type;
-        return Nil if $right-type =:= Mu
-          || nqp::istype($right-type.HOW, Perl6::Metamodel::SubsetHOW)
-          || nqp::istype($right-type.HOW, Perl6::Metamodel::GenericHOW);
+        my @info := self.IMPL-CT-ARG-TYPES($resolver, [$left, $right]);
+        return Nil unless nqp::elems(@info);
 
-        my $ret := $infix.IMPL-NATIVE-RETURN-TYPE($routine,
-            [$left-type, $right-type],
-            [nqp::objprimspec($left-type), nqp::objprimspec($right-type)]);
+        my $ret := $infix.IMPL-NATIVE-RETURN-TYPE($routine, @info[0], @info[1]);
         nqp::bindattr(self, RakuAST::ApplyInfix, '$!native-return-type', $ret)
             unless nqp::isnull($ret);
         Nil
@@ -3190,13 +3201,16 @@ class RakuAST::ApplyPrefix
         self.add-sunk-worry($resolver, self.origin ?? self.origin.Str !! self.DEPARSE)
             if self.sunk && self.IMPL-SUNK-OPERATOR-PURE(self.prefix);
 
-        self.IMPL-RECORD-NATIVE-RETURN-TYPE;
+        self.IMPL-RECORD-NATIVE-RETURN-TYPE($resolver);
     }
 
     # Record the native return type when the operator settles on a single
     # candidate, so a native-typed target coerces with the matching unbox
-    # and an enclosing operator sees this result as native.
-    method IMPL-RECORD-NATIVE-RETURN-TYPE() {
+    # and an enclosing operator sees this result as native. The operand is
+    # read through the same analysis the inline pass uses. A lone literal
+    # operand reads as the boxed value it is, which matches the boxed form
+    # the emission passes.
+    method IMPL-RECORD-NATIVE-RETURN-TYPE(RakuAST::Resolver $resolver) {
         my $prefix := $!prefix;
         return Nil unless nqp::istype($prefix, RakuAST::Prefix) && $prefix.is-resolved;
         return Nil unless nqp::can($prefix.resolution, 'compile-time-value');
@@ -3205,13 +3219,10 @@ class RakuAST::ApplyPrefix
 
         my $operand := $!operand;
         return Nil unless nqp::isconcrete($operand);
-        my $type := $operand.return-type;
-        return Nil if $type =:= Mu
-          || nqp::istype($type.HOW, Perl6::Metamodel::SubsetHOW)
-          || nqp::istype($type.HOW, Perl6::Metamodel::GenericHOW);
+        my @info := self.IMPL-CT-ARG-TYPES($resolver, [$operand]);
+        return Nil unless nqp::elems(@info);
 
-        my $ret := $prefix.IMPL-NATIVE-RETURN-TYPE($routine,
-            [$type], [nqp::objprimspec($type)]);
+        my $ret := $prefix.IMPL-NATIVE-RETURN-TYPE($routine, @info[0], @info[1]);
         nqp::bindattr(self, RakuAST::ApplyPrefix, '$!native-return-type', $ret)
             unless nqp::isnull($ret);
         Nil

--- a/src/Raku/ast/literals.rakumod
+++ b/src/Raku/ast/literals.rakumod
@@ -39,6 +39,7 @@ class RakuAST::Literal
     method expression() { self }
     method return-type() { $!value.WHAT }
     method native-type-flag() { Nil }
+    method IMPL-NATIVE-LITERAL-KIND() { self.native-type-flag }
     method compile-time-value() { $!value }
     method IMPL-CAN-INTERPRET() { True }
     method IMPL-INTERPRET(RakuAST::IMPL::InterpContext $ctx) { $!value }
@@ -87,8 +88,25 @@ class RakuAST::Constant
 class RakuAST::IntLiteral
   is RakuAST::Literal
 {
-    # A value too wide for a native int cannot take part in a native dispatch.
-    method native-type-flag() { nqp::isbig_I(self.value) ?? Nil !! 1 }
+    # Whether the value is exactly representable as a native int. Asking how
+    # the Int is stored answers a different question: the small-value slot is
+    # narrower than a native int, so a value that fits one may still be held
+    # as a bigint. The round trip through the native settles it, and declines
+    # rather than propagates should the unbox refuse a value it cannot hold.
+    method IMPL-FITS-NATIVE-INT() {
+        my $value := self.value;
+        my int $big := 0;
+        try $big := nqp::isbig_I($value);
+        return 1 unless $big;
+        my int $fits := 0;
+        try $fits := nqp::iseq_I(
+            nqp::box_i(nqp::unbox_i($value), nqp::what($value)), $value);
+        $fits
+    }
+
+    # A value that does not fit a native int cannot take part in a native
+    # dispatch.
+    method native-type-flag() { self.IMPL-FITS-NATIVE-INT ?? 1 !! Nil }
 
     method type-name() { 'integer' }
 
@@ -96,13 +114,13 @@ class RakuAST::IntLiteral
         my $value := self.value;
         $context.ensure-sc($value);
         my $wval := QAST::WVal.new( :$value );
-        nqp::isbig_I($value)
-          ?? $wval
-          !! QAST::Want.new(
+        self.IMPL-FITS-NATIVE-INT
+          ?? QAST::Want.new(
                $wval,
                'Ii',
                QAST::IVal.new(:value(nqp::unbox_i($value)))
              )
+          !! $wval
     }
 }
 
@@ -254,6 +272,15 @@ class RakuAST::QuotedString
             # Always a string if no processors.
             Str
         }
+    }
+
+    # A constant quoted string compiles to the same Want shape a str literal
+    # does, so it takes part in native pairing the same way. A processor
+    # changes what the value compiles to, so any processor declines.
+    method IMPL-NATIVE-LITERAL-KIND() {
+        return Nil if $!processors && nqp::elems($!processors);
+        my $value := self.literal-value;
+        nqp::isconcrete($value) && nqp::istype($value, Str) ?? 3 !! Nil
     }
 
     method ast-type {

--- a/src/Raku/ast/scoping.rakumod
+++ b/src/Raku/ast/scoping.rakumod
@@ -1047,14 +1047,10 @@ class RakuAST::Lookup
     # Given a resolved routine and the compile-time argument types and native
     # flags, return the native return type of the single candidate the call
     # settles on, or NQPMu when it settles on none or on a non-native one.
+    # A literal-flagged argument is trusted here because the flags read a
+    # literal exactly as the call site passes it: native when paired with a
+    # native argument, the boxed value otherwise.
     method IMPL-NATIVE-RETURN-TYPE($routine, @types, @flags) {
-        # A literal argument counts as native here while the emitted call
-        # passes the boxed value, so run-time dispatch may answer with
-        # another candidate than the analysis settled on.
-        my int $ARG_IS_LITERAL := 32;
-        for @flags {
-            return NQPMu if $_ +& $ARG_IS_LITERAL;
-        }
         my $callee := NQPMu;
         if nqp::can($routine, 'is_dispatcher') && $routine.is_dispatcher {
             if $routine.onlystar {

--- a/t/02-rakudo/native-literal-dispatch.t
+++ b/t/02-rakudo/native-literal-dispatch.t
@@ -1,0 +1,139 @@
+use Test;
+
+plan 24;
+
+# A literal carries no declared type, so its representation comes from its
+# context: beside an operand or argument whose type is a native kind the
+# literal can hold, it is passed in that kind and dispatches accordingly,
+# and it stays the boxed value it literally is otherwise. The same rule
+# decides the compile time analysis and the passed representation, so the
+# answer cannot depend on the optimization level or on whether a candidate
+# happens to be inlinable.
+
+my int $i = 3;
+
+{
+    multi pick-r(int $a, int $b) { "int" }
+    multi pick-r(int $a, Int $b) { "Int" }
+    is pick-r($i, 1), "int", 'a literal beside a native int reaches the native candidate';
+
+    multi pick-l(Int $a, int $b) { "Int" }
+    multi pick-l(int $a, int $b) { "int" }
+    is pick-l(1, $i), "int", 'a literal on the left adopts the native context too';
+
+    multi pick-n(int $a, int $b) { my $s = join "", "i", "nt"; $s }
+    multi pick-n(int $a, Int $b) { my $s = join "", "I", "nt"; $s }
+    is pick-n($i, 1), "int", 'the native candidate answers whether or not its body can inline';
+}
+
+{
+    multi lone(int $x) { "int" }
+    multi lone(Int $x) { "Int" }
+    is lone(0), "Int", 'a lone literal dispatches as the boxed value it is';
+    is lone($i), "int", 'a native variable reaches the native candidate';
+}
+
+{
+    multi pp(int $a, int $b) { "int" }
+    multi pp(int $a, Int $b) { "Int" }
+    sub via-param(int $p) { pp($p, 1) }
+    is via-param(3), "int", 'a parameter read provides the native context through its declared type';
+}
+
+{
+    multi three(int $a, int $b, int $c) { "int" }
+    multi three(int $a, int $b, Int $c) { "Int" }
+    is three($i, $i, 1), "Int", 'a literal among three positionals has no single native context';
+
+    multi named(int $a, int $b, :$k) { "int" }
+    multi named(int $a, Int $b, :$k) { "Int" }
+    is named($i, 1, :k), "Int", 'a named argument leaves a literal boxed';
+
+    my class M {
+        multi method m(int $a, int $b) { "int" }
+        multi method m(int $a, Int $b) { "Int" }
+    }
+    is M.m($i, 1), "Int", 'a method call argument stays the boxed value';
+}
+
+{
+    my num $n = 1e0;
+    multi kindm(num $a, int $b) { "int" }
+    multi kindm(num $a, Int $b) { "Int" }
+    is kindm($n, 1), "Int", 'an int literal does not adopt a num context';
+
+    multi kn(num $a, num $b) { "num" }
+    multi kn(num $a, Num $b) { "Num" }
+    is kn($n, 1e0), "num", 'a num literal beside a native num reaches the native candidate';
+
+    my str $s = "x";
+    multi ks(str $a, str $b) { "str" }
+    multi ks(str $a, Str $b) { "Str" }
+    is ks($s, "y"), "str", 'a str literal beside a native str reaches the native candidate';
+    is ks($s, q:to/END/), "str", 'a constant heredoc pairs like a str literal';
+    hello
+    END
+}
+
+# Whether a literal has a native form depends on fitting a native int, not
+# on how the Int object happens to be stored.
+{
+    multi wide(int $a, int $b) { "int" }
+    multi wide(int $a, Int $b) { "Int" }
+    is wide($i, 2147483648), "int", 'a literal above the small-Int storage limit still has its native form';
+    is wide($i, 9223372036854775807), "int", 'the largest native int literal has its native form';
+    is wide($i, 9223372036854775808), "Int", 'a literal too wide for a native int stays boxed';
+    is-deeply $i + 2147483648, 2147483651, 'native arithmetic on a wide literal computes the right value';
+}
+
+# The CORE arithmetic consequences of the rule.
+{
+    my int $v = 5;
+    my num $y;
+    $y = 2 * $v;
+    is $y, 10e0, 'a literal paired with a native int computes a native result that widens to num';
+
+    my int $d = 4;
+    dies-ok { my $r = $d div 0 }, 'div by a literal zero throws like div by a native zero';
+
+    my int $m = 9223372036854775807;
+    is $m + 1, -9223372036854775808, 'native addition of a literal wraps like native variables do';
+}
+
+# A literal is a value, so a candidate that requires a native container is
+# ruled out at compile time, on both readings of the literal.
+{
+    sub compile-refuses($code, $desc) {
+        my $error = '';
+        try {
+            EVAL $code;
+            CATCH { default { $error = .gist.Str } }
+        }
+        ok $error.contains('will never work'), $desc;
+    }
+    compile-refuses 'multi rwl(int $x is rw) { }; rwl(42)',
+        'a lone literal rules out a native rw candidate at compile time';
+    compile-refuses 'multi rwp(int $a, int $b is rw) { }; my int $i = 3; rwp($i, 42)',
+        'a paired literal rules out a native rw candidate at compile time';
+}
+
+# The settled candidate's native return type is carried for a paired
+# literal, since the analysis read the literal exactly as it is passed.
+{
+    multi scaled(int $a, int $b --> int) { $a * $b }
+    my int $v = 3;
+    my num $y;
+    $y = scaled($v, 4);
+    is $y, 12e0, 'a settled native-return multi with a paired literal widens to num';
+}
+
+# The representation rule is about the arguments, not the callee, so an
+# indirect call behaves like a direct one.
+{
+    multi pick-i(int $a, int $b) { "int" }
+    multi pick-i(int $a, Int $b) { "Int" }
+    my $f = &pick-i;
+    is $f($i, 1), "int", 'an indirect call passes a paired literal natively';
+}
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously a literal beside a native operand or argument was counted as native by the compile time dispatch analysis, but the emitted call passed the boxed value. The analysis could only commit its choice when the chosen candidate was inlinable. So which candidate actually ran depended on the optimization level and on the shape of the candidate's body, and CORE arithmetic changed meaning with the optimizer:

```raku
my int $i = 4;
my $r = $i div 0;  # throws by default, soft Failure at --optimize=off

my int $m = 9223372036854775807;
say $m + 1;        # wraps by default, promotes to Int at --optimize=off
```

This makes the representation of a literal a rule instead of an optimizer side effect. A literal has no declared type, so its representation comes from its context. Beside an operand or argument whose static type is a native kind the literal can hold, it is passed in that kind and dispatches accordingly. Anywhere else it stays the boxed value it literally is. A lone literal stays boxed because there is no native context to adapt to. A call with more than two positionals stays boxed because there is no single native context. A method call is left alone as well, since its callee is resolved at runtime from an open set of candidates and no compile time analysis ever commits a choice for it. Short-circuit operands and adverbed operators also keep the boxed form.

The same predicate decides the candidate analysis and the emitted representation, so the two cannot disagree. On the RakuAST frontend it runs at check time, so the answer is the same at every optimization level. The resulting semantics match what native variables already do: `$i div 0` throws like `$i div $j`, and `$m + 1` wraps at the int64 boundary like `$m + $one`, which is also what the spec tests assert for int64 overflow.

The legacy frontend applies the same rule by rewriting the paired literal to its native form before the optimizer's dispatch analysis runs. Runtime dispatch then reaches the same candidate the analysis settles on whether or not anything inlines. Like the rest of that machinery this applies when the optimizer runs.

Whether an integer literal has a native form at all was being decided with `nqp::isbig_I`. That answers how the Int object is stored, and the storage slot is 32 bits while a native int is 64, so every literal from 2**31 up was treated as if it could not be a machine integer. It is now decided by whether the value round-trips through a native int. A loop doing `$a +| 2147483648` into a native int goes from a boxed dispatch per iteration to the same raw op a small literal gets, about 13x faster.

The compile time diagnostic for a candidate that takes a native `is rw` parameter still fires, and now also fires for a paired literal on the RakuAST frontend, as it already did on the legacy one.
