### PR TITLE
RakuAST: give a flattened '@' parameter the Positional bind failover

### DIFF
--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -1651,6 +1651,37 @@ class RakuAST::Block
                 )
             )
         );
+        # The binder gives a Positional parameter one failover ahead
+        # of the nominal type check: a value that does
+        # PositionalBindFailover binds as its cached List, which is
+        # how a Seq binds to an '@' parameter.
+        my $lookups := $param.IMPL-UNWRAP-LIST($param.get-implicit-lookups);
+        if $nominal =:= $lookups[0].resolution.compile-time-value {
+            my $failover := $lookups[1].resolution.compile-time-value;
+            $context.ensure-sc($failover);
+            $dispatch := QAST::Stmts.new(
+                QAST::Op.new(
+                    :op('if'),
+                    QAST::Op.new(
+                        :op('istype'),
+                        QAST::Var.new( :name($val-name), :scope('local') ),
+                        QAST::WVal.new( :value($failover) )
+                    ),
+                    QAST::Op.new(
+                        :op('bind'),
+                        QAST::Var.new( :name($val-name), :scope('local') ),
+                        QAST::Op.new(
+                            :op('decont'),
+                            QAST::Op.new(
+                                :op('callmethod'), :name('cache'),
+                                QAST::Var.new( :name($val-name), :scope('local') )
+                            )
+                        )
+                    )
+                ),
+                $dispatch
+            );
+        }
         my $advance := QAST::Op.new(
             :op('if'),
             QAST::Op.new(

--- a/t/02-rakudo/flattened-param-bind.t
+++ b/t/02-rakudo/flattened-param-bind.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 19;
+plan 23;
 
 # A sunk for statement and a given statement can inline the body,
 # binding the value straight into the parameter's lowered local. That
@@ -77,6 +77,38 @@ throws-like { for 1, 2 -> &row { } }, X::TypeCheck::Binding::Parameter,
     for { 40 }, { 2 } -> &f { @got.push(f()) }
     is-deeply @got, [40, 2],
         'an & loop parameter binds Callable values and is callable in the body';
+}
+
+{
+    my $s = (1, 2).Seq;
+    my @rows;
+    for ($s,) -> @row { @rows.push(@row.join('-')) }
+    is-deeply @rows, ["1-2"],
+        'an itemized Seq element binds to an @ loop parameter';
+}
+
+{
+    my $s = (1, 2).Seq;
+    my $type;
+    for ($s,) -> @row { $type = @row.WHAT.^name }
+    is $type, 'List',
+        'the parameter holds the cached List of the Seq element';
+}
+
+{
+    my $s = ("A", "B").Seq;
+    my %h;
+    given $s -> @row { %h{@row.join('-')} = 1 }
+    is-deeply %h.keys.List, ("A-B",),
+        'an itemized Seq given topic binds to an @ parameter';
+}
+
+{
+    my $s = (1, 2).Seq;
+    my @seen;
+    for (any($s, [9]),) -> @row { @seen.push(@row[0]) }
+    is-deeply @seen, [1, 9],
+        'a Seq eigenstate binds through its cached List';
 }
 
 {


### PR DESCRIPTION
Previously a Seq value reaching the inline sigil check of a flattened for or given parameter threw the nominal type error, since the check only tested the value against the nominal type. The real binder first caches a value that does PositionalBindFailover into a List when the nominal type is Positional, which is how a Seq binds to an '@' parameter.

This rebinds such a value to its cached List before the inline check runs. The rebind sits inside the worklist loop, so a Seq eigenstate of an autothreading Junction gets the same failover.