### PR TITLE
Clean up all generated build artifacts on make clean

### DIFF
--- a/tools/templates/Makefile-backend-common.in
+++ b/tools/templates/Makefile-backend-common.in
@@ -103,6 +103,7 @@
 @bpv(CLEANUPS_ALL)@ = \
   *.manifest \
   @nfp(@bpm(BLIB_RAKUDO)@/*.@bext@)@ \
+  @nfp(@bpm(BLIB_RAKUDO_R)@/*.@bext@)@ \
   @nfp(@bpm(BLIB_RAKUDO)@/BOOTSTRAP/*.@bext@)@ \\@for_specs(
   @bsm(SETTING_@ucspec@)@ \
   CORE.@lcspec@.setting.@bext@ \)@

--- a/tools/templates/Makefile-common-rules.in
+++ b/tools/templates/Makefile-common-rules.in
@@ -16,7 +16,7 @@ spectest_update: $(SPECTEST_DATA) all
 
 realclean: clean
 	$(RM_F) Makefile config.status MANIFEST
-	$(RM_RF) @nfpl(lib/.precomp/ t/04-nativecall/.precomp/ gen/build_rakudo_home/)@
+	$(RM_RF) @nfpl(lib/.precomp/ t/04-nativecall/.precomp/)@
 
 distclean: realclean
 

--- a/tools/templates/Makefile.in
+++ b/tools/templates/Makefile.in
@@ -16,6 +16,7 @@ clean: @for_backends(@backend_prefix@-clean )@
 	$(RM_F) rakudo@runner_suffix@
 	$(RM_F) @nfp(gen/rakudo@runner_suffix@)@
 	@if(platform==windows $(RM_RF) @nfp(gen/win-runner)@ win-runner.exe-tmpl runner.obj whereami.obj)@
+	$(RM_RF) @nfp(gen/build_rakudo_home/)@
 	$(PERL5) @shquot(@script(clean-precomps.pl)@)@ @shquot(@base_dir@)@
 
 test:		@for_backends(@backend_prefix@-test$(HARNESS_TYPE) )@

--- a/tools/templates/js/Makefile.in
+++ b/tools/templates/js/Makefile.in
@@ -15,6 +15,7 @@
 	@nfp(@bpm(BLIB)@/*.js.map)@ \
 	@bpm(BLIB_RAKUDO)@/load-compiler.js \
 	@bpm(BLIB_RAKUDO)@/*.js.map \
+	@bpm(BLIB_RAKUDO_R)@/*.js.map \
 	@bpm(BLIB_RAKUDO)@/BOOTSTRAP/*.js.map
 
 # Have this target before including Makefile-backend-common to prevent the


### PR DESCRIPTION
Previously make clean removed the bytecode under blib/Perl6 but left blib/Raku in place, so Grammar and Actions survived a clean and could be picked up by a later build. CLEANUPS_ALL now covers BLIB_RAKUDO_R alongside BLIB_RAKUDO, and the js backend cleanup list gains the matching source map entry.

gen/build_rakudo_home is created by the all target and holds the RAKUDO_HOME used during the build, including its core, site and vendor precomp stores. It was only removed by realclean. It moves to clean, which realclean already runs.