### PR TITLE
RakuAST: bind a flattened block argument like a call would

### DIFF
--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -1555,14 +1555,25 @@ class RakuAST::Block
                     my str $local-name := $_.IMPL-LOWERED-LOCAL-NAME;
                     $stmts.push(QAST::Var.new(
                         :scope('local'), :decl('var'), :name($local-name) ));
-                    # hllize as the parameter binder would have, since
-                    # an iterator driven from nqp-side code can hand out
-                    # unboxed values.
+                    # Bind as the parameter binder would have. Hllize,
+                    # since an iterator driven from nqp code can hand
+                    # out unboxed values. Wrap in a fresh read-only
+                    # Scalar so an Iterable value stays a single item
+                    # and assignment to the parameter dies.
                     $stmts.push(QAST::Op.new(
                         :op('bind'),
                         QAST::Var.new( :name($local-name), :scope('local') ),
-                        QAST::Op.new( :op('hllize'),
-                            QAST::Op.new( :op('decont'), $arg-qast ) )
+                        QAST::Op.new(
+                            :op('p6bindattrinvres'),
+                            QAST::Op.new(
+                                :op('create'),
+                                QAST::WVal.new( :value(Scalar) )
+                            ),
+                            QAST::WVal.new( :value(Scalar) ),
+                            QAST::SVal.new( :value('$!value') ),
+                            QAST::Op.new( :op('hllize'),
+                                QAST::Op.new( :op('decont'), $arg-qast ) )
+                        )
                     ));
                 }
                 else {
@@ -1915,7 +1926,9 @@ class RakuAST::PointyBlock
     # The single plain positional parameter, when the signature is
     # simple enough that binding a flattened invocation's argument to
     # the parameter's local matches what the call would have done: no
-    # type to check, no default, no where, no adverbs, no traits.
+    # type to check, no default, no where, no adverbs, no traits. Only
+    # a '$' sigil qualifies. The other sigils carry a nominal type
+    # check that only the real binder performs.
     method IMPL-FLATTEN-ARG-DECLARATION() {
         my @params := self.IMPL-UNWRAP-LIST($!signature.parameters);
         return nqp::null unless nqp::elems(@params) == 1;
@@ -1934,6 +1947,7 @@ class RakuAST::PointyBlock
             || nqp::elems($param.IMPL-UNWRAP-LIST($param.traits));
         my $target := $param.target;
         return nqp::null unless nqp::istype($target, RakuAST::ParameterTarget::Var)
+            && $target.sigil eq '$'
             && nqp::isconcrete($target.declaration)
             && !nqp::elems($target.declaration.IMPL-UNWRAP-LIST($target.declaration.traits));
         $target.declaration

--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -1542,10 +1542,170 @@ class RakuAST::Block
     # when unused, so the argument is discarded.
     method IMPL-FLATTEN-ARG-DECLARATION() { nqp::null }
 
+    # The parameter owning that declaration.
+    method IMPL-FLATTEN-ARG-PARAMETER() { nqp::null }
+
     # As IMPL-QAST-FLATTENED, but binding the given argument QAST into
     # the block's argument declaration, the way calling the block with
     # one positional would have.
     method IMPL-QAST-FLATTENED-WITH-ARG(RakuAST::IMPL::QASTContext $context, Mu $arg-qast) {
+        my $param := self.IMPL-FLATTEN-ARG-PARAMETER;
+        my $nominal := nqp::isnull($param)
+            ?? Mu
+            !! nqp::getattr($param.meta-object, Parameter, '$!type');
+
+        # A parameter of nominal type Mu binds any value, so no check is
+        # needed. Bind as the parameter binder would have. Hllize, since
+        # an iterator driven from nqp code can hand out unboxed values.
+        # Wrap in a fresh read-only Scalar so an Iterable value stays a
+        # single item and assignment to the parameter dies.
+        if $nominal =:= Mu {
+            return self.IMPL-QAST-FLATTENED-ENTRY($context, QAST::Op.new(
+                :op('p6bindattrinvres'),
+                QAST::Op.new(
+                    :op('create'),
+                    QAST::WVal.new( :value(Scalar) )
+                ),
+                QAST::WVal.new( :value(Scalar) ),
+                QAST::SVal.new( :value('$!value') ),
+                QAST::Op.new( :op('hllize'),
+                    QAST::Op.new( :op('decont'), $arg-qast ) )
+            ));
+        }
+
+        # An '@', '%' or '&' parameter carries a nominal type that the
+        # binder checks, and a concrete Junction argument autothreads
+        # over its eigenstates instead of binding. Check inline, running
+        # the body once per value off a worklist that a Junction expands
+        # into, depth first, the way the autothreader recurses. A value
+        # that is neither throws the binder's type error. The worklist
+        # loop carries no handlers, so a loop control in the body
+        # reaches the loop the body belongs to.
+        my str $val-name   := QAST::Node.unique('flat_arg');
+        my str $queue-name := QAST::Node.unique('flat_arg_queue');
+        my $param-obj := $param.meta-object;
+        $context.ensure-sc($param-obj);
+        $context.ensure-sc($nominal);
+        my str $var-name := nqp::getattr_s($param-obj, Parameter, '$!variable_name');
+        my $dispatch := QAST::Op.new(
+            :op('if'),
+            QAST::Op.new(
+                :op('istype'),
+                QAST::Var.new( :name($val-name), :scope('local') ),
+                QAST::WVal.new( :value($nominal) )
+            ),
+            self.IMPL-QAST-FLATTENED-ENTRY($context,
+                QAST::Var.new( :name($val-name), :scope('local') )),
+            QAST::Op.new(
+                :op('if'),
+                QAST::Op.new(
+                    :op('if'),
+                    QAST::Op.new(
+                        :op('istype'),
+                        QAST::Var.new( :name($val-name), :scope('local') ),
+                        QAST::WVal.new( :value(Junction) )
+                    ),
+                    QAST::Op.new(
+                        :op('isconcrete'),
+                        QAST::Var.new( :name($val-name), :scope('local') )
+                    ),
+                    QAST::IVal.new( :value(0) )
+                ),
+                QAST::Stmts.new(
+                    QAST::Op.new(
+                        :op('if'),
+                        QAST::Op.new(
+                            :op('isnull'),
+                            QAST::Var.new( :name($queue-name), :scope('local') )
+                        ),
+                        QAST::Op.new(
+                            :op('bind'),
+                            QAST::Var.new( :name($queue-name), :scope('local') ),
+                            QAST::Op.new( :op('list') )
+                        )
+                    ),
+                    QAST::Op.new(
+                        :op('splice'),
+                        QAST::Var.new( :name($queue-name), :scope('local') ),
+                        QAST::Op.new(
+                            :op('getattr'),
+                            QAST::Var.new( :name($val-name), :scope('local') ),
+                            QAST::WVal.new( :value(Junction) ),
+                            QAST::SVal.new( :value('$!eigenstates') )
+                        ),
+                        QAST::IVal.new( :value(0) ),
+                        QAST::IVal.new( :value(0) )
+                    )
+                ),
+                QAST::Op.new(
+                    :op('callmethod'), :name('throw_or_die'),
+                    QAST::WVal.new( :value(Perl6::Metamodel::Configuration) ),
+                    QAST::SVal.new( :value('X::TypeCheck::Binding::Parameter') ),
+                    QAST::SVal.new( :value(
+                        "Nominal type check failed for parameter '" ~ $var-name ~ "'"
+                    ) ),
+                    QAST::Var.new( :name($val-name), :scope('local'), :named('got') ),
+                    QAST::WVal.new( :value($nominal), :named('expected') ),
+                    QAST::SVal.new( :value($var-name), :named('symbol') ),
+                    QAST::WVal.new( :value($param-obj), :named('parameter') )
+                )
+            )
+        );
+        my $advance := QAST::Op.new(
+            :op('if'),
+            QAST::Op.new(
+                :op('if'),
+                QAST::Op.new(
+                    :op('not_i'),
+                    QAST::Op.new(
+                        :op('isnull'),
+                        QAST::Var.new( :name($queue-name), :scope('local') )
+                    )
+                ),
+                QAST::Op.new(
+                    :op('elems'),
+                    QAST::Var.new( :name($queue-name), :scope('local') )
+                ),
+                QAST::IVal.new( :value(0) )
+            ),
+            QAST::Stmts.new(
+                QAST::Op.new(
+                    :op('bind'),
+                    QAST::Var.new( :name($val-name), :scope('local') ),
+                    QAST::Op.new(
+                        :op('shift'),
+                        QAST::Var.new( :name($queue-name), :scope('local') )
+                    )
+                ),
+                QAST::IVal.new( :value(1) )
+            ),
+            QAST::IVal.new( :value(0) )
+        );
+        QAST::Stmts.new(
+            QAST::Op.new(
+                :op('bind'),
+                QAST::Var.new( :name($val-name), :scope('local'), :decl('var') ),
+                QAST::Op.new( :op('hllize'),
+                    QAST::Op.new( :op('decont'), $arg-qast ) )
+            ),
+            QAST::Op.new(
+                :op('bind'),
+                QAST::Var.new( :name($queue-name), :scope('local'), :decl('var') ),
+                QAST::Op.new( :op('null') )
+            ),
+            QAST::Op.new(
+                :op('repeat_while'),
+                $advance,
+                $dispatch,
+                QAST::IVal.new( :value(1), :named('nohandler') )
+            )
+        )
+    }
+
+    # The statements run on each entry of a flattened invocation: the
+    # argument declaration bound to the given value, the other lowered
+    # declarations with fresh containers, and the body.
+    method IMPL-QAST-FLATTENED-ENTRY(RakuAST::IMPL::QASTContext $context, Mu $value-qast) {
         my $arg-decl := self.IMPL-FLATTEN-ARG-DECLARATION;
         my $stmts := QAST::Stmts.new();
         for self.IMPL-UNWRAP-LIST(self.ast-lexical-declarations()) {
@@ -1555,25 +1715,10 @@ class RakuAST::Block
                     my str $local-name := $_.IMPL-LOWERED-LOCAL-NAME;
                     $stmts.push(QAST::Var.new(
                         :scope('local'), :decl('var'), :name($local-name) ));
-                    # Bind as the parameter binder would have. Hllize,
-                    # since an iterator driven from nqp code can hand
-                    # out unboxed values. Wrap in a fresh read-only
-                    # Scalar so an Iterable value stays a single item
-                    # and assignment to the parameter dies.
                     $stmts.push(QAST::Op.new(
                         :op('bind'),
                         QAST::Var.new( :name($local-name), :scope('local') ),
-                        QAST::Op.new(
-                            :op('p6bindattrinvres'),
-                            QAST::Op.new(
-                                :op('create'),
-                                QAST::WVal.new( :value(Scalar) )
-                            ),
-                            QAST::WVal.new( :value(Scalar) ),
-                            QAST::SVal.new( :value('$!value') ),
-                            QAST::Op.new( :op('hllize'),
-                                QAST::Op.new( :op('decont'), $arg-qast ) )
-                        )
+                        $value-qast
                     ));
                 }
                 else {
@@ -1926,10 +2071,8 @@ class RakuAST::PointyBlock
     # The single plain positional parameter, when the signature is
     # simple enough that binding a flattened invocation's argument to
     # the parameter's local matches what the call would have done: no
-    # type to check, no default, no where, no adverbs, no traits. Only
-    # a '$' sigil qualifies. The other sigils carry a nominal type
-    # check that only the real binder performs.
-    method IMPL-FLATTEN-ARG-DECLARATION() {
+    # explicit type, no default, no where, no adverbs, no traits.
+    method IMPL-FLATTEN-ARG-PARAMETER() {
         my @params := self.IMPL-UNWRAP-LIST($!signature.parameters);
         return nqp::null unless nqp::elems(@params) == 1;
         my $param := @params[0];
@@ -1947,10 +2090,14 @@ class RakuAST::PointyBlock
             || nqp::elems($param.IMPL-UNWRAP-LIST($param.traits));
         my $target := $param.target;
         return nqp::null unless nqp::istype($target, RakuAST::ParameterTarget::Var)
-            && $target.sigil eq '$'
             && nqp::isconcrete($target.declaration)
             && !nqp::elems($target.declaration.IMPL-UNWRAP-LIST($target.declaration.traits));
-        $target.declaration
+        $param
+    }
+
+    method IMPL-FLATTEN-ARG-DECLARATION() {
+        my $param := self.IMPL-FLATTEN-ARG-PARAMETER;
+        nqp::isnull($param) ?? nqp::null() !! $param.target.declaration
     }
 
     method new(RakuAST::Signature :$signature,

--- a/src/Raku/ast/statements.rakumod
+++ b/src/Raku/ast/statements.rakumod
@@ -1895,6 +1895,8 @@ class RakuAST::Statement::Given
     # The body of the given statement.
     has RakuAST::Block $.body;
 
+    has int $!is-sunk;
+
     method new(RakuAST::Expression :$source!, RakuAST::Block :$body!, List :$labels) {
         my $obj := nqp::create(self);
         nqp::bindattr($obj, RakuAST::Statement::Given, '$!source', $source);
@@ -1904,12 +1906,26 @@ class RakuAST::Statement::Given
     }
 
     method propagate-sink(Bool $is-sunk) {
+        nqp::bindattr_i(self, RakuAST::Statement::Given, '$!is-sunk',
+            $is-sunk ?? 1 !! 0);
         $!source.apply-sink(False);
         $!body.apply-sink($is-sunk);
     }
 
     method apply-implicit-block-semantics(:$resolver, :$context) {
         $!body.set-implicit-topic(True, :required);
+    }
+
+    # Whether the body is eligible to flatten. A parameter carrying a
+    # nominal type compiles its check as a worklist loop, which
+    # produces no value and does not collect autothreaded results into
+    # a Junction the way a call does, so such a body only flattens
+    # when the statement is sunk.
+    method IMPL-CAN-FLATTEN-BODY() {
+        return 1 if $!is-sunk;
+        my $param := $!body.IMPL-FLATTEN-ARG-PARAMETER;
+        nqp::isnull($param)
+            || nqp::getattr($param.meta-object, Parameter, '$!type') =:= Mu
     }
 
     method IMPL-TO-QAST(RakuAST::IMPL::QASTContext $context) {

--- a/src/Raku/ast/var-lowering.rakumod
+++ b/src/Raku/ast/var-lowering.rakumod
@@ -266,11 +266,11 @@ class RakuAST::IMPL::VarLowering {
         }
 
         # A sunk serial for statement drives its body directly, and a
-        # given calls its body with the topicalized value, so both walk
-        # their bodies as argument-taking flatten candidates: a plain
-        # body flattens when its topic goes unused, and a pointy body
-        # with one plain parameter has the iteration value bound to the
-        # parameter's local instead.
+        # given calls its body with the topicalized value, so each may
+        # walk its body as a flatten candidate that takes an argument:
+        # a plain body flattens when its topic goes unused, and a
+        # pointy body with one plain parameter has the value bound to
+        # the parameter's local instead.
         if nqp::istype($node, RakuAST::Statement::For)
             && $node.mode eq 'serial'
             && $node.IMPL-DISCARD-RESULT
@@ -285,7 +285,12 @@ class RakuAST::IMPL::VarLowering {
         if nqp::istype($node, RakuAST::Statement::Given) {
             self.IMPL-REGISTER-IMPLICIT-LOOKUPS($node);
             self.IMPL-WALK($node.source);
-            self.IMPL-WALK-FLATTEN-CANDIDATE($node.body, :arg);
+            if $node.IMPL-CAN-FLATTEN-BODY {
+                self.IMPL-WALK-FLATTEN-CANDIDATE($node.body, :arg);
+            }
+            else {
+                self.IMPL-WALK($node.body);
+            }
             $node.visit-labels(-> $label { self.IMPL-WALK($label) });
             return Nil;
         }

--- a/t/02-rakudo/flattened-param-bind.t
+++ b/t/02-rakudo/flattened-param-bind.t
@@ -1,0 +1,60 @@
+use Test;
+
+plan 8;
+
+# A sunk for statement can inline its body, binding the pulled value
+# straight into the parameter's lowered local. That bind must match what
+# calling the block would have done. The value gets a fresh read-only
+# Scalar, so an itemized element stays a single item. A parameter with a
+# sigil other than '$' is left to the real binder, which checks its
+# nominal type.
+
+{
+    my @data = 1, $("ALPHA", "BETA"), 2;
+    my %index;
+    for @data -> $item {
+        %index{$item} = 42;
+    }
+    is-deeply %index.keys.sort.List, ("1", "2", "ALPHA BETA"),
+        'an itemized element stays a single hash key inside the loop body';
+}
+
+{
+    my @data = 1, 2;
+    my @types;
+    for @data -> $item {
+        @types.push($item.VAR.^name);
+    }
+    is-deeply @types, ["Scalar", "Scalar"],
+        'the loop parameter reports a Scalar container via .VAR';
+}
+
+dies-ok {
+    my @data = 5,;
+    for @data -> $item { $item = 99 }
+}, 'assigning to the read-only loop parameter dies';
+
+{
+    my @data = 5,;
+    try { for @data -> $item { $item = 99 } }
+    is @data[0], 5,
+        'the source element is untouched after an assignment attempt';
+}
+
+throws-like { for 1, 2 -> @row { } }, X::TypeCheck::Binding::Parameter,
+    'binding a value that is not Positional to an @ loop parameter dies';
+
+throws-like { for 1, 2 -> %row { } }, X::TypeCheck::Binding::Parameter,
+    'binding a value that is not Associative to a % loop parameter dies';
+
+throws-like { for 1, 2 -> &row { } }, X::TypeCheck::Binding::Parameter,
+    'binding a value that is not Callable to an & loop parameter dies';
+
+{
+    my @rows;
+    for [1, 2], [3, 4] -> @row { @rows.push(@row.join('-')) }
+    is-deeply @rows, ["1-2", "3-4"],
+        'an @ loop parameter binds Positional values';
+}
+
+# vim: expandtab shiftwidth=4

--- a/t/02-rakudo/flattened-param-bind.t
+++ b/t/02-rakudo/flattened-param-bind.t
@@ -1,13 +1,14 @@
 use Test;
 
-plan 8;
+plan 19;
 
-# A sunk for statement can inline its body, binding the pulled value
-# straight into the parameter's lowered local. That bind must match what
-# calling the block would have done. The value gets a fresh read-only
-# Scalar, so an itemized element stays a single item. A parameter with a
-# sigil other than '$' is left to the real binder, which checks its
-# nominal type.
+# A sunk for statement and a given statement can inline the body,
+# binding the value straight into the parameter's lowered local. That
+# bind must match what calling the block would have done. The value
+# gets a fresh read-only Scalar, so an itemized element stays a single
+# item. A parameter with an '@', '%' or '&' sigil gets the nominal type
+# check the binder would have run, and a concrete Junction value
+# autothreads over its eigenstates rather than binding.
 
 {
     my @data = 1, $("ALPHA", "BETA"), 2;
@@ -55,6 +56,73 @@ throws-like { for 1, 2 -> &row { } }, X::TypeCheck::Binding::Parameter,
     for [1, 2], [3, 4] -> @row { @rows.push(@row.join('-')) }
     is-deeply @rows, ["1-2", "3-4"],
         'an @ loop parameter binds Positional values';
+}
+
+{
+    my @src = [1, 2],;
+    for @src -> @row { @row.push(3) }
+    is-deeply @src[0], [1, 2, 3],
+        'an @ loop parameter binds the source array itself, not a copy';
+}
+
+{
+    my @keys;
+    for {:a(1)}, {:b(2)} -> %h { @keys.push(%h.keys[0]) }
+    is-deeply @keys.sort.List, ("a", "b"),
+        'a % loop parameter binds Associative values';
+}
+
+{
+    my @got;
+    for { 40 }, { 2 } -> &f { @got.push(f()) }
+    is-deeply @got, [40, 2],
+        'an & loop parameter binds Callable values and is callable in the body';
+}
+
+{
+    my @seen;
+    for (any([1], all([2], [3])), [9]) -> @row { @seen.push(@row[0]) }
+    is-deeply @seen, [1, 2, 3, 9],
+        'a Junction element autothreads over its eigenstates, depth first';
+}
+
+{
+    my @seen;
+    try { for (any([1], 5),) -> @row { @seen.push(@row[0]) } }
+    is-deeply @seen, [1],
+        'eigenstates before a failing one still run the body';
+    is $!.message,
+        q{Type check failed in binding to parameter '@row'; expected Positional but got Int (5)},
+        'a failing eigenstate reports the binder error for the parameter';
+}
+
+{
+    my %h;
+    given $("A", "B") -> $x { %h{$x} = 1 }
+    is-deeply %h.keys.List, ("A B",),
+        'an itemized given topic stays a single hash key';
+}
+
+throws-like { given 5 -> @row { } }, X::TypeCheck::Binding::Parameter,
+    'binding a value that is not Positional to an @ given parameter dies';
+
+{
+    my @seen;
+    given any([1], [2]) -> @row { @seen.push(@row[0]) }
+    is-deeply @seen, [1, 2],
+        'a Junction given topic autothreads through an @ parameter';
+}
+
+{
+    my $r = do given [1, 2] -> @row { @row.sum };
+    is $r, 3,
+        'a value producing given with an @ parameter returns the body value';
+}
+
+{
+    my $r = do given $("A",) -> $x { $x[0] };
+    is $r, "A",
+        'a value producing given with a scalar parameter returns the body value';
 }
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously a sunk `for` statement or a `given` statement with a simple one parameter body would inline the body, binding the value straight into the parameter's lowered local. That bind decontainerized the value outright, however calling the block runs the binder, which wraps the value for a plain scalar parameter in a fresh read-only `Scalar`. Losing the container changes behavior anywhere itemization matters, e.g. an itemized list used as a hash key turned into a slice:

```raku
my @data = 1, $("A", "B"), 2;
my %h;
for @data -> $item { %h{$item} = 1 }
say %h.keys.sort.raku;   # ("1", "2", "A B") when calling, ("1", "2", "A", "B") when inlined
```

The inlined bind also skipped the nominal type check entirely, so `for 1, 2 -> @row { }` bound the `Int` values instead of dying.

This makes the flattened bind match what the call would have done. The first commit wraps the bound value in a fresh read-only `Scalar` the way the binder does for a plain scalar parameter. The second emits the nominal type check inline so `@`, `%` and `&` parameters keep flattening: a matching value runs the body directly, a concrete `Junction` autothreads over its eigenstates the way the autothreader would, and anything else throws the same `X::TypeCheck::Binding::Parameter` the binder produces. A value producing `given` with such a parameter keeps calling its body, since the flattened form of the check produces no value and cannot collect autothreaded results into a `Junction`.

Behavior now matches the legacy frontend across itemization, `.VAR`, assignment to the parameter dying, the type check error and message, autothreading order, and loop controls. The `Scalar` allocation is one a call had always paid, and the inlined loops remain faster than the map fallback. Found via Data::StaticTable, whose tests fail on an itemized cell used as an index key.
