### PR TITLE
Instantiate generic container descriptors for is copy parameters

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -10123,13 +10123,29 @@ Did you mean a call like '"
                         }
                     }
                     if $wrap {
+                        my $descriptor_ast;
+                        if nqp::existskey(%info, 'container_descriptor') {
+                            $descriptor_ast := QAST::WVal.new( :value(%info<container_descriptor>) );
+                            # A generic descriptor still carries the unresolved
+                            # type variable and would reject every assignment
+                            # into the container. Resolve it in the current
+                            # frame, where type captures and role type
+                            # environments are visible as lexicals.
+                            if %info<container_descriptor>.is_generic {
+                                $descriptor_ast := QAST::Op.new(
+                                    :op('callmethod'), :name('instantiate_generic'),
+                                    $descriptor_ast,
+                                    QAST::Op.new( :op('ctx') )
+                                );
+                            }
+                        }
                         $var.push(QAST::Op.new(
                             :op('bind'),
                             WANTED(QAST::Var.new( :name(%info<variable_name>), :scope('lexical') ),'lower_signature/wrap'),
-                            nqp::existskey(%info, 'container_descriptor')
+                            $descriptor_ast
                                 ?? QAST::Op.new(
                                         :op('p6scalarwithvalue'),
-                                        QAST::WVal.new( :value(%info<container_descriptor>) ),
+                                        $descriptor_ast,
                                         QAST::Var.new( :name(get_decont_name() || $name), :scope('local') )
                                    )
                                 !! QAST::Op.new(

--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -582,9 +582,18 @@ my class Binder {
                     # provided and make it rw if it's an `is copy`.
                     else {
                         my $new_cont := nqp::create(Scalar);
-                        nqp::bindattr($new_cont, Scalar, '$!descriptor',
-                          nqp::getattr($param, Parameter, '$!container_descriptor')
-                        );
+                        my $desc :=
+                          nqp::getattr($param, Parameter, '$!container_descriptor');
+                        # A generic descriptor still carries the unresolved
+                        # type variable and would reject every assignment
+                        # into the container. Resolve it against the binding
+                        # context, which reaches type captures and role type
+                        # environments through the frame chain.
+                        $desc := $desc.instantiate_generic($lexpad)
+                          if $flags +& nqp::const::SIG_ELEM_TYPE_GENERIC
+                          && nqp::isconcrete($desc)
+                          && $desc.is_generic;
+                        nqp::bindattr($new_cont, Scalar, '$!descriptor', $desc);
                         nqp::bindattr($new_cont, Scalar, '$!value', $bindee);
                         $bindee := $new_cont;
                     }

--- a/src/Raku/ast/signature.rakumod
+++ b/src/Raku/ast/signature.rakumod
@@ -1834,9 +1834,22 @@ class RakuAST::Parameter
                     }
                     else {
                         if $container_descriptor {
+                            my $descriptor-qast := QAST::WVal.new(:value($container_descriptor));
+                            # A generic descriptor still carries the unresolved
+                            # type variable and would reject every assignment
+                            # into the container. Resolve it in the current
+                            # frame, where type captures and role type
+                            # environments are visible as lexicals.
+                            if $container_descriptor.is_generic {
+                                $descriptor-qast := QAST::Op.new(
+                                    :op<callmethod>, :name<instantiate_generic>,
+                                    $descriptor-qast,
+                                    QAST::Op.new( :op<ctx> )
+                                );
+                            }
                             $value := QAST::Op.new(
                                 :op<p6scalarwithvalue>,
-                                QAST::WVal.new(:value($container_descriptor)),
+                                $descriptor-qast,
                                 $value
                             );
                         }

--- a/t/02-rakudo/generic-copy-param.t
+++ b/t/02-rakudo/generic-copy-param.t
@@ -1,0 +1,114 @@
+use Test;
+
+plan 23;
+
+# An `is copy` parameter wraps its argument in a fresh Scalar whose container
+# descriptor comes from the Parameter object. For a parameter with a generic
+# type the descriptor holds the unresolved type variable until it is
+# instantiated on each call from the frame where the type variable is bound.
+# These tests exercise that instantiation across the binding paths.
+
+role IntShape[::T] {
+    method bump(T $x is copy) { $x = $x + 1; $x }
+}
+is IntShape[Int].new.bump(5), 6,
+    'a role method can assign to a generic copy param via the pun';
+
+role StrShape[::T] {
+    method shout(T $x is copy) { $x ~= '!'; $x }
+}
+class Shouter does StrShape[Str] { }
+is Shouter.new.shout('a'), 'a!',
+    'a role method composed into a class can assign to a generic copy param';
+
+# One role instantiated at two types must enforce each type separately.
+role Settable[::T] {
+    method set(T $x is copy, $v) { $x = $v; $x }
+}
+is Settable[Int].new.set(1, 2), 2,
+    'the Int instantiation of a role accepts an Int assignment';
+is Settable[Str].new.set('a', 'b'), 'b',
+    'the Str instantiation of the same role accepts a Str assignment';
+throws-like { Settable[Str].new.set('a', 5) }, X::TypeCheck::Assignment,
+    'the Str instantiation of the same role rejects an Int assignment';
+
+sub double(::T $a, T $x is copy) { $x = $x * 2; $x }
+is double(Int, 5), 10,
+    'a sub can assign to a copy param typed by a capture in the same signature';
+
+sub bump-definite(::T $a, T:D $x is copy) { $x = $x + 1; $x }
+is bump-definite(Int, 41), 42,
+    'a T:D copy param accepts assignment after instantiation';
+
+sub coerce(::T $a, T() $x is copy) { $x = $x + 1; $x }
+is coerce(Int, '41'), 42,
+    'a coercive generic copy param coerces its argument and accepts assignment';
+
+role Chainable {
+    method chain(::?CLASS $x is copy) { $x = self; $x }
+}
+class Chained does Chainable { }
+isa-ok Chained.new.chain(Chained), Chained,
+    'a ::?CLASS copy param accepts assignment in a composing class';
+
+sub bump-named(::T $a, T :$x is copy) { $x = $x + 1; $x }
+is bump-named(Int, x => 5), 6,
+    'a named generic copy param accepts assignment';
+
+sub bump-default(::T $a, T $x is copy = 10) { $x = $x + 1; $x }
+is bump-default(Int), 11,
+    'an omitted generic copy param assigns over its default';
+is bump-default(Int, 20), 21,
+    'a passed generic copy param with a default accepts assignment';
+
+multi bump-multi(::T $a, T $x is copy) { $x = $x + 1; $x }
+is bump-multi(Int, 5), 6,
+    'a multi sub can assign to a generic copy param';
+
+role MultiShape[::T] {
+    multi method bump(T $x is copy) { $x = $x + 1; $x }
+}
+is MultiShape[Int].new.bump(5), 6,
+    'a role multi method can assign to a generic copy param';
+
+# Sub-signature parameter, which binds through the runtime binder rather
+# than the lowered signature code.
+sub bump-subsig(::T $a, @b ($x, T $y is copy)) { $y = $y + 1; $y }
+is bump-subsig(Int, [1, 5]), 6,
+    'a generic copy param inside a sub-signature accepts assignment';
+
+role Strict[::T] {
+    method poke(T $x is copy) { $x = 'oops'; $x }
+}
+throws-like { Strict[Int].new.poke(5) }, X::TypeCheck::Assignment,
+    'the instantiated copy container still rejects a wrongly typed assignment';
+
+sub report-of(::T $a, T $x is copy) { $x.VAR.of }
+ok report-of(Int, 5) =:= Int,
+    'the copy container of a generic copy param reports the instantiated type';
+
+sub renil(::T $a, T $x is copy) { $x = Nil; $x }
+ok renil(Int, 5) =:= Int,
+    'assigning Nil to a generic copy param restores the instantiated default';
+
+sub keep(::T $a, T $x is copy) { $x = $x + 1 }
+my $orig = 5;
+keep(Int, $orig);
+is $orig, 5,
+    'assigning to a generic copy param leaves the argument untouched';
+
+sub pick-pos(::T $a, T $x is copy where * > 0) { $x = $x + 1; $x }
+is pick-pos(Int, 5), 6,
+    'a constrained generic copy param accepts assignment';
+
+sub plain(Int $x is copy) { $x = $x + 1; $x }
+is plain(5), 6,
+    'a non-generic typed copy param still accepts assignment';
+my $bad = 'nope';
+dies-ok { plain($bad) },
+    'a non-generic typed copy param still rejects a wrongly typed argument';
+sub loose($x is copy) { $x = 'any'; $x }
+is loose(5), 'any',
+    'an untyped copy param still accepts any assignment';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously a parameter that combined a generic type with `is copy` could never be assigned to. The copy container was built with the compile time descriptor, whose `of` is the unresolved type variable, so its typecheck rejected every value no matter what the type variable was instantiated to:

```
$ raku -e 'role R[::T] { method m(T $x is copy) { $x = $x + 1; $x } }; say R[Int].new.m(5)'
Type check failed in assignment to $x; expected T but got Int (5)
```

This instantiates the descriptor on each call against the frame where the type variable is bound, so the container for `R[Int]` ends up typed by `Int` and each instantiation enforces its own type. Assigning a `Str` inside an `R[Int]` method still throws the usual `X::TypeCheck::Assignment`, and assigning `Nil` restores the instantiated default rather than the type variable. The same fix is applied in both frontends and in the runtime binder, as sub-signature parameters bind through the binder even when the enclosing signature is lowered.

This covers role type parameters, type captures used later in the same signature (e.g. `sub f(::T $a, T $x is copy)`), definite and coercive generics, named and optional parameters, and multis.