### PR TITLE
RakuAST: elide unused implicits from methods and generated accessors

### DIFF
--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -3600,10 +3600,41 @@ class RakuAST::Method::AttributeAccessor
 
     method declarator() { 'submethod' }
 
+    # The body is fully synthetic: nothing in it can reach the special
+    # variables, so only self is declared.
+    method PRODUCE-IMPLICIT-DECLARATIONS() {
+        [ RakuAST::VarDeclaration::Implicit::Self.new() ]
+    }
+
     method PRODUCE-META-OBJECT(:$resolver, :$context) {
         my $meta := nqp::findmethod(RakuAST::Routine, 'PRODUCE-META-OBJECT')(self);
         $meta.set_rw if $!rw;
         $meta
+    }
+
+    # The block takes the shape the legacy frontend installs: the
+    # invocant as a raw local parameter and a discarded named slurpy,
+    # with no binder run. A Raku level caller passes hllized values
+    # already, and an nqp level caller gets exactly what the legacy
+    # frontend has always exposed. A type object invocant reaches the
+    # body, where the attribute access dies. The lexical %_ stays
+    # declared without per call setup, as the legacy frontend leaves
+    # it.
+    method IMPL-QAST-FORM-BLOCK(RakuAST::IMPL::QASTContext $context, str :$blocktype,
+            RakuAST::Expression :$expression) {
+        my $block := QAST::Block.new(
+            :name(self.name.canonicalize), :blocktype('declaration_static'),
+            QAST::Stmts.new(
+                QAST::Var.new( :decl<param>, :scope<local>, :name('self') ),
+                QAST::Var.new( :decl<param>, :scope<local>, :name('_'),
+                    :slurpy, :named ),
+                QAST::Var.new( :decl<static>, :scope<lexical>, :name('%_') )
+            ),
+            self.IMPL-COMPILE-BODY($context)
+        );
+        $block.arity(1);
+        $block.annotate('count', 1);
+        $block
     }
 
     method IMPL-COMPILE-BODY(RakuAST::IMPL::QASTContext $context) {
@@ -3617,7 +3648,7 @@ class RakuAST::Method::AttributeAccessor
             :scope($native && $!rw ?? 'attributeref' !! 'attribute'),
             :name($!attr-name),
             :returns($!type),
-            QAST::Var.new( :scope<lexical>, :name('self') ),
+            QAST::Op.new( :op<decont>, QAST::Var.new( :scope<local>, :name('self') ) ),
             QAST::WVal.new( :value($!package-type) ),
         );
 

--- a/src/Raku/ast/package.rakumod
+++ b/src/Raku/ast/package.rakumod
@@ -974,6 +974,10 @@ class RakuAST::CompilerServices
     has RakuAST::IMPL::QASTContext $!context;
     has QAST::Stmts $!qast;
 
+    # The one signature the package's accessors share, made from the
+    # first accessor's own.
+    has Mu $!acc-sig;
+
     method new(RakuAST::Package $package, RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
         my $obj := nqp::create(self);
         nqp::bindattr($obj, RakuAST::CompilerServices, '$!package', $package);
@@ -999,7 +1003,29 @@ class RakuAST::CompilerServices
         $!resolver.pop-scope();
         $!resolver.pop-scope();
         $!qast.push: $accessor.IMPL-QAST-BLOCK($!context);
-        $accessor.meta-object
+        my $code := $accessor.meta-object;
+
+        # The package's accessors share one signature, with a definite
+        # invocant. Composition normalizes every accessor's package to
+        # the composing type, so one signature fits them all. The block
+        # binds the invocant raw: the definite type informs
+        # introspection and derivation, not a run time check, and a
+        # type object invocant reaches the body, where the attribute
+        # access dies. Mirrors what the legacy frontend installs.
+        if nqp::isconcrete($!acc-sig) {
+            nqp::bindattr($code, Code, '$!signature', $!acc-sig);
+        }
+        else {
+            my $sig := nqp::getattr($code, Code, '$!signature');
+            my $definite := Perl6::Metamodel::DefiniteHOW.new_type(
+                :base_type($package_type), :definite(1));
+            $!context.ensure-sc($definite);
+            nqp::bindattr(
+                nqp::atpos(nqp::getattr($sig, Signature, '@!params'), 0),
+                Parameter, '$!type', $definite);
+            nqp::bindattr(self, RakuAST::CompilerServices, '$!acc-sig', $sig);
+        }
+        $code
     }
 
     method IMPL-ADD-QAST(QAST::Node $target) {
@@ -1021,6 +1047,7 @@ class RakuAST::CompilerServices
         nqp::bindattr(self, RakuAST::CompilerServices, '$!resolver', RakuAST::Resolver);
         nqp::bindattr(self, RakuAST::CompilerServices, '$!context', RakuAST::IMPL::QASTContext);
         nqp::bindattr(self, RakuAST::CompilerServices, '$!qast', QAST::Stmts);
+        nqp::bindattr(self, RakuAST::CompilerServices, '$!acc-sig', Mu);
         Nil
     }
 }

--- a/src/Raku/ast/var-lowering.rakumod
+++ b/src/Raku/ast/var-lowering.rakumod
@@ -544,6 +544,15 @@ class RakuAST::IMPL::VarLowering {
             elsif nqp::istype($decl, RakuAST::VarDeclaration::Implicit::Cursor) {
                 $decl.IMPL-SET-UNUSED() if !$used && !$poisoned;
             }
+            elsif nqp::istype($decl, RakuAST::VarDeclaration::Implicit::Routine) {
+                # The &?BLOCK subclass must keep its declaration: its
+                # reader always reads it by name and is not a Lookup,
+                # so no use of it can register here.
+                $decl.IMPL-SET-UNUSED()
+                    if !$used && !$poisoned
+                    && !nqp::istype($decl,
+                        RakuAST::VarDeclaration::Implicit::CurrentBlock);
+            }
         }
         Nil
     }

--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -2980,6 +2980,7 @@ class RakuAST::VarDeclaration::Implicit::Routine
     }
 
     method IMPL-QAST-DECL(RakuAST::IMPL::QASTContext $context) {
+        return QAST::Op.new( :op('null') ) if self.IMPL-UNUSED;
         # We cannot just put the AST node's meta-object into a WVal for this, because
         # we may be running a clone of that object.
         QAST::Op.new:

--- a/t/08-performance/21-rakuast-unused-implicits.t
+++ b/t/08-performance/21-rakuast-unused-implicits.t
@@ -3,7 +3,7 @@ use Test::Helpers::QAST;
 use Test;
 use QAST:from<NQP>;
 use nqp;
-plan 15;
+plan 40;
 
 # A routine declares fresh $_ and $¢ containers it usually never uses,
 # and a block binds its topic from the enclosing one. When nothing in
@@ -115,4 +115,209 @@ else {
     }
     is C.new(1, 2).handles.join(','), '1,2',
         'flattening %_ into another call still works';
+}
+
+# A method binds &?ROUTINE to its own code object only when something
+# uses it, which saves a getcodeobj bind per call.
+
+sub qast-op-present (Mu $qast, Str:D $op --> Bool:D) {
+    if nqp::istype($qast, QAST::Op) && $qast.op eq $op {
+        return True;
+    }
+    if qast-descendable $qast {
+        for $qast.list {
+            qast-op-present $_, $op and return True;
+        }
+    }
+    False
+}
+
+qast-is 'my class C { method m() { 42 } }; say C.m', :full, -> \v {
+    not qast-op-present(v, 'getcodeobj')
+}, 'a method that never touches &?ROUTINE does not bind it';
+
+qast-is 'my class C { method m() { &?ROUTINE.name } }; say C.m', :full, -> \v {
+    qast-op-present(v, 'getcodeobj')
+}, 'a method using &?ROUTINE keeps its binding';
+
+{
+    my class C { method m() { &?ROUTINE.name } }
+    is C.m, 'm', '&?ROUTINE in a method names the method';
+}
+
+{
+    sub named-r() { &?ROUTINE.name }
+    is named-r(), 'named-r', '&?ROUTINE in a sub names the sub';
+}
+
+{
+    my class C { method m() { my $c = { &?ROUTINE.name }; $c() } }
+    is C.new.m, 'm', '&?ROUTINE reached from a nested block names the enclosing method';
+}
+
+# samewith is on the analyzer's poison list, so the routine binding
+# stays for it.
+{
+    my class C { multi method m(Int $x) { $x ?? samewith(0) !! 'base' } }
+    is C.new.m(5), 'base', 'samewith in a method redispatches through its kept binding';
+}
+
+if nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' {
+    {
+        my class C { method m() { EVAL q[&?ROUTINE.name] } }
+        is C.new.m, 'm', 'EVAL reaching &?ROUTINE by name keeps the binding';
+    }
+}
+else {
+    skip 'legacy never installs &?ROUTINE for an EVAL-only use', 1;
+}
+
+# A generated accessor's body is fully synthetic, so it declares no
+# special variables at all, saving their container clones per call.
+
+sub find-block (Mu $qast, Str:D $name) {
+    if nqp::istype($qast, QAST::Block) && $qast.name eq $name {
+        return $qast;
+    }
+    if qast-descendable $qast {
+        for $qast.list {
+            my $found := find-block($_, $name);
+            return $found if nqp::isconcrete($found);
+        }
+    }
+    Mu
+}
+
+if nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' {
+    qast-is 'my class C { has $.acc }; say C.new(acc => 1).acc', :full, -> \v {
+        my $block = find-block(v, 'acc');
+        nqp::isconcrete($block)
+        and not qast-var-decl($block, '$/', 'contvar')
+        and not qast-var-decl($block, '$!', 'contvar')
+        and not qast-var-decl($block, '$_', 'contvar')
+        and not qast-var-decl($block, '$¢', 'contvar')
+    }, 'a generated accessor declares no special variable containers';
+}
+else {
+    skip 'the accessor shape is specific to the RakuAST frontend', 1;
+}
+
+{
+    my class C { has $.acc = 5 }
+    is C.new.acc(:stray), 5, 'an accessor still absorbs stray named arguments';
+}
+
+{
+    my class C { has int $.n is rw }
+    my $o = C.new;
+    $o.n = 7;
+    is $o.n, 7, 'a native rw accessor still writes and reads through its reference';
+}
+
+{
+    my class C { has $.s is rw }
+    my $o = C.new;
+    $o.s = 'set';
+    is $o.s, 'set', 'a scalar rw accessor still writes and reads its container';
+}
+
+{
+    my role R { has $.r = 'role-attr' }
+    my class C does R { }
+    is C.new.r, 'role-attr', 'an accessor composed from a role still reads its attribute';
+}
+
+# A generated accessor binds its invocant as a raw local parameter and
+# discards stray nameds through a local slurpy, with no binder run.
+
+if nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' {
+    qast-is 'my class C { has $.acc2 }; say C.new(acc2 => 1).acc2', :full, -> \v {
+        my $block = find-block(v, 'acc2');
+        nqp::isconcrete($block)
+        and qast-var-decl($block, 'self', 'param')
+        and not qast-var-decl($block, 'self', 'var')
+    }, 'a generated accessor takes its invocant as a raw parameter';
+}
+else {
+    skip 'the accessor block shape is specific to the RakuAST frontend', 1;
+}
+
+# The package's accessors share one signature with a definite invocant.
+# The legacy frontend fills its shared parameter template once, so the
+# invocant name there is whichever package composed first, and only
+# this frontend names the right package.
+
+{
+    my class Shared { has $.one; has $.two }
+    my class SharedSub is Shared { }
+    if nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' {
+        is Shared.^find_method('one').signature.raku, ':(Shared:D $:: *%_)',
+            'a generated accessor signature names its own package with a definite invocant';
+        is Shared.^find_method('one').cando(\(SharedSub.new)).elems, 1,
+            'a subclass instance fits the shared accessor signature';
+    }
+    else {
+        skip 'the legacy invocant name leaks from the first composed package', 2;
+    }
+    ok Shared.^find_method('one').signature =:= Shared.^find_method('two').signature,
+        'accessors of one package share one signature';
+}
+
+{
+    my class TO { has $.v = 3 }
+    dies-ok { TO.v }, 'an accessor invoked on the type object still dies';
+    my $m = TO.^find_method('v');
+    is $m(TO.new), 3, 'an accessor found through the MOP still invokes';
+    dies-ok { $m(TO.new, 42) }, 'an accessor rejects an extra positional argument';
+}
+
+{
+    my class Deep { has $.d = 5 }
+    my class Deeper is Deep { method d() { callsame() + 1 } }
+    is Deeper.new.d, 6, 'callsame from an overriding method reaches the accessor';
+}
+
+{
+    my class Wrapped { has $.w = 2 }
+    my $m = Wrapped.^find_method('w');
+    my $h = $m.wrap(sub ($self) { 10 + callsame() });
+    is Wrapped.new.w, 12, 'a wrapped accessor runs its wrapper around the raw block';
+    $m.unwrap($h);
+    is Wrapped.new.w, 2, 'an unwrapped accessor reads directly again';
+}
+
+{
+    my class Mixed { has $.m = 9 }
+    my $obj = Mixed.new but role Extra { method extra() { 'x' } };
+    is $obj.m, 9, 'an accessor still reads through a mixin instance';
+}
+
+# The shared signature and its definite invocant type survive the
+# precompilation store.
+
+{
+    my $dir = $*TMPDIR.add("rakuast-accessor-sig-$*PID");
+    $dir.mkdir;
+    $dir.add('AccessorSigTest.rakumod').spurt(q:to/MODULE/);
+        unit module AccessorSigTest;
+        class Point is export { has $.px; has $.py }
+        MODULE
+    my $probe = 'use AccessorSigTest; my $m = Point.^find_method("px"); print $m.signature.raku ~ "|" ~ ($m.signature =:= Point.^find_method("py").signature) ~ "|" ~ Point.new(px => 3).px';
+    my $expected = ':(AccessorSigTest::Point:D $:: *%_)|True|3';
+    for 'compiles', 'loads from the precompilation store' -> $stage {
+        my $proc = run $*EXECUTABLE, '-I', $dir.absolute, '-e', $probe, :out, :err;
+        my $out = $proc.out.slurp(:close);
+        $proc.err.slurp(:close);
+        if nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' {
+            is $out, $expected, "the shared accessor signature $stage";
+        }
+        else {
+            ok $out.ends-with('|True|3'), "the shared accessor signature $stage";
+        }
+    }
+    sub nuke(IO::Path $p) {
+        if $p.d { nuke($_) for $p.dir; $p.rmdir }
+        else { $p.unlink }
+    }
+    nuke($dir);
 }


### PR DESCRIPTION
Previously every method bound &?ROUTINE to its own code object on every call. The implicit declaration list is produced before the body parse can report whether anything uses it, so the binding could not be demand driven there. The lowering pass sees the whole body, so the emission decision moves there instead. An unused &?ROUTINE emits nothing. A use keeps the bind, as does a construct reaching lexicals by name.

A generated accessor also paid for machinery its fully synthetic body cannot use: fresh containers for the special variables, a hash for %_, and the general binder's hllize, decont, and type check of the invocant. Its block now takes the shape the legacy frontend installs, i.e. the invocant as a raw local parameter and a discarded named slurpy, and it declares only self. The package's accessors also share one signature with a definite invocant. The legacy frontend reuses one signature parameter template across the unit and installs its invocant entry only once, so the invocant type there names whichever package composed first. Here the shared signature is made from the package's own first accessor, so introspection names the right type.