### PR TITLE
RakuAST: bind a <-> block's native parameter as a reference

### DIFF
--- a/src/Raku/ast/signature.rakumod
+++ b/src/Raku/ast/signature.rakumod
@@ -948,11 +948,12 @@ class RakuAST::Parameter
                 # A <-> block starter flags every parameter rw and a trait
                 # does not clear that, so the target follows the flag even
                 # under an is copy trait. A variable declarator signature
-                # flags its parameters rw as well, but its targets declare
-                # ordinary variables, and a native one must stay a plain
-                # lexical for assignment to reach it.
-                $!target.set-rw if $trait-rw eq 'rw'
-                    || ($!default-rw && !$!target.var-declaration);
+                # flags its parameters rw as well and accepts an explicit
+                # rw trait, but its targets declare ordinary variables,
+                # and a native one must stay a plain lexical for
+                # assignment to reach it.
+                $!target.set-rw if ($trait-rw eq 'rw' || $!default-rw)
+                    && !$!target.var-declaration;
                 $!target.set-ro(False);
             }
         }
@@ -1250,7 +1251,11 @@ class RakuAST::Parameter
     method PERFORM-CHECK(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
         self.add-trait-sorries;
 
-        if nqp::istype($!owner, RakuAST::Sub) {
+        # A variable declarator signature in the body of MAIN owns its
+        # parameters too, but they are not what MAIN is called with, so
+        # they earn no dispatch advice.
+        if nqp::istype($!owner, RakuAST::Sub)
+            && !($!target && $!target.var-declaration) {
             my $name := $!owner.name;
             if $name && $name.is-identifier && $name.canonicalize eq 'MAIN' {
                 for self.IMPL-UNWRAP-LIST(self.traits) {

--- a/src/Raku/ast/signature.rakumod
+++ b/src/Raku/ast/signature.rakumod
@@ -925,17 +925,18 @@ class RakuAST::Parameter
         if $!target {
             $!target.set-ro(True);
             my $name := $!target.introspection-name;
-            my $rw := $!default-rw;
+            my str $trait-rw := '';
             for self.IMPL-UNWRAP-LIST(self.traits) {
                 if nqp::istype($_, RakuAST::Trait::Is)
                     && (
                         $_.name.canonicalize eq 'copy' || $_.name.canonicalize eq 'rw'
                     )
                 {
-                    $rw := $_.name.canonicalize;
+                    $trait-rw := $_.name.canonicalize;
                     last;
                 }
             }
+            my str $rw := $trait-rw || ($!default-rw ?? 'rw' !! '');
 
             if $rw {
                 if $rw ne 'copy' || !$!type || !nqp::objprimspec($!type.meta-object) {
@@ -944,7 +945,14 @@ class RakuAST::Parameter
                     nqp::bindattr($parameter, Parameter, '$!container_descriptor', $cd);
                     $!target.set-bindable(True);
                 }
-                $!target.set-rw if $rw eq 'rw';
+                # A <-> block starter flags every parameter rw and a trait
+                # does not clear that, so the target follows the flag even
+                # under an is copy trait. A variable declarator signature
+                # flags its parameters rw as well, but its targets declare
+                # ordinary variables, and a native one must stay a plain
+                # lexical for assignment to reach it.
+                $!target.set-rw if $trait-rw eq 'rw'
+                    || ($!default-rw && !$!target.var-declaration);
                 $!target.set-ro(False);
             }
         }
@@ -1990,6 +1998,8 @@ class RakuAST::ParameterTarget
     method set-rw() { }
     method set-ro(Bool $ro) { }
     method set-where(RakuAST::Expression $where) { }
+    method var-declaration() { False }
+    method set-var-declaration() { }
     method sigil() { '' }
     method name() { '' }
     method desigilname() { self.name }
@@ -2014,12 +2024,15 @@ class RakuAST::ParameterTarget::Var
     has RakuAST::VarDeclaration::Simple $.declaration;
     has str $!scope;
     has Bool $!is-bindable;
+    has Bool $!var-declaration;
 
     method new(str :$name!, Bool :$forced-dynamic, Bool :$var-declaration) {
         my $obj := nqp::create(self);
         nqp::bindattr_s($obj, RakuAST::ParameterTarget::Var, '$!name', $name);
         nqp::bindattr($obj, RakuAST::ParameterTarget::Var, '$!type', Mu);
         nqp::bindattr($obj, RakuAST::ParameterTarget::Var, '$!is-bindable', False);
+        nqp::bindattr($obj, RakuAST::ParameterTarget::Var, '$!var-declaration',
+            $var-declaration ?? True !! False);
         my $sigil := $obj.sigil;
         my $twigil := $obj.twigil;
         if $twigil eq '!' && !$var-declaration {
@@ -2120,6 +2133,12 @@ class RakuAST::ParameterTarget::Var
     method set-bindable(Bool $bindable) {
         nqp::bindattr(self, RakuAST::ParameterTarget::Var, '$!is-bindable', $bindable);
         $!declaration.set-bindable($bindable) if $!declaration;
+    }
+
+    method var-declaration() { $!var-declaration }
+
+    method set-var-declaration() {
+        nqp::bindattr(self, RakuAST::ParameterTarget::Var, '$!var-declaration', True);
     }
 
     method set-rw() {

--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -2186,10 +2186,26 @@ class RakuAST::VarDeclaration::Signature
                     && nqp::istype($target, RakuAST::ParameterTarget::Var)
                     && $target.declaration {
                     my $declaration := $target.declaration;
+                    # A trait with no variable meaning stays on the
+                    # parameter, where it is inert, since nothing ever
+                    # binds through the signature.
+                    my constant PARAM-ONLY-TRAITS := nqp::hash(
+                        'readonly', 1,  'rw',  1,  'copy',   1,
+                        'required', 1,  'raw', 1,  'onearg', 1,
+                        'item',     1
+                    );
+                    my @keep;
                     for self.IMPL-UNWRAP-LIST($param.traits) {
-                        $declaration.add-trait($_);
+                        if nqp::istype($_, RakuAST::Trait::Is)
+                            && $_.name
+                            && nqp::existskey(PARAM-ONLY-TRAITS, $_.name.canonicalize) {
+                            nqp::push(@keep, $_);
+                        }
+                        else {
+                            $declaration.add-trait($_);
+                        }
                     }
-                    $param.set-traits([]);
+                    $param.set-traits(@keep);
                     $param.clear-optionality;
                     if $param.default {
                         $declaration.set-initializer(

--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -2220,6 +2220,7 @@ class RakuAST::VarDeclaration::Signature
             }
             $param.set-bindable(False) if $binding;
             $param.set-default-rw unless $binding;
+            $param.target.set-var-declaration if $param.target;
             for $traits {
                 $param.target.replace-scope($scope);
                 $param.target.add-trait(nqp::clone($_)) if $param.target;

--- a/t/02-rakudo/declarator-signature-param-traits.t
+++ b/t/02-rakudo/declarator-signature-param-traits.t
@@ -1,0 +1,59 @@
+use lib <t/packages/Test-Helpers>;
+use Test;
+use Test::Helpers;
+
+# A variable declarator signature accepts the parameter traits that
+# have no variable meaning. They stay on the parameter, where a list
+# of declarations leaves them inert, since nothing ever binds through
+# the signature. A trait with variable meaning still applies to the
+# declared variable, and an unknown trait is still rejected.
+
+plan 14;
+
+is EVAL('my ($a is rw); $a = 3; $a'), 3,
+  'a declarator signature accepts is rw and the variable assigns';
+
+is EVAL('my ($a is copy); $a = 3; $a'), 3,
+  'a declarator signature accepts is copy and the variable assigns';
+
+is EVAL('my ($a is readonly); $a = 3; $a'), 3,
+  'a declarator signature accepts is readonly and the variable assigns';
+
+is EVAL('my ($a is raw); $a = 3; $a'), 3,
+  'a declarator signature accepts is raw and the variable assigns';
+
+is EVAL('my ($a is required); $a = 3; $a'), 3,
+  'a declarator signature accepts is required and the variable assigns';
+
+is EVAL('my ($a is onearg); $a = 3; $a'), 3,
+  'a declarator signature accepts is onearg and the variable assigns';
+
+throws-like { EVAL 'my ($a is item)' },
+  Exception,
+  message => /"Cannot use 'is item' on parameter"/,
+  'an is item trait in a declarator signature reports as a parameter trait';
+
+is EVAL('my (int $a is rw); $a = 3; $a'), 3,
+  'a declarator signature accepts is rw on a native int variable';
+
+is EVAL('my (int $a is copy); $a = 3; $a'), 3,
+  'a declarator signature accepts is copy on a native int variable';
+
+is EVAL('my ($a is rw is default(42)); $a = 3; $a'), 3,
+  'a parameter trait beside a variable trait leaves both accepted';
+
+is EVAL('our ($o is rw); $o = 3; $o'), 3,
+  'an our declarator signature accepts is rw and the variable assigns';
+
+is EVAL('sub f { state ($s is copy); ++$s }; f; f'), 2,
+  'a state declarator signature accepts is copy and the variable persists';
+
+throws-like { EVAL 'my ($a is rw) := 42' },
+  Exception,
+  message => /'unpack or Capture'/,
+  'a binding declarator signature still binds through the parameter';
+
+is-run 'sub MAIN() { my ($a is rw); $a = 3; print $a }', :out<3>,
+  'a declarator signature inside sub MAIN earns no dispatch advice';
+
+# vim: expandtab shiftwidth=4

--- a/t/02-rakudo/native-rw-param-writeback.t
+++ b/t/02-rakudo/native-rw-param-writeback.t
@@ -1,0 +1,119 @@
+use Test;
+
+# A rw parameter of native type binds the caller's native reference, so
+# an assignment to the parameter writes back through it. The rw-ness can
+# come from an is rw trait or from the <-> block starter. In a <-> block
+# an is copy trait keeps the parameter rw, since the block starter sets
+# the rw flag on every parameter.
+
+plan 16;
+
+{
+    my int @a = 1, 2, 3;
+    for @a <-> int $i { $i++ }
+    is-deeply @a, array[int].new(2, 3, 4),
+      'a for loop over a native int array writes back through <-> int';
+}
+
+{
+    my uint @a = 1, 2, 3;
+    for @a <-> uint $u { $u++ }
+    is-deeply @a, array[uint].new(2, 3, 4),
+      'a for loop over a native uint array writes back through <-> uint';
+}
+
+{
+    my num @a = 1e0, 2e0;
+    for @a <-> num $n { $n = $n * 2e0 }
+    is-deeply @a, array[num].new(2e0, 4e0),
+      'a for loop over a native num array writes back through <-> num';
+}
+
+{
+    my str @a = 'a', 'b';
+    for @a <-> str $s { $s = $s ~ '!' }
+    is-deeply @a, array[str].new('a!', 'b!'),
+      'a for loop over a native str array writes back through <-> str';
+}
+
+{
+    my int @a = 1, 2, 3, 4;
+    for @a <-> int $i, int $j { $i++; $j-- }
+    is-deeply @a, array[int].new(2, 1, 4, 3),
+      'a for loop taking two <-> int parameters writes back through both';
+}
+
+{
+    my &block = <-> int $i { $i = 42 };
+    my int $x = 1;
+    block($x);
+    is $x, 42,
+      'calling a <-> block with a native int variable writes back';
+    ok &block.signature.params[0].rw,
+      'a native parameter of a <-> block introspects as rw';
+}
+
+{
+    my int @a = 1, 2, 3;
+    for @a <-> int $i is copy { $i++ }
+    is-deeply @a, array[int].new(2, 3, 4),
+      'an is copy native parameter of a <-> block still writes back';
+}
+
+{
+    my @a = 1, 2, 3;
+    for @a <-> $i is copy { $i++ }
+    is-deeply @a, [2, 3, 4],
+      'an is copy ordinary parameter of a <-> block still writes back';
+}
+
+{
+    sub f(int $i is rw) { $i = 9 }
+    my int $x = 1;
+    f($x);
+    is $x, 9,
+      'a sub with a native int is rw parameter writes back';
+}
+
+{
+    sub f(int $i is copy) { $i++ }
+    my int $x = 1;
+    f($x);
+    is $x, 1,
+      'a sub with a native int is copy parameter does not write back';
+}
+
+{
+    my @a = 1, 2, 3;
+    for @a <-> $i { $i++ }
+    is-deeply @a, [2, 3, 4],
+      'a for loop over an ordinary array writes back through a <-> parameter';
+}
+
+# A variable declarator signature also flags its parameters rw, but
+# its targets declare ordinary variables. A native one must stay a
+# plain lexical so assignment reaches it.
+{
+    my (int $a, num $b);
+    $a = 42;
+    $b = 4e2;
+    is $a, 42,
+      'a native int declared in a declarator signature accepts assignment';
+    is $b, 4e2,
+      'a native num declared in a declarator signature accepts assignment';
+}
+
+{
+    my (int $a) = 5;
+    is $a, 5,
+      'a declarator signature holding one native int takes its initializer';
+}
+
+# The frontends throw different exception types here, so the message
+# carries the assertion.
+throws-like { for 1..3 <-> int $i { } },
+  Exception,
+  message => /'modifiable native int'/,
+  'a for loop over a range of values rejects a <-> int parameter';
+
+# vim: expandtab shiftwidth=4

--- a/t/12-rakuast/xx-fixed-in-rakuast.rakutest
+++ b/t/12-rakuast/xx-fixed-in-rakuast.rakutest
@@ -2,7 +2,7 @@ use Test;
 use lib <t/packages/Test-Helpers>;
 use Test::Helpers;
 
-plan 132;
+plan 135;
 
 # t/spec/S03-sequence/misc.t
 # https://github.com/rakudo/rakudo/issues/5520
@@ -959,6 +959,34 @@ subtest 'use of &?ROUTINE and &?BLOCK' => {
     is-deeply Q| my int8 @a = 1, 2, 3; for @a <-> int8 $i { $i++ }; @a |.AST.EVAL,
         array[int8].new(2, 3, 4),
         'a for loop over a sized native array writes back through <->';
+}
+
+# ???
+# The legacy frontend left an is rw trait inside a has declaration
+# list on the parameter, so the accessor stayed read only and an
+# assignment to it died. The trait lands on the attribute declaration
+# and the accessor is writable.
+{
+    is Q| class C { has ($.a is rw) }; my $c = C.new(a => 1); $c.a = 9; $c.a |.AST.EVAL,
+        9, 'an is rw trait inside a has declaration list gives a writable accessor';
+}
+
+# ???
+# The legacy frontend dropped an is default trait inside a declaration
+# list, leaving the variable's container with its bare type default.
+# The trait lands on the variable declaration and takes effect.
+{
+    is Q| my ($a is default(42)); $a |.AST.EVAL, 42,
+        'an is default trait inside a declaration list reaches the variable';
+}
+
+# ???
+# The legacy frontend silently discarded an unknown trait inside a
+# declaration list. It is rejected at compile time.
+{
+    throws-like { Q| my ($a is nonesuch) |.AST.EVAL },
+        Exception, message => /'nonesuch'/,
+        'an unknown trait inside a declaration list is rejected';
 }
 
 # vim: expandtab shiftwidth=4

--- a/t/12-rakuast/xx-fixed-in-rakuast.rakutest
+++ b/t/12-rakuast/xx-fixed-in-rakuast.rakutest
@@ -2,7 +2,7 @@ use Test;
 use lib <t/packages/Test-Helpers>;
 use Test::Helpers;
 
-plan 131;
+plan 132;
 
 # t/spec/S03-sequence/misc.t
 # https://github.com/rakudo/rakudo/issues/5520
@@ -948,6 +948,17 @@ subtest 'use of &?ROUTINE and &?BLOCK' => {
         :out<Nil>, :err(/'Useless use of constant integer 42'
             .*? 'Useless use of constant integer 43'/),
         'the last statement of a CATCH default block also warns as useless';
+}
+
+# ???
+# A rw parameter of a sized native type made the legacy frontend read
+# the bound reference back at full width into the sized register, which
+# died with a bytecode validation error on decont_i. The reference
+# binds and writes back cleanly.
+{
+    is-deeply Q| my int8 @a = 1, 2, 3; for @a <-> int8 $i { $i++ }; @a |.AST.EVAL,
+        array[int8].new(2, 3, 4),
+        'a for loop over a sized native array writes back through <->';
 }
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously a native parameter of a `<->` block was declared as a plain lexical, so the caller's native reference was dereferenced at bind time and an assignment inside the block never reached the caller:

```raku
my int @a = 1, 2, 3;
for @a <-> int $i { $i++ }
say @a; # [1 2 3], the legacy frontend gives [2 3 4]
```

This binds the reference into a `lexicalref` slot the way the legacy frontend does, so the loop above writes back, as does calling any `<->` block with a native variable argument. An `is copy` trait does not clear the rw flag a `<->` block sets, so such a parameter still writes back too, matching legacy.

The rw flag has a second producer, however. A variable declarator signature such as `my (int $a) = 5` also flags its parameters rw so its containers bind assignable, and marking those targets rw turned assignment to them into an error. The parameter target now records that it belongs to a variable declarator and the flag leaves it alone.

That same construct had a related problem: `my ($a is rw)` did not compile at all, since a non-binding declarator moves every parameter trait onto the variable declaration it carries, where the rw family of traits does not exist. A trait with no variable meaning now stays on the parameter, where it is inert, which is what the legacy frontend does. Traits with variable meaning such as `is default` still move, and a declarator in the body of `sub MAIN` no longer trips the "is rw on parameters of MAIN" advice.

A couple of adjacent cases where the legacy frontend fails outright are pinned in `xx-fixed-in-rakuast`: a `<->` loop over a sized native array (legacy dies with a bytecode validation error) and `has ($.a is rw)` (legacy leaves the accessor read only).
