### PR TITLE
RakuAST: never fold a constant-string indirect lookup

### DIFF
--- a/src/Raku/ast/call.rakumod
+++ b/src/Raku/ast/call.rakumod
@@ -1394,10 +1394,16 @@ class RakuAST::Call::VarMethod
 
     method default-operator-properties() { self.default-properties('.&') }
 
-    method needs-resolution() { $!name.is-identifier }
+    method needs-resolution() {
+        $!name.is-identifier && !$!name.is-indirect-lookup
+    }
 
     method PERFORM-BEGIN(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
-        my $resolved := $resolver.resolve-name($!name, :sigil('&'));
+        # An indirect lookup is a runtime symbolic lookup, so it keeps no
+        # compile-time resolution, as with Term::Name.
+        my $resolved := $!name.is-indirect-lookup
+            ?? Nil
+            !! $resolver.resolve-name($!name, :sigil('&'));
         if $resolved {
             self.set-resolution($resolved);
         }
@@ -1435,7 +1441,9 @@ class RakuAST::Call::VarMethod
         unless $!name.is-identifier {
             nqp::die('compiling complex call names NYI')
         }
-        my $name-qast  := self.resolution.IMPL-LOOKUP-QAST($context);
+        my $name-qast  := $!name.is-indirect-lookup
+            ?? $!name.IMPL-QAST-INDIRECT-LOOKUP($context, :sigil('&'))
+            !! self.resolution.IMPL-LOOKUP-QAST($context);
         my $dispatcher := self.dispatcher;
 
         my $call := $dispatcher
@@ -1458,20 +1466,39 @@ class RakuAST::Call::VarMethod
     method IMPL-POSTFIX-HYPER-QAST(RakuAST::IMPL::QASTContext $context, Mu $operand-qast) {
         my $dispatcher := self.dispatcher;
 
+        # The routine appears twice in the dispatch. A runtime indirect
+        # lookup must run once and feed both positions, so its result is
+        # bound to a temporary at the first and read back at the second.
+        my $name-qast;
+        my $name-again;
+        if $!name.is-indirect-lookup {
+            my str $tmp := QAST::Node.unique('indirect_var_method');
+            $name-qast := QAST::Op.new(
+                :op('bind'),
+                QAST::Var.new( :name($tmp), :scope('local'), :decl('var') ),
+                $!name.IMPL-QAST-INDIRECT-LOOKUP($context, :sigil('&'))
+            );
+            $name-again := QAST::Var.new( :name($tmp), :scope('local') );
+        }
+        else {
+            $name-qast  := self.resolution.IMPL-LOOKUP-QAST($context);
+            $name-again := self.resolution.IMPL-LOOKUP-QAST($context);
+        }
+
         my $call := $dispatcher
             ?? QAST::Op.new:
                 :op('callmethod'), :name('dispatch:<hyper>'),
                 $operand-qast,
-                self.resolution.IMPL-LOOKUP-QAST($context),
+                $name-qast,
                 QAST::SVal.new( :value($dispatcher) ),
                 QAST::SVal.new( :value('dispatch:<var>') ),
-                self.resolution.IMPL-LOOKUP-QAST($context)
+                $name-again
             !! QAST::Op.new:
                 :op('callmethod'), :name('dispatch:<hyper>'),
                 $operand-qast,
-                self.resolution.IMPL-LOOKUP-QAST($context),
+                $name-qast,
                 QAST::SVal.new( :value('dispatch:<var>') ),
-                self.resolution.IMPL-LOOKUP-QAST($context);
+                $name-again;
         self.args.IMPL-ADD-QAST-ARGS($context, $call);
         $call
     }

--- a/src/Raku/ast/resolver.rakumod
+++ b/src/Raku/ast/resolver.rakumod
@@ -600,6 +600,11 @@ class RakuAST::Resolver {
 
     # Check if a name is a known type.
     method is-name-type(RakuAST::Name $Rname) {
+        # An indirect lookup is a term, not a type name, even when its
+        # constant string names a known type: the symbol is looked up at
+        # run time.
+        return False if $Rname.is-indirect-lookup;
+
         my $constant := self.resolve-name($Rname);
         if nqp::istype($constant, RakuAST::CompileTimeValue) {
             # Name resolves, but is it an instance or a type object?

--- a/src/Raku/ast/term.rakumod
+++ b/src/Raku/ast/term.rakumod
@@ -38,6 +38,14 @@ class RakuAST::Term::Name
     }
 
     method PERFORM-PARSE(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
+        # An indirect lookup is a runtime symbolic lookup, which consults the
+        # symbols a require merged into %?REQUIRE-SYMBOLS before anything
+        # visible at compile time. Resolving its constant-string form here
+        # would let consumers fold the parse-time symbol instead, so it stays
+        # unresolved and evaluates where it is written. In a BEGIN-time
+        # context that evaluation still happens during compilation.
+        return Nil if $!name.is-indirect-lookup;
+
         my $resolved := $resolver.resolve-name($!name);
         if $resolved {
             self.set-resolution($resolved);
@@ -96,6 +104,12 @@ class RakuAST::Term::Name
                 $!name.is-package-lookup
                     ?? QAST::Op.new(:op<who>, $lookup)
                     !! $lookup;
+            }
+            elsif $!name.is-indirect-lookup {
+                # An unresolved indirect lookup is a runtime symbolic lookup.
+                # Its lookup consults %?REQUIRE-SYMBOLS, which the pseudo-stash
+                # lookup below does not.
+                $!name.IMPL-QAST-INDIRECT-LOOKUP($context);
             }
             else {
                 $!name.IMPL-QAST-PSEUDO-PACKAGE-LOOKUP($context);

--- a/t/02-rakudo/indirect-name-constant.t
+++ b/t/02-rakudo/indirect-name-constant.t
@@ -1,0 +1,59 @@
+use lib <t/02-rakudo/test-packages>;
+use Test;
+
+plan 11;
+
+# `require` merges the required unit's symbols into the caller's
+# %?REQUIRE-SYMBOLS, which the runtime symbolic lookup consults before
+# anything visible at compile time. An indirect lookup written with a
+# constant string, like ::("EXPORT"), must therefore run at run time
+# rather than fold to whatever the string resolves to during
+# compilation. A direct EXPORT::<...> reference still resolves at
+# compile time.
+
+class BundleShadow {
+    method which() { "lexical" }
+    class Inner { method which() { "lexical-inner" } }
+}
+sub bundle-shadow($v) { "lexical-" ~ $v }
+
+require ::("BundleExport");
+require ::("ShadowUnit");
+
+ok ::("EXPORT").WHO<DEFAULT>:exists,
+    'the required module EXPORT::DEFAULT is visible through ::("EXPORT")';
+
+my @pairs = ::("EXPORT").WHO<DEFAULT>.WHO.pairs;
+is @pairs.map(*.key).sort, ('&bundle-export',),
+    'the required module exports are read from ::("EXPORT")';
+
+is ::("EXPORT").WHO<DEFAULT>.WHO<&bundle-export>('x'), 'bundled x',
+    'the re-read exported sub is callable';
+
+is ::("BundleShadow").which, 'required',
+    'a require-injected class shadows a same-named lexical class in ::("...")';
+
+is ::("BundleShadow::Inner").which, 'required-inner',
+    'a multi-part ::("...") walks the require-injected package at run time';
+
+is (sub ($a = ::("BundleShadow")) { $a.which })(), 'required',
+    'a parameter default holding ::("...") looks the symbol up per call';
+
+is "{ ::("BundleShadow").which }", 'required',
+    'a ::("...") interpolated in a string runs the symbolic lookup';
+
+is 5.&::("bundle-shadow"), 'required-5',
+    'a .&::("...") call runs the symbolic lookup that sees require-injected subs';
+
+my $hyper-name = "bundle-shadow";
+is-deeply (1, 2)>>.&::($hyper-name), ("required-1", "required-2"),
+    'a hyper .&::($name) call resolves the routine at run time';
+
+my constant IndirectInt = ::("Int");
+is IndirectInt.^name, 'Int',
+    'a constant initialized from an indirect lookup evaluates it at BEGIN time';
+
+is BundleShadow.which, 'lexical',
+    'a direct name still resolves to the lexical class';
+
+# vim: expandtab shiftwidth=4

--- a/t/02-rakudo/package-adopts-imported-stub-who.t
+++ b/t/02-rakudo/package-adopts-imported-stub-who.t
@@ -5,7 +5,7 @@ plan 2;
 
 # Importing StealWhoLeaf brings in a stub StealWho package carrying Leaf.
 use StealWhoLeaf;
-my constant $stub-who = ::("StealWho").WHO;
+my constant $stub-who = StealWho.WHO;
 
 class StealWho {
 }

--- a/t/02-rakudo/test-packages/BundleExport.rakumod
+++ b/t/02-rakudo/test-packages/BundleExport.rakumod
@@ -1,0 +1,8 @@
+unit module BundleExport;
+
+# A module whose exports are declared through an explicit EXPORT::DEFAULT
+# package (the older idiom, as Test::Async bundles use), rather than the
+# `is export` trait.
+package EXPORT::DEFAULT {
+    our sub bundle-export($v) { "bundled " ~ $v }
+}

--- a/t/02-rakudo/test-packages/ShadowUnit.rakumod
+++ b/t/02-rakudo/test-packages/ShadowUnit.rakumod
@@ -1,0 +1,11 @@
+# A module whose top-level package-scoped symbols land in its GLOBALish and,
+# on a `require`, in the caller's %?REQUIRE-SYMBOLS, shadowing same-named
+# symbols the caller can see at compile time.
+class BundleShadow {
+    method which() { "required" }
+    class Inner {
+        method which() { "required-inner" }
+    }
+}
+
+our sub bundle-shadow($v) { "required-" ~ $v }


### PR DESCRIPTION
Previously an indirect lookup written with a constant string, like ::("EXPORT") or ::("Foo"), resolved during compilation. Consumers of compile-time values then folded the parse-time symbol, and a .&::("foo") call compiled a direct call to its parse-time resolution. The runtime symbolic lookup consults the symbols a require merged into the caller's %?REQUIRE-SYMBOLS before anything visible at compile time, so any name a require injects at run time diverged from the legacy frontend, which compiles these as runtime lookups. ::("EXPORT") diverged unconditionally, since every compilation unit has its own EXPORT package, which made reading a required module's exports through `require ::($bundle); ::("EXPORT").WHO<DEFAULT>` return nothing. This surfaced from Test::Async, whose bundles declare exports through an explicit EXPORT::DEFAULT package that its aggregator re-exports.

This makes an indirect lookup a runtime symbolic lookup regardless of how its name is written:

- Term::Name declines to resolve an indirect name at parse time, so it reaches code generation as a runtime lookup and no consumer can fold it. A BEGIN-time context keeps working, since evaluating the expression there runs the lookup during compilation, so `my constant T = ::("Int")` retains its meaning.
- The resolver reports an indirect lookup as a term rather than a type, so it is not routed into the undeclared-type check.
- Code generation for an unresolved indirect pseudo-package lookup uses the lookup that consults %?REQUIRE-SYMBOLS instead of the pseudo-stash lookup.
- Call::VarMethod compiles .&::("foo") as the runtime lookup as well, and the hyper form binds the looked-up routine to a temporary so a single lookup feeds both positions of the dispatch. This also fixes `>>.&::($name)`, which failed to compile with a resolution error.

Declaration-time paths that evaluate a name during compilation keep resolving, so `augment class ::("Foo")` and an `is ::("Foo")` trait still work, and `is ::("EXPORT")` reports the same inheritance error as a written `is EXPORT`.

The stub-who adoption test captured an imported stub package through a BEGIN-time ::("StealWho") that only found the stub via the fold, because the runtime lexical chain does not expose use-imported package symbols during BEGIN. It now captures the stash through the direct name, which expresses the same intent. That BEGIN-time visibility gap predates this change and also affects LEXICAL:: introspection under this frontend.