### PR TITLE
Cache interpolated regex compilations by pattern source

### DIFF
--- a/src/core.c/INTERPOLATE.rakumod
+++ b/src/core.c/INTERPOLATE.rakumod
@@ -615,27 +615,99 @@ augment class Match {
         nqp::getlexdyn('$?REGEX')(self)
     }
 
+    # One compiled-regex slot per combination of :i, :m, and whether code
+    # interpolation was allowed.  Slot values for a given object are
+    # interchangeable, so unsynchronized binds at worst waste a compile.
     my role CachedCompiledRegex {
-        has $.regex;
+        has $.regexes;
     }
-    multi sub MAKE_REGEX(Regex \arg, $, $, int \monkey, $) {
-        arg
+    sub FLAG_SLOT(\i, \m, int \monkey --> int) {
+        nqp::add_i(
+          nqp::add_i(i ?? 1 !! 0, m ?? 2 !! 0),
+          nqp::if(monkey, 4, 0)
+        )
     }
-    multi sub MAKE_REGEX(CachedCompiledRegex \arg, $, $, int \monkey, $) {
-        arg.regex
-    }
-    multi sub MAKE_REGEX(\arg, \i, \m, int \monkey, \context) {
+
+    # Compiling an interpolated pattern creates bytecode that MoarVM never
+    # deallocates, so equal pattern text must reuse one compilation.
+    # Updates are copy on write via nqp::cas since Lock is not available
+    # this early in the setting.
+    my $compiled-regexes = nqp::hash();
+
+    sub EVAL_REGEX(str $source, int \monkey, \context) {
         my $*RESTRICTED = "Prohibited regex interpolation"
          unless monkey;  # Comes from when regex was originally compiled.
+        EVAL($source, :context(context))
+    }
 
-        my \rx = EVAL('anon regex { ' ~ nqp::if(i,
+    sub COMPILED_REGEX(\arg, \i, \m, int \monkey, \context) {
+        my str $text   = '' ~ arg;
+        my str $source = 'anon regex { ' ~ nqp::if(i,
           nqp::if(m,
             ':i :m ',
             ':i '),
           nqp::if(m,
             ':m ',
-            ' ')) ~ arg ~ '}', :context(context));
-        arg does CachedCompiledRegex(rx);
+            ' ')) ~ $text ~ '}';
+
+        # Pattern text with subrule calls, variables, or code blocks
+        # compiles against the lexical scope of the interpolation site,
+        # so equal text is not equivalent between call sites.
+        return EVAL_REGEX($source, monkey, context)
+          unless nqp::iseq_i(nqp::index($text, '<', 0), -1)
+             &&  nqp::iseq_i(nqp::index($text, '$', 0), -1)
+             &&  nqp::iseq_i(nqp::index($text, '@', 0), -1)
+             &&  nqp::iseq_i(nqp::index($text, '%', 0), -1)
+             &&  nqp::iseq_i(nqp::index($text, '&', 0), -1)
+             &&  nqp::iseq_i(nqp::index($text, '{', 0), -1);
+
+        # The monkey bit is part of the key so a pattern compiled with code
+        # interpolation allowed is never reused where it is prohibited.
+        my str $key = nqp::concat(monkey ?? 'm' !! 'r', $source);
+
+        nqp::ifnull(
+          nqp::atkey(nqp::atomicload($compiled-regexes), $key),
+          do {
+              my \fresh = EVAL_REGEX($source, monkey, context);
+              my int $done;
+              until $done {
+                  my \seen = nqp::atomicload($compiled-regexes);
+                  if nqp::existskey(seen, $key) {
+                      $done = 1;
+                  }
+                  else {
+                      # Start over when full rather than growing forever
+                      my \updated = nqp::islt_i(nqp::elems(seen), 1024)
+                        ?? nqp::clone(seen)
+                        !! nqp::hash();
+                      nqp::bindkey(updated, $key, fresh);
+                      $done = nqp::eqaddr(
+                        nqp::cas($compiled-regexes, seen, updated),
+                        seen
+                      );
+                  }
+              }
+              fresh
+          }
+        )
+    }
+
+    multi sub MAKE_REGEX(Regex \arg, $, $, int \monkey, $) {
+        arg
+    }
+    multi sub MAKE_REGEX(CachedCompiledRegex \arg, \i, \m, int \monkey, \context) {
+        my \slots = arg.regexes;
+        my int $slot = FLAG_SLOT(i, m, monkey);
+        nqp::ifnull(
+          nqp::atpos(slots, $slot),
+          nqp::bindpos(slots, $slot, COMPILED_REGEX(arg, i, m, monkey, context))
+        )
+    }
+    multi sub MAKE_REGEX(\arg, \i, \m, int \monkey, \context) {
+        my \rx = COMPILED_REGEX(arg, i, m, monkey, context);
+        my \slots = nqp::setelems(nqp::create(IterationBuffer), 8);
+        nqp::bindpos(slots, FLAG_SLOT(i, m, monkey), rx);
+        arg does CachedCompiledRegex(slots);
         rx
     }
 }

--- a/t/02-rakudo/regex-interpolation-cache.t
+++ b/t/02-rakudo/regex-interpolation-cache.t
@@ -1,0 +1,136 @@
+use Test;
+
+plan 25;
+
+# Interpolating the same string object under different modifiers must not
+# reuse the regex compiled for the first set of modifiers.
+{
+    my $pattern = "ab" ~ "c";
+    nok "ABC" ~~ /<$pattern>/,
+        'same string object matches case sensitively without :i';
+    ok "ABC" ~~ /:i <$pattern>/,
+        'same string object matches case insensitively under :i';
+    ok "abc" ~~ /<$pattern>/,
+        'same string object still matches case sensitively after :i use';
+}
+{
+    my $accent = "a" ~ "";
+    nok "á" ~~ /<$accent>/,
+        'same string object matches marks sensitively without :m';
+    ok "á" ~~ /:m <$accent>/,
+        'same string object ignores marks under :m';
+    nok "á" ~~ /<$accent>/,
+        'same string object still matches marks sensitively after :m use';
+    nok "Á" ~~ /:i <$accent>/,
+        ':i alone still respects marks on the same string object';
+    ok "Á" ~~ /:i:m <$accent>/,
+        ':i:m combines case and mark insensitivity on the same string object';
+}
+
+# Equal pattern text carried by distinct string objects yields a working
+# regex every time.
+{
+    my int $matched;
+    for ^20 {
+        ++$matched if "foo123" ~~ /<{ "f" ~ Q/oo\d+/ }>/;
+    }
+    is $matched, 20,
+        'code interpolation producing a fresh string object matches every time';
+}
+
+# Equal pattern text under different modifiers stays distinct even when
+# every interpolation produces a fresh string object.
+{
+    ok "ABC" ~~ /:i <{ "a" ~ "bc" }>/,
+        ':i applies to freshly interpolated pattern text';
+    nok "ABC" ~~ /<{ "a" ~ "bc" }>/,
+        'equal pattern text without :i stays case sensitive';
+}
+
+# Elements of an interpolated array are compiled like single strings.
+{
+    my @alts = "abc", "def";
+    ok "xdefy" ~~ /<@alts>/,
+        'array alternation matches an element';
+    nok "DEF" ~~ /<@alts>/,
+        'array alternation is case sensitive by default';
+    ok "DEF" ~~ /:i <@alts>/,
+        'the same array matches case insensitively under :i';
+    ok "xabcy" ~~ /<@alts>/,
+        'the same array still matches case sensitively after :i use';
+}
+
+# Pattern text referencing the lexical scope of the interpolation site
+# must be compiled against the scope of each use, not reused from an
+# earlier use of equal text elsewhere.
+{
+    my @pat = Q/$/, "x";
+    my sub match-lexical($x, $target) {
+        so $target ~~ /^<{ @pat.join }>$/
+    }
+    ok match-lexical("AAA", "AAA"),
+        'interpolated pattern referencing a caller lexical matches on the first call';
+    ok match-lexical("BBB", "BBB"),
+        'equal pattern text binds the current caller lexical on later calls';
+
+    my regex vowel { <[aeiou]> }
+    my sub narrower() {
+        my regex vowel { <[xyz]> }
+        so "x" ~~ /<{ "<&vo" ~ "wel>" }>/
+    }
+    ok narrower(),
+        'interpolated subrule call resolves the local lexical regex';
+    ok "e" ~~ /<{ "<&vo" ~ "wel>" }>/,
+        'equal pattern text resolves the outer lexical regex afterward';
+}
+
+# A regex interpolated where code interpolation was allowed must not be
+# reused where it is prohibited, whether the pattern text arrives in the
+# same string object or a fresh one.  Test exports a MONKEY-SEE-NO-EVAL
+# that allows code interpolation everywhere, so the prohibited scopes
+# must opt out explicitly.
+{
+    use MONKEY-SEE-NO-EVAL;
+    my $pattern = Q/a <?{ True }> b/;
+    ok "ab" ~~ /<$pattern>/,
+        'code assertion interpolates where code interpolation is allowed';
+    {
+        no MONKEY-SEE-NO-EVAL;
+        throws-like { "ab" ~~ /<$pattern>/ }, X::SecurityPolicy::Eval,
+            'the same string object still dies where code interpolation is prohibited';
+        my $copy = $pattern.substr(0);
+        throws-like { "ab" ~~ /<$copy>/ }, X::SecurityPolicy::Eval,
+            'a fresh object with equal pattern text also dies there';
+    }
+}
+
+# A prohibited interpolation that throws must not poison a later allowed
+# interpolation of the same pattern text.
+{
+    {
+        no MONKEY-SEE-NO-EVAL;
+        my $pattern = Q/x <?{ True }> y/;
+        throws-like { "xy" ~~ /<$pattern>/ }, X::SecurityPolicy::Eval,
+            'code assertion dies where code interpolation is prohibited';
+    }
+    {
+        use MONKEY-SEE-NO-EVAL;
+        my $pattern = Q/x <?{ True }> y/;
+        ok "xy" ~~ /<$pattern>/,
+            'the same pattern text compiles where code interpolation is allowed afterward';
+    }
+}
+
+# Filling the source cache past its capacity must not break matching of
+# evicted or later patterns.
+{
+    my int $matched;
+    for ^1100 -> $i {
+        ++$matched if "n$i" ~~ /<{ "n" ~ $i }>/;
+    }
+    ++$matched if "n7" ~~ /<{ "n" ~ 7 }>/;
+    is $matched, 1101,
+        'distinct pattern texts past the cache capacity all still match';
+}
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously a string interpolated into a regex was compiled with EVAL and the resulting regex was cached by mixing a role into the string object itself. Code such as `<{ %h.keys.join("|") }>` produces a new string object on every match attempt, so every attempt compiled the pattern again. MoarVM never deallocates bytecode, so long running programs using such patterns grew without bound. The mixed in cache also ignored the :i and :m modifiers and whether code interpolation was allowed, reusing whatever regex the first interpolation of that object had compiled.

This adds a cache keyed on the generated pattern source so equal pattern text reuses the compiled regex no matter which object carried it. Only pattern text free of subrule calls, variables, and code blocks is cached by value, since anything else compiles against the lexical scope of the interpolation site and cannot be shared between call sites. The cache is copy on write with `nqp::cas` because Lock is not available at this point of the setting build order. It holds at most 1024 entries and starts over when full. The mixed in per object cache now keeps one regex per combination of :i, :m, and code interpolation being allowed, so a restricted interpolation can never reuse a regex that was compiled with code blocks permitted.

Fixes #4284