### PR TITLE
RakuAST: silent-replace a class nested in a same-named unit class

### DIFF
--- a/src/Raku/ast/scoping.rakumod
+++ b/src/Raku/ast/scoping.rakumod
@@ -1516,20 +1516,29 @@ class RakuAST::PackageInstaller {
             if $resolved { # first parts of the name found
                 $resolved := self.IMPL-UNWRAP-LIST($resolved);
                 $target := $resolved[0];
-                # Capture the parent only when the setting itself resolves
-                # the leading name part. A leading part resolved from a
+                # Capture the parent when the compilation unit's own scopes
+                # or the setting resolve the leading name part. The own
+                # scopes carry it for a class nested in a same-named unit
+                # class, whose install must adopt the enclosing WHO, and an
+                # in-source duplicate still dies through the our-package
+                # declaration tracker. A leading part resolved from a
                 # caller's frame, such as an EVAL redeclaring a class its
                 # caller declared, is a plain redeclaration and must still
                 # reach the collision check.
                 if $resolved[2] eq 'lexical' {
-                    my $lexical-first := $resolver.resolve-lexical-constant($first);
-                    my $in-setting := $resolver.resolve-lexical-constant-in-setting($first);
-                    $setting-resolved-target := $target
-                        if nqp::isconcrete($lexical-first)
-                        && nqp::isconcrete($in-setting)
-                        && nqp::eqaddr(
-                            $in-setting.compile-time-value,
-                            $lexical-first.compile-time-value);
+                    if nqp::isconcrete($resolver.resolve-lexical-constant-in-scopes($first)) {
+                        $setting-resolved-target := $target;
+                    }
+                    else {
+                        my $lexical-first := $resolver.resolve-lexical-constant($first);
+                        my $in-setting := $resolver.resolve-lexical-constant-in-setting($first);
+                        $setting-resolved-target := $target
+                            if nqp::isconcrete($lexical-first)
+                            && nqp::isconcrete($in-setting)
+                            && nqp::eqaddr(
+                                $in-setting.compile-time-value,
+                                $lexical-first.compile-time-value);
+                    }
                 }
                 # Upgrade a lexically imported top level package to global.
                 # Only a name the compilation unit's own scopes carry

--- a/t/02-rakudo/our-package-redeclaration.t
+++ b/t/02-rakudo/our-package-redeclaration.t
@@ -2,7 +2,7 @@ use lib <t/packages/Test-Helpers>;
 use Test;
 use Test::Helpers;
 
-plan 12;
+plan 13;
 
 is-run q:to/CODE/,
     EVAL q[class A {}];
@@ -112,5 +112,13 @@ is-run q:to/CODE/,
     CODE
     :out('same'), :err(''),
     'a class whose body trait dies re-throws on a same-name retry, not X::Redeclaration';
+
+is-run q:to/CODE/,
+    unit class Nested::Shadow;
+    class Nested::Shadow { method tag { "inner" } }
+    print Nested::Shadow.tag;
+    CODE
+    :out('inner'), :err(''),
+    'a class nested in a same-named unit class silent-replaces';
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously the install collision check captured a silent-replace parent only when the setting resolved the leading name part, so a class nested inside a same-named unit class died with "Redeclaration of symbol 'Linux::Joystick'". The leading part of that name resolves to the stub the unit class itself created, which lives in the compilation unit's own scopes. This broke Linux::Joystick in blin.

This also captures the parent when the unit's own scopes resolve the leading part. An in-source duplicate still dies, as the our-package declaration tracker reports it before the collision check decides anything, and a leading part resolved from a caller's frame keeps dying as a plain redeclaration.