### PR TITLE
Make loop controls work in hyper and race iteration

### DIFF
--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -671,7 +671,16 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
         # Setting label on already created statement
         if $<label> {
             my $ast := $<statement>.ast;
-            $ast.add-label($<label>.ast);
+
+            # A for loop with a statement prefix such as `hyper` parses as
+            # an expression statement wrapping the for loop; the label
+            # belongs on the loop so that loop controls can target it.
+            my $target := $ast;
+            if nqp::istype($ast, Nodify('Statement::Expression'))
+                && nqp::istype($ast.expression, Nodify('Statement::For')) {
+                $target := $ast.expression;
+            }
+            $target.add-label($<label>.ast);
             make $ast;
             return;       # nothing left to do here
         }

--- a/src/core.c/ParallelSequence.rakumod
+++ b/src/core.c/ParallelSequence.rakumod
@@ -33,9 +33,9 @@ my role ParallelSequence[::Joiner] does Iterable does Sequence {
             self, $!work-stage-head, $matcher, %options
     }
 
-    method map(::?CLASS:D: $matcher, *%options) {
+    method map(::?CLASS:D: $matcher, :$label, *%options) {
         Rakudo::Internals::HyperRaceSharedImpl.map:
-            self, $!work-stage-head, $matcher, %options
+            self, $!work-stage-head, $matcher, %options, :$label
     }
 
     method invert(::?CLASS:D:) {

--- a/src/core.c/Rakudo/Internals/HyperPipeline.rakumod
+++ b/src/core.c/Rakudo/Internals/HyperPipeline.rakumod
@@ -2,6 +2,35 @@
 # Given a pipeline must end with a HyperJoiner, it expects to be passed
 # something of this type.
 my class Rakudo::Internals::HyperPipeline {
+    # Records the earliest batch that a loop control stopped the iteration
+    # in. Shared by the workers of one pipeline as a signal to cut the work
+    # short: once set, the batcher stops producing and batches past the
+    # cutoff are no longer processed. The joiners do not depend on it; they
+    # terminate on the stop markers the batches themselves carry.
+    my class StopStatus {
+#?if moar
+        has atomicint $!cutoff = -1;
+#?endif
+#?if !moar
+        has int $!cutoff = -1;
+#?endif
+
+        method cutoff() { $!cutoff }
+
+        method stop(int $sequence --> Nil) {
+#?if moar
+            loop {
+                my int $current = $!cutoff;
+                last if $current >= 0 && $current <= $sequence;
+                last if nqp::cas_i($!cutoff, $current, $sequence) == $current;
+            }
+#?endif
+#?if !moar
+            $!cutoff = $sequence if $!cutoff < 0 || $sequence < $!cutoff;
+#?endif
+        }
+    }
+
     method start(Rakudo::Internals::HyperJoiner $stage, HyperConfiguration $config) {
         # Create channel that the last non-join operation in the pipeline will
         # put its results into, and start a worker to handle the channel.
@@ -12,6 +41,10 @@ my class Rakudo::Internals::HyperPipeline {
         # and set join stage to send on it when batch-used is called.
         my $ready-channel = Channel.new;
         $stage.SET-BATCH-USED-CHANNEL($ready-channel);
+
+        # Shared by the stages of this pipeline that react to a loop
+        # control stopping the iteration early.
+        my $stop = StopStatus.new;
 
         # Go through the rest of the stages.
         my $cur-stage = $stage.source;
@@ -28,10 +61,10 @@ my class Rakudo::Internals::HyperPipeline {
                         die "A HyperBatcher may only be at the pipeline start";
                     }
                     $cur-dest-channel = self!maybe-processor-workers:
-                        [@processors], $cur-dest-channel, $config.degree;
+                        [@processors], $cur-dest-channel, $config.degree, $stop;
                     @processors = ();
                     self!batch-worker($cur-stage, $cur-dest-channel, $ready-channel,
-                        $config.batch);
+                        $config.batch, $stop);
                 }
                 default {
                     die "Unrecognized hyper pipeline stage " ~ .^name();
@@ -45,7 +78,7 @@ my class Rakudo::Internals::HyperPipeline {
     }
 
     method !batch-worker(Rakudo::Internals::HyperBatcher $stage, Channel $dest-channel,
-                         Channel $ready-channel, int $size) {
+                         Channel $ready-channel, int $size, StopStatus $stop) {
         start {
             my $AWAITER := $*AWAITER;
             loop {
@@ -55,6 +88,7 @@ my class Rakudo::Internals::HyperPipeline {
                     }
                 }
                 $AWAITER.await($ready-channel);
+                last if $stop.cutoff >= 0;
                 my $batch := $stage.produce-batch($size);
                 $dest-channel.send($batch);
                 last if $batch.last;
@@ -62,7 +96,8 @@ my class Rakudo::Internals::HyperPipeline {
         }
     }
 
-    method !maybe-processor-workers(@processors, Channel $dest-channel, Int:D $degree) {
+    method !maybe-processor-workers(@processors, Channel $dest-channel, Int:D $degree,
+                                    StopStatus $stop) {
         return $dest-channel unless @processors;
         my $source-channel := Channel.new;
         for ^$degree {
@@ -78,8 +113,17 @@ my class Rakudo::Internals::HyperPipeline {
                 my $AWAITER := $*AWAITER;
                 loop {
                     my $batch := $AWAITER.await($source-channel);
-                    for @processors {
-                        .process-batch($batch);
+                    my int $cutoff = $stop.cutoff;
+                    if $cutoff >= 0 && $batch.sequence-number > $cutoff {
+                        # The iteration already stopped in an earlier batch;
+                        # this one can contribute nothing.
+                        $batch.replace-with(nqp::create(IterationBuffer));
+                    }
+                    else {
+                        for @processors {
+                            .process-batch($batch);
+                        }
+                        $stop.stop($batch.sequence-number) if $batch.stopped;
                     }
                     $dest-channel.send($batch);
                 }

--- a/src/core.c/Rakudo/Internals/HyperRaceSharedImpl.rakumod
+++ b/src/core.c/Rakudo/Internals/HyperRaceSharedImpl.rakumod
@@ -5,32 +5,55 @@ class Rakudo::Internals::HyperRaceSharedImpl {
 
         method process-batch(Rakudo::Internals::HyperWorkBatch $batch --> Nil) {
             my $items := $batch.items;
-            my $elems := nqp::elems($items);
+            my int $elems = nqp::elems($items);
             my &matcher := nqp::istype($!matcher, Callable)
               ?? $!matcher.clone
               !! $!matcher;
-            my int $from = -1;
+            my int $from = 0;
             my int $to   = -1;
+            my int $stopped = 0;
+            my $item;
 
             nqp::if(
               nqp::istype(&matcher,Callable)
                 && nqp::not_i(nqp::istype(&matcher,Regex)),
               nqp::while(
-                nqp::islt_i(++$from,$elems),
-                nqp::if(
-                  matcher(my $item := nqp::atpos($items,$from)),
-                  nqp::bindpos($items,++$to,$item)
-                )
+                nqp::islt_i($from,$elems) && nqp::not_i($stopped),
+                nqp::handle(
+                  nqp::stmts(
+                    nqp::if(
+                      matcher(($item := nqp::atpos($items,$from))),
+                      nqp::bindpos($items,++$to,$item)
+                    ),
+                    ($from = nqp::add_i($from,1))
+                  ),
+                  'LABELED', Any,
+                  'NEXT', ($from = nqp::add_i($from,1)),
+                  'REDO', nqp::null,
+                  'LAST', ($stopped = 1)
+                ),
+                :nohandler
               ),
               nqp::while(
-                nqp::islt_i(++$from,$elems),
-                nqp::if(
-                  &matcher.ACCEPTS($item := nqp::atpos($items,$from)),
-                  nqp::bindpos($items,++$to,$item)
-                )
+                nqp::islt_i($from,$elems) && nqp::not_i($stopped),
+                nqp::handle(
+                  nqp::stmts(
+                    nqp::if(
+                      &matcher.ACCEPTS(($item := nqp::atpos($items,$from))),
+                      nqp::bindpos($items,++$to,$item)
+                    ),
+                    ($from = nqp::add_i($from,1))
+                  ),
+                  'LABELED', Any,
+                  'NEXT', ($from = nqp::add_i($from,1)),
+                  'REDO', nqp::null,
+                  'LAST', ($stopped = 1)
+                ),
+                :nohandler
               )
             );
-            nqp::setelems($items,nqp::add_i($to,1))
+            nqp::setelems($items,nqp::add_i($to,1));
+            $batch.mark-stopped if $stopped;
         }
     }
     multi method grep(\hyper, $source, \matcher, %options) {
@@ -50,38 +73,79 @@ class Rakudo::Internals::HyperRaceSharedImpl {
 
     my class Mapper does Rakudo::Internals::HyperProcessor {
         has &!mapper is built;
+        has $!label  is built;
+
+        # Push a control exception's payload, if any, following the same
+        # Slip semantics as the serial map iterators.
+        method !push-control-payload(Mu \result --> Nil) {
+            my $payload := nqp::getpayload(nqp::exception);
+            nqp::unless(
+              nqp::isnull($payload),
+              nqp::if(
+                nqp::istype($payload,Slip),
+                nqp::if(
+                  $payload.DEFINITE,
+                  nqp::unless(
+                    nqp::eqaddr($payload,Empty),
+                    $payload.iterator.push-all(result)
+                  ),
+                  nqp::push(result,$payload)
+                ),
+                nqp::push(result,$payload)
+              )
+            )
+        }
 
         method process-batch(Rakudo::Internals::HyperWorkBatch $batch --> Nil) {
             my $result := nqp::create(IterationBuffer);
             my $items := $batch.items;
             my int $n = $items.elems;
             my &mapper := &!mapper.clone;
-            my int $i = -1;
+            my $label := nqp::decont($!label);
+            my int $i = 0;
+            my int $stopped = 0;
 
             nqp::while(
-              nqp::islt_i(++$i,$n),
-              nqp::if(
-                nqp::istype((my \val = mapper(nqp::atpos($items, $i))),Slip)
-                  && nqp::not_i(nqp::iscont(val)),
-                val.iterator.push-all($result),
-                nqp::push($result,val)
-              )
+              nqp::islt_i($i,$n) && nqp::not_i($stopped),
+              nqp::handle(
+                nqp::stmts(
+                  nqp::if(
+                    nqp::istype((my \val = mapper(nqp::atpos($items, $i))),Slip)
+                      && nqp::not_i(nqp::iscont(val)),
+                    val.iterator.push-all($result),
+                    nqp::push($result,val)
+                  ),
+                  ($i = nqp::add_i($i,1))
+                ),
+                'LABELED', $label,
+                'NEXT', nqp::stmts(
+                  self!push-control-payload($result),
+                  ($i = nqp::add_i($i,1))
+                ),
+                'REDO', nqp::null,
+                'LAST', nqp::stmts(
+                  self!push-control-payload($result),
+                  ($stopped = 1)
+                )
+              ),
+              :nohandler
             );
-            $batch.replace-with($result)
+            $batch.replace-with($result);
+            $batch.mark-stopped if $stopped;
         }
     }
-    multi method map(\hyper, $source, &mapper, %options) {
+    multi method map(\hyper, $source, &mapper, %options, :$label) {
         NYI('Phasers in hyper/race').throw
           if nqp::istype(&mapper,Block) && &mapper.has-phasers;
 
         if %options || &mapper.count > 1 {
             # Fall back to sequential map for cases we can't yet handle
-            self.rehyper(hyper, hyper.Any::map(&mapper, |%options))
+            self.rehyper(hyper, hyper.Any::map(&mapper, |%options, :$label))
         }
         else {
             hyper.bless:
                 configuration => hyper.configuration,
-                work-stage-head => Mapper.new(:$source, :&mapper)
+                work-stage-head => Mapper.new(:$source, :&mapper, :$label)
         }
     }
     multi method invert(\hyper, $source) {
@@ -93,15 +157,33 @@ class Rakudo::Internals::HyperRaceSharedImpl {
     my class Sinker does Rakudo::Internals::HyperJoiner {
         has Promise $.complete .= new;
 
-        has int $!last-target = -1;
-        has int $!batches-seen = 0;
+        has int $!target = -1;
+        has int $!next-unseen = 0;
+        has int $!done = 0;
+        has $!seen;
+
+        submethod TWEAK() {
+            $!seen := nqp::list_i;
+        }
+
+        # Completes once every batch up to the target sequence number has
+        # been consumed. The target is the batch the batcher marked as last,
+        # or the earliest batch a loop control stopped the iteration in;
+        # batches beyond a stop may still arrive and are of no interest.
         method consume-batch(Rakudo::Internals::HyperWorkBatch $batch --> Nil) {
-            ++$!batches-seen;
             self.batch-used();
-            if $batch.last {
-                $!last-target = $batch.sequence-number;
+            my int $sequence = $batch.sequence-number;
+            if ($batch.last || $batch.stopped)
+                && ($!target < 0 || $sequence < $!target) {
+                $!target = $sequence;
             }
-            if $!last-target >= 0 && $!batches-seen == $!last-target + 1 {
+            nqp::bindpos_i($!seen,$sequence,1);
+            nqp::while(
+              nqp::atpos_i($!seen,$!next-unseen),
+              ++$!next-unseen
+            );
+            if $!target >= 0 && $!next-unseen > $!target && !$!done {
+                $!done = 1;
                 $!complete.keep(True);
             }
         }

--- a/src/core.c/Rakudo/Internals/HyperToIterator.rakumod
+++ b/src/core.c/Rakudo/Internals/HyperToIterator.rakumod
@@ -12,6 +12,7 @@ my role X::HyperRace::Died {
 my class Rakudo::Internals::HyperToIterator does Rakudo::Internals::HyperJoiner does Iterator {
     has int $!seen-last;
     has int $!offset;
+    has int $!stop-cutoff;
     has $!batches;
     has $!waiting;
     has $!current-items;
@@ -21,12 +22,28 @@ my class Rakudo::Internals::HyperToIterator does Rakudo::Internals::HyperJoiner 
         $!batches := Channel.new;
         $!waiting := nqp::list;
         $!current-items := EMPTY_BUFFER;
+        $!stop-cutoff = -1;
     }
 
     method consume-batch(Rakudo::Internals::HyperWorkBatch $batch --> Nil) {
+        my int $sequence = $batch.sequence-number;
+
+        if $batch.stopped                      # loop control ended iteration
+            && ($!stop-cutoff < 0 || $sequence < $!stop-cutoff) {
+            $!stop-cutoff = $sequence;
+            my int $keep = $!stop-cutoff + 1 - $!offset;
+            nqp::setelems($!waiting,$keep)     # discard queued later batches
+              if $keep >= 0 && nqp::isgt_i(nqp::elems($!waiting),$keep);
+        }
+
+        if $!stop-cutoff >= 0 && $sequence > $!stop-cutoff {
+            self.batch-used();                 # dropped, but keep the
+            return;                            # backpressure flowing
+        }
+
         nqp::bindpos(                          # store the batch at its place
           $!waiting,
-          nqp::sub_i($batch.sequence-number,$!offset),
+          nqp::sub_i($sequence,$!offset),
           $batch
         );
 
@@ -39,7 +56,8 @@ my class Rakudo::Internals::HyperToIterator does Rakudo::Internals::HyperJoiner 
         );
 
         $!seen-last = 1                        # set flag we've seen last one
-          if $batch.last;
+          if $batch.last
+          || ($!stop-cutoff >= 0 && $!offset > $!stop-cutoff);
         $!batches.close                        # close channel if we're done
           if $!seen-last && nqp::not_i(nqp::elems($!waiting));
     }

--- a/src/core.c/Rakudo/Internals/HyperWorkBatch.rakumod
+++ b/src/core.c/Rakudo/Internals/HyperWorkBatch.rakumod
@@ -13,6 +13,11 @@ my class Rakudo::Internals::HyperWorkBatch does Iterable {
     has Bool $.first;
     has Bool $.last;
 
+    # Set when a loop control ended the iteration inside this batch. The
+    # batch's items are truncated at the point of the control, and no batch
+    # with a higher sequence number may contribute values.
+    has int $!stopped;
+
     method !SET-SELF(\sequence-number, \items, \first, \last) {
         $!sequence-number = sequence-number;
         $!items := items;
@@ -50,6 +55,9 @@ my class Rakudo::Internals::HyperWorkBatch does Iterable {
     method replace-with(IterationBuffer $ib --> Nil) {
         $!items := $ib;
     }
+
+    method stopped() { nqp::hllbool($!stopped) }
+    method mark-stopped(--> Nil) { $!stopped = 1 }
 }
 
 # vim: expandtab shiftwidth=4

--- a/src/core.c/Rakudo/Internals/RaceToIterator.rakumod
+++ b/src/core.c/Rakudo/Internals/RaceToIterator.rakumod
@@ -1,15 +1,35 @@
 my class Rakudo::Internals::RaceToIterator does Rakudo::Internals::HyperJoiner does Iterator {
     has Channel $.batches .= new;
 
-    has int $!last-target = -1;
-    has int $!batches-seen = 0;
+    has int $!target = -1;
+    has int $!next-unseen = 0;
+    has $!seen;
+
+    submethod TWEAK() {
+        $!seen := nqp::list_i;
+    }
+
+    # Closes the batches channel once every batch up to the target sequence
+    # number has been consumed. The target is the batch the batcher marked
+    # as last, or the earliest batch a loop control stopped the iteration
+    # in; batches beyond a stop are dropped.
     method consume-batch(Rakudo::Internals::HyperWorkBatch $batch --> Nil) {
-        $!batches.send($batch);
-        ++$!batches-seen;
-        if $batch.last {
-            $!last-target = $batch.sequence-number;
+        my int $sequence = $batch.sequence-number;
+        if ($batch.last || $batch.stopped)
+            && ($!target < 0 || $sequence < $!target) {
+            $!target = $sequence;
         }
-        if $!last-target >= 0 && $!batches-seen == $!last-target + 1 {
+        if $!target >= 0 && $sequence > $!target {
+            self.batch-used();                 # dropped, but keep the
+            return;                            # backpressure flowing
+        }
+        $!batches.send($batch);
+        nqp::bindpos_i($!seen,$sequence,1);
+        nqp::while(
+          nqp::atpos_i($!seen,$!next-unseen),
+          ++$!next-unseen
+        );
+        if $!target >= 0 && $!next-unseen > $!target {
             $!batches.close;
         }
     }

--- a/t/02-rakudo/hyper-race-loop-control.t
+++ b/t/02-rakudo/hyper-race-loop-control.t
@@ -1,0 +1,117 @@
+use Test;
+
+plan 21;
+
+# Loop controls inside hyper/race iteration stop, skip, or repeat the
+# parallel iteration instead of being silently discarded, and a label on
+# such a loop neither disables parallelization nor breaks compilation.
+# https://github.com/rakudo/rakudo/issues/2208
+
+# A hyper map is ordered, so ending the iteration with `last` produces
+# exactly the values before the control was thrown: earlier batches in
+# full, the stopping batch truncated, later batches discarded.
+is-deeply (1..1000).hyper(:batch(10), :degree(4)).map({ last if $_ == 25; $_ }).List,
+    (1..24).List,
+    'last in a hyper map keeps exactly the values before the control';
+
+is-deeply (1..100).hyper(:batch(10), :degree(4)).map({ last if $_ == 99; $_ }).List,
+    (1..98).List,
+    'last in the final batch of a hyper map truncates that batch';
+
+is-deeply (1..20).hyper(:batch(5), :degree(4)).map({ next if $_ %% 2; $_ }).List,
+    (1, 3, 5, 7, 9, 11, 13, 15, 17, 19),
+    'next in a hyper map skips the value';
+
+{
+    my atomicint $redone;
+    is-deeply (1..20).hyper(:batch(5), :degree(4)).map({
+        if $_ == 7 && $redone == 0 {
+            $redone⚛++;
+            redo;
+        }
+        $_
+    }).List, (1..20).List, 'redo in a hyper map reruns the block for the value';
+    is $redone, 1, 'the redone block ran exactly one extra time';
+}
+
+{
+    my atomicint $ran;
+    hyper for 1..100_000 { $ran⚛++; last if $_ == 5 }
+    ok $ran < 100_000, 'last ends a sunk hyper for loop early';
+}
+
+{
+    my atomicint $ran;
+    race for 1..100_000 { $ran⚛++; last if $_ == 5 }
+    ok $ran < 100_000, 'last ends a sunk race for loop early';
+}
+
+{
+    my atomicint $ran;
+    FOO: hyper for 1..100_000 { $ran⚛++; last FOO if $_ == 5 }
+    ok $ran < 100_000, 'a labeled last ends a sunk hyper for loop early';
+}
+
+{
+    my atomicint $ran;
+    lives-ok { FOO: hyper for 1..100 { $ran⚛++; next FOO } },
+        'a labeled next in a hyper for loop compiles and runs';
+    is $ran, 100, 'the labeled next ran the body for every value';
+}
+
+{
+    my atomicint $ran;
+    hyper for 1..1000 {
+        for 1..3 { last }
+        $ran⚛++;
+    }
+    is $ran, 1000, 'last in a nested serial loop does not end the hyper loop';
+}
+
+{
+    my @result = (1..10000).race(:batch(64), :degree(4)).map({ last if $_ == 100; $_ });
+    ok @result.elems < 10000, 'last in a race map ends the iteration early';
+    ok (1..99).Set (<=) @result.Set,
+        'a race map stopped by last still emits every value before the last';
+}
+
+# A grep matcher block supports the same loop controls as a serial grep:
+# next excludes the value, last keeps the matches before the control and
+# ends the iteration, redo re-evaluates the value.
+is-deeply (1..100).hyper(:batch(10), :degree(4)).grep({ last if $_ == 11; $_ %% 2 }).List,
+    (2, 4, 6, 8, 10),
+    'last in a hyper grep keeps exactly the matches before the control';
+
+is-deeply (1..20).hyper(:batch(5), :degree(4)).grep({ next if $_ == 4; $_ %% 2 }).List,
+    (2, 6, 8, 10, 12, 14, 16, 18, 20),
+    'next in a hyper grep excludes the value';
+
+{
+    my atomicint $redone;
+    is-deeply (1..20).hyper(:batch(5), :degree(4)).grep({
+        if $_ == 4 && $redone == 0 {
+            $redone⚛++;
+            redo;
+        }
+        $_ %% 2
+    }).List, (2, 4, 6, 8, 10, 12, 14, 16, 18, 20),
+        'redo in a hyper grep re-evaluates the value';
+    is $redone, 1, 'the redone matcher ran exactly one extra time';
+}
+
+ok (1..100_000).race(:batch(64), :degree(4)).grep({ last if $_ == 100; True }).elems < 100_000,
+    'last in a race grep ends the iteration early';
+
+# The machinery invoked without any loop control is unaffected.
+is-deeply (1..10000).hyper(:batch(64), :degree(4)).map(* + 1).List,
+    (2..10001).List,
+    'a hyper map without loop controls produces all values in order';
+
+is (1..10000).race(:batch(64), :degree(4)).map(* + 1).elems, 10000,
+    'a race map without loop controls produces all values';
+
+throws-like { hyper for 1..100 { die "boom" if $_ == 5 } },
+    X::HyperRace::Died,
+    'an exception in a hyper for loop still reaches the caller';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously a `last` inside a hyper or race operation was swallowed by the batch processing loop. It truncated the batch it happened in while the iteration itself carried on, and a labeled loop control escaped its worker thread as a "labeled last without loop construct" error. Passing a loop label to such a map also forced the sequential fallback, so labeling a `hyper for` or `race for` loop quietly disabled its parallelization. Under RakuAST a label on a prefixed for loop additionally ended up on the wrapping expression statement instead of the loop, so `last FOO` died outright.

This teaches the parallel mapper and grepper the same control exception handling their serial counterparts use, including the loop label for the mapper and the control exception payload semantics of both, such as `last 42` in a map and `last True` verdicts in a 6.e grep. A `next` skips the value, a `redo` reruns the block, and a `last` truncates the batch at the control point and marks the iteration stopped. The pipeline reacts to the stop by no longer producing batches and by emptying already produced batches past the stop. The joiners complete once every batch up to the stop has been consumed and drop later in-flight batches.

An ordered hyper map or grep ended by `last` produces exactly the values its serial counterpart would. A race also emits values from batches that were already delivered when the stop arrived, which race semantics permit. An error a worker raises in speculative work after a stop completed the iteration is dropped, as the serial equivalent would never have run that work. An error that arrives before completion surfaces normally.

The RakuAST frontend now attaches a label on a prefixed for loop to the loop itself, matching the plain `FOO: for @a { }` form. The legacy frontend already passed the label into the map call and only needed the runtime side to accept it.

Fixes #2208
