### PR TITLE
RakuAST: compile resolved operator calls as static lookups

### DIFF
--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -745,6 +745,9 @@ class RakuAST::Node {
             self.IMPL-MARK-RANGE-FOR($resolver, $expr);
             self.IMPL-MARK-STATIC-CALL($resolver, $expr);
             self.IMPL-MARK-STATIC-CHAIN($resolver, $expr);
+            self.IMPL-MARK-STATIC-INFIX($resolver, $expr);
+            self.IMPL-MARK-STATIC-PREFIX($resolver, $expr);
+            self.IMPL-MARK-STATIC-POSTFIX($resolver, $expr);
             self.IMPL-MARK-RETURN-DECONT($resolver, $expr);
             self.IMPL-MARK-ARRAY-INIT($resolver, $expr);
             self.IMPL-MARK-CT-DISPATCH($resolver, $expr);
@@ -955,6 +958,47 @@ class RakuAST::Node {
         $infix.IMPL-SET-CHAINSTATIC()
             if self.IMPL-RESOLUTION-BOUND-ONCE($resolver, $infix.resolution,
                 '&infix' ~ $resolver.IMPL-CANONICALIZE-PAIR($infix.operator));
+        Nil
+    }
+
+    # Mark an infix operator whose lexical is bound once for a static
+    # callee lookup at code generation. A chaining one is the chain mark's
+    # business, since it compiles to a chain op instead.
+    method IMPL-MARK-STATIC-INFIX(RakuAST::Resolver $resolver, Mu $expr) {
+        return Nil unless nqp::istype($expr, RakuAST::ApplyInfix);
+        my $infix := $expr.infix;
+        return Nil unless nqp::istype($infix, RakuAST::Infix)
+            && $infix.is-resolved
+            && !$infix.properties.chain;
+        $infix.IMPL-SET-CALLSTATIC()
+            if self.IMPL-RESOLUTION-BOUND-ONCE($resolver, $infix.resolution,
+                '&infix' ~ $resolver.IMPL-CANONICALIZE-PAIR($infix.operator));
+        Nil
+    }
+
+    # Mark a prefix operator whose lexical is bound once for a static callee
+    # lookup at code generation.
+    method IMPL-MARK-STATIC-PREFIX(RakuAST::Resolver $resolver, Mu $expr) {
+        return Nil unless nqp::istype($expr, RakuAST::ApplyPrefix);
+        my $prefix := $expr.prefix;
+        return Nil unless nqp::istype($prefix, RakuAST::Prefix)
+            && $prefix.is-resolved;
+        $prefix.IMPL-SET-CALLSTATIC()
+            if self.IMPL-RESOLUTION-BOUND-ONCE($resolver, $prefix.resolution,
+                '&prefix' ~ $resolver.IMPL-CANONICALIZE-PAIR($prefix.operator));
+        Nil
+    }
+
+    # Mark a postfix operator whose lexical is bound once for a static callee
+    # lookup at code generation.
+    method IMPL-MARK-STATIC-POSTFIX(RakuAST::Resolver $resolver, Mu $expr) {
+        return Nil unless nqp::istype($expr, RakuAST::ApplyPostfix);
+        my $postfix := $expr.postfix;
+        return Nil unless nqp::istype($postfix, RakuAST::Postfix)
+            && $postfix.is-resolved;
+        $postfix.IMPL-SET-CALLSTATIC()
+            if self.IMPL-RESOLUTION-BOUND-ONCE($resolver, $postfix.resolution,
+                '&postfix' ~ $resolver.IMPL-CANONICALIZE-PAIR($postfix.operator));
         Nil
     }
 

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -520,6 +520,15 @@ class RakuAST::Infix
         nqp::bindattr_i(self, RakuAST::Infix, '$!chainstatic', 1)
     }
 
+    # Set by the optimize pass when the resolved operator's lexical is bound
+    # once, so an operator call that does not chain compiles its callee
+    # lookup as a static one the VM resolves a single time.
+    has int $!callstatic;
+
+    method IMPL-SET-CALLSTATIC() {
+        nqp::bindattr_i(self, RakuAST::Infix, '$!callstatic', 1)
+    }
+
     # Set by the optimize pass when the operand types decide the dispatch at
     # compile time: the routine, for a multi the chosen candidate, whose
     # inline info, when it has any, is spliced in place of the operator call.
@@ -704,7 +713,7 @@ class RakuAST::Infix
             my $folded := self.IMPL-JUNCTION-FOLD-QAST($context,
                 self.properties.chain
                     ?? ($!chainstatic ?? 'chainstatic' !! 'chain')
-                    !! 'call',
+                    !! ($!callstatic ?? 'callstatic' !! 'call'),
                 $name, $left-qast, $right-qast,
                 $!junction-fold, $!junction-fold-junction);
             return $folded unless nqp::isnull($folded);
@@ -715,7 +724,7 @@ class RakuAST::Infix
         self.IMPL-SIMPLIFY-REF-ARGS(QAST::Op.new(
             :op(self.properties.chain
                   ?? ($!chainstatic ?? 'chainstatic' !! 'chain')
-                  !! 'call'),
+                  !! ($!callstatic ?? 'callstatic' !! 'call')),
             :$name,
             $left-qast,
             $right-qast
@@ -3078,6 +3087,15 @@ class RakuAST::Prefix
         True
     }
 
+    # Set by the optimize pass when the resolved operator's lexical is bound
+    # once, so the callee lookup can be compiled as a static one the VM
+    # resolves a single time.
+    has int $!callstatic;
+
+    method IMPL-SET-CALLSTATIC() {
+        nqp::bindattr_i(self, RakuAST::Prefix, '$!callstatic', 1)
+    }
+
     method IMPL-PREFIX-QAST(RakuAST::IMPL::QASTContext $context, Mu $operand-qast) {
         my $name;
         if self.is-resolved || !$*COMPILING_CORE_SETTING {
@@ -3086,7 +3104,7 @@ class RakuAST::Prefix
         else {
             $name := '&prefix' ~ RakuAST::Resolver.IMPL-CANONICALIZE-PAIR($!operator);
         }
-        my $op := QAST::Op.new( :op('call'), :$name, $operand-qast );
+        my $op := QAST::Op.new( :op($!callstatic ?? 'callstatic' !! 'call'), :$name, $operand-qast );
         self.IMPL-ADD-COLONPAIRS-TO-OP($context, $op);
         self.IMPL-SIMPLIFY-REF-ARGS($op)
     }
@@ -3396,12 +3414,22 @@ class RakuAST::Postfix
         True
     }
 
+    # Set by the optimize pass when the resolved operator's lexical is bound
+    # once, so the callee lookup can be compiled as a static one the VM
+    # resolves a single time.
+    has int $!callstatic;
+
+    method IMPL-SET-CALLSTATIC() {
+        nqp::bindattr_i(self, RakuAST::Postfix, '$!callstatic', 1)
+    }
+
     method IMPL-POSTFIX-QAST(
       RakuAST::IMPL::QASTContext $context,
                               Mu $operand-qast
     ) {
         my $op := QAST::Op.new(
-          :op('call'), :name(self.resolution.lexical-name), $operand-qast
+          :op($!callstatic ?? 'callstatic' !! 'call'),
+          :name(self.resolution.lexical-name), $operand-qast
         );
         self.IMPL-ADD-COLONPAIRS-TO-OP($context, $op);
         self.IMPL-SIMPLIFY-REF-ARGS($op)

--- a/t/08-performance/18-rakuast-callstatic.t
+++ b/t/08-performance/18-rakuast-callstatic.t
@@ -3,7 +3,7 @@ use Test::Helpers::QAST;
 use Test;
 use QAST:from<NQP>;
 use nqp;
-plan 28;
+plan 40;
 
 # A call to a named setting routine compiles its callee lookup as a static
 # one, which the VM may resolve a single time. So does a call to a routine
@@ -86,6 +86,45 @@ qast-is '{ my multi sub infix:<==>(\a, \b) { return 3 }; my $x = "a"; my $y = "b
     not qast-op-named(v, 'chainstatic', '&infix:<==>')
 }, 'a comparison against a nested user operator keeps the plain lookup';
 
+qast-is 'my $x = 1; my $y = $x * 2', -> \v {
+        qast-op-named(v, 'callstatic', '&infix:<*>')
+    and not qast-op-named(v, 'call', '&infix:<*>')
+}, 'a setting infix that does not chain compiles to a static callee lookup';
+
+qast-is 'my $x = 5; my $y = -$x', -> \v {
+        qast-op-named(v, 'callstatic', '&prefix:<->')
+    and not qast-op-named(v, 'call', '&prefix:<->')
+}, 'a setting prefix compiles to a static callee lookup';
+
+qast-is 'my $x = 1; my $y = $x++', -> \v {
+        qast-op-named(v, 'callstatic', '&postfix:<++>')
+    and not qast-op-named(v, 'call', '&postfix:<++>')
+}, 'a setting postfix compiles to a static callee lookup';
+
+qast-is '{ my sub prefix:<neg>(\a) { return 0 }; my $x = 1; neg $x }', :full, -> \v {
+    not qast-op-named(v, 'callstatic', '&prefix:<neg>')
+}, 'a nested user prefix keeps the plain callee lookup';
+
+qast-is '{ my sub infix:<mul>(\a, \b) { return 3 }; my $x = 1; my $y = 2; $x mul $y }', :full, -> \v {
+    not qast-op-named(v, 'callstatic', '&infix:<mul>')
+}, 'a nested user infix keeps the plain callee lookup';
+
+qast-is 'my &prefix:<-> = sub ($a) { 99 }; my $x = 5; my $y = -$x', -> \v {
+    not qast-op-named(v, 'callstatic', '&prefix:<->')
+}, 'a prefix bound through an operator variable keeps the plain callee lookup';
+
+# The soft pragma promises late rebinding, so this frontend declines
+# the mark under it, while the legacy optimizer still pins a setting
+# callee that is not itself soft.
+if nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' {
+    qast-is 'use soft; my $x = 5; my $y = -$x', -> \v {
+        not qast-op-named(v, 'callstatic', '&prefix:<->')
+    }, 'a setting prefix under the soft pragma keeps the plain callee lookup';
+}
+else {
+    skip 'the soft shape is specific to the RakuAST frontend', 1;
+}
+
 # These observe that statically looked up callees still behave.
 {
     my $s = "HI";
@@ -139,6 +178,19 @@ sub rt-mid { $rt-mid-calls++; 2 }
 ok 1 < rt-mid() < 3, 'a chained comparison with a call in the middle holds';
 is $rt-mid-calls, 1, 'the middle operand of a chained comparison runs once';
 ok ?(any(1, 2) < 3), 'a Junction autothreads through a static comparison';
+
+# Operator calls still behave through static callee lookups.
+my $neg-me = 5;
+is -$neg-me, -5, 'a setting prefix called through a static lookup returns its value';
+my $step-me = 5;
+my $stepped = $step-me++;
+is $stepped, 5, 'a postfix increment through a static lookup yields the original value';
+is $step-me, 6, 'a postfix increment through a static lookup steps the variable';
+sub infix:<rt-mul>($a, $b) { $a * $b }
+is 2 rt-mul 3, 6, 'a user infix declared in the outermost scope computes through a static lookup';
+sub prefix:<rt-neg>($a) { 0 - $a }
+&prefix:<rt-neg>.wrap(-> $a { 999 });
+is rt-neg 5, 999, 'a wrapped prefix in the outermost scope runs its wrapper through a static lookup';
 
 # The fatalize pass recognizes a static callee lookup both as a call whose
 # Failure it promotes and as a boolifying consumer that disarms its argument.


### PR DESCRIPTION
Previously only a named sub call and a chaining comparison compiled their callee lookup as a static one, while a resolved prefix, infix, or postfix operator call looked up its callee lexical by name again on every execution. This marks operator calls the same way, gated on the same check that the resolution is bound once, so the VM resolves the callee a single time. A loop spending its time in operator calls runs about a third faster, matching the legacy frontend, whose optimizer makes every resolved call a static one.