### PR TITLE
RakuAST: Make using a Perl 5 regex a compile time error

### DIFF
--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -3713,8 +3713,8 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
     # regex and constructing its AST correctly. Of note, these are
     # s (sigspace, as it controls how whitespce is parsed), m (so we
     # can construct character class ranges correctly), and P5 (Perl5,
-    # so we know which regex language to parse). These get special
-    # handling.
+    # a regex language that is not supported, so asking for it is an
+    # error). These get special handling.
     my constant SPECIAL-RX-ADVERBS := nqp::hash(
         'ignoremark', 'm',
         'm',          'm',
@@ -3736,10 +3736,14 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
             my $key := SPECIAL-RX-ADVERBS{$ast.key};
             if $key {
                 my $value := $ast.simple-compile-time-quote-value;
-                nqp::isconcrete($value)
-                  ?? (%*RX{$key} := ?$value)
-                  !! $_.typed-panic: 'X::Value::Dynamic',
-                       what => 'Adverb ' ~ $ast.key;
+                unless nqp::isconcrete($value) {
+                    $_.typed-panic: 'X::Value::Dynamic',
+                      what => 'Adverb ' ~ $ast.key;
+                }
+                if $key eq 'P5' && $value {
+                    $_.typed-panic: 'X::Syntax::Regex::P5';
+                }
+                %*RX{$key} := ?$value;
             }
         }
         make @pairs;
@@ -5347,6 +5351,6 @@ class Raku::RegexActions is HLL::Actions does Raku::CommonActions {
 
 class Raku::P5RegexActions is HLL::Actions does Raku::CommonActions {
     method nibbler($/) {
-        self.attach: $/, Nodify('Regex::Assertion::Fail').new;
+        $/.typed-panic: 'X::Syntax::Regex::P5';
     }
 }

--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -3924,8 +3924,8 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
     # regex and constructing its AST correctly. Of note, these are
     # s (sigspace, as it controls how whitespce is parsed), m (so we
     # can construct character class ranges correctly), and P5 (Perl5,
-    # so we know which regex language to parse). These get special
-    # handling.
+    # a regex language that is not supported, so using it is an error).
+    # These get special handling.
     my constant SPECIAL-RX-ADVERBS := nqp::hash(
         'ignoremark', 'm',
         'm',          'm',
@@ -3946,6 +3946,10 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
 
             my $key := SPECIAL-RX-ADVERBS{$ast.key};
             if $key {
+                if $key eq 'P5' {
+                    $_.typed-panic: 'X::Syntax::Regex::P5',
+                      adverb => $ast.key;
+                }
                 my $value := $ast.simple-compile-time-quote-value;
                 nqp::isconcrete($value)
                   ?? (%*RX{$key} := ?$value)
@@ -5573,6 +5577,6 @@ class Raku::RegexActions is HLL::Actions does Raku::CommonActions {
 
 class Raku::P5RegexActions is HLL::Actions does Raku::CommonActions {
     method nibbler($/) {
-        self.attach: $/, Nodify('Regex::Assertion::Fail').new;
+        $/.typed-panic: 'X::Syntax::Regex::P5';
     }
 }

--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -4656,7 +4656,12 @@ class RakuAST::QuotedRegex
         for self.IMPL-UNWRAP-LIST(self.adverbs) {
             my str $key := $_.key;
             my str $norm := self.IMPL-NORMALIZE-ADVERB($key);
-            if self.IMPL-IS-COMPILATION-ADVERB($norm) {
+            if $norm eq 'P5' {
+                self.add-sorry:
+                  $resolver.build-exception: 'X::Syntax::Regex::P5',
+                    adverb => $key;
+            }
+            elsif self.IMPL-IS-COMPILATION-ADVERB($norm) {
                 # Compile-time adverbs must have a simple compile time value.
                 unless nqp::isconcrete($_.simple-compile-time-quote-value()) {
                     self.add-sorry:
@@ -4804,7 +4809,12 @@ class RakuAST::Substitution
         for self.IMPL-UNWRAP-LIST(self.adverbs) {
             my str $key := $_.key;
             my str $norm := self.IMPL-NORMALIZE-ADVERB($key);
-            if self.IMPL-IS-COMPILATION-ADVERB(self.IMPL-SUBST-TO-MATCH-ADVERB($norm)) {
+            if $norm eq 'P5' {
+                self.add-sorry:
+                  $resolver.build-exception: 'X::Syntax::Regex::P5',
+                    adverb => $key;
+            }
+            elsif self.IMPL-IS-COMPILATION-ADVERB(self.IMPL-SUBST-TO-MATCH-ADVERB($norm)) {
                 # Compile-time adverbs must have a simple compile time value.
                 unless nqp::isconcrete($_.simple-compile-time-quote-value()) {
                     self.add-sorry:

--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -3788,7 +3788,11 @@ class RakuAST::QuotedRegex
         for self.IMPL-UNWRAP-LIST(self.adverbs) {
             my str $key := $_.key;
             my str $norm := self.IMPL-NORMALIZE-ADVERB($key);
-            if self.IMPL-IS-COMPILATION-ADVERB($norm) {
+            if $norm eq 'P5' && $_.simple-compile-time-quote-value() {
+                self.add-sorry:
+                  $resolver.build-exception: 'X::Syntax::Regex::P5';
+            }
+            elsif self.IMPL-IS-COMPILATION-ADVERB($norm) {
                 # Compile-time adverbs must have a simple compile time value.
                 unless nqp::isconcrete($_.simple-compile-time-quote-value()) {
                     self.add-sorry:
@@ -3935,7 +3939,11 @@ class RakuAST::Substitution
         for self.IMPL-UNWRAP-LIST(self.adverbs) {
             my str $key := $_.key;
             my str $norm := self.IMPL-NORMALIZE-ADVERB($key);
-            if self.IMPL-IS-COMPILATION-ADVERB(self.IMPL-SUBST-TO-MATCH-ADVERB($norm)) {
+            if $norm eq 'P5' && $_.simple-compile-time-quote-value() {
+                self.add-sorry:
+                  $resolver.build-exception: 'X::Syntax::Regex::P5';
+            }
+            elsif self.IMPL-IS-COMPILATION-ADVERB(self.IMPL-SUBST-TO-MATCH-ADVERB($norm)) {
                 # Compile-time adverbs must have a simple compile time value.
                 unless nqp::isconcrete($_.simple-compile-time-quote-value()) {
                     self.add-sorry:

--- a/src/core.c/Exception.rakumod
+++ b/src/core.c/Exception.rakumod
@@ -2259,6 +2259,13 @@ my class X::Syntax::Regex::Adverb does X::Syntax {
     method message() { "Adverb $.adverb not allowed on $.construct" }
 }
 
+my class X::Syntax::Regex::P5 does X::Syntax {
+    has $.adverb = 'P5';
+    method message() {
+        "Perl 5 regexes are not supported. Please remove the :$.adverb adverb and write a Raku regex"
+    }
+}
+
 my class X::Syntax::Regex::UnrecognizedMetachar does X::Syntax {
     has $.metachar;
     method message() { "Unrecognized regex metacharacter $.metachar (must be quoted to match literally)" }

--- a/src/core.c/Exception.rakumod
+++ b/src/core.c/Exception.rakumod
@@ -2235,6 +2235,12 @@ my class X::Syntax::Regex::Adverb does X::Syntax {
     method message() { "Adverb $.adverb not allowed on $.construct" }
 }
 
+my class X::Syntax::Regex::P5 does X::Syntax {
+    method message() {
+        "Perl 5 regexes are not supported; please rewrite as a Raku regex"
+    }
+}
+
 my class X::Syntax::Regex::UnrecognizedMetachar does X::Syntax {
     has $.metachar;
     method message() { "Unrecognized regex metacharacter $.metachar (must be quoted to match literally)" }

--- a/t/05-messages/03-errors.t
+++ b/t/05-messages/03-errors.t
@@ -2,7 +2,7 @@ use lib <t/packages/Test-Helpers>;
 use Test;
 use Test::Helpers;
 
-plan 30;
+plan 31;
 
 subtest '.map does not explode in optimizer' => {
     plan 3;
@@ -228,6 +228,24 @@ subtest 'constraint failure on an unpassed optional parameter explains the impli
         X::TypeCheck::Binding::Parameter,
         message => { not .contains('was not passed') },
         'an explicit default failing the constraint does not claim the parameter has none';
+}
+
+subtest 'Perl 5 regexes report they are not supported' => {
+    plan 4;
+
+    if %*ENV<RAKUDO_RAKUAST> {
+        throws-like ｢"foo" ~~ m:P5/o+/｣, X::Syntax::Regex::P5,
+            'the :P5 adverb on a match is a compile time error';
+        throws-like ｢"foo" ~~ rx:Perl5/o+/｣, X::Syntax::Regex::P5,
+            'the :Perl5 adverb on an rx quote is a compile time error';
+        throws-like ｢my $x = "foo"; $x ~~ s:P5/o+/i/｣, X::Syntax::Regex::P5,
+            'the :P5 adverb on a substitution is a compile time error';
+    }
+    else {
+        skip 'only the Raku AST grammar rejects Perl 5 regexes', 3;
+    }
+    is "foo" ~~ m:!P5/o+/, 'oo',
+        'a negated :P5 adverb still compiles and matches';
 }
 
 # vim: expandtab shiftwidth=4

--- a/t/05-messages/03-errors.t
+++ b/t/05-messages/03-errors.t
@@ -1,8 +1,9 @@
 use lib <t/packages/Test-Helpers>;
+use nqp;
 use Test;
 use Test::Helpers;
 
-plan 30;
+plan 31;
 
 subtest '.map does not explode in optimizer' => {
     plan 3;
@@ -228,6 +229,24 @@ subtest 'constraint failure on an unpassed optional parameter explains the impli
         X::TypeCheck::Binding::Parameter,
         message => { not .contains('was not passed') },
         'an explicit default failing the constraint does not claim the parameter has none';
+}
+
+subtest 'Perl 5 regexes report they are not supported' => {
+    plan 4;
+
+    if nqp::gethllsym('Raku', 'COMPILER-FRONTEND') eq 'rakuast' {
+        throws-like ｢"foo" ~~ m:P5/o+/｣, X::Syntax::Regex::P5,
+            'the :P5 adverb on a match is a compile time error';
+        throws-like ｢"foo" ~~ rx:Perl5/o+/｣, X::Syntax::Regex::P5,
+            'the :Perl5 adverb on an rx quote is a compile time error';
+        throws-like ｢my $x = "foo"; $x ~~ s:P5/o+/i/｣, X::Syntax::Regex::P5,
+            'the :P5 adverb on a substitution is a compile time error';
+        throws-like ｢"foo" ~~ m:!P5/o+/｣, X::Syntax::Regex::P5,
+            'a negated :P5 adverb is a compile time error as well';
+    }
+    else {
+        skip 'only the Raku AST grammar rejects Perl 5 regexes', 4;
+    }
 }
 
 # vim: expandtab shiftwidth=4

--- a/t/12-rakuast/regex-substitution.rakutest
+++ b/t/12-rakuast/regex-substitution.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 7;
+plan 8;
 
 my $ast;
 my $deparsed;
@@ -189,6 +189,32 @@ CODE
         is $/.gist, '｢o｣', "$type: did it set \$/ correctly";
         is $string, "fxo", "$type: is the result correct";
     }
+}
+
+subtest 'Perl 5 substitutions are rejected' => {
+    plan 2;
+
+    # s:P5/o/x/
+    my $P5 := RakuAST::Substitution.new(
+      pattern     => RakuAST::Regex::Literal.new("o"),
+      adverbs     => RakuAST::ColonPair::True.new("P5"),
+      replacement => RakuAST::QuotedString.new(
+        segments => [RakuAST::StrLiteral.new("x")]
+      )
+    );
+    throws-like { EVAL($P5) }, X::Syntax::Regex::P5,
+      'the :P5 adverb on a substitution is a compile time error';
+
+    # s:!P5/o/x/
+    my $not-P5 := RakuAST::Substitution.new(
+      pattern     => RakuAST::Regex::Literal.new("o"),
+      adverbs     => RakuAST::ColonPair::False.new("P5"),
+      replacement => RakuAST::QuotedString.new(
+        segments => [RakuAST::StrLiteral.new("x")]
+      )
+    );
+    throws-like { EVAL($not-P5) }, X::Syntax::Regex::P5,
+      'a negated :P5 adverb on a substitution is a compile time error as well';
 }
 
 # vim: expandtab shiftwidth=4

--- a/t/12-rakuast/regex-substitution.rakutest
+++ b/t/12-rakuast/regex-substitution.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 7;
+plan 8;
 
 my $ast;
 my $deparsed;
@@ -189,6 +189,21 @@ CODE
         is $/.gist, '｢o｣', "$type: did it set \$/ correctly";
         is $string, "fxo", "$type: is the result correct";
     }
+}
+
+subtest 'Perl 5 substitutions are rejected' => {
+    plan 1;
+
+    # s:P5/o/x/
+    my $P5 := RakuAST::Substitution.new(
+      pattern     => RakuAST::Regex::Literal.new("o"),
+      adverbs     => RakuAST::ColonPair::True.new("P5"),
+      replacement => RakuAST::QuotedString.new(
+        segments => [RakuAST::StrLiteral.new("x")]
+      )
+    );
+    throws-like { EVAL($P5) }, X::Syntax::Regex::P5,
+      'the :P5 adverb on a substitution is a compile time error';
 }
 
 # vim: expandtab shiftwidth=4

--- a/t/12-rakuast/regex.rakutest
+++ b/t/12-rakuast/regex.rakutest
@@ -2,7 +2,7 @@ use v6.e.PREVIEW;
 use nqp;
 use Test;
 
-plan 56;
+plan 57;
 
 my $ast;
 my $deparsed;
@@ -772,6 +772,26 @@ subtest 'Match with a dba name' => {
     todo('the legacy frontend breaks matching on :dba', 1)
         unless nqp::gethllsym('Raku', 'COMPILER-FRONTEND') eq 'rakuast';
     match-ok "42", '42';
+}
+
+subtest 'Perl 5 regexes are rejected' => {
+    plan 2;
+
+    # rx:P5/o/
+    my $P5 := RakuAST::QuotedRegex.new(
+      body    => RakuAST::Regex::Literal.new("o"),
+      adverbs => RakuAST::ColonPair::True.new("P5")
+    );
+    throws-like { EVAL($P5) }, X::Syntax::Regex::P5,
+      'the :P5 adverb on a quoted regex is a compile time error';
+
+    # rx:!P5/o/
+    my $not-P5 := RakuAST::QuotedRegex.new(
+      body    => RakuAST::Regex::Literal.new("o"),
+      adverbs => RakuAST::ColonPair::False.new("P5")
+    );
+    throws-like { EVAL($not-P5) }, X::Syntax::Regex::P5,
+      'a negated :P5 adverb on a quoted regex is a compile time error as well';
 }
 
 # vim: expandtab shiftwidth=4

--- a/t/12-rakuast/regex.rakutest
+++ b/t/12-rakuast/regex.rakutest
@@ -2,7 +2,7 @@ use v6.e.PREVIEW;
 use nqp;
 use Test;
 
-plan 56;
+plan 57;
 
 my $ast;
 my $deparsed;
@@ -772,6 +772,26 @@ subtest 'Match with a dba name' => {
     todo('the legacy frontend breaks matching on :dba', 1)
         unless nqp::gethllsym('Raku', 'COMPILER-FRONTEND') eq 'rakuast';
     match-ok "42", '42';
+}
+
+subtest 'Perl 5 regexes are rejected' => {
+    plan 2;
+
+    # rx:P5/o/
+    my $P5 := RakuAST::QuotedRegex.new(
+      body    => RakuAST::Regex::Literal.new("o"),
+      adverbs => RakuAST::ColonPair::True.new("P5")
+    );
+    throws-like { EVAL($P5) }, X::Syntax::Regex::P5,
+      'the :P5 adverb on a quoted regex is a compile time error';
+
+    # rx:!P5/o/
+    my $not-P5 := RakuAST::QuotedRegex.new(
+      body    => RakuAST::Regex::Literal.new("o"),
+      adverbs => RakuAST::ColonPair::False.new("P5")
+    );
+    is "foo" ~~ EVAL($not-P5), 'o',
+      'a negated :P5 adverb still compiles and matches';
 }
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously the :P5 and :Perl5 regex adverbs selected the Perl 5 regex slang, whose actions stubbed out the entire regex body as an always failing assertion. That let constructs such as m:P5/o+/ and s:P5/o+/i/ compile but silently never match. Perl 5 regexes are not going to be supported by the new grammar.

This makes a truthy :P5 or :Perl5 adverb a compile time X::Syntax::Regex::P5 error on all of the quoting constructs that can carry it. Directly constructed RakuAST nodes that carry a truthy :P5 adverb get the same error when checked.