### PR TITLE
RakuAST: let a begin-time indirect lookup see the unit's lexicals

### DIFF
--- a/src/Raku/ast/begintime.rakumod
+++ b/src/Raku/ast/begintime.rakumod
@@ -15,12 +15,31 @@ class RakuAST::BeginTime
         nqp::die('Missing PERFORM-BEGIN implementation in ' ~ self.HOW.name(self));
     }
 
+    # What a pseudo-stash lookup asks once the context chain it walks runs
+    # out. Code run for a begin-time effect has the setting as its outer,
+    # so that chain reaches setting symbols and stops short of what the
+    # unit being compiled declares. The token restricts the answer to
+    # frames this compilation produced: the lookup consults the resolver
+    # only when the frame it runs in sees the same token, so foreign code
+    # the effect merely runs is not answered for. Null without a context,
+    # since no frame can then carry the token.
+    method IMPL-BEGIN-TIME-LOOKUP-STATE(
+               RakuAST::Resolver $resolver,
+      RakuAST::IMPL::QASTContext $context
+    ) {
+        nqp::isconcrete($context)
+          ?? nqp::list($resolver, $context.begin-time-marker)
+          !! nqp::null()
+    }
+
     # Ensure the begin-time effects are performed.
     method ensure-begin-performed(
                RakuAST::Resolver $resolver,
       RakuAST::IMPL::QASTContext $context
     ) {
         unless $!begin-performed {
+            my $*BEGIN-TIME-LOOKUP :=
+              RakuAST::BeginTime.IMPL-BEGIN-TIME-LOOKUP-STATE($resolver, $context);
             self.PERFORM-BEGIN($resolver, $context);
             nqp::bindattr_i(self, RakuAST::BeginTime, '$!begin-performed', 1);
         }
@@ -35,6 +54,8 @@ class RakuAST::BeginTime
       RakuAST::IMPL::QASTContext $context
     ) {
         my $*IMPL-COMPILE-DYNAMICALLY := 1;
+        my $*BEGIN-TIME-LOOKUP :=
+          RakuAST::BeginTime.IMPL-BEGIN-TIME-LOOKUP-STATE($resolver, $context);
 
         # Handle any execution error appropriately
         CATCH {
@@ -159,6 +180,8 @@ class RakuAST::BeginTime
       RakuAST::IMPL::QASTContext $context
     ) {
         my $*IMPL-COMPILE-DYNAMICALLY := 1;
+        my $*BEGIN-TIME-LOOKUP :=
+          RakuAST::BeginTime.IMPL-BEGIN-TIME-LOOKUP-STATE($resolver, $context);
 
         # A primed argument (a WhateverCode) may be interpreted here, as
         # its static block compiles against a real QAST context.

--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -591,6 +591,18 @@ class RakuAST::Code
             ));
         }
 
+        # Mark the frame as code of the unit being compiled, so a begin-time
+        # indirect lookup can consult the compiler's resolver from it. The
+        # marker is this compilation's identity token: foreign code run
+        # during a begin-time effect has no frame carrying it, and a frame
+        # from another compilation carries a different one.
+        my $marker := $context.begin-time-marker;
+        $context.ensure-sc($marker);
+        $wrapper[0].push(QAST::Var.new(
+            :name('!BEGIN_TIME_MARKER'), :scope('lexical'),
+            :decl('static'), :value($marker)
+        ));
+
         for self.IMPL-EXTRA-BEGIN-TIME-DECLS($resolver, $context) {
             if nqp::istype($_, RakuAST::CompileTimeValue) {
                 my $value := $_.compile-time-value;

--- a/src/Raku/ast/impl.rakumod
+++ b/src/Raku/ast/impl.rakumod
@@ -41,6 +41,14 @@ class RakuAST::IMPL::QASTContext {
     has Hash $!cuid-to-parse-time-resolver;
     has Bool $!parse-time-resolver-cleanup-scheduled;
 
+    # Identity token for this compilation. Dynamically-compiled frames
+    # carry it as a lexical, and a begin-time effect leaves it in a
+    # dynamic, so a begin-time indirect lookup can tell code belonging
+    # to the unit being compiled from foreign code it merely runs. An
+    # inert instance: frames carrying it can be serialized, which a
+    # frame holding the resolver could not.
+    has Mu $!begin-time-marker;
+
     # Code objects whose IMPL-STUB-CODE bound a freshcoderef to
     # Code.$!do but whose IMPL-LINK-META-OBJECT has not yet registered
     # that coderef with the SC. If the owning AST is discarded before
@@ -70,6 +78,7 @@ class RakuAST::IMPL::QASTContext {
         nqp::bindattr($obj, RakuAST::IMPL::QASTContext, '$!world-bridge', Mu);
         nqp::bindattr($obj, RakuAST::IMPL::QASTContext, '$!cuid-to-parse-time-resolver', {});
         nqp::bindattr($obj, RakuAST::IMPL::QASTContext, '$!stubbed-code-objects', {});
+        nqp::bindattr($obj, RakuAST::IMPL::QASTContext, '$!begin-time-marker', nqp::create(Mu));
         $obj
     }
 
@@ -91,8 +100,11 @@ class RakuAST::IMPL::QASTContext {
         nqp::bindattr_i($context, RakuAST::IMPL::QASTContext, '$!is-nested', 1);
         nqp::bindattr($context, RakuAST::IMPL::QASTContext, '$!cuid-to-parse-time-resolver', {});
         nqp::bindattr($context, RakuAST::IMPL::QASTContext, '$!stubbed-code-objects', {});
+        nqp::bindattr($context, RakuAST::IMPL::QASTContext, '$!begin-time-marker', nqp::create(Mu));
         $context
     }
+
+    method begin-time-marker() { $!begin-time-marker }
 
     # Get the handle of the serialization context.
     method sc-handle() {

--- a/src/Raku/ast/parsetime.rakumod
+++ b/src/Raku/ast/parsetime.rakumod
@@ -25,6 +25,8 @@ class RakuAST::ParseTime
     # Called when a BEGIN-time construct needs to evaluate code. Tries to
     # interpret simple things to avoid the cost of compilation.
     method IMPL-BEGIN-TIME-EVALUATE(RakuAST::Node $code, RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
+        my $*BEGIN-TIME-LOOKUP :=
+          RakuAST::BeginTime.IMPL-BEGIN-TIME-LOOKUP-STATE($resolver, $context);
         if $code.IMPL-CAN-INTERPRET {
             $code.IMPL-INTERPRET(RakuAST::IMPL::InterpContext.new(:$resolver, :$context))
         }
@@ -55,6 +57,8 @@ class RakuAST::ParseTime
     # with a set of arguments.
     method IMPL-BEGIN-TIME-CALL(RakuAST::Node $callee, RakuAST::ArgList $args,
             RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
+        my $*BEGIN-TIME-LOOKUP :=
+          RakuAST::BeginTime.IMPL-BEGIN-TIME-LOOKUP-STATE($resolver, $context);
         # A primed argument (a WhateverCode) may be interpreted here, as
         # its static block compiles against a real QAST context.
         my $*IMPL-INTERPRET-PRIMED := 1;

--- a/src/core.c/PseudoStash.rakumod
+++ b/src/core.c/PseudoStash.rakumod
@@ -6,11 +6,34 @@ my class PseudoStash is Map {
     has int $!mode;
 
     # Lookup modes.
-    my int constant PICK_CHAIN_BY_NAME = 0;
-    my int constant STATIC_CHAIN       = 1;
-    my int constant DYNAMIC_CHAIN      = 2;
-    my int constant PRECISE_SCOPE      = 4;
-    my int constant REQUIRE_DYNAMIC    = 8;
+    my int constant PICK_CHAIN_BY_NAME  = 0;
+    my int constant STATIC_CHAIN        = 1;
+    my int constant DYNAMIC_CHAIN       = 2;
+    my int constant PRECISE_SCOPE       = 4;
+    my int constant REQUIRE_DYNAMIC     = 8;
+    my int constant BEGIN_TIME_FALLBACK = 16;
+
+    # Code the compiler runs at BEGIN time lives in a frame whose outer is
+    # the setting, so a static-chain walk from it reaches setting symbols
+    # but not what the unit being compiled declares. While a begin-time
+    # effect runs the compiler leaves its resolver and that compilation's
+    # token in $*BEGIN-TIME-LOOKUP, and the frames it compiles dynamically
+    # for the unit see the token, so only the unit's own code is answered
+    # for. Consulted by stashes carrying BEGIN_TIME_FALLBACK and by
+    # INDIRECT_NAME_LOOKUP, in both cases once every other source of the
+    # name has missed.
+    method BEGIN-TIME-DECLARATION(str $key) is implementation-detail {
+        my $state := nqp::getlexdyn('$*BEGIN-TIME-LOOKUP');
+        nqp::isnull($state)
+          ?? Nil
+          !! nqp::not_i(nqp::isnull(
+               my $marker := nqp::getlexrel(
+                 nqp::getattr(self, PseudoStash, '$!ctx'),
+                 '!BEGIN_TIME_MARKER')))
+               && nqp::eqaddr($marker, nqp::atpos($state, 1))
+            ?? (nqp::atpos($state, 0).resolve-lexical-constant-in-scopes($key) || Nil)
+            !! Nil
+    }
 
     method new() {
         my $obj := nqp::create(self);
@@ -140,7 +163,8 @@ my class PseudoStash is Map {
         },
         'LEXICAL', -> $cur {
             my $stash := nqp::clone($cur);
-            nqp::bindattr_i($stash, PseudoStash, '$!mode', STATIC_CHAIN);
+            nqp::bindattr_i($stash, PseudoStash, '$!mode',
+              STATIC_CHAIN +| BEGIN_TIME_FALLBACK);
             nqp::setwho(
                 Metamodel::ModuleHOW.new_type(:name('LEXICAL')),
                 $stash);
@@ -156,7 +180,8 @@ my class PseudoStash is Map {
                 my $stash := nqp::create(PseudoStash);
                 nqp::bindattr($stash, Map, '$!storage', nqp::ctxlexpad($ctx));
                 nqp::bindattr($stash, PseudoStash, '$!ctx', $ctx);
-                nqp::bindattr_i($stash, PseudoStash, '$!mode', STATIC_CHAIN);
+                nqp::bindattr_i($stash, PseudoStash, '$!mode',
+                  STATIC_CHAIN +| BEGIN_TIME_FALLBACK);
                 nqp::setwho(
                     Metamodel::ModuleHOW.new_type(:name('OUTERS')),
                     $stash)
@@ -164,7 +189,10 @@ my class PseudoStash is Map {
         },
         'DYNAMIC', -> $cur {
             my $stash := nqp::clone($cur);
-            nqp::bindattr_i($stash, PseudoStash, '$!mode', DYNAMIC_CHAIN);
+            # A name without the * twigil walks the static chain here, so
+            # it has the same begin-time gap a LEXICAL:: lookup has.
+            nqp::bindattr_i($stash, PseudoStash, '$!mode',
+              DYNAMIC_CHAIN +| BEGIN_TIME_FALLBACK);
             nqp::setwho(
                 Metamodel::ModuleHOW.new_type(:name('DYNAMIC')),
                 $stash);
@@ -279,7 +307,12 @@ my class PseudoStash is Map {
                 nqp::ifnull(                                    # STATIC_CHAIN
                   nqp::getlexrel(
                     nqp::getattr(self,PseudoStash,'$!ctx'),nqp::unbox_s($key)),
-                  Nil )))))
+                  nqp::if(
+                    nqp::bitand_i($!mode,BEGIN_TIME_FALLBACK)
+                      && nqp::isconcrete(my $declaration :=
+                           self.BEGIN-TIME-DECLARATION(nqp::unbox_s($key))),
+                    $declaration.compile-time-value,
+                    Nil ))))))
     }
     multi method ASSIGN-KEY(PseudoStash:D: Str() $key, Mu \value) is raw {
         self.AT-KEY($key) = value
@@ -318,11 +351,15 @@ my class PseudoStash is Map {
                     nqp::getlexreldyn(
                       nqp::getattr(self, PseudoStash, '$!ctx'),
                       nqp::unbox_s($key)))),
-                nqp::not_i(           # STATIC_CHAIN
+                nqp::if(              # STATIC_CHAIN
                   nqp::isnull(
                     nqp::getlexrel(
                       nqp::getattr(self, PseudoStash, '$!ctx'),
-                      nqp::unbox_s($key))))))))
+                      nqp::unbox_s($key))),
+                  nqp::bitand_i($!mode,BEGIN_TIME_FALLBACK)
+                    && nqp::isconcrete(
+                         self.BEGIN-TIME-DECLARATION(nqp::unbox_s($key))),
+                  1)))))
     }
 }
 

--- a/src/core.c/operators.rakumod
+++ b/src/core.c/operators.rakumod
@@ -259,7 +259,13 @@ sub INDIRECT_NAME_LOOKUP($root, *@chunks) is raw is implementation-detail {
               ?? GLOBAL::.AT-KEY($first)
               !! nqp::iseq_s($first,'GLOBAL')
                 ?? GLOBAL
-                !! not-found($name);
+                # At BEGIN time the walk cannot reach what the unit being
+                # compiled declares, so ask the compiler as a last resort.
+                !! nqp::isnull(nqp::getlexdyn('$*BEGIN-TIME-LOOKUP'))
+                  ?? not-found($name)
+                  !! (my $declaration := $root.BEGIN-TIME-DECLARATION($first))
+                    ?? $declaration.compile-time-value
+                    !! not-found($name);
 
         nqp::while(
           nqp::elems($parts)

--- a/src/core.e/PseudoStash.rakumod
+++ b/src/core.e/PseudoStash.rakumod
@@ -3,11 +3,12 @@ my class PseudoStash is CORE::v6c::PseudoStash {
     has $!walker;
 
     # Lookup modes. Must be kept in sync with CORE::v6c::PseudoStash mode constants.
-    my int constant PICK_CHAIN_BY_NAME = 0;
-    my int constant STATIC_CHAIN       = 1;
-    my int constant DYNAMIC_CHAIN      = 2;
-    my int constant PRECISE_SCOPE      = 4;
-    my int constant REQUIRE_DYNAMIC    = 8;
+    my int constant PICK_CHAIN_BY_NAME  = 0;
+    my int constant STATIC_CHAIN        = 1;
+    my int constant DYNAMIC_CHAIN       = 2;
+    my int constant PRECISE_SCOPE       = 4;
+    my int constant REQUIRE_DYNAMIC     = 8;
+    my int constant BEGIN_TIME_FALLBACK = 16;
 
     # A convenience shortcut
     my constant PseudoStash6c = CORE::v6c::PseudoStash;
@@ -86,7 +87,7 @@ my class PseudoStash is CORE::v6c::PseudoStash {
         'LEXICAL', sub ($cur) {
             PseudoStash.NEW-PACKAGE(
                 :ctx(nqp::getattr(nqp::decont($cur), PseudoStash6c, '$!ctx')),
-                :mode(STATIC_CHAIN +| DYNAMIC_CHAIN),
+                :mode(STATIC_CHAIN +| DYNAMIC_CHAIN +| BEGIN_TIME_FALLBACK),
                 :name<LEXICAL>
             )
         },
@@ -97,7 +98,8 @@ my class PseudoStash is CORE::v6c::PseudoStash {
 
             nqp::isnull($ctx)
                 ?? Nil
-                !! PseudoStash.NEW-PACKAGE( :$ctx, :mode(STATIC_CHAIN), :name<OUTERS> )
+                !! PseudoStash.NEW-PACKAGE(
+                     :$ctx, :mode(STATIC_CHAIN +| BEGIN_TIME_FALLBACK), :name<OUTERS> )
         },
         'DYNAMIC', sub ($cur) {
             PseudoStash.NEW-PACKAGE(
@@ -407,6 +409,16 @@ my class PseudoStash is CORE::v6c::PseudoStash {
                     nqp::stmts(
                         (my Mu $sym-info := nqp::atkey(nqp::getattr(self, Map, '$!storage'), $key)),
                         ($val := SYM-VALUE($sym-info, $key))))));
+        # BEGIN-TIME-DECLARATION on the parent class answers for what the
+        # unit being compiled declares, which no context walk can reach.
+        nqp::if(
+            (nqp::isnull($val)
+              && nqp::bitand_i(
+                   nqp::getattr_i(self, PseudoStash6c, '$!mode'),
+                   BEGIN_TIME_FALLBACK)
+              && nqp::isconcrete(
+                   my $declaration := self.BEGIN-TIME-DECLARATION($key))),
+            ($val := $declaration.compile-time-value));
         nqp::if(
             nqp::isnull($val),
             Failure.new(X::NoSuchSymbol.new(symbol => $!package.^name ~ '::<' ~ $key ~ '>')),
@@ -441,7 +453,11 @@ my class PseudoStash is CORE::v6c::PseudoStash {
                 nqp::existskey($pseudoers, $key),
                 nqp::if(
                     (self.REIFY-STORAGE(until-symbol => $key)),
-                    nqp::not_i(nqp::istype(nqp::atkey(nqp::getattr(self, Map, '$!storage'), $key), Exception)))))
+                    nqp::not_i(nqp::istype(nqp::atkey(nqp::getattr(self, Map, '$!storage'), $key), Exception)),
+                    nqp::bitand_i(
+                      nqp::getattr_i(self, PseudoStash6c, '$!mode'),
+                      BEGIN_TIME_FALLBACK)
+                      && nqp::isconcrete(self.BEGIN-TIME-DECLARATION($key)))))
     }
 
     my role CtxSymIterator does Rakudo::Iterator::Mappy {

--- a/t/02-rakudo/begin-indirect-lexical-6e.t
+++ b/t/02-rakudo/begin-indirect-lexical-6e.t
@@ -1,0 +1,35 @@
+use v6.e.PREVIEW;
+use lib <t/02-rakudo/test-packages>;
+use Test;
+
+plan 6;
+
+# The 6.e setting carries its own PseudoStash, so the begin-time lookups
+# t/02-rakudo/begin-indirect-lexical.t pins for 6.c need pinning against
+# that implementation as well.
+
+my sub script-hex($x) { "script-" ~ $x }
+
+is (BEGIN ::('&script-hex'))("a"), 'script-a',
+    'a 6.e BEGIN indirect lookup finds a sub declared in the compiling unit';
+
+ok (BEGIN LEXICAL::.EXISTS-KEY('&script-hex')),
+    '6.e LEXICAL:: at BEGIN time knows a sub declared in the compiling unit';
+
+is (BEGIN LEXICAL::<&script-hex>)("b"), 'script-b',
+    '6.e LEXICAL:: at BEGIN time reaches the sub itself';
+
+ok (BEGIN OUTERS::.EXISTS-KEY('&script-hex')),
+    '6.e OUTERS:: at BEGIN time knows a sub declared in the compiling unit';
+
+nok (BEGIN LEXICAL::.EXISTS-KEY('&no-such-name')),
+    '6.e LEXICAL:: at BEGIN time still reports an undeclared name as absent';
+
+# Foreign code a begin-time effect runs stays isolated under 6.e too.
+my sub loader-secret() { 1 }
+use BeginIndirectForeign;
+
+is (BEGIN foreign-lexical-probe()), 'not found',
+    'an imported sub cannot see the calling 6.e unit through LEXICAL:: at BEGIN time';
+
+# vim: expandtab shiftwidth=4

--- a/t/02-rakudo/begin-indirect-lexical.t
+++ b/t/02-rakudo/begin-indirect-lexical.t
@@ -1,0 +1,162 @@
+use lib <t/02-rakudo/test-packages>;
+use Test;
+use nqp;
+
+plan 32;
+
+# An indirect lookup performs its lookup when the expression evaluates. At
+# BEGIN time that evaluation happens in a thunk the compiler builds and runs,
+# whose outer is the setting, so a pseudo-stash walking that thunk's contexts
+# reaches setting symbols but nothing the compiling unit declares. The
+# compiler answers for the unit's own declarations, and only for those: a
+# unit-local name that came back as a "no such symbol" Failure instead would
+# hold compiler frames in its backtrace and break precompilation, and an
+# answer handed to foreign code would let a loaded unit read scopes it
+# cannot see on either frontend.
+
+my sub script-hex($x) { "script-" ~ $x }
+my $script-value = 7;
+class ScriptClass { method which() { "script-class" } }
+
+is (BEGIN ::('&script-hex'))("a"), 'script-a',
+    'a BEGIN indirect lookup finds a sub declared in the compiling unit';
+
+is (BEGIN ::('&sprintf'))("%d", 3), '3',
+    'a BEGIN indirect lookup still finds a setting sub';
+
+is (BEGIN ::('ScriptClass')).which, 'script-class',
+    'a BEGIN indirect lookup finds a class declared in the compiling unit';
+
+is (BEGIN ::('$script-value')).^name, 'Any',
+    'a BEGIN indirect lookup of a scalar reaches its container, unassigned so far';
+
+my constant $constant-sub = ::('&script-hex');
+is $constant-sub("b"), 'script-b',
+    'a constant initialized from an indirect lookup holds the unit-local sub';
+
+is ::('&script-hex')("c"), 'script-c',
+    'a run time indirect lookup of a unit-local sub keeps working';
+
+# A name built at run time names nothing in the tree, so the lookup has only
+# the walk and what the compiler can still answer for.
+is (BEGIN ::("&" ~ "script-hex"))("f"), 'script-f',
+    'a BEGIN indirect lookup built from a computed string finds a unit-local sub';
+
+# The lookup site sits below the frame the compiler builds for the BEGIN
+# code, so the answer must hold at any depth, not only in that frame.
+my sub via-helper() { ::('&script-hex')('k') }
+is (BEGIN via-helper()), 'script-k',
+    'an indirect lookup in a sub the BEGIN calls finds a unit-local sub';
+
+my sub via-lexical-helper() { LEXICAL::<&script-hex>('l') }
+is (BEGIN via-lexical-helper()), 'script-l',
+    'a LEXICAL:: lookup in a sub the BEGIN calls finds a unit-local sub';
+
+# The lookup must reach the variable's own container, not a copy of it.
+my $begin-set;
+BEGIN ::('$begin-set') = 42;
+is $begin-set, 42,
+    'assigning through a BEGIN indirect lookup reaches the unit variable';
+
+# A name nothing declares consults the resolver and still misses. The
+# miss is boolified in place: a try here would write the exception into
+# a serialized $! container and break the compilation on both frontends.
+nok (BEGIN ?::('&no-such-name')),
+    'a BEGIN indirect lookup of an undeclared name still comes up empty';
+
+nok (BEGIN LEXICAL::.EXISTS-KEY('&no-such-name')),
+    'LEXICAL:: at BEGIN time still reports an undeclared name as absent';
+
+is (BEGIN ::("Script" ~ "Class")).which, 'script-class',
+    'a BEGIN indirect lookup built from a computed string finds a unit-local class';
+
+# The same lookups inside a module, which precompiles and so has to serialize
+# whatever the constants ended up holding.
+use BeginIndirectLexical;
+
+is $BeginIndirectLexical::local-sub("d"), 'local-d',
+    'a precompiled module constant holds a sub the module itself declared';
+
+is $BeginIndirectLexical::imported-sub("e"), 'exported-e',
+    'a precompiled module constant holds a sub the module imported';
+
+is $BeginIndirectLexical::setting-sub("%d", 4), '4',
+    'a precompiled module constant holds a setting sub';
+
+is $BeginIndirectLexical::local-class.which, 'local-class',
+    'a precompiled module constant holds a class the module itself declared';
+
+is $BeginIndirectLexical::computed-sub("g"), 'exported-g',
+    'a precompiled module constant holds a sub found through a computed string';
+
+is $BeginIndirectLexical::missing-lookup, False,
+    'a precompiled module constant holds the handled miss of an undeclared name';
+
+# A loaded unit runs its own code while this one is still at BEGIN time. What
+# it resolves has to stay its own business.
+my sub consumer-only() { 1 }
+use BeginIndirectProbe;
+
+is $BeginIndirectProbe::mainline-saw, 'not found',
+    'a loaded unit does not reach the loading unit through an indirect lookup';
+
+# Foreign code a begin-time effect runs is in the same position as a loaded
+# unit's mainline: its frames are not the compiling unit's, so its indirect
+# lookups must not be answered for either.
+my sub loader-secret() { 1 }
+use BeginIndirectForeign;
+
+is (BEGIN foreign-probe()), 'not found',
+    'an imported sub called at BEGIN time does not reach the calling unit';
+
+sub trait-carrier() is begin-indirect-probing { }
+is $BeginIndirectForeign::trait-saw, 'not found',
+    'an imported trait handler does not reach the unit applying the trait';
+
+# A closure another unit made at its own BEGIN time runs in frames of that
+# compilation, which must not pass for frames of this one. The call happens
+# inside a BEGIN, so it is compiled through EVAL where the legacy frontend,
+# which cannot invoke a precompiled BEGIN-made closure at all, can skip it.
+use BeginIndirectClosure;
+
+if nqp::gethllsym('Raku', 'COMPILER-FRONTEND') eq 'rakuast' {
+    is EVAL('BEGIN BeginIndirectClosure::begin-closure()'), 'not found',
+        'a BEGIN-made closure from a loaded unit does not reach the loading unit';
+}
+else {
+    skip 'the legacy frontend cannot invoke a precompiled BEGIN-made closure';
+}
+
+# LEXICAL:: walks the same chain an indirect lookup does, so it gets the
+# same answer for the compiling unit's code and the same silence for
+# foreign code.
+ok (BEGIN LEXICAL::.EXISTS-KEY('&script-hex')),
+    'LEXICAL:: at BEGIN time knows a sub declared in the compiling unit';
+
+is (BEGIN LEXICAL::<&script-hex>)("h"), 'script-h',
+    'LEXICAL:: at BEGIN time reaches the sub itself';
+
+is (BEGIN foreign-lexical-probe()), 'not found',
+    'an imported sub cannot see the calling unit through LEXICAL:: at BEGIN time';
+
+# A name without the * twigil walks the static chain through DYNAMIC:: and
+# OUTERS:: as well, so those share the gap and the answer.
+is (BEGIN DYNAMIC::<&script-hex>)("i"), 'script-i',
+    'DYNAMIC:: at BEGIN time reaches a unit sub through its static-chain path';
+
+is (BEGIN OUTERS::<&script-hex>)("j"), 'script-j',
+    'OUTERS:: at BEGIN time reaches a sub declared in the compiling unit';
+
+ok (BEGIN DYNAMIC::.EXISTS-KEY('&script-hex')),
+    'DYNAMIC:: at BEGIN time knows a sub declared in the compiling unit';
+
+ok (BEGIN OUTERS::.EXISTS-KEY('&script-hex')),
+    'OUTERS:: at BEGIN time knows a sub declared in the compiling unit';
+
+is (BEGIN foreign-dynamic-probe()), 'not found',
+    'an imported sub cannot see the calling unit through DYNAMIC:: at BEGIN time';
+
+is (BEGIN foreign-outers-probe()), 'not found',
+    'an imported sub cannot see the calling unit through OUTERS:: at BEGIN time';
+
+# vim: expandtab shiftwidth=4

--- a/t/02-rakudo/test-packages/BeginIndirectClosure.rakumod
+++ b/t/02-rakudo/test-packages/BeginIndirectClosure.rakumod
@@ -1,0 +1,14 @@
+# The closure below is made by running this unit's own BEGIN block, so the
+# frames it captures were compiled for this compilation. Called during some
+# other unit's begin-time effect, its indirect lookup must still resolve
+# against this unit's scopes only.
+unit module BeginIndirectClosure;
+
+our constant &begin-closure = BEGIN {
+    my $made = 'made-at-begin';
+    sub () {
+        $made eq 'made-at-begin'
+          ?? ((try ::('&loader-secret')).defined ?? 'found' !! 'not found')
+          !! 'capture broken'
+    }
+};

--- a/t/02-rakudo/test-packages/BeginIndirectExporter.rakumod
+++ b/t/02-rakudo/test-packages/BeginIndirectExporter.rakumod
@@ -1,0 +1,3 @@
+unit module BeginIndirectExporter;
+
+my sub exported-hex($x) is export { "exported-" ~ $x }

--- a/t/02-rakudo/test-packages/BeginIndirectForeign.rakumod
+++ b/t/02-rakudo/test-packages/BeginIndirectForeign.rakumod
@@ -1,0 +1,25 @@
+# Code in this unit is foreign to whichever unit runs it at BEGIN time. An
+# indirect lookup here resolves against this unit's own scopes, never against
+# the unit whose begin-time effect invoked it.
+unit module BeginIndirectForeign;
+
+sub foreign-probe() is export {
+    (try ::('&loader-secret')).defined ?? 'found' !! 'not found'
+}
+
+sub foreign-lexical-probe() is export {
+    LEXICAL::.EXISTS-KEY('&loader-secret') ?? 'found' !! 'not found'
+}
+
+sub foreign-dynamic-probe() is export {
+    (try DYNAMIC::<&loader-secret>).defined ?? 'found' !! 'not found'
+}
+
+sub foreign-outers-probe() is export {
+    OUTERS::.EXISTS-KEY('&loader-secret') ?? 'found' !! 'not found'
+}
+
+our $trait-saw = 'never ran';
+multi sub trait_mod:<is>(Routine $r, :$begin-indirect-probing!) is export {
+    $trait-saw = (try ::('&loader-secret')).defined ?? 'found' !! 'not found';
+}

--- a/t/02-rakudo/test-packages/BeginIndirectLexical.rakumod
+++ b/t/02-rakudo/test-packages/BeginIndirectLexical.rakumod
@@ -1,0 +1,20 @@
+# The indirect lookups here run at BEGIN time, so they read this unit's
+# lexicals through a pseudo-stash while the unit is still compiling. Their
+# results are held in constants, so they are serialized when this module is
+# precompiled: a lookup that came back empty would put a Failure carrying
+# compiler frames into the constant and break serialization.
+use BeginIndirectExporter;
+
+unit module BeginIndirectLexical;
+
+my sub local-hex($x) { "local-" ~ $x }
+my class LocalClass { method which() { "local-class" } }
+
+our constant $local-sub = ::('&local-hex');
+our constant $imported-sub = ::('&exported-hex');
+our constant $setting-sub = ::('&sprintf');
+our constant $local-class = ::('LocalClass');
+our constant $computed-sub = ::("&" ~ "exported-hex");
+# A name nothing declares, so the resolver is consulted and comes up
+# empty. The boolified Failure must not poison this unit's serialization.
+our constant $missing-lookup = ?::('&nowhere-declared');

--- a/t/02-rakudo/test-packages/BeginIndirectProbe.rakumod
+++ b/t/02-rakudo/test-packages/BeginIndirectProbe.rakumod
@@ -1,0 +1,8 @@
+# This unit's own code runs while whoever loads it is at BEGIN time. It is
+# compiled already and resolves against its own scopes, so an indirect lookup
+# here must not reach the scopes of the unit being compiled.
+unit module BeginIndirectProbe;
+
+our $mainline-saw = (try ::('&consumer-only')).defined ?? 'found' !! 'not found';
+
+our sub export-saw() { $mainline-saw }


### PR DESCRIPTION
An indirect lookup performs its lookup when the expression evaluates, through a pseudo-stash that walks contexts rather than reading a name the compiler resolved. Code the compiler runs at BEGIN time lives in a frame whose outer is wired to the setting, so that walk reached setting symbols and nothing the unit being compiled declares. A unit-local name came back as a "no such symbol" Failure, and because that Failure's backtrace holds the compiler frames it was built in, holding one in a constant broke precompilation with "missing static code ref for closure".

The compiler now leaves its resolver in $*BEGIN-TIME-LOOKUP while it performs a begin-time effect, and the lookup asks that resolver once the context chain runs out. It is asked last, after %?REQUIRE-SYMBOLS, the walk and GLOBAL, so it can never shadow a symbol another source answers for, and it is asked only for the name wanted, so no other declaration is produced on its behalf. A name built at run time is covered as well, since this needs no name in the tree to work from.

Only code belonging to the unit being compiled may be answered for. Foreign code a begin-time effect merely runs, such as a loaded unit's mainline, an EXPORT sub, an imported routine a BEGIN calls, or an imported trait handler, resolves against its own scopes on either frontend. A dynamic alone cannot draw that line, since it flows into every callee. Each compilation therefore carries an identity token, planted by IMPL-COMPILE-DYNAMICALLY as a lexical in the frames it compiles for the unit and left beside the resolver in $*BEGIN-TIME-LOOKUP, and the lookup answers only when the frame it runs in has the running compilation's token on its static chain. Comparing token identity rather than presence also keeps a BEGIN-made closure loaded from another unit from passing for this unit's code. The token is an inert instance, so a frame a closure captured serializes as before, which a frame holding the resolver could not.

LEXICAL:: walks the same chain an indirect lookup does and had the same gap: at BEGIN time it reached setting symbols and nothing the unit declares, on keyed lookups where the legacy frontend sees the unit's subs, containers and imports. So do DYNAMIC:: and OUTERS::, whose lookups for a name without the * twigil take the same static-chain path. Stashes made by those pseudoers carry a BEGIN_TIME_FALLBACK mode bit, and AT-KEY and EXISTS-KEY consult the token-gated fallback when the chain walk misses. The fallback lives once, as an implementation-detail method on the 6.c PseudoStash. The 6.e PseudoStash, a separate implementation, inherits it for its own AT-KEY and EXISTS-KEY, and INDIRECT_NAME_LOOKUP calls it on its root. The 6.e DYNAMIC:: requires dynamic variables, so it takes no fallback.

The fallback asks resolve-lexical-constant-in-scopes, since the chain walk already reaches the outer context and the setting, and it does not guard the call with try: the resolver signals not-found by Nil, so an exception there is a compiler bug, and the begin-time CATCH machinery reports it as a located compile error instead of a swallowed miss that would resurface as the serialization failure above. Every begin-time entry point, the ParseTime copies of
IMPL-BEGIN-TIME-EVALUATE and IMPL-BEGIN-TIME-CALL included, binds the dynamic through the one producer IMPL-BEGIN-TIME-LOOKUP-STATE, so the sites cannot drift and user code run from a parse-time effect is answered for as well.