### PR TITLE
Report (at compile time) trying to store a wrong value in a typed variable

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -7817,6 +7817,21 @@ Did you mean a call like '"
         ).annotate_self('smartmatch', 1);
     }
 
+    # A bind through a pseudo package naming a lexical scope replaces a
+    # container this analysis never resolves, so no store in the unit can be
+    # judged. Whether the leading part names such a scope rides on the lookup
+    # symbol_lookup builds, on the package the stash is taken from for a
+    # subscripted bind and on the whole lookup for a sigil qualified one.
+    sub note_pseudo_package_bind($/, $subscript) {
+        $*W.mark_pseudo_package_bind
+            if $subscript.ann('lexical_pseudo_package')
+            || nqp::elems($subscript)
+            && nqp::istype($subscript[0], QAST::Op)
+            && $subscript[0].op eq 'who'
+            && nqp::elems($subscript[0])
+            && $subscript[0][0].ann('lexical_pseudo_package');
+    }
+
     sub bind_op($/, $target, $source, $sigish) {
         my $world := $*W;
         # Check we know how to bind to the thing on the LHS.
@@ -7875,6 +7890,10 @@ Did you mean a call like '"
                 if $world.is_lexical_marked_ro($target.name) || !$was_lexical {
                     $world.throw($/, ['X', 'Bind', 'Rebind'], target => $target.name);
                 }
+
+                # A bind replaces the container the declaration made, so no
+                # store into this variable has to satisfy the type it named.
+                $world.mark_lexical_bind_targeted($target.name);
             }
 
             # Finally, just need to make a bind.
@@ -7885,6 +7904,7 @@ Did you mean a call like '"
                 ((my $target_0_name := $target[0].name) eq '&postcircumfix:<[ ]>' ||
                  $target_0_name eq '&postcircumfix:<{ }>' ||
                  $target_0_name eq '&postcircumfix:<[; ]>') {
+            note_pseudo_package_bind($/, $target[0]);
             $source.named('BIND');
             $target[0].push($source);
             $target.nosink(1);
@@ -7894,6 +7914,7 @@ Did you mean a call like '"
               ((my $target_name := $target.name) eq '&postcircumfix:<[ ]>' ||
                $target_name eq '&postcircumfix:<{ }>' ||
                $target_name eq '&postcircumfix:<[; ]>') {
+            note_pseudo_package_bind($/, $target);
             $source.named('BIND');
             $target.push($source);
             $target.nosink(1);

--- a/src/Perl6/Optimizer.nqp
+++ b/src/Perl6/Optimizer.nqp
@@ -2516,6 +2516,134 @@ class Perl6::Optimizer {
         }
     }
 
+    # Reports the first of the given nodes holding a value the variable's value
+    # type can never accept.
+    method report_impossible_value($var, @values) {
+        # The lookup is only trusted when it ran to the end, so that a
+        # descriptor answering a value type but no complaint cannot be read as
+        # one that carries no complaint.
+        my int $described := 0;
+        my int $constrained := 0;
+        my $of := nqp::null();
+        my $complainee := nqp::null();
+        try {
+            my %sym := $!symbols.find_lexical_symbol($var.name);
+            my $descriptor := %sym<descriptor>;
+            $of         := $descriptor.of;
+            $complainee := $descriptor.complainee;
+            # A parameter is given a descriptor built from its nominal type, so
+            # a definite type or a subset leaves no trace on it. The symbol
+            # records that it was narrowed instead. A where clause only narrows
+            # what the nominal type already accepts, so it leaves that type
+            # speaking for a store.
+            # A container named by the declaration brings its own STORE, which
+            # is free to convert what it is given or to store it somewhere else.
+            # A bind replaces the container outright, and one naming its target
+            # is recorded as it is compiled, which is before this runs.
+            $constrained := %sym<constrained> || %sym<explicit_container>
+                || %sym<bind_targeted> ?? 1 !! 0;
+            $described   := 1;
+        }
+        return 0 unless $described;
+        return 0 if $constrained;
+
+        # A bind through a pseudo package names its target at run time, so which
+        # container it replaced is not knowable and no store can be judged.
+        return 0 if $*W.has_pseudo_package_bind;
+
+        # An anonymous variable is known here only by the name the compiler
+        # made up for it, which is no help to whoever wrote the store.
+        return 0 if nqp::eqat($var.name, 'ANON_VAR_', 1);
+
+        # A value used as a type has no type of its own to name in the advice.
+        return 0 if nqp::isconcrete($of);
+
+        # A `will complain` explanation is a block written for the value that
+        # failed. Running it is the run time check's to do, on the variable or
+        # on the type.
+        return 0 if nqp::isconcrete($complainee)
+            || nqp::istype($of.HOW, Perl6::Metamodel::Explaining);
+
+        # A generic is only settled later, and a role reports itself as nominal
+        # while accepting by what does it, so neither is checked here. A
+        # coercion, a definite type and a subset are all nominalizable rather
+        # than nominal, so the one test covers them too.
+        my $archetypes := $of.HOW.archetypes($of);
+        return 0 unless $archetypes.nominal
+            && !$archetypes.generic
+            && !$archetypes.composable;
+
+        # A native refuses a store by failing to unbox rather than by failing a
+        # type check, so its boxed type is what a value is checked against.
+        my int $primspec := nqp::objprimspec($of);
+        my $vartype := $primspec ?? $of.HOW.mro($of)[1] !! $of;
+        # A compile time complaint is confined to the types the advice is
+        # written for. Any other type is left to the run time check.
+        return 0 unless nqp::istype($vartype, $!symbols.find_in_setting('Cool'));
+
+        my $iterable := $!symbols.find_in_setting('Iterable');
+        for @values {
+            my $value := self.stored_value($_);
+            next if nqp::isnull($value);
+            # An iterable value may be spread across several stores rather than
+            # stored whole, so what the value type sees is not settled here.
+            next if nqp::istype($value, $iterable);
+            unless nqp::istype($value, $vartype) {
+                # The value carries the source position worth pointing at. A
+                # value the compiler built rather than read from source has
+                # none, so the variable stands in for it. Reporting reads that
+                # position, so a store with none to give is left alone.
+                my $at := $_.node ?? $_ !! $var;
+                return 0 unless $at.node;
+                $!problems.add_exception(['X', 'Syntax', 'Number', 'LiteralType'],
+                        $at,
+                        :varname($var.name), :vartype($of), :$value, :native($primspec)
+                    );
+                return 1;
+            }
+        }
+        0
+    }
+
+    # The one value this node is known to produce, or null when it produces
+    # something the compiler cannot name here. A type object reaches a WVal too
+    # and names a type rather than a value, so only a concrete one counts. This
+    # runs before the children of the op are visited, so an expression waiting
+    # to be folded is still an op here and answers nothing.
+    method stored_value($node) {
+        # A single statement list stands for what its one statement produces.
+        return self.stored_value($node[0])
+            if nqp::istype($node, QAST::Stmts) && nqp::elems($node) == 1;
+
+        if nqp::istype($node, QAST::Want) {
+            my str $want := $node[1];
+            return $node[0].value
+                if ($want eq 'Ii' || $want eq 'Nn' || $want eq 'Ss')
+                && nqp::istype($node[0], QAST::WVal);
+        }
+        elsif nqp::istype($node, QAST::WVal) {
+            return $node.value if nqp::isconcrete($node.value);
+        }
+        elsif nqp::istype($node, QAST::Var) && $node.scope eq 'lexical' {
+            # A constant written with a sigil stays a lexical here, and the
+            # compiler already holds the value it stands for. An imported
+            # variable and a lexical an EVAL was handed are held as their
+            # container, which says nothing about what they will hold by the
+            # time the store runs, and a lowered away lexical is held as a
+            # marker standing in for a variable that is gone.
+            my $value := nqp::null();
+            try {
+                my %sym := $!symbols.find_lexical_symbol($node.name);
+                $value := $!symbols.force_value(%sym, $node.name, 0);
+            }
+            return $value
+                if nqp::isconcrete($value)
+                && !nqp::iscont($value)
+                && !nqp::istype($value, $!symbols.LoweredAwayLexical);
+        }
+        nqp::null()
+    }
+
     # Range operators we can optimize into loops, and how to do it.
     sub get_bound($node,$extra) {
 
@@ -2719,116 +2847,17 @@ class Perl6::Optimizer {
             }
         }
 
-        # Let's see if we can catch a type mismatch in assignment at compile-time.
-        # Especially with Num, Rat, and Int there's often surprises at run-time.
-        if ($optype eq 'p6assign' || $optype eq 'assign_n' || $optype eq 'assign_i')
+        # A typed variable checks what it is given against its value type at run
+        # time. Knowing both that type and the stored value settles the outcome
+        # here, so a store that can never pass is reported here.
+        if ($optype eq 'p6assign' || $optype eq 'assign_i' || $optype eq 'assign_n'
+              || $optype eq 'assign_s' || $optype eq 'assign_u')
             && nqp::istype($op[0], QAST::Var)
-            && ($op[0].scope eq 'lexical' || $op[0].scope eq 'lexicalref') {
-            if nqp::istype($op[1], QAST::Want) {
-                # grab the var's symbol from our blocks
-                my $varsym := $symbols.find_lexical_symbol($op[0].name);
-                my $type := $varsym<type>;
-
-                my $want_type := $op[1][1];
-                my $varname := $op[0].name;
-
-                if $want_type eq 'Ii' {
-                    if $type =:= (my $numtype := $symbols.find_in_setting("Num"))
-                      || nqp::objprimspec($type) == nqp::const::BIND_VAL_NUM {
-                        $!problems.add_exception(['X', 'Syntax', 'Number', 'LiteralType'], $op[1],
-                                :$varname, :vartype($numtype), :value($op[1][2].value), :suggestiontype<Real>,
-                                :valuetype<Int>,
-                                :native(!($type =:= $numtype))
-                            );
-                    } elsif $type =:= $symbols.find_in_setting("Rat") {
-                        $!problems.add_exception(['X', 'Syntax', 'Number', 'LiteralType'], $op[1],
-                                :$varname, :vartype($type), :value($op[1][2].value), :suggestiontype<Real>,
-                                :valuetype<Int>
-                            );
-                    } elsif $type =:= $symbols.find_in_setting("Complex") {
-                        $!problems.add_exception(['X', 'Syntax', 'Number', 'LiteralType'], $op[1],
-                                :$varname, :vartype($type), :value($op[1][2].value), :suggestiontype<Numeric>,
-                                :valuetype<Int>
-                            );
-                    }
-                } elsif $want_type eq 'Nn' {
-                    my $value := $op[1][2];
-                    if $value.HOW.name($value) eq 'QAST::NVal' {
-                        if $type =:= (my $inttype := $symbols.find_in_setting("Int"))
-                          || nqp::objprimspec($type) == nqp::const::BIND_VAL_INT {
-                            $!problems.add_exception(['X', 'Syntax', 'Number', 'LiteralType'], $op[1],
-                                    :$varname, :vartype($inttype), :value($value.value), :suggestiontype<Real>,
-                                    :valuetype<Num>,
-                                    :native(!($type =:= $inttype))
-                                );
-                        } elsif $type =:= $symbols.find_in_setting("Rat") {
-                            $!problems.add_exception(['X', 'Syntax', 'Number', 'LiteralType'], $op[1],
-                                    :$varname, :vartype($type), :value($value.value), :suggestiontype<Real>,
-                                    :valuetype<Num>
-                                );
-                        } elsif $type =:= $symbols.find_in_setting("Complex") {
-                            $!problems.add_exception(['X', 'Syntax', 'Number', 'LiteralType'], $op[1],
-                                    :$varname, :vartype($type), :value($value.value), :suggestiontype<Numeric>,
-                                    :valuetype<Num>
-                                );
-                        }
-                    }
-                }
-            }
-            elsif nqp::istype($op[1], QAST::WVal) {
-                my $varsym := $symbols.find_lexical_symbol($op[0].name);
-                my $type := $varsym<type>;
-
-                my $value := $op[1].value;
-                my $val_type := $value.HOW.name($value);
-                my $varname := $op[0].name;
-                if $val_type eq 'Rat' || $val_type eq 'RatStr' {
-                    if $type =:= (my $inttype := $symbols.find_in_setting("Int"))
-                          || nqp::objprimspec($type) == nqp::const::BIND_VAL_INT {
-                        $!problems.add_exception(['X', 'Syntax', 'Number', 'LiteralType'], $op[0],
-                                :$varname, :vartype($inttype), :value($value), :suggestiontype<Real>,
-                                :valuetype<Rat>,
-                                :native(!($type =:= $inttype))
-                            );
-                    } elsif $type =:= (my $numtype := $symbols.find_in_setting("Num"))
-                        || nqp::objprimspec($type) == nqp::const::BIND_VAL_NUM {
-                        $!problems.add_exception(['X', 'Syntax', 'Number', 'LiteralType'], $op[0],
-                                :$varname, :vartype($numtype), :value($value), :suggestiontype<Real>,
-                                :valuetype<Rat>,
-                                :native(!($type =:= $numtype))
-                            );
-                    } elsif $type =:= $symbols.find_in_setting("Complex") {
-                        $!problems.add_exception(['X', 'Syntax', 'Number', 'LiteralType'], $op[0],
-                                :$varname, :vartype($type), :value($value), :suggestiontype<Numeric>,
-                                :valuetype<Rat>
-                            );
-                    }
-                }
-                elsif $val_type eq 'Complex' || $val_type eq 'ComplexStr' {
-                    if $type =:= (my $inttype := $symbols.find_in_setting("Int"))
-                      || nqp::objprimspec($type) == nqp::const::BIND_VAL_INT {
-                        $!problems.add_exception(['X', 'Syntax', 'Number', 'LiteralType'], $op[0],
-                                :$varname, :vartype($inttype), :value($value), :suggestiontype<Numeric>,
-                                :valuetype<Complex>,
-                                :native(!($type =:= $inttype))
-                            );
-                    } elsif $type =:= (my $numtype := $symbols.find_in_setting("Num"))
-                        || nqp::objprimspec($type) == nqp::const::BIND_VAL_NUM {
-                        $!problems.add_exception(['X', 'Syntax', 'Number', 'LiteralType'], $op[0],
-                                :$varname, :vartype($numtype), :value($value), :suggestiontype<Numeric>,
-                                :valuetype<Complex>,
-                                :native(!($type =:= $numtype))
-                            );
-                    } elsif $type =:= $symbols.find_in_setting("Rat") {
-                        $!problems.add_exception(['X', 'Syntax', 'Number', 'LiteralType'], $op[0],
-                                :$varname, :vartype($type), :value($value), :suggestiontype<Numeric>,
-                                :valuetype<Complex>
-                            );
-                    }
-                }
-            }
+            && ($op[0].scope eq 'lexical' || $op[0].scope eq 'lexicalref')
+            && nqp::eqat($op[0].name, '$', 0)
+            && $symbols.is_lexical_declared($op[0].name) {
+            self.report_impossible_value($op[0], [$op[1]]);
         }
-
 
         if $optype eq 'chain' {
             $!chain_depth := $!chain_depth + 1;

--- a/src/Perl6/Optimizer.nqp
+++ b/src/Perl6/Optimizer.nqp
@@ -2644,6 +2644,14 @@ class Perl6::Optimizer {
         nqp::null()
     }
 
+    # Whether every one of the given nodes holds a value the compiler can name.
+    method all_values_known(@nodes) {
+        for @nodes {
+            return 0 if nqp::isnull(self.stored_value($_));
+        }
+        1
+    }
+
     # Range operators we can optimize into loops, and how to do it.
     sub get_bound($node,$extra) {
 
@@ -2857,6 +2865,45 @@ class Perl6::Optimizer {
             && nqp::eqat($op[0].name, '$', 0)
             && $symbols.is_lexical_declared($op[0].name) {
             self.report_impossible_value($op[0], [$op[1]]);
+        }
+
+        # A list variable is assigned element by element, so every element it is
+        # given is checked against its element type. The store the compiler
+        # builds for an assignment carries no source position of its own, while
+        # a written out call to STORE is a method call the declaration does not
+        # speak for.
+        if $optype eq 'callmethod' && $opname eq 'STORE' && nqp::elems($op) >= 2
+            && !$op.node {
+            # A shaped declaration binds the array it built before storing into it.
+            my $target := nqp::istype($op[0], QAST::Op) && $op[0].op eq 'bind'
+                && nqp::elems($op[0])
+                ?? $op[0][0]
+                !! $op[0];
+            if nqp::istype($target, QAST::Var)
+                && ($target.scope eq 'lexical' || $target.scope eq 'lexicalref')
+                && nqp::eqat($target.name, '@', 0)
+                && $symbols.is_lexical_declared($target.name) {
+                my $values := $op[1];
+                # An array composer wraps the element list in a call, and each
+                # pair of grouping parentheses wraps it in a statement list.
+                # Both assign that list element by element.
+                $values := $values[0]
+                    if nqp::istype($values, QAST::Op) && $values.op eq 'call'
+                    && $values.name eq '&circumfix:<[ ]>' && nqp::elems($values) == 1;
+                while nqp::istype($values, QAST::Stmts) && nqp::elems($values) == 1 {
+                    $values := $values[0];
+                }
+                my int $comma := nqp::istype($values, QAST::Op) && $values.op eq 'call'
+                    && $values.name eq '&infix:<,>' ?? 1 !! 0;
+                # A word list reaches this walk as one operand per word. One
+                # that interpolates settles at run time which words it
+                # produces, so it is judged only when every word is known.
+                my int $judged := !($comma && $values.ann('qw'))
+                    || self.all_values_known($values.list);
+                self.report_impossible_value($target,
+                    $comma ?? $values.list !! [$values])
+                    if $judged;
+            }
         }
 
         if $optype eq 'chain' {

--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -303,6 +303,21 @@ class Perl6::World is HLL::World {
             nqp::die("Could not find container descriptor for $name");
         }
 
+        # Hunts through scopes to find a lexical and records that a bind has
+        # replaced the container its declaration made.
+        method mark_lexical_bind_targeted(str $name) {
+            my int $i := +@!PADS;
+            while $i > 0 {
+                $i := $i - 1;
+                my %sym := @!PADS[$i].symbol($name);
+                if %sym {
+                    @!PADS[$i].symbol($name, :bind_targeted(1));
+                    return 1;
+                }
+            }
+            0;
+        }
+
         # Hunts through scopes to find a lexical and returns if it is
         # known to be read-only.
         method is_lexical_marked_ro(str $name) {
@@ -479,6 +494,11 @@ class Perl6::World is HLL::World {
 
     has int $!in_unit_parse;
     has int $!have_outer;
+
+    # Whether a bind written through a pseudo package appeared. It replaces the
+    # container of a lexical the compiler cannot name, so no store in the unit
+    # can be judged against the type its declaration made.
+    has int $!pseudo_package_bind;
     has int $!setting_loaded;
     has $!setting_name;
     has $!setting_revision;
@@ -1816,7 +1836,9 @@ class Perl6::World is HLL::World {
             $var.annotate('our_decl', 1) if $scope eq 'our';
             $block[0].unshift($var);
         }
-        $block.symbol($name, :scope('lexical'), :type(%cont_info<bind_constraint>), :descriptor($descriptor));
+        $block.symbol($name, :scope('lexical'), :type(%cont_info<bind_constraint>),
+            :descriptor($descriptor),
+            :explicit_container(%cont_info<explicit_container> ?? 1 !! 0));
 
         # If it's a native type, no container as we inline natives straight
         # into registers. Do need to take care of initial value though.
@@ -2058,6 +2080,7 @@ class Perl6::World is HLL::World {
             if @cont_type {
                 %info<bind_constraint> := @cont_type[0];
                 %info<container_base> := @cont_type[0];
+                %info<explicit_container> := 1;
             }
             else {
                 %info<bind_constraint> := self.find_single_symbol_in_setting('Positional');
@@ -2288,6 +2311,15 @@ class Perl6::World is HLL::World {
     method is_lexical_marked_ro(str $name) {
         self.context().is_lexical_marked_ro($name)
     }
+
+    # Hunts through scopes to find a lexical and records that a bind has
+    # replaced the container its declaration made.
+    method mark_lexical_bind_targeted(str $name) {
+        self.context().mark_lexical_bind_targeted($name)
+    }
+
+    method mark_pseudo_package_bind() { $!pseudo_package_bind := 1 }
+    method has_pseudo_package_bind()  { $!pseudo_package_bind }
 
     # Installs a symbol into the package.
     method install_package_symbol($/, $package, $name, $obj, $declaration) {
@@ -2564,7 +2596,24 @@ class Perl6::World is HLL::World {
                     nqp::bindattr($param_obj, $param_type, '$!container_descriptor', $desc);
                     $lexpad.symbol($varname, :descriptor($desc), :$type);
                 }
-                $lexpad.symbol($varname, :ro(0));
+                # A type as written narrower than a plain type is recorded here
+                # already widened, keeping what it narrowed as a flag or as a
+                # post constraint, so the type the symbol carries is not the
+                # whole of what the parameter accepts. A subset is kept as the
+                # type object itself. A where clause and a literal value are
+                # kept concrete, and both only narrow what the recorded type
+                # already accepts, so they leave it speaking for a store.
+                my int $constrained := $flags +& (nqp::const::SIG_ELEM_DEFINED_ONLY
+                    +| nqp::const::SIG_ELEM_UNDEFINED_ONLY) ?? 1 !! 0;
+                if !$constrained && $_<post_constraints> {
+                    for $_<post_constraints> -> $constraint {
+                        unless nqp::isconcrete($constraint) {
+                            $constrained := 1;
+                            last;
+                        }
+                    }
+                }
+                $lexpad.symbol($varname, :ro(0), :constrained($constrained));
             }
             elsif $varname { $lexpad.symbol($varname, :ro(1)) }
 
@@ -5042,6 +5091,17 @@ class Perl6::World is HLL::World {
         LongName.is_pseudo_package($comp)
     }
 
+    # The pseudo-packages naming a lexical scope, which a bind through them can
+    # reach. A package stash aliases the container a lexical holds rather than
+    # holding the lexical, so a bind there leaves the lexical with what it had.
+    my %lexical_pseudo := nqp::hash(
+        'MY', 1, 'OUTER', 1, 'OUTERS', 1, 'UNIT', 1,
+        'SETTING', 1, 'CORE', 1, 'LEXICAL', 1, 'CALLER', 1,
+        'CALLERS', 1, 'DYNAMIC', 1, 'CLIENT', 1, 'COMPILING', 1);
+    method is_lexical_pseudo_package($comp) {
+        nqp::existskey(%lexical_pseudo, $comp)
+    }
+
     # Checks if a given symbol is declared.
     method is_name(@name) {
         my int $is_name := 0;
@@ -5431,6 +5491,10 @@ class Perl6::World is HLL::World {
                     $lookup,
                     self.add_string_constant($_));
             }
+            # The leading part settles what the lookup can reach, and it is the
+            # only place the name survives into what is built here.
+            $lookup.annotate('lexical_pseudo_package', 1)
+                if self.is_lexical_pseudo_package(@name[0]);
             return $lookup;
         }
 

--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -848,13 +848,6 @@ class RakuAST::Node {
             # nor the soft pragma may skip them.
             self.IMPL-WITHDRAW-NEGATE-NOT($expr);
             self.IMPL-WITHDRAW-LONE-LINK($expr);
-
-            # A bind statement replaces its target's container, so it
-            # withdraws native subscript eligibility from the target's
-            # declaration. A retraction rather than an optimization: it runs
-            # whether or not a rewrite replaced this node and regardless of
-            # the soft pragma.
-            self.IMPL-POISON-NATIVE-INDEX-BIND($expr);
         }
 
         # Lowerings that direct code generation rather than replacing the
@@ -1288,24 +1281,6 @@ class RakuAST::Node {
         $expr.IMPL-SET-CALLSTATIC(
             self.IMPL-RESOLUTION-BOUND-ONCE($resolver, $expr.resolution,
                 '&' ~ $expr.name.canonicalize) ?? 1 !! 0);
-        Nil
-    }
-
-    # A bind statement targeting a lexical with a simple declaration
-    # marks that declaration, so the native subscript emission stands
-    # down: the bound container need not be the declared one. An EVAL
-    # cannot rebind an outer lexical on this frontend, so the statements
-    # seen here are all the binds there are.
-    method IMPL-POISON-NATIVE-INDEX-BIND(Mu $expr) {
-        return Nil unless nqp::istype($expr, RakuAST::ApplyInfix);
-        my $infix := $expr.infix;
-        return Nil unless nqp::istype($infix, RakuAST::Infix)
-            && ($infix.operator eq ':=' || $infix.operator eq '::=');
-        my $left := $expr.left;
-        $left.resolution.IMPL-SET-BIND-TARGETED()
-            if nqp::istype($left, RakuAST::Var::Lexical)
-            && $left.is-resolved
-            && nqp::istype($left.resolution, RakuAST::VarDeclaration::Simple);
         Nil
     }
 

--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -716,6 +716,49 @@ class RakuAST::Node {
         False
     }
 
+    # The one value this node is known to produce, or Nil when it produces
+    # something the compiler cannot name. A number, a version, a quoted string
+    # that needs nothing evaluated, an enum value, the line and file the
+    # compiler is reading, a whatever, what a BEGIN block produced, a constant
+    # declaration and a reference to a constant all qualify. A word list of
+    # several words answers the list it builds rather than a word. The answer
+    # can be a type object, so a caller wanting a value a store would see checks
+    # it for concreteness.
+    method IMPL-STORED-VALUE() {
+        return self.compile-time-value if nqp::istype(self, RakuAST::Literal);
+        return self.maybe-compile-time-value
+            if nqp::istype(self, RakuAST::QuotedString);
+        return self.maybe-compile-time-value
+            if nqp::istype(self, RakuAST::Term::Enum) && self.has-compile-time-value;
+        return self.line if nqp::istype(self, RakuAST::Var::Compiler::Line);
+        return self.file if nqp::istype(self, RakuAST::Var::Compiler::File);
+        # A whatever and a BEGIN block each keep what they produced to
+        # themselves, the one the singleton it stands for and the other the
+        # value its body left behind.
+        return nqp::getattr(self, RakuAST::Term::Whatever, '$!whatever')
+            if nqp::istype(self, RakuAST::Term::Whatever);
+        return nqp::getattr(self, RakuAST::Term::HyperWhatever, '$!whatever')
+            if nqp::istype(self, RakuAST::Term::HyperWhatever);
+        return nqp::getattr(self, RakuAST::StatementPrefix::Phaser::Begin, '$!value')
+            if nqp::istype(self, RakuAST::StatementPrefix::Phaser::Begin)
+            && nqp::getattr_i(self, RakuAST::StatementPrefix::Phaser::Begin, '$!has-value');
+        # A constant declaration evaluates to what it was declared as.
+        return self.compile-time-value
+            if nqp::istype(self, RakuAST::VarDeclaration::Constant);
+        if (nqp::istype(self, RakuAST::Var::Lexical)
+                || nqp::istype(self, RakuAST::Term::Name))
+            && self.is-resolved
+            && self.IMPL-CONSTANT-RESOLUTION(self.resolution)
+        {
+            my $value := self.resolution.compile-time-value;
+            # A routine is reached by a reference to its declaration rather than
+            # held as a value, and one declared in the unit resolves to no
+            # constant at all, so neither spelling is judged.
+            return nqp::istype($value, Code) ?? Nil !! $value;
+        }
+        Nil
+    }
+
     # Optimize a child expression, returning a node to use in its place (the
     # same node if nothing applies). The optimize walk offers every visited
     # child to this method, and this is where the expression-level
@@ -3662,6 +3705,7 @@ class RakuAST::Node {
         (nqp::istype($decl, RakuAST::VarDeclaration::Constant)
           || nqp::istype($decl, RakuAST::VarDeclaration::Implicit::EnumValue)
           || nqp::istype($decl, RakuAST::Declaration::External::Constant)
+          || nqp::istype($decl, RakuAST::Declaration::External::Setting)
           || nqp::istype($decl, RakuAST::Declaration::ResolvedConstant))
           && !nqp::iscont($decl.compile-time-value)
             ?? 1 !! 0

--- a/src/Raku/ast/compunit.rakumod
+++ b/src/Raku/ast/compunit.rakumod
@@ -453,6 +453,10 @@ class RakuAST::CompUnit
     method PERFORM-CHECK(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
         nqp::findmethod(RakuAST::LexicalScope, 'PERFORM-CHECK')(self, $resolver, $context);
 
+        # Every statement has been checked, so which variables a bind has taken
+        # over is settled and the stores held back can be judged.
+        $resolver.report-pending-impossible-values;
+
         while $!check-phasers {
             my $check-phaser := nqp::pop($!check-phasers);
             {

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -2677,6 +2677,43 @@ class RakuAST::ApplyInfix
         # adverb as the plain application does.
         my $base := $infix;
         $base := $base.infix while nqp::istype($base, RakuAST::MetaInfix);
+
+        # A metaoperator wraps the operator it is built from, and reducing a
+        # bind over two operands binds them.
+        my $bind-infix := nqp::istype($infix, RakuAST::BracketedInfix)
+            ?? $infix.infix
+            !! $infix;
+        if nqp::istype($bind-infix, RakuAST::Infix) {
+            my str $bind-op := $bind-infix.operator;
+            if $bind-op eq ':=' || $bind-op eq '≔' {
+                # A bind through a pseudo package naming a lexical scope
+                # replaces a container this analysis never resolves, so no
+                # store in the unit can be judged. The scope is named by the
+                # subscripted term of one spelling and by the qualifier of the
+                # sigil qualified one.
+                if nqp::istype($left, RakuAST::ApplyPostfix)
+                    && nqp::istype($left.operand, RakuAST::Term::Name)
+                    && $left.operand.name.is-lexical-pseudo-package
+                    || nqp::istype($left, RakuAST::Var::Package)
+                    && $left.name.is-lexical-pseudo-package {
+                    $resolver.mark-pseudo-package-bind;
+                }
+
+                # A bind replaces its target's container, so the type the
+                # declaration named speaks for no store into that variable. A
+                # parameter resolves to a target wearing its declaration, so
+                # unwrap before marking.
+                if nqp::istype($left, RakuAST::Var::Lexical) && $left.is-resolved {
+                    my $bound := $left.resolution;
+                    $bound := $bound.declaration
+                        if nqp::istype($bound, RakuAST::ParameterTarget::Var)
+                        && nqp::isconcrete($bound.declaration);
+                    $bound.IMPL-SET-BIND-TARGETED
+                        if nqp::istype($bound, RakuAST::VarDeclaration::Simple);
+                }
+            }
+        }
+
         if nqp::elems(self.colonpairs)
           && nqp::istype($base, RakuAST::Infix)
           && (nqp::chars($infix.properties.thunky) || $infix.properties.chain) {
@@ -2762,36 +2799,38 @@ class RakuAST::ApplyInfix
                 }
             }
 
-            my $type := self.left.return-type;
             if nqp::istype($infix, RakuAST::Assignment) {
-                if !nqp::istype(self.left, RakuAST::Literal) && !nqp::eqaddr($type, Mu)
-                    # Subset type checking can have side effects, so don't do that at compile time.
-                    && !nqp::istype($type.HOW, Perl6::Metamodel::SubsetHOW)
-                    # An attribute read answers its declared type for the
-                    # optimize pass, while an assignment to one keeps its
-                    # run time check.
-                    && !nqp::istype(self.left, RakuAST::Var::Attribute)
-                {
-                    my $right := self.right;
-                    if nqp::istype($right,RakuAST::Literal) {
-                        my int $primspec := nqp::objprimspec($type);
-                        if $primspec {
-                            $type := $type.HOW.mro($type)[1];
-                        }
-
-                        my $value := $right.compile-time-value;
-                        if !nqp::istype($value, $type)
-                          && nqp::istype($type, $resolver.type-from-setting('Numeric')) {
-                            self.add-sorry:
-                              $resolver.build-exception:
-                                'X::Syntax::Number::LiteralType',
-                                :vartype($type),
-                                :$value,
-                                :varname(nqp::istype(self.left, RakuAST::Var::Lexical)
-                                    ?? self.left.name !! ''),
-                                :native($primspec);
-                        }
+                # Only a declaration names a type the store has to satisfy, and
+                # it also knows the element type, the sigil and any complaint,
+                # so let it build the complaint. Anything else reached from here
+                # answers the type a bind checks against, or the type of a value
+                # it happens to hold, neither of which is what a store sees.
+                my $declaration := Nil;
+                if nqp::istype(self.left, RakuAST::Var::Lexical) && self.left.is-resolved {
+                    my $resolution := self.left.resolution;
+                    if nqp::istype($resolution, RakuAST::VarDeclaration::Simple) {
+                        $declaration := $resolution;
                     }
+                    # A declarator signature declares variables while wearing a
+                    # parameter target, and a parameter names the type its store
+                    # has to satisfy. A copied list parameter is the exception,
+                    # being handed a container without the element type.
+                    elsif nqp::istype($resolution, RakuAST::ParameterTarget::Var)
+                        && nqp::isconcrete($resolution.declaration)
+                        # A read only parameter cannot be stored into at all,
+                        # which is reported as an assignment to an immutable
+                        # value rather than as the value being wrong.
+                        && !$resolution.declaration.is-ro
+                        && ($resolution.var-declaration
+                            || $resolution.declaration.sigil eq '$') {
+                        $declaration := $resolution.declaration;
+                    }
+                }
+                if nqp::isconcrete($declaration) {
+                    my $exception := $declaration.IMPL-IMPOSSIBLE-VALUE-EXCEPTION(
+                        $resolver, self.right);
+                    $resolver.add-pending-impossible-value(self, $declaration, $exception)
+                        if nqp::isconcrete($exception);
                 }
 
                 if nqp::istype(self.left, RakuAST::Var::Lexical) && self.left.is-resolved

--- a/src/Raku/ast/name.rakumod
+++ b/src/Raku/ast/name.rakumod
@@ -260,6 +260,14 @@ class RakuAST::Name
         || nqp::istype($!parts[0], RakuAST::Name::Part::Empty)
     }
 
+    # Whether this names a lexical scope, which a bind through it can reach. A
+    # package stash aliases the container a lexical holds rather than holding
+    # the lexical, so a bind there leaves the lexical with what it had.
+    method is-lexical-pseudo-package() {
+        nqp::istype($!parts[0], RakuAST::Name::Part::Simple)
+            && $!parts[0].is-lexical-pseudo-package
+    }
+
     method is-package-search() {
         nqp::istype($!parts[0], RakuAST::Name::Part::Empty)
     }
@@ -417,6 +425,10 @@ class RakuAST::Name::Part {
         False
     }
 
+    method is-lexical-pseudo-package() {
+        False
+    }
+
     method visit-children(Code $visitor) {
     }
 
@@ -452,6 +464,12 @@ class RakuAST::Name::Part::Simple
         || $name eq 'SETTING'
         || $name eq 'UNIT'
         || $name eq 'COMPILING' # seems to be reserved
+    }
+
+    # OUR names the package stash of the current package, which holds the same
+    # container a lexical of that name aliases rather than holding the lexical.
+    method is-lexical-pseudo-package() {
+        self.is-pseudo-package && $!name ne 'OUR'
     }
 
     method is-empty() {

--- a/src/Raku/ast/resolver.rakumod
+++ b/src/Raku/ast/resolver.rakumod
@@ -22,6 +22,16 @@ class RakuAST::Resolver {
     # Nodes that are unresolved after check time.
     has Mu $!nodes-unresolved-after-check-time;
 
+    # Stores of a value their variable can never accept, held until the whole
+    # comp unit has been checked. A bind anywhere replaces the container the
+    # declaration made, and it may be written after the store it excuses.
+    has Mu $!pending-impossible-values;
+
+    # Whether a bind written through a pseudo package appeared. It replaces the
+    # container of a lexical the compiler cannot name, so no store in the unit
+    # can be judged against the type its declaration made.
+    has int $!pseudo-package-bind;
+
     # The current comp unit's EXPORT package.
     has Mu $!export-package;
 
@@ -751,6 +761,37 @@ class RakuAST::Resolver {
             nqp::bindattr(self, RakuAST::Resolver, '$!nodes-with-check-time-problems', []);
         }
         nqp::push($!nodes-with-check-time-problems, $node);
+        Nil
+    }
+
+    # Hold a store to report once every bind in the comp unit is known.
+    method add-pending-impossible-value(Mu $node, Mu $declaration, Mu $exception) {
+        unless $!pending-impossible-values {
+            nqp::bindattr(self, RakuAST::Resolver, '$!pending-impossible-values', []);
+        }
+        nqp::push($!pending-impossible-values, [$node, $declaration, $exception]);
+        Nil
+    }
+
+    method mark-pseudo-package-bind() {
+        nqp::bindattr_i(self, RakuAST::Resolver, '$!pseudo-package-bind', 1);
+        Nil
+    }
+
+    # Report the held stores whose variable no bind has taken over.
+    method report-pending-impossible-values() {
+        if $!pending-impossible-values && !$!pseudo-package-bind {
+            for $!pending-impossible-values -> @pending {
+                unless @pending[1].IMPL-BIND-TARGETED {
+                    # A node already on the list is reported whole, so listing
+                    # it twice repeats every complaint it carries.
+                    my int $listed := @pending[0].has-check-time-problems ?? 1 !! 0;
+                    @pending[0].add-sorry(@pending[2]);
+                    self.add-node-with-check-time-problems(@pending[0]) unless $listed;
+                }
+            }
+            nqp::bindattr(self, RakuAST::Resolver, '$!pending-impossible-values', []);
+        }
         Nil
     }
 

--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -1428,8 +1428,7 @@ class RakuAST::VarDeclaration::Simple
         }
 
         my $type := self.type;
-        # Subset type checking can have side effects, so don't do that at compile time.
-        if nqp::istype($type, RakuAST::Type::Simple) && !nqp::istype($type.meta-object.HOW, Perl6::Metamodel::SubsetHOW) {
+        if nqp::istype($type, RakuAST::Type::Simple) {
             my $initializer := self.initializer;
             if nqp::istype($initializer,RakuAST::Initializer::Assign)
                  || nqp::istype($initializer,RakuAST::Initializer::Bind) {
@@ -1441,25 +1440,18 @@ class RakuAST::VarDeclaration::Simple
                             :name(self.name);
                 }
 
-                my $expression := $initializer.expression;
-                if nqp::istype($expression, RakuAST::Literal) {
-                    my $vartype := $type.meta-object;
-                    my int $primspec := nqp::objprimspec($vartype);
-                    if $primspec {
-                        $vartype := $vartype.HOW.mro($vartype)[1];
-                    }
-
-                    my $value := $expression.compile-time-value;
-                    if !nqp::istype($value, $vartype)
-                      && nqp::istype(
-                           $vartype,
-                           $resolver.type-from-setting('Numeric')
-                         ) {
-                        self.add-sorry:
-                          $resolver.build-exception: 'X::Syntax::Number::LiteralType',
-                            :varname(self.name), :$vartype, :$value,
-                            :native($primspec);
-                    }
+                # A bind replaces the container instead of storing into it. The
+                # value is checked whole against the bind constraint, and a
+                # store written elsewhere meets the bound container rather than
+                # the one this declaration made.
+                if $initializer.is-binding {
+                    self.IMPL-SET-BIND-TARGETED;
+                }
+                else {
+                    my $exception := self.IMPL-IMPOSSIBLE-VALUE-EXCEPTION(
+                        $resolver, $initializer.expression);
+                    $resolver.add-pending-impossible-value(self, self, $exception)
+                        if nqp::isconcrete($exception);
                 }
             }
         }
@@ -1533,6 +1525,133 @@ class RakuAST::VarDeclaration::Simple
                     $resolver.build-exception: 'X::Syntax::Variable::BadType', type => $type.compile-time-value;
             }
         }
+    }
+
+    # The exception for the first value an expression would store into the
+    # variable that its type can never accept. Nil when there is no such value,
+    # and also whenever this declines to look, so Nil is not a promise that the
+    # store will succeed.
+    method IMPL-IMPOSSIBLE-VALUE-EXCEPTION(RakuAST::Resolver $resolver, Mu $expression) {
+        # A hash takes a flat list of keys and values, so a value it is given
+        # need not be one the element type sees.
+        return Nil if self.sigil eq '%';
+
+        # A list variable is assigned element by element, so what the expression
+        # builds as a whole is not what the element type sees.
+        return Nil if self.sigil eq '@';
+
+        # An anonymous variable is known here only by the name the compiler made
+        # up for it, which is no help to whoever wrote the store.
+        return Nil if nqp::istype(self, RakuAST::VarDeclaration::Anonymous);
+
+        # A name in a package installs there rather than making a container the
+        # declared type speaks for.
+        return Nil if $!desigilname.is-multi-part;
+
+        # A bind replaces the container the declaration made, so the type it
+        # names speaks for no store into it.
+        return Nil if self.IMPL-BIND-TARGETED;
+
+        # A container named by the declaration brings its own STORE, which is
+        # free to convert what it is given or to store it somewhere else, so
+        # what the value type accepts is not what the store has to satisfy.
+        return Nil if self.IMPL-HAS-EXPLICIT-CONTAINER-BASE-TYPE;
+
+        # An attribute default is reported against the attribute itself, which
+        # names the attribute rather than a variable.
+        return Nil if self.is-attribute;
+
+        my $type := self.type;
+        return Nil unless nqp::istype($type, RakuAST::Type::Simple);
+
+        # A value used as a type has no type of its own to name in the advice.
+        my $vartype := $type.meta-object;
+        return Nil if nqp::isconcrete($vartype);
+
+        # A `will complain` explanation is a block written for the value that
+        # failed. Running it is the run time check's to do, on the variable or
+        # on the type.
+        return Nil if self.IMPL-HAS-COMPLAINT
+            || nqp::istype($vartype.HOW, Perl6::Metamodel::Explaining);
+
+        # A generic is only settled later, and a role reports itself as nominal
+        # while accepting by what does it, so neither is checked here. A
+        # coercion, a definite type and a subset are all nominalizable rather
+        # than nominal, so the one test covers them too, and it keeps subset
+        # checking, which can have side effects, out of compile time.
+        my $archetypes := $vartype.HOW.archetypes($vartype);
+        return Nil
+            unless $archetypes.nominal
+                && !$archetypes.generic
+                && !$archetypes.composable;
+
+        # A native refuses a store by failing to unbox rather than by failing a
+        # type check, so its boxed type is what a value is checked against.
+        my $declared := $vartype;
+        my int $primspec := nqp::objprimspec($vartype);
+        $vartype := $vartype.HOW.mro($vartype)[1] if $primspec;
+
+        # A compile time complaint is confined to the types the advice is
+        # written for. Any other type is left to the run time check.
+        return Nil unless nqp::istype($vartype, $resolver.type-from-setting('Cool'));
+
+        my $iterable := $resolver.type-from-setting('Iterable');
+        for self.IMPL-STORED-VALUES($expression) {
+            # An iterable value may be spread across several stores rather
+            # than stored whole, so what the value type sees is not settled
+            # here.
+            next if nqp::istype($_, $iterable);
+            unless nqp::istype($_, $vartype) {
+                return $resolver.build-exception('X::Syntax::Number::LiteralType',
+                    :varname(self.name), :vartype($declared), :value($_),
+                    :native($primspec));
+            }
+        }
+        Nil
+    }
+
+    # Whether the variable itself carries a `will complain` explanation. One
+    # attached to its type is reached through that type's meta-object instead.
+    method IMPL-HAS-COMPLAINT() {
+        for self.IMPL-UNWRAP-LIST(self.traits) {
+            return True if nqp::istype($_, RakuAST::Trait::Will) && $_.phase eq 'complain';
+        }
+        False
+    }
+
+    # The values an expression is known to store into the variable. An operand
+    # producing something the compiler cannot name contributes nothing.
+    method IMPL-STORED-VALUES(Mu $expression) {
+        my @values;
+        self.IMPL-COLLECT-STORED-VALUES($expression, @values);
+        @values
+    }
+
+    # Collects into the given list, descending only where the value the store
+    # sees is not the expression itself.
+    method IMPL-COLLECT-STORED-VALUES(Mu $expression, Mu $values) {
+        # Grouping parentheses stand for what they wrap.
+        if nqp::istype($expression, RakuAST::Circumfix::Parentheses) {
+            my $semilist := $expression.semilist;
+            return Nil unless nqp::istype($semilist, RakuAST::SemiList);
+            my @statements := self.IMPL-UNWRAP-LIST($semilist.code-statements);
+            # A semicolon list of any length but one builds a list of its own,
+            # which the variable stores whole.
+            return Nil if nqp::elems(@statements) != 1;
+            for @statements {
+                # Only an expression statement produces a value to name, and it
+                # is the only statement carrying the modifiers asked about next.
+                next unless nqp::istype($_, RakuAST::Statement::Expression);
+                # A condition modifier can yield nothing and a loop modifier
+                # yields a list, so a modified statement stores nothing known.
+                next if $_.condition-modifier || $_.loop-modifier;
+                self.IMPL-COLLECT-STORED-VALUES($_.expression, $values);
+            }
+            return Nil;
+        }
+        my $value := $expression.IMPL-STORED-VALUE;
+        nqp::push($values, $value) if nqp::isconcrete($value);
+        Nil
     }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {

--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -1536,10 +1536,6 @@ class RakuAST::VarDeclaration::Simple
         # need not be one the element type sees.
         return Nil if self.sigil eq '%';
 
-        # A list variable is assigned element by element, so what the expression
-        # builds as a whole is not what the element type sees.
-        return Nil if self.sigil eq '@';
-
         # An anonymous variable is known here only by the name the compiler made
         # up for it, which is no help to whoever wrote the store.
         return Nil if nqp::istype(self, RakuAST::VarDeclaration::Anonymous);
@@ -1623,21 +1619,31 @@ class RakuAST::VarDeclaration::Simple
     # producing something the compiler cannot name contributes nothing.
     method IMPL-STORED-VALUES(Mu $expression) {
         my @values;
-        self.IMPL-COLLECT-STORED-VALUES($expression, @values);
+        self.IMPL-COLLECT-STORED-VALUES($expression, @values, self.sigil eq '@');
         @values
     }
 
     # Collects into the given list, descending only where the value the store
-    # sees is not the expression itself.
-    method IMPL-COLLECT-STORED-VALUES(Mu $expression, Mu $values) {
-        # Grouping parentheses stand for what they wrap.
-        if nqp::istype($expression, RakuAST::Circumfix::Parentheses) {
+    # sees is not the expression itself. A list variable is assigned element by
+    # element, so a comma list there contributes each of its operands and a
+    # semicolon list one value per statement, while an item variable stores what
+    # either of those builds whole.
+    method IMPL-COLLECT-STORED-VALUES(Mu $expression, Mu $values, int $elementwise) {
+        # Grouping parentheses stand for what they wrap. An array composer
+        # builds an array, which a list assignment spreads out only when the
+        # composer is the whole of what it is given, so within a list it counts
+        # as the one value it builds.
+        if nqp::istype($expression, RakuAST::Circumfix::Parentheses)
+          || $elementwise && nqp::istype($expression, RakuAST::Circumfix::ArrayComposer)
+        {
             my $semilist := $expression.semilist;
             return Nil unless nqp::istype($semilist, RakuAST::SemiList);
             my @statements := self.IMPL-UNWRAP-LIST($semilist.code-statements);
             # A semicolon list of any length but one builds a list of its own,
-            # which the variable stores whole.
-            return Nil if nqp::elems(@statements) != 1;
+            # which only a list variable takes apart, and then only into one
+            # element per statement.
+            return Nil if !$elementwise && nqp::elems(@statements) != 1;
+            my int $inner := nqp::elems(@statements) == 1 ?? $elementwise !! 0;
             for @statements {
                 # Only an expression statement produces a value to name, and it
                 # is the only statement carrying the modifiers asked about next.
@@ -1645,11 +1651,31 @@ class RakuAST::VarDeclaration::Simple
                 # A condition modifier can yield nothing and a loop modifier
                 # yields a list, so a modified statement stores nothing known.
                 next if $_.condition-modifier || $_.loop-modifier;
-                self.IMPL-COLLECT-STORED-VALUES($_.expression, $values);
+                self.IMPL-COLLECT-STORED-VALUES($_.expression, $values, $inner);
+            }
+            return Nil;
+        }
+        if $elementwise
+          && nqp::istype($expression, RakuAST::ApplyListInfix)
+          && nqp::istype($expression.infix, RakuAST::Infix)
+          && $expression.infix.operator eq ','
+        {
+            for self.IMPL-UNWRAP-LIST($expression.operands) {
+                self.IMPL-COLLECT-STORED-VALUES($_, $values, 0);
             }
             return Nil;
         }
         my $value := $expression.IMPL-STORED-VALUE;
+        # A word list answers the list of words it builds, which a list
+        # assignment stores one word at a time.
+        if $elementwise && nqp::istype($expression, RakuAST::QuotedString)
+          && nqp::isconcrete($value) && nqp::istype($value, List)
+        {
+            for self.IMPL-UNWRAP-LIST($value) {
+                nqp::push($values, $_);
+            }
+            return Nil;
+        }
         nqp::push($values, $value) if nqp::isconcrete($value);
         Nil
     }

--- a/src/core.c/Exception.rakumod
+++ b/src/core.c/Exception.rakumod
@@ -3109,25 +3109,44 @@ my class X::TypeCheck::Assignment is X::TypeCheck {
 }
 my class X::Syntax::Number::LiteralType is X::TypeCheck::Assignment does X::Syntax {
     has $.varname;
-    has $.vartype;
+    # Bound rather than assigned, so that a variable declared Nil keeps Nil as
+    # its type here instead of resetting to the default.
+    has $.vartype is built(:bind);
     has $.value;
-    has $.valuetype      = $!value.^name;
-    has $.suggestiontype = ($!vartype,$!value).are.^name;
+    # The value is whatever the compiler held, so asking it to describe itself
+    # can fail, and a failure while reporting an error loses the error.
+    has $.valuetype      = (try $!value.^name) // '?';
+    has $.suggestiontype = (try ($!vartype,$!value).are.^name) // 'Any';
     has $.native         = nqp::objprimspec($!valuetype);
+
+    # Anything handling an assignment type check reads the value, the type it
+    # was checked against and the variable it was going to under the names the
+    # parent gives them, so answer them there as well.
+    submethod TWEAK() {
+        nqp::bindattr(self, X::TypeCheck, '$!got', $!value);
+        nqp::bindattr(self, X::TypeCheck, '$!expected', $!vartype);
+        nqp::bindattr(self, X::TypeCheck::Assignment, '$!symbol', $!varname);
+    }
 
     method message() {
         my $vartype := $!vartype.WHAT.^name;
         my $conversionmethod := $vartype.tc;
         $vartype := $vartype.lc if $.native;
         my $vt := $!value.^name;
-        my $value := nqp::istype($.value,Allomorph)
-          ?? $!value.Str
-          !! $!value.raku;
+        my $value := (nqp::istype($.value,Allomorph)
+          ?? (try $!value.Str)
+          !! (try $!value.raku)) // $.valuetype;
         my $val = "Cannot assign a literal of type $.valuetype ($value) to
         a { "native" if $.native } variable ($.varname) of type $vartype. You can declare
         the variable to be of type $.suggestiontype, or try to coerce the
         value with $value.$conversionmethod or $conversionmethod\($value\)";
-        try $val ~= ", or just write the value as " ~ $!value."$vartype"().raku;
+        # A coercion that cannot convert the value answers a Failure rather than
+        # throwing, and there is no other spelling to suggest in that case.
+        try {
+            my $written := $!value."$conversionmethod"();
+            $val ~= ", or just write the value as " ~ $written.raku
+                if $written.defined;
+        }
         if nqp::istype($!vartype.HOW, Metamodel::Explaining) {
             my $complainee = $!vartype.HOW.complainee;
             $val ~= '; ' ~ ($complainee ~~ Callable || $complainee.^can('CALL-ME')

--- a/src/core.c/Exception.rakumod
+++ b/src/core.c/Exception.rakumod
@@ -3112,7 +3112,9 @@ my class X::Syntax::Number::LiteralType is X::TypeCheck::Assignment does X::Synt
     # Bound rather than assigned, so that a variable declared Nil keeps Nil as
     # its type here instead of resetting to the default.
     has $.vartype is built(:bind);
-    has $.value;
+    # X::TypeCheck is handed this value uncontainerized, so hold it that way
+    # here.
+    has $.value is built(:bind);
     # The value is whatever the compiler held, so asking it to describe itself
     # can fail, and a failure while reporting an error loses the error.
     has $.valuetype      = (try $!value.^name) // '?';
@@ -3130,16 +3132,20 @@ my class X::Syntax::Number::LiteralType is X::TypeCheck::Assignment does X::Synt
 
     method message() {
         my $vartype := $!vartype.WHAT.^name;
-        my $conversionmethod := $vartype.tc;
-        $vartype := $vartype.lc if $.native;
-        my $vt := $!value.^name;
-        my $value := (nqp::istype($.value,Allomorph)
-          ?? (try $!value.Str)
-          !! (try $!value.raku)) // $.valuetype;
+        # A native unboxes from a boxed type, and that is the type a coercion
+        # names. The variable is still of the type it was declared with.
+        my $conversionmethod := ($.native ?? $!vartype.^mro[1].^name !! $vartype).tc;
+        my $value := (try Str(nqp::istype($.value,Allomorph)
+          ?? $!value.Str
+          !! $!value.raku)) // $.valuetype;
         my $val = "Cannot assign a literal of type $.valuetype ($value) to
         a { "native" if $.native } variable ($.varname) of type $vartype. You can declare
-        the variable to be of type $.suggestiontype, or try to coerce the
-        value with $value.$conversionmethod or $conversionmethod\($value\)";
+        the variable to be of type $.suggestiontype";
+        # A type the value has no coercion method for is one there is no way to
+        # spell the conversion to, so only a value that can name it is advised.
+        $val ~= ", or try to coerce the
+        value with $value.$conversionmethod or $conversionmethod\($value\)"
+            if (try $!value.^can($conversionmethod)).so;
         # A coercion that cannot convert the value answers a Failure rather than
         # throwing, and there is no other spelling to suggest in that case.
         try {

--- a/t/05-messages/03-errors.t
+++ b/t/05-messages/03-errors.t
@@ -1,9 +1,9 @@
-use lib <t/packages/Test-Helpers>;
+use lib <t/packages/Test-Helpers t/packages/05-messages/lib>;
 use Test;
 use nqp;
 use Test::Helpers;
 
-plan 31;
+plan 33;
 
 subtest '.map does not explode in optimizer' => {
     plan 3;
@@ -327,6 +327,302 @@ $a xx 2 :foo｣,
     else {
         skip 'the source split is placed by the RakuAST frontend', 10;
     }
+}
+
+subtest 'a store of a value a variable can never accept is reported at compile time' => {
+    plan 35;
+    throws-like ｢my Str $x = 1｣,
+        X::Syntax::Number::LiteralType,
+        'an item declaration reports a value its type can never accept';
+
+    throws-like ｢my Str $x; $x = 1｣,
+        X::Syntax::Number::LiteralType,
+        'an item assignment is reported the same as an item declaration';
+
+    throws-like ｢state Str $x = 1｣,
+        X::Syntax::Number::LiteralType,
+        'a state declaration is judged the same as a my declaration';
+
+    throws-like ｢my Int $x = ("foo")｣,
+        X::Syntax::Number::LiteralType,
+        'grouping parentheses around an item value are looked through';
+
+    throws-like ｢constant Half = 1/2; my Str $x = Half｣,
+        X::Syntax::Number::LiteralType,
+        message => *.contains('Rat'),
+        'a constant stands for a value the compiler already knows';
+
+    throws-like ｢my int $x = "foo"｣,
+        X::Syntax::Number::LiteralType,
+        message => *.contains('native variable'),
+        'a native item type reports a value it can never unbox';
+
+    throws-like ｢my uint8 $x = "foo"｣,
+        X::Syntax::Number::LiteralType,
+        message => { .contains('of type uint8') && .contains('Int("foo")') },
+        'a native is named as declared, and coerced to the type it unboxes from';
+
+    throws-like ｢my num $x = "foo"｣,
+        X::Syntax::Number::LiteralType,
+        message => { .contains('type num') && .contains('Num("foo")') },
+        'a native floating point unboxes from a type of its own family';
+
+    throws-like ｢my num $x = 1｣,
+        X::Syntax::Number::LiteralType,
+        message => *.contains('write the value as 1e0'),
+        'a native is offered the value written as the type it unboxes from';
+
+    throws-like ｢my str $x = 1｣,
+        X::Syntax::Number::LiteralType,
+        message => *.contains('type str'),
+        'a native string reports a number it can never unbox';
+
+    throws-like ｢my Nil $x = 1｣,
+        X::Syntax::Number::LiteralType,
+        message => *.contains('type Nil'),
+        'a Nil type is named as itself rather than reset to a default';
+
+    throws-like ｢my Bool $x = <abc>｣,
+        X::Syntax::Number::LiteralType,
+        'a single word is the one value it stands for';
+
+    throws-like ｢enum Colour <white>; my Colour $c = "nope"｣,
+        X::Syntax::Number::LiteralType,
+        'a user defined enumeration reports a value it can never accept';
+
+    throws-like ｢sub f(Str $x is copy) { $x = 43 }｣,
+        X::Syntax::Number::LiteralType,
+        'a copied item parameter is given a container of the type it names';
+
+    throws-like ｢sub f(Str $x is rw) { $x = 43 }｣,
+        X::Syntax::Number::LiteralType,
+        'a parameter storing a value its own type rejects is reported';
+
+    throws-like ｢my (Int $a); $a = "str"｣,
+        X::Syntax::Number::LiteralType,
+        'a variable declared in a declarator signature is reported too';
+
+    throws-like ｢my Int $x = (("foo"))｣,
+        X::Syntax::Number::LiteralType,
+        'nested grouping parentheses are looked through';
+
+    throws-like ｢sub g($q) { my Int $a; $a := $q }; my Int $a; $a = "x"｣,
+        X::Syntax::Number::LiteralType,
+        'a bind to one variable leaves another of the same name in another scope alone';
+
+    throws-like ｢my Str $x = $?LINE｣,
+        X::Syntax::Number::LiteralType,
+        'a compile time variable is the value the compiler reads for it';
+
+    throws-like ｢constant $half = 0.5; my Str $x = $half｣,
+        X::Syntax::Number::LiteralType,
+        'a constant written with a sigil is the value it stands for';
+
+    throws-like ｢sub f(Str $x is copy where { True }) { $x = 42 }｣,
+        X::Syntax::Number::LiteralType,
+        'a where clause narrows what a type accepts rather than widening it';
+
+    throws-like ｢my Int $x = "foo"｣,
+        X::Syntax::Number::LiteralType,
+        got => 'foo', expected => Int, symbol => '$x',
+        'the report answers the value, the type and the variable it was going to';
+
+    throws-like ｢my Int $x = 4.2｣,
+        X::Syntax::Number::LiteralType,
+        message => { .contains('of type Real') && .contains('write the value as 4') },
+        'a type both the value and the variable fit is named as the one to declare';
+
+    throws-like ｢my Complex $x = 1｣,
+        X::Syntax::Number::LiteralType,
+        message => *.contains('of type Numeric'),
+        'a value and a variable sharing only Numeric are told to declare that';
+
+    throws-like ｢my IO::Path $x = 1.5｣,
+        X::Syntax::Number::LiteralType,
+        message => { not .contains('coerce') },
+        'a type the value has no coercion method for is not advised as one';
+
+    throws-like ｢my Int $x = pi｣,
+        X::Syntax::Number::LiteralType,
+        message => *.contains('Num'),
+        'a constant the setting declares is the value it stands for';
+
+    throws-like ｢my Str $x = BEGIN 1｣,
+        X::Syntax::Number::LiteralType,
+        message => *.contains('Int (1)'),
+        'a BEGIN block has run by now, so what it produced is a value';
+
+    throws-like ｢my Int $x = "foo"｣,
+        X::Syntax::Number::LiteralType,
+        message => { not .contains('write the value as') },
+        'a value the coercion cannot convert is not offered back as a spelling';
+
+    throws-like ｢use TypedExports; my Str $x = Answer｣,
+        X::Syntax::Number::LiteralType,
+        message => *.contains('Int (42)'),
+        'a constant read out of another comp unit is a value the compiler holds';
+
+    throws-like ｢my Int $x = *｣,
+        X::Syntax::Number::LiteralType,
+        message => *.contains('Whatever (*)'),
+        'a whatever is the singleton it stands for';
+
+    throws-like ｢my Int $x = **｣,
+        X::Syntax::Number::LiteralType,
+        'a hyper whatever stands for a singleton of its own';
+
+    throws-like ｢my Str $x = constant Q1 = 1｣,
+        X::Syntax::Number::LiteralType,
+        message => *.contains('Int (1)'),
+        'a constant declaration evaluates to what it was declared as';
+
+    throws-like ｢my Str $x = 1; OUR::<$y> := 5｣,
+        X::Syntax::Number::LiteralType,
+        'a bind through the package stash of the current package reaches no lexical';
+
+    throws-like ｢my Str $x = 1; GLOBAL::<$y> := 5｣,
+        X::Syntax::Number::LiteralType,
+        'a bind through the global stash reaches no lexical either';
+
+    throws-like ｢my Str $x = 1; $OUR::y := 5｣,
+        X::Syntax::Number::LiteralType,
+        'a sigil qualified bind through a package stash reaches no lexical';
+}
+
+subtest 'a store the compiler cannot judge is left to the run time check' => {
+    plan 34;
+
+    # The compile time report is a subclass of the run time one, so ruling out
+    # its wording is what says the check was left where it was.
+    my &at-run-time = { not .contains('Cannot assign a literal') };
+
+    throws-like ｢my Str $ = 1｣,
+        X::TypeCheck, :message(&at-run-time),
+        'an anonymous variable is known here only by a name the compiler made up';
+
+    lives-ok { EVAL ｢sub f(Int $x is copy) { my $c = 1; $x := $c; $x = "b" }; f(1)｣ },
+        'a rebound parameter meets the container the bind gave it';
+
+    lives-ok { EVAL ｢my Str $s; sub f() { $s = 42 }; my $c = "x"; $s := $c; f()｣ },
+        'a store in a routine can run after a bind written later in the file';
+
+    throws-like ｢my Int $a; sub g($q) { $a := $q }; $a = "x"｣,
+        X::TypeCheck, :message(&at-run-time),
+        'a bind reaches a declaration made outside the scope the bind is written in';
+
+    lives-ok { EVAL ｢sub f(Int $x is copy) { $x = "b"; my $c = 1; $x := $c }｣ },
+        'a parameter bound after the store is excused like any other variable';
+
+    throws-like ｢my Str $s; $s = 42; BEGIN { EVAL q|1| }; my $c = "x"; $s := $c｣,
+        X::TypeCheck, :message(&at-run-time),
+        'a comp unit compiled part way through does not judge the stores held back';
+
+    throws-like ｢my Str $x = <a b>｣,
+        X::TypeCheck, :message(&at-run-time),
+        'a word list stored whole is spread across stores the element type sees';
+
+    lives-ok { EVAL ｢use TypedExports; $count = "x"; my Str $a = $count｣ },
+        'an imported variable is held as its container, not as a value it once had';
+
+    lives-ok { EVAL ｢my Str $Foo::a = 1｣ },
+        'a name in a package makes no container the declared type speaks for';
+
+    lives-ok { EVAL ｢my Int $x; my $y = 3; MY::<$x> := $y; $x = "abc"｣ },
+        'a bind through a pseudo package reaches a variable this cannot name';
+
+    lives-ok { EVAL ｢my Int $x; my $y = 3; my $n = q[$x]; MY::{$n} := $y; $x = "abc"｣ },
+        'a pseudo package bind naming its target at run time stands the check down';
+
+    lives-ok { EVAL ｢my Int $x; sub f() { my $y = 3; OUTER::<$x> := $y }; f(); $x = "abc"｣ },
+        'a pseudo package naming an enclosing scope reaches a lexical just as well';
+
+    lives-ok { EVAL ｢my Int $x; my $y = 3; $MY::x := $y; $x = "abc"｣ },
+        'a sigil qualified pseudo package bind reaches a lexical the same way';
+
+    throws-like ｢my Str $x = &say｣,
+        X::TypeCheck, :message(&at-run-time),
+        'a routine is reached by a reference to its declaration, not held as a value';
+
+    throws-like ｢my Int $x = * + 1｣,
+        X::TypeCheck, :message(&at-run-time),
+        'a whatever taking part in an expression builds a closure at run time';
+
+    throws-like ｢my Int:D $x = "foo"｣,
+        X::TypeCheck, :message(&at-run-time),
+        'a definite type is nominalizable rather than nominal';
+
+    throws-like ｢role R { }; my R $x = 1｣,
+        X::TypeCheck, :message(&at-run-time),
+        'a role accepts by what does it rather than by type check';
+
+    throws-like ｢sub f(::T $t) { my T $x = "foo" }; f(1)｣,
+        X::TypeCheck, :message(&at-run-time),
+        'a generic is only settled later';
+
+    throws-like ｢my Date $x = 1｣,
+        X::TypeCheck, :message(&at-run-time),
+        'a type that is not Cool has no coercion advice to give';
+
+    throws-like ｢constant Only42 = 42; my Only42 $x = 43｣,
+        X::TypeCheck, :message(&at-run-time),
+        'a value used as a type has no type of its own to name';
+
+    throws-like ｢my Int %h = 4.2｣,
+        X::Hash::Store::OddNumber,
+        'a hash takes a flat list of keys and values';
+
+    throws-like ｢sub f(Str $x) { $x = 43 }; f("a")｣,
+        X::AdHoc, :message(*.contains('immutable value')),
+        'a read only parameter reports the assignment rather than the value';
+
+    lives-ok { EVAL ｢my Str %h = 1, "a"｣ },
+        'a hash key is not a value the element type sees';
+
+    lives-ok { EVAL ｢my Str $x;
+                       $x := Proxy.new(FETCH => -> $ { "a" }, STORE => -> $, $v { });
+                       $x = 42｣ },
+        'a bind to a proxy leaves the store to whatever the proxy does with it';
+
+    lives-ok { EVAL ｢subset Nonempty of Str where *.chars;
+                       sub f(Nonempty $x is copy) { $x = 1 }｣ },
+        'a parameter type narrowed by a subset is recorded already widened';
+
+    lives-ok { EVAL ｢sub f(Str:D $x is copy) { $x = 1 }｣ },
+        'a parameter type narrowed by definiteness is recorded already widened';
+
+    lives-ok { EVAL ｢my List $x = (1; 2)｣ },
+        'an item variable stores what a semicolon list builds, not its statements';
+
+    throws-like ｢class Holder { has Str $.y is rw }; Holder.new.y = 1｣,
+        X::TypeCheck::Assignment, :message(&at-run-time),
+        'an assignment to an attribute keeps its run time check';
+
+    lives-ok { EVAL ｢class Keeper { has Str $!y; method m() { $!y = 1 } }｣ },
+        'a store to an attribute in a method body is left to the run time check';
+
+    lives-ok { EVAL ｢my Str $x = Nil｣ },
+        'Nil resets a container to its default rather than storing a value';
+
+    throws-like ｢my Str $x = 1 + 1｣,
+        X::TypeCheck, :message(&at-run-time),
+        'an expression waiting to be folded is not a value yet';
+
+    throws-like ｢class C { has Str $.x = 42 }｣,
+        X::Comp, :message(*.contains('default value')),
+        'an attribute default is reported against the attribute';
+
+    throws-like ｢use experimental :will-complain;
+                 my Str $s will complain { "gimme a Str, not {.^name}" }; $s = 1｣,
+        X::TypeCheck::Assignment,
+        message => { .contains('gimme a Str, not Int') && at-run-time($_) },
+        'a complaint on the variable is written by the run time check';
+
+    throws-like ｢use experimental :will-complain;
+                 my class Wanted is Cool will complain { "gimme a Wanted, not {.^name}" } { };
+                 my Wanted $x = 42｣,
+        X::TypeCheck::Assignment,
+        message => { .contains('gimme a Wanted, not Int') and at-run-time($_) },
+        'a complaint on the type is written by the run time check too';
 }
 
 # vim: expandtab shiftwidth=4

--- a/t/05-messages/03-errors.t
+++ b/t/05-messages/03-errors.t
@@ -330,7 +330,38 @@ $a xx 2 :foo｣,
 }
 
 subtest 'a store of a value a variable can never accept is reported at compile time' => {
-    plan 35;
+    plan 53;
+
+    throws-like ｢my Str @a = 1,2,3｣,
+        X::Syntax::Number::LiteralType,
+        message => *.contains('Int (1)' & 'type Str'),
+        'a comma list of literals names the first one the element type rejects';
+
+    throws-like ｢my Str @a = "a", 2｣,
+        X::Syntax::Number::LiteralType,
+        message => *.contains('Int (2)'),
+        'a literal later in the list is reported once the earlier ones are accepted';
+
+    throws-like ｢my Str @a = (1,2,3)｣,
+        X::Syntax::Number::LiteralType,
+        'grouping parentheses around the list are looked through';
+
+    throws-like ｢my Str @a = [1,2,3]｣,
+        X::Syntax::Number::LiteralType,
+        'an array composer around the list is looked through';
+
+    throws-like ｢my Str @a = (1; 2)｣,
+        X::Syntax::Number::LiteralType,
+        'each statement of a semicolon list stores an element';
+
+    throws-like ｢my Str @a = 1｣,
+        X::Syntax::Number::LiteralType,
+        'a single literal is reported the same as a list of them';
+
+    throws-like ｢my Str @a; @a = 1,2,3｣,
+        X::Syntax::Number::LiteralType,
+        'a list assignment is reported the same as a list declaration';
+
     throws-like ｢my Str $x = 1｣,
         X::Syntax::Number::LiteralType,
         'an item declaration reports a value its type can never accept';
@@ -347,10 +378,29 @@ subtest 'a store of a value a variable can never accept is reported at compile t
         X::Syntax::Number::LiteralType,
         'grouping parentheses around an item value are looked through';
 
+    throws-like ｢my Int @a = "foo"｣,
+        X::Syntax::Number::LiteralType,
+        message => *.contains('Str ("foo")'),
+        'a string literal is reported the same as a number';
+
+    throws-like ｢my Str @a = v1.2｣,
+        X::Syntax::Number::LiteralType,
+        message => *.contains('Version'),
+        'a version literal is reported the same as a number';
+
     throws-like ｢constant Half = 1/2; my Str $x = Half｣,
         X::Syntax::Number::LiteralType,
         message => *.contains('Rat'),
         'a constant stands for a value the compiler already knows';
+
+    throws-like ｢my Bool @b = 1,2｣,
+        X::Syntax::Number::LiteralType,
+        'an enumeration element type reports a value it can never accept';
+
+    throws-like ｢my num @a = 1,2｣,
+        X::Syntax::Number::LiteralType,
+        message => *.contains('native variable'),
+        'a native element type reports a value it can never unbox';
 
     throws-like ｢my int $x = "foo"｣,
         X::Syntax::Number::LiteralType,
@@ -385,6 +435,18 @@ subtest 'a store of a value a variable can never accept is reported at compile t
     throws-like ｢my Bool $x = <abc>｣,
         X::Syntax::Number::LiteralType,
         'a single word is the one value it stands for';
+
+    throws-like ｢my Int @a = <a b>｣,
+        X::Syntax::Number::LiteralType,
+        'a word list is judged word by word';
+
+    throws-like ｢my Int @a = qw{a b}｣,
+        X::Syntax::Number::LiteralType,
+        'a qw word list is judged like the comma list it stands for';
+
+    throws-like ｢my Bool @a = <1 2 3>｣,
+        X::Syntax::Number::LiteralType,
+        'a word list of numbers is judged as the allomorphs it builds';
 
     throws-like ｢enum Colour <white>; my Colour $c = "nope"｣,
         X::Syntax::Number::LiteralType,
@@ -442,6 +504,15 @@ subtest 'a store of a value a variable can never accept is reported at compile t
         message => { not .contains('coerce') },
         'a type the value has no coercion method for is not advised as one';
 
+    throws-like ｢my %h; my $v = 1; %h<k> := $v; my Str @a = 1,2,3｣,
+        X::Syntax::Number::LiteralType,
+        'a bind into an aggregate leaves the containers declarations made alone';
+
+    throws-like ｢my Str @a[2] = 1,2｣,
+        X::Syntax::Number::LiteralType,
+        message => *.contains('Int (1)'),
+        'a shaped declaration is judged like the unshaped one it binds';
+
     throws-like ｢my Int $x = pi｣,
         X::Syntax::Number::LiteralType,
         message => *.contains('Num'),
@@ -452,10 +523,27 @@ subtest 'a store of a value a variable can never accept is reported at compile t
         message => *.contains('Int (1)'),
         'a BEGIN block has run by now, so what it produced is a value';
 
+    throws-like ｢my Str @a = ("a"; 2)｣,
+        X::Syntax::Number::LiteralType,
+        message => *.contains('Int (2)'),
+        'a later statement of a semicolon list is judged once the earlier ones fit';
+
     throws-like ｢my Int $x = "foo"｣,
         X::Syntax::Number::LiteralType,
         message => { not .contains('write the value as') },
         'a value the coercion cannot convert is not offered back as a spelling';
+
+    if %*ENV<RAKUDO_RAKUAST> {
+        throws-like ｢my Str @a = @a, 1｣,
+            X::Comp,
+            message => { .comb('Cannot assign a literal') == 1 },
+            'a store held back for a declaration already complaining is listed exactly once';
+    }
+    else {
+        throws-like ｢my Str @a = @a, 1｣,
+            X::Syntax::Variable::Initializer,
+            'a declaration complaining about its initializer reports before any store is judged';
+    }
 
     throws-like ｢use TypedExports; my Str $x = Answer｣,
         X::Syntax::Number::LiteralType,
@@ -490,15 +578,27 @@ subtest 'a store of a value a variable can never accept is reported at compile t
 }
 
 subtest 'a store the compiler cannot judge is left to the run time check' => {
-    plan 34;
+    plan 53;
 
     # The compile time report is a subclass of the run time one, so ruling out
     # its wording is what says the check was left where it was.
     my &at-run-time = { not .contains('Cannot assign a literal') };
 
+    throws-like ｢my $w = "a"; my Int @a = «$w b»｣,
+        X::TypeCheck, :message(&at-run-time),
+        'an interpolating word list settles at run time which words it produces';
+
+    throws-like ｢my Str @a; @a.STORE(1)｣,
+        X::TypeCheck, :message(&at-run-time),
+        'a written out call to STORE is one the declaration does not speak for';
+
     throws-like ｢my Str $ = 1｣,
         X::TypeCheck, :message(&at-run-time),
         'an anonymous variable is known here only by a name the compiler made up';
+
+    throws-like ｢my @l = 1; my Int $x; $x = "s"; $x := @l[0]｣,
+        X::TypeCheck, :message(&at-run-time),
+        'a bind stands the check down for a store written before it';
 
     lives-ok { EVAL ｢sub f(Int $x is copy) { my $c = 1; $x := $c; $x = "b" }; f(1)｣ },
         'a rebound parameter meets the container the bind gave it';
@@ -539,6 +639,9 @@ subtest 'a store the compiler cannot judge is left to the run time check' => {
     lives-ok { EVAL ｢my Int $x; my $y = 3; $MY::x := $y; $x = "abc"｣ },
         'a sigil qualified pseudo package bind reaches a lexical the same way';
 
+    lives-ok { EVAL ｢my Str @a; @MY::a := [1]; @a = 1, 2｣ },
+        'a sigil qualified pseudo package bind reaches a list variable too';
+
     throws-like ｢my Str $x = &say｣,
         X::TypeCheck, :message(&at-run-time),
         'a routine is reached by a reference to its declaration, not held as a value';
@@ -546,6 +649,16 @@ subtest 'a store the compiler cannot judge is left to the run time check' => {
     throws-like ｢my Int $x = * + 1｣,
         X::TypeCheck, :message(&at-run-time),
         'a whatever taking part in an expression builds a closure at run time';
+
+    lives-ok { EVAL ｢my Int @a = <1 2 3>｣ },
+        'a word list of numbers builds allomorphs an Int array accepts';
+
+    lives-ok { EVAL ｢my Str() @a = 1,2,3｣ },
+        'a coercion converts what it is given';
+
+    throws-like ｢subset S of Str; my S @a = 1,2｣,
+        X::TypeCheck, :message(&at-run-time),
+        'a subset is left alone, since checking one can have side effects';
 
     throws-like ｢my Int:D $x = "foo"｣,
         X::TypeCheck, :message(&at-run-time),
@@ -571,17 +684,49 @@ subtest 'a store the compiler cannot judge is left to the run time check' => {
         X::Hash::Store::OddNumber,
         'a hash takes a flat list of keys and values';
 
+    throws-like ｢my Str @a := 3｣,
+        X::TypeCheck::Binding,
+        'a bind is checked whole against the bind constraint';
+
     throws-like ｢sub f(Str $x) { $x = 43 }; f("a")｣,
         X::AdHoc, :message(*.contains('immutable value')),
         'a read only parameter reports the assignment rather than the value';
 
+    lives-ok { EVAL ｢my Int @a = 1, Empty, 3｣ },
+        'a value that flattens contributes its elements rather than itself';
+
+    lives-ok { EVAL ｢my Str @a = (1 if 0)｣ },
+        'a condition modifier can leave the list without that element';
+
+    lives-ok { EVAL ｢my Str @a = (1 for ^0)｣ },
+        'a loop modifier yields a list rather than the element written';
+
+    lives-ok { EVAL ｢my Int @a = (if 1 { 2 })｣ },
+        'a statement that is not an expression stores nothing this can name';
+
+    lives-ok { EVAL ｢my Array @x = [1,2],[3,4]｣ },
+        'an array composer inside a list is the one array it builds';
+
     lives-ok { EVAL ｢my Str %h = 1, "a"｣ },
         'a hash key is not a value the element type sees';
+
+    lives-ok { EVAL ｢my @l = 1; my Int $x := @l[0]; $x = "s"｣ },
+        'a bind replaces the container the declaration made';
 
     lives-ok { EVAL ｢my Str $x;
                        $x := Proxy.new(FETCH => -> $ { "a" }, STORE => -> $, $v { });
                        $x = 42｣ },
         'a bind to a proxy leaves the store to whatever the proxy does with it';
+
+    lives-ok { EVAL ｢my List @a = ((1,2); (3,4))｣ },
+        'each statement of a semicolon list is one element, taken no further apart';
+
+    lives-ok { EVAL ｢my class Coercing is Array {
+                         method STORE(\values, :$INITIALIZE) {
+                             self.Array::STORE(values.list.map(*.Int))
+                         } }
+                       my Int @a is Coercing = "5","6"｣ },
+        'a container named by the declaration brings its own STORE';
 
     lives-ok { EVAL ｢subset Nonempty of Str where *.chars;
                        sub f(Nonempty $x is copy) { $x = 1 }｣ },
@@ -589,6 +734,9 @@ subtest 'a store the compiler cannot judge is left to the run time check' => {
 
     lives-ok { EVAL ｢sub f(Str:D $x is copy) { $x = 1 }｣ },
         'a parameter type narrowed by definiteness is recorded already widened';
+
+    lives-ok { EVAL ｢sub f(Str @a is copy) { @a = 1,2 }｣ },
+        'a copied list parameter is given a container without the element type';
 
     lives-ok { EVAL ｢my List $x = (1; 2)｣ },
         'an item variable stores what a semicolon list builds, not its statements';
@@ -602,6 +750,9 @@ subtest 'a store the compiler cannot judge is left to the run time check' => {
 
     lives-ok { EVAL ｢my Str $x = Nil｣ },
         'Nil resets a container to its default rather than storing a value';
+
+    lives-ok { EVAL ｢my Int @a = 1, Nil｣ },
+        'Nil in a list resets that element rather than storing a value';
 
     throws-like ｢my Str $x = 1 + 1｣,
         X::TypeCheck, :message(&at-run-time),
@@ -623,6 +774,9 @@ subtest 'a store the compiler cannot judge is left to the run time check' => {
         X::TypeCheck::Assignment,
         message => { .contains('gimme a Wanted, not Int') and at-run-time($_) },
         'a complaint on the type is written by the run time check too';
+
+    lives-ok { EVAL ｢use TypedExports; $count = 43.5; @names = 1, 2｣ },
+        'an imported symbol answers the type of a value, not of its container';
 }
 
 # vim: expandtab shiftwidth=4

--- a/t/packages/05-messages/lib/TypedExports.rakumod
+++ b/t/packages/05-messages/lib/TypedExports.rakumod
@@ -1,0 +1,9 @@
+unit module TypedExports;
+
+# An exported variable answers the type of the value it holds, which says
+# nothing about what its container accepts.
+our $count is export = 0;
+our @names is export;
+
+# A constant is the value it stands for, wherever it is read from.
+constant Answer is export = 42;


### PR DESCRIPTION
Previously a store of a value the variable's declared type can never accept, e.g. `my Int $x = "foo"` or `my Str @a = 1,2,3`, compiled fine and only failed at run time, and only if that code was reached. The compiler already knows both the value and the type in these cases, so this makes it a compile time error on both frontends. That covers item and list variables, declaration initializers and later assignments, constants, enums, natives, and parameters that get a container of their own (`is copy`).

The check only reports when it is sure. A bind replaces the container a declaration made, so a variable a bind targets is left alone regardless of where in the unit the bind is written, and a bind through a pseudo package naming a lexical scope (`MY::<$x> := ...`, `$CALLER::x := ...`) stands the whole unit down. Subsets, roles, generics, coercion and definite types, a container with its own `STORE`, hashes, and anything whose value is not known at compile time are left to the run time check as before. There is one knowingly imprecise corner: an `is rw` parameter stores into the caller's container, which may be wider than the declared type, however `sub f(Str $x is rw) { $x = 43 }` is reported anyway since that is a bug in practically every case.

`X::Syntax::Number::LiteralType` was previously only for numeric literals into numeric natives. It is now the compile time counterpart of `X::TypeCheck::Assignment` (a subclass of it), answers `.got`, `.expected` and `.symbol`, and names a native as declared along with the type it unboxes from. The last commit removes a native subscript rule the optimize pass had of its own, since the bind mark the check leaves already covers it.
