### PR TITLE
RakuAST: lower a for loop over a literal integer sequence

### DIFF
--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -911,9 +911,10 @@ class RakuAST::Node {
         Nil
     }
 
-    # Mark a for loop whose source is an integer range built by a CORE range
-    # constructor (`..` and its exclusive variants, prefix `^`, or `reverse`
-    # of one) for lowering to a native counting loop at code generation. Both
+    # Mark a for loop whose source is an integer range or sequence built
+    # by a CORE constructor (`..` and its exclusive variants, a two
+    # operand `...`, prefix `^`, or `reverse` of one) for lowering to a
+    # native counting loop at code generation. Both
     # the statement form and the statement modifier form qualify. Only the
     # source shape and the operator's origin are decided here; code generation
     # checks the loop itself (sunk, serial, simple body) and the bounds, and

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -4351,7 +4351,7 @@ class RakuAST::Statement::For
             my $flatten-body := $flatten ?? $!body !! Mu;
             my $body-qast := $flatten ?? Mu !! $!body.IMPL-TO-QAST($context);
 
-            # An integer-range source the optimize pass approved becomes a
+            # An integer range or sequence source the optimize pass approved becomes a
             # native counting loop, unless a bound turns out not to be a
             # native-friendly integer.
             if $!can-lower-range

--- a/src/Raku/ast/statement-mods.rakumod
+++ b/src/Raku/ast/statement-mods.rakumod
@@ -421,7 +421,7 @@ class RakuAST::StatementModifier::For
             my @lookups := self.IMPL-UNWRAP-LIST(self.get-implicit-lookups);
             my $Nil := @lookups[1].resolution.compile-time-value;
 
-            # An integer-range source the optimize pass approved becomes a
+            # An integer range or sequence source the optimize pass approved becomes a
             # native counting loop, unless a bound turns out not to be a
             # native-friendly integer.
             if $!can-lower-range

--- a/src/Raku/ast/statements.rakumod
+++ b/src/Raku/ast/statements.rakumod
@@ -192,8 +192,9 @@ class RakuAST::ForLoopImplementation
     }
 
     # The operator node of a for source that is shaped like an integer
-    # range: an infix range constructor, a ^ prefix, or an argument-less
-    # reverse method call on either. Returns Nil for any other shape.
+    # range: an infix range constructor, an infix sequence constructor
+    # with two operands, a ^ prefix, or an argument-less reverse method
+    # call on any of them. Returns Nil for any other shape.
     method IMPL-RANGE-FOR-OPERATOR(Mu $source) {
         my $expr := self.IMPL-UNWRAP-RANGE-EXPRESSION($source);
         if nqp::istype($expr, RakuAST::ApplyPostfix)
@@ -207,6 +208,12 @@ class RakuAST::ForLoopImplementation
             my str $op := $expr.infix.operator;
             return $expr.infix
                 if $op eq '..' || $op eq '..^' || $op eq '^..' || $op eq '^..^';
+        }
+        elsif nqp::istype($expr, RakuAST::ApplyListInfix)
+            && nqp::istype($expr.infix, RakuAST::Infix)
+            && $expr.infix.operator eq '...' {
+            return $expr.infix
+                if nqp::elems(self.IMPL-UNWRAP-LIST($expr.operands)) == 2;
         }
         elsif nqp::istype($expr, RakuAST::ApplyPrefix)
             && nqp::istype($expr.prefix, RakuAST::Prefix)
@@ -243,12 +250,19 @@ class RakuAST::ForLoopImplementation
         Mu
     }
 
+    # Whether a sequence bound is a plain Int and nothing more derived.
+    method IMPL-SEQUENCE-BOUND-IS-INT(Mu $node) {
+        $node.has-compile-time-value
+            && nqp::eqaddr(nqp::what(nqp::decont($node.maybe-compile-time-value)), Int)
+    }
+
     # The native counting loop for a sunk statement-level `for` over an
-    # integer range, the equivalent of the legacy optimizer's for-range
-    # rewrite. Steps a native int from start to end and calls the body
-    # with it, never building the Range or its iterator. Returns Mu when
-    # a bound disqualifies; the caller then falls back to the iterator
-    # form. The caller has already verified the operator is the CORE one
+    # integer range or sequence, the counterpart of the legacy
+    # optimizer's for-range rewrite, which also lowers a stepped list
+    # start while this declines it. Steps a native int from start to
+    # end and calls the body with it, never building the Range or Seq
+    # or its iterator. Returns Mu when a bound disqualifies; the caller
+    # then falls back to the iterator form. The caller has already verified the operator is the CORE one
     # via the optimize pass and that the body is a simple one-argument
     # block with no phasers.
     method IMPL-TO-QAST-RANGE(RakuAST::IMPL::QASTContext $context,
@@ -267,6 +281,7 @@ class RakuAST::ForLoopImplementation
         my $end-node;
         my int $start-extra := 0;
         my int $end-extra   := 0;
+        my int $sequence    := 0;
         if nqp::istype($expr, RakuAST::ApplyInfix)
             && nqp::istype($expr.infix, RakuAST::Infix) {
             my str $op := $expr.infix.operator;
@@ -276,6 +291,15 @@ class RakuAST::ForLoopImplementation
             $end-extra := -1 if $op eq '..^' || $op eq '^..^';
             $start-node := $expr.left;
             $end-node := $expr.right;
+        }
+        elsif nqp::istype($expr, RakuAST::ApplyListInfix)
+            && nqp::istype($expr.infix, RakuAST::Infix)
+            && $expr.infix.operator eq '...' {
+            my @operands := self.IMPL-UNWRAP-LIST($expr.operands);
+            return Mu unless nqp::elems(@operands) == 2;
+            $sequence := 1;
+            $start-node := @operands[0];
+            $end-node := @operands[1];
         }
         elsif nqp::istype($expr, RakuAST::ApplyPrefix)
             && nqp::istype($expr.prefix, RakuAST::Prefix)
@@ -295,11 +319,25 @@ class RakuAST::ForLoopImplementation
         return Mu if $end-qast =:= Mu;
 
         my int $step := 1;
+        if $sequence {
+            # A sequence counts toward its endpoint from either side, so
+            # the direction is part of its meaning and both bounds must
+            # be known to pick it. A variable bound keeps the iterator
+            # form. So does an Int subtype: a sequence walks its
+            # endpoints with .succ, so a Bool, an enum, or an allomorph
+            # yields elements of its own type and steps by its own
+            # succession.
+            return Mu unless nqp::istype($start-qast, QAST::IVal)
+                && nqp::istype($end-qast, QAST::IVal)
+                && self.IMPL-SEQUENCE-BOUND-IS-INT($start-node)
+                && self.IMPL-SEQUENCE-BOUND-IS-INT($end-node);
+            $step := -1 if $start-qast.value > $end-qast.value;
+        }
         if $reverse {
             my $swap := $start-qast;
             $start-qast := $end-qast;
             $end-qast := $swap;
-            $step := -1;
+            $step := -$step;
         }
 
         # Bind the iteration and end values into native int temporaries,

--- a/t/02-rakudo/for-range-native-loop.t
+++ b/t/02-rakudo/for-range-native-loop.t
@@ -1,11 +1,13 @@
 use Test;
 
-plan 14;
+plan 39;
 
-# A sunk statement-level `for` loop over a CORE integer range compiles to a
-# native counting loop. These tests pin the observable behavior: the values
-# each range constructor produces, control flow, and the cases that must
-# keep the general compilation.
+# A sunk statement-level `for` loop over a CORE integer range, or over a
+# CORE integer sequence with two compile time integer bounds, compiles to
+# a native
+# counting loop. These tests pin the observable behavior: the values each
+# constructor produces, control flow, and the cases that must keep the
+# general compilation.
 
 {
     my @seen;
@@ -92,4 +94,163 @@ plan 14;
     my @seen;
     for 1..6 { next if $_ %% 2; @seen.push($_) }
     is-deeply @seen, [1, 3, 5], 'next works in a range for loop';
+}
+
+{
+    my @seen;
+    for 1...5 { @seen.push($_) }
+    is-deeply @seen, [1, 2, 3, 4, 5], 'an ascending sequence produces its values';
+}
+
+{
+    my @seen;
+    for 5...1 { @seen.push($_) }
+    is-deeply @seen, [5, 4, 3, 2, 1], 'a descending sequence produces its values';
+}
+
+{
+    my @seen;
+    for 3...3 { @seen.push($_) }
+    is-deeply @seen, [3], 'a single element sequence produces its value';
+}
+
+{
+    my @seen;
+    for 1...0 { @seen.push($_) }
+    is-deeply @seen, [1, 0], 'a sequence to zero descends rather than staying empty';
+}
+
+{
+    my @seen;
+    for (2...6).reverse { @seen.push($_) }
+    is-deeply @seen, [6, 5, 4, 3, 2], 'a reversed sequence produces its values backward';
+}
+
+{
+    my @seen;
+    for 1...4 -> int $i { @seen.push($i) }
+    is-deeply @seen, [1, 2, 3, 4], 'a sequence loop binds a native int parameter';
+}
+
+{
+    my int $n = 5;
+    my @seen;
+    for 1...$n { @seen.push($_) }
+    is-deeply @seen, [1, 2, 3, 4, 5], 'a variable bound keeps the sequence values';
+}
+
+{
+    my @seen;
+    for 1,3...9 { @seen.push($_) }
+    is-deeply @seen, [1, 3, 5, 7, 9], 'a stepped sequence keeps its values';
+}
+
+{
+    my @seen;
+    for "a"..."e" { @seen.push($_) }
+    is-deeply @seen, ["a", "b", "c", "d", "e"], 'a string sequence keeps its values';
+}
+
+{
+    my @seen;
+    for 1...10 { last if $_ > 3; @seen.push($_) }
+    is-deeply @seen, [1, 2, 3], 'last works in a sequence for loop';
+}
+
+{
+    my @seen;
+    for 1...6 { next if $_ %% 2; @seen.push($_) }
+    is-deeply @seen, [1, 3, 5], 'next works in a sequence for loop';
+}
+
+{
+    sub infix:<...>($a, $b) { (42,) }
+    my @seen;
+    for 3...4 { @seen.push($_) }
+    is-deeply @seen, [42], 'a lexically redefined sequence constructor is honored';
+}
+
+{
+    my @seen;
+    for (5...1).reverse { @seen.push($_) }
+    is-deeply @seen, [1, 2, 3, 4, 5], 'a reversed descending sequence counts up';
+}
+
+{
+    my @seen;
+    for 1...* { last if $_ > 4; @seen.push($_) }
+    is-deeply @seen, [1, 2, 3, 4], 'last leaves a sequence with no end bound';
+}
+
+{
+    my @seen;
+    for 10_000_000_000...10_000_000_002 { @seen.push($_) }
+    is-deeply @seen, [10_000_000_000, 10_000_000_001, 10_000_000_002],
+        'a sequence with bounds past 32 bits still produces its values';
+}
+
+{
+    my @seen;
+    for -3...3 { @seen.push($_) }
+    is-deeply @seen, [-3, -2, -1, 0, 1, 2, 3], 'a sequence with a negative start produces its values';
+}
+
+{
+    my @seen;
+    for 3...-3 { @seen.push($_) }
+    is-deeply @seen, [3, 2, 1, 0, -1, -2, -3], 'a sequence descending past zero produces its values';
+}
+
+{
+    my @seen;
+    my $redone = 0;
+    for 1...3 { @seen.push($_); redo if $_ == 2 && !$redone++ }
+    is-deeply @seen, [1, 2, 2, 3], 'redo repeats a sequence loop iteration once';
+}
+
+{
+    my @seen;
+    @seen.push($_) for 1...5;
+    is-deeply @seen, [1, 2, 3, 4, 5], 'a modifier for over a sequence produces its values';
+}
+
+{
+    my @seen = do for 1...3 { $_ * 10 };
+    is-deeply @seen, [10, 20, 30], 'a non sunk for over a sequence keeps its result values';
+}
+
+{
+    my @seen;
+    LOOP: for 1...5 { @seen.push($_); last LOOP if $_ == 3 }
+    is-deeply @seen, [1, 2, 3], 'last with a label leaves a sequence loop';
+}
+
+# A sequence walks its endpoints with .succ, so a bound whose value is
+# an Int subtype produces elements of its own type and steps by its
+# own succession. Those keep the general compilation.
+
+{
+    my @seen;
+    for False...True { @seen.push($_) }
+    is-deeply @seen, [False], 'a Bool sequence stops at its single Bool element';
+}
+
+{
+    my enum E <a b c>;
+    my @seen;
+    for E::a...E::c { @seen.push($_) }
+    is-deeply @seen, [E::a, E::b, E::c], 'an enum sequence produces enum elements';
+}
+
+{
+    my enum G (g1 => 1, g2 => 5);
+    my @seen;
+    for G::g1...G::g2 { @seen.push($_) }
+    is-deeply @seen, [G::g1, G::g2], 'a sparse enum sequence steps by enum succession';
+}
+
+{
+    my @seen;
+    for <1>...<3> { @seen.push($_.^name) }
+    is-deeply @seen, ["IntStr", "Int", "Int"], 'an allomorph start keeps its own type';
 }


### PR DESCRIPTION
Previously a sunk for statement over an integer sequence built the Seq and pulled its iterator on every execution, while the range form compiled to a native counting loop. A sequence whose two bounds are compile time integers takes the counting loop as well. The direction is part of a sequence's meaning, so the bounds pick the step, and a variable bound or a stepped list start keeps the iterator form. A bound must also be a plain Int: a sequence walks its endpoints with .succ, so a Bool, an enum, or an allomorph produces elements of its own type and steps by its own succession. A reverse call swaps the bounds and flips the step. Only the CORE operator lowers.