### PR TITLE
RakuAST: keep containers in begin-time evaluated values

### DIFF
--- a/src/Raku/ast/begintime.rakumod
+++ b/src/Raku/ast/begintime.rakumod
@@ -128,7 +128,10 @@ class RakuAST::BeginTime
     # like the compunit GLOBAL merge. Box VM-level scalars into their
     # Raku types; leave VM-level aggregates alone, as constants holding
     # nqp hashes and lists rely on staying unboxed.
-    method IMPL-BOX-VM-VALUE(Mu $result) {
+    # The result parameter must stay raw: a begin-time value may be a
+    # container, like a Proxy a constant binds, and the entry decont the
+    # method compiler emits for a non-raw parameter would strip it.
+    method IMPL-BOX-VM-VALUE(Mu $result is raw) {
         unless nqp::isnull($result) {
             # A native reference must not escape either. The frame
             # holding the referenced slot is gone once this evaluation

--- a/t/02-rakudo/begin-value-container-precomp.t
+++ b/t/02-rakudo/begin-value-container-precomp.t
@@ -1,0 +1,27 @@
+use lib <t/02-rakudo/test-packages>;
+use Test;
+use nqp;
+
+# A constant binds the container its initializer produces, and a
+# precompiled module serializes that container, so a Proxy constant keeps
+# calling its FETCH after a precompiled load. The legacy frontend loses
+# the FETCH closure in serialization, so this coverage is gated to the
+# RakuAST frontend.
+
+plan 3;
+
+if nqp::gethllsym('Raku', 'COMPILER-FRONTEND') eq 'rakuast' {
+    require BeginValueContainer;
+    my \prox = ::('BeginValueContainer::PROX');
+    my \scal = ::('BeginValueContainer::SCAL');
+    is prox.VAR.^name, 'Proxy', 'a precompiled Proxy constant binds the Proxy itself';
+    my $first  = prox;
+    my $second = prox;
+    isnt $first, $second, 'each read of a precompiled Proxy constant calls its FETCH';
+    is scal.VAR.^name, 'Scalar', 'a precompiled scalar constant keeps the container';
+}
+else {
+    skip 'legacy serialization loses the Proxy FETCH closure', 3;
+}
+
+# vim: expandtab shiftwidth=4

--- a/t/02-rakudo/begin-value-container.t
+++ b/t/02-rakudo/begin-value-container.t
@@ -1,0 +1,32 @@
+use Test;
+
+# A begin-time evaluated value may be a container. A constant declaration
+# binds the container itself, so a Proxy constant keeps calling its FETCH
+# on every read, and the same holds for the value of a BEGIN expression.
+
+plan 5;
+
+{
+    my $n = 0;
+    constant P = Proxy.new(FETCH => method () { ++$n }, STORE => method ($v) { });
+    my $first  = P;
+    my $second = P;
+    isnt $first, $second, 'each read of a Proxy constant calls its FETCH';
+    is P.VAR.^name, 'Proxy', 'a Proxy constant binds the Proxy itself';
+}
+
+{
+    my $n = 0;
+    my $b := BEGIN Proxy.new(FETCH => method () { ++$n }, STORE => method ($v) { });
+    my $first  = $b;
+    my $second = $b;
+    isnt $first, $second, 'each read of a BEGIN Proxy value calls its FETCH';
+}
+
+{
+    constant X = (my $ = 42);
+    is X, 42, 'a constant bound to an anonymous scalar reads its value';
+    is X.VAR.^name, 'Scalar', 'a constant bound to an anonymous scalar keeps the container';
+}
+
+# vim: expandtab shiftwidth=4

--- a/t/02-rakudo/test-packages/BeginValueContainer.rakumod
+++ b/t/02-rakudo/test-packages/BeginValueContainer.rakumod
@@ -1,0 +1,8 @@
+unit module BeginValueContainer;
+
+my $n = 0;
+constant PROX is export = Proxy.new(
+    FETCH => method ()   { ++$n },
+    STORE => method ($v) { },
+);
+constant SCAL is export = (my $ = 42);


### PR DESCRIPTION
Previously every begin-time evaluated value passed through IMPL-BOX-VM-VALUE, and the method compiler emits an entry decont for every parameter not marked raw, so a constant bound to a Proxy snapshotted one FETCH at declaration and a BEGIN expression lost its container the same way. The legacy frontend binds the container itself, so a Proxy constant calls its FETCH on every read. Mark the parameter raw so the container survives the crossing.