### PR TITLE
Report unhandled exceptions from threads like any other

### DIFF
--- a/src/core.c/Exception.rakumod
+++ b/src/core.c/Exception.rakumod
@@ -585,24 +585,37 @@ sub COMP_EXCEPTION(|) is implementation-detail {
 do {
 
     sub print_exception(|) {
-        my Mu $ex := nqp::atpos(nqp::p6argvmarray(), 0);
+        my Mu $args := nqp::p6argvmarray();
+        my Mu $ex := nqp::atpos($args, 0);
+        # The context line opens the default report. Output from a
+        # configured exceptions handler replaces the whole report,
+        # context included.
+        my $context := nqp::isgt_i(nqp::elems($args), 1)
+          ?? nqp::atpos($args, 1)
+          !! Nil;
         my $e := EXCEPTION($ex);
         $*EXIT      = 1;
         $*EXCEPTION = $e;
+        my Mu $err := $*ERR;
 
         if %*ENV<RAKU_EXCEPTIONS_HANDLER> -> $handler {
             my $class := ::("Exceptions::$handler");
             unless nqp::istype($class,Failure) {
                 temp %*ENV<RAKU_EXCEPTIONS_HANDLER> = ""; # prevent looping
-                unless $class.process($e) {
+                my $continue := try $class.process($e);
+                if $! -> $handler-ex {
+                    $err.say("Exception handler Exceptions::$handler died with: "
+                      ~ ((try $handler-ex.message) // $handler-ex.^name));
+                }
+                elsif !$continue {
                     nqp::getcurhllsym('&THE_END')();
                     return
                 }
             }
         }
 
-        my Mu $err := $*ERR;
         try {
+            $err.say($context) if $context.defined;
             my $v := $e.vault-backtrace;
 
             $e.backtrace;  # This is where most backtraces actually happen
@@ -692,8 +705,11 @@ do {
     my Mu $comp := nqp::getcomp('Raku');
     $comp.^add_method('handle-exception',
         method (|) {
-            my Mu $ex := nqp::atpos(nqp::p6argvmarray(), 1);
-            print_exception($ex);
+            my Mu $args := nqp::p6argvmarray();
+            my Mu $ex := nqp::atpos($args, 1);
+            nqp::isgt_i(nqp::elems($args), 2)
+              ?? print_exception($ex, nqp::atpos($args, 2))
+              !! print_exception($ex);
             nqp::exit(1);
             0;
         }

--- a/src/core.c/Exception.rakumod
+++ b/src/core.c/Exception.rakumod
@@ -646,12 +646,14 @@ do {
             CONTROL { when CX::Warn { .resume } }
         }
         if $! -> $secondary-ex {
+            my Mu $vm-secondary := nqp::getattr(nqp::decont($secondary-ex),
+              Exception, '$!ex');
             $err.say: "===SORRY!=== Error while reporting exception " ~ $e.^name
                 ~ (try { ": secondary " ~ $secondary-ex.^name ~ " has been thrown" } || "")
                 ~ (try { "\n  The original message was: " ~ $e.message } || "")
                 ~ (try { "\n  The secondary message is: " ~ $secondary-ex.message } || "")
                 ~ (try { "\n  The original backtrace:\n" ~ $e.backtrace.Str.indent(4) } || "");
-            nqp::rethrow(nqp::getattr(nqp::decont($!), Exception, '$!ex'))
+            nqp::rethrow($vm-secondary)
         }
     }
 

--- a/src/core.c/Exception.rakumod
+++ b/src/core.c/Exception.rakumod
@@ -606,7 +606,13 @@ do {
             my $v := $e.vault-backtrace;
 
             $e.backtrace;  # This is where most backtraces actually happen
-            if $e.is-compile-time || $e.backtrace && $e.backtrace.is-runtime {
+            # The compiler renders its own low level variant for the
+            # mainline and exits before ever calling this.
+            if Rakudo::Internals.LL-EXCEPTION {
+                $err.say($e.message);
+                $err.say($e.backtrace.full);
+            }
+            elsif $e.is-compile-time || $e.backtrace && $e.backtrace.is-runtime {
                 $err.say($e.gist);
                 if $v and !$e.gist.ends-with($v.Str) {
                     $err.say("Actually thrown at:");

--- a/src/core.c/Scheduler.rakumod
+++ b/src/core.c/Scheduler.rakumod
@@ -18,15 +18,16 @@ my role Scheduler {
         }
         else {
             # No default handler, so terminate the application.
-            note "Unhandled exception in code scheduled on thread " ~ $*THREAD.id;
-            if Rakudo::Internals.LL-EXCEPTION {
-                note $exception.message;
-                note $exception.backtrace.full;
+            my Mu $ex := nqp::decont($exception);
+            $ex := nqp::decont(X::AdHoc.new(payload => $exception.gist))
+              unless nqp::istype($ex, Exception) && nqp::isconcrete($ex);
+            my Mu $vm-ex := nqp::getattr($ex, Exception, '$!ex');
+            unless nqp::isconcrete($vm-ex) {
+                $vm-ex := nqp::newexception();
+                nqp::setpayload($vm-ex, $ex);
             }
-            else {
-                note $exception.gist;
-            }
-            exit(1);
+            nqp::getcomp('Raku').handle-exception($vm-ex,
+              "Unhandled exception in code scheduled on thread " ~ $*THREAD.id);
         }
     }
 

--- a/src/core.c/Thread.rakumod
+++ b/src/core.c/Thread.rakumod
@@ -68,6 +68,18 @@ my class Thread {
                     nqp::getcomp('Raku').handle-control($vm-ex);
                 }
             }
+            CATCH {
+                default {
+#?if !jvm
+                    ++⚛$aborted;
+#?endif
+#?if jvm
+                    ++$aborted;
+#?endif
+                    my Mu $vm-ex := nqp::getattr(nqp::decont($_), Exception, '$!ex');
+                    nqp::getcomp('Raku').handle-exception($vm-ex);
+                }
+            }
             my $*STACK-ID = Rakudo::Internals.NEXT-ID;
             code();
 #?if !jvm

--- a/t/02-rakudo/thread-unhandled-exception.t
+++ b/t/02-rakudo/thread-unhandled-exception.t
@@ -1,11 +1,13 @@
 use Test;
 
-# An exception that escapes a raw Thread must be reported through the
-# same renderer an unhandled mainline exception uses, including the
-# handler named in RAKU_EXCEPTIONS_HANDLER and the low level variant
-# under --ll-exception, and must exit the process with 1.
+# An exception that escapes a raw Thread or a thread pool worker must
+# be reported through the same renderer an unhandled mainline exception
+# uses, including the handler named in RAKU_EXCEPTIONS_HANDLER and the
+# low level variant under --ll-exception, and must exit the process
+# with 1. The pool report keeps its usual header when no handler takes
+# over.
 
-plan 10;
+plan 33;
 
 sub run-child($code, $handler?, *@flags) {
     my %env = %*ENV;
@@ -51,5 +53,84 @@ ok $err.contains('END RAN'),
     'END phasers run for a process whose Thread died';
 is $result.exitcode, 1,
     'A process whose Thread died runs END phasers and exits with 1';
+
+my $pool-code = 'start { die "from pool" }; sleep 5';
+my $header    = 'Unhandled exception in code scheduled on thread';
+
+($err, $result) = run-child($pool-code);
+ok $err.contains($header) && $err.contains('from pool'),
+    'A pool worker that died keeps its usual report without the handler set';
+is $result.exitcode, 1,
+    'A process whose pool worker died exits with 1';
+
+($err, $result) = run-child($pool-code, 'JSON');
+ok $err.contains('"X::AdHoc"') && $err.contains('from pool'),
+    'RAKU_EXCEPTIONS_HANDLER renders the exception of a pool worker that died';
+nok $err.contains($header),
+    'The handler output of a pool worker that died has no default report';
+is $result.exitcode, 1,
+    'A process whose pool worker died with the handler set exits with 1';
+
+($err, $result) = run-child($pool-code, 'DoesNotExistCabbage');
+ok $err.contains($header) && $err.contains('from pool'),
+    'A handler that cannot be loaded falls back to the usual pool report';
+is $result.exitcode, 1,
+    'A process whose pool worker died with an unloadable handler exits with 1';
+
+($err, $result) = run-child(
+    'class Exceptions::Decline { method process($e) { $*ERR.say("DECLINE-SAW"); True } }; '
+        ~ $pool-code,
+    'Decline');
+ok $err.contains('DECLINE-SAW') && $err.contains($header) && $err.contains('from pool'),
+    'A handler that declines is followed by the usual pool report';
+is $result.exitcode, 1,
+    'A process whose pool worker died with a declining handler exits with 1';
+
+($err, $result) = run-child(
+    'class Exceptions::Boom { method process($e) { die "handler broke" } }; '
+        ~ $pool-code,
+    'Boom');
+ok $err.contains($header) && $err.contains('from pool'),
+    'A handler that died is followed by the usual pool report';
+ok $err.contains('Exceptions::Boom died'),
+    'A handler that died is reported itself';
+ok $err.contains('handler broke'),
+    'The exception a handler died with is reported';
+is $result.exitcode, 1,
+    'A process whose pool worker died with a dying handler exits with 1';
+
+($err, $result) = run-child($pool-code, Nil, '--ll-exception');
+ok $err.contains($header) && $err.contains('from pool')
+    && $err.contains('SETTING::src/core.c/'),
+    'The pool report keeps the full backtrace under --ll-exception';
+is $result.exitcode, 1,
+    'A process whose pool worker died under --ll-exception exits with 1';
+
+($err, $result) = run-child(
+    'my $p = Promise.new(:report-broken-if-sunk); $p.break("boom"); $p.sink; sleep 5');
+ok $err.contains($header) && $err.contains('boom'),
+    'A sunk broken Promise with an exception that was never thrown is reported';
+is $result.exitcode, 1,
+    'A process with a sunk broken Promise exits with 1';
+
+($err, $result) = run-child('END note "END RAN"; ' ~ $pool-code);
+ok $err.contains('END RAN'),
+    'END phasers run for a process whose pool worker died';
+is $result.exitcode, 1,
+    'A process whose pool worker died runs END phasers and exits with 1';
+
+($err, $result) = run-child(
+    'my $p = Promise.new(:report-broken-if-sunk); $p.break(X::AdHoc); $p.sink; sleep 5');
+ok $err.contains($header) && $err.contains('(AdHoc)'),
+    'A sunk Promise broken with an exception type object is reported';
+is $result.exitcode, 1,
+    'A process with a sunk Promise broken with a type object exits with 1';
+
+($err, $result) = run-child(
+    'start { $*SCHEDULER.handle_uncaught("plain string uncaught") }; sleep 5');
+ok $err.contains($header) && $err.contains('plain string uncaught'),
+    'A value that is not an exception passed to handle_uncaught is reported';
+is $result.exitcode, 1,
+    'A process that passed a plain value to handle_uncaught exits with 1';
 
 # vim: expandtab shiftwidth=4

--- a/t/02-rakudo/thread-unhandled-exception.t
+++ b/t/02-rakudo/thread-unhandled-exception.t
@@ -1,0 +1,55 @@
+use Test;
+
+# An exception that escapes a raw Thread must be reported through the
+# same renderer an unhandled mainline exception uses, including the
+# handler named in RAKU_EXCEPTIONS_HANDLER and the low level variant
+# under --ll-exception, and must exit the process with 1.
+
+plan 10;
+
+sub run-child($code, $handler?, *@flags) {
+    my %env = %*ENV;
+    with $handler {
+        %env<RAKU_EXCEPTIONS_HANDLER> = $_;
+    }
+    else {
+        %env<RAKU_EXCEPTIONS_HANDLER>:delete;
+    }
+    my $proc = Proc::Async.new($*EXECUTABLE, |@flags, '-e', $code);
+    my $err = '';
+    $proc.stderr.tap: { $err ~= $_ };
+    my $result = await $proc.start(:ENV(%env));
+    ($err, $result)
+}
+
+my $thread-code = 'Thread.start({ die "from thread" }); sleep 5';
+
+my ($err, $result) = run-child($thread-code);
+ok $err.contains('from thread'),
+    'The exception message of a Thread that died reaches stderr';
+nok $err.contains('No exception handler located'),
+    'A Thread that died does not produce the low level VM report';
+is $result.exitcode, 1,
+    'A process whose Thread died from an exception exits with 1';
+
+($err, $result) = run-child($thread-code, 'JSON');
+ok $err.contains('"X::AdHoc"') && $err.contains('from thread'),
+    'RAKU_EXCEPTIONS_HANDLER renders the exception of a Thread that died';
+nok $err.contains('  in block'),
+    'The handler output of a Thread that died has no default report';
+is $result.exitcode, 1,
+    'A process whose Thread died with the handler set exits with 1';
+
+($err, $result) = run-child($thread-code, Nil, '--ll-exception');
+ok $err.contains('from thread') && $err.contains('SETTING::src/core.c/'),
+    'A Thread that died keeps the full backtrace under --ll-exception';
+is $result.exitcode, 1,
+    'A process whose Thread died under --ll-exception exits with 1';
+
+($err, $result) = run-child('END note "END RAN"; ' ~ $thread-code);
+ok $err.contains('END RAN'),
+    'END phasers run for a process whose Thread died';
+is $result.exitcode, 1,
+    'A process whose Thread died runs END phasers and exits with 1';
+
+# vim: expandtab shiftwidth=4

--- a/t/02-rakudo/thread-unhandled-exception.t
+++ b/t/02-rakudo/thread-unhandled-exception.t
@@ -5,9 +5,10 @@ use Test;
 # uses, including the handler named in RAKU_EXCEPTIONS_HANDLER and the
 # low level variant under --ll-exception, and must exit the process
 # with 1. The pool report keeps its usual header when no handler takes
-# over.
+# over, and a failure inside the reporting itself is recovered and
+# still names the original exception.
 
-plan 33;
+plan 38;
 
 sub run-child($code, $handler?, *@flags) {
     my %env = %*ENV;
@@ -132,5 +133,19 @@ ok $err.contains($header) && $err.contains('plain string uncaught'),
     'A value that is not an exception passed to handle_uncaught is reported';
 is $result.exitcode, 1,
     'A process that passed a plain value to handle_uncaught exits with 1';
+
+($err, $result) = run-child(
+    'class X::BadGist is Exception { method message { "orig-msg" }; method gist { die "gist-died" } }; '
+        ~ '$*SCHEDULER.cue({ X::BadGist.new.throw }); sleep 5');
+ok $err.contains('Error while reporting exception') && $err.contains('orig-msg'),
+    'A report whose rendering died still reports the original message';
+ok $err.contains('gist-died'),
+    'A report whose rendering died names the failure that broke it';
+nok $err.contains("Did you forget a '.new'"),
+    'A report whose rendering died does not blame unrelated code';
+nok $err.contains('No exception handler located'),
+    'A report whose rendering died does not end in the low level VM report';
+is $result.exitcode, 1,
+    'A process whose report rendering died exits with 1';
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously an exception that escaped a raw Thread printed a low level VM dump, and one that killed a thread pool worker printed its own hardcoded report. Neither consulted RAKU_EXCEPTIONS_HANDLER, and a dying Thread did not run END phasers or say anything useful at all:

    $ RAKU_EXCEPTIONS_HANDLER=JSON raku -e 'Thread.start({ die "oops" }); sleep 1'
    No exception handler located for catch
       at SETTING::src/core.c/Exception.rakumod:65  (...CORE.c.setting.moarvm:throw)
     from SETTING::src/core.c/control.rakumod:253  (...CORE.c.setting.moarvm:die)
     ...

This routes both through the code the mainline already uses for an unhandled exception. A dying Thread now reports the way the mainline would, the example above prints the JSON, END phasers run, and --ll-exception is honored. The pool passes its usual header line along as context, so without a handler its report stays exactly what it was, including the low level variant. With a handler the handler output replaces the whole report, the same way it always has on the mainline.

Delegating the pool report means the renderer now runs in places that can hand it degenerate input, so the series also hardens it. An exception that was never thrown, an exception type object, or a plain value all still produce a report and a nonzero exit, where some of those previously produced silence and exit 0 once routed through the renderer. A handler whose process method dies falls back to the default report with a note instead of taking the report down with it. And when rendering itself fails, the recovery block now rethrows the actual secondary error rather than a Nil lookup attributed to unrelated user code.

Fixes #2462
