### PR TITLE
Don't count handler calls to test an operator wrap

### DIFF
--- a/t/12-rakuast/xx-fixed-in-rakuast.rakutest
+++ b/t/12-rakuast/xx-fixed-in-rakuast.rakutest
@@ -78,15 +78,19 @@ plan 131;
 # increment that no longer increments loops forever. Each wrap is
 # therefore applied, exercised and removed within a single EVAL whose
 # code was compiled before the wrap took effect, and the assertions
-# run only once the operator is restored.
+# run only once the operator is restored. Counting handler calls does not
+# work. Every other caller that dispatches the operator during that window
+# runs the handler too, and whether a given caller dispatches it at all
+# depends on precomp state. The increment is checked by its effect on the
+# variable instead.
 {
     my @result;
     Q§ my $handle = &infix:<|>.wrap: -> | { @result.push("ok"); True }; -> $ where {$_ ~~ Int|Num} {}(42); &infix:<|>.unwrap($handle) §.AST.EVAL;
     is-deeply @result, ["ok"], "wrapping infix:<|> works";
 
-    @result = [];
-    Q§ use soft; my $handle = &postfix:<++>.wrap: -> | { @result.push("ok2") }; my int $x; $x++; &postfix:<++>.unwrap($handle) §.AST(:compunit).EVAL;
-    is-deeply @result, ["ok2"], "wrapping postfix:<++> works under soft";
+    my $x;
+    Q§ use soft; my $handle = &postfix:<++>.wrap: -> | { }; my int $i; $i++; &postfix:<++>.unwrap($handle); $x = $i §.AST(:compunit).EVAL;
+    is-deeply $x, 0, "wrapping postfix:<++> works under soft";
 }
 
 # ???


### PR DESCRIPTION
Previously the wrap test recorded each handler call into an array and compared that array against a single expected entry. A wrap replaces the operator routine for every caller in the process however, so any core code that dispatched `postfix:<++>` between the wrap and the unwrap appended to the array as well. Whether a given site dispatches the routine or runs a raw op depends on precomp state, so the test failed sporadically with hundreds of entries.

This checks that the variable was left alone instead. That is what `use soft` is for. Without it the increment lowers to a raw op and never reaches the wrap. Other callers dispatching the operator during the window no longer affect the result. The handler body is empty now, which also keeps an array push out of the window in which the operator is broken.