### PR TITLE
RakuAST: metaop purity follows the wrapped operator in sink analysis

### DIFF
--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -1466,6 +1466,20 @@ class RakuAST::MetaInfix
                                 RakuAST::Expression *@operands, Bool :$meta) {
         self.infix.IMPL-THUNK-ARGUMENTS($resolver, $context, |@operands, :meta)
     }
+
+    # A meta operator has the effects of the operator it wraps, so a
+    # sunk Z= still assigns while a sunk Z+ is a useless use.
+    method is-pure() { self.infix.is-pure }
+
+    method IMPL-RESULT-NEEDS-ITERATION() { self.infix.IMPL-RESULT-NEEDS-ITERATION }
+
+    # The operands are consumed by the meta operator, so they are never
+    # themselves in sink context.
+    method IMPL-APPLY-SINK-TO-OPERANDS(List $operands, Bool $is-sunk) {
+        for $operands {
+            $_.apply-sink(False);
+        }
+    }
 }
 
 # An assign meta-operator, operator on another infix.
@@ -1704,14 +1718,6 @@ class RakuAST::MetaInfix::Assign
         QAST::Op.new:
             :op('callstatic'), :name(self.IMPL-OPERATOR-NAME(1)),
             $!infix.IMPL-HOP-INFIX-QAST($context)
-    }
-
-    method IMPL-APPLY-SINK-TO-OPERANDS(List $operands, Bool $is-sunk) {
-        my $i := 0;
-        while $i < nqp::elems($operands) {
-            $operands[$i].apply-sink(False);
-            $i++;
-        }
     }
 
     method IMPL-LIST-INFIX-QAST(RakuAST::IMPL::QASTContext $context, Mu $operands) {
@@ -1961,6 +1967,13 @@ class RakuAST::MetaInfix::Cross
         $visitor($!infix);
     }
 
+    # The cross produces a lazy sequence, so when the wrapped operator
+    # has side effects a sunk result must still be iterated to run
+    # those effects.
+    method IMPL-RESULT-NEEDS-ITERATION() {
+        !$!infix.is-pure || $!infix.IMPL-RESULT-NEEDS-ITERATION
+    }
+
     method properties() { OperatorProperties.infix('X') }
 
     method reducer-name() {
@@ -2051,6 +2064,13 @@ class RakuAST::MetaInfix::Zip
 
     method visit-children(Code $visitor) {
         $visitor($!infix);
+    }
+
+    # The zip produces a lazy sequence, so when the wrapped operator
+    # has side effects a sunk result must still be iterated to run
+    # those effects.
+    method IMPL-RESULT-NEEDS-ITERATION() {
+        !$!infix.is-pure || $!infix.IMPL-RESULT-NEEDS-ITERATION
     }
 
     method properties() { OperatorProperties.infix('Z') }

--- a/t/02-rakudo/sink-warnings-legacy-parity.t
+++ b/t/02-rakudo/sink-warnings-legacy-parity.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 15;
+plan 23;
 
 sub stderr-of(Str $code) {
     run($*EXECUTABLE.absolute, '-e', $code, :err).err.slurp(:close)
@@ -88,5 +88,48 @@ nok useless-of(
         '{*}'
     ),
     '`{*}` is not a useless-use subject in a non-tail proto body';
+
+# An assignment carried by a zip, cross or reverse meta operator still
+# assigns when its result is discarded, so `Z=`, `X=` and `R=` are not
+# useless in sink context. Their operands are consumed by the meta
+# operator rather than being discarded, so they are not subjects either.
+# Legacy stays silent on all three.
+
+nok useless-lines(stderr-of 'my @a = 1,2; my @b = 3,4; sub f { @a Z= @b; 42 }; f()').elems,
+    '`Z=` produces no useless-use subjects in sink context';
+
+nok useless-lines(stderr-of 'my @a = 1,2; sub f { @a X= 9; 42 }; f()').elems,
+    '`X=` produces no useless-use subjects in sink context';
+
+nok useless-lines(stderr-of 'my $x = 1; my $y = 2; sub f { $x R= $y; 42 }; f()').elems,
+    '`R=` produces no useless-use subjects in sink context';
+
+# A meta operator wrapping a pure operator stays a useless use, and only
+# the operator itself is the subject.
+
+my $zip-err = stderr-of 'my @a = 1,2; my @b = 3,4; sub f { @a Z+ @b; 42 }; f()';
+ok useless-of($zip-err, 'Z+'),
+    '`Z+` of a pure operator is still a useless-use subject in sink context';
+nok useless-of($zip-err, '@a'),
+    'the operands of a sunk `Z+` are not useless-use subjects';
+
+# An assignment carried by a meta operator must still run when sunk,
+# including iterating the lazy sequence a zip or cross produces.
+
+{
+    my @a = 1,2,3;
+    my @b = 4,5,6;
+    @a Z= @b;
+    is-deeply @a, [4,5,6], 'sunk `Z=` assigned zipwise';
+
+    my @c = 1,2;
+    @c X= 9;
+    is-deeply @c, [9,9], 'sunk `X=` assigned each element';
+
+    my $x = 0;
+    my $y = 1;
+    $x R= $y;
+    is $y, 0, 'sunk `R=` assigned to its right operand';
+}
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously a sunk metaop assignment like `@a Z= @b`, `@a X= 9` or `$x R= $y` warned "Useless use of Z= in sink context" and warned again for each bare variable operand, because the RakuAST::MetaInfix subclasses inherited the Infixish default purity of True along with the default operand sinking. The legacy frontend stays silent on all of these. The assignments themselves already ran, so only the warnings were wrong.

RakuAST::MetaInfix now delegates is-pure and
IMPL-RESULT-NEEDS-ITERATION to the operator it wraps and applies sink to its operands as consumed values, matching what MetaInfix::Assign already did for forms like `@a Z+= @b`. MetaInfix::Zip and MetaInfix::Cross keep a sunk result iterated when the wrapped operator has side effects, since their result is a lazy sequence. A metaop wrapping a pure operator, like a sunk `@a Z+ @b`, still warns, and now only names the operator itself rather than also its operands.