### PR TITLE
Share the revision gate mixin across gated routines

### DIFF
--- a/src/core.c/traits.rakumod
+++ b/src/core.c/traits.rakumod
@@ -376,11 +376,24 @@ multi sub trait_mod:<of>(Routine:D $target, Mu:U $type) {
 }
 
 multi sub trait_mod:<is>(Routine:D $r, Str :$revision-gated!) {
+    my role is-revision-gated[$revision] { method REQUIRED-REVISION(--> Int) { $revision } }
+    # One shared parameterization per language revision. Parameterizations
+    # intern by argument identity, and the revision computed at each trait
+    # application site is a distinct Int object during the setting build, so
+    # parameterizing directly would produce a distinct role and mixin type
+    # for every gated routine.
+    my constant REVISION-GATES = nqp::list(
+        is-revision-gated.^parameterize(1),
+        is-revision-gated.^parameterize(2),
+        is-revision-gated.^parameterize(3),
+    );
     my $chars := nqp::chars($revision-gated);
     my $internal-revision := 1 + nqp::ord($revision-gated, $chars - 1) - nqp::ord("c");
     $r.set-revision-gated;
     $r.^mixin(
-        role is-revision-gated[$revision] { method REQUIRED-REVISION(--> Int) { $revision } }.^parameterize($internal-revision)
+        $internal-revision >= 1 && $internal-revision <= nqp::elems(REVISION-GATES)
+            ?? nqp::atpos(REVISION-GATES, $internal-revision - 1)
+            !! is-revision-gated.^parameterize($internal-revision)
     );
 }
 

--- a/t/08-performance/35-curried-role-interning.t
+++ b/t/08-performance/35-curried-role-interning.t
@@ -1,7 +1,7 @@
 use nqp;
 use Test;
 
-plan 5;
+plan 6;
 
 # Type-check caches match on object identity, so a curried role reached
 # through role composition must be the same object as the parameterization
@@ -54,6 +54,13 @@ plan 5;
         nqp::decont(Half[Str].^roles(:!transitive)[0]),
         nqp::decont(Duo[Int, Str])
     ), 'curry mixing concrete and generic args instantiates to the interned parameterization';
+}
+
+{
+    sub a is revision-gated("6.e") { }
+    sub b is revision-gated("6.e") { }
+    ok nqp::eqaddr(nqp::decont(&a.WHAT), nqp::decont(&b.WHAT)),
+        'routines gated on the same revision share their mixin type';
 }
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously every `is revision-gated` application parameterized the is-revision-gated role with a freshly computed Int. Parameterizations intern by argument identity, and during the setting build each site's revision Int is a distinct object, so every gated routine minted its own curried role, mixin type, and mixin cache type, all serialized into the setting and deserialized again on every startup.

This keeps one parameterization per language revision in a constant table so every gated routine with the same revision shares its mixin type, falling back to direct parameterization for revisions beyond the table.