### PR TITLE
RakuAST: type attributes by their explicit container base

### DIFF
--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -1556,11 +1556,15 @@ class RakuAST::VarDeclaration::Simple
 
             my $meta-object := $!attribute-package.attribute-type.new(
               name => self.sigil ~ '!' ~ self.desigilname.canonicalize,
-              # An inlined attribute with an explicit container type (e.g.
-              # `HAS ... is CArray[int32]`) needs the parameterized container
-              # as its type for the REPR to lay it out; the bind constraint
-              # is a bare Mu on that path.
-              type => $scope eq 'HAS' && self.IMPL-HAS-EXPLICIT-CONTAINER-BASE-TYPE
+              # An attribute with an explicit container base type (e.g.
+              # `has Int @.a is Array`) needs the parameterized container as
+              # its type, both for introspection and for REPRs that lay
+              # attributes out by type. The bind constraint is a bare Mu on
+              # that path. Only sigils whose base type is the container
+              # itself qualify. An `is` type on a scalar names its scalar
+              # container type rather than the value type.
+              type => self.IMPL-HAS-EXPLICIT-CONTAINER-BASE-TYPE
+                  && ($scope eq 'HAS' || self.sigil eq '@' || self.sigil eq '%')
                 ?? self.IMPL-CONTAINER-TYPE($of)
                 !! $type,
               has_accessor          => self.twigil eq '.',

--- a/t/02-rakudo/attr-explicit-container-base.t
+++ b/t/02-rakudo/attr-explicit-container-base.t
@@ -1,0 +1,47 @@
+use Test;
+use NativeCall;
+
+plan 8;
+
+# An explicit container base type on an attribute (e.g. `has Int @.a is
+# Array`) must become the attribute's type, as it does for HAS scoped
+# attributes. An attribute typed Mu instead makes introspection lie and
+# makes REPRs that check attribute types reject valid code. A CStruct with
+# `has CArray[uint8] @.zero[4] is CArray` fails to compose that way.
+
+my class ImplicitBase { has Int @.a; }
+is ImplicitBase.^attributes[0].type.^name, 'Positional[Int]',
+    'a typed array attribute without an explicit base is typed Positional';
+
+my class ArrayBase { has Int @.a is Array; }
+is ArrayBase.^attributes[0].type.^name, 'Array[Int]',
+    'is Array on a typed array attribute parameterizes the base type';
+
+my class ListBase { has @.a is List; }
+is ListBase.^attributes[0].type.^name, 'List',
+    'is List on an untyped array attribute becomes the attribute type';
+
+my class HashBase { has Int %.h is Hash; }
+is HashBase.^attributes[0].type.^name, 'Hash[Int]',
+    'is Hash on a typed hash attribute parameterizes the base type';
+
+my class ParameterizedBase { has %.h is Hash[Int]; }
+is ParameterizedBase.^attributes[0].type.^name, 'Hash[Int]',
+    'an already parameterized base type is used as-is';
+
+my class Struct is repr<CStruct> {
+    has CArray[uint8] @.zero[4] is CArray;
+}
+is Struct.^attributes[0].type.^name,
+    'NativeCall::Types::CArray[NativeCall::Types::CArray[uint8]]',
+    'is CArray on a shaped CStruct attribute types it as a CArray';
+ok Struct.^attributes[0].type.REPR eq 'CArray',
+    'the CStruct composes because the attribute type has the CArray REPR';
+
+my class Inlined is repr<CStruct> {
+    HAS int32 @.b[3] is CArray;
+}
+is Inlined.^attributes[0].type.REPR, 'CArray',
+    'an inlined HAS attribute with is CArray keeps its CArray type';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously an explicit container base type on a has scoped attribute (e.g. `has Int @.a is Array`) left the attribute's type as Mu. The bind constraint is a bare Mu whenever an explicit base type is in play and the attribute took its type from the bind constraint. On the legacy frontend such an attribute is typed with the parameterized base type. Beyond introspection lying, REPRs that check attribute types rejected valid code: a CStruct with `has CArray[uint8] @.zero[4] is CArray` failed to compose. This surfaced in GLib's GLib::Compat::Definitions via blin.

This types the attribute with the parameterized container base type, as was already done for HAS scoped attributes. Only the sigils whose base type is the container itself qualify. An `is` type on a scalar names its scalar container type rather than the value type, and the legacy frontend rejects those outright.