### PR TITLE
RakuAST: lower the implicit invocant to a frame local

### DIFF
--- a/src/Raku/Grammar.nqp
+++ b/src/Raku/Grammar.nqp
@@ -4253,7 +4253,7 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
         }
         {
             # Declare self early for attribute parameters
-            $*R.declare-lexical($/.Nodify('VarDeclaration::Implicit::Self').new)
+            $*R.declare-lexical($*BLOCK.IMPL-SELF-DECLARATION)
         }
         [ '(' <signature(1, :ON-ROUTINE(1))> ')' ]?
         <trait($*BLOCK)>* :!s

--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -3462,6 +3462,7 @@ class RakuAST::Method
     has RakuAST::Blockoid $.body;
     has Bool              $.meta;
     has Bool              $.private;
+    has Mu                $!self-declaration;
 
     method new(          str :$scope,
                          str :$multiness,
@@ -3517,10 +3518,19 @@ class RakuAST::Method
 
     method IMPL-META-OBJECT-TYPE() { Method }
 
+    # The one self declaration of this method. The grammar declares it
+    # into scope ahead of the signature parse and the implicit list
+    # carries it, so a resolution of self anywhere in the method
+    # reaches the instance its frame declares.
+    method IMPL-SELF-DECLARATION() {
+        $!self-declaration
+            // nqp::bindattr(self, RakuAST::Method, '$!self-declaration',
+                RakuAST::VarDeclaration::Implicit::Self.new)
+    }
+
     method PRODUCE-IMPLICIT-DECLARATIONS() {
         my $list := nqp::findmethod(RakuAST::Routine, 'PRODUCE-IMPLICIT-DECLARATIONS')(self);
-        self.IMPL-UNWRAP-LIST($list).push:
-            RakuAST::VarDeclaration::Implicit::Self.new();
+        self.IMPL-UNWRAP-LIST($list).push: self.IMPL-SELF-DECLARATION;
         $list
     }
 
@@ -3603,7 +3613,7 @@ class RakuAST::Method::AttributeAccessor
     # The body is fully synthetic: nothing in it can reach the special
     # variables, so only self is declared.
     method PRODUCE-IMPLICIT-DECLARATIONS() {
-        [ RakuAST::VarDeclaration::Implicit::Self.new() ]
+        [ self.IMPL-SELF-DECLARATION ]
     }
 
     method PRODUCE-META-OBJECT(:$resolver, :$context) {

--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -2622,6 +2622,17 @@ class RakuAST::Routine
         $!signature && $!signature.IMPL-HAS-PARAMETER($name)
     }
 
+    # The implicit self declaration of this routine, or null for a
+    # routine without one.
+    method IMPL-SELF-DECLARATION() {
+        if nqp::istype(self, RakuAST::ImplicitDeclarations) {
+            for self.IMPL-UNWRAP-LIST(self.get-implicit-declarations()) {
+                return $_ if nqp::istype($_, RakuAST::VarDeclaration::Implicit::Self);
+            }
+        }
+        nqp::null
+    }
+
     method IMPL-QAST-FORM-BLOCK(RakuAST::IMPL::QASTContext $context, str :$blocktype,
             RakuAST::Expression :$expression) {
         # RegexThunk needs the body compiled first
@@ -2636,7 +2647,7 @@ class RakuAST::Routine
                 ), :key);
         self.IMPL-ADD-LOWERED-DEBUG-MAPPINGS($block);
         my $signature := self.placeholder-signature || $!signature;
-        $block.push($signature.IMPL-QAST-BINDINGS($context, :needs-full-binder(self.custom-args), :multi(self.multiness eq 'multi')));
+        $block.push($signature.IMPL-QAST-BINDINGS($context, :needs-full-binder(self.custom-args), :multi(self.multiness eq 'multi'), :invocant-decl(self.IMPL-SELF-DECLARATION)));
         $block.custom_args(1) if self.custom-args;
         $block.arity($signature.arity);
         $block.annotate('count', $signature.count);
@@ -2866,6 +2877,11 @@ class RakuAST::Routine
                 return '';
             }
             return '' if $scope eq 'lexical' && $node.name eq 'self';
+            if $scope eq 'local' {
+                my $self-decl := self.IMPL-SELF-DECLARATION;
+                return '' if nqp::isconcrete($self-decl)
+                    && $node.name eq $self-decl.IMPL-LOWERED-LOCAL-NAME;
+            }
         }
         elsif nqp::istype($node, QAST::WVal) {
             return '' unless nqp::iscont($node.value);

--- a/src/Raku/ast/scoping.rakumod
+++ b/src/Raku/ast/scoping.rakumod
@@ -60,7 +60,8 @@ class RakuAST::LexicalScope
     method IMPL-ADD-LOWERED-DEBUG-MAPPINGS(Mu $block) {
         for self.IMPL-UNWRAP-LIST(self.ast-lexical-declarations()) {
             if (nqp::istype($_, RakuAST::VarDeclaration::Simple)
-                || nqp::istype($_, RakuAST::ParameterTarget::Term))
+                || nqp::istype($_, RakuAST::ParameterTarget::Term)
+                || nqp::istype($_, RakuAST::VarDeclaration::Implicit::Self))
                 && $_.IMPL-LOWERED-LOCAL-NAME {
                 $block.add_local_debug_mapping(
                     $_.IMPL-LOWERED-LOCAL-NAME, $_.lexical-name);

--- a/src/Raku/ast/signature.rakumod
+++ b/src/Raku/ast/signature.rakumod
@@ -318,7 +318,7 @@ class RakuAST::Signature
         QAST::WVal.new(:value($signature))
     }
 
-    method IMPL-QAST-BINDINGS(RakuAST::IMPL::QASTContext $context, :$needs-full-binder, :$multi) {
+    method IMPL-QAST-BINDINGS(RakuAST::IMPL::QASTContext $context, :$needs-full-binder, :$multi, Mu :$invocant-decl) {
         my $bindings := QAST::Stmts.new();
         my $parameters := $!parameters // [];
         if $needs-full-binder {
@@ -337,10 +337,10 @@ class RakuAST::Signature
         }
         else {
             if $!implicit-invocant {
-                $bindings.push($!implicit-invocant.IMPL-TO-QAST($context));
+                $bindings.push($!implicit-invocant.IMPL-TO-QAST($context, :$invocant-decl));
             }
             for $parameters {
-                $bindings.push($_.IMPL-TO-QAST($context));
+                $bindings.push($_.IMPL-TO-QAST($context, :$invocant-decl));
             }
             if $!implicit-slurpy-hash {
                 $bindings.push($!implicit-slurpy-hash.IMPL-TO-QAST($context));
@@ -1397,7 +1397,7 @@ class RakuAST::Parameter
         }
     }
 
-    method IMPL-TO-QAST(RakuAST::IMPL::QASTContext $context) {
+    method IMPL-TO-QAST(RakuAST::IMPL::QASTContext $context, Mu :$invocant-decl) {
         nqp::die('RakuAST::Parameter::IMPL-TO-QAST reached for a sub-signature parameter. The owning routine must have custom-args True so dispatch routes through Signature::IMPL-QAST-BINDINGS.')
             if $!sub-signature;
         # Flag constants we need to pay attention to.
@@ -1775,13 +1775,16 @@ class RakuAST::Parameter
 
         # Bind parameter into its target.
         if self.invocant {
-            $param-qast.push(QAST::Op.new(
-                :op('bind'),
-                QAST::Var.new( :name('self'), :scope('lexical') ),
-                $get-decont-var() // QAST::Op.new(
-                        :op('decont'),
-                        $temp-qast-var,
-                    )));
+            my $invocant-value := $get-decont-var() // QAST::Op.new(
+                :op('decont'),
+                $temp-qast-var,
+            );
+            $param-qast.push(nqp::isconcrete($invocant-decl)
+                ?? $invocant-decl.IMPL-BIND-QAST($context, $invocant-value)
+                !! QAST::Op.new(
+                    :op('bind'),
+                    QAST::Var.new( :name('self'), :scope('lexical') ),
+                    $invocant-value));
         }
         if nqp::isconcrete($!target) && !$discard {
             if $flags +& (

--- a/src/Raku/ast/var-lowering.rakumod
+++ b/src/Raku/ast/var-lowering.rakumod
@@ -126,6 +126,10 @@ class RakuAST::IMPL::VarLoweringFrame {
         nqp::atkey($!candidate-ids, $id)
     }
 
+    method record-for-name(str $name) {
+        nqp::atkey($!candidate-names, $name)
+    }
+
     method candidates() { $!candidates }
 }
 
@@ -487,8 +491,25 @@ class RakuAST::IMPL::VarLowering {
                 if nqp::istype($node, RakuAST::Code) && $node.custom-args;
         }
 
-        self.IMPL-REGISTER-USE($node)
-            if nqp::istype($node, RakuAST::Lookup) && $node.is-resolved;
+        if nqp::istype($node, RakuAST::Lookup) && $node.is-resolved {
+            self.IMPL-REGISTER-USE($node);
+            # These resolutions compile to a read of the lexical self
+            # by name: an attribute reached through its aliasing
+            # declaration, and a self resolution the walk does not
+            # track. An attribute declared in a `has (...)` list is
+            # reached through the parameter target wrapping it.
+            my $resolution := $node.resolution;
+            if nqp::istype($resolution, RakuAST::ParameterTarget::Var)
+                && nqp::isconcrete($resolution.declaration) {
+                $resolution := $resolution.declaration;
+            }
+            self.IMPL-MARK-SELF-USED-BY-NAME()
+                if nqp::istype($resolution, RakuAST::VarDeclaration::AttributeAlias)
+                || (nqp::istype($resolution, RakuAST::VarDeclaration::Simple)
+                    && $resolution.is-attribute)
+                || (nqp::istype($resolution, RakuAST::VarDeclaration::Implicit::Self)
+                    && !self.IMPL-SELF-RESOLUTION-TRACKED($resolution));
+        }
         self.IMPL-REGISTER-IMPLICIT-LOOKUPS($node);
         self.IMPL-CHECK-POISON($node);
 
@@ -505,8 +526,14 @@ class RakuAST::IMPL::VarLowering {
         # identities decide whether the implicits go unused.
         if $is-scope && nqp::istype($node, RakuAST::ImplicitDeclarations) {
             for $node.IMPL-UNWRAP-LIST($node.get-implicit-declarations()) {
-                $frame.register-implicit(~nqp::objectid($_), $_)
-                    if nqp::istype($_, RakuAST::VarDeclaration::Implicit);
+                if nqp::istype($_, RakuAST::VarDeclaration::Implicit) {
+                    $frame.register-implicit(~nqp::objectid($_), $_);
+                    # The invocant is bound once at frame entry and only
+                    # read after, so it is a lowering candidate like a
+                    # term parameter.
+                    $frame.register($_, '')
+                        if nqp::istype($_, RakuAST::VarDeclaration::Implicit::Self);
+                }
             }
         }
         if $is-scope && nqp::istype($node, RakuAST::Routine)
@@ -895,6 +922,40 @@ class RakuAST::IMPL::VarLowering {
                 self.IMPL-MARK-MAGICAL-USED('$_')
                     if $op eq '~~' || $op eq '!~~'
                     || $op eq 'andthen' || $op eq 'orelse' || $op eq 'notandthen';
+            }
+        }
+        Nil
+    }
+
+    # A self resolution not registered with any frame of this walk
+    # belongs to a scope outside it, and its emission cannot follow a
+    # lowering decision made here.
+    method IMPL-SELF-RESOLUTION-TRACKED(Mu $resolution) {
+        my str $id := ~nqp::objectid($resolution);
+        my int $i := nqp::elems($!frames);
+        while --$i >= 0 {
+            my $frame := nqp::atpos($!frames, $i);
+            return 1 unless nqp::isnull($frame.record-for-id($id));
+            return 1 unless nqp::isnull($frame.implicit-record-for-id($id));
+        }
+        0
+    }
+
+    # A use that compiles to a read of the lexical self by name keeps
+    # the innermost self declaration a lexical, since a lowered one
+    # would leave the by-name symbol holding the sentinel.
+    method IMPL-MARK-SELF-USED-BY-NAME() {
+        my int $i := nqp::elems($!frames);
+        while --$i >= 0 {
+            my $frame := nqp::atpos($!frames, $i);
+            if $frame.is-scope {
+                my $record := $frame.record-for-name('self');
+                unless nqp::isnull($record) {
+                    nqp::bindkey($record, 'used', 1);
+                    nqp::bindkey($record, 'declined', 'by-name')
+                        unless nqp::atkey($record, 'declined');
+                    return Nil;
+                }
             }
         }
         Nil

--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -2904,6 +2904,10 @@ class RakuAST::VarDeclaration::Implicit::Block
 class RakuAST::VarDeclaration::Implicit::Self
   is RakuAST::VarDeclaration::Implicit
 {
+    has int $!lowered-to-local;
+    has Mu $!lowered-away-sentinel;
+    has str $!lowered-local-name;
+
     method new() {
         my $obj := nqp::create(self);
         nqp::bindattr_s($obj, RakuAST::VarDeclaration::Implicit, '$!name', 'self');
@@ -2911,8 +2915,67 @@ class RakuAST::VarDeclaration::Implicit::Self
         $obj
     }
 
+    method IMPL-SET-LOWERED-TO-LOCAL(Mu $sentinel) {
+        nqp::bindattr_i(self, RakuAST::VarDeclaration::Implicit::Self, '$!lowered-to-local', 1);
+        nqp::bindattr(self, RakuAST::VarDeclaration::Implicit::Self, '$!lowered-away-sentinel', $sentinel);
+    }
+
+    # The frame-local name for a lowered invocant, minted on first
+    # request so the binding and every lookup agree, or the empty string
+    # when self stays a by-name lexical.
+    method IMPL-LOWERED-LOCAL-NAME() {
+        return $!lowered-local-name if $!lowered-local-name;
+        return '' unless $!lowered-to-local;
+        return '' if nqp::isnull($!lowered-away-sentinel);
+        nqp::bindattr_s(self, RakuAST::VarDeclaration::Implicit::Self,
+            '$!lowered-local-name',
+            QAST::Node.unique('__lowered_self'));
+        if nqp::atkey(nqp::getenvhash(), 'RAKUDO_LOWERING_DEBUG') {
+            RakuAST::IMPL::VarLowering.IMPL-NOTE(
+                'lex2local: minted ' ~ $!lowered-local-name ~ ' for self');
+        }
+        $!lowered-local-name
+    }
+
     method IMPL-QAST-DECL(RakuAST::IMPL::QASTContext $context) {
-        QAST::Var.new( :decl('var'), :scope('lexical'), :name(self.name) )
+        if self.IMPL-LOWERED-LOCAL-NAME {
+            # The local is declared here, in the block's declaration
+            # section, so it exists before the invocant binding writes
+            # it. The by-name lexical stays declared for introspection,
+            # static with the sentinel as its value so no per-entry
+            # setup is paid for it.
+            $context.ensure-sc($!lowered-away-sentinel);
+            QAST::Stmts.new(
+                QAST::Var.new(
+                    :decl('static'), :scope('lexical'), :name(self.name),
+                    :value($!lowered-away-sentinel)
+                ),
+                QAST::Var.new(
+                    :decl('var'), :scope('local'), :name($!lowered-local-name)
+                )
+            )
+        }
+        else {
+            QAST::Var.new( :decl('var'), :scope('lexical'), :name(self.name) )
+        }
+    }
+
+    method IMPL-LOOKUP-QAST(RakuAST::IMPL::QASTContext $context, Mu :$rvalue) {
+        my str $local-name := self.IMPL-LOWERED-LOCAL-NAME;
+        $local-name
+            ?? QAST::Var.new( :name($local-name), :scope('local') )
+            !! QAST::Var.new( :name(self.name), :scope('lexical') )
+    }
+
+    method IMPL-BIND-QAST(RakuAST::IMPL::QASTContext $context, Mu $source-qast) {
+        my str $local-name := self.IMPL-LOWERED-LOCAL-NAME;
+        QAST::Op.new(
+            :op('bind'),
+            $local-name
+                ?? QAST::Var.new( :name($local-name), :scope('local') )
+                !! QAST::Var.new( :name(self.name), :scope('lexical') ),
+            $source-qast
+        )
     }
 }
 

--- a/t/08-performance/34-rakuast-lower-self.t
+++ b/t/08-performance/34-rakuast-lower-self.t
@@ -1,0 +1,202 @@
+use lib <t/packages/Test-Helpers>;
+use Test::Helpers::QAST;
+use Test;
+use QAST:from<NQP>;
+use nqp;
+plan 33;
+
+# The implicit invocant lowers to a frame local: the invocant binding
+# writes a register and every self or attribute access reads one, with
+# the by-name lexical kept static for introspection. A use from a
+# nested frame needs the lexical, as does an attribute reached through
+# its aliasing declaration, whose access compiles to a by-name read of
+# self. The shapes are this frontend's.
+
+sub qast-has-lowered(Mu $qast, str $prefix --> Bool:D) {
+    if nqp::istype($qast, QAST::Var) {
+        return True if $qast.scope eq 'local' && $qast.name.starts-with($prefix);
+    }
+    if qast-descendable($qast) {
+        for $qast.list {
+            qast-has-lowered($_, $prefix) and return True;
+        }
+    }
+    False
+}
+
+sub qast-has-lexical-decl(Mu $qast, str $name --> Bool:D) {
+    if nqp::istype($qast, QAST::Var) {
+        return True if $qast.scope eq 'lexical' && $qast.name eq $name && $qast.decl;
+    }
+    if qast-descendable($qast) {
+        for $qast.list {
+            qast-has-lexical-decl($_, $name) and return True;
+        }
+    }
+    False
+}
+
+sub qast-has-op(Mu $qast, str $op --> Bool:D) {
+    if nqp::istype($qast, QAST::Op) {
+        return True if $qast.op eq $op;
+    }
+    if qast-descendable($qast) {
+        for $qast.list {
+            qast-has-op($_, $op) and return True;
+        }
+    }
+    False
+}
+
+# A method can be compiled more than once, as a unit emission and as a
+# dynamic compilation for BEGIN use, so a per-block check runs against
+# every block of the given name rather than the whole unit.
+sub qast-block-passes(Mu $qast, str $name, &check --> Bool:D) {
+    if nqp::istype($qast, QAST::Block) && $qast.name eq $name {
+        return True if check($qast);
+    }
+    if qast-descendable($qast) {
+        for $qast.list {
+            qast-block-passes($_, $name, &check) and return True;
+        }
+    }
+    False
+}
+
+if nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' {
+    qast-is 'my class T { method m() { self.defined } }; T.new.m', :full, -> \v {
+        qast-has-lowered(v, '__lowered_self')
+    }, 'the invocant lowers to a frame local';
+
+    qast-is 'my class T { has $.x; method m() { $!x } }; T.new.m', :full, -> \v {
+        qast-has-lowered(v, '__lowered_self')
+    }, 'an attribute access reads the invocant through its local';
+
+    qast-is 'my class T { has $.x; method m($!x) { self.defined } }; T.new.m(1)', :full, -> \v {
+        qast-has-lowered(v, '__lowered_self')
+    }, 'a method with an attributive parameter lowers its invocant';
+
+    qast-is 'my class T { submethod s() { self.defined } }; T.new.s', :full, -> \v {
+        qast-has-lowered(v, '__lowered_self')
+    }, 'a submethod lowers its invocant';
+
+    qast-is 'my class T { method m($self:) { $self.defined } }; T.new.m', :full, -> \v {
+        qast-has-lowered(v, '__lowered_self')
+    }, 'a method with an explicit invocant still lowers self';
+
+    qast-is 'my class T { has $.x; method m() { (1, 2).map({ self.x }) } }; T.new.m', :full, -> \v {
+        qast-has-lexical-decl(v, 'self')
+        and not qast-has-lowered(v, '__lowered_self')
+    }, 'an invocant a nested frame uses keeps the lexical';
+
+    qast-is 'my class T { method m() { EVAL q|self| } }; T.new.m', :full, -> \v {
+        qast-has-lexical-decl(v, 'self')
+        and not qast-has-lowered(v, '__lowered_self')
+    }, 'an EVAL in the method keeps the invocant a lexical';
+
+    qast-is 'my class T { has $x; method m() { $x } }; T.new.m', :full, -> \v {
+        qast-has-lexical-decl(v, 'self')
+        and not qast-has-lowered(v, '__lowered_self')
+    }, 'an attribute reached through its alias keeps the invocant a lexical';
+
+    qast-is 'my class T { has ($a, $b); method m() { $a } }; T.new.m', :full, -> \v {
+        qast-has-lexical-decl(v, 'self')
+        and not qast-has-lowered(v, '__lowered_self')
+    }, 'an attribute from a has list keeps the invocant a lexical';
+
+    qast-is 'my grammar G { token TOP { \w+ } }; G.parse("a")', :full, -> \v {
+        qast-has-lexical-decl(v, 'self')
+        and not qast-has-lowered(v, '__lowered_self')
+    }, 'a regex declaration keeps its invocant a lexical';
+
+    qast-is 'my class T { method m() { self } }; T.new.m', :full, -> \v {
+        qast-block-passes(v, 'm', -> \b { qast-has-lowered(b, '__lowered_self') })
+        and not qast-block-passes(v, 'm', -> \b {
+            qast-has-op(b, 'p6decontrv') or qast-has-op(b, 'p6decontrv_6c')
+        })
+    }, 'a method returning its lowered invocant still elides the return decont';
+}
+else {
+    skip 'the lowering shapes are specific to the RakuAST frontend', 11;
+}
+
+# Behavior stays identical.
+
+{
+    my class C { has $.x; method m() { $!x + 1 } }
+    is C.new(x => 41).m, 42, 'an attribute access in a method yields its value';
+
+    my class D { has $.x; method m($!x) { self } }
+    is D.new.m(42).x, 42, 'an attributive parameter binds into the invocant';
+
+    my class E { has num $.re; method !SET-SELF($!re) { self }
+        method make(\v) { nqp::create(self)!SET-SELF(v) } }
+    is E.make(2e0).re, 2e0, 'a private method with an attributive parameter constructs';
+
+    my class F { has $.x; method m() { (1..3).map({ self.x * $_ }).sum } }
+    is F.new(x => 2).m, 12, 'a closure in a method reads the invocant';
+
+    my class G2 { method m() { self } }
+    ok G2.new.m ~~ G2, 'a method returns its invocant deconted';
+
+    my class P1 { method m() { "P" } }
+    my class C1 is P1 { method m() { "C" ~ callsame } }
+    is C1.m, 'CP', 'deferral in a method still runs';
+
+    my class H1 { has $.x; method m() { EVAL q|self.x| } }
+    is H1.new(x => 7).m, 7, 'an EVAL in a method reads the invocant, not a sentinel';
+
+    my class I1 { method m() { MY::<self>.^name } }
+    is I1.new.m, 'I1', 'a MY:: lookup reads the invocant, not a sentinel';
+
+    my class I2 { method m() { ::("self").^name } }
+    is I2.new.m, 'I2', 'an indirect lookup reads the invocant, not a sentinel';
+
+    my class J1 { has $x; method set(\v) { $x = v; self }; method m() { $x } }
+    is J1.new.set(9).m, 9, 'an aliased attribute reads and writes through self';
+
+    my class J2 { has ($a, $b); submethod BUILD(:$!a, :$!b) { }
+        method m() { $a + $b } }
+    is J2.new(a => 20, b => 22).m, 42, 'attributes from a has list read through self';
+
+    my class K1 { has $.x; method m($v = self.x) { $v } }
+    is K1.new(x => 7).m, 7, 'a parameter default reads the live invocant';
+
+    my class L1 { has $.x; method m($v where { $_ < self.x }) { $v } }
+    is L1.new(x => 10).m(5), 5, 'a where clause reads the live invocant';
+    dies-ok { L1.new(x => 3).m(5) }, 'a where clause rejects against the live invocant';
+
+    my role R1 { method m() { self.n * 2 } }
+    my class M1 does R1 { method n() { 21 } }
+    is M1.new.m, 42, 'a role method reads self through its generic invocant';
+
+    my role R2 { has $.x; method m() { $!x + self.x } }
+    my class D2 does R2 {}
+    is D2.new(x => 21).m, 42, 'a role method reads an attribute through its generic invocant';
+
+    my class B1 { has num $.re; method !SET-SELF($!re) { self }
+        method make(\v) { nqp::create(self)!SET-SELF(v) } }
+    my constant K = B1.make(3e0);
+    is K.re, 3e0, 'a method compiled for BEGIN time constructs through self';
+
+    my class M2 {
+        has $.x;
+        proto method m(|) {*}
+        multi method m() { $!x }
+        multi method m($v) { self.x + $v }
+    }
+    is M2.new(x => 40).m, 40, 'a multi candidate reads an attribute through self';
+    is M2.new(x => 40).m(2), 42, 'another multi candidate reads self through a method call';
+
+    my class P2 { has $.x; method m() { $!x } }
+    my class C2 is P2 { method m() { nextsame } }
+    is C2.new(x => 42).m, 42, 'nextsame reaches a candidate that reads an attribute';
+
+    my $held = 5;
+    my class S5 { method m(\selfish) { selfish } }
+    is S5.m($held).VAR.^name, 'Int', 'a term parameter named like self still returns deconted';
+    my sub selfsub(\selfmade) { selfmade }
+    is selfsub($held).VAR.^name, 'Int', 'a sub term parameter named like self still returns deconted';
+}
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously `self` stayed a by-name frame lexical, so the invocant binding and every `self` or attribute access in a method paid a lexical operation, while sigiled and sigilless parameters already lowered to frame locals. This registers the implicit self declaration with the lowering walk as a candidate like a term parameter. When nothing escapes it the frame declares a local, the invocant binding writes it, and every resolved use reads it. The by-name lexical stays declared for introspection, static with the sentinel as its value, the same shape other lowered declarations use. The hot setting iterator frames now read the invocant through a register like the legacy frontend does.

The first commit fixes something this depends on. The grammar declared a throwaway implicit `self` ahead of the signature parse so attribute parameters could resolve it, which meant a resolution of `self` made in a signature pointed at an instance the method's frame never declares. Emission through such a resolution cannot follow decisions made on the declaration the frame carries. The method now creates its self declaration once, the grammar declares that instance into scope, and the produced implicit list carries the same one.

A use from a nested frame keeps the lexical, as do EVAL and pseudo package lookups through the existing poisons, regex declarations, attributes reached through their aliasing declaration, and any self resolution the walk does not track.
