### PR TITLE
RakuAST: reconcile a unit's GLOBALish with same-named packages

### DIFF
--- a/src/Raku/ast/call.rakumod
+++ b/src/Raku/ast/call.rakumod
@@ -1597,6 +1597,7 @@ class RakuAST::Call::BlockMethod
 class RakuAST::Stub
   is RakuAST::ImplicitLookups
   is RakuAST::Term
+  is RakuAST::CheckTime
 {
     has RakuAST::ArgList $.args;
 
@@ -1607,6 +1608,13 @@ class RakuAST::Stub
     }
 
     method PERFORM-CHECK(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
+        # A stub in the setting mentions X::StubCode before that class is
+        # declared, so the begin time resolution of the implicit lookup
+        # comes up empty. Retry now that the whole compilation unit has
+        # been parsed, so the emitted code carries the resolved type
+        # rather than a run time package walk from GLOBAL.
+        my $lookup := self.IMPL-UNWRAP-LIST(self.get-implicit-lookups)[0];
+        $lookup.PERFORM-CHECK($resolver, $context) unless $lookup.is-resolved;
         True
     }
 

--- a/src/Raku/ast/resolver.rakumod
+++ b/src/Raku/ast/resolver.rakumod
@@ -1287,6 +1287,29 @@ class RakuAST::Resolver::EVAL
     }
 
     # Resolves a name to the lexical constant it refers to in the
+    # enclosing scope, consulting only the compilation unit's own
+    # scopes. The innermost scope is not searched. Neither the outer
+    # context nor the setting is consulted. This finds the declaration
+    # that a same-named declaration in the current scope shadows.
+    method resolve-shadowed-lexical-constant-in-scopes(Str $name) {
+        if $name eq 'GLOBAL' {
+            return self.global-package;
+        }
+        my @scopes := $!scopes;
+        my int $i  := nqp::elems(@scopes);
+        if $i > 1 {
+            $i := $i - 1;
+            while $i-- {
+                my $found := @scopes[$i].find-lexical($name);
+                if nqp::isconcrete($found) {
+                    return nqp::istype($found, RakuAST::CompileTimeValue) ?? $found !! Nil;
+                }
+            }
+        }
+        Nil
+    }
+
+    # Resolves a name to the lexical constant it refers to in the
     # enclosing scope: the innermost scope is not searched. This finds
     # the declaration that a same-named declaration in the current
     # scope shadows. The fallback chain matches resolve-lexical-constant
@@ -1312,6 +1335,24 @@ class RakuAST::Resolver::EVAL
         nqp::isnull($setting) || !$setting
           ?? Nil
           !! self.IMPL-RESOLVE-LEXICAL-IN-SETTING($setting, $name)
+    }
+
+    # Resolves a name to the lexical constant declared in the
+    # compilation unit's own scopes. The outer context and setting are
+    # not consulted.
+    method resolve-lexical-constant-in-scopes(Str $name) {
+        if $name eq 'GLOBAL' {
+            return self.global-package;
+        }
+        my @scopes := $!scopes;
+        my int $i  := nqp::elems(@scopes);
+        while $i-- {
+            my $found := @scopes[$i].find-lexical($name);
+            if nqp::isconcrete($found) {
+                return nqp::istype($found, RakuAST::CompileTimeValue) ?? $found !! Nil;
+            }
+        }
+        Nil
     }
 
     # Resolves a name to its lexical declaration if that declaration has a
@@ -1574,6 +1615,29 @@ class RakuAST::Resolver::Compile
     }
 
     # Resolves a name to the lexical constant it refers to in the
+    # enclosing scope, consulting only the compilation unit's own
+    # scopes. The innermost scope is not searched and the outer
+    # context is not consulted. This finds the declaration that a
+    # same-named declaration in the current scope shadows.
+    method resolve-shadowed-lexical-constant-in-scopes(Str $name) {
+        if $name eq 'GLOBAL' {
+            return self.global-package;
+        }
+        my @scopes := $!scopes;
+        my int $i  := nqp::elems(@scopes);
+        if $i > 1 {
+            $i := $i - 1;
+            while $i-- {
+                my $found := @scopes[$i].find-lexical($name);
+                if nqp::isconcrete($found) {
+                    return nqp::istype($found, RakuAST::CompileTimeValue) ?? $found !! Nil;
+                }
+            }
+        }
+        Nil
+    }
+
+    # Resolves a name to the lexical constant it refers to in the
     # enclosing scope: the innermost scope is not searched. This finds
     # the declaration that a same-named declaration in the current
     # scope shadows. The fallback matches resolve-lexical-constant
@@ -1594,6 +1658,24 @@ class RakuAST::Resolver::Compile
             }
         }
         self.resolve-lexical-constant-in-outer($name)
+    }
+
+    # Resolves a name to the lexical constant declared in the
+    # compilation unit's own scopes. The outer context is not
+    # consulted.
+    method resolve-lexical-constant-in-scopes(Str $name) {
+        if $name eq 'GLOBAL' {
+            return self.global-package;
+        }
+        my @scopes := $!scopes;
+        my int $i  := nqp::elems(@scopes);
+        while $i-- {
+            my $found := @scopes[$i].find-lexical($name);
+            if nqp::isconcrete($found) {
+                return nqp::istype($found, RakuAST::CompileTimeValue) ?? $found !! Nil;
+            }
+        }
+        Nil
     }
 
     # Resolves a name to its lexical declaration if that declaration has a

--- a/src/Raku/ast/scoping.rakumod
+++ b/src/Raku/ast/scoping.rakumod
@@ -1449,22 +1449,35 @@ class RakuAST::PackageInstaller {
             # GLOBALish into the consumer, which is the only route there
             # to a symbol nested under a unit-scoped module. The shadowed
             # lookup skips the whole current scope; a pre-existing symbol
-            # here is an import's generated lexical, preferred first. No
-            # upgrade while compiling the setting, whose lexicals all
+            # here is an import's generated lexical, preferred first.
+            # A name the compunit merely resolves from the setting or
+            # outer context must stay out of GLOBALish. Hoisting it
+            # would publish the setting type to every consumer and
+            # collide with the consumer's own view of that name. The
+            # exception is an our-scoped declaration installing into the
+            # global stash itself, where the install below adopts the
+            # hoisted entry's WHO and overwrites the entry right away.
+            # No upgrade while compiling the setting, whose lexicals all
             # resolve without it. This runs after the collision check
             # above: when the current package is the global one, the
-            # upgrade writes the very stash that check reads, and the
-            # install below overwrites the entry either way.
+            # upgrade writes the very stash that check reads.
             my $setting := $resolver.setting;
             if !nqp::isnull($setting) && $setting {
+                my $replaces-global-entry := $scope eq 'our'
+                    && nqp::eqaddr($current-package, $resolver.get-global);
                 my $pre-existing := $generated && nqp::istype($generated, RakuAST::CompileTimeValue)
                     ?? $generated
                     !! $lexical;
                 if nqp::isconcrete($pre-existing) && nqp::istype($pre-existing, RakuAST::CompileTimeValue) {
-                    $pre-existing := $resolver.resolve-shadowed-lexical-constant($final)
+                    $pre-existing := $replaces-global-entry
+                        ?? $resolver.resolve-shadowed-lexical-constant($final)
+                        !! $resolver.resolve-shadowed-lexical-constant-in-scopes($final)
                         if nqp::eqaddr($pre-existing.compile-time-value, $type-object);
                     if nqp::isconcrete($pre-existing)
-                        && !nqp::eqaddr($pre-existing.compile-time-value, $type-object) {
+                        && !nqp::eqaddr($pre-existing.compile-time-value, $type-object)
+                        && ($replaces-global-entry
+                            || nqp::istype($pre-existing, RakuAST::Declaration::Import)
+                            || !nqp::istype($pre-existing, RakuAST::Declaration::External)) {
                         self.IMPL-STASH-BIND(
                           $resolver.get-global, $final, $pre-existing.compile-time-value
                         );
@@ -1504,8 +1517,14 @@ class RakuAST::PackageInstaller {
                 $resolved := self.IMPL-UNWRAP-LIST($resolved);
                 $target := $resolved[0];
                 $setting-resolved-target := $target if $resolved[2] eq 'lexical';
-                if $scope eq 'our' && nqp::elems(@parts) >= 1 && $resolved[2] eq 'lexical' {
-                    # Upgrade lexically imported top level package to global
+                # Upgrade a lexically imported top level package to global.
+                # Only a name the compilation unit's own scopes carry
+                # qualifies, such as an import. A leading part resolved
+                # from the setting or outer context must not be published
+                # into this unit's GLOBALish, which every consumer merges
+                # in.
+                if $scope eq 'our' && nqp::elems(@parts) >= 1 && $resolved[2] eq 'lexical'
+                    && nqp::isconcrete($resolver.resolve-lexical-constant-in-scopes($first)) {
                     ($resolver.get-global.WHO){$first} := $resolver.resolve-lexical($first).compile-time-value;
                 }
                 my $parts  := $resolved[1];

--- a/src/Raku/ast/scoping.rakumod
+++ b/src/Raku/ast/scoping.rakumod
@@ -1382,12 +1382,12 @@ class RakuAST::PackageInstaller {
         my $lexical;
         my $lexical-stub;
         my $type-object := nqp::eqaddr($meta-object, Mu) ?? self.stubbed-meta-object !! $meta-object;
-        # If the multi-part install resolves its parent through the
-        # setting / outer lexical chain (cross-compunit reload),
-        # capture *which* parent that was and treat the install-
-        # collision as silent only when $target is still that exact
-        # parent at check time (the loop below may reassign $target
-        # to a freshly-created intermediate stub, which is ours).
+        # When the setting resolves the parent of a multi-part install,
+        # the declaration is a cross-compunit reload. Capture which
+        # parent that was and treat the install collision as silent
+        # only when $target is still that exact parent at check time.
+        # The chase loop below may reassign $target to a freshly
+        # created intermediate stub, which is ours.
         my $setting-resolved-target;
 
         my $illegal-pseudo-package := $name.contains-pseudo-package-illegal-for-declaration;
@@ -1516,7 +1516,21 @@ class RakuAST::PackageInstaller {
             if $resolved { # first parts of the name found
                 $resolved := self.IMPL-UNWRAP-LIST($resolved);
                 $target := $resolved[0];
-                $setting-resolved-target := $target if $resolved[2] eq 'lexical';
+                # Capture the parent only when the setting itself resolves
+                # the leading name part. A leading part resolved from a
+                # caller's frame, such as an EVAL redeclaring a class its
+                # caller declared, is a plain redeclaration and must still
+                # reach the collision check.
+                if $resolved[2] eq 'lexical' {
+                    my $lexical-first := $resolver.resolve-lexical-constant($first);
+                    my $in-setting := $resolver.resolve-lexical-constant-in-setting($first);
+                    $setting-resolved-target := $target
+                        if nqp::isconcrete($lexical-first)
+                        && nqp::isconcrete($in-setting)
+                        && nqp::eqaddr(
+                            $in-setting.compile-time-value,
+                            $lexical-first.compile-time-value);
+                }
                 # Upgrade a lexically imported top level package to global.
                 # Only a name the compilation unit's own scopes carry
                 # qualifies, such as an import. A leading part resolved
@@ -1623,7 +1637,7 @@ class RakuAST::PackageInstaller {
     # PackageHOW upgrades; 6.d `module Foo::Bar { class Foo::Bar { } }`
     # enclosing-module replace; identifier and `my`-scope (caught
     # elsewhere); and cross-compunit reload (target resolved through
-    # the setting / outer chain), matching legacy `install_package`.
+    # the setting), matching legacy `install_package`.
     method IMPL-SHOULD-SILENT-REPLACE(Mu $existing, Mu $current-package, RakuAST::Name $name, str $orig-scope, int $target-from-setting) {
         nqp::istype($existing.HOW, Perl6::Metamodel::PackageHOW)
         || (nqp::getcomp('Raku').language_revision < 3

--- a/src/Raku/ast/statements.rakumod
+++ b/src/Raku/ast/statements.rakumod
@@ -2311,7 +2311,7 @@ class RakuAST::ModuleLoading {
         );
         my $comp-unit := $registry.head.need($spec);
         my $globalish := $comp-unit.handle.globalish-package;
-        self.IMPL-IMPORT-ONE($resolver, self.IMPL-STASH-HASH($globalish));
+        self.IMPL-IMPORT-ONE($resolver, self.IMPL-STASH-HASH($globalish), :globalish(True));
         $comp-unit
     }
 
@@ -2363,7 +2363,7 @@ class RakuAST::ModuleLoading {
         }
     }
 
-    method IMPL-IMPORT-ONE(RakuAST::Resolver $resolver, Mu $stash, Bool :$need-decont) {
+    method IMPL-IMPORT-ONE(RakuAST::Resolver $resolver, Mu $stash, Bool :$need-decont, Bool :$globalish) {
         my $target-scope := $resolver.current-scope;
         for self.IMPL-SORTED-KEYS($stash) -> $key {
             next if $key eq 'EXPORT';
@@ -2390,6 +2390,12 @@ class RakuAST::ModuleLoading {
                 $existing.merge($declarand, :$resolver) unless $existing.compile-time-value =:= $declarand.compile-time-value;
             }
             else {
+                # A unit's mainline can write through a GLOBAL-rooted name
+                # as it loads, vivifying a stub package in the merged GLOBAL
+                # under a name its GLOBALish also carries. A fresh lexical
+                # would shadow that stub and hide its symbols.
+                $declarand := self.IMPL-MERGE-GLOBAL-STUB($resolver, $key, $declarand)
+                    if $globalish;
                 $target-scope.merge-generated-lexical-declaration: $declarand, :$resolver;
             }
 
@@ -2403,6 +2409,48 @@ class RakuAST::ModuleLoading {
                 ));
             }
         }
+    }
+
+    # Reconcile an imported top-level GLOBALish package with a same-named
+    # entry already in the merged GLOBAL, applying the conflict rules of
+    # ModuleLoader's merge_globals. Returns the declaration to install,
+    # which carries the surviving package.
+    method IMPL-MERGE-GLOBAL-STUB(RakuAST::Resolver $resolver, str $key, Mu $declarand) {
+        my $global := $resolver.get-global;
+        return $declarand if nqp::eqaddr($global, Mu);
+        # The WHO is a plain hash rather than a Stash in some compilation
+        # contexts, such as an EVAL against an NQP-created GLOBALish.
+        my $who := $global.WHO;
+        my $storage := nqp::ishash($who)
+            ?? $who
+            !! nqp::istype($who, Map)
+                ?? nqp::getattr($who, Map, '$!storage')
+                !! nqp::null;
+        return $declarand if nqp::isnull($storage) || !nqp::existskey($storage, $key);
+        my $current := nqp::decont(nqp::atkey($storage, $key));
+        my $value   := nqp::decont($declarand.compile-time-value);
+        return $declarand if nqp::eqaddr($current, $value);
+        my $loader := nqp::gethllsym('Raku', 'ModuleLoader');
+        if self.IMPL-IS-STUB-PACKAGE($value) {
+            # A stub gives way: the package GLOBAL holds stays canonical.
+            $loader.merge_globals($current.WHO, $value.WHO);
+            RakuAST::Declaration::Import.new(:lexical-name($key), :compile-time-value($current))
+        }
+        elsif self.IMPL-IS-STUB-PACKAGE($current) {
+            # A real package displaces the stub GLOBAL holds.
+            $loader.merge_globals($value.WHO, $current.WHO);
+            nqp::bindkey($storage, $key, $value);
+            $declarand
+        }
+        else {
+            $declarand
+        }
+    }
+
+    method IMPL-IS-STUB-PACKAGE(Mu $value) {
+        my $how := $value.HOW;
+        my str $name := $how.HOW.name($how);
+        $name eq 'Perl6::Metamodel::PackageHOW' || $name eq 'KnowHOW'
     }
 
     method IMPL-IMPORT-EXPORTHOW(RakuAST::Resolver $resolver, Mu $handle) {

--- a/t/02-rakudo/exporthow-my-scope.t
+++ b/t/02-rakudo/exporthow-my-scope.t
@@ -1,7 +1,8 @@
 use lib <t/02-rakudo/test-packages>;
 use Test;
+use nqp;
 
-plan 2;
+plan 4;
 
 # ExportHowBare overrides the `class` declarator through a bare `package
 # EXPORTHOW`. Loading it must not die "Merging GLOBAL symbols failed: duplicate
@@ -16,3 +17,18 @@ lives-ok { EVAL 'use ExportHowBare; 1' },
 # the exported HOW, which adds a `composed-by-bare-exporthow` method at compose.
 is EVAL('use ExportHowBare; class Marker { }; Marker.composed-by-bare-exporthow'),
     True, 'the bare EXPORTHOW override composes classes with its own HOW';
+
+# EXPORTHOW is per compilation unit: a module that merely uses an
+# EXPORTHOW-carrying module must not hand an EXPORTHOW of its own to
+# consumers. When resolving the name hoisted the setting's EXPORTHOW into
+# the intermediate module's GLOBALish, a consumer re-registered every
+# setting entry as a package declarator, and its next `subset` parsed as a
+# package whose SubsetHOW.new_type died asking for the refinee. This broke
+# any module using Terminal::Print, whose Grid uses OO::Monitors.
+lives-ok { EVAL 'use UsesExportHowBare; subset TransitiveProbe of Int where 1; 1' },
+    'a subset still parses after using a module that used an EXPORTHOW module';
+
+todo 'the legacy frontend hands a used module\'s declarator overrides on to consumers'
+    unless nqp::gethllsym('Raku', 'COMPILER-FRONTEND') eq 'rakuast';
+is EVAL('use UsesExportHowBare; class TransitiveMarker { }; TransitiveMarker.^find_method("composed-by-bare-exporthow") ?? "leaked" !! "clean"'),
+    'clean', 'the class declarator override does not travel transitively';

--- a/t/02-rakudo/global-package-var-cross-unit.t
+++ b/t/02-rakudo/global-package-var-cross-unit.t
@@ -1,8 +1,9 @@
 use lib <t/packages/Test-Helpers>;
 use Test;
 use Test::Helpers;
+use nqp;
 
-plan 3;
+plan 6;
 
 # A GLOBAL package variable written at run time by a precompiled module
 # must be visible outside that module. Each compilation unit has its own
@@ -30,5 +31,41 @@ is-run 'use GlobalWriter; set-it; print get-dynamic()',
 is-run 'use GlobalWriter; set-scalar; print $*cross-unit-scalar',
     :@compiler-args, :out<5>,
     'a scalar written to GLOBAL by a module reaches the dynamic fallback';
+
+# A run-time write through a GLOBAL-rooted name can vivify a stub package
+# under a name some unit also declares. Importing that unit's GLOBALish
+# must unify the two packages rather than install a lexical alias that
+# shadows the stub and hides its symbols.
+
+$mod-store.add('SelfWriter.rakumod').spurt: q:to/EOF/;
+    package SelfNamespace {
+        &GLOBAL::SelfNamespace::dld = &dld;
+        sub dld { 42 }
+    }
+    EOF
+
+is-run 'use SelfWriter; print SelfNamespace::dld()',
+    :@compiler-args, :out<42>,
+    'a sub a module binds into a GLOBAL-rooted package it also declares is callable by qualified name';
+
+is-run 'use SelfWriter; print SelfNamespace.WHO =:= GLOBAL::SelfNamespace.WHO',
+    :@compiler-args, :out<True>,
+    'the imported package and the GLOBAL entry of the same name are one object';
+
+$mod-store.add('StubWriter.rakumod').spurt: q:to/EOF/;
+    unit module StubWriter;
+    $GLOBAL::CrossUnitClass::stub-val = 5;
+    EOF
+$mod-store.add('RealClass.rakumod').spurt: q:to/EOF/;
+    class CrossUnitClass {
+        method val() { 37 }
+    }
+    EOF
+
+todo 'the legacy frontend does not merge a vivified GLOBAL stub into an imported class'
+    unless nqp::gethllsym('Raku', 'COMPILER-FRONTEND') eq 'rakuast';
+is-run 'use StubWriter; use RealClass; print CrossUnitClass.val + $CrossUnitClass::stub-val',
+    :@compiler-args, :out<42>,
+    'a class merges symbols from a same-named stub package an earlier module vivified in GLOBAL';
 
 # vim: expandtab shiftwidth=4

--- a/t/02-rakudo/import-shadows-setting-type.t
+++ b/t/02-rakudo/import-shadows-setting-type.t
@@ -1,0 +1,40 @@
+use lib <t/02-rakudo/test-packages>;
+use Test;
+
+plan 6;
+
+# A module may export its own type under a name the setting already
+# uses, such as a refined DateTime subclass exported as `DateTime`.
+# The import must install a fresh lexical that shadows the setting
+# type, as the traditional frontend does. The module's compilation
+# must not publish the setting type into its GLOBALish along the way.
+# Consumers merge that stash in, and a setting type there collides
+# with the module's own export. DateTime::strftime failed this way
+# with "Redeclaration of symbol 'DateTime'". Modules declaring
+# packages nested under a setting name leaked the setting type to
+# every consumer, CompUnit::Repository::Staging among them.
+
+{
+    use ShadowsSettingType :refine;
+    is Set.shadow-tag, 'shadowed',
+        'the imported same-named subclass shadows the setting type';
+    nok Set === CORE::Set,
+        'the shadowing import is the module class, not the setting type';
+}
+
+{
+    use ShadowsSettingType;
+    ok Set === CORE::Set,
+        'without the export tag the setting type is untouched';
+    is shadow-helper(), 'helper',
+        'the default exports of the module still import';
+}
+
+{
+    use NestedUnderSettingName;
+    is CompUnit::Repository::TestShadow.tag, 'nested',
+        'a package nested under a setting name is reachable in the consumer';
+    my class CompUnit { method tag() { 'local' } }
+    is CompUnit.tag, 'local',
+        'the consumer can declare its own class under the setting name the module nested under';
+}

--- a/t/02-rakudo/test-packages/NestedUnderSettingName.rakumod
+++ b/t/02-rakudo/test-packages/NestedUnderSettingName.rakumod
@@ -1,0 +1,3 @@
+class CompUnit::Repository::TestShadow {
+    method tag() { 'nested' }
+}

--- a/t/02-rakudo/test-packages/ShadowsSettingType.rakumod
+++ b/t/02-rakudo/test-packages/ShadowsSettingType.rakumod
@@ -1,0 +1,3 @@
+sub shadow-helper() is export(:DEFAULT, :refine) { 'helper' }
+my class Set is Set { method shadow-tag() { 'shadowed' } }
+BEGIN EXPORT::refine::<Set> := Set;

--- a/t/02-rakudo/test-packages/UsesExportHowBare.rakumod
+++ b/t/02-rakudo/test-packages/UsesExportHowBare.rakumod
@@ -1,0 +1,4 @@
+# Consumes a module that carries an EXPORTHOW without declaring one of its
+# own, so a consumer of this module can check that no EXPORTHOW travels along.
+use ExportHowBare;
+unit module UsesExportHowBare;


### PR DESCRIPTION
Previously a unit's GLOBALish could disagree with a same-named package living somewhere else. Importing a GLOBALish always installed each top level package as a fresh lexical, even when the merged GLOBAL already held that name from a run-time `GLOBAL::` write, which left the existing package's symbols unreachable by qualified lookup. The package installer also hoisted whatever a declared name used to resolve to into GLOBALish, including setting types, so a module shadowing a setting type broke every consumer that imported it:

```
$ cat lib/Refined.rakumod
sub helper() is export(:refine) { }
my class Set is Set { method tag { "refined" } }
BEGIN EXPORT::refine::<Set> := Set;

$ raku -I lib -e 'use Refined :refine; say Set.tag'
===SORRY!=== Error while compiling -e
Redeclaration of symbol 'Set'.
```

This reconciles an imported package with the entry GLOBAL already holds and restricts the hoist to names the unit's own scopes carry, matching the legacy frontend in both cases. That fixes Acme::Polyglot::Levenshtein::Damerau, DateTime::strftime, Java::Generate, and several other blin failures of the same shape. It also unblocks zef installs more generally, as CompUnit::Repository::Staging itself carried the setting `CompUnit` in its GLOBALish and re-broke every distribution staged behind it.

The hoist restriction also covers EXPORTHOW. A module using OO::Monitors carried the setting's EXPORTHOW in its GLOBALish, so a consumer re-registered every setting declarator through the legacy unchecked-supersede path and its next `subset` parsed as a package declaration, dying with "Required named parameter 'refinee' not passed". This broke Terminal::Print and everything downstream of it in blin, Terminal::Widgets among them.

A stub now resolves its X::StubCode lookup at check time. The setting mentions that class before Exception.rakumod declares it, so the begin time resolution came up empty and the emitted code walked GLOBAL at run time, which only worked while the hoist seeded that entry. The install collision check also captures a cross-compunit reload parent only when the setting itself resolves the leading name part, so a run time EVAL redeclaring its caller's class dies with X::Redeclaration while zef's reload of CompUnit::Repository::Staging keeps its silent replace.
