### PR TITLE
RakuAST: lower term parameters and skip needless invocant probing

### DIFF
--- a/src/Raku/ast/scoping.rakumod
+++ b/src/Raku/ast/scoping.rakumod
@@ -59,7 +59,8 @@ class RakuAST::LexicalScope
     # on the block, so backtraces and debuggers can still name them.
     method IMPL-ADD-LOWERED-DEBUG-MAPPINGS(Mu $block) {
         for self.IMPL-UNWRAP-LIST(self.ast-lexical-declarations()) {
-            if nqp::istype($_, RakuAST::VarDeclaration::Simple)
+            if (nqp::istype($_, RakuAST::VarDeclaration::Simple)
+                || nqp::istype($_, RakuAST::ParameterTarget::Term))
                 && $_.IMPL-LOWERED-LOCAL-NAME {
                 $block.add_local_debug_mapping(
                     $_.IMPL-LOWERED-LOCAL-NAME, $_.lexical-name);

--- a/src/Raku/ast/signature.rakumod
+++ b/src/Raku/ast/signature.rakumod
@@ -2294,6 +2294,9 @@ class RakuAST::ParameterTarget::Term
     has RakuAST::Type $.type;
     has RakuAST::Expression $.where;
     has Bool $!is-bindable;
+    has int $!lowered-to-local;
+    has Mu $!lowered-away-sentinel;
+    has str $!lowered-local-name;
 
     method new(RakuAST::Name $name!) {
         my $obj := nqp::create(self);
@@ -2301,6 +2304,36 @@ class RakuAST::ParameterTarget::Term
         nqp::bindattr($obj, RakuAST::ParameterTarget::Term, '$!type', Mu);
         nqp::bindattr($obj, RakuAST::ParameterTarget::Term, '$!is-bindable', False);
         $obj
+    }
+
+    method IMPL-SET-LOWERED-TO-LOCAL(Mu $sentinel) {
+        nqp::bindattr_i(self, RakuAST::ParameterTarget::Term, '$!lowered-to-local', 1);
+        nqp::bindattr(self, RakuAST::ParameterTarget::Term, '$!lowered-away-sentinel', $sentinel);
+    }
+
+    # The frame-local name for a lowered term parameter, minted on first
+    # request so the binding and every lookup agree, or the empty string
+    # when the term stays a by-name lexical.
+    method IMPL-LOWERED-LOCAL-NAME() {
+        return $!lowered-local-name if $!lowered-local-name;
+        return '' unless $!lowered-to-local;
+        return '' if nqp::isnull($!lowered-away-sentinel);
+        nqp::bindattr_s(self, RakuAST::ParameterTarget::Term,
+            '$!lowered-local-name',
+            QAST::Node.unique('__lowered_' ~ $!name.canonicalize));
+        if nqp::atkey(nqp::getenvhash(), 'RAKUDO_LOWERING_DEBUG') {
+            my str $where := '';
+            my $origin := self.origin;
+            if nqp::isconcrete($origin) {
+                my $source := $origin.source;
+                $where := ' at ' ~ $source.original-file
+                    ~ ':' ~ $source.original-line($origin.from);
+            }
+            RakuAST::IMPL::VarLowering.IMPL-NOTE(
+                'lex2local: minted ' ~ $!lowered-local-name ~ ' for term '
+                    ~ $!name.canonicalize ~ $where);
+        }
+        $!lowered-local-name
     }
 
     method lexical-name() {
@@ -2373,6 +2406,24 @@ class RakuAST::ParameterTarget::Term
                 :value($container), :returns(self.IMPL-OF-TYPE)
             )
         }
+        elsif self.IMPL-LOWERED-LOCAL-NAME {
+            # The local is declared here, in the block's declaration
+            # section, so it exists before anything references it. The
+            # by-name lexical stays declared for introspection, static
+            # with the sentinel as its value so no per-entry setup is
+            # paid for it.
+            $context.ensure-sc($!lowered-away-sentinel);
+            QAST::Stmts.new(
+                QAST::Var.new(
+                    :decl('static'), :scope('lexical'), :name($!name.canonicalize),
+                    :value($!lowered-away-sentinel)
+                ),
+                QAST::Var.new(
+                    :decl('var'), :scope('local'), :name($!lowered-local-name),
+                    :returns(self.IMPL-OF-TYPE)
+                )
+            )
+        }
         else {
             QAST::Var.new(
                 :decl('var'), :scope('lexical'), :name($!name.canonicalize),
@@ -2382,15 +2433,26 @@ class RakuAST::ParameterTarget::Term
     }
 
     method IMPL-BIND-QAST(RakuAST::IMPL::QASTContext $context, Mu $source-qast) {
-        QAST::Op.new(
-            :op('bind'),
-            QAST::Var.new( :scope('lexical'), :name($!name.canonicalize) ),
-            $source-qast
-        )
+        my str $local-name := self.IMPL-LOWERED-LOCAL-NAME;
+        $local-name
+            ?? QAST::Op.new(
+                :op('bind'),
+                QAST::Var.new( :scope('local'), :name($local-name),
+                    :returns(self.IMPL-OF-TYPE) ),
+                $source-qast
+            )
+            !! QAST::Op.new(
+                :op('bind'),
+                QAST::Var.new( :scope('lexical'), :name($!name.canonicalize) ),
+                $source-qast
+            )
     }
 
     method IMPL-LOOKUP-QAST(RakuAST::IMPL::QASTContext $context) {
-        QAST::Var.new( :name($!name.canonicalize), :scope('lexical'), :returns(self.IMPL-OF-TYPE))
+        my str $local-name := self.IMPL-LOWERED-LOCAL-NAME;
+        $local-name
+            ?? QAST::Var.new( :name($local-name), :scope('local'), :returns(self.IMPL-OF-TYPE))
+            !! QAST::Var.new( :name($!name.canonicalize), :scope('lexical'), :returns(self.IMPL-OF-TYPE))
     }
 
     method has-compile-time-value() { False }

--- a/src/Raku/ast/signature.rakumod
+++ b/src/Raku/ast/signature.rakumod
@@ -1589,7 +1589,10 @@ class RakuAST::Parameter
 
         my $inst-param;
         # Make sure we have (possibly instantiated) parameter object ready when we need it
-        if $is-generic || $!signature-constraint {
+        # An implicit invocant is generic on a role method, but its type is
+        # compiler-written and never a coercion, so it needs no runtime
+        # probing.
+        if ($is-generic && !$!implicit-invocant) || $!signature-constraint {
             my $inst-param-name := QAST::Node.unique('__lowered_param_obj_');
             my $i := $!owner.signature.IMPL-PARAM-POSITION(self);
             $param-qast.push( # Fetch instantiated Parameter object
@@ -1606,7 +1609,7 @@ class RakuAST::Parameter
         # Handle coercion.
         # For a generic we can't know beforehand if it's going to be a coercive or any other nominalizable. Thus
         # we have to fetch the instantiated parameter object and do run-time processing.
-        if $is-generic {
+        if $is-generic && !$!implicit-invocant {
             # For a generic-typed parameter get its instantiated clone and see if its type is a coercion.
             $get-decont-var := -> { NQPMu }
             my $low-param-type := QAST::Node.unique('__lowered_param_type');

--- a/src/Raku/ast/var-lowering.rakumod
+++ b/src/Raku/ast/var-lowering.rakumod
@@ -406,6 +406,10 @@ class RakuAST::IMPL::VarLowering {
                 if nqp::isconcrete($decl)
                 && nqp::istype($decl, RakuAST::VarDeclaration::Simple);
         }
+        elsif nqp::istype($node, RakuAST::Parameter)
+            && nqp::istype($node.target, RakuAST::ParameterTarget::Term) {
+            self.IMPL-REGISTER-TERM-PARAM($node);
+        }
         elsif nqp::istype($node, RakuAST::VarDeclaration::Simple) {
             self.IMPL-REGISTER-DECL($node)
                 unless nqp::getattr($node, RakuAST::VarDeclaration::Simple, '$!is-parameter');
@@ -674,6 +678,41 @@ class RakuAST::IMPL::VarLowering {
                 return Nil;
             }
         }
+        Nil
+    }
+
+    # Register a sigilless term parameter with its scope's frame. The
+    # target is its own declaration and every use resolves straight to
+    # it. A bindable one keeps its container semantics, a native one
+    # has no local form for its l-values, and one declared under a
+    # thunk of its scope crosses a frame boundary the nesting does not
+    # show.
+    method IMPL-REGISTER-TERM-PARAM(Mu $param) {
+        my $target := $param.target;
+        my int $i := nqp::elems($!frames);
+        my $scope-frame;
+        my int $scope-index := -1;
+        while --$i >= 0 {
+            my $frame := nqp::atpos($!frames, $i);
+            if $frame.is-scope {
+                $scope-frame := $frame;
+                $scope-index := $i;
+                last;
+            }
+        }
+        return Nil if $scope-index < 0;
+
+        my str $declined := '';
+        if $target.can-be-bound-to {
+            $declined := 'bindable';
+        }
+        elsif nqp::objprimspec($target.IMPL-OF-TYPE) {
+            $declined := 'native';
+        }
+        elsif $scope-index != nqp::elems($!frames) - 1 {
+            $declined := 'thunked';
+        }
+        $scope-frame.register($target, $declined);
         Nil
     }
 

--- a/t/08-performance/33-rakuast-lower-term-params.t
+++ b/t/08-performance/33-rakuast-lower-term-params.t
@@ -3,13 +3,15 @@ use Test::Helpers::QAST;
 use Test;
 use QAST:from<NQP>;
 use nqp;
-plan 19;
+plan 23;
 
 # A sigilless term parameter lowers to a frame local: its binding
 # writes a register and every use reads one, with the by-name
 # lexical kept static for introspection. A use from a nested frame
 # needs the lexical, as do bindable and native terms, so those keep
-# it. The shapes are this frontend's.
+# it. A role method's implicit invocant is generic but never
+# coercive, so no runtime probe of its parameter object is emitted.
+# The shapes are this frontend's.
 
 sub qast-has-lowered(Mu $qast, str $prefix --> Bool:D) {
     if nqp::istype($qast, QAST::Var) {
@@ -19,6 +21,19 @@ sub qast-has-lowered(Mu $qast, str $prefix --> Bool:D) {
         for $qast.list {
             qast-has-lowered($_, $prefix) and return True;
         }
+    }
+    False
+}
+
+# The parameter transforms hang ops under the QAST::Var param node
+# itself, which qast-descendable never enters, so probing for them
+# needs a walk of every node's children.
+sub qast-deep-has-op(Mu $qast, str $op --> Bool:D) {
+    if nqp::istype($qast, QAST::Op) {
+        return True if $qast.op eq $op;
+    }
+    for $qast.list {
+        qast-deep-has-op($_, $op) and return True;
     }
     False
 }
@@ -61,9 +76,18 @@ if nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' {
         qast-has-lexical-decl(v, 't')
         and not qast-has-lowered(v, '__lowered_t')
     }, 'a native term parameter keeps the lexical';
+
+    qast-is 'use nqp; my role R { method m() { nqp::add_i(1,2) } }; my class C does R {}; say C.new.m', :full, -> \v {
+        qast-deep-has-op(v, 'add_i')
+        and not qast-deep-has-op(v, 'bitand_i')
+    }, 'a role method probes no parameter flags for its implicit invocant';
+
+    qast-is 'my role R2[::T] { method m(T \x) { x.defined } }; my class C2 does R2[Int] {}; C2.new.m(1)', :full, -> \v {
+        qast-deep-has-op(v, 'bitand_i')
+    }, 'a generic non-invocant parameter still probes its parameter flags';
 }
 else {
-    skip 'the lowering shapes are specific to the RakuAST frontend', 6;
+    skip 'the lowering shapes are specific to the RakuAST frontend', 8;
 }
 
 # Behavior stays identical.
@@ -100,6 +124,10 @@ else {
     my role S2[::T] { method t() { T.^name } }
     my class D does S2[Int] {}
     is D.new.t, 'Int', 'a parametric role method still resolves its type parameter';
+    my class S3 { method m(Str(Int) $x:) { $x } }
+    is-deeply S3.^find_method('m')(42), '42', 'an explicit coercive invocant still coerces';
+    my class S4 { method m(\me:) { me * 2 } }
+    is S4.^find_method('m')(21), 42, 'an explicit term invocant passes its value';
 }
 
 # vim: expandtab shiftwidth=4

--- a/t/08-performance/33-rakuast-lower-term-params.t
+++ b/t/08-performance/33-rakuast-lower-term-params.t
@@ -1,0 +1,105 @@
+use lib <t/packages/Test-Helpers>;
+use Test::Helpers::QAST;
+use Test;
+use QAST:from<NQP>;
+use nqp;
+plan 19;
+
+# A sigilless term parameter lowers to a frame local: its binding
+# writes a register and every use reads one, with the by-name
+# lexical kept static for introspection. A use from a nested frame
+# needs the lexical, as do bindable and native terms, so those keep
+# it. The shapes are this frontend's.
+
+sub qast-has-lowered(Mu $qast, str $prefix --> Bool:D) {
+    if nqp::istype($qast, QAST::Var) {
+        return True if $qast.scope eq 'local' && $qast.name.starts-with($prefix);
+    }
+    if qast-descendable($qast) {
+        for $qast.list {
+            qast-has-lowered($_, $prefix) and return True;
+        }
+    }
+    False
+}
+
+sub qast-has-lexical-decl(Mu $qast, str $name --> Bool:D) {
+    if nqp::istype($qast, QAST::Var) {
+        return True if $qast.scope eq 'lexical' && $qast.name eq $name && $qast.decl;
+    }
+    if qast-descendable($qast) {
+        for $qast.list {
+            qast-has-lexical-decl($_, $name) and return True;
+        }
+    }
+    False
+}
+
+if nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' {
+    qast-is 'my class T { method m(\t) { t.defined } }; T.new.m(1)', :full, -> \v {
+        qast-has-lowered(v, '__lowered_t')
+    }, 'a term parameter lowers to a frame local';
+
+    qast-is 'my class T { method m(\t is raw) { t.defined } }; T.new.m(1)', :full, -> \v {
+        qast-has-lowered(v, '__lowered_t')
+    }, 'a raw term parameter lowers, since it cannot be rebound';
+
+    qast-is 'my class T { method m(\t) { my $c = { t.defined }; $c() } }; T.new.m(1)', :full, -> \v {
+        qast-has-lexical-decl(v, 't')
+        and not qast-has-lowered(v, '__lowered_t')
+    }, 'a term parameter a nested frame uses keeps the lexical';
+
+    qast-is 'my class T { method m(|c) { c.elems } }; T.new.m(1)', :full, -> \v {
+        qast-has-lowered(v, '__lowered_c')
+    }, 'a capture parameter lowers to a frame local';
+
+    qast-is 'my class T { method m(+vals) { vals.elems } }; T.new.m(1, 2)', :full, -> \v {
+        qast-has-lowered(v, '__lowered_vals')
+    }, 'a slurpy term parameter lowers to a frame local';
+
+    qast-is 'my class T { method m(int \t) { t.defined } }; T.new.m(1)', :full, -> \v {
+        qast-has-lexical-decl(v, 't')
+        and not qast-has-lowered(v, '__lowered_t')
+    }, 'a native term parameter keeps the lexical';
+}
+else {
+    skip 'the lowering shapes are specific to the RakuAST frontend', 6;
+}
+
+# Behavior stays identical.
+
+{
+    my class T { method m(\a, \b) { a + b } }
+    is T.new.m(40, 2), 42, 'lowered term parameters pass their values';
+    my class U { method m(\t) { my $c = { t * 2 }; $c() } }
+    is U.new.m(21), 42, 'a term parameter a closure captures reads through the lexical';
+    my class V { method m(|c) { c.elems } }
+    is V.new.m(1, 2, 3), 3, 'a capture parameter collects its arguments';
+    my class W { method m(+vals) { vals.sum } }
+    is W.new.m(20, 22), 42, 'a slurpy term parameter collects its arguments';
+    my class X1 { method m(\t is raw) { t } }
+    is X1.new.m(42), 42, 'a raw term parameter passes its value';
+    my sub f(\t) { t ~ "!" }
+    is f("hi"), 'hi!', 'a term parameter in a sub passes its value';
+    my class Y1 { method m(Int \t) { t + 1 } }
+    is Y1.new.m(41), 42, 'a typed term parameter passes its value';
+    my class N1 { method m(int \t) { t + 1 } }
+    is N1.new.m(41), 42, 'a native term parameter passes its value';
+    my sub g() { my (\a, \b) := (40, 2); a + b }
+    is g(), 42, 'a signature declaration binds its term targets';
+    my class I1 { method m(\t) { ::("t") } }
+    is I1.new.m(42), 42, 'an indirect lookup reads a term parameter, not a sentinel';
+    my class I2 { method m(\t) { MY::<t> } }
+    is I2.new.m(42), 42, 'a MY:: lookup reads a term parameter, not a sentinel';
+}
+
+{
+    my role R { method double() { self.x * 2 } }
+    my class C does R { method x() { 21 } }
+    is C.new.double, 42, 'a role method reads self through its generic invocant';
+    my role S2[::T] { method t() { T.^name } }
+    my class D does S2[Int] {}
+    is D.new.t, 'Int', 'a parametric role method still resolves its type parameter';
+}
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
This continues closing the code generation gap between the RakuAST and legacy frontends.