### PR TITLE
RakuAST: form a setting operator's meta-op at compile time

### DIFF
--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -1399,15 +1399,17 @@ class RakuAST::Node {
                 # decision they took is withdrawn here.
                 my int $linked := 0;
                 if nqp::istype($left, RakuAST::ApplyInfix)
-                    && nqp::istype($left.infix, RakuAST::Infix)
+                    && nqp::istype($left.infix, RakuAST::Infixish)
                     && $left.infix.properties.chain {
-                    $left.infix.IMPL-CLEAR-CT-INLINE-CANDIDATE();
+                    $left.infix.IMPL-CLEAR-CT-INLINE-CANDIDATE()
+                        if nqp::istype($left.infix, RakuAST::Infix);
                     $linked := 1;
                 }
                 if nqp::istype($right, RakuAST::ApplyInfix)
-                    && nqp::istype($right.infix, RakuAST::Infix)
+                    && nqp::istype($right.infix, RakuAST::Infixish)
                     && $right.infix.properties.chain {
-                    $right.infix.IMPL-CLEAR-CT-INLINE-CANDIDATE();
+                    $right.infix.IMPL-CLEAR-CT-INLINE-CANDIDATE()
+                        if nqp::istype($right.infix, RakuAST::Infix);
                     $linked := 1;
                 }
                 return Nil if $linked;
@@ -1697,10 +1699,10 @@ class RakuAST::Node {
         return $expr unless $negated || $op eq '~~';
         my $left := $expr.left;
         return $expr if nqp::istype($left, RakuAST::ApplyInfix)
-            && nqp::istype($left.infix, RakuAST::Infix)
+            && nqp::istype($left.infix, RakuAST::Infixish)
             && $left.infix.properties.chain;
         return $expr if nqp::istype(self, RakuAST::ApplyInfix)
-            && nqp::istype(self.infix, RakuAST::Infix)
+            && nqp::istype(self.infix, RakuAST::Infixish)
             && self.infix.properties.chain
             && nqp::eqaddr(self.left, $expr);
         return $expr unless nqp::istype($expr.right, RakuAST::Literal);
@@ -1880,7 +1882,7 @@ class RakuAST::Node {
         return Nil unless $op eq '~~' || $op eq '!~~';
         my $left := $cond.left;
         return Nil if nqp::istype($left, RakuAST::ApplyInfix)
-            && nqp::istype($left.infix, RakuAST::Infix)
+            && nqp::istype($left.infix, RakuAST::Infixish)
             && $left.infix.properties.chain;
         return Nil unless self.IMPL-OPERATOR-IS-CORE($resolver, $infix);
         return Nil if self.IMPL-IN-SOFT-SCOPE($resolver);
@@ -1945,10 +1947,10 @@ class RakuAST::Node {
         my $left := $cond.left;
         my $right := $cond.right;
         return Nil if nqp::istype($left, RakuAST::ApplyInfix)
-            && nqp::istype($left.infix, RakuAST::Infix)
+            && nqp::istype($left.infix, RakuAST::Infixish)
             && $left.infix.properties.chain;
         return Nil if nqp::istype($right, RakuAST::ApplyInfix)
-            && nqp::istype($right.infix, RakuAST::Infix)
+            && nqp::istype($right.infix, RakuAST::Infixish)
             && $right.infix.properties.chain;
         return Nil unless self.IMPL-OPERATOR-IS-CORE($resolver, $infix);
         return Nil if self.IMPL-IN-SOFT-SCOPE($resolver);
@@ -2271,10 +2273,10 @@ class RakuAST::Node {
         return $expr unless $op eq '~~' || $op eq '!~~';
         my $left := $expr.left;
         return $expr if nqp::istype($left, RakuAST::ApplyInfix)
-            && nqp::istype($left.infix, RakuAST::Infix)
+            && nqp::istype($left.infix, RakuAST::Infixish)
             && $left.infix.properties.chain;
         return $expr if nqp::istype(self, RakuAST::ApplyInfix)
-            && nqp::istype(self.infix, RakuAST::Infix)
+            && nqp::istype(self.infix, RakuAST::Infixish)
             && self.infix.properties.chain
             && nqp::eqaddr(self.left, $expr);
         return $expr unless self.IMPL-OPERATOR-IS-CORE($resolver, $infix);
@@ -2540,7 +2542,7 @@ class RakuAST::Node {
     # links took.
     method IMPL-MARK-CHAIN-LINKS(RakuAST::Resolver $resolver, Mu $expr) {
         return Nil unless nqp::istype($expr, RakuAST::ApplyInfix)
-            && nqp::istype($expr.infix, RakuAST::Infix)
+            && nqp::istype($expr.infix, RakuAST::Infixish)
             && $expr.infix.properties.chain;
         my $left := $expr.left;
         $left.infix.IMPL-CLEAR-SMARTMATCH-MARKS()
@@ -2681,10 +2683,10 @@ class RakuAST::Node {
         return $expr unless $negated || $op eq '~~';
         my $left := $expr.left;
         return $expr if nqp::istype($left, RakuAST::ApplyInfix)
-            && nqp::istype($left.infix, RakuAST::Infix)
+            && nqp::istype($left.infix, RakuAST::Infixish)
             && $left.infix.properties.chain;
         return $expr if nqp::istype(self, RakuAST::ApplyInfix)
-            && nqp::istype(self.infix, RakuAST::Infix)
+            && nqp::istype(self.infix, RakuAST::Infixish)
             && self.infix.properties.chain
             && nqp::eqaddr(self.left, $expr);
 

--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -732,6 +732,11 @@ class RakuAST::Node {
             $result := self.IMPL-UNROLL-SLICE($resolver, $expr);
         }
 
+        # The negate withdrawal runs before the gated marks: it is a
+        # retraction of an operand's mark, so neither a rewrite having
+        # replaced this node nor the soft pragma may skip it.
+        self.IMPL-WITHDRAW-NEGATE-NOT($expr);
+
         # Lowerings that direct code generation rather than replacing the
         # node register their marks here, gated on the optimize pass running.
         # They each drop a layer of operator dispatch or pin down a routine
@@ -748,6 +753,7 @@ class RakuAST::Node {
             self.IMPL-MARK-STATIC-INFIX($resolver, $expr);
             self.IMPL-MARK-STATIC-PREFIX($resolver, $expr);
             self.IMPL-MARK-STATIC-POSTFIX($resolver, $expr);
+            self.IMPL-MARK-NEGATE-NOT($resolver, $expr);
             self.IMPL-MARK-RETURN-DECONT($resolver, $expr);
             self.IMPL-MARK-ARRAY-INIT($resolver, $expr);
             self.IMPL-MARK-CT-DISPATCH($resolver, $expr);
@@ -999,6 +1005,46 @@ class RakuAST::Node {
         $postfix.IMPL-SET-CALLSTATIC()
             if self.IMPL-RESOLUTION-BOUND-ONCE($resolver, $postfix.resolution,
                 '&postfix' ~ $resolver.IMPL-CANONICALIZE-PAIR($postfix.operator));
+        Nil
+    }
+
+    # Mark a standalone negated comparison for compiling as the setting
+    # prefix ! around the plain comparison call, which is what the
+    # meta-op computes for two arguments. A link of a longer chain keeps
+    # the meta-op, since the chain protocol needs a callee, so the
+    # enclosing link withdraws the mark its operand took.
+    method IMPL-MARK-NEGATE-NOT(RakuAST::Resolver $resolver, Mu $expr) {
+        return Nil unless nqp::istype($expr, RakuAST::ApplyInfix);
+        my $infix := $expr.infix;
+        return Nil unless nqp::istype($infix, RakuAST::MetaInfix::Negate)
+            && $infix.properties.chain;
+        for [$expr.left, $expr.right] {
+            return Nil if nqp::istype($_, RakuAST::ApplyInfix)
+                && $_.infix.properties.chain;
+        }
+        my $not := $resolver.resolve-lexical-constant-in-setting('&prefix:<!>');
+        $infix.IMPL-SET-NEGATE-NOT($not.compile-time-value)
+            if nqp::isconcrete($not)
+            && nqp::istype($not, RakuAST::CompileTimeValue);
+        Nil
+    }
+
+    # Withdraw the standalone mark from a negated operand that turns out
+    # to be a link of a longer chain. A retraction rather than an
+    # optimization: it runs whether or not a rewrite replaced the
+    # enclosing node and regardless of the soft pragma, since a link
+    # must never emit as a standalone negation.
+    method IMPL-WITHDRAW-NEGATE-NOT(Mu $expr) {
+        return Nil unless nqp::istype($expr, RakuAST::ApplyInfix);
+        my $infix := $expr.infix;
+        return Nil unless nqp::istype($infix, RakuAST::Infixish)
+            && $infix.properties.chain;
+        for [$expr.left, $expr.right] {
+            $_.infix.IMPL-CLEAR-NEGATE-NOT()
+                if nqp::istype($_, RakuAST::ApplyInfix)
+                && nqp::istype($_.infix, RakuAST::MetaInfix::Negate)
+                && $_.infix.properties.chain;
+        }
         Nil
     }
 

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -1800,6 +1800,25 @@ class RakuAST::MetaInfix::Negate
 {
     has RakuAST::Infixish $.infix;
 
+    # Set by the optimize pass on a standalone application: the negation
+    # compiles as the setting prefix ! around the plain comparison call,
+    # which is what the meta-op computes for two arguments, sparing its
+    # formation and invocation. Holds the resolved prefix ! routine. A
+    # link of a longer chain keeps the meta-op, since the chain protocol
+    # needs a callee.
+    has int $!negate-not;
+    has Mu $!negate-not-op;
+
+    method IMPL-SET-NEGATE-NOT(Mu $op) {
+        nqp::bindattr_i(self, RakuAST::MetaInfix::Negate, '$!negate-not', 1);
+        nqp::bindattr(self, RakuAST::MetaInfix::Negate, '$!negate-not-op', $op);
+    }
+
+    method IMPL-CLEAR-NEGATE-NOT() {
+        nqp::bindattr_i(self, RakuAST::MetaInfix::Negate, '$!negate-not', 0);
+        nqp::bindattr(self, RakuAST::MetaInfix::Negate, '$!negate-not-op', Mu);
+    }
+
     method new(RakuAST::Infixish $infix) {
         my $obj := nqp::create(self);
         nqp::bindattr($obj, RakuAST::MetaInfix::Negate, '$!infix', $infix);
@@ -1840,6 +1859,18 @@ class RakuAST::MetaInfix::Negate
     }
 
     method IMPL-INFIX-QAST(RakuAST::IMPL::QASTContext $context, Mu $left-qast, Mu $right-qast) {
+        if $!negate-not {
+            $context.ensure-sc($!negate-not-op);
+            return QAST::Op.new:
+                :op('call'),
+                QAST::WVal.new( :value($!negate-not-op) ),
+                QAST::Op.new(
+                    :op('call'),
+                    $!infix.IMPL-HOP-INFIX-QAST($context),
+                    $left-qast,
+                    $right-qast
+                );
+        }
         QAST::Op.new:
             :op($!infix.properties.chain ?? 'chain' !! 'call'),
             self.IMPL-HOP-INFIX-QAST($context),

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -254,6 +254,29 @@ class RakuAST::Infixish
         self.IMPL-OPERATOR
     }
 
+    # The given operator, or the meta-op a caller forms over it, as a
+    # compile-time constant, or null when it cannot be one. A setting
+    # operator's lookup yields the same code object at run time, so the
+    # value formed from it here serves every evaluation, which for a
+    # meta-op spares the formation call and its closure on each one.
+    # Anything else forms at run time, and so does everything while
+    # compiling a CORE setting itself, where closures the compiler
+    # forms must not be serialized into the bootstrap. Mirrors the
+    # constant reducer in Term::Reduce.
+    method IMPL-CONSTANT-HOP-INFIX-QAST(RakuAST::IMPL::QASTContext $context, Mu $infix) {
+        if nqp::istype($infix, RakuAST::Infix)
+            && $infix.is-resolved
+            && nqp::istype($infix.resolution, RakuAST::Declaration::External::Setting)
+            && !($*COMPILING_CORE_SETTING // 0) {
+            my $meta-op := self.IMPL-HOP-INFIX;
+            $context.ensure-sc($meta-op);
+            QAST::WVal.new( :value($meta-op) )
+        }
+        else {
+            nqp::null()
+        }
+    }
+
     method IMPL-APPLY-SINK-TO-OPERANDS(List $operands, Bool $is-sunk) {
         for $operands {
             $_.apply-sink($is-sunk);
@@ -922,6 +945,8 @@ class RakuAST::Infix
     }
 
     method IMPL-HOP-INFIX-QAST(RakuAST::IMPL::QASTContext $context) {
+        my $constant := self.IMPL-CONSTANT-HOP-INFIX-QAST($context, self);
+        return $constant unless nqp::isnull($constant);
         my $name := self.resolution.lexical-name;
         QAST::Var.new( :scope('lexical'), :$name )
     }
@@ -1823,6 +1848,8 @@ class RakuAST::MetaInfix::Negate
     }
 
     method IMPL-HOP-INFIX-QAST(RakuAST::IMPL::QASTContext $context) {
+        my $constant := self.IMPL-CONSTANT-HOP-INFIX-QAST($context, $!infix);
+        return $constant unless nqp::isnull($constant);
         QAST::Op.new(:op<call>,
           :name<&METAOP_NEGATE>, $!infix.IMPL-HOP-INFIX-QAST($context)
         )
@@ -1888,6 +1915,8 @@ class RakuAST::MetaInfix::Reverse
     }
 
     method IMPL-HOP-INFIX-QAST(RakuAST::IMPL::QASTContext $context) {
+        my $constant := self.IMPL-CONSTANT-HOP-INFIX-QAST($context, $!infix);
+        return $constant unless nqp::isnull($constant);
         QAST::Op.new:
             :op('callstatic'), :name('&METAOP_REVERSE'),
             $!infix.IMPL-HOP-INFIX-QAST($context)
@@ -1934,6 +1963,14 @@ class RakuAST::MetaInfix::Sequence
 
     method IMPL-OPERATOR() {
         self.infix.IMPL-OPERATOR
+    }
+
+    # Sequencing pins the evaluation order of the operands, not the
+    # operator, so the formed value is the wrapped operator's own. The
+    # generic formation does not apply: there is no METAOP routine for
+    # sequencing, as the empty implicit lookups say.
+    method IMPL-HOP-INFIX() {
+        self.infix.IMPL-HOP-INFIX
     }
 
     method IMPL-INFIX-QAST(RakuAST::IMPL::QASTContext $context, Mu $left-qast, Mu $right-qast) {
@@ -2009,6 +2046,8 @@ class RakuAST::MetaInfix::Cross
     }
 
     method IMPL-HOP-INFIX-QAST(RakuAST::IMPL::QASTContext $context) {
+        my $constant := self.IMPL-CONSTANT-HOP-INFIX-QAST($context, $!infix);
+        return $constant unless nqp::isnull($constant);
         QAST::Op.new:
             :op('callstatic'), :name('&METAOP_CROSS'),
             $!infix.IMPL-HOP-INFIX-QAST($context),
@@ -2018,7 +2057,7 @@ class RakuAST::MetaInfix::Cross
     method IMPL-HOP-INFIX() {
         my $lookups := self.IMPL-UNWRAP-LIST(self.get-implicit-lookups);
         $lookups[0].resolution.compile-time-value()(
-            self.infix.IMPL-OPERATOR,
+            self.infix.IMPL-HOP-INFIX,
             $lookups[1].resolution.compile-time-value,
         )
     }
@@ -2108,6 +2147,8 @@ class RakuAST::MetaInfix::Zip
     }
 
     method IMPL-HOP-INFIX-QAST(RakuAST::IMPL::QASTContext $context) {
+        my $constant := self.IMPL-CONSTANT-HOP-INFIX-QAST($context, $!infix);
+        return $constant unless nqp::isnull($constant);
         QAST::Op.new:
             :op('callstatic'), :name('&METAOP_ZIP'),
             $!infix.IMPL-HOP-INFIX-QAST($context),
@@ -2117,7 +2158,7 @@ class RakuAST::MetaInfix::Zip
     method IMPL-HOP-INFIX() {
         my $lookups := self.IMPL-UNWRAP-LIST(self.get-implicit-lookups);
         $lookups[0].resolution.compile-time-value()(
-            self.infix.IMPL-OPERATOR,
+            self.infix.IMPL-HOP-INFIX,
             $lookups[1].resolution.compile-time-value,
         )
     }
@@ -2209,6 +2250,8 @@ class RakuAST::MetaInfix::Hyper
     }
 
     method IMPL-HOP-INFIX-QAST(RakuAST::IMPL::QASTContext $context) {
+        my $constant := self.IMPL-CONSTANT-HOP-INFIX-QAST($context, $!infix);
+        return $constant unless nqp::isnull($constant);
         my $call := QAST::Op.new:
             :op('callstatic'), :name('&METAOP_HYPER'),
             $!infix.IMPL-HOP-INFIX-QAST($context);
@@ -2223,7 +2266,7 @@ class RakuAST::MetaInfix::Hyper
 
     method IMPL-HOP-INFIX() {
         self.IMPL-UNWRAP-LIST(self.get-implicit-lookups())[0].resolution.compile-time-value()(
-            self.infix.resolution.compile-time-value,
+            self.infix.IMPL-HOP-INFIX,
             :dwim-left($!dwim-left),
             :dwim-right($!dwim-right)
         )

--- a/t/08-performance/28-rakuast-metaop-hoist.t
+++ b/t/08-performance/28-rakuast-metaop-hoist.t
@@ -3,7 +3,7 @@ use Test::Helpers::QAST;
 use Test;
 use QAST:from<NQP>;
 use nqp;
-plan 51;
+plan 55;
 
 # A meta-op over a setting operator is formed once at compile time and
 # emitted as a constant, since the operator lookup yields the same code
@@ -163,6 +163,29 @@ else {
 }
 
 nok ([!==] 1, 1, 3), 'a chain reduce of a negated comparison fails on a failing link';
+
+# A negated comparison as the left of a smartmatch is a chain link, so
+# the reduced smartmatch forms decline it and the chain protocol runs.
+
+{
+    my $typematch = 1 !== 2 ~~ Bool;
+    nok $typematch, 'a smartmatch of a type declines to collapse over a negated link';
+}
+
+{
+    my $negated-typematch = 1 !== 2 !~~ Bool;
+    ok $negated-typematch, 'a negated smartmatch of a type declines to collapse over a negated link';
+}
+
+{
+    my $litmatch = 1 !== 2 ~~ 1;
+    nok $litmatch, 'a smartmatch of a literal declines to collapse over a negated link';
+}
+
+{
+    my $pairmatch = 1 !== 0 ~~ :so;
+    nok $pairmatch, 'a smartmatch of a pair declines to collapse over a negated link';
+}
 
 # A sequenced comparison keeps every operator property, so it links
 # into a chain with a negation. The legacy frontend cannot run the

--- a/t/08-performance/28-rakuast-metaop-hoist.t
+++ b/t/08-performance/28-rakuast-metaop-hoist.t
@@ -1,0 +1,210 @@
+use lib <t/packages/Test-Helpers>;
+use Test::Helpers::QAST;
+use Test;
+use QAST:from<NQP>;
+use nqp;
+plan 30;
+
+# A meta-op over a setting operator is formed once at compile time and
+# emitted as a constant, since the operator lookup yields the same code
+# object at run time. A meta-op formed at run time makes the formation
+# call and allocates a closure per evaluation, which stays the path for
+# a lexical operator and for a meta-op operand. The shapes the
+# assertions pin down are this frontend's.
+
+sub qast-wval-callee (Mu $qast --> Bool:D) {
+    if nqp::istype($qast, QAST::Op)
+        && ($qast.op eq 'call' || $qast.op eq 'chain') {
+        for $qast.list {
+            return True if nqp::istype($_, QAST::WVal);
+            last;
+        }
+    }
+    if qast-descendable $qast {
+        for $qast.list {
+            qast-wval-callee $_ and return True;
+        }
+    }
+    False
+}
+
+sub qast-var-named (Mu $qast, Str:D $name --> Bool:D) {
+    if nqp::istype($qast, QAST::Var) && $qast.name eq $name {
+        return True;
+    }
+    if qast-descendable $qast {
+        for $qast.list {
+            qast-var-named $_, $name and return True;
+        }
+    }
+    False
+}
+
+if nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' {
+    qast-is 'my @r = (1,2) Z+ (3,4)', :full, -> \v {
+        not qast-contains-call(v, '&METAOP_ZIP')
+        and qast-wval-callee(v)
+    }, 'a zip of a setting operator becomes a constant meta-op callee';
+
+    qast-is 'my @r = (1,2) X~ (3,4)', :full, -> \v {
+        not qast-contains-call(v, '&METAOP_CROSS')
+        and qast-wval-callee(v)
+    }, 'a cross of a setting operator becomes a constant meta-op callee';
+
+    qast-is 'my @a = 1,2; my @b = 3,4; my @r = @a »+« @b', :full, -> \v {
+        not qast-contains-call(v, '&METAOP_HYPER')
+        and qast-wval-callee(v)
+    }, 'a hyper of a setting operator becomes a constant meta-op callee';
+
+    qast-is 'my $x = 1; my $y = 2; say $x !== $y', :full, -> \v {
+        not qast-contains-call(v, '&METAOP_NEGATE')
+        and qast-wval-callee(v)
+    }, 'a negation of a setting operator becomes a constant meta-op callee';
+
+    qast-is 'my @r = 1 R, 2', :full, -> \v {
+        not qast-contains-call(v, '&METAOP_REVERSE')
+        and qast-wval-callee(v)
+    }, 'a reversal of a setting operator becomes a constant meta-op callee';
+
+    qast-is 'sub infix:<foo>($a,$b) { $a + $b }; my @r = (1,2) Zfoo (3,4)', :full, -> \v {
+        qast-contains-call(v, '&METAOP_ZIP')
+    }, 'a zip of a lexical operator still forms its meta-op at run time';
+
+    # The zip declines over an assign meta-op operand, while the plain
+    # operator inside that operand still emits as a constant rather
+    # than a lookup by name.
+    qast-is 'my @a = 1,2; @a Z+= (3,4)', :full, -> \v {
+        qast-contains-call(v, '&METAOP_ZIP')
+        and qast-contains-call(v, '&METAOP_ASSIGN')
+        and not qast-var-named(v, '&infix:<+>')
+    }, 'a zip of an assign meta-op forms at run time over a constant operator';
+
+    qast-is 'my @r = (1,2) ZR- (10,20)', :full, -> \v {
+        qast-contains-call(v, '&METAOP_ZIP')
+        and not qast-contains-call(v, '&METAOP_REVERSE')
+    }, 'a zip of a reversal forms at run time over a constant reversal';
+}
+else {
+    skip 'the formation shapes are specific to the RakuAST frontend', 8;
+}
+
+# Behavior stays identical.
+
+is ((1,2) Z+ (3,4)).join(','), '4,6',
+    'a zip of a setting operator computes through its constant meta-op';
+
+is ((1,2) X~ (3,4)).join(','), '13,14,23,24',
+    'a cross of a setting operator computes through its constant meta-op';
+
+{
+    my @a = 1,2;
+    my @b = 3,4;
+    is (@a »+« @b).join(','), '4,6',
+        'a hyper of a setting operator computes through its constant meta-op';
+}
+
+ok 1 !== 2, 'a negated setting comparison holds through its constant meta-op';
+
+is (5 R- 1), -4, 'a reversed setting operator swaps its operands';
+
+is ((1,2) Z=> (3,4)).map({ .key ~ ':' ~ .value }).join(','), '1:3,2:4',
+    'a zip building pairs computes through its constant meta-op';
+
+is-deeply ((1,2) R, (3,4)), ((3,4),(1,2)),
+    'a reversed comma builds its list through its constant meta-op';
+
+{
+    sub infix:<foo>($a, $b) { $a * $b }
+    is ((1,2) Zfoo (3,4)).join(','), '3,8',
+        'a zip of a lexical operator computes through its formed meta-op';
+}
+
+is ((1,2,3) »+» (10,20)).join(','), '11,22,13',
+    'a right dwim hyper extends the shorter side through its constant meta-op';
+
+is ((1,2,3) «+« (10,20)).join(','), '11,22',
+    'a left dwim hyper truncates to the fixed side through its constant meta-op';
+
+dies-ok { ((1,2,3) »+« (1,2)).eager },
+    'a non dwim hyper still dies on lists of different lengths';
+
+is ((1,2) ZR- (10,20)).join(','), '9,18',
+    'a zip of a reversal computes through its constant reversal';
+
+nok 2 R!== 2, 'a reversal of a negation compares correctly';
+
+{
+    my @a = 1,2;
+    @a Z+= (10,20);
+    is @a.join(','), '11,22',
+        'a zip assign computes through its constant operator';
+}
+
+{
+    my $a = 3;
+    $a max= 7;
+    is $a, 7, 'a max assign computes through its constant operator';
+}
+
+{
+    use soft;
+    my $h = &infix:<+>.wrap(sub ($a, $b) { 1000 });
+    my @w = (1,2) Z+ (3,4);
+    &infix:<+>.unwrap($h);
+    my @r = (1,2) Z+ (3,4);
+    is @w.join(','), '1000,1000',
+        'a wrap of a setting operator shows through its constant meta-op';
+    is @r.join(','), '4,6',
+        'an unwrap of a setting operator shows through its constant meta-op';
+}
+
+is ((0,2) Z|| (5,6)).join(','), '5,2',
+    'a zip of a thunky operator computes through its constant meta-op';
+
+# A sequencing meta-op forms the wrapped operator's own value, so it
+# composes under the other meta-ops. The legacy frontend cannot compile
+# these callable forms at all.
+
+if nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' {
+    is Q|&[S+]|.EVAL.(2, 3), 5,
+        'a sequenced setting operator forms as the operator itself';
+
+    isa-ok (try Q|&[RRRRRRRRZZZZZZZZZZZZZZZZZZRRRRRRRRRSSSSSSSS+]|.EVAL), Block,
+        'a deep stack of meta-ops over a setting operator still forms a callable';
+}
+else {
+    skip 'the callable meta-op forms do not compile under the legacy frontend', 2;
+}
+
+# The formed meta-op is a closure the compiler made, so a precompiled
+# module carries it through serialization.
+
+{
+    my $dir = $*TMPDIR.add("rakuast-metaop-hoist-$*PID");
+    $dir.mkdir;
+    $dir.add('MetaOpHoistTest.rakumod').spurt(q:to/MODULE/);
+        unit module MetaOpHoistTest;
+        sub combined() is export {
+            ((1,2) Z+ (3,4)).join(',') ~ '|'
+              ~ ((1,2) X~ (3,4)).join(',') ~ '|'
+              ~ ((1,2,3) »+» (10,20)).join(',') ~ '|'
+              ~ (5 R- 1) ~ '|'
+              ~ (1 !== 2)
+        }
+        MODULE
+    my $expected = '4,6|13,14,23,24|11,22,13|-4|True';
+    for 'compiles', 'loads from the precompilation store' -> $stage {
+        my $proc = run $*EXECUTABLE, '-I', $dir.absolute, '-e',
+            'use MetaOpHoistTest; print combined()', :out, :err;
+        my $out = $proc.out.slurp(:close);
+        $proc.err.slurp(:close);
+        is $out, $expected, "a module using constant meta-ops $stage";
+    }
+    sub nuke(IO::Path $p) {
+        if $p.d { nuke($_) for $p.dir; $p.rmdir }
+        else { $p.unlink }
+    }
+    nuke($dir);
+}
+
+# vim: expandtab shiftwidth=4

--- a/t/08-performance/28-rakuast-metaop-hoist.t
+++ b/t/08-performance/28-rakuast-metaop-hoist.t
@@ -3,7 +3,7 @@ use Test::Helpers::QAST;
 use Test;
 use QAST:from<NQP>;
 use nqp;
-plan 30;
+plan 51;
 
 # A meta-op over a setting operator is formed once at compile time and
 # emitted as a constant, since the operator lookup yields the same code
@@ -83,9 +83,25 @@ if nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' {
         qast-contains-call(v, '&METAOP_ZIP')
         and not qast-contains-call(v, '&METAOP_REVERSE')
     }, 'a zip of a reversal forms at run time over a constant reversal';
+
+    # A standalone negated comparison compiles as the setting prefix !
+    # around the plain comparison, so no chain op remains, while a link
+    # of a longer chain keeps the chain protocol.
+    qast-is 'my $x = 1; my $y = 2; say $x !== $y', :full, -> \v {
+        not qast-contains-op(v, 'chain')
+    }, 'a standalone negated comparison compiles without a chain op';
+
+    qast-is 'my ($a,$b,$c) = 1,2,3; say $a !== $b !== $c', :full, -> \v {
+        qast-contains-op(v, 'chain')
+        and not qast-contains-call(v, '&METAOP_NEGATE')
+    }, 'a chained negated comparison keeps its chain over constant meta-ops';
+
+    qast-is 'use soft; my $x = 1; my $y = 2; say $x !== $y', :full, -> \v {
+        qast-contains-op(v, 'chain')
+    }, 'a negated comparison under the soft pragma keeps its meta-op';
 }
 else {
-    skip 'the formation shapes are specific to the RakuAST frontend', 8;
+    skip 'the formation shapes are specific to the RakuAST frontend', 11;
 }
 
 # Behavior stays identical.
@@ -104,6 +120,60 @@ is ((1,2) X~ (3,4)).join(','), '13,14,23,24',
 }
 
 ok 1 !== 2, 'a negated setting comparison holds through its constant meta-op';
+
+nok 1 !== 1, 'a negated setting comparison fails where the comparison holds';
+
+ok 1 !== 2 !== 3, 'a chain of negated comparisons holds through its links';
+
+nok 1 !== 1 !== 3, 'a chain of negated comparisons fails on a failing link';
+
+ok 1 !== 2 == 2, 'a chain mixing negated and plain comparisons holds';
+
+nok 5 !== any(5,6), 'a negated comparison autothreads a Junction argument';
+
+ok so(5 !== all(6,7)), 'a negated comparison over an all Junction collapses correctly';
+
+nok 2 !< 3, 'a negated ordering comparison fails where the ordering holds';
+
+{
+    my $calls = 0;
+    sub mid() { $calls++; 2 }
+    ok 1 !== mid() !== 3, 'a negated chain with a call in the middle holds';
+    is $calls, 1, 'the middle operand of a negated chain runs once';
+}
+
+{
+    sub infix:<same-as>($a, $b) is equiv(&infix:<==>) { $a == $b }
+    ok 1 !same-as 2, 'a negated user chaining operator holds where the comparison fails';
+}
+
+nok (* !== 2)(2), 'a curried negated comparison fails on the negated value';
+
+ok (* !== 2)(3), 'a curried negated comparison holds elsewhere';
+
+# Parentheses make the negation a value, as they do a plain comparison
+# on both frontends. The legacy frontend alone chains through them for
+# the negated form.
+if nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' {
+    my $paren = (1 !== 2) == True;
+    ok $paren, 'a parenthesized negation compares as a value, not a chain link';
+}
+else {
+    skip 'the legacy frontend chains through a parenthesized negation', 1;
+}
+
+nok ([!==] 1, 1, 3), 'a chain reduce of a negated comparison fails on a failing link';
+
+# A sequenced comparison keeps every operator property, so it links
+# into a chain with a negation. The legacy frontend cannot run the
+# sequenced form at all.
+if nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' {
+    ok 1 !== 2 S== 2, 'a chain mixing negation and sequencing holds through both links';
+    nok 1 !== 1 S== 1, 'a chain mixing negation and sequencing withdraws the operand mark';
+}
+else {
+    skip 'the sequenced comparison does not run under the legacy frontend', 2;
+}
 
 is (5 R- 1), -4, 'a reversed setting operator swaps its operands';
 
@@ -171,9 +241,18 @@ if nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' {
 
     isa-ok (try Q|&[RRRRRRRRZZZZZZZZZZZZZZZZZZRRRRRRRRRSSSSSSSS+]|.EVAL), Block,
         'a deep stack of meta-ops over a setting operator still forms a callable';
+
+    ok Q|&[!==]|.EVAL.(1, 2),
+        'a negated comparison in callable form computes through its meta-op';
+
+    # The negation resolves the setting prefix !, so a lexical prefix !
+    # does not intercept a negated comparison. The legacy frontend lets
+    # the lexical one intercept.
+    is Q|my sub prefix:<!>($x) { 'hijack' }; 1 !== 2|.EVAL, True,
+        'a lexical prefix ! does not intercept a negated comparison';
 }
 else {
-    skip 'the callable meta-op forms do not compile under the legacy frontend', 2;
+    skip 'the callable meta-op forms do not compile under the legacy frontend', 4;
 }
 
 # The formed meta-op is a closure the compiler made, so a precompiled


### PR DESCRIPTION
Previously a zip, cross, hyper, negate, or reverse of an operator called the METAOP routine to form the meta-op on every evaluation, and each of those calls allocated a fresh closure. A setting operator's lookup yields the same code object at run time, so the meta-op formed over it at compile time is a constant, which `Term::Reduce` already relies on for its reducer. The first commit forms those meta-ops once and emits the constant. Anything else keeps the run time formation, i.e. lexical operators and meta-op operands, as does a CORE setting compiling itself, where closures the compiler forms must not be serialized into the bootstrap.

The second commit compiles a standalone negated comparison such as `$x !== $y` as the setting `prefix:<!>` around the plain comparison call, which is what the meta-op computes for two arguments. A link of a longer chain keeps the meta-op, since the chain protocol needs a callee, and the enclosing link withdraws the mark its operand took. The legacy frontend compiles the standalone form this way as well. A negated comparison now runs ahead of it, since the inner callee is a constant rather than a lookup by name.

Working on the negation surfaced a bug in the optimize pass that predates this PR. The guards that decline an optimization over a chain link tested for `RakuAST::Infix`, while a link's infix can be any `Infixish`, a negated comparison being the common case. So the reduced smartmatch forms collapsed over a negated link, and `1 !== 2 ~~ Bool` answered `True` where chain semantics answers `False`, however the legacy frontend answers correctly. The withdrawal of a link's own reduced smartmatch decision had the same hole from the other side. The third commit widens the link tests to `Infixish` across the collapse forms, the junction folds, the chain link withdrawal, and the compile time dispatch mark.