### PR TITLE
RakuAST: match legacy compile time errors for native literal misuse

### DIFF
--- a/src/Raku/ast/call.rakumod
+++ b/src/Raku/ast/call.rakumod
@@ -452,9 +452,13 @@ class RakuAST::Call::Name
                     nqp::push(@flags, nqp::objprimspec($type));
                 }
                 if $ok {
-                    if nqp::elems(@types) == 1 && nqp::istype(@args[0], RakuAST::Literal) {
-                        my $rev := @args[0].native-type-flag;
-                        @flags[0] := nqp::defined($rev) ?? $rev +| $ARG_IS_LITERAL !! 0;
+                    if nqp::elems(@types) == 1 {
+                        # The literal kind covers a constant quoted string as
+                        # well as the literal nodes, so a string passed to an
+                        # `int` parameter is refused here rather than failing
+                        # to unbox at run time.
+                        my $rev := @args[0].IMPL-NATIVE-LITERAL-KIND;
+                        @flags[0] := $rev +| $ARG_IS_LITERAL if nqp::defined($rev);
                     }
                     elsif nqp::elems(@types) == 2 {
                         # A native-paired literal is passed in its native

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -2640,7 +2640,8 @@ class RakuAST::ApplyInfix
                 {
                     my $right := self.right;
                     if nqp::istype($right,RakuAST::Literal) {
-                        if nqp::objprimspec($type) {
+                        my int $primspec := nqp::objprimspec($type);
+                        if $primspec {
                             $type := $type.HOW.mro($type)[1];
                         }
 
@@ -2651,7 +2652,10 @@ class RakuAST::ApplyInfix
                               $resolver.build-exception:
                                 'X::Syntax::Number::LiteralType',
                                 :vartype($type),
-                                :$value;
+                                :$value,
+                                :varname(nqp::istype(self.left, RakuAST::Var::Lexical)
+                                    ?? self.left.name !! ''),
+                                :native($primspec);
                         }
                     }
                 }

--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -1430,7 +1430,8 @@ class RakuAST::VarDeclaration::Simple
                 my $expression := $initializer.expression;
                 if nqp::istype($expression, RakuAST::Literal) {
                     my $vartype := $type.meta-object;
-                    if nqp::objprimspec($vartype) {
+                    my int $primspec := nqp::objprimspec($vartype);
+                    if $primspec {
                         $vartype := $vartype.HOW.mro($vartype)[1];
                     }
 
@@ -1442,7 +1443,8 @@ class RakuAST::VarDeclaration::Simple
                          ) {
                         self.add-sorry:
                           $resolver.build-exception: 'X::Syntax::Number::LiteralType',
-                            :varname(self.name), :$vartype, :$value;
+                            :varname(self.name), :$vartype, :$value,
+                            :native($primspec);
                     }
                 }
             }

--- a/src/core.c/Exception.rakumod
+++ b/src/core.c/Exception.rakumod
@@ -3060,7 +3060,7 @@ my class X::Syntax::Number::LiteralType is X::TypeCheck::Assignment does X::Synt
     has $.vartype;
     has $.value;
     has $.valuetype      = $!value.^name;
-    has $.suggestiontype = ($!vartype,$!valuetype).are.^name;
+    has $.suggestiontype = ($!vartype,$!value).are.^name;
     has $.native         = nqp::objprimspec($!valuetype);
 
     method message() {

--- a/t/02-rakudo/native-arg-compile-errors.t
+++ b/t/02-rakudo/native-arg-compile-errors.t
@@ -1,0 +1,66 @@
+use Test;
+
+# A lone constant string argument reads as a str literal in the call
+# analysis, so passing one to a routine that can only take a native int
+# or num is refused at compile time. An assignment of an unfitting
+# numeric literal to a native variable names the variable and its native
+# type in the refusal.
+
+plan 9;
+
+sub compile-refuses($code, $expected, $desc) {
+    my $error = '';
+    {
+        EVAL $code;
+        CATCH { default { $error = .gist.Str } }
+    }
+    ok $error.contains($expected), $desc;
+}
+
+sub compiles($code, $desc) {
+    my $error = '';
+    {
+        EVAL $code;
+        CATCH { default { $error = .gist.Str } }
+    }
+    is $error, '', $desc;
+}
+
+compile-refuses 'sub f(int $x) { }; f("x")',
+    'will never work',
+    'a string argument to an int parameter is refused at compile time';
+
+compile-refuses 'sub f(num $x) { }; f("x")',
+    'will never work',
+    'a string argument to a num parameter is refused at compile time';
+
+compile-refuses 'sub f(Int $x) { }; f("x")',
+    'will never work',
+    'a string argument to an Int parameter is refused at compile time';
+
+{
+    sub f(str $x) { $x }
+    is f("x"), 'x', 'a string argument to a str parameter still binds';
+}
+
+compiles 'sub f(int $x) { }; my $v = "2"; my &c = { f("$v") };',
+    'an interpolated string argument is not refused at compile time';
+
+compiles 'sub f(int $x) { }; my &c = { f(<x>) };',
+    'a word-quoted argument with a val processor is not refused at compile time';
+
+compile-refuses 'multi f(int $x) { }; multi f(num $x) { }; f("x")',
+    'will never work',
+    'a string argument to all-native multi candidates is refused at compile time';
+
+{
+    multi f(int $x) { 'native' }
+    multi f(Str $x) { 'string' }
+    is f("x"), 'string', 'a string argument to a mixed multi still picks the Str candidate';
+}
+
+compile-refuses 'my int $i; $i = 1.5',
+    'type Real',
+    'assigning a Rat literal to a native int variable suggests the Real type';
+
+# vim: expandtab shiftwidth=4

--- a/t/02-rakudo/native-arg-compile-errors.t
+++ b/t/02-rakudo/native-arg-compile-errors.t
@@ -6,7 +6,7 @@ use Test;
 # numeric literal to a native variable names the variable and its native
 # type in the refusal.
 
-plan 9;
+plan 12;
 
 sub compile-refuses($code, $expected, $desc) {
     my $error = '';
@@ -60,7 +60,19 @@ compile-refuses 'multi f(int $x) { }; multi f(num $x) { }; f("x")',
 }
 
 compile-refuses 'my int $i; $i = 1.5',
+    'variable ($i)',
+    'assigning a Rat literal to a native int variable names the variable';
+
+compile-refuses 'my int $i; $i = 1.5',
+    'type int',
+    'assigning a Rat literal to a native int variable names the native type';
+
+compile-refuses 'my int $i; $i = 1.5',
     'type Real',
     'assigning a Rat literal to a native int variable suggests the Real type';
+
+compile-refuses 'my int $i = 1.5',
+    'native variable ($i)',
+    'a Rat literal initializer on a native int declaration names the native variable';
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously a constant string argument to a routine that can only take a native int or num compiled fine under RakuAST and failed to unbox at run time, where the legacy frontend refuses it at compile time:

```
$ raku -e 'sub f(int $x) { }; f("x")'
This type cannot unbox to a native integer: P6opaque, Str
```

The single argument analysis only read a `RakuAST::Literal` node for its native kind, and `"x"` parses as a QuotedString. Reading the native literal kind instead covers both, so this is now the same compile time error legacy gives, for single subs and for all-native multis. An interpolated or otherwise processed string still compiles, and a mixed multi still dispatches to its Str candidate.

The message for assigning an unfitting numeric literal to a native variable was also off: RakuAST said `Cannot assign a literal of type Rat (1.5) to a variable () of type Int. You can declare the variable to be of type Cool` with no variable name, the boxed type, and a useless suggestion. The suggestion default in the exception computed the narrowest common type from the value's type *name* rather than the value, which always lands on Cool, and the RakuAST emission sites passed neither the variable name nor the native flag. Both the assignment and declaration initializer forms now match legacy exactly: `Cannot assign a literal of type Rat (1.5) to a native variable ($i) of type int. You can declare the variable to be of type Real, ...`
