### PR TITLE
Box generic attributes, parameters and returns instantiated with native types

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -3480,7 +3480,14 @@ class Perl6::Actions is HLL::Actions does STDActions {
             for @usages {
                 my $past := $_;
                 my $attr := $world.get_attribute_meta_object($past.node, $name);
-                $past.returns($attr.type);
+                my $type := $attr.type;
+                $past.returns($type);
+                if nqp::objprimspec($type) {
+                    $world.throw($past.node // $/, ['X', 'Bind', 'NativeType'],
+                        name => $name
+                    ) if $past.ann('attribute_bind_target');
+                    $past.scope('attributeref');
+                }
             }
         }
 
@@ -7830,15 +7837,24 @@ Did you mean a call like '"
 
             # Now go by scope.
             if $target.scope eq 'attribute' {
-                # Source needs type check.
+                # An attribute used ahead of its declaration has no type
+                # yet, so its bindability is only checked at class close.
+                $target.annotate('attribute_bind_target', 1);
+
+                # Source needs type check. An attribute used ahead of its
+                # declaration is not on the package yet, so it gets no
+                # assertion here.
                 my $type;
+                my int $found := 0;
                 try {
                     my $package := $/.package;
                     $type := $package.HOW.get_attribute_for_usage(
                         $package, $target.name
                     ).type;
+                    $found := 1;
                 }
-                unless $type =:= $world.find_single_symbol_in_setting('Mu') {
+                if $found
+                  && !($type =:= $world.find_single_symbol_in_setting('Mu')) {
                     $source := QAST::Op.new(
                         :op('p6bindassert'),
                         $source, QAST::WVal.new( :value($type) ))

--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -9777,10 +9777,32 @@ Did you mean a call like '"
                         return 0;
                     }
 
+                    # The signature these parameters were compiled against
+                    # is instantiated with the box type when the capture
+                    # resolves to a native type, since the body treats the
+                    # parameter as a boxed value. Accept what the
+                    # instantiated signature accepts.
                     $var.push(QAST::ParamTypeCheck.new(QAST::Op.new(
-                        :op('istype_nd'),
-                        QAST::Var.new( :name(get_decont_name()), :scope('local') ),
-                        QAST::Var.new( :name($genericname), :scope<typevar> )
+                        :op('if'),
+                        QAST::Op.new(
+                            :op('istype_nd'),
+                            QAST::Var.new( :name(get_decont_name()), :scope('local') ),
+                            QAST::Var.new( :name($genericname), :scope<typevar> )
+                        ),
+                        QAST::IVal.new( :value(1) ),
+                        QAST::Op.new(
+                            :op('istype_nd'),
+                            QAST::Var.new( :name(get_decont_name()), :scope('local') ),
+                            QAST::Op.new(
+                                :op('callmethod'), :name('box_or_self'),
+                                QAST::Op.new(
+                                    :op('gethllsym'),
+                                    QAST::SVal.new( :value('Raku') ),
+                                    QAST::SVal.new( :value('NativeInstantiation') )
+                                ),
+                                QAST::Var.new( :name($genericname), :scope<typevar> )
+                            )
+                        )
                     )));
                 } elsif !($param_type =:= $world.find_single_symbol_in_setting('Mu')) {
                     if $ptype_archetypes.generic {

--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -2220,9 +2220,29 @@ BEGIN {
         my $bc   := nqp::getattr($self, Attribute, '$!build_closure');
         my $ci   := nqp::getattr($self, Attribute, '$!container_initializer');
 
-        nqp::bindattr($ins, Attribute, '$!type',
-          $type.HOW.instantiate_generic($type, $type_environment)
-        ) if $type.HOW.archetypes($type).generic;
+        # Code accessing a generically typed attribute is compiled with
+        # object access ops before the concrete type is known and is
+        # never recompiled. Native storage cannot serve those accesses:
+        # reads box to the raw native type and writes have no container
+        # to store into. So when the concrete type turns out native, the
+        # attribute stores under the native type's box type instead.
+        my $native_box := nqp::null();
+        if $type.HOW.archetypes($type).generic {
+            my $ins_type :=
+              $type.HOW.instantiate_generic($type, $type_environment);
+            if nqp::objprimspec($ins_type) {
+                my @mro   := $ins_type.HOW.mro($ins_type);
+                my int $m := nqp::elems(@mro);
+                my int $i := 1;
+                ++$i while $i < $m
+                  && nqp::objprimspec(nqp::atpos(@mro, $i));
+                if $i < $m {
+                    $native_box := nqp::atpos(@mro, $i);
+                    $ins_type   := $native_box;
+                }
+            }
+            nqp::bindattr($ins, Attribute, '$!type', $ins_type);
+        }
 
         nqp::bindattr($ins, Attribute, '$!container_initializer',
 #?if !jvm
@@ -2236,6 +2256,12 @@ BEGIN {
         my $cd_ins := $cd;
         if $cd.is_generic {
             $cd_ins := $cd.instantiate_generic($type_environment);
+            unless nqp::isnull($native_box) {
+                $cd_ins.set_of($native_box)
+                  if nqp::objprimspec($cd_ins.of);
+                $cd_ins.set_default($native_box)
+                  if nqp::objprimspec($cd_ins.default);
+            }
             nqp::bindattr($ins, Attribute, '$!container_descriptor', $cd_ins);
         }
 
@@ -2273,6 +2299,15 @@ BEGIN {
 
                 nqp::bindattr($avc-copy, $avc_mro, '$!descriptor', $cd_ins)
                   if $avc_mro.HOW.has_attribute($avc_mro, '$!descriptor');
+
+                if !nqp::isnull($native_box)
+                  && $avc_mro.HOW.has_attribute($avc_mro, '$!value') {
+                    my $avc_value :=
+                      nqp::getattr($avc-copy, $avc_mro, '$!value');
+                    nqp::bindattr($avc-copy, $avc_mro, '$!value', $native_box)
+                      unless nqp::isnull($avc_value)
+                        || nqp::objprimspec($avc_value) == 0;
+                }
             }
             nqp::bindattr($ins, Attribute, '$!auto_viv_container', $avc-copy);
         }

--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -115,6 +115,54 @@ my stub Int64PosRef metaclass Perl6::Metamodel::NativeRefHOW { ... };
 my stub Int64MultidimRef metaclass Perl6::Metamodel::NativeRefHOW { ... };
 #?endif
 
+#- NativeInstantiation ---------------------------------------------------------
+# Role bodies compile against generic types with object access ops and boxed
+# value semantics, and are never recompiled for an instantiation. A generic
+# type that instantiates to a native type therefore has to degrade to the
+# native type's box type wherever the instantiation decides storage or
+# checks values.
+my class NativeInstantiation {
+    # Returns the box type for a native type, rewrapped for a definite type
+    # over a native type, or null when no boxing applies. Callers pass
+    # values as well as types through this. Container descriptor defaults
+    # and auto_viv container values arrive here, and a concrete value
+    # reports null. The box is selected by primitive spec, so a native
+    # type with unrelated object ancestors still constrains its values to
+    # what the storage can hold.
+    method box($type) {
+        return nqp::null()
+          if nqp::isnull($type) || nqp::isconcrete_nd($type);
+
+        my $prim_type    := $type;
+        my $how          := $type.HOW;
+        my int $definite := 0;
+        if nqp::can($how, 'archetypes')
+          && $how.archetypes($type).definite
+          && nqp::can($how, 'base_type') {
+            $prim_type := $how.base_type($type);
+            $definite  := 1;
+        }
+
+        my int $spec := nqp::objprimspec($prim_type);
+        if $spec {
+            my $box := $spec == 2 ?? Num !! $spec == 3 ?? Str !! Int;
+            return $definite
+              ?? Perl6::Metamodel::DefiniteHOW.new_type(
+                   :base_type($box), :definite($how.definite($type)))
+              !! $box;
+        }
+        nqp::null()
+    }
+
+    # Returns the box type when boxing applies and the type itself
+    # otherwise.
+    method box_or_self($type) {
+        my $box := self.box($type);
+        nqp::isnull($box) ?? $type !! $box
+    }
+}
+nqp::bindhllsym('Raku', 'NativeInstantiation', NativeInstantiation);
+
 #- Binder ----------------------------------------------------------------------
 # Implement the signature binder.
 # The JVM backend really only uses trial_bind,
@@ -429,6 +477,11 @@ my class Binder {
                 if $flags +& nqp::const::SIG_ELEM_TYPE_GENERIC {
                     $param_type :=
                       $param_type.HOW.instantiate_generic($param_type, $lexpad);
+
+                    # The parameter binds a boxed value, so a native
+                    # instantiation checks against the box type.
+                    my $box := NativeInstantiation.box($param_type);
+                    $param_type := $box unless nqp::isnull($box);
                 }
 
                 # If the expected type is Positional, see if we need to do the
@@ -2220,27 +2273,14 @@ BEGIN {
         my $bc   := nqp::getattr($self, Attribute, '$!build_closure');
         my $ci   := nqp::getattr($self, Attribute, '$!container_initializer');
 
-        # Code accessing a generically typed attribute is compiled with
-        # object access ops before the concrete type is known and is
-        # never recompiled. Native storage cannot serve those accesses:
-        # reads box to the raw native type and writes have no container
-        # to store into. So when the concrete type turns out native, the
-        # attribute stores under the native type's box type instead.
-        my $native_box := nqp::null();
+        # Native storage cannot serve the object flavored accesses the
+        # role body compiled, so a native instantiation stores under the
+        # box type instead.
         if $type.HOW.archetypes($type).generic {
             my $ins_type :=
               $type.HOW.instantiate_generic($type, $type_environment);
-            if nqp::objprimspec($ins_type) {
-                my @mro   := $ins_type.HOW.mro($ins_type);
-                my int $m := nqp::elems(@mro);
-                my int $i := 1;
-                ++$i while $i < $m
-                  && nqp::objprimspec(nqp::atpos(@mro, $i));
-                if $i < $m {
-                    $native_box := nqp::atpos(@mro, $i);
-                    $ins_type   := $native_box;
-                }
-            }
+            my $box := NativeInstantiation.box($ins_type);
+            $ins_type := $box unless nqp::isnull($box);
             nqp::bindattr($ins, Attribute, '$!type', $ins_type);
         }
 
@@ -2256,12 +2296,10 @@ BEGIN {
         my $cd_ins := $cd;
         if $cd.is_generic {
             $cd_ins := $cd.instantiate_generic($type_environment);
-            unless nqp::isnull($native_box) {
-                $cd_ins.set_of($native_box)
-                  if nqp::objprimspec($cd_ins.of);
-                $cd_ins.set_default($native_box)
-                  if nqp::objprimspec($cd_ins.default);
-            }
+            my $of_box := NativeInstantiation.box($cd_ins.of);
+            $cd_ins.set_of($of_box) unless nqp::isnull($of_box);
+            my $default_box := NativeInstantiation.box($cd_ins.default);
+            $cd_ins.set_default($default_box) unless nqp::isnull($default_box);
             nqp::bindattr($ins, Attribute, '$!container_descriptor', $cd_ins);
         }
 
@@ -2300,13 +2338,11 @@ BEGIN {
                 nqp::bindattr($avc-copy, $avc_mro, '$!descriptor', $cd_ins)
                   if $avc_mro.HOW.has_attribute($avc_mro, '$!descriptor');
 
-                if !nqp::isnull($native_box)
-                  && $avc_mro.HOW.has_attribute($avc_mro, '$!value') {
-                    my $avc_value :=
-                      nqp::getattr($avc-copy, $avc_mro, '$!value');
-                    nqp::bindattr($avc-copy, $avc_mro, '$!value', $native_box)
-                      unless nqp::isnull($avc_value)
-                        || nqp::objprimspec($avc_value) == 0;
+                if $avc_mro.HOW.has_attribute($avc_mro, '$!value') {
+                    my $value_box := NativeInstantiation.box(
+                      nqp::getattr($avc-copy, $avc_mro, '$!value'));
+                    nqp::bindattr($avc-copy, $avc_mro, '$!value', $value_box)
+                      unless nqp::isnull($value_box);
                 }
             }
             nqp::bindattr($ins, Attribute, '$!auto_viv_container', $avc-copy);
@@ -2703,10 +2739,18 @@ BEGIN {
         }
 
         my $returns := nqp::getattr($self, Signature, '$!returns');
-        nqp::bindattr($ins, Signature, '$!returns',
-          $returns.HOW.instantiate_generic($returns, $type_environment)
-        ) if nqp::not_i(nqp::isnull($returns))
-          && $returns.HOW.archetypes($returns).generic;
+        if nqp::not_i(nqp::isnull($returns))
+          && $returns.HOW.archetypes($returns).generic {
+            my $ins_returns :=
+              $returns.HOW.instantiate_generic($returns, $type_environment);
+
+            # The routine body produces boxed values, so a native
+            # instantiation checks returns against the box type.
+            my $box := NativeInstantiation.box($ins_returns);
+            $ins_returns := $box unless nqp::isnull($box);
+
+            nqp::bindattr($ins, Signature, '$!returns', $ins_returns);
+        }
 
         $ins
     }));
@@ -2844,8 +2888,21 @@ BEGIN {
 
         if $type.HOW.archetypes($type).generic {
             $ins_type := $type.HOW.instantiate_generic($type,$type_environment);
-            $ins_cd   := $cd.instantiate_generic($type_environment)
-              unless nqp::isnull($cd);
+
+            # The routine body treats the parameter as a boxed value, so a
+            # native instantiation takes the box type, as a generic
+            # attribute's storage does.
+            my $box := NativeInstantiation.box($ins_type);
+            $ins_type := $box unless nqp::isnull($box);
+
+            unless nqp::isnull($cd) {
+                $ins_cd := $cd.instantiate_generic($type_environment);
+                my $of_box := NativeInstantiation.box($ins_cd.of);
+                $ins_cd.set_of($of_box) unless nqp::isnull($of_box);
+                my $default_box := NativeInstantiation.box($ins_cd.default);
+                $ins_cd.set_default($default_box)
+                  unless nqp::isnull($default_box);
+            }
         }
 
         $ins_ap := $ap.HOW.instantiate_generic($ap, $type_environment)

--- a/src/Raku/ast/signature.rakumod
+++ b/src/Raku/ast/signature.rakumod
@@ -1478,11 +1478,33 @@ class RakuAST::Parameter
                 # concretization, so the check would reject an invocant of
                 # another class that does the same role.
                 unless $!implicit-invocant {
+                    # The signature these parameters were compiled against
+                    # is instantiated with the box type when the capture
+                    # resolves to a native type, since the body treats the
+                    # parameter as a boxed value. Accept what the
+                    # instantiated signature accepts.
                     my $genericname := $param-type.HOW.name($!package.stubbed-meta-object);
                     $param-qast.push(QAST::ParamTypeCheck.new(QAST::Op.new(
-                        :op('istype_nd'),
-                        $get-decont-var(),
-                        QAST::Var.new( :name($genericname), :scope<typevar> )
+                        :op('if'),
+                        QAST::Op.new(
+                            :op('istype_nd'),
+                            $get-decont-var(),
+                            QAST::Var.new( :name($genericname), :scope<typevar> )
+                        ),
+                        QAST::IVal.new( :value(1) ),
+                        QAST::Op.new(
+                            :op('istype_nd'),
+                            $get-decont-var(),
+                            QAST::Op.new(
+                                :op('callmethod'), :name('box_or_self'),
+                                QAST::Op.new(
+                                    :op('gethllsym'),
+                                    QAST::SVal.new( :value('Raku') ),
+                                    QAST::SVal.new( :value('NativeInstantiation') )
+                                ),
+                                QAST::Var.new( :name($genericname), :scope<typevar> )
+                            )
+                        )
                     )));
                 }
             }

--- a/src/Raku/ast/variable-access.rakumod
+++ b/src/Raku/ast/variable-access.rakumod
@@ -393,13 +393,113 @@ class RakuAST::Var::Attribute
         }
         # Code generated inside a BEGIN block can reference an attribute the
         # still-open class declares further down its body. The attribute is
-        # not on the stub yet, but the access only needs the name and package
-        # at runtime, so emit it untyped. A genuinely undeclared attribute is
-        # rejected at check or compose time and never runs this code.
-        QAST::Var.new(
-            :scope('attribute'), :name($!name), :returns(Mu),
-            self.IMPL-UNWRAP-LIST(self.get-implicit-lookups)[0].IMPL-TO-QAST($context),
-            self.IMPL-QAST-PACKAGE-LOOKUP($context)
+        # not on the stub yet, so whether it needs native reference access
+        # cannot be known here. The access switches on the primitive spec
+        # the attribute reports at runtime. A native attribute is accessed
+        # through a native reference, which serves as a writable container.
+        # Any other attribute takes the plain object access. A genuinely
+        # undeclared attribute is rejected at check or compose time and
+        # never runs this code.
+        my str $obj-name  := QAST::Node.unique('late_attr_obj');
+        my str $cls-name  := QAST::Node.unique('late_attr_cls');
+        my str $spec-name := QAST::Node.unique('late_attr_spec');
+        my $name-sval     := QAST::SVal.new(:value($!name));
+        QAST::Stmts.new(
+            QAST::Op.new(
+                :op('bind'),
+                QAST::Var.new(:name($obj-name), :scope('local'), :decl('var')),
+                self.IMPL-UNWRAP-LIST(self.get-implicit-lookups)[0].IMPL-TO-QAST($context)
+            ),
+            QAST::Op.new(
+                :op('bind'),
+                QAST::Var.new(:name($cls-name), :scope('local'), :decl('var')),
+                self.IMPL-QAST-PACKAGE-LOOKUP($context)
+            ),
+            QAST::Op.new(
+                :op('bind'),
+                QAST::Var.new(:name($spec-name), :scope('local'), :decl('var'), :returns(int)),
+                QAST::Op.new(
+                    :op('objprimspec'),
+                    QAST::Op.new(
+                        :op('callmethod'), :name('type'),
+                        QAST::Op.new(
+                            :op('callmethod'), :name('get_attribute_for_usage'),
+                            QAST::Op.new(
+                                :op('how'),
+                                QAST::Var.new(:name($cls-name), :scope('local'))
+                            ),
+                            QAST::Var.new(:name($cls-name), :scope('local')),
+                            $name-sval
+                        )
+                    )
+                )
+            ),
+            QAST::Op.new(
+                :op('if'),
+                QAST::Op.new(
+                    :op('iseq_i'),
+                    QAST::Var.new(:name($spec-name), :scope('local'), :returns(int)),
+                    QAST::IVal.new(:value(2))
+                ),
+                QAST::Op.new(
+                    :op('getattrref_n'),
+                    QAST::Var.new(:name($obj-name), :scope('local')),
+                    QAST::Var.new(:name($cls-name), :scope('local')),
+                    $name-sval
+                ),
+                QAST::Op.new(
+                    :op('if'),
+                    QAST::Op.new(
+                        :op('iseq_i'),
+                        QAST::Var.new(:name($spec-name), :scope('local'), :returns(int)),
+                        QAST::IVal.new(:value(3))
+                    ),
+                    QAST::Op.new(
+                        :op('getattrref_s'),
+                        QAST::Var.new(:name($obj-name), :scope('local')),
+                        QAST::Var.new(:name($cls-name), :scope('local')),
+                        $name-sval
+                    ),
+                    QAST::Op.new(
+                        :op('if'),
+                        QAST::Op.new(
+                            :op('iseq_i'),
+                            QAST::Var.new(:name($spec-name), :scope('local'), :returns(int)),
+                            QAST::IVal.new(:value(0))
+                        ),
+                        QAST::Var.new(
+                            :scope('attribute'), :name($!name), :returns(Mu),
+                            QAST::Var.new(:name($obj-name), :scope('local')),
+                            QAST::Var.new(:name($cls-name), :scope('local'))
+                        ),
+                        QAST::Op.new(
+                            :op('if'),
+                            QAST::Op.new(
+                                :op('iseq_i'),
+                                QAST::Var.new(:name($spec-name), :scope('local'), :returns(int)),
+                                QAST::IVal.new(:value(10))
+                            ),
+                            # An unsigned attribute read through the signed
+                            # reference sign extends, so it takes the
+                            # unsigned reference.
+                            QAST::Op.new(
+                                :op('getattrref_u'),
+                                QAST::Var.new(:name($obj-name), :scope('local')),
+                                QAST::Var.new(:name($cls-name), :scope('local')),
+                                $name-sval
+                            ),
+                            # Every remaining spec is a signed integer
+                            # flavor.
+                            QAST::Op.new(
+                                :op('getattrref_i'),
+                                QAST::Var.new(:name($obj-name), :scope('local')),
+                                QAST::Var.new(:name($cls-name), :scope('local')),
+                                $name-sval
+                            )
+                        )
+                    )
+                )
+            )
         )
     }
 

--- a/src/vm/moar/dispatchers.nqp
+++ b/src/vm/moar/dispatchers.nqp
@@ -4889,6 +4889,16 @@ nqp::register('raku-coercion', -> $capture {
 # which may be a definiteness or coercion type.
 nqp::register('raku-rv-typecheck-generic', -> $capture {
     nqp::guard('type', nqp::track('arg', $capture, 1));
+
+    # A generic return type that instantiates to a native type checks
+    # against the box type, since the routine body produces boxed values.
+    my $type := nqp::captureposarg($capture, 1);
+    my $box  := nqp::gethllsym('Raku', 'NativeInstantiation').box($type);
+    unless nqp::isnull($box) {
+        $capture := nqp::syscall('dispatcher-insert-arg-literal-obj',
+          nqp::syscall('dispatcher-drop-arg', $capture, 1), 1, $box);
+    }
+
     nqp::delegate('raku-rv-typecheck', $capture);
 });
 

--- a/t/02-rakudo/begin-attr-before-declaration.t
+++ b/t/02-rakudo/begin-attr-before-declaration.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 4;
+plan 7;
 
 # A method literal built inside a BEGIN block generates its code before the
 # class finishes parsing, so an attribute declared further down the body is
@@ -35,6 +35,36 @@ plan 4;
     }
     is C.new.run(42), 42,
         'a BEGIN-built method can assign a later scalar attribute';
+}
+
+{
+    my class C {
+        my $m = BEGIN method () { $!scalar = 5; $!scalar };
+        has $.scalar is rw;
+        method run() { $m(self) }
+    }
+    is C.new.run, 5,
+        'a BEGIN-built method assigns a later untyped scalar attribute';
+}
+
+{
+    my class C {
+        my $m = BEGIN method () { $!count++; $!count };
+        has Int $.count = 1;
+        method run() { $m(self) }
+    }
+    is C.new.run, 2,
+        'a BEGIN-built method steps a later Int attribute';
+}
+
+{
+    my class C {
+        my $m = BEGIN method ($v) { $!scalar := $v; $!scalar };
+        has $.scalar;
+        method run($v) { $m(self, $v) }
+    }
+    is C.new.run(7), 7,
+        'a BEGIN-built method binds a later untyped scalar attribute';
 }
 
 # The undeclared-attribute error still fires for an attribute the class

--- a/t/02-rakudo/generic-native-attributes.t
+++ b/t/02-rakudo/generic-native-attributes.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 24;
+plan 27;
 
 # A role method accessing a generically typed attribute compiles before the
 # concrete type is known, so it uses object access ops and is never
@@ -120,6 +120,25 @@ plan 24;
     ok C.^attributes.first(*.name eq '$!x').type =:= int,
         'a role attribute declared int keeps its native type';
     is C.new.w, 2, 'postfix increment works on a role attribute declared int';
+}
+
+# A method compiled before the attribute declaration is known picks up the
+# native type once the class closes.
+{
+    my class C { method m() { $!x++; $!x }; has int $!x = 1 }
+    is C.new.m, 2, 'a method ahead of a native attribute declaration steps it';
+}
+
+{
+    my role R { has int $!x = 1 }
+    my class C does R { method m() { $!x++; $!x } }
+    is C.new.m, 2, 'a class body method steps a native attribute supplied by a role';
+}
+
+{
+    my role R[::T] { has T $!x }
+    my class C does R[int] { method m() { $!x++; $!x } }
+    is C.new.m, 1, 'a class body method steps a generic role attribute instantiated with int';
 }
 
 # A generic attribute instantiated with a non native type is untouched by

--- a/t/02-rakudo/generic-native-attributes.t
+++ b/t/02-rakudo/generic-native-attributes.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 27;
+plan 46;
 
 # A role method accessing a generically typed attribute compiles before the
 # concrete type is known, so it uses object access ops and is never
@@ -86,6 +86,23 @@ plan 27;
     ok C.new.w =:= Int, 'assigning Nil resets an int instantiated generic attribute to Int';
 }
 
+# A definite generic type over a native type boxes the same way, keeping
+# the definiteness constraint.
+{
+    my role R[::T] { has T:D $!x is built; method w() { $!x++; $!x } }
+    my class C does R[int] {}
+    is C.new(x => 1).w, 2, 'a definite generic attribute instantiated with int steps';
+}
+
+{
+    my role R[::T] { has T:D $!x is built }
+    my class C does R[int] {}
+    ok C.^attributes.first(*.name eq '$!x').type =:= Int:D,
+        'a definite int instantiated generic attribute reports Int:D as its type';
+    throws-like { C.new(x => Int) }, Exception,
+        'a definite int instantiated generic attribute rejects a type object';
+}
+
 # Construction time paths reach the boxed storage as well.
 {
     my role R[::T] { has T $.x = 3 }
@@ -122,11 +139,82 @@ plan 27;
     is C.new.w, 2, 'postfix increment works on a role attribute declared int';
 }
 
+# The instantiation reaches attributes through nested role topologies.
+{
+    my role R[::T] { has T $!x; method w() { $!x++; $!x } }
+    my role S[::T] does R[T] { method v() { self.w + 1 } }
+    my class C does S[int] {}
+    is C.new.w, 1, 'a generic attribute survives a role to role generic pass through instantiated with int';
+    is C.new.v, 2, 'a method in the outer role reaches the passed through generic attribute';
+}
+
+{
+    my role R[::T] { has T $!x; method w() { $!x++; $!x } }
+    my role S does R[int] { method v() { self.w + 1 } }
+    my class C does S {}
+    is C.new.w, 1, 'a generic attribute instantiated with int inside an intermediate role steps';
+    is C.new.v, 2, 'a method in the consuming role reaches the instantiated generic attribute';
+}
+
+# Punned and runtime mixed in roles compose the boxed storage as well.
+{
+    my role R[::T] { has T $.x; method w() { $!x++; $!x } }
+    is R[int].new.w, 1, 'a punned role steps a generic attribute instantiated with int';
+    is R[int].new(x => 5).x, 5, 'a punned role constructs a generic attribute instantiated with int';
+    ok R[int].new.x =:= Int, 'an untouched generic attribute on a pun reads as the Int type object';
+}
+
+{
+    my role R[::T] { has T $!x; method w() { $!x++; $!x } }
+    my class C {}
+    my $c = C.new does R[int];
+    is $c.w, 1, 'a runtime does mixin steps a generic attribute instantiated with int';
+    my $d = C.new but R[int];
+    is $d.w, 1, 'a runtime but mixin steps a generic attribute instantiated with int';
+}
+
+# Sized flavors box the same way as the full width types.
+{
+    my role R[::T] { has T $!x; method w() { $!x++; $!x } }
+    my class C does R[int16] {}
+    is C.new.w, 1, 'postfix increment works on a generic attribute instantiated with int16';
+}
+
+{
+    my role R[::T] { has T $!x; method w() { $!x += 2e0; $!x } }
+    my class C does R[num32] {}
+    is C.new.w, 2e0, 'compound assignment works on a generic attribute instantiated with num32';
+}
+
+# An undefined constrained generic attribute stores the box type object.
+{
+    my role R[::T] { has T:U $!x is built; method w() { $!x.^name } }
+    my class C does R[int] {}
+    is C.new(x => Int).w, 'Int', 'an undefined generic attribute instantiated with int stores the box type object';
+    throws-like { C.new(x => 5) }, Exception,
+        'an undefined generic attribute instantiated with int rejects a concrete value';
+}
+
 # A method compiled before the attribute declaration is known picks up the
 # native type once the class closes.
 {
     my class C { method m() { $!x++; $!x }; has int $!x = 1 }
     is C.new.m, 2, 'a method ahead of a native attribute declaration steps it';
+}
+
+{
+    my class C { method m() { $!n += 1.5e0; $!n }; has num $!n = 1e0 }
+    is C.new.m, 2.5e0, 'a method ahead of a native num attribute declaration compound assigns it';
+}
+
+{
+    my class C { method m() { $!s ~= "b"; $!s }; has str $!s = "a" }
+    is C.new.m, 'ab', 'a method ahead of a native str attribute declaration concatenates onto it';
+}
+
+{
+    my class C { method m() { $!u++; $!u }; has uint8 $!u = 1 }
+    is C.new.m, 2, 'a method ahead of a native uint8 attribute declaration steps it';
 }
 
 {

--- a/t/02-rakudo/generic-native-attributes.t
+++ b/t/02-rakudo/generic-native-attributes.t
@@ -1,0 +1,135 @@
+use Test;
+
+plan 24;
+
+# A role method accessing a generically typed attribute compiles before the
+# concrete type is known, so it uses object access ops and is never
+# recompiled. Native storage cannot serve those accesses, so an attribute
+# whose generic type instantiates to a native type stores under the box
+# type instead.
+
+{
+    my role R[::T] {
+        has T $!x;
+        method step()     { $!x++; $!x }
+        method stepdown() { $!x--; $!x }
+        method bump()     { ++$!x }
+        method set($v)    { $!x = $v; $!x }
+        method add($v)    { $!x += $v; $!x }
+        method read()     { $!x }
+    }
+    my class C does R[int] {}
+
+    my $c = C.new;
+    is $c.step, 1, 'postfix increment works on a generic attribute instantiated with int';
+    is $c.stepdown, 0, 'postfix decrement works on a generic attribute instantiated with int';
+    is $c.bump, 1, 'prefix increment works on a generic attribute instantiated with int';
+    is $c.set(5), 5, 'assignment works on a generic attribute instantiated with int';
+    is $c.add(3), 8, 'compound assignment works on a generic attribute instantiated with int';
+    is $c.read, 8, 'a read returns the stored value';
+    isa-ok $c.read, Int, 'a read of an int instantiated generic attribute returns an Int';
+}
+
+{
+    my role R[::T] { has T $!x; method w() { $!x++; $!x } }
+    my class C does R[num] {}
+    my $c = C.new;
+    $c.w;
+    is $c.w, 2e0, 'postfix increment works on a generic attribute instantiated with num';
+}
+
+{
+    my role R[::T] { has T $!x; method w() { $!x = "a"; $!x ~= "b"; $!x } }
+    my class C does R[str] {}
+    is C.new.w, "ab", 'assignment and concatenation work on a generic attribute instantiated with str';
+}
+
+{
+    my role R[::T] { has T $!x; method w() { $!x++; $!x } }
+    my class C does R[uint] {}
+    is C.new.w, 1, 'postfix increment works on a generic attribute instantiated with uint';
+}
+
+{
+    my role R[::T] { has T $!x; method w() { $!x += 3; $!x } }
+    my class C does R[int8] {}
+    is C.new.w, 3, 'compound assignment works on a generic attribute instantiated with int8';
+}
+
+# The instantiated attribute reports the box type, since that is what it
+# stores.
+{
+    my role R[::T] { has T $!x }
+    my class C does R[int] {}
+    ok C.^attributes.first(*.name eq '$!x').type =:= Int,
+        'an int instantiated generic attribute reports Int as its type';
+}
+
+{
+    my role R[::T] { has T $!x; method w() { $!x } }
+    my class C does R[int] {}
+    ok C.new.w =:= Int, 'an untouched int instantiated generic attribute reads as the Int type object';
+}
+
+# The box type still constrains assignment.
+{
+    my role R[::T] { has T $!x; method w($v) { $!x = $v } }
+    my class C does R[int] {}
+    throws-like { C.new.w("nope") }, X::TypeCheck,
+        'assigning a non-numeric value to an int instantiated generic attribute dies';
+}
+
+# Nil assignment resets to the box type object.
+{
+    my role R[::T] { has T $!x; method w() { $!x = 5; $!x = Nil; $!x } }
+    my class C does R[int] {}
+    ok C.new.w =:= Int, 'assigning Nil resets an int instantiated generic attribute to Int';
+}
+
+# Construction time paths reach the boxed storage as well.
+{
+    my role R[::T] { has T $.x = 3 }
+    my class C does R[int] {}
+    is C.new.x, 3, 'a default value initializes an int instantiated generic attribute';
+    is C.new(x => 5).x, 5, 'a named constructor argument initializes an int instantiated generic attribute';
+}
+
+{
+    my role R[::T] { has T $.x is rw }
+    my class C does R[int] {}
+    my $c = C.new;
+    $c.x = 7;
+    is $c.x, 7, 'the generated rw accessor writes an int instantiated generic attribute';
+}
+
+{
+    my role R[::T] { has T $!x; method w() { $!x++; $!x } }
+    my class C does R[int] {}
+    my $a = C.new;
+    my $b = C.new;
+    $a.w; $a.w;
+    is $b.w, 1, 'each object steps its own copy of an int instantiated generic attribute';
+    is $a.w, 3, 'stepping one object does not disturb another';
+}
+
+# An attribute with a statically known native type keeps native storage
+# when the role supplying it composes into a class.
+{
+    my role R { has int $!x = 1; method w() { $!x++; $!x } }
+    my class C does R {}
+    ok C.^attributes.first(*.name eq '$!x').type =:= int,
+        'a role attribute declared int keeps its native type';
+    is C.new.w, 2, 'postfix increment works on a role attribute declared int';
+}
+
+# A generic attribute instantiated with a non native type is untouched by
+# the native boxing.
+{
+    my role R[::T] { has T $!x; method w() { $!x++; $!x } }
+    my class C does R[Int] {}
+    is C.new.w, 1, 'postfix increment works on a generic attribute instantiated with Int';
+    ok C.^attributes.first(*.name eq '$!x').type =:= Int,
+        'an Int instantiated generic attribute reports Int as its type';
+}
+
+# vim: expandtab shiftwidth=4

--- a/t/02-rakudo/generic-native-parameters.t
+++ b/t/02-rakudo/generic-native-parameters.t
@@ -1,0 +1,154 @@
+use Test;
+
+plan 27;
+
+# A role method body compiles before the concrete types are known and
+# treats its parameters and return values as boxed objects. A generic
+# parameter or return type that instantiates to a native type therefore
+# checks against the box type.
+
+{
+    my role R[::T] { method w(T $v) { $v + 1 } }
+    my class C does R[int] {}
+    is C.new.w(5), 6, 'a generic parameter instantiated with int accepts an Int argument';
+    my int $x = 4;
+    is C.new.w($x), 5, 'a generic parameter instantiated with int accepts a native int argument';
+    throws-like { C.new.w("nope") }, X::TypeCheck::Binding::Parameter,
+        'a generic parameter instantiated with int rejects a Str argument';
+}
+
+{
+    my role R[::T] { multi method w(T $v) { $v + 1 } }
+    my class C does R[int] {}
+    is C.new.w(5), 6, 'a multi with a generic parameter instantiated with int dispatches';
+}
+
+{
+    my role R[::T] {
+        multi method w(T $v)   { "generic" }
+        multi method w(Str $v) { "string"  }
+    }
+    my class C does R[int] {}
+    is C.new.w(5), 'generic', 'an Int argument picks the generic candidate instantiated with int';
+    is C.new.w("hi"), 'string', 'a Str argument picks the Str candidate beside an int instantiated one';
+    my int $x = 3;
+    is C.new.w($x), 'generic', 'a native int argument picks the generic candidate instantiated with int';
+}
+
+# A typevar bound to a definite native type boxes with the definiteness
+# kept, in the signature and in the compiled parameter check alike.
+{
+    my role R[::T] { method w(T $v) { $v + 1 } }
+    my class C does R[int:D] {}
+    is C.new.w(5), 6, 'a generic parameter instantiated with int:D accepts a value';
+    throws-like { C.new.w(Int) }, Exception,
+        'a generic parameter instantiated with int:D rejects a type object';
+}
+
+{
+    my role R[::T] { method w(--> T) { 5 } }
+    my class C does R[int] {}
+    is C.new.w, 5, 'a generic return type instantiated with int passes an Int return';
+}
+
+{
+    my role R[::T] { method w(--> T) { "nope" } }
+    my class C does R[int] {}
+    throws-like { C.new.w }, X::TypeCheck::Return,
+        'a generic return type instantiated with int rejects a Str return';
+}
+
+{
+    my role R[::T] { method w(--> T:D) { 5 } }
+    my class C does R[int] {}
+    is C.new.w, 5, 'a definite generic return type instantiated with int passes a value';
+}
+
+{
+    my role R[::T] { method w(--> T:D) { Int } }
+    my class C does R[int] {}
+    throws-like { C.new.w }, Exception,
+        'a definite generic return type instantiated with int rejects a type object';
+}
+
+{
+    my role R[::T] { method w(--> T:D) { "nope" } }
+    my class C does R[int] {}
+    throws-like { C.new.w }, X::TypeCheck::Return,
+        'a definite generic return type instantiated with int rejects a Str value';
+}
+
+# Sized flavors box the same way as the full width types.
+{
+    my role R[::T] { method w(T $v) { $v + 1 } }
+    my class C does R[int16] {}
+    is C.new.w(5), 6, 'a generic parameter instantiated with int16 accepts an Int argument';
+    throws-like { C.new.w("nope") }, X::TypeCheck::Binding::Parameter,
+        'a generic parameter instantiated with int16 rejects a Str argument';
+}
+
+{
+    my role R[::T] { method w(T $v) { $v + 1e0 } }
+    my class C does R[num32] {}
+    is C.new.w(1.5e0), 2.5e0, 'a generic parameter instantiated with num32 accepts a Num argument';
+}
+
+{
+    my role R[::T] { method w(T $v) { $v + 1 } }
+    my class C does R[uint8] {}
+    is C.new.w(5), 6, 'a generic parameter instantiated with uint8 accepts an Int argument';
+}
+
+{
+    my role R[::T] { method w(T:D $v) { $v + 1 } }
+    my class C does R[int] {}
+    is C.new.w(5), 6, 'a definite generic parameter instantiated with int accepts a value';
+    throws-like { C.new.w(Int) }, X::Parameter::InvalidConcreteness,
+        'a definite generic parameter instantiated with int rejects a type object';
+}
+
+{
+    my role R[::T] { method w(T:U $v) { $v.^name } }
+    my class C does R[int] {}
+    is C.new.w(Int), 'Int', 'an undefined generic parameter instantiated with int accepts the box type object';
+}
+
+{
+    my role R[::T] { method w(T $v) { $v + 1e0 } }
+    my class C does R[num] {}
+    is C.new.w(1.5e0), 2.5e0, 'a generic parameter instantiated with num accepts a Num argument';
+}
+
+{
+    my role R[::T] { method w(T $v) { $v ~ "b" } }
+    my class C does R[str] {}
+    is C.new.w("a"), 'ab', 'a generic parameter instantiated with str accepts a Str argument';
+}
+
+# The instantiated signature reports the box type, since that is what it
+# checks against.
+{
+    my role R[::T] { method w(T $v) { } }
+    my class C does R[int] {}
+    ok C.^lookup('w').signature.params[1].type =:= Int,
+        'an int instantiated generic parameter reports Int as its type';
+}
+
+# A generic parameter instantiated with a non native type is untouched.
+{
+    my role R[::T] { method w(T $v) { $v * 2 } }
+    my class C does R[Int] {}
+    is C.new.w(5), 10, 'a generic parameter instantiated with Int still binds';
+    ok C.^lookup('w').signature.params[1].type =:= Int,
+        'an Int instantiated generic parameter reports Int as its type';
+}
+
+# A statically typed native parameter in a role keeps native binding.
+{
+    my role R { method w(int $v) { $v + 1 } }
+    my class C does R {}
+    my int $x = 4;
+    is C.new.w($x), 5, 'a role method parameter declared int still binds a native argument';
+}
+
+# vim: expandtab shiftwidth=4

--- a/t/02-rakudo/generic-native-precomp.t
+++ b/t/02-rakudo/generic-native-precomp.t
@@ -1,0 +1,30 @@
+use lib <t/packages/Test-Helpers>;
+use Test;
+use Test::Helpers;
+
+plan 3;
+
+# The instantiated attribute of a generic role, with its boxed type,
+# container descriptor, and auto viv container, survives the
+# precompilation store.
+
+my $lib = make-temp-dir;
+$lib.add('GenNat.rakumod').spurt: q:to/MODULE/;
+    unit module GenNat;
+    role R[::T] is export { has T $.x; method w() { $!x++; $!x } }
+    class C does R[int] is export { }
+    MODULE
+
+my ($step, $constructed, $type-ok) = EVAL qq:to/CODE/;
+    use lib '$lib.absolute()';
+    use GenNat;
+    (C.new.w,
+     C.new(x => 5).x,
+     C.^attributes.first(*.name eq '\$!x').type =:= Int)
+    CODE
+
+is $step, 1, 'a precompiled class steps a generic attribute instantiated with int';
+is $constructed, 5, 'a precompiled class constructs a generic attribute instantiated with int';
+ok $type-ok, 'a precompiled int instantiated generic attribute reports Int as its type';
+
+# vim: expandtab shiftwidth=4

--- a/t/12-rakuast/xx-fixed-in-rakuast.rakutest
+++ b/t/12-rakuast/xx-fixed-in-rakuast.rakutest
@@ -2,7 +2,7 @@ use Test;
 use lib <t/packages/Test-Helpers>;
 use Test::Helpers;
 
-plan 135;
+plan 141;
 
 # t/spec/S03-sequence/misc.t
 # https://github.com/rakudo/rakudo/issues/5520
@@ -987,6 +987,28 @@ subtest 'use of &?ROUTINE and &?BLOCK' => {
     throws-like { Q| my ($a is nonesuch) |.AST.EVAL },
         Exception, message => /'nonesuch'/,
         'an unknown trait inside a declaration list is rejected';
+}
+
+# A method built inside a BEGIN block compiles before a native attribute
+# declared further down the class body exists, so the access cannot be
+# typed at compile time. The legacy frontend emits an object access whose
+# read boxes to the raw native type and cannot be written. The access
+# switches on the attribute's primitive spec at runtime and takes a
+# native reference for native storage, the unsigned flavor for unsigned
+# storage.
+{
+    is Q| class B1 { BEGIN B1.^add_method("w", method () { $!x++; $!x }); has int $!x = 1; }; B1.new.w |.AST.EVAL,
+        2, 'a BEGIN-built method steps a later declared int attribute';
+    is Q| class B2 { BEGIN B2.^add_method("w", method ($v) { $!x = $v; $!x }); has int $!x = 1; }; B2.new.w(9) |.AST.EVAL,
+        9, 'a BEGIN-built method assigns a later declared int attribute';
+    is Q| class B3 { BEGIN B3.^add_method("w", method () { $!n += 1.5e0; $!n }); has num $!n = 1e0; }; B3.new.w |.AST.EVAL,
+        2.5e0, 'a BEGIN-built method compound assigns a later declared num attribute';
+    is Q| class B4 { BEGIN B4.^add_method("w", method () { $!s ~= "b"; $!s }); has str $!s = "a"; }; B4.new.w |.AST.EVAL,
+        'ab', 'a BEGIN-built method concatenates onto a later declared str attribute';
+    is Q| class B5 { BEGIN B5.^add_method("w", method () { $!u = 200; $!u }); has uint8 $!u; }; B5.new.w |.AST.EVAL,
+        200, 'a BEGIN-built method stores a high uint8 value without sign extension';
+    is Q| class B6 { BEGIN B6.^add_method("w", method () { $!u = 4000000000; $!u }); has uint32 $!u; }; B6.new.w |.AST.EVAL,
+        4000000000, 'a BEGIN-built method stores a high uint32 value without sign extension';
 }
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously a role with a generically typed attribute or signature was broken when instantiated with a native type argument. Role bodies compile once with object access ops and boxed value semantics and are never recompiled, so `has T $!x` composed via `R[int]` produced native storage no compiled access could use: reads returned a box of the raw native type whose methods die, and writes had no container to store into, failing with errors like "Cannot resolve caller postfix:<++>(int:D)". Signatures were equally unusable, with `method w(T $v)` under `R[int]` rejecting every argument, boxed or native, with "expected int but got Int", and `--> T` rejecting every return value.

This makes such instantiations degrade to the native type's box type wherever the instantiation decides storage or checks values. A shared NativeInstantiation metamodel class computes the box, selected by primitive spec (Int, Num or Str) and rewrapped for definite types so `T:D` instantiates to `Int:D`. It is applied in the Attribute, Parameter and Signature instantiations, the runtime binder's generic instantiation, and the return typecheck dispatcher. The compiled type capture checks in both frontends fall back to the box when the typevar resolves to a native type, so the compiled bind accepts exactly what the instantiated signature accepts.

Attribute usages compiled before the declaration is known get the same treatment. The legacy class close fixup switches deferred usages of native attributes to attribute reference access, matching a usage compiled after the declaration, and reports X::Bind::NativeType for bind targets instead of leaking a code generation error. Under RakuAST, a method compiled inside a BEGIN block, such as one added with ^add_method ahead of the has line, reaches the attribute through a runtime switch on its primitive spec and takes a native reference for native storage, with unsigned storage using the unsigned reference flavor.

Two visible behavior notes: such an attribute reports the box type from `.^attributes`, since that is what it stores, and a per call type capture such as `sub f(::T \t, T $x)` now accepts a boxed value when the capture is a native type.