### PR TITLE
RakuAST: do not import EXPORTHOW from a loaded unit's GLOBALish

### DIFF
--- a/src/Raku/ast/statements.rakumod
+++ b/src/Raku/ast/statements.rakumod
@@ -2383,6 +2383,14 @@ class RakuAST::ModuleLoading {
         my $target-scope := $resolver.current-scope;
         for self.IMPL-SORTED-KEYS($stash) -> $key {
             next if $key eq 'EXPORT';
+            # A unit's GLOBALish can carry an EXPORTHOW entry aliasing the
+            # setting's own EXPORTHOW module. EXPORTHOW is a compile-time
+            # directive package read from a unit's lexical scope through its
+            # handle, not an importable symbol: installing the alias as a
+            # lexical would hand later my scoped EXPORTHOW declarations to
+            # the merge machinery, which mutates the setting's table and
+            # loses the declaration.
+            next if $globalish && $key eq 'EXPORTHOW';
             my $value := $stash{$key};
             if $need-decont && nqp::islt_i(nqp::index('$&', nqp::substr($key,0,1)),0) {
                 $value := nqp::decont($value);

--- a/t/02-rakudo/exporthow-after-load.t
+++ b/t/02-rakudo/exporthow-after-load.t
@@ -1,0 +1,27 @@
+use lib <t/packages/02-rakudo/lib>;
+use Test;
+
+plan 2;
+
+# A unit that declares a my scoped EXPORTHOW leaks an EXPORTHOW entry into
+# its GLOBALish. Loading such a unit imports its GLOBALish, and installing
+# that entry as a lexical hands any later my scoped EXPORTHOW declaration in
+# the loading unit to the declaration merge machinery, which mutates the
+# setting's declarator table and loses the declaration. The consumer of the
+# loading unit then fails to parse the declarator at all.
+
+{
+    use ExporthowDeclarer;
+    my declarer-class A { }
+    ok A.HOW ~~ Metamodel::ClassHOW,
+        'a declarator from a directly used module declares a class';
+}
+
+{
+    use ExporthowAfterLoad;
+    my after-load-class B { }
+    ok B.HOW ~~ Metamodel::ClassHOW,
+        'a declarator declared after loading another module that carries an EXPORTHOW survives';
+}
+
+# vim: expandtab shiftwidth=4

--- a/t/packages/02-rakudo/lib/ExporthowAfterLoad.rakumod
+++ b/t/packages/02-rakudo/lib/ExporthowAfterLoad.rakumod
@@ -1,0 +1,9 @@
+# The EXPORTHOW declaration must survive the preceding load: the loaded
+# unit's GLOBALish carries an EXPORTHOW entry, and importing that entry as a
+# lexical would swallow this declaration in a merge.
+need ExporthowDeclarer;
+my package EXPORTHOW {
+    package DECLARE {
+        constant after-load-class = Metamodel::ClassHOW;
+    }
+}

--- a/t/packages/02-rakudo/lib/ExporthowDeclarer.rakumod
+++ b/t/packages/02-rakudo/lib/ExporthowDeclarer.rakumod
@@ -1,0 +1,7 @@
+# A unit that declares a my scoped EXPORTHOW. Declaring one also places an
+# EXPORTHOW entry in the unit's GLOBALish, which loaders of this unit see.
+my package EXPORTHOW {
+    package DECLARE {
+        constant declarer-class = Metamodel::ClassHOW;
+    }
+}


### PR DESCRIPTION
A unit that declares a my scoped EXPORTHOW also carries an EXPORTHOW entry in its GLOBALish aliasing the setting's own EXPORTHOW module. Previously loading such a unit imported that entry as a generated lexical alongside the rest of the GLOBALish. A later my scoped EXPORTHOW declaration in the loading unit then merged into that generated lexical instead of declaring fresh, which both mutated the setting's declarator table and lost the declaration, so consumers of the loading unit failed to parse its declarators. The legacy frontend does not import GLOBALish entries as unit lexicals and was unaffected. This surfaced in CompUnit::Util's re-exporthow tests.

This skips the EXPORTHOW key when importing a loaded unit's GLOBALish, as the EXPORT key already is unconditionally. EXPORTHOW is a compile-time directive package read from a unit's scope through its handle, not an importable symbol. Imports of EXPORT tag stashes are unaffected.