### PR TITLE
RakuAST: keep the key type on keyed hashes with an explicit base

### DIFF
--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -261,9 +261,18 @@ class RakuAST::ContainerCreator {
         }
         else {
             # $explicit-base is already the base type of any `is Type:D`.
-            $container-type := self.type
-                ?? $explicit-base.HOW.parameterize($explicit-base, $of)
-                !! $explicit-base;
+            if $key-type =:= NQPMu {
+                $container-type := self.type
+                    ?? $explicit-base.HOW.parameterize($explicit-base, $of)
+                    !! $explicit-base;
+            }
+            else {
+                my $value-type := self.type
+                    ?? $of
+                    !! (nqp::getcomp('Raku').language_revision >= 3 ?? Mu !! Any);
+                $container-type := $explicit-base.HOW.parameterize(
+                    $explicit-base, $value-type, $key-type);
+            }
         }
 
         nqp::bindattr(self, RakuAST::ContainerCreator, '$!initialized', True);

--- a/t/02-rakudo/keyed-hash-explicit-base.t
+++ b/t/02-rakudo/keyed-hash-explicit-base.t
@@ -1,0 +1,44 @@
+use Test;
+
+plan 8;
+
+# An explicit container base type on a keyed hash, as in `my %h{C} is Hash`,
+# must still be parameterized with the key type. Getting this wrong built a
+# plain Hash that stringified its object keys.
+
+my class C { }
+
+{
+    my %h{C} is Hash;
+    is %h.^name, 'Hash[Any,C]', 'a keyed `is Hash` hash keeps its key type';
+    my $c = C.new;
+    %h{$c} = 42;
+    is-deeply %h.keys.head, $c, 'a keyed `is Hash` hash stores object keys';
+    is %h{$c}, 42, 'a keyed `is Hash` hash retrieves by object key';
+}
+
+{
+    my Int %h{C} is Hash;
+    is %h.^name, 'Hash[Int,C]', 'a typed keyed `is Hash` hash keeps both types';
+    my $c = C.new;
+    %h{$c} = 5;
+    is %h{$c}, 5, 'a typed keyed `is Hash` hash stores and retrieves';
+}
+
+{
+    my %h{C} is Hash[Int];
+    is %h.^name, 'Hash[Int][Any,C]', 'a keyed hash parameterizes a parameterized base';
+}
+
+{
+    my class A {
+        has %.h{C} is Hash;
+    }
+    is A.new.h.^name, 'Hash[Any,C]', 'a keyed `is Hash` attribute keeps its key type';
+}
+
+# The unkeyed and untraited forms are unchanged.
+{
+    my %h{C};
+    is %h.^name, 'Hash[Any,C]', 'a keyed hash without a base trait still keeps its key type';
+}


### PR DESCRIPTION
Previously a keyed hash declaration with an explicit container base type, such as `my %h{C} is Hash`, built a plain string-keyed Hash. The explicit base was never parameterized with the declared key type, so object keys stringified and the values stored under them became unreachable by object. The legacy frontend parameterizes the base with the value and key types. This surfaced in Log::Timeline, whose socket output tracks connections in `my %connections{IO::Socket::Async} is Hash` and calls .print on the keys.

This parameterizes the explicit base with the value and key types when a key type is declared, matching the legacy frontend for the untyped, typed, and attribute forms.