### PR TITLE
RakuAST: optimize the compiled regex QAST at code generation

### DIFF
--- a/src/Raku/ast/compunit.rakumod
+++ b/src/Raku/ast/compunit.rakumod
@@ -222,6 +222,7 @@ class RakuAST::CompUnit
         # Diagnostic switch: turns compile-time dispatch decisions off so a
         # suspect inlining can be ruled in or out without a rebuild.
         my $*NO-CT-DISPATCH := nqp::existskey(nqp::getenvhash(), 'RAKUDO_NO_CT_DISPATCH');
+        $!context.set-optimize-regex() if nqp::isconcrete($!context);
         $resolver.push-scope(self);
         $!mainline.IMPL-OPTIMIZE($resolver);
         self.IMPL-OPTIMIZE($resolver);

--- a/src/Raku/ast/impl.rakumod
+++ b/src/Raku/ast/impl.rakumod
@@ -27,6 +27,16 @@ class RakuAST::IMPL::QASTContext {
     has int $.is-nested;
     has Mu $.language-revision; # Same type as in CORE-SETTING-REV
 
+    # Set as the optimize stage begins on this unit, so regex code
+    # generation runs its QAST optimizations over the compiled regex.
+    # Code compiled before the stage runs, as a use at BEGIN time
+    # forces, keeps the plain compilation.
+    has int $.optimize-regex;
+
+    method set-optimize-regex() {
+        nqp::bindattr_i(self, RakuAST::IMPL::QASTContext, '$!optimize-regex', 1)
+    }
+
     # Optional nested Perl6::World; when set, add-code-ref delegates
     # to it so the shared $!num_code_refs counter advances.
     has Mu $.world-bridge;

--- a/src/Raku/ast/regex.rakumod
+++ b/src/Raku/ast/regex.rakumod
@@ -50,7 +50,121 @@ class RakuAST::Regex
         unless $no-scan {
             $wrap-qast.unshift(QAST::Regex.new( :rxtype('scan') ));
         }
+
+        # The QAST regex optimizations run after the NFA is stored, so
+        # LTM sees the original shape. Gated on the optimize stage having
+        # run, like the marks on the AST. The level is pinned: this
+        # frontend's only optimization switch is whether the stage ran.
+        if $context.optimize-regex {
+            self.IMPL-SIMPLIFY-BEFORE-ASSERTIONS($wrap-qast);
+            # The optimizer relocates a stubbed assertion block into
+            # the block passed here. That path needs an assertion argument
+            # held as an inline block, which this frontend never emits:
+            # the argument is a lexical thunk. So a throwaway block serves,
+            # and anything relocated into it after all would vanish from
+            # the compiled output, so that is a loud death instead.
+            my $parking := QAST::Block.new(QAST::Stmts.new);
+            $wrap-qast := QRegex::Optimizer.new.optimize($wrap-qast,
+                $parking, :optimize(2));
+            nqp::die('Regex optimizer relocated a block it should not see')
+                if nqp::elems($parking[0].list);
+        }
         $wrap-qast
+    }
+
+    # A `before` assertion invokes its argument's thunk at match time: a
+    # method call plus a nested cursor per position tried. An argument
+    # that is a single simple check collapses into the corresponding
+    # zerowidth atom instead. The thunk's compiled body rides along on
+    # the argument reference for LTM, so it is at hand here.
+    method IMPL-SIMPLIFY-BEFORE-ASSERTIONS(Mu $node) {
+        my int $i := 0;
+        my int $n := nqp::elems(@($node));
+        while $i < $n {
+            my $visit := $node[$i];
+            if nqp::istype($visit, QAST::Regex) {
+                my $simple := self.IMPL-BEFORE-SIMPLE-ATOM($visit);
+                if nqp::isnull($simple) {
+                    self.IMPL-SIMPLIFY-BEFORE-ASSERTIONS($visit);
+                }
+                else {
+                    $node[$i] := $simple;
+                }
+            }
+            $i := $i + 1;
+        }
+        Nil
+    }
+
+    # The zerowidth atom a `before` assertion reduces to, or null when it
+    # is anything but a simple one. Only a literal, an enumerated
+    # character list, a character class, or a character range qualifies,
+    # each without case or mark insensitivity, whose zerowidth form the
+    # regex engine checks directly. The end of the string decides the
+    # negated cases: every qualifying argument demands a character, so
+    # the thunk fails there and its negation holds there. A negated
+    # argument atom folded into the emitted node would invert that, so
+    # it stays a thunk. A negated assertion of the enumerated character
+    # list reduces directly, since its negated zerowidth op holds at the
+    # end of the string. The class and range ops demand a character even
+    # when negated, so their negated forms pair with an anchor to the end
+    # of the string in a sequential alternation instead. The negated
+    # literal op fails wherever fewer characters remain than the length,
+    # all positions where the negated assertion must hold, so no anchor
+    # pairing preserves it and it stays a thunk.
+    method IMPL-BEFORE-SIMPLE-ATOM(Mu $qast) {
+        return nqp::null()
+            unless $qast.rxtype eq 'subrule'
+            && $qast.subtype eq 'zerowidth'
+            && nqp::elems(@($qast)) == 1
+            && nqp::istype($qast[0], QAST::NodeList)
+            && nqp::elems(@($qast[0])) == 2
+            && nqp::istype($qast[0][0], QAST::SVal)
+            && $qast[0][0].value eq 'before'
+            && nqp::istype($qast[0][1], QAST::Var)
+            && nqp::istype($qast[0][1].ann('orig_qast'), QAST::Regex);
+        my $atom := $qast[0][1].ann('orig_qast');
+        while $atom.rxtype eq 'concat' && nqp::elems(@($atom)) == 1
+            && nqp::istype($atom[0], QAST::Regex) {
+            $atom := $atom[0];
+        }
+        return nqp::null() unless $atom.subtype eq '' && !$atom.negate;
+        my str $rxtype := $atom.rxtype;
+        my int $negate := $qast.negate ?? 1 !! 0;
+        if $rxtype eq 'literal' {
+            return nqp::null() if $negate;
+            QAST::Regex.new( :rxtype<literal>, :subtype<zerowidth>,
+                :node($atom.node), $atom[0] )
+        }
+        elsif $rxtype eq 'enumcharlist' {
+            QAST::Regex.new( :rxtype<enumcharlist>, :subtype<zerowidth>,
+                :node($atom.node), :$negate, $atom[0] )
+        }
+        elsif $rxtype eq 'cclass' {
+            self.IMPL-HOLD-AT-EOS($negate, QAST::Regex.new(
+                :rxtype<cclass>, :subtype<zerowidth>,
+                :node($atom.node), :$negate, :name($atom.name) ))
+        }
+        elsif $rxtype eq 'charrange' {
+            self.IMPL-HOLD-AT-EOS($negate, QAST::Regex.new(
+                :rxtype<charrange>, :subtype<zerowidth>,
+                :node($atom.node), :$negate, $atom[0], $atom[1], $atom[2] ))
+        }
+        else {
+            nqp::null()
+        }
+    }
+
+    # A negated zerowidth atom that demands a character pairs with an
+    # anchor to the end of the string in a sequential alternation, which
+    # holds there as the reduced assertion must. The positive form passes
+    # through: it fails at the end of the string either way.
+    method IMPL-HOLD-AT-EOS(int $negate, Mu $qast) {
+        $negate
+            ?? QAST::Regex.new( :rxtype<altseq>, :node($qast.node),
+                QAST::Regex.new( :rxtype<anchor>, :subtype<eos>, :node($qast.node) ),
+                $qast )
+            !! $qast
     }
 
     method IMPL-REGEX-BLOCK-CALL(RakuAST::IMPL::QASTContext $context, RakuAST::Block $block) {

--- a/t/08-performance/22-rakuast-regex-optimize.t
+++ b/t/08-performance/22-rakuast-regex-optimize.t
@@ -1,0 +1,151 @@
+use lib <t/packages/Test-Helpers>;
+use Test::Helpers::QAST;
+use Test;
+use QAST:from<NQP>;
+use nqp;
+plan 26;
+
+# A `before` assertion whose argument is a single simple check compiles
+# to the corresponding zerowidth atom instead of invoking the argument's
+# thunk, a method call plus a nested cursor, at every position tried. A
+# regex that begins with an anchor to the start of the string drops
+# its scan loop. The legacy optimizer's version of the assertion rewrite needs
+# the argument held as an inline block, a shape the legacy Rakudo
+# frontend rarely produces, so the shape assertions here are this
+# frontend's.
+
+sub find-regex-node (Mu $qast, Str:D :$rxtype!, Str :$subtype, Str :$name --> Bool:D) {
+    if nqp::istype($qast, QAST::Regex)
+        && $qast.rxtype eq $rxtype
+        && (!$subtype.defined || $qast.subtype eq $subtype)
+        && (!$name.defined || $qast.name eq $name) {
+        return True;
+    }
+    if nqp::istype($qast, QAST::Node) {
+        for $qast.list {
+            find-regex-node($_, :$rxtype, :$subtype, :$name) and return True;
+        }
+    }
+    False
+}
+
+if nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' {
+    qast-is 'my $r = rx/ <?before abc> b /', :full, -> \v {
+        find-regex-node(v, :rxtype<literal>, :subtype<zerowidth>)
+        and not find-regex-node(v, :rxtype<subrule>, :name<before>)
+    }, 'a before assertion of a literal compiles to a zerowidth literal';
+
+    qast-is 'my $r = rx/ <?before \d> b /', :full, -> \v {
+        find-regex-node(v, :rxtype<cclass>, :subtype<zerowidth>)
+        and not find-regex-node(v, :rxtype<subrule>, :name<before>)
+    }, 'a before assertion of a character class compiles to a zerowidth class';
+
+    qast-is 'my $r = rx/ <!before <[abc]>> b /', :full, -> \v {
+        find-regex-node(v, :rxtype<enumcharlist>, :subtype<zerowidth>)
+        and not find-regex-node(v, :rxtype<subrule>, :name<before>)
+    }, 'a negated before assertion of a character list compiles to a zerowidth list';
+
+    # The class op demands a character even when negated, so the reduced
+    # form pairs it with an anchor to the end of the string, where the
+    # thunk's failure makes the negated assertion hold.
+    qast-is 'my $r = rx/ <!before \d> b /', :full, -> \v {
+        find-regex-node(v, :rxtype<altseq>)
+        and find-regex-node(v, :rxtype<cclass>, :subtype<zerowidth>)
+        and not find-regex-node(v, :rxtype<subrule>, :name<before>)
+    }, 'a negated before assertion of a character class pairs its class with an anchor';
+
+    qast-is 'my $r = rx/ <?before a+b> b /', :full, -> \v {
+        find-regex-node(v, :rxtype<subrule>, :name<before>)
+    }, 'a before assertion of a quantified argument keeps its thunk';
+
+    qast-is 'my $r = rx/ :i <?before abc> b /', :full, -> \v {
+        find-regex-node(v, :rxtype<subrule>, :name<before>)
+    }, 'a before assertion under the ignorecase modifier keeps its thunk';
+
+    qast-is 'my $r = rx/ a <?after a> /', :full, -> \v {
+        find-regex-node(v, :rxtype<subrule>, :name<after>)
+    }, 'an after assertion keeps its thunk';
+}
+else {
+    skip 'the assertion shapes are specific to the RakuAST frontend', 7;
+}
+
+qast-is 'my $r = rx/^ foo /', :full, -> \v {
+    not find-regex-node(v, :rxtype<scan>)
+}, 'a regex anchored to the beginning of the string drops its scan';
+
+qast-is 'my $r = rx/ foo /', :full, -> \v {
+    find-regex-node(v, :rxtype<scan>)
+}, 'an unanchored regex keeps its scan';
+
+# Behavior stays identical.
+
+{
+    my $m = "abc" ~~ / <?before b> /;
+    is "$m.from()|$m.to()", '1|1', 'a reduced before assertion matches zero width at the right position';
+}
+
+is ("aab" ~~ / a* <?before b> /), 'aa',
+    'backtracking settles where the reduced before assertion holds';
+
+is ("ab" ~~ / . <!before \d> /), 'a',
+    'a reduced negated before assertion holds where its class does not match';
+
+{
+    my token t1 { <?before a> \w+ };
+    my token t2 { <?before b> \w+ };
+    my regex both { <t1> || <t2> };
+    is ("banana" ~~ /<both>/)<both><t2>, 'banana',
+        'longest token matching still sees through a before assertion';
+}
+
+{
+    my $s = "abc";
+    $s ~~ s/ <?before b> /X/;
+    is $s, 'aXbc', 'a substitution at a reduced before assertion inserts at its position';
+}
+
+{
+    my $n = 0;
+    "aaab" ~~ / [ <?before \w> . { $n++ } ]+ /;
+    is $n, 4, 'a quantified group with a reduced before assertion iterates per position';
+}
+
+is ("HELLO world" ~~ / :i <?before hello> \w+ /), 'HELLO',
+    'a before assertion under the ignorecase modifier still matches through its thunk';
+
+is ("9z" ~~ / <?before <[0..9]>> . /), '9',
+    'a before assertion of a character range matches';
+
+# The end of the string is where a negated assertion and a negated
+# argument differ: every simple argument demands a character, so its
+# thunk fails there, and the assertion's negation decides the outcome.
+
+is ("a" ~~ / a <!before \d> /), 'a',
+    'a negated before assertion of a character class holds at the end of the string';
+
+is ("x" ~~ / x <!before <[abc]>> /), 'x',
+    'a reduced negated before assertion of a character list holds at the end of the string';
+
+is ("x" ~~ / x <!before <-[abc]>> /), 'x',
+    'a negated before assertion of a negated character list holds at the end of the string';
+
+is ("x" ~~ / x <!before <[0..9]>> /), 'x',
+    'a negated before assertion of a character range holds at the end of the string';
+
+nok ("x9" ~~ / x <!before <[0..9]>> /).defined,
+    'a negated before assertion of a character range fails on a range character';
+
+nok ("a" ~~ / a <?before <-[b]>> /).defined,
+    'a before assertion of a negated character list fails at the end of the string';
+
+nok ("a" ~~ / a <?before \D> /).defined,
+    'a before assertion of a negated character class fails at the end of the string';
+
+is ("x" ~~ / x <!before yz> /), 'x',
+    'a negated before assertion of a literal holds at the end of the string';
+
+is ("xay" ~~ / x <?after x> a /), 'xa',
+    'an after assertion matches through its thunk';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously the compiled regex QAST went to the backend untouched: the only call into QRegex::Optimizer sits in the legacy optimizer, so every regex kept its scan loop in front of an anchor to the start of the string and kept its nested concats.

The optimizer now runs where the compiled regex is wrapped, after its NFA is stored so longest token matching sees the original shape, and gated on the optimize stage having run, like the marks on the AST.

A before assertion whose argument is a single simple check also reduces to the corresponding zerowidth atom, instead of invoking the argument's thunk, a method call plus a nested cursor, at every position tried. The thunk's compiled body rides along on the argument reference for longest token matching, so it is at hand to classify. The end of the string decides the negated cases: every argument that qualifies demands a character, so the thunk fails there. A negated argument atom folded into the emitted node would invert that, so it stays a thunk, and the class and range ops, which demand a character even when negated, pair with an anchor to the end of the string in a sequential alternation. The legacy optimizer's version of this rewrite needs the argument held as an inline block, a shape its frontend rarely produces, and folds negation in ways that miss these cases at the end of the string.