### PR TITLE
Deliver spawn failures to the merged output supply

### DIFF
--- a/src/core.c/Proc/Async.rakumod
+++ b/src/core.c/Proc/Async.rakumod
@@ -449,9 +449,20 @@ my class Proc::Async {
           $!stderr_descriptor_used
         )) if $!stderr_supply;
 
-        @!promises.push(
-          self!capture($callbacks,'merge',$!merge_supply)
-        ) if $!merge_supply;
+        if $!merge_supply {
+            @!promises.push(
+              self!capture($callbacks,'merge',$!merge_supply)
+            );
+#?if moar
+            # MoarVM reports a spawn failure under the stdout_bytes and
+            # stderr_bytes keys, also when the pipes were created for a
+            # merged stream.
+            nqp::bindkey($callbacks, 'stdout_bytes',
+              nqp::atkey($callbacks, 'merge_bytes'));
+            nqp::bindkey($callbacks, 'stderr_bytes',
+              nqp::atkey($callbacks, 'merge_bytes'));
+#?endif
+        }
 
         nqp::bindkey($callbacks, 'buf_type', nqp::create(buf8.^pun));
         nqp::bindkey($callbacks, 'write', True) if $.w;
@@ -463,6 +474,13 @@ my class Proc::Async {
             nqp::bindkey($callbacks, 'pty', True);
             nqp::bindkey($callbacks, 'pty-cols', $!pty-cols);
             nqp::bindkey($callbacks, 'pty-rows', $!pty-rows);
+#?if moar
+            # A pty reports spawn failures under the stdout_bytes key even
+            # when nothing is set up to read stdout. The error callback
+            # reports the failure regardless.
+            nqp::bindkey($callbacks, 'stdout_bytes', -> Mu, Mu, Mu { })
+              unless nqp::existskey($callbacks, 'stdout_bytes');
+#?endif
         }
 
         $!process_handle := nqp::spawnprocasync($scheduler.queue(:hint-affinity),

--- a/src/core.c/Rakudo/Internals.rakumod
+++ b/src/core.c/Rakudo/Internals.rakumod
@@ -696,8 +696,12 @@ my class Rakudo::Internals {
         method process(Mu \seq, Mu \data, Mu \err) {
             $!lock.protect: {
                 if err {
-                    &!on-error(err);
-                    $!bust = 1;
+                    # Both pipes behind a merged output stream can
+                    # report the same failure.
+                    unless $!bust {
+                        &!on-error(err);
+                        $!bust = 1;
+                    }
                 }
                 elsif nqp::isconcrete(data) {
                     my int $insert-pos = seq - $!buffer-start-seq;

--- a/t/02-rakudo/proc-async-spawn-failure.t
+++ b/t/02-rakudo/proc-async-spawn-failure.t
@@ -1,0 +1,30 @@
+use Test;
+
+plan 3;
+
+# https://github.com/rakudo/rakudo/issues/2207
+
+my $merged = Proc::Async.new('does-not-exist-cabbage-mooncake-unicycle');
+my $merge-supply = $merged.Supply;
+my $merged-promise = $merged.start;
+throws-like { react { whenever $merge-supply { } } }, X::AdHoc,
+    'The merged Supply of an async process that does not exist quits with the spawn error',
+    message => /'does-not-exist-cabbage-mooncake-unicycle'/;
+dies-ok { await $merged-promise },
+    'Promise for an async process that does not exist is broken when its merged Supply is tapped';
+
+if $*DISTRO.is-win {
+    skip 'no pty support on Windows', 1;
+}
+else {
+    my $pty = Proc::Async.new('does-not-exist-cabbage-mooncake-unicycle',
+        :pty((:cols(80), :rows(24))));
+    dies-ok { await $pty.start },
+        'Promise for a pty process that does not exist is broken';
+}
+
+# The crashes guarded here kill a thread pool worker asynchronously. Give
+# such a crash time to take the process down before the plan completes.
+await Promise.in(0.5);
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously a Proc::Async with a tapped .Supply whose process could not be spawned crashed the thread pool with a null callback invocation instead of reporting the failure, and the same happened for a pty process without a tapped stdout. MoarVM reports a spawn failure once for each pipe it had created, under the stdout_bytes and stderr_bytes callback keys, also when those pipes were created for a merged stream or a pty. Neither case had those callbacks registered.

This routes the failure reports for a merged stream into its merge handler and makes the sequencer deliver only the first error, since both pipes report the same failure. For a pty without a stdout reader the report is swallowed, as the error callback already breaks the ready and exit promises. The merged supply now quits with the spawn error the same way the stdout and stderr supplies do.

Fixes #2207