### PR TITLE
RakuAST: generate the POPULATE method from the build plan

### DIFF
--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -3661,6 +3661,439 @@ class RakuAST::Method::AttributeAccessor
     }
 }
 
+# The generated POPULATE method: a flattened compile of the class's
+# BUILDALLPLAN, which Mu.POPULATE otherwise interprets per object
+# construction. Created by RakuAST::CompilerServices when the
+# metamodel composes a class, mirroring what the legacy frontend's
+# generate_buildplan_executor installs. The setting values the plan
+# needs arrive resolved through the constructor, since this file
+# cannot name them and composition may run before they exist.
+class RakuAST::Submethod::BuildPlanExecutor
+  is RakuAST::Submethod
+{
+    has Mu $!package-type;
+    has Mu $!build-plan;
+    has Mu $!True;
+    has Mu $!Failure;
+    has Mu $!X-Attribute-Required;
+    has Mu $!return-routine;
+
+    method new(Mu :$package-type, Mu :$build-plan, Mu :$True,
+            Mu :$Failure, Mu :$X-Attribute-Required, Mu :$return-routine) {
+        my $obj := nqp::create(self);
+        nqp::bindattr_s($obj, RakuAST::Declaration, '$!scope', 'has');
+        nqp::bindattr_s($obj, RakuAST::Routine, '$!multiness', '');
+        nqp::bindattr($obj, RakuAST::Method, '$!private', False);
+        nqp::bindattr($obj, RakuAST::Method, '$!meta', False);
+        nqp::bindattr($obj, RakuAST::Routine, '$!need-routine-variable', False);
+        nqp::bindattr($obj, RakuAST::Method, '$!body', RakuAST::Blockoid.new);
+        nqp::bindattr($obj, RakuAST::Routine, '$!signature', RakuAST::Signature.new);
+        nqp::bindattr($obj, RakuAST::Routine, '$!name',
+            RakuAST::Name.from-identifier('POPULATE'));
+        nqp::bindattr($obj, RakuAST::Submethod::BuildPlanExecutor, '$!package-type', $package-type);
+        nqp::bindattr($obj, RakuAST::Submethod::BuildPlanExecutor, '$!build-plan', $build-plan);
+        nqp::bindattr($obj, RakuAST::Submethod::BuildPlanExecutor, '$!True', $True);
+        nqp::bindattr($obj, RakuAST::Submethod::BuildPlanExecutor, '$!Failure', $Failure);
+        nqp::bindattr($obj, RakuAST::Submethod::BuildPlanExecutor, '$!X-Attribute-Required', $X-Attribute-Required);
+        nqp::bindattr($obj, RakuAST::Submethod::BuildPlanExecutor, '$!return-routine', $return-routine);
+        $obj
+    }
+
+    # The body is fully synthetic: nothing in it can reach the special
+    # variables, so only self is declared.
+    method PRODUCE-IMPLICIT-DECLARATIONS() {
+        [ RakuAST::VarDeclaration::Implicit::Self.new() ]
+    }
+
+    # The block binds the invocant and the initialization hash as raw
+    # locals with no binder run, the shape the legacy frontend
+    # installs. The definite invocant type on the signature informs
+    # introspection, not a run time check. The lexical %_ stays
+    # declared without per call setup.
+    method IMPL-QAST-FORM-BLOCK(RakuAST::IMPL::QASTContext $context, str :$blocktype,
+            RakuAST::Expression :$expression) {
+        # The statements carry the composing class's file and line. A
+        # setting class's frame then reads as setting code, which keeps
+        # a callframe walk that skips setting frames moving past it,
+        # and a user class's frame reports the user's own file. The
+        # origin comes from the package via the compiler services.
+        my $block := QAST::Block.new(
+            :name<POPULATE>, :blocktype('declaration_static'),
+            self.IMPL-SET-NODE(QAST::Stmts.new(
+                QAST::Var.new( :decl<param>, :scope<local>, :name('self') ),
+                QAST::Var.new( :decl<param>, :scope<local>, :name('%init') ),
+                QAST::Var.new( :decl<var>, :scope<local>, :name('init') ),
+                QAST::Var.new( :decl<var>, :scope<local>, :name('return') ),
+                QAST::Var.new( :decl<static>, :scope<lexical>, :name('%_') )
+            )),
+            self.IMPL-COMPILE-BODY($context)
+        );
+        self.IMPL-SET-NODE($block);
+        $block.arity(2);
+        $block.annotate('count', 2);
+        $block
+    }
+
+    method IMPL-COMPILE-BODY(RakuAST::IMPL::QASTContext $context) {
+        # Mapping of primspec to attribute op postfix
+        my @psp := ('','_i','_n','_s','','','','','','','_u');
+        my $build-plan := $!build-plan;
+        my $self := QAST::Var.new( :scope<local>, :name('self') );
+        my $init := QAST::Var.new( :scope<local>, :name('init') );
+
+        my $stmts := self.IMPL-SET-NODE(QAST::Stmts.new);
+
+        # An empty plan produces the shared do nothing POPULATE, which
+        # never touches the initialization hash.
+        my int $count := nqp::elems($build-plan);
+        unless $count {
+            $stmts.push($self);
+            return $stmts;
+        }
+
+        my int $needs-wrapping;
+
+        # my $init := nqp::getattr(%init,Map,'$!storage')
+        $context.ensure-sc(Map);
+        $stmts.push(QAST::Op.new( :op<bind>,
+            $init,
+            QAST::Op.new( :op<getattr>,
+                QAST::Var.new( :scope<local>, :name('%init') ),
+                QAST::WVal.new( :value(Map) ),
+                QAST::SVal.new( :value('$!storage') )
+            )
+        ));
+
+        my int $i := -1;
+        while nqp::islt_i($i := nqp::add_i($i, 1), $count) {
+            if nqp::islist(my $task := nqp::atpos($build-plan, $i)) {
+                $context.ensure-sc(nqp::atpos($task, 1));
+                my $class := QAST::WVal.new( :value(nqp::atpos($task, 1)) );
+                my $attr := QAST::SVal.new( :value(nqp::atpos($task, 2)) );
+
+                my int $code := nqp::atpos($task, 0);
+
+                # 0,1100,1200,1300 = initialize opaque from %init
+                if $code == 0 || $code == 1100 || $code == 1200 || $code == 1300 {
+                    my $getattr := QAST::Op.new( :op<getattr>, $self, $class, $attr );
+
+                    # nqp::unless(
+                    #   nqp::isnull(my \tmp = nqp::atkey($init,'a')),
+                    my $tmp := QAST::Node.unique('buildall_tmp_');
+                    my $if := QAST::Op.new( :op<unless>,
+                        QAST::Op.new( :op<isnull>,
+                            QAST::Op.new( :op<bind>,
+                                QAST::Var.new( :name($tmp), :scope<local>, :decl<var> ),
+                                QAST::Op.new( :op<atkey>,
+                                    $init,
+                                    QAST::SVal.new( :value(nqp::atpos($task, 3)) )
+                                )
+                            )
+                        )
+                    );
+
+                    my str $sigil := nqp::substr(nqp::atpos($task, 2), 0, 1);
+
+                    # nqp::getattr(self,Foo,'$!a').STORE(tmp, :INITIALIZE)
+                    if $sigil eq '@' || $sigil eq '%' {
+                        $context.ensure-sc($!True);
+                        $if.push(
+                            QAST::Op.new( :op<callmethod>, :name<STORE>,
+                                $getattr,
+                                QAST::Var.new( :name($tmp), :scope<local> ),
+                                QAST::WVal.new( :value($!True), :named('INITIALIZE') )
+                            )
+                        );
+                    }
+
+                    # nqp::bindattr(self,Foo,'$!a',tmp)
+                    elsif $code == 1300 {
+                        my $arg := QAST::Var.new( :name($tmp), :scope<local> );
+                        if nqp::elems($task) == 5 {
+                            $context.ensure-sc(nqp::atpos($task, 4));
+                            $arg := QAST::Op.new( :op('p6bindassert'),
+                                $arg,
+                                QAST::WVal.new( :value(nqp::atpos($task, 4)) )
+                            );
+                        }
+                        $if.push(
+                            QAST::Op.new( :op('bindattr'), $self, $class, $attr, $arg )
+                        );
+                    }
+
+                    # nqp::getattr(self,Foo,'$!a') = tmp
+                    else {
+                        $if.push(
+                            QAST::Op.new(
+                                :op( $sigil eq '$' || $sigil eq '&'
+                                       ?? 'p6assign' !! 'p6store' ),
+                                $getattr,
+                                QAST::Var.new( :name($tmp), :scope<local> )
+                            )
+                        );
+                    }
+
+                    # 1100,1200: bindattr(self,Foo,'$!a',nqp::list or hash)
+                    # when the key is absent
+                    if $code == 1100 || $code == 1200 {
+                        $if.push(
+                            QAST::Op.new( :op<bindattr>,
+                                $self, $class, $attr,
+                                QAST::Op.new( :op($code == 1100 ?? 'list' !! 'hash') )
+                            )
+                        );
+                    }
+
+                    $stmts.push($if);
+                }
+
+                # 1,2,3,10 = initialize native from %init
+                elsif $code < 100 {
+                    my $tmp := QAST::Node.unique('buildall_tmp_');
+                    $stmts.push(
+                        QAST::Op.new( :op<unless>,
+                            QAST::Op.new( :op<isnull>,
+                                QAST::Op.new( :op<bind>,
+                                    QAST::Var.new( :decl<var>, :name($tmp), :scope<local> ),
+                                    QAST::Op.new( :op<atkey>,
+                                        $init,
+                                        QAST::SVal.new( :value(nqp::atpos($task, 3)) )
+                                    )
+                                )
+                            ),
+                            QAST::Op.new( :op('bindattr' ~ @psp[$code]),
+                                $self, $class, $attr,
+                                QAST::Op.new( :op<decont>,
+                                    QAST::Var.new( :name($tmp), :scope<local> ) )
+                            )
+                        )
+                    );
+                }
+
+                # 400,1400 = set opaque with default if not set yet
+                elsif $code == 400 || $code == 1400 {
+                    my $getattr := QAST::Op.new( :op<getattr>, $self, $class, $attr );
+                    my $unless := QAST::Op.new( :op<unless>,
+                        QAST::Op.new( :op<p6attrinited>, $getattr )
+                    );
+
+                    $context.ensure-sc(nqp::atpos($task, 3));
+                    my $initializer := nqp::istype(nqp::atpos($task, 3), Block)
+                        ?? QAST::Op.new( :op<call>,
+                             QAST::WVal.new( :value(nqp::atpos($task, 3)) ),
+                             $self, $getattr )
+                        !! QAST::WVal.new( :value(nqp::atpos($task, 3)) );
+
+                    my str $sigil := nqp::substr(nqp::atpos($task, 2), 0, 1);
+                    if $sigil eq '@' || $sigil eq '%' {
+                        $context.ensure-sc($!True);
+                        $unless.push(
+                            QAST::Op.new( :op<callmethod>, :name<STORE>,
+                                $getattr, $initializer,
+                                QAST::WVal.new( :value($!True), :named('INITIALIZE') )
+                            )
+                        );
+                    }
+                    elsif $code == 1400 {
+                        if nqp::elems($task) == 5 {
+                            $context.ensure-sc(nqp::atpos($task, 4));
+                            $initializer := QAST::Op.new( :op('p6bindassert'),
+                                $initializer,
+                                QAST::WVal.new( :value(nqp::atpos($task, 4)) )
+                            );
+                        }
+                        $unless.push(
+                            QAST::Op.new( :op('bindattr'),
+                                $self, $class, $attr, $initializer )
+                        );
+                    }
+                    else {
+                        $unless.push(
+                            QAST::Op.new(
+                                :op( $sigil eq '$' || $sigil eq '&'
+                                       ?? 'p6assign' !! 'p6store' ),
+                                $getattr, $initializer
+                            )
+                        );
+                    }
+
+                    $stmts.push($unless);
+                }
+
+                # 401,402,410 = set native numeric with default if not set
+                elsif $code == 401 || $code == 402 || $code == 410 {
+                    my $getattr := QAST::Op.new(
+                        :op('getattr' ~ @psp[$code - 400]),
+                        $self, $class, $attr
+                    );
+                    $context.ensure-sc(nqp::atpos($task, 3));
+                    $stmts.push(
+                        QAST::Op.new( :op<if>,
+                            QAST::Op.new(
+                                :op('iseq' ~ ($code == 410 ?? '_i' !! @psp[$code - 400])),
+                                $getattr,
+                                $code == 402
+                                    ?? QAST::NVal.new( :value(0e0) )
+                                    !! QAST::IVal.new( :value(0) )
+                            ),
+                            QAST::Op.new( :op('bindattr' ~ @psp[$code - 400]),
+                                $self, $class, $attr,
+                                nqp::istype(nqp::atpos($task, 3), Block)
+                                    ?? QAST::Op.new( :op<call>,
+                                         QAST::WVal.new( :value(nqp::atpos($task, 3)) ),
+                                         $self, $getattr )
+                                    !! ($code == 402
+                                         ?? QAST::NVal.new( :value(nqp::atpos($task, 3)) )
+                                         !! QAST::IVal.new( :value(nqp::atpos($task, 3)) ))
+                            )
+                        )
+                    );
+                }
+
+                # 403 = set native string with default if not set
+                elsif $code == 403 {
+                    my $getattr := QAST::Op.new( :op<getattr_s>, $self, $class, $attr );
+                    $context.ensure-sc(nqp::atpos($task, 3));
+                    $stmts.push(
+                        QAST::Op.new( :op<if>,
+                            QAST::Op.new( :op<isnull_s>, $getattr ),
+                            QAST::Op.new( :op<bindattr_s>,
+                                $self, $class, $attr,
+                                nqp::istype(nqp::atpos($task, 3), Block)
+                                    ?? QAST::Op.new( :op<call>,
+                                         QAST::WVal.new( :value(nqp::atpos($task, 3)) ),
+                                         $self, $getattr )
+                                    !! QAST::SVal.new( :value(nqp::atpos($task, 3)) )
+                            )
+                        )
+                    );
+                }
+
+                # 800 = die if opaque not yet initialized
+                # 1501,1502,1510 = die if int, num, uint is zero
+                # 1503 = die if str is null_s
+                elsif $code == 800 || $code > 1500 && $code < 1600 {
+                    my $check;
+                    if $code == 1501 {
+                        $check := QAST::Op.new( :op<getattr_i>, $self, $class, $attr );
+                    }
+                    elsif $code == 1502 {
+                        $check := QAST::Op.new( :op<getattr_n>, $self, $class, $attr );
+                    }
+                    elsif $code == 1503 {
+                        $check := QAST::Op.new( :op<not_i>,
+                            QAST::Op.new( :op<isnull_s>,
+                                QAST::Op.new( :op<getattr_s>, $self, $class, $attr )
+                            )
+                        );
+                    }
+                    elsif $code == 1510 {
+                        $check := QAST::Op.new( :op<getattr_u>, $self, $class, $attr );
+                    }
+                    else {
+                        $check := QAST::Op.new( :op<p6attrinited>,
+                            QAST::Op.new( :op<getattr>, $self, $class, $attr )
+                        );
+                    }
+                    $context.ensure-sc($!X-Attribute-Required);
+                    $context.ensure-sc(nqp::atpos($task, 3));
+                    $stmts.push(
+                        QAST::Op.new( :op<unless>,
+                            $check,
+                            QAST::Op.new( :op<callmethod>, :name<throw>,
+                                QAST::Op.new( :op<callmethod>, :name<new>,
+                                    QAST::WVal.new( :value($!X-Attribute-Required) ),
+                                    QAST::SVal.new( :named('name'),
+                                        :value(nqp::atpos($task, 2)) ),
+                                    QAST::WVal.new( :named('why'),
+                                        :value(nqp::atpos($task, 3)) )
+                                )
+                            )
+                        )
+                    );
+                }
+
+                # 900 = run attribute container initializer
+                elsif $code == 900 {
+                    $context.ensure-sc(nqp::atpos($task, 3));
+                    $stmts.push(
+                        QAST::Op.new( :op<bindattr>,
+                            $self, $class, $attr,
+                            QAST::Op.new( :op<call>,
+                                QAST::WVal.new( :value(nqp::atpos($task, 3)) ) )
+                        )
+                    );
+                }
+
+                # 1000 = vivify a mixin attribute for the side effect
+                elsif $code == 1000 {
+                    $stmts.push(
+                        QAST::Op.new( :op<getattr>, $self, $class, $attr )
+                    );
+                }
+
+                else {
+                    nqp::die('Invalid '
+                      ~ $!package-type.HOW.name($!package-type)
+                      ~ '.POPULATE plan: ' ~ $code);
+                }
+            }
+
+            # BUILD or TWEAK submethod: call it with the original nameds
+            # and return any Failure it produces
+            else {
+                $needs-wrapping := 1;
+                $context.ensure-sc($task);
+                $context.ensure-sc($!Failure);
+                $context.ensure-sc($!return-routine);
+                my $return := QAST::Var.new( :scope<local>, :name<return> );
+                $stmts.push(
+                    QAST::Op.new( :op<if>,
+                        QAST::Op.new( :op<istype>,
+                            QAST::Op.new( :op<bind>,
+                                $return,
+                                QAST::Op.new( :op<if>,
+                                    QAST::Op.new( :op<elems>, $init ),
+                                    QAST::Op.new( :op<call>,
+                                        QAST::WVal.new( :value($task) ),
+                                        $self,
+                                        QAST::Var.new( :scope<local>, :name<init>,
+                                            :flat(1), :named(1) )
+                                    ),
+                                    QAST::Op.new( :op<call>,
+                                        QAST::WVal.new( :value($task) ),
+                                        $self
+                                    )
+                                )
+                            ),
+                            QAST::WVal.new( :value($!Failure) )
+                        ),
+                        QAST::Op.new( :op<call>,
+                            QAST::WVal.new( :value($!return-routine) ),
+                            $return
+                        )
+                    )
+                );
+            }
+        }
+
+        $stmts.push($self);
+
+        # The return call for a Failure producing BUILD or TWEAK is a
+        # control exception, which needs its catching counterpart in
+        # this frame.
+        if $needs-wrapping {
+            $stmts := QAST::Op.new( :op<handlepayload>,
+                $stmts,
+                'RETURN',
+                QAST::Op.new( :op<lastexpayload> )
+            );
+        }
+
+        $stmts
+    }
+}
+
 class RakuAST::Method::ClassAccessor
   is RakuAST::Method
 {

--- a/src/Raku/ast/impl.rakumod
+++ b/src/Raku/ast/impl.rakumod
@@ -59,6 +59,11 @@ class RakuAST::IMPL::QASTContext {
     # frame holding the resolver could not.
     has Mu $!begin-time-marker;
 
+    # The POPULATE method shared by every class in this compilation
+    # unit whose build plan is empty. Lives here rather than on the
+    # compiler services, which are released after each composition.
+    has Mu $!empty-buildplan-method;
+
     # Code objects whose IMPL-STUB-CODE bound a freshcoderef to
     # Code.$!do but whose IMPL-LINK-META-OBJECT has not yet registered
     # that coderef with the SC. If the owning AST is discarded before
@@ -111,10 +116,19 @@ class RakuAST::IMPL::QASTContext {
         nqp::bindattr($context, RakuAST::IMPL::QASTContext, '$!cuid-to-parse-time-resolver', {});
         nqp::bindattr($context, RakuAST::IMPL::QASTContext, '$!stubbed-code-objects', {});
         nqp::bindattr($context, RakuAST::IMPL::QASTContext, '$!begin-time-marker', nqp::create(Mu));
+        # A nested compunit serializes on its own, so it cannot reuse a
+        # method object rooted in the outer unit's context.
+        nqp::bindattr($context, RakuAST::IMPL::QASTContext, '$!empty-buildplan-method', Mu);
         $context
     }
 
     method begin-time-marker() { $!begin-time-marker }
+
+    method empty-buildplan-method() { $!empty-buildplan-method }
+    method set-empty-buildplan-method(Mu $method) {
+        nqp::bindattr(self, RakuAST::IMPL::QASTContext, '$!empty-buildplan-method', $method);
+        Nil
+    }
 
     # Get the handle of the serialization context.
     method sc-handle() {

--- a/src/Raku/ast/package.rakumod
+++ b/src/Raku/ast/package.rakumod
@@ -1028,6 +1028,151 @@ class RakuAST::CompilerServices
         $code
     }
 
+    # Resolve one setting symbol to its compile time value, looking at
+    # the enclosing lexical scopes as well when the setting itself is
+    # what is compiling. Returns null for a symbol that does not
+    # resolve, which during the setting build means the symbol's
+    # declaration has not compiled yet.
+    method IMPL-SETTING-VALUE(RakuAST::Name $name) {
+        my $found := $!resolver.resolve-name-constant-in-setting($name);
+        $found := $!resolver.resolve-name-constant($name)
+            unless nqp::isconcrete($found);
+        nqp::isconcrete($found) && nqp::can($found, 'compile-time-value')
+            ?? $found.compile-time-value
+            !! nqp::null
+    }
+
+    # Compile the build plan into a POPULATE method for the composing
+    # class, replacing the generic interpretation of the plan that
+    # Mu.POPULATE does per object construction. Returns a type object
+    # when the plan cannot be compiled, as when it needs a setting
+    # symbol that has not compiled yet, in which case the metamodel
+    # leaves the class on the generic path.
+    method generate_buildplan_executor(Mu $obj, Mu $in-build-plan) {
+        my $build-plan := nqp::decont($in-build-plan);
+        unless nqp::islist($build-plan) {
+            $build-plan := nqp::getattr($build-plan, List, '$!reified');
+            return Mu unless nqp::islist($build-plan);
+        }
+
+        my int $count := nqp::elems($build-plan);
+
+        # An empty plan gets the one do nothing POPULATE the unit
+        # shares, with an Any invocant so any class can hold it.
+        unless $count {
+            my $shared := $!context.empty-buildplan-method;
+            return $shared if nqp::isconcrete($shared);
+            my $method := self.IMPL-MAKE-EXECUTOR(Any, nqp::list(),
+                nqp::null(), nqp::null(), nqp::null(), nqp::null());
+            if nqp::isconcrete($method) {
+                # The method serves whichever class has no plan, so its
+                # introspective package is Any, like its invocant,
+                # rather than the class whose composition made it.
+                nqp::bindattr($method, Routine, '$!package', Any);
+                $!context.set-empty-buildplan-method($method);
+            }
+            return $method;
+        }
+
+        # The plan decides which setting symbols the compile needs, so
+        # a class without a given feature does not pay that symbol's
+        # resolution or get declined for its absence.
+        my int $needs-true;
+        my int $needs-required;
+        my int $needs-submethod;
+        my int $i := -1;
+        while nqp::islt_i($i := nqp::add_i($i, 1), $count) {
+            if nqp::islist(my $task := nqp::atpos($build-plan, $i)) {
+                my int $code := nqp::atpos($task, 0);
+                if $code == 0 || $code == 1100 || $code == 1200 || $code == 1300
+                    || $code == 400 || $code == 1400 {
+                    my str $sigil := nqp::substr(nqp::atpos($task, 2), 0, 1);
+                    $needs-true := 1 if $sigil eq '@' || $sigil eq '%';
+                }
+                elsif $code == 800 || $code > 1500 && $code < 1600 {
+                    $needs-required := 1;
+                }
+            }
+            else {
+                $needs-submethod := 1;
+            }
+        }
+
+        my $True := nqp::null;
+        if $needs-true {
+            $True := self.IMPL-SETTING-VALUE(
+                RakuAST::Name.from-identifier-parts('Bool', 'True'));
+            return Mu if nqp::isnull($True);
+        }
+        my $X-Attribute-Required := nqp::null;
+        if $needs-required {
+            $X-Attribute-Required := self.IMPL-SETTING-VALUE(
+                RakuAST::Name.from-identifier-parts('X', 'Attribute', 'Required'));
+            return Mu if nqp::isnull($X-Attribute-Required);
+        }
+        my $Failure := nqp::null;
+        my $return-routine := nqp::null;
+        if $needs-submethod {
+            $Failure := self.IMPL-SETTING-VALUE(
+                RakuAST::Name.from-identifier('Failure'));
+            $return-routine := self.IMPL-SETTING-VALUE(
+                RakuAST::Name.from-identifier('&return'));
+            return Mu if nqp::isnull($Failure) || nqp::isnull($return-routine);
+        }
+
+        self.IMPL-MAKE-EXECUTOR($obj, $build-plan,
+            $True, $Failure, $X-Attribute-Required, $return-routine)
+    }
+
+    method IMPL-MAKE-EXECUTOR(Mu $invocant-base, Mu $build-plan, Mu $True,
+            Mu $Failure, Mu $X-Attribute-Required, Mu $return-routine) {
+        my $executor := RakuAST::Submethod::BuildPlanExecutor.new(
+            :package-type($invocant-base),
+            :$build-plan,
+            :$True,
+            :$Failure,
+            :$X-Attribute-Required,
+            :$return-routine,
+        );
+        # The package node's own origin is not attached until its parse
+        # action finishes, which is after composition, so the body's
+        # origin supplies the file and line.
+        my $origin := $!package.body.origin;
+        $origin := $!package.origin unless nqp::isconcrete($origin);
+        $executor.set-origin($origin) if nqp::isconcrete($origin);
+        $!resolver.push-scope($!package);
+        $!resolver.push-scope($executor);
+        # No check time: the method is fully synthetic, with no user
+        # code a check could diagnose.
+        $executor.to-begin-time($!resolver, $!context);
+        $!resolver.pop-scope();
+        $!resolver.pop-scope();
+        $!qast.push: $executor.IMPL-QAST-BLOCK($!context);
+        my $code := $executor.meta-object;
+
+        # The block binds the invocant raw, so the definite type on
+        # the signature informs introspection and derivation, not a
+        # run time check. Mirrors what the legacy frontend installs.
+        my $definite := Perl6::Metamodel::DefiniteHOW.new_type(
+            :base_type($invocant-base), :definite(1));
+        $!context.ensure-sc($definite);
+        nqp::bindattr(
+            nqp::atpos(nqp::getattr(
+                nqp::getattr($code, Code, '$!signature'),
+                Signature, '@!params'), 0),
+            Parameter, '$!type', $definite);
+
+        # Keep the generated frames out of user backtraces, as the
+        # legacy frontend does. Cosmetic, so a setting build point
+        # where the trait does not resolve yet just skips it.
+        my $trait-mod-is := self.IMPL-SETTING-VALUE(
+            RakuAST::Name.from-identifier('&trait_mod:<is>'));
+        $trait-mod-is($code, :hidden-from-backtrace)
+            unless nqp::isnull($trait-mod-is);
+
+        $code
+    }
+
     method IMPL-ADD-QAST(QAST::Node $target) {
         $target.push: $!qast if nqp::elems($!qast.list);
     }

--- a/t/02-rakudo/generated-populate.t
+++ b/t/02-rakudo/generated-populate.t
@@ -1,0 +1,202 @@
+use lib <t/packages/Test-Helpers>;
+use Test;
+use Test::Helpers;
+
+plan 56;
+
+# Classes composed by the compiler get a generated POPULATE
+# submethod compiled from the BUILDALLPLAN, on both frontends, with
+# a class declaring its own POPULATE keeping it. These
+# tests pin the observable construction semantics that method must
+# reproduce from the generic Mu.POPULATE interpretation, and the
+# introspective shape of the generated method itself.
+
+{
+    my class Point { has $.x = 1; has @.tags }
+    my $m = Point.^lookup('POPULATE');
+    ok $m.defined, 'a class with attributes gets its own POPULATE';
+    isa-ok $m, Submethod, 'the generated POPULATE is a submethod';
+    is $m.package.^name, 'Point', 'the generated POPULATE belongs to its class';
+    ok $m.?is-hidden-from-backtrace, 'the generated POPULATE hides from backtraces';
+    my class Bare { }
+    ok Bare.^lookup('POPULATE').defined, 'a class without attributes has a POPULATE';
+}
+
+{
+    my class Sigils { has $.s; has @.a; has %.h; has &.c }
+    my $o = Sigils.new(s => 1, a => [1, 2], h => { x => 1 }, c => { 42 });
+    is $o.s, 1, 'a scalar attribute takes its named argument';
+    is-deeply $o.a, [1, 2], 'an array attribute stores its named argument';
+    is-deeply $o.h, { x => 1 }, 'a hash attribute stores its named argument';
+    is $o.c.(), 42, 'a code attribute takes its named argument';
+}
+
+{
+    my class Defaults {
+        has $.plain = 5;
+        has Int $.typed = 7;
+        has @.list = 1, 2;
+    }
+    my $o = Defaults.new;
+    is $o.plain, 5, 'a constant default applies when the named is absent';
+    is $o.typed, 7, 'a typed attribute default applies';
+    is-deeply $o.list, [1, 2], 'an array attribute default applies';
+    is Defaults.new(plain => 9).plain, 9, 'a named argument beats the default';
+}
+
+{
+    my class SelfDefault { has $.base = 10; has $.derived = self.base * 2 }
+    is SelfDefault.new.derived, 20, 'a default closure reads self';
+}
+
+{
+    my class Req { has $.r is required }
+    throws-like { Req.new }, X::Attribute::Required,
+        'an absent required attribute throws';
+    my class ReqInt { has int $.i is required }
+    throws-like { ReqInt.new }, X::Attribute::Required,
+        'an absent required native int attribute throws';
+    is Req.new(r => 1).r, 1, 'a supplied required attribute binds';
+}
+
+{
+    my class Bound { has Int $.v is built(:bind) }
+    is Bound.new(v => 3).v, 3, 'a bound attribute takes its value';
+    throws-like { Bound.new(v => 'nope') }, X::TypeCheck::Binding,
+        'a bound attribute type checks its value';
+    my class Hidden { has $.h is built(False) }
+    nok Hidden.new(h => 5).h.defined, 'is built(False) ignores the named argument';
+}
+
+{
+    my class Nat { has int $.i = 3; has num $.n = 2e0; has str $.s = 'd'; has uint $.u = 9 }
+    my $o = Nat.new(i => 1, n => 1e0, s => 'x', u => 2);
+    is $o.i, 1, 'a native int attribute takes its named argument';
+    is $o.n, 1e0, 'a native num attribute takes its named argument';
+    is $o.s, 'x', 'a native str attribute takes its named argument';
+    is $o.u, 2, 'a native uint attribute takes its named argument';
+    my $d = Nat.new;
+    is $d.i, 3, 'a native int attribute default applies';
+    is $d.n, 2e0, 'a native num attribute default applies';
+    is $d.s, 'd', 'a native str attribute default applies';
+    is $d.u, 9, 'a native uint attribute default applies';
+}
+
+{
+    my @src = 1, 2;
+    my %src = a => 1;
+    my class Cont { has @.a; has %.h }
+    my $o = Cont.new(a => @src, h => %src);
+    nok $o.a === @src, 'an array attribute is not the argument container itself';
+    nok $o.h === %src, 'a hash attribute is not the argument container itself';
+    @src.push(3);
+    %src<b> = 2;
+    is-deeply $o.a, [1, 2], 'an array attribute holds its own copy of the argument';
+    is-deeply $o.h, { a => 1 }, 'a hash attribute holds its own copy of the argument';
+}
+
+{
+    my class Dfl { has @.a is default(42) }
+    is Dfl.new.a[0], 42, 'an array attribute keeps its is default value';
+    my class Shaped { has @.s[2] }
+    is-deeply Shaped.new.s.shape, (2,), 'a shaped array attribute keeps its shape';
+}
+
+{
+    my @order;
+    my role R { has $.r = 3 }
+    my class P { has $.p = 1; submethod TWEAK { @order.push('P') } }
+    my class C is P does R { has $.c = 2; submethod TWEAK { @order.push('C') } }
+    my $o = C.new;
+    is $o.p, 1, 'a parent attribute default applies in a compiled subclass';
+    is $o.r, 3, 'a role attribute default applies in a compiled class';
+    is $o.c, 2, 'an own attribute default applies alongside inherited ones';
+    is-deeply @order, ['P', 'C'], 'a parent TWEAK runs before the child TWEAK';
+    my $n = C.new(p => 9, r => 8, c => 7);
+    is $n.p ~ $n.r ~ $n.c, '987', 'named arguments reach attributes at every level';
+}
+
+{
+    my class BuildKeeps { has $.x = 5; submethod BUILD() { } }
+    is BuildKeeps.new.x, 5, 'a default applies after a BUILD that leaves the attribute alone';
+    my class BuildWrites { has $.x = 5; submethod BUILD() { $!x = 1 } }
+    is BuildWrites.new.x, 1, 'a BUILD write suppresses the default';
+}
+
+{
+    my class BoundDflt { has Int $.v is built(:bind) = 5; has $.u is built(:bind) = 6 }
+    is BoundDflt.new.v, 5, 'a typed bound attribute default binds';
+    is BoundDflt.new.u, 6, 'an untyped bound attribute default binds';
+    my $b = BoundDflt.new(v => 1, u => 2);
+    is $b.v + $b.u, 3, 'named arguments beat bound defaults';
+}
+
+{
+    my class ReqNum { has num $.n is required }
+    throws-like { ReqNum.new }, X::Attribute::Required,
+        'an absent required native num attribute throws';
+    my class ReqStr { has str $.s is required }
+    throws-like { ReqStr.new }, X::Attribute::Required,
+        'an absent required native str attribute throws';
+    my class ReqUint { has uint $.u is required }
+    throws-like { ReqUint.new }, X::Attribute::Required,
+        'an absent required native uint attribute throws';
+    is ReqStr.new(s => '').s, '', 'an empty string satisfies a required native str attribute';
+}
+
+{
+    my class WithBuild { has $.x; submethod BUILD(:$x) { $!x = ($x // 0) * 2 } }
+    is WithBuild.new(x => 21).x, 42, 'BUILD receives the constructor nameds';
+    my class WithTweak { has $.x = 1; submethod TWEAK() { $!x++ } }
+    is WithTweak.new.x, 2, 'TWEAK runs after attribute initialization';
+    my class FailBuild { submethod BUILD() { fail 'nope' } }
+    isa-ok FailBuild.new, Failure, 'a Failure from BUILD becomes the .new result';
+}
+
+{
+    my class Custom { has $.x; method POPULATE(%h) { $!x = 123; self } }
+    is Custom.new(x => 5).x, 123, 'a user written POPULATE is not replaced';
+}
+
+{
+    my $seen-file;
+    my class FrameProbe {
+        has $.x;
+        submethod TWEAK { $seen-file = callframe(1).file }
+    }
+    FrameProbe.new(x => 1);
+    ok $seen-file.contains('generated-populate'),
+        'the generated POPULATE frame carries the file of its class';
+}
+
+{
+    my \RT = Metamodel::ClassHOW.new_type(name => 'RT');
+    RT.^add_attribute(Attribute.new(
+        name => '$!v', type => Mu, package => RT, has_accessor => 1));
+    RT.^compose;
+    is RT.new(v => 7).v, 7, 'a class composed at runtime still constructs';
+    my class Parent { has $.p = 1 }
+    my \Kid = Metamodel::ClassHOW.new_type(name => 'Kid');
+    Kid.^add_parent(Parent);
+    Kid.^add_attribute(Attribute.new(
+        name => '$!k', type => Mu, package => Kid, has_accessor => 1));
+    Kid.^compose;
+    my $kid = Kid.new(p => 3, k => 4);
+    is $kid.p + $kid.k, 7, 'a runtime subclass of a compiled class constructs';
+}
+
+{
+    my $tmp = make-temp-dir;
+    $tmp.add('PopulateRoundTrip.rakumod').spurt: q:to/EOF/;
+    class RoundTrip is export {
+        has Int $.v is built(:bind) = 5;
+        has @.a is default(42);
+        has str $.s is required;
+    }
+    EOF
+    is-run 'use PopulateRoundTrip; my $o = RoundTrip.new(s => "x"); print $o.v, $o.a[0], $o.s',
+        'a precompiled class constructs through its generated POPULATE',
+        :compiler-args['-I', $tmp.absolute], :out<542x>;
+}
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously the RakuAST frontend did not implement the metamodel's generate_buildplan_executor hook, so every class it compiled constructed objects through Mu.POPULATE interpreting the BUILDALLPLAN on each call, while the legacy frontend has generated a per class POPULATE submethod at class composition for years. This implements the hook on RakuAST::CompilerServices, compiling the plan into a POPULATE submethod the same way. That takes object construction on the RakuAST frontend from about 4x slower than the legacy frontend to parity or near parity, for user classes and for most classes in the core setting. Classes composed before the needed setting symbols have compiled, as during the early setting bootstrap, and classes composed at runtime through the MOP keep the interpreting fallback. Benchmarks and the reasoning behind the approach follow.

**Relation to the plan to get rid of BUILDPLAN**

There has been talk of eventually making the BUILDPLAN obsolete by giving each class a POPULATE method built from RakuAST at composition time. This change doesn't conflict with that. It implements the same metamodel hook the legacy frontend has implemented for years, so if that plan ever lands both implementations get removed at the same time. In the meantime the BUILDPLAN stays the single source of truth for construction semantics, which is what keeps both frontends constructing objects the same way. Classes composed at runtime through the MOP keep the interpreting fallback, which they need under either approach.

**Why not just get rid of the BUILDPLAN instead**

The BUILDPLAN is what the metamodel computes from the MRO, composed roles, defaults, typed and native attributes, and BUILD/TWEAK submethods. Generating POPULATE from anything else means deriving all of that a second time, and anywhere the two derivations disagree is a silent construction bug. There is also no answer yet for classes composed at runtime through the MOP, which have no compiler available at composition time. Until there is one the BUILDPLAN and its interpreter have to stay anyway, so removing it isn't currently possible. Compiling the plan gets the construction cost down now and removes cleanly if that ever changes.

**Prior discussion**

nine went over this on #raku-dev back in March 2025 when getting rid of the BUILDPLAN came up [here](https://irclogs.raku.org/raku-dev/2025-03-19.html#14:03): "It only works on the old frontend because of generate_buildplan_executor. The bug is in Mu.POPULATE", "There's still gonna be the bootstrapping issue and the case where a class is purely generated via MOP at runtime", and "Feeding from generated meta-object is not enough. The MOP would still need access to the compiler. After all, the whole point of CompilerServices is to give the MOP access to the compiler". That's the approach taken here: the MOP gets the compiler through CompilerServices when there is one, and falls back to interpreting the plan when there isn't.
