### PR TITLE
Complete the merged output supply on its last stream EOF

### DIFF
--- a/src/core.c/Proc/Async.rakumod
+++ b/src/core.c/Proc/Async.rakumod
@@ -325,7 +325,10 @@ my class Proc::Async {
     method !capture(\callbacks,\std,\the-supply --> Promise) {
         my $promise := Promise.new;
         my $vow := $promise.vow;
+        # A merged stream is fed by two pipes, so it ends with two
+        # end of stream reports.
         my $ss := Rakudo::Internals::SupplySequencer.new(
+            dones-expected => std eq 'merge' ?? 2 !! 1,
             on-data-ready => -> \data { the-supply.emit(data) },
             on-completed  => -> { the-supply.done(); $vow.keep(the-supply) },
             on-error      => -> \err { the-supply.quit(err); $vow.keep((the-supply,err)) });

--- a/src/core.c/Rakudo/Internals.rakumod
+++ b/src/core.c/Rakudo/Internals.rakumod
@@ -680,15 +680,19 @@ my class Rakudo::Internals {
         has &!on-error;
         has $!buffer;
         has int $!buffer-start-seq;
-        has int $!done-target;
+        has int $!dones-expected;
+        has int $!dones-seen;
+        has int $!completed;
         has int $!bust;
         has $!lock;
 
         submethod BUILD(
-          :&!on-data-ready!, :&!on-completed!, :&!on-error! --> Nil) {
+          :&!on-data-ready!, :&!on-completed!, :&!on-error!,
+          :$!dones-expected = 1 --> Nil) {
             $!buffer := nqp::list();
             $!buffer-start-seq = 0;
-            $!done-target = -1;
+            $!dones-seen = 0;
+            $!completed = 0;
             $!bust = 0;
             $!lock := Lock::Async.new;
         }
@@ -697,8 +701,10 @@ my class Rakudo::Internals {
             $!lock.protect: {
                 if err {
                     # Both pipes behind a merged output stream can
-                    # report the same failure.
-                    unless $!bust {
+                    # report failures. The completion and error
+                    # callbacks are mutually exclusive and run at most
+                    # once.
+                    unless $!bust || $!completed {
                         &!on-error(err);
                         $!bust = 1;
                     }
@@ -709,7 +715,10 @@ my class Rakudo::Internals {
                     self!emit-events();
                 }
                 else {
-                    $!done-target = seq;
+                    # An end of stream report consumes a sequence number
+                    # that no output ever fills.
+                    nqp::bindpos($!buffer, seq - $!buffer-start-seq, Mu);
+                    $!dones-seen = $!dones-seen + 1;
                     self!emit-events();
                 }
             }
@@ -718,10 +727,14 @@ my class Rakudo::Internals {
         method !emit-events() {
             unless $!bust {
                 until nqp::elems($!buffer) == 0 || nqp::isnull(nqp::atpos($!buffer, 0)) {
-                    &!on-data-ready(nqp::shift($!buffer));
+                    my \item = nqp::shift($!buffer);
+                    &!on-data-ready(item) if nqp::isconcrete(item);
                     $!buffer-start-seq = $!buffer-start-seq + 1;
                 }
-                if $!buffer-start-seq == $!done-target {
+                if !$!completed
+                  && $!dones-seen == $!dones-expected
+                  && nqp::elems($!buffer) == 0 {
+                    $!completed = 1;
                     &!on-completed();
                 }
             }

--- a/t/02-rakudo/proc-async-merge-stream-close.t
+++ b/t/02-rakudo/proc-async-merge-stream-close.t
@@ -1,0 +1,52 @@
+use Test;
+
+# A process can close one output stream while the other keeps producing.
+# The merged Supply must deliver the output that arrives after the first
+# stream closed and complete only when both streams have ended.
+
+plan 10;
+
+sub merged-run($child-code) {
+    my $proc = Proc::Async.new($*EXECUTABLE, '-e', $child-code);
+    my @chunks;
+    my $done = False;
+    $proc.Supply.tap: { @chunks.push($_) }, done => { $done = True };
+    my $finished = $proc.start;
+    await Promise.anyof($finished, Promise.in(60));
+    $proc.kill(SIGKILL) if $finished.status == Planned;
+    (@chunks, $done)
+}
+
+my ($chunks, $done) = merged-run
+    '$*ERR.print("early"); $*OUT.close; sleep 0.3; $*ERR.print("late")';
+ok $chunks.join.contains('early'),
+    'Merged output includes stderr output produced before stdout closed';
+ok $chunks.join.contains('late'),
+    'Merged output includes stderr output produced after stdout closed';
+ok $chunks.all.defined,
+    'Every merged chunk is defined after stdout closed early';
+ok $done,
+    'Merged Supply completes when stderr ends after stdout closed early';
+
+($chunks, $done) = merged-run
+    '$*OUT.print("early"); $*ERR.close; sleep 0.3; $*OUT.print("late")';
+ok $chunks.join.contains('early'),
+    'Merged output includes stdout output produced before stderr closed';
+ok $chunks.join.contains('late'),
+    'Merged output includes stdout output produced after stderr closed';
+ok $chunks.all.defined,
+    'Every merged chunk is defined after stderr closed early';
+ok $done,
+    'Merged Supply completes when stdout ends after stderr closed early';
+
+($chunks, $done) = merged-run 'exit 0';
+is $chunks.join, '',
+    'A merged child that writes nothing produces no output';
+ok $done,
+    'Merged Supply completes for a child that writes nothing';
+
+# The crashes guarded here kill a thread pool worker asynchronously. Give
+# such a crash time to take the process down before the plan completes.
+await Promise.in(0.5);
+
+# vim: expandtab shiftwidth=4

--- a/t/02-rakudo/supply-sequencer.t
+++ b/t/02-rakudo/supply-sequencer.t
@@ -1,0 +1,47 @@
+use Test;
+
+# Drives Rakudo::Internals::SupplySequencer through the calling contract
+# Proc::Async uses. The reordered and post-completion shapes cannot be
+# produced by a real process.
+
+plan 5;
+
+sub driven(:$dones-expected = 1, **@tuples) {
+    my @events;
+    my $ss = Rakudo::Internals::SupplySequencer.new:
+        :$dones-expected,
+        on-data-ready => -> \data { @events.push(data.decode) },
+        on-completed  => -> { @events.push('done') },
+        on-error      => -> \err { @events.push("error " ~ err) };
+    $ss.process(|$_) for @tuples;
+    @events
+}
+
+is-deeply driven((0, 'a'.encode, Str), (1, 'b'.encode, Str), (2, Blob, Str)),
+    ['a', 'b', 'done'],
+    'A single stream delivers its output and completes on its EOF report';
+
+is-deeply driven(:2dones-expected,
+        (0, 'a'.encode, Str), (1, Blob, Str),
+        (2, 'b'.encode, Str), (3, Blob, Str)),
+    ['a', 'b', 'done'],
+    'A merged stream delivers output arriving between its EOF reports';
+
+is-deeply driven(:2dones-expected,
+        (0, 'a'.encode, Str), (3, Blob, Str),
+        (1, Blob, Str), (2, 'b'.encode, Str)),
+    ['a', 'b', 'done'],
+    'A merged stream completes exactly once on reordered EOF reports';
+
+is-deeply driven(:2dones-expected,
+        (0, 'a'.encode, Str), (1, Blob, Str), (2, Blob, Str),
+        (Int, Str, 'late failure')),
+    ['a', 'done'],
+    'A failure report arriving after completion is not delivered';
+
+is-deeply driven(:2dones-expected,
+        (Int, Str, 'first failure'), (Int, Str, 'second failure')),
+    ['error first failure'],
+    'Only the first of two failure reports is delivered';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously the merged output supply of a Proc::Async completed when the first of its two streams reached EOF. A process that closed one stream while the other kept producing then delivered the remaining output into a completed sequencer. That kept the capture promise a second time, which crashed a thread pool worker, and the output produced after the first EOF was never emitted:

    my $p = Proc::Async.new('/bin/sh', '-c', 'echo early >&2; exec 1>&-; sleep 0.5; echo late >&2');
    $p.Supply.tap: { .print };
    await $p.start;
    # Unhandled exception in code scheduled on thread 4
    # Cannot keep/break a Promise more than once (status: Kept)

This teaches the sequencer the number of EOF reports to expect, two for a merged stream, marks each report's position in the reorder buffer so later output can drain past it, and completes once every report has arrived and all buffered output has been emitted. The completion and error callbacks are also mutually exclusive and run at most once. Previously a failure report from each of the two pipes could keep the capture promise twice. The example above now prints both chunks and exits cleanly.

Note that awaiting .start now waits for both streams to end before resolving, matching what tapping .stdout and .stderr separately (and Proc with :merge) always did. A merged stream that appeared to finish at the first EOF was this bug.