### PR TITLE
Let a boxed value reach a native-only multi candidate by unboxing

### DIFF
--- a/src/Perl6/Optimizer.nqp
+++ b/src/Perl6/Optimizer.nqp
@@ -3382,12 +3382,12 @@ class Perl6::Optimizer {
             my $dispatcher := nqp::can($obj, "is_dispatcher") && $obj.is_dispatcher;
             if $dispatcher && $obj.onlystar {
                 # Try to do compile-time multi-dispatch. Need to consider
-                # both the proto and the multi candidates. The dispatch
-                # decision reads the arguments as the call site passes them,
-                # while an impossible dispatch is diagnosed with the reading
-                # that also counts a lone literal as native, so a candidate
-                # taking a native `is rw` parameter is still ruled out at
-                # compile time.
+                # both the proto and the multi candidates. Both the
+                # dispatch decision and an impossible dispatch read the
+                # arguments as the call site passes them, so a boxed value
+                # that can reach a native parameter by unboxing is not
+                # judged impossible. The proto trial bind still diagnoses
+                # with the reading that counts a lone literal as native.
                 my @ct_arg_info := self.analyze_args_for_ct_call($op);
                 if +@ct_arg_info {
                     my @types := @ct_arg_info[0];
@@ -3406,8 +3406,7 @@ class Perl6::Optimizer {
                     }
                     else {
                         my $diag_proto := nqp::p6trialbind($obj.signature, @types, @diag_flags);
-                        my @diag_multi := $obj.analyze_dispatch(@types, @diag_flags);
-                        if $diag_proto == -1 || @diag_multi[0] == -1 {
+                        if $diag_proto == -1 || @ct_result_multi[0] == -1 {
                             self.report_inevitable_dispatch_failure(
                                 $op, @types, @diag_flags, $obj,
                                 :protoguilt($diag_proto == -1)
@@ -4176,10 +4175,11 @@ class Perl6::Optimizer {
 
         # A lone literal has no native context to adapt to, so it dispatches
         # as the boxed value it is, and rewrite_paired_literal_args already
-        # gave a paired literal its native reading. Ruling out a candidate
-        # that takes a native `is rw` parameter still needs the native
-        # reading of a lone literal, so that is reported separately. Only
-        # the plain flags decide what runs.
+        # gave a paired literal its native reading. The native reading of a
+        # lone literal is reported separately for the trial bind diagnosis,
+        # which can refuse a literal of the wrong native kind against a
+        # native parameter in an explicit signature. Only the plain flags
+        # decide what runs.
         my @diag_flags := nqp::clone(@flags);
         if nqp::elems(@types) == 1 && $num_allo == 1 {
             my $rev := %allo_rev{@allomorphs[0]};

--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -4113,7 +4113,49 @@ BEGIN {
         my int $pure_type_result := 1;
         my $many_res := $many ?? nqp::list !! Mu;
         my @possibles;
+        my @unbox_possibles;
+        my int $had_matchable;
         my int $done_bind_check;
+
+        # Mirrors the dispatch plan's named argument admission: every
+        # required named needs one of its aliases present, and without a
+        # named slurpy every passed named needs to be allowed.
+        my sub named_args_mismatch(%info) {
+            my $required := nqp::atkey(%info, 'required_names');
+            if $required {
+                my int $i;
+                my int $n := nqp::elems($required);
+                while $i < $n {
+                    my $names := nqp::atpos($required, $i);
+                    my int $found;
+                    my int $j;
+                    my int $m := nqp::elems($names);
+                    while $j < $m {
+                        if nqp::captureexistsnamed(
+                             $capture, nqp::atpos_s($names, $j)
+                           ) {
+                            $found := 1;
+                            $j := $m;
+                        }
+                        ++$j;
+                    }
+                    return 1 unless $found;
+                    ++$i;
+                }
+            }
+            my %nameds := nqp::capturenamedshash($capture);
+            if %nameds && !nqp::atkey(%info, 'allows_all_names') {
+                my $allowed := nqp::atkey(%info, 'allowed_names');
+                return 1 unless $allowed;
+                my $iter := nqp::iterator(%nameds);
+                while $iter {
+                    return 1 unless nqp::existskey(
+                      $allowed, nqp::iterkey_s(nqp::shift($iter))
+                    );
+                }
+            }
+            0
+        }
 
         # Only do itemized argument disambiguation when the group contains
         # a candidate with params having the 'is item' trait.
@@ -4153,6 +4195,7 @@ BEGIN {
                       if $type_check_count > $num_args;
 
                     my int $no_mismatch := 1;
+                    my int $unbox_fallback;
                     my int $i;
                     while $i < $type_check_count
                       && $no_mismatch {
@@ -4182,9 +4225,7 @@ BEGIN {
                             if $got_prim == nqp::const::BIND_VAL_OBJ {
 
                                 # Object, but could be a native container.
-                                # If not, mismatch.
-                                $no_mismatch := 0
-                                  unless (
+                                unless (
                                     ($flags +& nqp::const::TYPE_NATIVE_STR)
                                       && nqp::iscont_s($arg)
                                   ) || (
@@ -4196,7 +4237,41 @@ BEGIN {
                                   ) || (
                                     ($flags +& nqp::const::TYPE_NATIVE_NUM)
                                       && nqp::iscont_n($arg)
-                                  )
+                                  ) {
+
+                                    # Not a native container. A concrete
+                                    # value of the native's box type can
+                                    # still bind by unboxing, which is
+                                    # only considered when no candidate
+                                    # is in the running otherwise. A
+                                    # parameter needing write access
+                                    # cannot be served by an unboxed
+                                    # copy.
+                                    my $val := $arg;
+                                    $val := nqp::getattr(
+                                      $val, Scalar, '$!value')
+                                      if nqp::istype_nd($val, Scalar)
+                                      && nqp::isconcrete_nd($val);
+                                    if nqp::not_i(nqp::atpos_i(
+                                         nqp::atkey($candidate,'rwness'), $i
+                                       ))
+                                      && ($flags +& nqp::const::DEFCON_MASK)
+                                           != nqp::const::DEFCON_UNDEFINED
+                                      && nqp::isconcrete_nd($val)
+                                      && nqp::istype_nd($val,
+                                           $flags
+                                             +& nqp::const::TYPE_NATIVE_STR
+                                             ?? Str
+                                             !! $flags
+                                                  +& nqp::const::TYPE_NATIVE_NUM
+                                               ?? Num
+                                               !! Int) {
+                                        $unbox_fallback := 1;
+                                    }
+                                    else {
+                                        $no_mismatch := 0;
+                                    }
+                                }
                             }
 
                             # Got a native, does it match?
@@ -4316,8 +4391,13 @@ BEGIN {
                         ++$i;
                     }
 
-                    # If it's an admissible candidate; add to list.
-                    nqp::push(@possibles, $candidate) if $no_mismatch;
+                    # If it's an admissible candidate; add to list, or
+                    # set it aside if it can only match by unboxing.
+                    if $no_mismatch {
+                        $unbox_fallback
+                          ?? nqp::push(@unbox_possibles, $candidate)
+                          !! nqp::push(@possibles, $candidate);
+                    }
                 }
 
                 ++$cur_idx;
@@ -4353,10 +4433,14 @@ BEGIN {
                               if nqp::isnull($new_possibles);
                         }
 
-                        # Otherwise, may need full bind check.
+                        # Otherwise, may need full bind check. A candidate
+                        # the named arguments rule out was never in the
+                        # running, so it does not suppress the unbox retry.
                         elsif nqp::existskey(%info, 'bind_check')
                             && !$candidate-with-itemized-params
                         {
+                            $had_matchable := 1
+                              unless named_args_mismatch(%info);
                             my $sub := nqp::atkey(%info, 'sub');
                             my $cs  := nqp::getattr($sub, Code, '@!compstuff');
 
@@ -4400,6 +4484,7 @@ BEGIN {
 
                         # Otherwise, it's just nominal; accept it.
                         else {
+                            $had_matchable := 1;
                             nqp::push(
                               nqp::ifnull(
                                 $new_possibles,
@@ -4437,6 +4522,51 @@ BEGIN {
                   || nqp::not_i(nqp::isconcrete(
                        nqp::atpos(@candidates, ++$cur_idx)
                      ));
+            }
+        }
+
+        # No candidate was in the running, but some can potentially bind
+        # by unboxing an argument. Try those in order, letting a bind
+        # check decide each, so a boxed value reaches a native-only
+        # candidate the same way it reaches the equivalent non-multi
+        # routine. A candidate that was in the running and merely failed
+        # its bind check suppresses the retry, matching the dispatch
+        # plan, which keeps such a candidate and stops at its failure.
+        # The trial bind can throw, unboxing a value that does not fit,
+        # binding a lexical it cannot represent, or running a constraint
+        # that dies, and a candidate whose trial throws cannot be shown
+        # bindable.
+        unless $had_matchable {
+            my int $m := nqp::elems(@unbox_possibles);
+            my int $i;
+            while $i < $m {
+                my %info := nqp::atpos(@unbox_possibles, $i);
+                unless nqp::existskey(%info, 'req_named')
+                  && nqp::not_i(nqp::captureexistsnamed(
+                       $capture, nqp::atkey(%info, 'req_named')
+                     )) {
+                    my $sub := nqp::atkey(%info, 'sub');
+                    my $cs  := nqp::getattr($sub, Code, '@!compstuff');
+                    unless nqp::isnull($cs) {
+                        my $ctf := $cs[1];
+                        $ctf() if $ctf;
+                    }
+                    unless $done_bind_check {
+                        # Need a copy of the capture, as we may later do
+                        # a multi-dispatch when evaluating a constraint.
+                        $capture := nqp::clone($capture);
+                        $done_bind_check := 1;
+                    }
+                    if try nqp::p6isbindable(
+                         nqp::getattr($sub, Code, '$!signature'), $capture
+                       ) {
+                        $many
+                          ?? nqp::push($many_res, $sub)
+                          !! nqp::push(@possibles, %info);
+                        $i := $m unless $many;
+                    }
+                }
+                ++$i;
             }
         }
 
@@ -4807,8 +4937,25 @@ BEGIN {
                     # Did we get one?
                     if $got_prim == nqp::const::BIND_VAL_OBJ {
 
-                        # Object; won't do.
+                        # Object. It can still reach this candidate at
+                        # runtime by unboxing into the native parameter,
+                        # provided its type relates to the native's box
+                        # type. A parameter needing write access cannot
+                        # be served by an unboxed copy of a literal.
                         $type_mismatch := 1;
+                        my $box :=
+                          $type_flags +& nqp::const::TYPE_NATIVE_STR
+                            ?? Str
+                            !! $type_flags +& nqp::const::TYPE_NATIVE_NUM
+                              ?? Num
+                              !! Int;
+                        my $type := nqp::atpos(@args, $i).WHAT;
+                        if (nqp::atpos_i(nqp::atkey($candidate,'rwness'), $i)
+                             && nqp::atpos(@flags, $i) +& $ARG_IS_LITERAL)
+                          || (nqp::not_i(nqp::istype($type, $box))
+                               && nqp::not_i(nqp::istype($box, $type))) {
+                            $type_match_impossible := 1;
+                        }
                         last;
                     }
 

--- a/src/Raku/ast/call.rakumod
+++ b/src/Raku/ast/call.rakumod
@@ -457,13 +457,21 @@ class RakuAST::Call::Name
                     nqp::push(@flags, nqp::objprimspec($type));
                 }
                 if $ok {
+                    my @diag_flags := @flags;
                     if nqp::elems(@types) == 1 {
                         # The literal kind covers a constant quoted string as
                         # well as the literal nodes, so a string passed to an
                         # `int` parameter is refused here rather than failing
-                        # to unbox at run time.
+                        # to unbox at run time. The native reading only feeds
+                        # the trial bind. The multi analysis reads the boxed
+                        # value the call site passes, which can still reach a
+                        # native parameter by unboxing.
                         my $rev := @args[0].IMPL-NATIVE-LITERAL-KIND;
-                        @flags[0] := $rev +| $ARG_IS_LITERAL if nqp::defined($rev);
+                        if nqp::defined($rev) {
+                            @flags[0] := $ARG_IS_LITERAL;
+                            @diag_flags := nqp::clone(@flags);
+                            @diag_flags[0] := $rev +| $ARG_IS_LITERAL;
+                        }
                     }
                     elsif nqp::elems(@types) == 2 {
                         # A native-paired literal is passed in its native
@@ -476,7 +484,7 @@ class RakuAST::Call::Name
                             @flags[$idx] := $paired.IMPL-NATIVE-LITERAL-KIND +| $ARG_IS_LITERAL;
                         }
                     }
-                    my $ct_result := nqp::p6trialbind($sig, @types, @flags);
+                    my $ct_result := nqp::p6trialbind($sig, @types, @diag_flags);
                     my @ct_result_multi;
                     if nqp::can($routine, 'is_dispatcher') && $routine.is_dispatcher && $routine.onlystar {
                         @ct_result_multi := $routine.analyze_dispatch(@types, @flags);
@@ -510,11 +518,12 @@ class RakuAST::Call::Name
                     else {
                         # The call is settled at compile time, so the chosen
                         # candidate's native return type describes the result.
-                        # The flags above read a lone literal as native to
-                        # diagnose an impossible dispatch, so the recording
-                        # re-reads the arguments as the call site passes
-                        # them, through the same analysis the inline pass
-                        # and the argument emission use.
+                        # The diag flags above read a lone literal as native
+                        # for the trial bind, and the plain flags replace a
+                        # lone literal's kind with the literal marker, so the
+                        # recording re-reads the arguments as the call site
+                        # passes them, through the same analysis the inline
+                        # pass and the argument emission use.
                         my @info := self.IMPL-CT-ARG-TYPES($resolver, @args);
                         if nqp::elems(@info) {
                             my $ret := self.IMPL-NATIVE-RETURN-TYPE($routine,

--- a/src/vm/moar/dispatchers.nqp
+++ b/src/vm/moar/dispatchers.nqp
@@ -2217,6 +2217,7 @@ sub raku-multi-plan(
     my $need_type_guard      := nqp::list_i;
     my $need_conc_guard      := nqp::list_i;
     my @possibles;
+    my @unbox-possibles;
     my int $candidates-with-itemizable-params;
 
     my int $done;
@@ -2251,6 +2252,7 @@ sub raku-multi-plan(
 
                 my int $type_mismatch;
                 my int $rwness_mismatch;
+                my int $unbox_fallback;
                 my int $positional-params;
                 my int $associative-params;
                 my int $i;
@@ -2316,17 +2318,49 @@ sub raku-multi-plan(
                         # Mark a type guard for this argument
                         nqp::bindpos_i($need_type_guard, $i, 1);
 
-                        # Make sure it's the expected kind of native container
+                        # See if it's the expected kind of native container
                         my $contish := nqp::captureposarg($capture, $i);
-                        $type_mismatch := 1
-                          unless (($type_flags +& nqp::const::TYPE_NATIVE_STR)
-                                   && nqp::iscont_s($contish))
-                              || (($type_flags +& nqp::const::TYPE_NATIVE_INT)
-                                   && nqp::iscont_i($contish))
-                              || (($type_flags +& nqp::const::TYPE_NATIVE_UINT)
-                                   && nqp::iscont_u($contish))
-                              || (($type_flags +& nqp::const::TYPE_NATIVE_NUM)
-                                   && nqp::iscont_n($contish));
+                        unless (($type_flags +& nqp::const::TYPE_NATIVE_STR)
+                                 && nqp::iscont_s($contish))
+                            || (($type_flags +& nqp::const::TYPE_NATIVE_INT)
+                                 && nqp::iscont_i($contish))
+                            || (($type_flags +& nqp::const::TYPE_NATIVE_UINT)
+                                 && nqp::iscont_u($contish))
+                            || (($type_flags +& nqp::const::TYPE_NATIVE_NUM)
+                                 && nqp::iscont_n($contish)) {
+
+                            # Not a native container. A concrete value of
+                            # the native's box type can still bind to the
+                            # parameter by unboxing, which the binder does
+                            # for a non-multi routine. Such a candidate is
+                            # set aside and only considered when no
+                            # candidate is in the running otherwise. A
+                            # parameter needing write access cannot be
+                            # served by an unboxed copy.
+                            my $value := $contish;
+                            if nqp::istype_nd($value, Scalar)
+                              && nqp::isconcrete_nd($value) {
+                                nqp::bindpos_i($need_scalar_read, $i, 1);
+                                $value := nqp::getattr(
+                                  $value, Scalar, '$!value');
+                            }
+                            nqp::bindpos_i($need_conc_guard, $i, 1);
+                            if !$rwness
+                              && $definedness != nqp::const::DEFCON_UNDEFINED
+                              && nqp::isconcrete_nd($value)
+                              && nqp::istype_nd($value,
+                                   $type_flags +& nqp::const::TYPE_NATIVE_STR
+                                     ?? Str
+                                     !! $type_flags
+                                          +& nqp::const::TYPE_NATIVE_NUM
+                                       ?? Num
+                                       !! Int) {
+                                $unbox_fallback := 1;
+                            }
+                            else {
+                                $type_mismatch := 1;
+                            }
+                        }
                     }
 
                     # Got an opaque, want an opaque
@@ -2445,9 +2479,13 @@ sub raku-multi-plan(
                     ++$i;
                 }
 
-                # Add it to the possibles list of this group.
-                nqp::push(@possibles, $cur_candidate)
-                  unless $type_mismatch || $rwness_mismatch;
+                # Add it to the possibles list of this group, or set it
+                # aside if it can only match by unboxing arguments.
+                unless $type_mismatch || $rwness_mismatch {
+                    $unbox_fallback
+                      ?? nqp::push(@unbox-possibles, $cur_candidate)
+                      !! nqp::push(@possibles, $cur_candidate);
+                }
             }
         }
 
@@ -2593,6 +2631,37 @@ sub raku-multi-plan(
           if nqp::atpos_i($need_conc_guard, $i);
 
         ++$i;
+    }
+
+    # No candidate was in the running, but some can potentially bind by
+    # unboxing an argument. Try those in order, letting a bind check
+    # decide each, so a boxed value reaches a native-only candidate the
+    # same way it reaches the equivalent non-multi routine.
+    if nqp::isnull($current-head) && nqp::elems(@unbox-possibles) {
+        my int $n := nqp::elems(@unbox-possibles);
+        my int $i;
+        while $i < $n {
+            my %info := nqp::atpos(@unbox-possibles, $i);
+            unless has-named-args-mismatch($capture, %info) {
+
+                # Ensure it's already compiled, otherwise we can have
+                # compiler frames obscuring the bind control record we
+                # use for trying the next candidate.
+                my $sub := nqp::atkey(%info, 'sub');
+                my $cs  := nqp::getattr($sub, Code, '@!compstuff');
+                unless nqp::isnull($cs) {
+                    my $ctf := nqp::atpos($cs, 1);
+                    $ctf() if $ctf;
+                }
+
+                my $node := MultiDispatchTry.new($sub);
+                nqp::isnull($current-head)
+                  ?? ($current-head := $node)
+                  !! $current-tail.set-next($node);
+                $current-tail := $node;
+            }
+            ++$i;
+        }
     }
 
     # Return the dispatch plan, just an end marker if none so far

--- a/t/02-rakudo/multi-dispatch-native-unbox.t
+++ b/t/02-rakudo/multi-dispatch-native-unbox.t
@@ -1,0 +1,241 @@
+use Test;
+
+plan 63;
+
+# A boxed value reaches a native-only multi candidate by unboxing, the
+# same way it reaches the equivalent non-multi routine. The dispatcher
+# only considers such candidates when no candidate matches otherwise.
+
+multi sub str-only(str $s) { "str:$s" }
+is str-only("f"), "str:f",
+    "a string literal dispatches to a lone str candidate";
+my Str $typed = "g";
+is str-only($typed), "str:g",
+    "a typed Str variable dispatches to a lone str candidate";
+my $untyped = "h";
+is str-only($untyped), "str:h",
+    "an untyped variable holding a Str dispatches to a lone str candidate";
+my $bound := "i";
+is str-only($bound), "str:i",
+    "a bound Str value dispatches to a lone str candidate";
+is str-only(<5>), "str:5",
+    "an allomorph dispatches to a lone str candidate";
+
+multi sub int-only(int $i) { "int:$i" }
+is int-only(42), "int:42",
+    "an integer literal dispatches to a lone int candidate";
+my $int-val = 43;
+is int-only($int-val), "int:43",
+    "a variable holding an Int dispatches to a lone int candidate";
+
+multi sub uint-only(uint $u) { "uint:$u" }
+is uint-only(44), "uint:44",
+    "an integer literal dispatches to a lone uint candidate";
+
+multi sub num-only(num $n) { "num:$n" }
+is num-only(4.5e0), "num:4.5",
+    "a num literal dispatches to a lone num candidate";
+my $num-val = 5.5e0;
+is num-only($num-val), "num:5.5",
+    "a variable holding a Num dispatches to a lone num candidate";
+
+class WithNativeMethod {
+    multi method m(str $s) { "method:$s" }
+}
+is WithNativeMethod.m("f"), "method:f",
+    "a string literal dispatches to a lone str method candidate";
+is WithNativeMethod.m($typed), "method:g",
+    "a Str variable dispatches to a lone str method candidate";
+
+# The unbox path must not change any dispatch that already resolves.
+multi sub tie-break(int $i) { "int" }
+multi sub tie-break(Int $i) { "Int" }
+is tie-break(1), "Int",
+    "a boxed integer keeps choosing the Int candidate over the int one";
+my int $native-int = 1;
+is tie-break($native-int), "int",
+    "a native int container keeps choosing the int candidate";
+
+multi sub str-tie(str $s) { "str" }
+multi sub str-tie(Str $s) { "Str" }
+is str-tie("x"), "Str",
+    "a boxed string keeps choosing the Str candidate over the str one";
+my str $native-str = "x";
+is str-tie($native-str), "str",
+    "a native str container keeps choosing the str candidate";
+
+# Constraints on the candidate still apply through the bind check.
+multi sub constrained(str $s where *.chars == 1) { "short:$s" }
+is constrained("f"), "short:f",
+    "a where constraint on a native parameter passes a fitting boxed value";
+throws-like { constrained("toolong") }, X::Multi::NoMatch,
+    "a where constraint on a native parameter rejects an unfitting boxed value";
+
+# What cannot unbox still fails to dispatch.
+dies-ok { EVAL q[multi sub int-target(int $i) { }; int-target("nope")] },
+    "a Str value does not dispatch to a lone int candidate";
+dies-ok { EVAL q[multi sub num-target(num $n) { }; num-target(42)] },
+    "an Int value does not dispatch to a lone num candidate";
+multi sub st-target(str $s) { $s }
+throws-like { st-target(Str) }, X::Multi::NoMatch,
+    "a type object does not dispatch to a lone str candidate";
+dies-ok { EVAL q[multi sub big-target(int $i) { }; big-target(2 ** 70)] },
+    "an Int too wide for a native int does not dispatch to a lone int candidate";
+
+# A parameter needing write access is only served by a native container.
+multi sub rw-target(str $s is rw) { $s = "set"; "bound" }
+throws-like { rw-target($typed) }, X::Multi::NoMatch,
+    "a boxed value does not dispatch to a lone native rw candidate";
+my str $rw-native = "f";
+is rw-target($rw-native), "bound",
+    "a native str container binds a native rw parameter";
+is $rw-native, "set",
+    "the native rw parameter writes back to its container";
+
+# Junction arguments still autothread over the candidates.
+multi sub junct(str $s) { "j:$s" }
+my $junction-result = junct("a" | "b");
+isa-ok $junction-result, Junction,
+    "a Junction argument autothreads over a lone str candidate";
+ok so ($junction-result eq "j:a"),
+    "the Junction result contains the first threaded value";
+ok so ($junction-result eq "j:b"),
+    "the Junction result contains the second threaded value";
+nok so ($junction-result eq "j:c"),
+    "the Junction result contains only threaded values";
+
+# A named native parameter binds a boxed value through the binder,
+# without the dispatcher's help.
+multi sub named-nat(str :$s!) { "named:$s" }
+is named-nat(s => "f"), "named:f",
+    "a boxed value binds a named native parameter of a multi";
+
+# Mixtures of native and boxed parameters and arguments.
+multi sub mixed(str $a, Int $b) { "mixed:$a:$b" }
+is mixed("x", 2), "mixed:x:2",
+    "a boxed string beside a matching Int dispatches to a str, Int candidate";
+multi sub two-native(str $a, int $b) { "two:$a:$b" }
+is two-native("x", 2), "two:x:2",
+    "two boxed values dispatch to a candidate with two native parameters";
+is two-native($native-str, 2), "two:x:2",
+    "a native container beside a boxed value dispatches to a two native candidate";
+
+# Native uint and num containers keep their first pass match.
+my uint $native-uint = 7;
+is uint-only($native-uint), "uint:7",
+    "a native uint container dispatches to a lone uint candidate";
+my num $native-num = 1.5e0;
+is num-only($native-num), "num:1.5",
+    "a native num container dispatches to a lone num candidate";
+multi sub uint-tie(uint $u) { "uint" }
+multi sub uint-tie(Int $i) { "Int" }
+is uint-tie(1), "Int",
+    "a boxed integer keeps choosing the Int candidate over the uint one";
+is uint-tie($native-uint), "uint",
+    "a native uint container keeps choosing the uint candidate";
+
+# One call site must re-dispatch when the argument changes kind.
+my @replay;
+for "a", "toolong", "b" -> $s {
+    @replay.push((try constrained($s)) // "no-match");
+}
+is-deeply @replay, ["short:a", "no-match", "short:b"],
+    "one call site re-evaluates the bind check per argument";
+sub via-capture(|c) { tie-break(|c) }
+my @kinds;
+@kinds.push(via-capture(1));
+@kinds.push(via-capture($native-int));
+@kinds.push(via-capture(2));
+@kinds.push(via-capture($native-int));
+is-deeply @kinds, ["Int", "int", "Int", "int"],
+    "one call site distinguishes native containers from boxed values";
+sub via-value($x) { str-only($x) }
+my @concreteness;
+@concreteness.push(via-value("a"));
+@concreteness.push((try via-value(Str)) // "no-match");
+@concreteness.push(via-value("b"));
+is-deeply @concreteness, ["str:a", "no-match", "str:b"],
+    "one call site distinguishes concrete values from type objects";
+
+# Candidates that can only match by unboxing are tried in narrowness
+# order, and a failed bind check moves on to the next one.
+multi sub ordered(str $s where *.chars == 1) { "first" }
+multi sub ordered(str $s) { "second" }
+is ordered("a"), "first",
+    "the narrower candidate is tried first in the unbox retry";
+is ordered("toolong"), "second",
+    "a failed bind check moves on to the next candidate in the unbox retry";
+
+# Any candidate that matches without unboxing wins, however wide.
+multi sub prefer-match(str $s) { "str" }
+multi sub prefer-match(Cool $s) { "Cool" }
+is prefer-match("x"), "Cool",
+    "a wider boxed candidate beats a narrower native candidate for a boxed value";
+
+# A required named still filters candidates during the unbox retry.
+multi sub named-skip(str $s, :$k!) { "with-k" }
+multi sub named-skip(str $s) { "plain" }
+is named-skip("x"), "plain",
+    "a candidate missing its required named is skipped in the unbox retry";
+is named-skip("x", :k), "with-k",
+    "a candidate with its required named present wins the unbox retry";
+
+# Method candidates keep the same tie behavior as subs.
+class MethodTie {
+    multi method m(int $i) { "int" }
+    multi method m(Int $i) { "Int" }
+}
+is MethodTie.m(1), "Int",
+    "a boxed integer keeps choosing the Int method candidate";
+
+# Introspection agrees with the dispatcher.
+multi sub cando-target(str $s) { $s }
+is +&cando-target.cando(\("f")), 1,
+    "cando finds a lone str candidate for a Str argument";
+is +&cando-target.cando(\(42)), 0,
+    "cando finds no candidate for an Int argument against a lone str candidate";
+is +&tie-break.cando(\(1)), 1,
+    "cando keeps reporting only the Int candidate for a boxed integer";
+is +&cando-target.cando(\(Str)), 0,
+    "cando finds no candidate for a type object against a lone str candidate";
+is +&rw-target.cando(\("f")), 0,
+    "cando finds no candidate for a boxed value against a lone native rw candidate";
+lives-ok { &uint-only.cando(\(1)) },
+    "cando survives a boxed integer against a lone uint candidate";
+is +&uint-only.cando(\(1)), 0,
+    "cando reports no uint candidate for a boxed integer while the trial binder cannot bind a uint lexical";
+multi sub big-cando(int $i) { $i }
+is +&big-cando.cando(\(2 ** 70)), 0,
+    "cando counts a throwing trial bind as not bindable for a too-wide Int";
+
+# A candidate that is in the running suppresses the unbox retry even
+# when its bind check fails, so cando and dispatch stay in agreement.
+multi sub gated(Int $i where * > 5) { "big" }
+multi sub gated(int $i) { "native" }
+is gated(9), "big",
+    "a matchable constrained candidate wins over an unbox-only candidate";
+throws-like { gated(3) }, X::Multi::NoMatch,
+    "a failed bind check on a matchable candidate suppresses the unbox retry";
+is +&gated.cando(\(3)), 0,
+    "cando agrees the unbox retry is suppressed by a matchable candidate";
+is +&gated.cando(\(9)), 1,
+    "cando reports the matchable constrained candidate when its bind check passes";
+
+# A candidate the named arguments rule out was never in the running,
+# so it does not suppress the unbox retry.
+multi sub alias-gate(Int $x, :aa(:$a)!) { "aliased" }
+multi sub alias-gate(int $x) { "n:$x" }
+is alias-gate(42), "n:42",
+    "a candidate missing its aliased required named does not suppress the unbox retry";
+is alias-gate(42, :aa), "aliased",
+    "a candidate with its aliased required named present wins outright";
+is +&alias-gate.cando(\(42)), 1,
+    "cando agrees the unbox retry runs when an aliased required named is missing";
+multi sub open-named(str $s, *%opts) { "native" }
+multi sub open-named(Cool $c where *.chars > 99) { "Cool" }
+is open-named("x", :k(1)), "native",
+    "a candidate rejecting a passed named does not suppress the unbox retry";
+is +&open-named.cando(\("x", :k(1))), 1,
+    "cando agrees the unbox retry runs when a candidate rejects a passed named";
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
The multi dispatch candidate filter requires a native value or a native container for a natively typed parameter. The binder is less strict. It unboxes a boxed value into the same parameter for a non-multi routine and for a named parameter. A call such as bar("f") against a lone (str $s) candidate could therefore only dispatch when the optimizer settled the call at compile time and skipped the filter. Whether that happened depended on the candidate body being inlinable and on the shape of the call site. The same call worked at the top level and failed inside a loop body. It always failed for method multis and at lower optimization levels. "Give a paired literal its native representation" then made a lone literal dispatch as the boxed value it is, so such a call failed everywhere. Failing consistently still leaves the multi form rejecting a value the equivalent sub form binds.

The dispatcher now sets aside a candidate whose only obstacle is a native parameter facing a concrete value of the native box type. When no candidate is in the running otherwise, those candidates are tried in order with a bind check deciding each. Within a tied group that order is the candidate order, as it is for constrained candidates on the normal path. A dispatch that resolves today keeps its candidate. The retry only exists on calls that otherwise fail, carries its bind check at run time, and is never settled at compile time. A parameter marked rw stays native container only. A boxed integer against an int and Int pair keeps choosing Int, and a native container keeps choosing the native candidate. find_best_dispatchee applies the same rule with the same gating, including the named argument admission the dispatch plan applies. A trial bind that throws counts as not bindable there instead of leaking a VM error out of introspection.

The compile time analysis judges an object argument against a native parameter by the same relation. A Str argument to a lone int candidate is still refused at compile time. An Int argument to a lone uint candidate no longer is. Both frontends judge a multi with the reading the call site passes and keep the native reading of a lone literal for the proto trial bind.