### PR TITLE
Port two missed fixes to the 6.e Grammar

### DIFF
--- a/src/core.e/Grammar.rakumod
+++ b/src/core.e/Grammar.rakumod
@@ -101,7 +101,7 @@ my class Grammar is Match {
         )
     }
 
-    method subparse(\target, :$rule = 'TOP', :$args, :$actions) {
+    method subparse(\target, :$rule = 'TOP', :$args, Mu :$actions) {
         my $grammar := self.new(:orig(target), |%_);
         $grammar.set_actions($actions)
           unless nqp::eqaddr(nqp::decont($actions),Mu);

--- a/src/core.e/Grammar.rakumod
+++ b/src/core.e/Grammar.rakumod
@@ -64,20 +64,28 @@ my class Grammar is Match {
         $grammar.set_actions($actions)
           unless nqp::eqaddr(nqp::decont($actions),Mu);
 
-        nqp::if(
-          (my $cursor := nqp::if(
+        my $cursor := nqp::if(
           $rule,
-            nqp::if(
-              $args,
-              $grammar."$rule"(|$args.Capture),
-              $grammar."$rule"()
-            ),
-            nqp::if(
-              $args,
-              $grammar.TOP(|$args.Capture),
-              $grammar.TOP()
-            ),
-          )),
+          nqp::if(
+            $args,
+            $grammar."$rule"(|$args.Capture),
+            $grammar."$rule"()
+          ),
+          nqp::if(
+            $args,
+            $grammar.TOP(|$args.Capture),
+            $grammar.TOP()
+          ),
+        );
+
+        unless nqp::istype($cursor,Match) {
+            my $name := $rule // 'TOP';
+            my $type := self.^find_method($name).^name;
+            die "$type '$name' returned a $cursor.^name() object ($cursor.gist()) rather than a Match object";
+        }
+
+        nqp::if(
+          $cursor,
           nqp::stmts(
             (my $match := $cursor.Match::MATCH),
             nqp::while(

--- a/t/02-rakudo/grammar-6e-parse-sanity.t
+++ b/t/02-rakudo/grammar-6e-parse-sanity.t
@@ -1,0 +1,32 @@
+use v6.e.PREVIEW;
+use Test;
+
+# A rule that does not return a Match must be reported by name instead
+# of failing on the first Match operation applied to its return value
+
+plan 3;
+
+grammar NotAMatch {
+    method TOP($?) { 42 }
+}
+
+throws-like { NotAMatch.parse("x") }, Exception,
+    message => /"'TOP' returned a Int object (42) rather than a Match object"/,
+    'a TOP returning a non-Match is reported by name';
+
+grammar NotAMatchRule {
+    method custom($?) { "oops" }
+}
+
+throws-like { NotAMatchRule.parse("x", :rule<custom>) }, Exception,
+    message => /"'custom' returned a Str object (oops) rather than a Match object"/,
+    'a named rule returning a non-Match is reported by name';
+
+grammar Fine {
+    token TOP { \w+ }
+}
+
+is Fine.parse("word").Str, 'word',
+    'a rule returning a Match still parses';
+
+# vim: expandtab shiftwidth=4

--- a/t/02-rakudo/grammar-6e-subparse-actions.t
+++ b/t/02-rakudo/grammar-6e-subparse-actions.t
@@ -1,0 +1,24 @@
+use v6.e.PREVIEW;
+use Test;
+
+# Passing Mu as the actions means: no actions, also for subparse
+
+plan 3;
+
+grammar G {
+    token TOP { \w+ }
+}
+
+is G.subparse("word", actions => Mu).Str, 'word',
+    'subparse accepts Mu as the actions';
+is G.parse("word", actions => Mu).Str, 'word',
+    'parse accepts Mu as the actions';
+
+my class Actions {
+    method TOP($/) { make ~$/ ~ '!' }
+}
+
+is G.subparse("word", actions => Actions).made, 'word!',
+    'subparse still runs a real actions class';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
The 6.e setting carries its own Grammar that reimplements `parse` and `subparse`, so fixes to the 6.c Grammar do not reach it on their own.

Previously a rule returning something other than a Match failed under 6.e with a binding error naming neither the rule nor the value, because the sanity check 92ead2bdff added to the 6.c Grammar never arrived. Such a return is now reported the same way as outside 6.e: `Method 'TOP' returned a Int object (42) rather than a Match object`. Additionally, be9b0742ee gave both settings the body handling for `actions => Mu` meaning no actions, but only the 6.c subparse got the Mu type on its actions parameter, so an explicit Mu died in the signature binding under 6.e. The 6.e subparse now accepts it, as parse already does.