### PR TITLE
RakuAST: fix native copy parameters with definite types

### DIFF
--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -808,14 +808,15 @@ class RakuAST::Node {
         my $operand := $expr.operand;
         return Nil unless (nqp::istype($operand, RakuAST::Var::Lexical) && $operand.is-resolved)
           || nqp::istype($operand, RakuAST::Var::Attribute);
-        my int $spec := nqp::objprimspec($operand.return-type);
+        my $target-type := self.IMPL-NATIVE-STEP-TARGET-TYPE($operand);
+        my int $spec := nqp::objprimspec($target-type);
         return Nil unless $spec == 1 || $spec == 2;
         # A post-increment recovers the original by reversing the step on the
         # assigned value, which round-trips only at the full native width. A
         # narrower type (int8, int16, num32) truncates on assignment, so the
         # reverse would not give the original back; leave those to the routine.
         # A prefix yields the stepped value directly, so it needs no such guard.
-        return Nil if $is-postfix && nqp::objprimbits($operand.return-type) != 64;
+        return Nil if $is-postfix && nqp::objprimbits($target-type) != 64;
         $expr.IMPL-SET-NATIVE-INCDEC($spec) if self.IMPL-OPERATOR-IS-CORE($resolver, $op-node);
         Nil
     }
@@ -837,7 +838,7 @@ class RakuAST::Node {
         my $left := $expr.left;
         return Nil unless (nqp::istype($left, RakuAST::Var::Lexical) && $left.is-resolved)
           || nqp::istype($left, RakuAST::Var::Attribute);
-        my int $spec := nqp::objprimspec($left.return-type);
+        my int $spec := nqp::objprimspec(self.IMPL-NATIVE-STEP-TARGET-TYPE($left));
         return Nil unless $spec == 1 || $spec == 2;
         # The right operand must be a native value: a native variable of the
         # same flavour, or a float literal. An integer literal is an `Int`, so
@@ -901,6 +902,26 @@ class RakuAST::Node {
         || (nqp::istype($node, RakuAST::ApplyInfix)
           && nqp::istype($node.infix, RakuAST::MetaInfix::Assign)
           && self.IMPL-SCALAR-METAOP-LHS-OK($node.left))
+    }
+
+    # The type a native step mark judges its write target by. A variable
+    # answers its declared type through its resolution, but a parameter
+    # target answers no type there, so the parameter's declaration is
+    # asked directly. Only a writable non-`rw` parameter qualifies: a
+    # read-only parameter must keep the routine call, which reports the
+    # mutability error, and an `is rw` parameter writes through a
+    # reference the raw ops do not follow.
+    method IMPL-NATIVE-STEP-TARGET-TYPE(Mu $target) {
+        if nqp::istype($target, RakuAST::Var::Lexical) && $target.is-resolved {
+            my $resolution := $target.resolution;
+            if nqp::istype($resolution, RakuAST::ParameterTarget::Var) {
+                my $declaration := $resolution.declaration;
+                return $declaration && !$declaration.is-ro && !$declaration.IMPL-IS-RW
+                    ?? $declaration.return-type
+                    !! Mu;
+            }
+        }
+        $target.return-type
     }
 
     # The QAST var for a native step target the marks accepted: an

--- a/src/Raku/ast/signature.rakumod
+++ b/src/Raku/ast/signature.rakumod
@@ -939,11 +939,24 @@ class RakuAST::Parameter
             my str $rw := $trait-rw || ($!default-rw ?? 'rw' !! '');
 
             if $rw {
-                if $rw ne 'copy' || !$!type || !nqp::objprimspec($!type.meta-object) {
+                # A definite type like `int:D` nominalizes to its native base.
+                # The wrapper answers no primitive spec, so testing it would
+                # send a native copy parameter down the container path, whose
+                # native-of descriptor rejects every boxed assignment. Ask the
+                # nominal type.
+                if $rw ne 'copy' || !$!type || !nqp::objprimspec($type) {
                     my $cd := RakuAST::IMPL::Containers.create-descriptor(
                         :of($type), :default($type), :dynamic(0), :$name);
                     nqp::bindattr($parameter, Parameter, '$!container_descriptor', $cd);
                     $!target.set-bindable(True);
+                }
+                elsif nqp::istype($!type, RakuAST::Type::Definedness)
+                    && nqp::istype($!target, RakuAST::ParameterTarget::Var) {
+                    # Retype the target to the base type so it declares a
+                    # plain native lexical rather than an object lexical.
+                    # Definedness stays with the binder, and a native value
+                    # is always defined.
+                    $!target.set-type($!type.base-type, :replace);
                 }
                 # A <-> block starter flags every parameter rw and a trait
                 # does not clear that, so the target follows the flag even
@@ -2134,9 +2147,9 @@ class RakuAST::ParameterTarget::Var
             :target(self.lexical-name)
     }
 
-    method set-type(RakuAST::Type $type, Bool :$outer) {
+    method set-type(RakuAST::Type $type, Bool :$outer, Bool :$replace) {
         nqp::bindattr(self, RakuAST::ParameterTarget::Var, '$!type', $type);
-        $!declaration.set-type($type, :$outer) if $!declaration;
+        $!declaration.set-type($type, :$outer, :$replace) if $!declaration;
         Nil
     }
 

--- a/t/02-rakudo/native-copy-param.t
+++ b/t/02-rakudo/native-copy-param.t
@@ -1,0 +1,112 @@
+use Test;
+
+# An `is copy` parameter of a native type declares a plain native lexical
+# the body assigns to, and a definite type like `int:D` nominalizes to the
+# same native base, so it takes the same path. The definedness constraint
+# stays with the binder, where a native argument always satisfies it. A
+# native step on a copy parameter lowers to the raw ops; a read-only or
+# rw parameter keeps the routine call.
+
+plan 18;
+
+{
+    sub f(int:D $x is copy) { $x = $x + 1; $x }
+    is f(3), 4, 'an int:D copy parameter accepts assignment of a boxed Int';
+}
+
+{
+    sub f(uint:D $x is copy) { $x = 5; $x }
+    is f(3), 5, 'a uint:D copy parameter accepts assignment of a boxed Int';
+}
+
+{
+    sub f(num:D $x is copy) { $x = 5e0; $x }
+    is f(3e0), 5e0, 'a num:D copy parameter accepts assignment of a boxed Num';
+}
+
+{
+    sub f(str:D $x is copy) { $x = 'b'; $x }
+    is f('a'), 'b', 'a str:D copy parameter accepts assignment of a boxed Str';
+}
+
+{
+    sub f(int:D $x is copy) { $x++; $x }
+    is f(10), 11, 'an int:D copy parameter steps with postfix increment';
+}
+
+{
+    sub f(int $i is copy) { $i++; $i++; --$i; $i }
+    is f(10), 11, 'an int copy parameter steps with postfix and prefix forms';
+}
+
+{
+    sub f(num $x is copy) { $x++; $x }
+    is f(1e0), 2e0, 'a num copy parameter steps with postfix increment';
+}
+
+{
+    sub f(int $i is copy, int $j) { $i += $j; $i }
+    is f(10, 4), 14, 'an int copy parameter compound-steps from a parameter operand through the metaop';
+}
+
+{
+    sub f(int $i is copy) { my int $j = 3; $i += $j; $i }
+    is f(10), 13, 'an int copy parameter compound-steps from a native lexical operand';
+}
+
+{
+    sub f(num $x is copy) { $x += 1.5e0; $x }
+    is f(2e0), 3.5e0, 'a num copy parameter compound-steps from a float literal';
+}
+
+{
+    sub f(int8 $i is copy) { $i++; $i }
+    is f(3), 4, 'a narrow native copy parameter steps through the routine';
+}
+
+{
+    sub f(int $i is copy = 7) { $i++; $i }
+    is f(), 8, 'an int copy parameter with a default steps from the default';
+}
+
+{
+    sub f(int $i is copy) { $i = $i + 1; $i }
+    my int $x = 5;
+    f($x);
+    is $x, 5, 'assignment to an int copy parameter leaves the caller variable alone';
+}
+
+{
+    sub f(int:D $x is rw) { $x = 9 }
+    my int $x = 5;
+    f($x);
+    is $x, 9, 'an int:D rw parameter still writes back to the caller';
+}
+
+{
+    sub f(int $i is rw) { $i++ }
+    my int $x = 5;
+    f($x);
+    is $x, 6, 'an increment of an int rw parameter writes back to the caller';
+}
+
+{
+    sub f(int:D $x is copy) { $x }
+    dies-ok { f(Int) }, 'a type object argument to an int:D copy parameter is rejected';
+}
+
+{
+    sub f(int $i) { $i++ }
+    my $error = '';
+    try f(3);
+    $error = $!.Str if $!;
+    ok $error.contains('mutable'),
+        'postfix increment on a read-only native parameter still reports immutability';
+}
+
+{
+    sub f(int:D $x) { $x }
+    is f(3), 3, 'a plain int:D parameter still binds a boxed Int';
+}
+
+# vim: expandtab shiftwidth=4

--- a/t/08-performance/14-rakuast-native-incdec.t
+++ b/t/08-performance/14-rakuast-native-incdec.t
@@ -1,7 +1,8 @@
 use lib <t/packages/Test-Helpers>;
 use Test::Helpers::QAST;
 use Test;
-plan 12;
+use nqp;
+plan 16;
 
 # A native int or num `++`/`--` lowers to a raw op instead of calling the
 # operator. Postfix returns the original value, prefix the stepped one.
@@ -55,5 +56,24 @@ qast-is 'my int $i; ++$i', -> \v { qast-contains-op v, 'add_i' },
     'a native prefix operand lowers to a raw op';
 qast-is 'my Int $i = 0; $i++', -> \v { not qast-contains-op v, 'add_i' },
     'a boxed operand keeps the operator call';
+
+# A native copy parameter steps its own native lexical, so it lowers like
+# a variable. An rw parameter writes through a reference the raw ops do
+# not follow, and a read-only parameter keeps the call that reports
+# immutability, so neither lowers. The legacy optimizer lowers the rw
+# shapes through a lexicalref instead, so all four are pinned to RakuAST.
+if nqp::gethllsym('Raku', 'COMPILER-FRONTEND') eq 'rakuast' {
+    qast-is 'sub f(int $i is copy) { $i++; $i }', :full, -> \v { qast-contains-op v, 'add_i' },
+        'a native copy parameter increment lowers to a raw op';
+    qast-is 'sub f(int:D $i is copy) { $i++; $i }', :full, -> \v { qast-contains-op v, 'add_i' },
+        'a definite native copy parameter increment lowers to a raw op';
+    qast-is 'sub f(int $i is rw) { $i++ }', :full, -> \v { not qast-contains-op v, 'add_i' },
+        'an rw native parameter keeps the operator call';
+    qast-is 'my &b = <-> int $x { $x++ }', :full, -> \v { not qast-contains-op v, 'add_i' },
+        'a <-> native parameter keeps the operator call';
+}
+else {
+    skip 'copy-parameter lowering shape is RakuAST-specific', 4;
+}
 
 # vim: expandtab shiftwidth=4

--- a/t/08-performance/15-rakuast-native-metaop.t
+++ b/t/08-performance/15-rakuast-native-metaop.t
@@ -1,7 +1,8 @@
 use lib <t/packages/Test-Helpers>;
 use Test::Helpers::QAST;
 use Test;
-plan 12;
+use nqp;
+plan 14;
 
 # A native int or num `+=`/`-=`/`*=` with a native operand lowers to a raw op
 # instead of calling the metaop.
@@ -49,7 +50,7 @@ qast-is 'my $a = 0; my $b = 1; $a += $b', -> \v { not qast-contains-op v, 'add_i
 # rather than wrapping, and it emits the native raw ops directly. The legacy
 # optimizer instead lowers an int literal to a wrapping op and reaches the
 # native ops a different way, so these are pinned to RakuAST.
-if %*ENV<RAKUDO_RAKUAST> {
+if nqp::gethllsym('Raku', 'COMPILER-FRONTEND') eq 'rakuast' {
     my int $i = 9223372036854775807;
     dies-ok { $i += 1 }, 'native int += an integer literal throws on overflow';
     qast-is 'my int $i; $i += 5', -> \v { not qast-contains-op v, 'add_i' },
@@ -58,9 +59,13 @@ if %*ENV<RAKUDO_RAKUAST> {
         'native int operands lower to a raw op';
     qast-is 'my num $a; $a += 1.5e0', -> \v { qast-contains-op v, 'add_n' },
         'a native float literal lowers to a raw op';
+    qast-is 'sub f(int $i is copy) { my int $n; $i += $n }', :full, -> \v { qast-contains-op v, 'add_i' },
+        'a native copy parameter compound-steps to a raw op';
+    qast-is 'sub f(num $x is copy) { $x += 1.5e0 }', :full, -> \v { qast-contains-op v, 'add_n' },
+        'a num copy parameter with a float literal lowers to a raw op';
 }
 else {
-    skip 'integer-literal and native lowering shape is RakuAST-specific', 4;
+    skip 'integer-literal and native lowering shape is RakuAST-specific', 6;
 }
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously an `is copy` parameter with a definite native type died on any assignment under RakuAST:

```
$ raku -e 'sub f(int:D $x is copy) { $x = 5 }; f(3)'
Type check failed in assignment to $x; expected int but got Int (5)
```

The native copy check asked the raw `int:D` wrapper for its primitive spec, which answers none, so the parameter was given a Scalar whose descriptor carried the native base type and rejected every boxed assignment. This asks the nominal type instead and points the target declaration at the native base type, so `int:D $x is copy` declares a plain native lexical the same way `int $x is copy` does. Definedness enforcement stays with the binder, and a native value is always defined.

The second commit extends the native increment and compound assignment lowerings to copy parameters. The marks read the operand type through its resolution, and a parameter target answers no type there, so `sub f(int $i is copy) { $i++ }` kept the full operator dispatch. They now ask the parameter target's declaration directly, gated to writable non-rw parameters so a read-only parameter still gets its mutability error and an rw parameter keeps writing through its reference. QAST tests pin both the lowering and the gates.
