### PR TITLE
RakuAST: compile a native array subscript to a raw position op

### DIFF
--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -737,6 +737,13 @@ class RakuAST::Node {
         # replaced this node nor the soft pragma may skip it.
         self.IMPL-WITHDRAW-NEGATE-NOT($expr);
 
+        # A bind statement replaces its target's container, so it
+        # withdraws native subscript eligibility from the target's
+        # declaration. A retraction rather than an optimization: it runs
+        # whether or not a rewrite replaced this node and regardless of
+        # the soft pragma.
+        self.IMPL-POISON-NATIVE-INDEX-BIND($expr);
+
         # Lowerings that direct code generation rather than replacing the
         # node register their marks here, gated on the optimize pass running.
         # They each drop a layer of operator dispatch or pin down a routine
@@ -754,6 +761,7 @@ class RakuAST::Node {
             self.IMPL-MARK-STATIC-PREFIX($resolver, $expr);
             self.IMPL-MARK-STATIC-POSTFIX($resolver, $expr);
             self.IMPL-MARK-NEGATE-NOT($resolver, $expr);
+            self.IMPL-MARK-NATIVE-INDEX($resolver, $expr);
             self.IMPL-MARK-RETURN-DECONT($resolver, $expr);
             self.IMPL-MARK-ARRAY-INIT($resolver, $expr);
             self.IMPL-MARK-CT-DISPATCH($resolver, $expr);
@@ -950,6 +958,124 @@ class RakuAST::Node {
         $expr.IMPL-SET-CALLSTATIC()
             if self.IMPL-RESOLUTION-BOUND-ONCE($resolver, $expr.resolution,
                 '&' ~ $expr.name.canonicalize);
+        Nil
+    }
+
+    # A bind statement targeting a lexical with a simple declaration
+    # marks that declaration, so the native subscript emission stands
+    # down: the bound container need not be the declared one. An EVAL
+    # cannot rebind an outer lexical on this frontend, so the statements
+    # seen here are all the binds there are.
+    method IMPL-POISON-NATIVE-INDEX-BIND(Mu $expr) {
+        return Nil unless nqp::istype($expr, RakuAST::ApplyInfix);
+        my $infix := $expr.infix;
+        return Nil unless nqp::istype($infix, RakuAST::Infix)
+            && ($infix.operator eq ':=' || $infix.operator eq '::=');
+        my $left := $expr.left;
+        $left.resolution.IMPL-SET-BIND-TARGETED()
+            if nqp::istype($left, RakuAST::Var::Lexical)
+            && $left.is-resolved
+            && nqp::istype($left.resolution, RakuAST::VarDeclaration::Simple);
+        Nil
+    }
+
+    # The native kind a read of this lexical is statically known to
+    # yield, or 0. A plain declaration answers through its return
+    # type. A parameter answers through the declaration its target
+    # wraps. A bindable target need not keep its declared slot, and
+    # an rw parameter reads through a reference rather than a native
+    # slot, so both answer 0. The rw and bindable flags land when the
+    # parameter produces its meta object, which runs before the
+    # optimize pass reads them here.
+    method IMPL-NATIVE-LEXICAL-PRIMSPEC(Mu $var) {
+        return 0 unless nqp::istype($var, RakuAST::Var::Lexical)
+            && $var.is-resolved;
+        my $decl := $var.resolution;
+        if nqp::istype($decl, RakuAST::ParameterTarget::Var) {
+            return 0 if $decl.can-be-bound-to;
+            my $wrapped := $decl.declaration;
+            return 0 unless nqp::isconcrete($wrapped) && !$wrapped.IMPL-IS-RW;
+            $decl := $wrapped;
+        }
+        nqp::objprimspec($decl.return-type)
+    }
+
+    # The native element kind a subscript of this application reads
+    # with a raw op, or 0 when the general call must stay. Only the
+    # simplest shape qualifies: a plain `my` declaration of an array
+    # whose element type is a native int, num, or str kind, no shape,
+    # no binding initializer and no traits, subscripted by an int
+    # literal that is at or above zero and fits a native int, or by a
+    # lexical whose read comes straight from a native int slot, with
+    # the setting subscript routine in force and no adverbs. The emission also
+    # declines when a bind statement targets the declaration, so the
+    # raw op only ever touches the declared container.
+    method IMPL-NATIVE-INDEX-SPEC(Mu $expr) {
+        my $postfix := $expr.postfix;
+        return 0 unless nqp::istype($postfix, RakuAST::Postcircumfix::ArrayIndex)
+            && !$postfix.is-multislice
+            && nqp::elems(self.IMPL-UNWRAP-LIST($postfix.colonpairs)) == 0
+            && $postfix.is-resolved
+            && nqp::istype($postfix.resolution, RakuAST::Declaration::External::Setting);
+        my $operand := $expr.operand;
+        return 0 unless nqp::istype($operand, RakuAST::Var::Lexical)
+            && $operand.is-resolved;
+        my $decl := $operand.resolution;
+        return 0 unless nqp::istype($decl, RakuAST::VarDeclaration::Simple)
+            && $decl.sigil eq '@'
+            && $decl.twigil eq ''
+            && $decl.scope eq 'my'
+            && !nqp::isconcrete($decl.shape)
+            && !nqp::isconcrete($decl.where)
+            && !nqp::istype($decl.initializer, RakuAST::Initializer::Bind)
+            && nqp::elems(self.IMPL-UNWRAP-LIST($decl.traits)) == 0;
+        my int $spec := nqp::objprimspec($decl.IMPL-OF-TYPE);
+        return 0 unless $spec == 1 || $spec == 2 || $spec == 3;
+        my $statements := $postfix.index.code-statements;
+        return 0 unless nqp::elems($statements) == 1
+            && nqp::istype($statements[0], RakuAST::Statement::Expression);
+        my $index := $statements[0].expression;
+        if nqp::istype($index, RakuAST::IntLiteral) {
+            return $index.IMPL-FITS-NATIVE-INT
+                && !nqp::islt_I($index.compile-time-value, nqp::box_i(0, Int))
+                ?? $spec
+                !! 0;
+        }
+        self.IMPL-NATIVE-LEXICAL-PRIMSPEC($index) == 1
+            ?? $spec
+            !! 0
+    }
+
+    # Mark a native array subscript for compiling with a raw op. A read
+    # emits the element reference the general call returns, so every
+    # context that writes through the result keeps working. A subscript
+    # carrying an assignment marks only when the statement is sunk, the
+    # raw bind yields no assignment result, and only when the value is
+    # a fitting literal or a native lexical of the element's kind, so
+    # the bind stores exactly what the assignment coercion would have.
+    method IMPL-MARK-NATIVE-INDEX(RakuAST::Resolver $resolver, Mu $expr) {
+        return Nil unless nqp::istype($expr, RakuAST::ApplyPostfix);
+        my int $spec := self.IMPL-NATIVE-INDEX-SPEC($expr);
+        return Nil unless $spec;
+        my $postfix := $expr.postfix;
+        my $value := $postfix.assignee;
+        if $value {
+            return Nil unless nqp::istype($expr, RakuAST::Sinkable) && $expr.sunk;
+            if $spec == 1 {
+                return Nil unless nqp::istype($value, RakuAST::IntLiteral)
+                    && $value.IMPL-FITS-NATIVE-INT
+                    || self.IMPL-NATIVE-LEXICAL-PRIMSPEC($value) == 1;
+            }
+            elsif $spec == 2 {
+                return Nil unless nqp::istype($value, RakuAST::NumLiteral)
+                    || self.IMPL-NATIVE-LEXICAL-PRIMSPEC($value) == 2;
+            }
+            else {
+                return Nil unless nqp::istype($value, RakuAST::StrLiteral)
+                    || self.IMPL-NATIVE-LEXICAL-PRIMSPEC($value) == 3;
+            }
+        }
+        $postfix.IMPL-SET-NATIVE-INDEX($spec, $expr.operand.resolution);
         Nil
     }
 

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -3674,6 +3674,19 @@ class RakuAST::Postcircumfix::ArrayIndex
     has RakuAST::SemiList   $.index;
     has RakuAST::Expression $.assignee;
 
+    # Set by the optimize pass when the subscripted array declaration
+    # and the index qualify, so the access compiles to a raw op. A
+    # lexical index keeps the general call behind a sign guard, and a
+    # bind statement targeting the declaration, found at any point of
+    # the pass, makes the emission stand down entirely.
+    has int $!native-spec;
+    has Mu $!native-decl;
+
+    method IMPL-SET-NATIVE-INDEX(int $spec, Mu $decl) {
+        nqp::bindattr_i(self, RakuAST::Postcircumfix::ArrayIndex, '$!native-spec', $spec);
+        nqp::bindattr(self, RakuAST::Postcircumfix::ArrayIndex, '$!native-decl', $decl);
+    }
+
     method new(
         RakuAST::SemiList :$index!,
       RakuAST::Expression :$assignee,
@@ -3791,6 +3804,51 @@ class RakuAST::Postcircumfix::ArrayIndex
                 ?? '&postcircumfix:<[; ]>'
                 !! '&postcircumfix:<[ ]>';
         }
+        if $!native-spec && !$!native-decl.IMPL-BIND-TARGETED {
+            # The raw op serves every index the mark admitted: a fitting
+            # literal at or above zero takes it outright, while a native
+            # lexical keeps the general call behind a sign guard, whose
+            # candidates own the negative index error. The operand and
+            # index nodes are pure by the mark's terms, so each may
+            # compile in both branches.
+            my $index := $!index.code-statements[0].expression;
+            my int $literal := nqp::istype($index, RakuAST::IntLiteral);
+            my $fast-index := $literal
+                ?? QAST::IVal.new( :value(nqp::unbox_i($index.compile-time-value)) )
+                !! $index.IMPL-TO-QAST($context);
+            my $fast;
+            if $!assignee {
+                my str $bind-op := $!native-spec == 1 ?? 'bindpos_i'
+                    !! $!native-spec == 2 ?? 'bindpos_n' !! 'bindpos_s';
+                my $value := $!assignee;
+                my $fast-value := nqp::istype($value, RakuAST::IntLiteral)
+                    ?? QAST::IVal.new( :value(nqp::unbox_i($value.compile-time-value)) )
+                    !! nqp::istype($value, RakuAST::NumLiteral)
+                        ?? QAST::NVal.new( :value(nqp::unbox_n($value.compile-time-value)) )
+                        !! nqp::istype($value, RakuAST::StrLiteral)
+                            ?? QAST::SVal.new( :value(nqp::unbox_s($value.compile-time-value)) )
+                            !! $value.IMPL-TO-QAST($context);
+                $fast := QAST::Op.new( :op($bind-op), $operand-qast, $fast-index, $fast-value );
+            }
+            else {
+                my str $ref-op := $!native-spec == 1 ?? 'atposref_i'
+                    !! $!native-spec == 2 ?? 'atposref_n' !! 'atposref_s';
+                $fast := QAST::Op.new( :op($ref-op), $operand-qast, $fast-index );
+            }
+            return $fast if $literal;
+            my $slow := QAST::Op.new( :op('call'), :$name, $operand-qast );
+            $slow.push(self.IMPL-INDEX-QAST($context));
+            $slow.push($!assignee.IMPL-TO-QAST($context)) if $!assignee;
+            return QAST::Op.new(
+                :op('if'),
+                QAST::Op.new( :op('islt_i'),
+                    $index.IMPL-TO-QAST($context),
+                    QAST::IVal.new( :value(0) ) ),
+                $slow,
+                $fast
+            );
+        }
+
         my $op := QAST::Op.new( :op('call'), :$name, $operand-qast );
         $op.push(self.IMPL-INDEX-QAST($context)) unless $!index.is-empty;
         $op.push($!assignee.IMPL-TO-QAST($context)) if $!assignee;

--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -907,6 +907,8 @@ class RakuAST::VarDeclaration::Simple
         nqp::bindattr(self, RakuAST::VarDeclaration::Simple, '$!is-rw', True);
     }
 
+    method IMPL-IS-RW() { $!is-rw }
+
     method set-ro(Bool $ro) {
         nqp::bindattr(self, RakuAST::VarDeclaration::Simple, '$!is-ro', $ro);
     }
@@ -998,6 +1000,17 @@ class RakuAST::VarDeclaration::Simple
     # at runtime. The documentation of other variable declarations is
     # only available through $=rakudoc.
     method podifiable() { self.is-attribute }
+
+    # Set when a bind statement targets this declaration: the bind
+    # replaces the declared container, so anything relying on the
+    # declaration's own container must stand down.
+    has int $!bind-targeted;
+
+    method IMPL-SET-BIND-TARGETED() {
+        nqp::bindattr_i(self, RakuAST::VarDeclaration::Simple, '$!bind-targeted', 1);
+    }
+
+    method IMPL-BIND-TARGETED() { $!bind-targeted }
 
     method IMPL-OF-TYPE() {
         $!type

--- a/t/08-performance/30-rakuast-native-index.t
+++ b/t/08-performance/30-rakuast-native-index.t
@@ -1,0 +1,304 @@
+use lib <t/packages/Test-Helpers>;
+use Test::Helpers::QAST;
+use Test;
+use QAST:from<NQP>;
+use nqp;
+plan 72;
+
+# A subscript of a plain native array by an int literal or a native
+# int lexical compiles to a raw position op. A read emits the element
+# reference the general call returns, so writable contexts keep
+# working, and a sunk assignment of a native value binds the element
+# directly. A negative index takes the general call, whose candidates
+# own that error. The shapes are this frontend's.
+
+if nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' {
+    qast-is 'my int @a = 1,2,3; my int $i = 1; my $v = @a[$i]', :full, -> \v {
+        qast-contains-op(v, 'atposref_i')
+        and qast-contains-op(v, 'islt_i')
+    }, 'a native int subscript by a native int lexical reads through the raw op behind a sign guard';
+
+    qast-is 'my int @a = 1,2,3; my $v = @a[1]', :full, -> \v {
+        qast-contains-op(v, 'atposref_i')
+        and not qast-contains-op(v, 'islt_i')
+    }, 'a native int subscript by an int literal reads through the raw op with no guard';
+
+    qast-is 'my num @n = 1e0, 2e0; my $v = @n[1]', :full, -> \v {
+        qast-contains-op(v, 'atposref_n')
+    }, 'a native num subscript reads through the raw op';
+
+    qast-is 'my str @s = <x y>; my $v = @s[1]', :full, -> \v {
+        qast-contains-op(v, 'atposref_s')
+    }, 'a native str subscript reads through the raw op';
+
+    qast-is 'my int @a; my int $i = 0; @a[$i] = 5; 1;', :full, -> \v {
+        qast-contains-op(v, 'bindpos_i')
+    }, 'a sunk native assignment binds the element through the raw op';
+
+    qast-is 'my int @a; my int $i = 0; my $x = (@a[$i] = 5);', :full, -> \v {
+        not qast-contains-op(v, 'bindpos_i')
+    }, 'an assignment whose result is used keeps the general call';
+
+    qast-is 'my @a = 1,2,3; my $v = @a[1]', :full, -> \v {
+        not qast-contains-op(v, 'atposref_i')
+    }, 'a subscript of a boxed array keeps the general call';
+
+    qast-is 'my int @a = 1,2,3; my $i = 1; my $v = @a[$i]', :full, -> \v {
+        not qast-contains-op(v, 'atposref_i')
+    }, 'a subscript by a boxed index keeps the general call';
+
+    qast-is 'my int @a = 1,2,3; my $v = @a[1]:exists', :full, -> \v {
+        not qast-contains-op(v, 'atposref_i')
+    }, 'a subscript with an adverb keeps the general call';
+
+    qast-is 'my int @a[3]; my $v = @a[1]', :full, -> \v {
+        not qast-contains-op(v, 'atposref_i')
+    }, 'a subscript of a shaped array keeps the general call';
+
+    qast-is 'my int @a = 1,2,3; my $v = @a[1-2]', :full, -> \v {
+        not qast-contains-op(v, 'atposref_i')
+    }, 'a subscript by a folded negative literal keeps the general call';
+
+    qast-is 'my int @a = 1,2,3; my $v = @a[10000000000000000000]', :full, -> \v {
+        not qast-contains-op(v, 'atposref_i')
+    }, 'a subscript by a literal too big for a native int keeps the general call';
+
+    qast-is 'use soft; my int @a = 1,2,3; my $v = @a[1]', :full, -> \v {
+        not qast-contains-op(v, 'atposref_i')
+    }, 'a subscript under the soft pragma keeps the general call';
+
+    qast-is 'sub f(int @a) { @a[0] }; my int @b = 1,2; f(@b)', :full, -> \v {
+        not qast-contains-op(v, 'atposref_i')
+    }, 'a subscript of a parameter array keeps the general call';
+
+    qast-is 'my int @a = 1,2,3; my int @b; @a := @b; my $v = @a[1]', :full, -> \v {
+        not qast-contains-op(v, 'atposref_i')
+    }, 'a subscript of a declaration a bind statement targets keeps the general call';
+
+    qast-is 'my num @n; my int $v = 1; my int $i = 0; @n[$i] = $v; 1', :full, -> \v {
+        not qast-contains-op(v, 'bindpos_n')
+    }, 'an assignment of a value of another native kind keeps the general call';
+
+    qast-is 'my int8 @t = 1,2; my $v = @t[1]', :full, -> \v {
+        qast-contains-op(v, 'atposref_i')
+    }, 'a sized int array subscript reads through the raw op';
+
+    qast-is 'my uint @u = 1,2; my $v = @u[1]', :full, -> \v {
+        not qast-contains-op(v, 'atposref_i')
+    }, 'an unsigned array subscript keeps the general call';
+
+    qast-is 'my int @a; for ^10 -> int $i { @a[$i] = 5 }; 1', :full, -> \v {
+        qast-contains-op(v, 'bindpos_i')
+    }, 'a loop body assignment by the native int loop parameter binds through the raw op';
+
+    qast-is 'my int @a; my sub f(int $i) { my $v = @a[$i]; 1 }; f(2)', :full, -> \v {
+        qast-contains-op(v, 'atposref_i')
+    }, 'a subscript by a native int parameter reads through the raw op';
+
+    qast-is 'my int @a; my sub f(int $i, int $v) { @a[$i] = $v; 1 }; f(0, 1)', :full, -> \v {
+        qast-contains-op(v, 'bindpos_i')
+    }, 'an assignment of a native int parameter binds through the raw op';
+
+    qast-is 'my int @a; my sub f(int $i is rw) { my $v = @a[$i]; 1 }; my int $x = 1; f($x)', :full, -> \v {
+        not qast-contains-op(v, 'atposref_i')
+    }, 'a subscript by an rw parameter keeps the general call';
+
+    qast-is 'my int @a; my sub f(Int $i) { my $v = @a[$i]; 1 }; f(2)', :full, -> \v {
+        not qast-contains-op(v, 'atposref_i')
+    }, 'a subscript by a boxed parameter keeps the general call';
+
+    qast-is 'my num @n; my sub f(int $i, num $v) { @n[$i] = $v; 1 }; f(0, 1e0)', :full, -> \v {
+        qast-contains-op(v, 'bindpos_n')
+    }, 'an assignment of a native num parameter binds through the raw op';
+
+    qast-is 'my str @s; my sub f(int $i, str $v) { @s[$i] = $v; 1 }; f(0, "x")', :full, -> \v {
+        qast-contains-op(v, 'bindpos_s')
+    }, 'an assignment of a native str parameter binds through the raw op';
+
+    qast-is 'my int @a; my sub f(num $i) { my $v = @a[$i]; 1 }; f(1e0)', :full, -> \v {
+        not qast-contains-op(v, 'atposref_i')
+    }, 'a subscript by a native num parameter keeps the general call';
+
+    qast-is 'my int @a; my sub f(int $v is rw) { @a[0] = $v; 1 }; my int $x = 1; f($x)', :full, -> \v {
+        not qast-contains-op(v, 'bindpos_i')
+    }, 'an assignment of an rw parameter value keeps the general call';
+
+    qast-is 'my int @a; my sub f(int $i = 1) { my $v = @a[$i]; 1 }; f()', :full, -> \v {
+        qast-contains-op(v, 'atposref_i')
+    }, 'a subscript by an optional parameter with a default reads through the raw op';
+
+    qast-is 'my int @a; my sub f(int $i is raw) { my $v = @a[$i]; 1 }; my int $x = 1; f($x)', :full, -> \v {
+        qast-contains-op(v, 'atposref_i')
+    }, 'a subscript by a raw parameter reads through the raw op';
+
+    qast-is 'my int @a; my sub f(int $i is copy) { my $v = @a[$i]; 1 }; f(1)', :full, -> \v {
+        qast-contains-op(v, 'atposref_i')
+    }, 'a subscript by a copy parameter reads through the raw op';
+
+    qast-is 'my int @a = 1,2,3; for ^3 -> int $i { my $v = @a[$i] }', :full, -> \v {
+        qast-contains-op(v, 'atposref_i')
+    }, 'a loop body read by the native int loop parameter reads through the raw op';
+
+    qast-is 'my int @a; my int @b = 1,2; for @b <-> int $i { my $v = @a[$i] }', :full, -> \v {
+        not qast-contains-op(v, 'atposref_i')
+    }, 'a subscript by a loop parameter that can be bound keeps the general call';
+}
+else {
+    skip 'the subscript shapes are specific to the RakuAST frontend', 32;
+}
+
+# Behavior stays identical.
+
+{
+    my int @a = 10, 20, 30;
+    my int $i = 1;
+    is @a[$i], 20, 'a raw read by a native lexical gives the element';
+    is @a[0], 10, 'a raw read by a literal gives the element';
+    is @a[9], 0, 'a raw read past the end gives the type default';
+    @a[$i] = 99;
+    is @a[1], 99, 'a raw bind stores the element';
+    @a[5] = 7;
+    is @a[5], 7, 'a raw bind past the end extends the array';
+    is @a.elems, 6, 'the extension sets the element count';
+    my int $neg = -1;
+    dies-ok { my $v = @a[$neg] }, 'a negative index read dies through the general call';
+    dies-ok { @a[$neg] = 1 }, 'a negative index write dies through the general call';
+    my $copy = @a[1];
+    $copy = 42;
+    is @a[1], 99, 'assigning a copy read from the element leaves the element alone';
+    sub bump($x is rw) { $x++ }
+    bump(@a[0]);
+    is @a[0], 11, 'a writable context writes through the element reference';
+    my $x = (@a[0] = 77);
+    is $x, 77, 'an assignment whose result is used yields the value';
+    is @a[0], 77, 'an assignment whose result is used still stores';
+}
+
+{
+    my num @n = 1e0, 2e5;
+    is @n[1], 2e5, 'a raw num read gives the element';
+    my int $j = 0;
+    @n[$j] = 9e0;
+    is @n[0], 9e0, 'a raw num bind stores the element';
+}
+
+{
+    my str @s = <x y z>;
+    my int $j = 1;
+    @s[$j] = 'q';
+    is @s[1], 'q', 'a raw str bind stores the element';
+}
+
+{
+    my int @sh[3];
+    @sh[0] = 1;
+    is @sh[0], 1, 'a shaped array subscript computes through the general call';
+}
+
+# A folded negative literal and an oversized literal decline the raw
+# op, so the general call raises the errors it owns.
+
+{
+    my int @a = 1, 2, 3;
+    dies-ok { my $v = @a[1-2] }, 'a folded negative literal read dies through the general call';
+    dies-ok { @a[1-2] = 99 }, 'a folded negative literal write dies through the general call';
+    is @a[2], 3, 'the failing write left the last element alone';
+    dies-ok { my $v = @a[10000000000000000000] },
+        'a literal too big for a native int dies through the general call';
+}
+
+# A bind statement replaces the container, so the subscript dispatches
+# to whatever was bound.
+
+{
+    my class P does Positional[int] {
+        method AT-POS($i) { 42 }
+        method of() { int }
+    }
+    my int @a = 1, 2, 3;
+    @a := P.new;
+    is @a[1], 42, 'a subscript after a bind statement dispatches to the bound container';
+}
+
+{
+    my sub postcircumfix:<[ ]>(\a, \i) { 42 }
+    my int @a = 1, 2, 3;
+    my int $i = 0;
+    is @a[$i], 42, 'a lexical subscript routine intercepts the subscript';
+}
+
+# A value of another native kind keeps the general call, whose
+# assignment owns the type error.
+
+{
+    my num @n;
+    my int $iv = 1;
+    my int $i = 0;
+    dies-ok { @n[$i] = $iv }, 'assigning an int lexical to a num element dies through the general call';
+    my int @a;
+    dies-ok { @a[$i] = 1.5 }, 'assigning a fractional literal to an int element dies through the general call';
+}
+
+{
+    my int8 @t;
+    my int $i = 0;
+    @t[$i] = 300;
+    is @t[0], 44, 'a sized int element truncates through the raw op as the general call does';
+}
+
+# A native int parameter reads from a native slot as a plain
+# declaration does, so it serves as an index and as an assigned
+# value. An rw parameter reads through a reference and takes the
+# general call.
+
+{
+    my int @a;
+    for ^5 -> int $i { @a[$i] = $i * 2 }
+    is-deeply @a, (my int @ = 0, 2, 4, 6, 8), 'a loop with a native int parameter fills the array';
+    my sub read(int $i) { @a[$i] }
+    is read(3), 6, 'a subscript by a parameter gives the element';
+    my sub write(int $i, int $v) { @a[$i] = $v; Nil }
+    write(0, 9);
+    is @a[0], 9, 'an assignment of a parameter value stores the element';
+    dies-ok { write(-1, 1) }, 'a negative parameter index dies through the general call';
+    my sub readraw(int $i is raw) { @a[$i] }
+    is readraw(1), 2, 'a subscript by a raw parameter gives the element';
+    my sub readcopy(int $i is copy) { $i = $i + 1; @a[$i] }
+    is readcopy(2), 6, 'a subscript by a modified copy parameter reads the new position';
+    my sub readrw(int $i is rw) { my $v = @a[$i]; $i = 0; $v }
+    my int $x = 4;
+    is readrw($x), 8, 'a subscript by an rw parameter computes through the general call';
+    is $x, 0, 'the rw parameter still writes back to the caller';
+}
+
+{
+    my num @n;
+    my sub fillnum(int $i, num $v) { @n[$i] = $v; Nil }
+    fillnum(0, 3.5e0);
+    is @n[0], 3.5e0, 'an assignment of a num parameter value stores the element';
+    my str @s;
+    my sub fillstr(int $i, str $v) { @s[$i] = $v; Nil }
+    fillstr(0, 'xy');
+    is @s[0], 'xy', 'an assignment of a str parameter value stores the element';
+}
+
+{
+    my int @a = 7, 8, 9;
+    my sub readopt(int $i = 1) { @a[$i] }
+    is readopt(), 8, 'a subscript by the parameter default reads that position';
+    is readopt(2), 9, 'a subscript by a passed optional parameter reads that position';
+}
+
+{
+    my int @a = 5, 6, 7;
+    my int $i = 1;
+    @a[$i] += 5;
+    is @a[1], 11, 'a compound assignment writes through the element reference';
+    @a[$i]++;
+    is @a[1], 12, 'an increment writes through the element reference';
+    my $before = @a.elems;
+    my $v = @a[9];
+    is @a.elems, $before, 'a read past the end does not extend the array';
+}
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously a subscript of a native array called the postcircumfix routine, which dispatched through its candidates and the array's AT-POS or ASSIGN-POS on every access. A plain native int, num, or str array declaration owns the stock native container, so a subscript by an int literal or a native int lexical compiles to the raw position op. A read emits the element reference the general call returns, keeping every writable context working. A sunk assignment of a native value binds the element directly, since the raw bind stores exactly what the assignment coercion would have. A negative lexical index takes the general call behind a sign guard, whose candidates own that error. A literal only qualifies when it is at or above zero and fits a native int. A bind statement that retargets the declaration withdraws the raw op. Everything else also keeps the general call: a boxed array or index, an adverb, a shape, a binding initializer, or a used assignment result.