### PR TITLE
RakuAST: intern the Callable mixin for constant return values

### DIFF
--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -2203,13 +2203,15 @@ class RakuAST::PointyBlock
         if $signature.meta-object.has_returns {
             my $Callable :=
               self.IMPL-UNWRAP-LIST(self.get-implicit-lookups)[0].compile-time-value;
+            # Parameterizations intern by argument identity, so a constant
+            # return value would create a distinct Callable parameterization
+            # and mixin type per literal. Use its type instead.
+            my $returns := $signature.meta-object.returns;
+            $returns := nqp::what($returns) if nqp::isconcrete($returns);
             {
                 $block.HOW.mixin(
                   $block,
-                  $Callable.HOW.parameterize(
-                    $Callable,
-                    $signature.meta-object.returns
-                  )
+                  $Callable.HOW.parameterize($Callable, $returns)
                 );
                 CATCH {
                     if $*COMPILING_CORE_SETTING != 1 {
@@ -2377,13 +2379,15 @@ class RakuAST::Routine
         if $signature.meta-object.has_returns {
             my $Callable :=
               self.IMPL-UNWRAP-LIST(self.get-implicit-lookups)[0].compile-time-value;
+            # Parameterizations intern by argument identity, so a constant
+            # return value would create a distinct Callable parameterization
+            # and mixin type per literal. Use its type instead.
+            my $returns := $signature.meta-object.returns;
+            $returns := nqp::what($returns) if nqp::isconcrete($returns);
             {
                 $routine.HOW.mixin(
                   $routine,
-                  $Callable.HOW.parameterize(
-                    $Callable,
-                    $signature.meta-object.returns
-                  )
+                  $Callable.HOW.parameterize($Callable, $returns)
                 );
                 CATCH {
                     if $*COMPILING_CORE_SETTING != 1 {

--- a/t/12-rakuast/xx-fixed-in-rakuast.rakutest
+++ b/t/12-rakuast/xx-fixed-in-rakuast.rakutest
@@ -2,7 +2,7 @@ use Test;
 use lib <t/packages/Test-Helpers>;
 use Test::Helpers;
 
-plan 141;
+plan 144;
 
 # t/spec/S03-sequence/misc.t
 # https://github.com/rakudo/rakudo/issues/5520
@@ -1009,6 +1009,16 @@ subtest 'use of &?ROUTINE and &?BLOCK' => {
         200, 'a BEGIN-built method stores a high uint8 value without sign extension';
     is Q| class B6 { BEGIN B6.^add_method("w", method () { $!u = 4000000000; $!u }); has uint32 $!u; }; B6.new.w |.AST.EVAL,
         4000000000, 'a BEGIN-built method stores a high uint32 value without sign extension';
+}
+
+# ???
+{
+    is Q| sub a(--> "x") { }; a |.AST.EVAL, "x",
+        'a constant return value is returned from a call';
+    ok Q| sub a(--> "x") { }; &a ~~ Callable[Str] |.AST.EVAL,
+        'a constant return value parameterizes Callable with its type';
+    ok Q| sub a(--> "x") { }; sub b(--> "y") { }; &a.WHAT =:= &b.WHAT |.AST.EVAL,
+        'subs with different constant return values share their Callable mixin type';
 }
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously a routine with a constant return value such as `--> ''` mixed a Callable parameterized with the literal value itself into the routine. Parameterizations intern by argument identity, so every distinct literal produced its own curried Callable, mixin type, and mixin cache type. In the core setting this serialized several hundred duplicate types into CORE.c.setting.moarvm, all deserialized again on every startup.

This parameterizes with the type of the value instead, so all string literal returns share the single interned Callable[Str] and the mixin type of their routines. The return value enforcement itself is unaffected, as that comes from the signature. This shrinks CORE.c.setting.moarvm by about 270KB and drops about 6300 objects and 3MB from the baseline heap of an empty program.