### PR TITLE
RakuAST: name stub packages without their container

### DIFF
--- a/src/Raku/ast/package.rakumod
+++ b/src/Raku/ast/package.rakumod
@@ -211,7 +211,12 @@ class RakuAST::Package
             $scope := 'our' if $scope eq 'unit';
             my $name := $!name;
             if $name && $name.is-installable {
-                my $type-object := self.stubbed-meta-object(:$resolver, :$context);
+                # Require stubs and resolved stub declarations can hand back
+                # the meta-object in a container; naming it through the
+                # container would stamp Scalar's debug name and Stash instead.
+                my $type-object := nqp::decont(
+                    self.stubbed-meta-object(:$resolver, :$context)
+                );
                 my $full-name := self.IMPL-FULL-NAME($resolver);
                 $type-object.HOW.set_name(
                     $type-object,

--- a/t/12-rakuast/xx-fixed-in-rakuast.rakutest
+++ b/t/12-rakuast/xx-fixed-in-rakuast.rakutest
@@ -2,7 +2,7 @@ use Test;
 use lib <t/packages/Test-Helpers>;
 use Test::Helpers;
 
-plan 144;
+plan 145;
 
 # t/spec/S03-sequence/misc.t
 # https://github.com/rakudo/rakudo/issues/5520
@@ -1019,6 +1019,14 @@ subtest 'use of &?ROUTINE and &?BLOCK' => {
         'a constant return value parameterizes Callable with its type';
     ok Q| sub a(--> "x") { }; sub b(--> "y") { }; &a.WHAT =:= &b.WHAT |.AST.EVAL,
         'subs with different constant return values share their Callable mixin type';
+}
+
+# ???
+{
+    use nqp;
+    Q| my role RequireStubHolder { my $x = try require NoSuchTestModule } |.AST.EVAL;
+    is nqp::getattr_s(nqp::decont(Scalar.WHO), Stash, '$!longname'), 'Scalar',
+        'a require stub declared inside a role does not rename Scalar';
 }
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously ensure-installed passed the stubbed meta-object straight to set_name and the Stash longname update. A require stub wraps its meta object in a Scalar container so the lexical can be rebound when the module actually loads, and resolved stub redeclarations can hand back a container as well. Since nqp ops do not decontainerize, the debug type name and Stash longname landed on Scalar itself rather than the stub, and whichever stub was named last had its name serialized into the core setting. Every Scalar in a heap snapshot of a RakuAST built setting reported itself as ReadlineBehavior::Readline, after the require inside the REPL's line editor probing.

This decontainerizes the meta-object before naming it.