### PR TITLE
RakuAST: close per call codegen gaps against the legacy frontend

### DIFF
--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -3096,15 +3096,21 @@ class RakuAST::Node {
     # a use of the name still turns the lowering off, where the resolution
     # stored on the node (made when the declaration had not been parsed yet)
     # would still claim the CORE routine. When the walk reaches no declaration
-    # at all (the operator is being defined as CORE itself compiles), the file
-    # vouches.
+    # at all, the origin check above already vouched, by file for a loaded
+    # setting or by the marker while a core setting compiles itself.
     method IMPL-OPERATOR-IS-CORE(RakuAST::Resolver $resolver, Mu $operator) {
         CATCH {
             return False;
         }
         my $routine := $operator.resolution.compile-time-value;
+        # A loaded setting stamps its symbols with a SETTING:: file. While
+        # a core setting is itself being compiled its own operators carry
+        # the plain source file instead, and every one of them is core.
         return False
-          unless nqp::can($routine, 'file') && $routine.file.starts-with('SETTING::');
+          unless nqp::can($routine, 'file')
+            && ($routine.file.starts-with('SETTING::')
+                || nqp::istrue(nqp::ifnull(
+                     nqp::getlexdyn('$*COMPILING_CORE_SETTING'), 0)));
         my str $category := nqp::istype($operator, RakuAST::Postfix) ?? '&postfix'
                          !! nqp::istype($operator, RakuAST::Prefix)  ?? '&prefix'
                          !! '&infix';

--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -760,6 +760,7 @@ class RakuAST::Node {
             self.IMPL-MARK-STATIC-INFIX($resolver, $expr);
             self.IMPL-MARK-STATIC-PREFIX($resolver, $expr);
             self.IMPL-MARK-STATIC-POSTFIX($resolver, $expr);
+            self.IMPL-MARK-CONSTANT-TERM($resolver, $expr);
             self.IMPL-MARK-NEGATE-NOT($resolver, $expr);
             self.IMPL-MARK-NATIVE-INDEX($resolver, $expr);
             self.IMPL-MARK-RETURN-DECONT($resolver, $expr);
@@ -1093,6 +1094,27 @@ class RakuAST::Node {
             }
         }
         $postfix.IMPL-SET-NATIVE-INDEX($spec, $expr.operand.resolution);
+        Nil
+    }
+
+    # Mark a plain constant term whose lexical is bound once for
+    # compiling as its value. A name read through the frame chain costs
+    # on every evaluation, and a setting name's lookup op keeps the
+    # surrounding frame from ever inlining. A container stays a lookup, since the
+    # fold would change what identity the read produces.
+    method IMPL-MARK-CONSTANT-TERM(RakuAST::Resolver $resolver, Mu $expr) {
+        return Nil unless nqp::istype($expr, RakuAST::Term::Name)
+            && $expr.is-resolved
+            && $expr.name.is-identifier
+            && !$expr.name.is-pseudo-package
+            && !$expr.name.is-package-search;
+        my $resolution := $expr.resolution;
+        return Nil unless nqp::istype($resolution, RakuAST::CompileTimeValue)
+            && $resolution.has-compile-time-value;
+        return Nil if nqp::iscont($resolution.compile-time-value);
+        $expr.IMPL-SET-COMPILE-TO-VALUE()
+            if self.IMPL-RESOLUTION-BOUND-ONCE($resolver, $resolution,
+                $expr.name.canonicalize);
         Nil
     }
 
@@ -1725,16 +1747,17 @@ class RakuAST::Node {
 
     # Whether a resolution's lexical is bound once, so the VM may resolve a
     # lookup of $name a single time and treat the result as a constant. Two
-    # kinds of binding qualify. A setting routine: the setting binds each
-    # routine name once and user code cannot rebind it. And a
-    # compile-time-valued binding in the outermost scope of the compilation
-    # unit (a sub declaration or an import), since that scope's frame is
-    # entered once per load and a sub declaration cannot be rebound. A
-    # declaration without a compile-time value, like `my &foo`, does not
-    # qualify: its binding is free to be rebound at runtime. Nor does a
-    # routine declared in a nested scope, since its enclosing frame is
-    # entered many times and each entry may bind a fresh clone. Nor does a
-    # callee compiled under the soft pragma, so it stays wrappable.
+    # kinds of binding qualify. A setting symbol: the setting binds each
+    # name once and user code cannot rebind it. And a compile-time-valued
+    # binding in the outermost scope of the compilation unit, such as a
+    # sub declaration, a constant, an enum value, or an import, since that
+    # scope's frame is entered once per load and such a binding cannot be
+    # rebound. A declaration without a compile-time value, like `my &foo`,
+    # does not qualify: its binding is free to be rebound at runtime. Nor
+    # does a routine declared in a nested scope, since its enclosing frame
+    # is entered many times and each entry may bind a fresh clone. Nor
+    # does a Code value compiled under the soft pragma, so it stays
+    # wrappable.
     method IMPL-RESOLUTION-BOUND-ONCE(RakuAST::Resolver $resolver, Mu $decl, str $name) {
         return 1 if nqp::istype($decl, RakuAST::Declaration::External::Setting);
 
@@ -1743,9 +1766,10 @@ class RakuAST::Node {
         my $routine := nqp::istype($decl, RakuAST::CompileTimeValue)
             ?? $decl.compile-time-value
             !! $decl.maybe-compile-time-value;
-        return 0 unless nqp::isconcrete($routine)
-            && nqp::istype($routine, Code)
-            && nqp::can($routine, 'soft') && !$routine.soft;
+        return 0 unless nqp::isconcrete($routine);
+        if nqp::istype($routine, Code) {
+            return 0 unless nqp::can($routine, 'soft') && !$routine.soft;
+        }
 
         # The nearest scope declaring the name must be the outermost one, and
         # the declaration found there must be the resolution itself, so a

--- a/src/Raku/ast/compunit.rakumod
+++ b/src/Raku/ast/compunit.rakumod
@@ -222,6 +222,13 @@ class RakuAST::CompUnit
         # Diagnostic switch: turns compile-time dispatch decisions off so a
         # suspect inlining can be ruled in or out without a rebuild.
         my $*NO-CT-DISPATCH := nqp::existskey(nqp::getenvhash(), 'RAKUDO_NO_CT_DISPATCH');
+        # The qast stage binds this for code generation, but the optimize
+        # stage runs first, and marks that gate on an operator's origin
+        # need to know a core setting is what is being compiled.
+        my $*COMPILING_CORE_SETTING := nqp::isconcrete($!setting-name)
+            && ($!setting-name eq 'NULL.c' || $!setting-name eq 'NULL.d'
+                || $!setting-name eq 'NULL.e')
+            ?? 1 !! 0;
         $!context.set-optimize-regex() if nqp::isconcrete($!context);
         $resolver.push-scope(self);
         $!mainline.IMPL-OPTIMIZE($resolver);

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -1619,6 +1619,8 @@ class RakuAST::MetaInfix::Assign
         nqp::bindattr_i(self, RakuAST::MetaInfix::Assign, '$!native-step', $primspec)
     }
 
+    method IMPL-NATIVE-STEP-SET() { $!native-step }
+
     method IMPL-SET-INLINE() {
         nqp::bindattr_i(self, RakuAST::MetaInfix::Assign, '$!inline', 1)
     }
@@ -3309,6 +3311,8 @@ class RakuAST::ApplyPrefix
         nqp::bindattr_i(self, RakuAST::ApplyPrefix, '$!native-incdec', $primspec)
     }
 
+    method IMPL-NATIVE-INCDEC-SET() { $!native-incdec }
+
     method PERFORM-BEGIN(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
         self.IMPL-MAYBE-PRIME($resolver, $context);
     }
@@ -4196,6 +4200,8 @@ class RakuAST::ApplyPostfix
     method IMPL-SET-NATIVE-INCDEC(int $primspec) {
         nqp::bindattr_i(self, RakuAST::ApplyPostfix, '$!native-incdec', $primspec)
     }
+
+    method IMPL-NATIVE-INCDEC-SET() { $!native-incdec }
 
     method IMPL-EXPR-QAST(RakuAST::IMPL::QASTContext $context) {
         return self.IMPL-NATIVE-INCDEC-QAST($context) if $!native-incdec;

--- a/src/Raku/ast/scoping.rakumod
+++ b/src/Raku/ast/scoping.rakumod
@@ -879,8 +879,8 @@ class RakuAST::Declaration::External::Constant
 }
 
 # A lexical declaration that comes with an external symbol, which has a fixed
-# value available during compilation but still has to be looked up during
-# runtime.
+# value available during compilation. A lookup happens at runtime, except
+# where the optimize pass folds a bound once constant term to its value.
 class RakuAST::Declaration::External::Setting
   is RakuAST::Declaration::External
   is RakuAST::CompileTimeValue

--- a/src/Raku/ast/signature.rakumod
+++ b/src/Raku/ast/signature.rakumod
@@ -1775,7 +1775,13 @@ class RakuAST::Parameter
                 $param-qast.push($!target.IMPL-BIND-QAST($context, $temp-qast-var));
             }
             else {
-                my $value := $get-decont-var() // QAST::Op.new(:op('decont'), $temp-qast-var);
+                # A native register holds no container, so the value binds
+                # straight through. The decont var would build
+                # hllize(decont(...)) around it, which the code generator
+                # can only satisfy by boxing the native first.
+                my $value := !$is-generic && !$is-coercive && $spec
+                    ?? $temp-qast-var
+                    !! $get-decont-var() // QAST::Op.new(:op('decont'), $temp-qast-var);
 
                 my $wrap := $flags +& nqp::const::SIG_ELEM_IS_COPY;
                 unless $wrap {

--- a/src/Raku/ast/term.rakumod
+++ b/src/Raku/ast/term.rakumod
@@ -9,6 +9,16 @@ class RakuAST::Term::Name
     has RakuAST::Name $.name;
     has Mu $!package;
 
+    # Set by the optimize pass when this term resolves to a constant
+    # whose lexical is bound once: the term compiles to its value. The
+    # late lookup this replaces costs on every read, and a setting
+    # name's lookup op keeps the surrounding frame from ever inlining.
+    has int $!compile-to-value;
+
+    method IMPL-SET-COMPILE-TO-VALUE() {
+        nqp::bindattr_i(self, RakuAST::Term::Name, '$!compile-to-value', 1);
+    }
+
     method new(RakuAST::Name $name) {
         my $obj := nqp::create(self);
         nqp::bindattr($obj, RakuAST::Term::Name, '$!name', $name);
@@ -93,6 +103,11 @@ class RakuAST::Term::Name
     }
 
     method IMPL-EXPR-QAST(RakuAST::IMPL::QASTContext $context) {
+        if $!compile-to-value {
+            my $value := nqp::decont(self.resolution.compile-time-value);
+            $context.ensure-sc($value);
+            return QAST::WVal.new( :value($value) );
+        }
         if $!name.is-pseudo-package {
             if $!name.is-package-search && !$!name.is-indirect-lookup
             && (my $stripped := $!name.without-first-part).is-global-lookup {

--- a/src/Raku/ast/var-lowering.rakumod
+++ b/src/Raku/ast/var-lowering.rakumod
@@ -22,6 +22,7 @@ class RakuAST::IMPL::VarLoweringFrame {
     has int $!flatten-blocked;
     has Mu $!deferred-uses;
     has str $!implicit-slurpy-id;
+    has int $!makes-calls;
 
     method new(RakuAST::Node $node, int $is-scope) {
         my $obj := nqp::create(self);
@@ -43,6 +44,12 @@ class RakuAST::IMPL::VarLoweringFrame {
         Nil
     }
     method is-poisoned() { $!poisoned }
+
+    method note-call() {
+        nqp::bindattr_i(self, RakuAST::IMPL::VarLoweringFrame, '$!makes-calls', 1);
+        Nil
+    }
+    method makes-calls() { $!makes-calls }
 
     method register-implicit(str $id, Mu $decl) {
         my $record := nqp::hash('decl', $decl);
@@ -198,6 +205,7 @@ class RakuAST::IMPL::VarLowering {
     method IMPL-WALK(RakuAST::Node $node) {
         self.IMPL-CHECK-NAME-REACHERS($node);
         self.IMPL-CHECK-FLATTEN-BLOCKERS($node);
+        self.IMPL-NOTE-FRAME-CALL() if self.IMPL-NODE-MAKES-CALL($node);
 
         # Trait arguments, type parameterizations, and constant
         # initializers are evaluated at BEGIN time by dynamically
@@ -219,6 +227,61 @@ class RakuAST::IMPL::VarLowering {
             return Nil;
         }
         self.IMPL-WALK-INNER($node)
+    }
+
+    # Whether this node's emission invokes a routine. The contextual
+    # magicals only drop from a frame that makes no calls, since a
+    # callee can reach them by name. A native step or increment mark
+    # compiles to a raw op and makes no call, and neither do assignments
+    # and binds, whose stores the legacy optimizer also never counts. A
+    # quoted string with interpolation stringifies its pieces through
+    # method calls, so only one with a compile time value is free.
+    method IMPL-NODE-MAKES-CALL(Mu $node) {
+        if nqp::istype($node, RakuAST::QuotedString) {
+            return $node.has-compile-time-value ?? 0 !! 1;
+        }
+        if nqp::istype($node, RakuAST::Call)
+            || nqp::istype($node, RakuAST::QuotedRegex)
+            || nqp::istype($node, RakuAST::Term::Reduce)
+            || nqp::istype($node, RakuAST::ApplyDottyInfix)
+            || nqp::istype($node, RakuAST::ApplyListInfix)
+            || nqp::istype($node, RakuAST::StatementPrefix)
+            || nqp::istype($node, RakuAST::Statement::For)
+            || nqp::istype($node, RakuAST::Statement::Given)
+            || nqp::istype($node, RakuAST::Statement::When)
+            || nqp::istype($node, RakuAST::Statement::Whenever) {
+            return 1;
+        }
+        if nqp::istype($node, RakuAST::ApplyInfix) {
+            my $infix := $node.infix;
+            return 0 if nqp::istype($infix, RakuAST::Infix)
+                && ($infix.operator eq '=' || $infix.operator eq ':='
+                    || $infix.operator eq '::=');
+            return 0 if nqp::istype($infix, RakuAST::MetaInfix::Assign)
+                && $infix.IMPL-NATIVE-STEP-SET;
+            return 1;
+        }
+        if nqp::istype($node, RakuAST::ApplyPrefix) {
+            return $node.IMPL-NATIVE-INCDEC-SET ?? 0 !! 1;
+        }
+        if nqp::istype($node, RakuAST::ApplyPostfix) {
+            return 0 if nqp::istype($node.postfix, RakuAST::Postfix)
+                && $node.IMPL-NATIVE-INCDEC-SET;
+            return 1;
+        }
+        0
+    }
+
+    # Every enclosing scope notes the call: the legacy optimizer folds a
+    # child block's call count into its parent, so a call anywhere below
+    # a routine keeps that routine's contextual magicals reachable.
+    method IMPL-NOTE-FRAME-CALL() {
+        my int $i := nqp::elems($!frames);
+        while --$i >= 0 {
+            my $frame := nqp::atpos($!frames, $i);
+            $frame.note-call() if $frame.is-scope;
+        }
+        Nil
     }
 
     method IMPL-WALK-INNER(RakuAST::Node $node) {
@@ -537,9 +600,19 @@ class RakuAST::IMPL::VarLowering {
                 }
             }
             elsif nqp::istype($decl, RakuAST::VarDeclaration::Implicit::Special) {
-                $decl.IMPL-SET-UNUSED()
-                    if $decl.name eq '$_'
-                    && !$used && !$poisoned && $!topic-not-dynamic;
+                my str $name := $decl.name;
+                if $name eq '$_' {
+                    $decl.IMPL-SET-UNUSED()
+                        if !$used && !$poisoned && $!topic-not-dynamic;
+                }
+                elsif $name eq '$/' || $name eq '$!' {
+                    # Contextual and dynamic in every language revision:
+                    # a callee can reach them by name, so only a frame
+                    # that makes no calls at all may drop an unused one,
+                    # the same rule the legacy optimizer applies.
+                    $decl.IMPL-SET-UNUSED()
+                        if !$used && !$poisoned && !$frame.makes-calls;
+                }
             }
             elsif nqp::istype($decl, RakuAST::VarDeclaration::Implicit::Cursor) {
                 $decl.IMPL-SET-UNUSED() if !$used && !$poisoned;

--- a/t/08-performance/21-rakuast-unused-implicits.t
+++ b/t/08-performance/21-rakuast-unused-implicits.t
@@ -3,7 +3,7 @@ use Test::Helpers::QAST;
 use Test;
 use QAST:from<NQP>;
 use nqp;
-plan 40;
+plan 53;
 
 # A routine declares fresh $_ and $¢ containers it usually never uses,
 # and a block binds its topic from the enclosing one. When nothing in
@@ -320,4 +320,75 @@ else {
         else { $p.unlink }
     }
     nuke($dir);
+}
+
+# A frame that never uses $/ or $! and makes no calls drops both
+# fresh containers, the rule the legacy optimizer applies. Both stay
+# dynamic in every language revision, so any call keeps them: a
+# callee can reach either by name.
+
+qast-is 'use nqp; my class T { method m() { nqp::add_i(1,2) } }; T.new.m', :full, -> \v {
+    qast-contains-op(v, 'add_i')
+    and not qast-var-decl(v, '$/', 'contvar')
+    and not qast-var-decl(v, '$!', 'contvar')
+}, 'a method of raw ops declares no fresh match or error variable';
+
+qast-is 'use nqp; my class T { method m($x) { if $x { $x.Str }; nqp::add_i(1,2) } }; T.new.m(1)', :full, -> \v {
+    qast-contains-op(v, 'add_i')
+    and qast-var-decl(v, '$/', 'contvar')
+    and qast-var-decl(v, '$!', 'contvar')
+}, 'a call inside a nested block keeps the method fresh containers';
+
+qast-is 'use nqp; my class T { method m($v) { nqp::add_i(1,2); "x: $v" } }; T.new.m(1)', :full, -> \v {
+    qast-contains-op(v, 'add_i')
+    and qast-var-decl(v, '$/', 'contvar')
+    and qast-var-decl(v, '$!', 'contvar')
+}, 'string interpolation counts as a call, keeping both containers';
+
+qast-is 'my class T { method m() { try die "x"; 1 } }; T.new.m', :full, -> \v {
+    qast-var-decl(v, '$/', 'contvar')
+    and qast-var-decl(v, '$!', 'contvar')
+}, 'a method that tries keeps both fresh containers';
+
+qast-is 'my class T { method m($x) { $x.Str; 42 } }; T.new.m(1)', :full, -> \v {
+    qast-var-decl(v, '$/', 'contvar')
+    and qast-var-decl(v, '$!', 'contvar')
+}, 'a method that makes a call keeps both fresh containers';
+
+if nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' {
+    qast-is 'my class T { has int $!i; method m() { $!i++; Nil } }; T.new.m', :full, -> \v {
+        not qast-var-decl(v, '$/', 'contvar')
+        and not qast-var-decl(v, '$!', 'contvar')
+    }, 'a native step compiles to a raw op, so it counts as no call';
+
+    qast-is 'my class T { method m($x) { my $y = $x; $y := 42; 1 } }; T.new.m(1)', :full, -> \v {
+        qast-contains-op(v, 'bind')
+        and not qast-var-decl(v, '$/', 'contvar')
+        and not qast-var-decl(v, '$!', 'contvar')
+    }, 'assignments and binds count as no call';
+}
+else {
+    skip 'the call counting shapes are specific to the RakuAST frontend', 2;
+}
+
+{
+    my sub write-caller-match() { use nqp; my $t := nqp::getlexcaller(Q[$/]); $t = 'clobbered'; 1 }
+    "aXa" ~~ /(X)/;
+    my class A { method m($x) { if $x { write-caller-match() }; 42 } }
+    A.new.m(1);
+    is ~$0, 'X', 'a nested callee writing its caller match variable cannot reach the mainline one';
+    my sub read-caller-match() { use nqp; nqp::getlexcaller(Q[$/]) }
+    my class B { method m($x) { my $r; if $x { $r = read-caller-match() }; $r } }
+    nok B.new.m(1).defined, 'a nested callee reading its caller match variable sees a fresh one';
+    my class M { method m($s) { $s.match(/(c)/); ~$0 } }
+    is M.new.m("abc"), 'c', 'a method calling match reads the result through its own match variable';
+}
+
+{
+    my class T { method m($s) { $s ~~ /b(.)/; ~$0 } }
+    is T.new.m("abc"), 'c', 'a method that matches keeps its own match variable';
+    my class E { method m() { try die "boom"; $!.message } }
+    is E.new.m, 'boom', 'a method that tries keeps its own error variable';
+    my class C { method m() { my $x = "a1" ~~ /\d/; ~$x } }
+    is C.new.m, '1', 'a match in a method still binds its result';
 }

--- a/t/08-performance/31-rakuast-constant-terms.t
+++ b/t/08-performance/31-rakuast-constant-terms.t
@@ -1,0 +1,131 @@
+use lib <t/packages/Test-Helpers>;
+use Test::Helpers::QAST;
+use Test;
+use QAST:from<NQP>;
+use nqp;
+plan 19;
+
+# A term that resolves to a constant whose lexical is bound once
+# compiles to its value. The name lookup it replaces costs on every
+# read, and its op keeps the surrounding frame from ever inlining.
+# A container keeps the lookup. The shapes are this frontend's.
+
+sub qast-count-lex(Mu $qast, str $name --> Int:D) {
+    my int $count = 0;
+    $count++ if nqp::istype($qast, QAST::Var)
+        && $qast.scope eq 'lexical' && $qast.name eq $name;
+    if qast-descendable($qast) {
+        for $qast.list {
+            $count += qast-count-lex($_, $name);
+        }
+    }
+    $count
+}
+sub qast-uses-lex(Mu $qast, str $name) { so qast-count-lex($qast, $name) }
+
+if nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' {
+    qast-is 'my $y = IterationEnd; $y', :full, -> \v {
+        not qast-uses-lex(v, 'IterationEnd')
+    }, 'a setting constant term compiles to its value';
+
+    qast-is 'my $y = True; $y', :full, -> \v {
+        not qast-uses-lex(v, 'True')
+    }, 'an enum value term compiles to its value';
+
+    # The constant's declaration owns two mentions of its lexical: the
+    # static declaration and the declaration statement's own value. A
+    # folded use adds none.
+    qast-is 'my constant X = 42; my $y = X; $y', :full, -> \v {
+        qast-count-lex(v, 'X') == 2
+    }, 'a unit constant term compiles to its value';
+
+    # The enum's declaration owns one mention of each value's lexical.
+    # A folded use adds none.
+    qast-is 'my enum Color <red green>; my $y = green; $y', :full, -> \v {
+        qast-count-lex(v, 'green') == 1
+    }, 'a unit enum value term compiles to its value';
+
+    qast-is 'use soft; my $y = IterationEnd; $y', :full, -> \v {
+        qast-uses-lex(v, 'IterationEnd')
+    }, 'the soft pragma keeps the lookup';
+
+    # The declaration owns two mentions and the package search form
+    # keeps its lookup, adding the third.
+    qast-is 'my constant X = 42; my $a = ::X; $a', :full, -> \v {
+        qast-count-lex(v, 'X') == 3
+    }, 'a package search of a constant name keeps the lookup';
+
+    # The outer declaration owns two mentions and its folded use adds
+    # none. The shadowing declaration owns two more, and its use keeps
+    # the lookup, adding the fifth.
+    qast-is 'my constant X = 1; my $a = X; { my constant X = 2; my $b = X; }', :full, -> \v {
+        qast-count-lex(v, 'X') == 5
+    }, 'a use of a shadowing constant keeps the lookup while the outer use folds';
+}
+else {
+    skip 'the constant term shapes are specific to the RakuAST frontend', 7;
+}
+
+# Behavior stays identical.
+
+{
+    my $e := IterationEnd;
+    ok $e =:= IterationEnd, 'the compiled value keeps the identity of the setting constant';
+    ok True, 'a folded True is still true';
+    nok False, 'a folded False is still false';
+    my enum Color <red green blue>;
+    my $c = green;
+    is $c, green, 'a folded enum value compares to itself';
+    is $c.value, 1, 'a folded enum value keeps its value';
+    my constant X = 4242;
+    is X + 0, 4242, 'a folded unit constant computes';
+}
+
+{
+    my constant X = 1;
+    my $outer = X;
+    my $inner;
+    { my constant X = 2; $inner = X; }
+    is $outer, 1, 'the outer constant reads its own value';
+    is $inner, 2, 'the shadowing constant reads its own value';
+    is X, 1, 'the outer constant reads unchanged after the block';
+}
+
+{
+    my constant T = Int;
+    my $y := T;
+    ok $y =:= Int, 'a constant holding a type object reads the very type object';
+}
+
+# The folded value serializes as a reference into its own context, so
+# a precompiled module must produce the same objects when its store
+# compiles and when it loads. The imported container proves the
+# container gate: a fold would have compiled the decontainerized
+# value, and the read would no longer see a Scalar.
+
+{
+    my $dir = $*TMPDIR.add("rakuast-constant-terms-$*PID");
+    $dir.mkdir;
+    $dir.add('ConstantTermTest.rakumod').spurt(q:to/MODULE/);
+        unit module ConstantTermTest;
+        my constant ANSWER = 424242;
+        my enum Shade <dark light>;
+        sub iter-end() is export { IterationEnd }
+        sub answer() is export { ANSWER }
+        sub shade() is export { light ~ '=' ~ light.value }
+        MODULE
+    $dir.add('ContainerExport.rakumod').spurt(q:to/MODULE/);
+        sub EXPORT() { my $v = 42; Map.new(('CV' => $v)) }
+        MODULE
+    my $probe = 'use ConstantTermTest; use ContainerExport; print +(iter-end() =:= IterationEnd) ~ "|" ~ answer() ~ "|" ~ shade() ~ "|" ~ CV.VAR.^name';
+    for 'compiles', 'loads from the precompilation store' -> $stage {
+        my $proc = run $*EXECUTABLE, '-I', $dir.absolute, '-e', $probe, :out, :err;
+        my $out = $proc.out.slurp(:close);
+        $proc.err.slurp(:close);
+        is $out, '1|424242|light=1|Scalar', "the folded constants $stage";
+    }
+    sub nuke(IO::Path $p) { if $p.d { nuke($_) for $p.dir; $p.rmdir } else { $p.unlink } }
+    nuke($dir);
+}
+
+# vim: expandtab shiftwidth=4

--- a/t/08-performance/32-rakuast-native-param-bind.t
+++ b/t/08-performance/32-rakuast-native-param-bind.t
@@ -1,0 +1,119 @@
+use lib <t/packages/Test-Helpers>;
+use Test::Helpers::QAST;
+use Test;
+use QAST:from<NQP>;
+use nqp;
+plan 26;
+
+# A native value parameter binds its register straight through: no
+# box, no hllize dispatch, and no unbox on the way to the target.
+# Each shape asserts an op from the method body, so a tree that lost
+# the body cannot pass. The shapes are this frontend's.
+
+if nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' {
+    qast-is 'my class T { method m(int $i) { $i + 1 } }; say T.new.m(2)', :full, -> \v {
+        qast-contains-op(v, 'add_i')
+        and not qast-contains-op(v, 'box_i')
+    }, 'a native int parameter binds without boxing';
+
+    qast-is 'my class T { method m(num $n) { $n + 1e0 } }; say T.new.m(1e0)', :full, -> \v {
+        qast-contains-op(v, 'add_n')
+        and not qast-contains-op(v, 'box_n')
+    }, 'a native num parameter binds without boxing';
+
+    qast-is 'use nqp; my class T { method m(str $s) { nqp::concat($s, "!") } }; say T.new.m("x")', :full, -> \v {
+        qast-contains-op(v, 'concat')
+        and not qast-contains-op(v, 'box_s')
+    }, 'a native str parameter binds without boxing';
+
+    qast-is 'use nqp; my class T { method m(int $i is rw) { $i = nqp::add_i(4,1) } }; my int $x; T.new.m($x); say $x', :full, -> \v {
+        qast-contains-op(v, 'add_i')
+        and not qast-contains-op(v, 'box_i')
+    }, 'an rw native parameter binds its reference without boxing';
+
+    qast-is 'my class T { method m(int $i = 5) { $i + 1 } }; say T.new.m', :full, -> \v {
+        qast-contains-op(v, 'add_i') and not qast-contains-op(v, 'box_i')
+    }, 'an optional native parameter with a default binds without boxing';
+
+    qast-is 'my class T { method m(int :$i = 3) { $i + 1 } }; say T.new.m(:i(2))', :full, -> \v {
+        qast-contains-op(v, 'add_i') and not qast-contains-op(v, 'box_i')
+    }, 'a named native parameter binds without boxing';
+
+    qast-is 'use nqp; my class T { method m(int $i is copy) { nqp::add_i($i, 1) } }; say T.new.m(2)', :full, -> \v {
+        qast-contains-op(v, 'add_i') and not qast-contains-op(v, 'box_i')
+    }, 'a copy native parameter takes its value without boxing';
+
+    qast-is 'my class T { method m(int $i, *@r) { $i + 1 } }; say T.new.m(1, 2, 3)', :full, -> \v {
+        qast-contains-op(v, 'add_i') and not qast-contains-op(v, 'box_i')
+    }, 'a native parameter beside a slurpy binds without boxing';
+
+    qast-is 'my class T { method m(int8 $i) { $i + 1 } }; say T.new.m(2)', :full, -> \v {
+        qast-contains-op(v, 'add_i')
+        and not qast-contains-op(v, 'box_i')
+    }, 'a sized int parameter binds without boxing';
+}
+else {
+    skip 'the binding shapes are specific to the RakuAST frontend', 9;
+}
+
+# Behavior stays identical.
+
+{
+    my sub f(int $i) { $i * 2 }
+    is f(21), 42, 'a native int parameter passes its value';
+    my sub g(num $n) { $n + 0.5e0 }
+    is g(1e0), 1.5e0, 'a native num parameter passes its value';
+    my sub h(str $s) { $s ~ "!" }
+    is h("hi"), 'hi!', 'a native str parameter passes its value';
+    my sub r(int $i is rw) { $i = 9 }
+    my int $x = 1;
+    r($x);
+    is $x, 9, 'an rw native parameter writes back to the caller';
+    my sub c(int $i is copy) { $i++; $i }
+    my int $y = 5;
+    is c($y), 6, 'a copy native parameter steps its own copy';
+    is $y, 5, 'the copy leaves the caller alone';
+    my sub t(int8 $i) { $i + 1 }
+    is t(127), 128, 'a sized int parameter computes at full width';
+}
+
+{
+    my class T { method m(int $i = 5) { $i + 1 } }
+    is T.new.m, 6, 'an omitted optional native takes its default';
+    is T.new.m(1), 2, 'a passed optional native takes the argument';
+}
+
+{
+    my class T { method m(int :$i = 3) { $i * 2 } }
+    is T.new.m(:i(4)), 8, 'a named native binds a passed named';
+    is T.new.m, 6, 'an omitted named native takes its default';
+}
+
+{
+    my class T {
+        multi method m(int $i) { "int:$i" }
+        multi method m(str $s) { "str:$s" }
+    }
+    my int $x = 2;
+    my str $s = "x";
+    is T.new.m($x), 'int:2', 'a multi dispatches a native int argument';
+    is T.new.m($s), 'str:x', 'a multi dispatches a native str argument';
+}
+
+{
+    my class T { method m(int $i, *@r) { $i + @r.elems } }
+    is T.new.m(1, 9, 9), 3, 'a native binds beside a slurpy';
+}
+
+{
+    my class T { method m(int $i where * > 0) { $i + 1 } }
+    is T.new.m(2), 3, 'a where passing native argument binds';
+    throws-like { T.new.m(-1) }, Exception, 'a where failing native argument rejects';
+}
+
+{
+    my class T { method m(int8 $i) { $i + 0 } }
+    is T.new.m(300), 44, 'a sized int truncates at bind';
+}
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Code compiled by the RakuAST frontend paid some per call and per read costs that code from the legacy frontend does not. This removes four of them, each as its own commit.

Routines no longer clone fresh `$/` and `$!` containers on entry when they never use them and make no calls, the same rule the legacy optimizer applies. A term that resolves to a constant with a bound once lexical, such as `IterationEnd`, `True`, or an enum value, compiles to its value instead of a name lookup, which also lets MoarVM inline frames the lookup op used to block. The operator marks of the optimize pass now also fire while a core setting itself is being compiled, so the setting's own hot loops get the same lowerings user code gets. And a native value parameter binds its register straight through instead of boxing, dispatching, and unboxing on every call.
