### PR TITLE
RakuAST: type parameter reads in the compile time call analyses

### DIFF
--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -1651,9 +1651,12 @@ class RakuAST::Node {
     }
 
     # The statically known type of this node in argument position: its
-    # return-type, falling back to the declared type of the variable a
-    # resolved parameter read refers to, since a parameter read reports no
-    # type of its own.
+    # return-type, falling back to the nominal type of a resolved
+    # parameter read, which reports no type of its own. A parameter
+    # constrains its argument by a nominal type, with definedness and
+    # subset refinements as run time checks on top of it, so those are
+    # stripped from its declared type. A coercion type converts its
+    # argument rather than constraining it, so it stays whole.
     method IMPL-STATIC-ARG-TYPE() {
         my $type := self.return-type;
         if $type =:= Mu
@@ -1662,6 +1665,18 @@ class RakuAST::Node {
             && nqp::istype(self.resolution, RakuAST::ParameterTarget::Var)
             && nqp::isconcrete(self.resolution.declaration) {
             try $type := self.resolution.declaration.return-type;
+            my int $stripped := 1;
+            while $stripped {
+                $stripped := 0;
+                if nqp::istype($type.HOW, Perl6::Metamodel::DefiniteHOW) {
+                    $type := $type.HOW.base_type($type);
+                    $stripped := 1;
+                }
+                elsif nqp::istype($type.HOW, Perl6::Metamodel::SubsetHOW) {
+                    $type := $type.HOW.refinee($type);
+                    $stripped := 1;
+                }
+            }
         }
         $type
     }

--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -847,9 +847,11 @@ class RakuAST::Node {
         # metaop. A float literal never overflows that way.
         my $right := $expr.right;
         my int $rhs-ok := 0;
-        if (nqp::istype($right, RakuAST::Var::Lexical) && $right.is-resolved
-          || nqp::istype($right, RakuAST::Var::Attribute))
+        if nqp::istype($right, RakuAST::Var::Attribute)
           && nqp::objprimspec($right.return-type) == $spec {
+            $rhs-ok := 1;
+        }
+        elsif self.IMPL-NATIVE-LEXICAL-PRIMSPEC($right) == $spec {
             $rhs-ok := 1;
         }
         elsif $spec == 2 && nqp::istype($right, RakuAST::NumLiteral) {

--- a/src/Raku/ast/call.rakumod
+++ b/src/Raku/ast/call.rakumod
@@ -443,7 +443,7 @@ class RakuAST::Call::Name
                 my $ok := 1;
                 my @args := self.IMPL-UNWRAP-LIST(self.args.args);
                 for @args {
-                    my $type := $_.return-type;
+                    my $type := $_.IMPL-STATIC-ARG-TYPE;
                     # No istype relation holds between a definite type
                     # and a nominal one, Mu:D and Any included, so the
                     # trial bind would call any such pairing impossible.

--- a/src/Raku/ast/call.rakumod
+++ b/src/Raku/ast/call.rakumod
@@ -444,6 +444,11 @@ class RakuAST::Call::Name
                 my @args := self.IMPL-UNWRAP-LIST(self.args.args);
                 for @args {
                     my $type := $_.return-type;
+                    # No istype relation holds between a definite type
+                    # and a nominal one, Mu:D and Any included, so the
+                    # trial bind would call any such pairing impossible.
+                    $type := $type.HOW.base_type($type)
+                        if nqp::istype($type.HOW, Perl6::Metamodel::DefiniteHOW);
                     nqp::push(@types, $type);
                     $ok := 0 if $type =:= Mu; # Don't know the type
                     last unless $ok;

--- a/src/core.c/Exception.rakumod
+++ b/src/core.c/Exception.rakumod
@@ -3091,14 +3091,22 @@ my class X::TypeCheck::Argument is X::TypeCheck {
     has $.objname;
     has $.signature;
     method message {
-            my $multi = $!signature && $!signature.contains("\n");
+            # The dispatch analysis passes the signature as a list: a
+            # single gist, or one entry per multi candidate, undefined
+            # when its gist failed. Stringifying the list or an
+            # undefined entry warns, and a setting compile reporting an
+            # error here has no warning handler.
+            my $signature = nqp::istype($!signature, Positional)
+              ?? $!signature.grep(*.defined).join
+              !! $!signature;
+            my $multi = $signature && $signature.contains("\n");
             "Calling {$!objname}({
                 .join(', ') with @!arguments
             }) will never work with " ~ (
                 $!protoguilt ?? 'signature of the proto ' !!
                 $multi       ?? 'any of these multi signatures:' !!
                                 'declared signature '
-            ) ~ $!signature;
+            ) ~ $signature;
     }
 }
 

--- a/t/02-rakudo/param-arg-compile-errors.t
+++ b/t/02-rakudo/param-arg-compile-errors.t
@@ -1,0 +1,107 @@
+use Test;
+use nqp;
+
+# A parameter read carries its declared type into the compile time call
+# analysis, so a call that can never bind is refused whether the
+# argument is a typed variable or a parameter. A definite argument type
+# is judged by its base type. Definedness stays a run time check.
+
+plan 19;
+
+sub compile-refuses($code, $expected, $desc) {
+    my $error = '';
+    {
+        EVAL $code;
+        CATCH { default { $error = .gist.Str } }
+    }
+    ok $error.contains($expected), $desc;
+}
+
+sub compiles($code, $desc) {
+    my $error = '';
+    {
+        EVAL $code;
+        CATCH { default { $error = .gist.Str } }
+    }
+    is $error, '', $desc;
+}
+
+compile-refuses 'sub g(Int $x) { }; sub f(Str $s) { g($s) }',
+    'will never work',
+    'a call through a read-only parameter that can never bind is refused at compile time';
+
+compile-refuses 'sub g(Int $x) { }; sub f(Str $s is copy) { g($s) }',
+    'will never work',
+    'a call through a copy parameter that can never bind is refused at compile time';
+
+compile-refuses 'sub g(Int $x) { }; sub f(Str $s is rw) { g($s) }',
+    'will never work',
+    'a call through an rw parameter that can never bind is refused at compile time';
+
+compile-refuses 'sub g(Int $x) { }; sub f(Str $s is raw) { g($s) }',
+    'will never work',
+    'a call through a raw parameter that can never bind is refused at compile time';
+
+compiles 'sub g(Int $x) { }; sub f($s) { g($s) }',
+    'an untyped parameter argument is not judged at compile time';
+
+compiles 'sub g(Cool $x) { }; sub f(Int $i) { g($i) }',
+    'a parameter argument that can bind compiles';
+
+compiles 'sub g($x) { }; sub f() { my Mu:D $i = 5; g($i) }',
+    'a definite Mu variable argument is not refused';
+
+compiles 'sub g($x) { }; sub f(Mu:D $v) { g($v) }',
+    'a definite Mu parameter argument is not refused';
+
+{
+    sub g($x) { $x }
+    sub f(Mu:D $v) { g($v) }
+    is f(5), 5, 'a definite Mu parameter argument still passes its value';
+}
+
+compile-refuses 'my subset S of Str; sub g(Int $x) { }; sub f(S $s) { g($s) }',
+    'will never work',
+    'a subset parameter argument is judged by its refinee';
+
+compiles 'my subset S of Str; sub g(Str $x) { }; sub f(S $s) { g($s) }',
+    'a subset parameter argument binds where its refinee binds';
+
+compile-refuses 'my subset S of Str:D; sub g(Int $x) { }; sub f(S $s) { g($s) }',
+    'will never work',
+    'a subset of a definite type strips to its nominal foundation';
+
+compile-refuses 'sub g(Int $x) { }; sub f(Str:D $s) { g($s) }',
+    'will never work',
+    'a definite typed parameter argument is judged by its base type';
+
+compile-refuses 'multi g(Int $x) { }; multi g(Rat $x) { }; sub f(Str $s) { g($s) }',
+    'will never work',
+    'a parameter argument no multi candidate can bind is refused at compile time';
+
+compile-refuses 'multi g(Int $x) { }; multi g(Rat $x) { }; sub f(Str $s) { g($s) }',
+    'any of these multi signatures:',
+    'refusing a multi call renders the candidate list';
+
+compile-refuses 'multi g(Int $x) { }; multi g(Rat $x) { }; sub f(Str $s) { g($s) }',
+    '(Rat $x)',
+    'the candidate list names each signature';
+
+compiles 'sub g(Str $x) { }; sub f(Int() $v) { g($v) }',
+    'a coercion typed parameter argument is not judged at compile time';
+
+compiles 'sub g(Cool $x) { }; sub f(Int:D $i) { g($i) }',
+    'a definite typed parameter argument binds where its base type binds';
+
+# The legacy frontend does not judge a definite typed variable
+# argument, so that refusal is pinned to RakuAST.
+if nqp::gethllsym('Raku', 'COMPILER-FRONTEND') eq 'rakuast' {
+    compile-refuses 'sub g(Str $x) { }; sub f() { my Int:D $i = 5; g($i) }',
+        'will never work',
+        'a definite typed variable argument is judged by its base type';
+}
+else {
+    skip 'the legacy frontend does not judge definite typed variable arguments', 1;
+}
+
+# vim: expandtab shiftwidth=4

--- a/t/08-performance/15-rakuast-native-metaop.t
+++ b/t/08-performance/15-rakuast-native-metaop.t
@@ -2,7 +2,7 @@ use lib <t/packages/Test-Helpers>;
 use Test::Helpers::QAST;
 use Test;
 use nqp;
-plan 14;
+plan 17;
 
 # A native int or num `+=`/`-=`/`*=` with a native operand lowers to a raw op
 # instead of calling the metaop.
@@ -63,9 +63,15 @@ if nqp::gethllsym('Raku', 'COMPILER-FRONTEND') eq 'rakuast' {
         'a native copy parameter compound-steps to a raw op';
     qast-is 'sub f(num $x is copy) { $x += 1.5e0 }', :full, -> \v { qast-contains-op v, 'add_n' },
         'a num copy parameter with a float literal lowers to a raw op';
+    qast-is 'sub f(int $j) { my int $t; $t += $j }', :full, -> \v { qast-contains-op v, 'add_i' },
+        'a native parameter read on the right lowers to a raw op';
+    qast-is 'sub f(int $j is rw) { my int $t; $t += $j }', :full, -> \v { not qast-contains-op v, 'add_i' },
+        'an rw parameter on the right keeps the metaop call';
+    qast-is 'class C { has int $!a; method m { my int $t; $t += $!a } }', :full, -> \v { qast-contains-op v, 'add_i' },
+        'a native attribute read on the right lowers to a raw op';
 }
 else {
-    skip 'integer-literal and native lowering shape is RakuAST-specific', 6;
+    skip 'integer-literal and native lowering shape is RakuAST-specific', 9;
 }
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously a parameter read answered no type to the compile time analyses, so `sub f(Str $s) { g($s) }` compiled fine when `g` declares `(Int $x)` while the same call through a typed variable was refused, and `sub f(int $j) { my int $t; $t += $j }` kept the metaop closure call instead of lowering to a raw op.

The call analysis now asks each argument through its static argument type, which answers a parameter read with the parameter's nominal type. Definedness and subset refinements are run time checks on top of that type, and a coercion type converts rather than constrains, so it is not judged. This matches how the legacy frontend records a parameter's nominal type and judges calls through it, and was verified against the legacy frontend across read-only, copy, rw, and raw parameters, subsets, subset-of-definite chains, definite types, coercion types, sigiled parameters, and natives.

Feeding real types through exposed a false positive the trial bind already had: no istype relation holds between a definite type and a nominal one in either direction, so `my Mu:D $v = 5; g($v)` was refused although the call works at run time. A `Mu:D` parameter in the CORE setting trips the same thing at build time. Definite argument types are now judged by their base type.

Formatting the refusal also warned on both frontends: `X::TypeCheck::Argument.message` called `.contains` on the signature list, which stringified it. A setting compile has no handler for warnings, so a diagnostic fired there died instead of reporting. The message now joins the defined entries first.

The native compound assignment mark now reads a lexical right operand through the native lexical primspec helper, so a native parameter on the right lowers to a raw op. A bindable or rw parameter keeps the metaop call, since its read does not come from a native slot.

The new refusals cover calls the legacy frontend already refuses or that fail their type check on every execution. One case goes beyond legacy: an impossible call through a `&`-sigil parameter is now caught, consistent with how both frontends already treat `@` and `%` parameters.