### PR TITLE
Intern curried roles created by generic instantiation

### DIFF
--- a/src/Perl6/Metamodel/CurriedRoleHOW.nqp
+++ b/src/Perl6/Metamodel/CurriedRoleHOW.nqp
@@ -234,11 +234,11 @@ class Perl6::Metamodel::CurriedRoleHOW
                   $value.HOW.instantiate_generic($value, $type_env)
                 ) if $value.HOW.archetypes($value).generic;
             }
-            self.new_type($!curried_role, |@new_pos, |%new_named)
+            $!curried_role.HOW.parameterize($!curried_role, |@new_pos, |%new_named)
         }
 
         else {
-            self.new_type($!curried_role, |@new_pos)
+            $!curried_role.HOW.parameterize($!curried_role, |@new_pos)
         }
     }
 

--- a/t/02-rakudo/curried-role-instantiation.t
+++ b/t/02-rakudo/curried-role-instantiation.t
@@ -1,0 +1,37 @@
+use Test;
+
+plan 5;
+
+# Instantiating a generic curried role must preserve everything the curry
+# was declared with: named and value arguments have to survive into the
+# composed class, and the pun repr of the role group has to reach the
+# instantiated curry.
+
+{
+    role Flagged[::T, :$flag] { method flag() { $flag } }
+    role Wrap[::U] does Flagged[U, :flag(42)] { }
+    class WrapInt does Wrap[Int] { }
+    is WrapInt.new.flag, 42,
+        'named curry arg survives generic instantiation';
+    ok WrapInt ~~ Flagged,
+        'class composing a curry with a named arg typechecks against the role group';
+}
+
+{
+    role Valued[Str $s] { method s() { $s } }
+    role UsesValued[::T] does Valued["x"] { }
+    class ValuedInt does UsesValued[Int] { }
+    is ValuedInt.new.s, "x",
+        'value curry arg survives generic instantiation';
+    ok ValuedInt ~~ Valued["x"],
+        'class composing a curry with a value arg typechecks against the parameterization';
+}
+
+{
+    role Struct[::T] is repr('CStruct') { has int32 $.x }
+    role UsesStruct[::T] does Struct[T] { }
+    is UsesStruct[Int].^roles(:!transitive)[0].^pun.REPR, 'CStruct',
+        'pun repr of the role group reaches a curry instantiated from a generic';
+}
+
+# vim: expandtab shiftwidth=4

--- a/t/08-performance/35-curried-role-interning.t
+++ b/t/08-performance/35-curried-role-interning.t
@@ -1,0 +1,59 @@
+use nqp;
+use Test;
+
+plan 5;
+
+# Type-check caches match on object identity, so a curried role reached
+# through role composition must be the same object as the parameterization
+# that writing it in source returns. A duplicate curry never hits the cache
+# and every type check against it falls back to the slow accepts_type path,
+# making dispatch to a routine with a typed array parameter many times
+# slower than dispatch to an untyped equivalent. The language itself cannot
+# observe the difference, so these tests assert the identity directly.
+
+{
+    role Item[::T] { }
+    role Box[::T] does Item[T] { }
+    ok nqp::eqaddr(
+        nqp::decont(Box[Int].^roles(:!transitive)[0]),
+        nqp::decont(Item[Int])
+    ), 'role instantiated from a generic curry is the interned parameterization';
+}
+
+{
+    my Int @a;
+    my $found = False;
+    for @a.WHAT.^role_typecheck_list -> \t {
+        $found = True if nqp::eqaddr(nqp::decont(t), nqp::decont(Positional[Int]));
+    }
+    ok $found, 'typed array typecheck list holds the interned Positional[Int]';
+}
+
+{
+    my Int %h;
+    my $found = False;
+    for %h.WHAT.^role_typecheck_list -> \t {
+        $found = True if nqp::eqaddr(nqp::decont(t), nqp::decont(Associative[Int]));
+    }
+    ok $found, 'typed hash typecheck list holds the interned Associative[Int]';
+}
+
+{
+    my Int @a;
+    my $found = False;
+    for @a.WHAT.^role_typecheck_list -> \t {
+        $found = True if nqp::eqaddr(nqp::decont(t), nqp::decont(Positional));
+    }
+    ok $found, 'typed array typecheck list also holds the non-parameterized Positional';
+}
+
+{
+    role Duo[::T, ::U] { }
+    role Half[::T] does Duo[Int, T] { }
+    ok nqp::eqaddr(
+        nqp::decont(Half[Str].^roles(:!transitive)[0]),
+        nqp::decont(Duo[Int, Str])
+    ), 'curry mixing concrete and generic args instantiates to the interned parameterization';
+}
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously CurriedRoleHOW.instantiate_generic built its instantiated curry with CurriedRoleHOW.new_type. Instantiating the Positional[TValue] that Array::Typed does thus produced a Positional[Int] distinct from the interned one that writing Positional[Int] in source returns. Type-check caches match on object identity, so a typed array never got a cache hit when checked against Positional[Int] and every such check fell back to CurriedRoleHOW.accepts_type. That made calls to a routine with a typed array parameter some 40x slower than the untyped equivalent.

This delegates to the curried role's own parameterize method, which for role groups interns through the 6model parameterization cache. The instantiated curry is then the same object as any directly written parameterization. Type-check caches hit and dispatch with typed arrays runs at the same speed as with untyped ones. The pun repr of the role group now also carries over to such curries.

Fixes #4097