### PR TITLE
Answer reductions over endless sequences

### DIFF
--- a/src/core.c/Range.rakumod
+++ b/src/core.c/Range.rakumod
@@ -415,14 +415,28 @@ my class Range is Cool does Iterable does Positional {
             True
           ),
           nqp::if(
+            # .Int hands back a Failure for an endpoint with no integer
+            # value, such as a NaN, an Inf, or a Rational with a zero
+            # denominator.  Ruling the first two out keeps that Failure from
+            # being made, and marking any other one handled keeps it off the
+            # garbage collector's report.  The bounds themselves come from
+            # .floor, which rounds down where .Int truncates towards zero.
             nqp::istype($!min,Real)
               && $!min.floor == $!min
               && nqp::istype($!max,Real)
-              && nqp::istype($!min.Int, Int)  # exclude NaN and Infs, who will fail() here
-              && nqp::istype($!max.Int, Int),
+              && nqp::isfalse(nqp::istype($!min,Num) && nqp::isnanorinf($!min))
+              && nqp::isfalse(nqp::istype($!max,Num) && nqp::isnanorinf($!max))
+              && nqp::if(
+                   nqp::isconcrete(my \low := $!min.Int) && nqp::istype(low,Failure),
+                   nqp::stmts((low.Failure::handled = True), 0),
+                   nqp::istype(low,Int))
+              && nqp::if(
+                   nqp::isconcrete(my \high := $!max.Int) && nqp::istype(high,Failure),
+                   nqp::stmts((high.Failure::handled = True), 0),
+                   nqp::istype(high,Int)),
             nqp::stmts(
               ($from = $!min.floor + $!excludes-min),
-              ($to   = $!max.floor - ($!excludes-max && $!max.Int == $!max)),
+              ($to   = $!max.floor - ($!excludes-max && high == $!max)),
               True
             ),
             False
@@ -432,10 +446,8 @@ my class Range is Cool does Iterable does Positional {
     multi method int-bounds() {
         $!is-int
           ?? ($!min + $!excludes-min, $!max - $!excludes-max)
-          !! nqp::istype($!min,Real) && $!min.floor == $!min && nqp::istype($!max,Real)
-                && nqp::istype($!min.Int, Int) # exclude NaN and Infs, who will fail() here
-                && nqp::istype($!max.Int, Int)
-            ?? ($!min.floor + $!excludes-min, $!max.floor - ($!excludes-max && $!max.Int == $!max))
+          !! self.int-bounds(my $from, my $to)
+            ?? (nqp::decont($from), nqp::decont($to))
             !! "Cannot determine integer bounds".Failure
     }
 

--- a/src/core.c/metaops.rakumod
+++ b/src/core.c/metaops.rakumod
@@ -157,6 +157,190 @@ sub METAOP_ZIP(\op, &reduce) is implementation-detail {
     )
 }
 
+# A reduction with a short-circuit operator settles on a value that no
+# further operand can change: a true value for ||/or, a false value for
+# &&/and, a defined value for //.
+my sub SETTLED-ON-TRUE(Mu \result)    is implementation-detail { result.Bool    }
+my sub SETTLED-ON-FALSE(Mu \result)   is implementation-detail { !result.Bool   }
+my sub SETTLED-ON-DEFINED(Mu \result) is implementation-detail { result.defined }
+
+# Returns the test for having settled, or the Callable type object for
+# operators that never settle.  The setting's own operators are matched by
+# address, so an operator declared elsewhere under one of these names folds
+# like any other.
+my sub REDUCE-SETTLED(\op) is implementation-detail {
+    my \candidate := nqp::decont(op);
+    nqp::eqaddr(candidate,nqp::decont(&infix:<||>))
+      || nqp::eqaddr(candidate,nqp::decont(&infix:<or>))
+      ?? &SETTLED-ON-TRUE
+      !! nqp::eqaddr(candidate,nqp::decont(&infix:<&&>))
+           || nqp::eqaddr(candidate,nqp::decont(&infix:<and>))
+        ?? &SETTLED-ON-FALSE
+        !! nqp::eqaddr(candidate,nqp::decont(&infix:<//>))
+          ?? &SETTLED-ON-DEFINED
+          !! Callable
+}
+
+# Reports whether a value is a Range that goes on producing values.  An
+# itemized argument counts as one value rather than as a sequence, so it is
+# not one of these.  Reporting itself infinite does not make a Range produce
+# anything, so the first value settles that.  The answers taken from one of
+# these assume the values a Range produces are the ones its endpoints
+# describe, so a Range producing values of its own choosing is not one.
+my sub REDUCE-ENDLESS-RANGE(Mu \value) is implementation-detail {
+    nqp::not_i(nqp::iscont(value))
+      && nqp::eqaddr(nqp::what(value),Range)
+      && nqp::isconcrete(value)
+      && value.infinite
+      && nqp::not_i(nqp::eqaddr(value.head,Nil))
+}
+
+# The settling reduction and the one for + each keep their own copy of this
+# fold: the first adds a test to the loop, and the second names its operator
+# rather than reaching it through a reference.
+my sub REDUCE-LEFT-FOLD(\op) is implementation-detail {
+    sub (+values) is raw {  # cannot be a block because of "is raw"
+        my $iterator := values.iterator;
+        nqp::if(
+          nqp::eqaddr((my $result := $iterator.pull-one),IterationEnd),
+          op.(),                         # identity
+          nqp::if(
+            nqp::eqaddr((my $value := $iterator.pull-one),IterationEnd),
+            op.($result),                # call with 1 param
+            nqp::stmts(
+              ($result := op.($result,$value)),
+              nqp::until(
+                nqp::eqaddr(($value := $iterator.pull-one),IterationEnd),
+                ($result := op.($result,$value))
+              ),
+              $result                    # final result
+            )
+          )
+        )
+    }
+}
+
+# Stops folding once the result has settled.  The test runs only after a
+# further value has been pulled, which is exactly when the operator itself
+# would have inspected the result, so a result the operator would have
+# handed back untouched stays untouched.
+my sub REDUCE-LEFT-SETTLING(\op, &settled) is implementation-detail {
+    sub (+values) is raw {  # cannot be a block because of "is raw"
+        my $iterator := values.iterator;
+        nqp::if(
+          nqp::eqaddr((my $result := $iterator.pull-one),IterationEnd),
+          op.(),                         # identity
+          nqp::if(
+            nqp::eqaddr((my $value := $iterator.pull-one),IterationEnd),
+            op.($result),                # call with 1 param
+            nqp::stmts(
+              ($result := op.($result,$value)),
+              nqp::until(
+                nqp::eqaddr(($value := $iterator.pull-one),IterationEnd)
+                  || settled($result),
+                ($result := op.($result,$value))
+              ),
+              $result                    # final result
+            )
+          )
+        )
+    }
+}
+
+my sub REDUCE-PLUS-VALUES(+values) is raw is implementation-detail {
+    my $iterator := values.iterator;
+    nqp::if(
+      nqp::eqaddr((my $result := $iterator.pull-one),IterationEnd),
+      infix:<+>(),                     # identity
+      nqp::if(
+        nqp::eqaddr((my $value := $iterator.pull-one),IterationEnd),
+        infix:<+>($result),            # call with 1 param
+        nqp::stmts(
+          ($result := infix:<+>($result,$value)),
+          nqp::until(
+            nqp::eqaddr(($value := $iterator.pull-one),IterationEnd),
+            ($result := infix:<+>($result,$value))
+          ),
+          $result                      # final result
+        )
+      )
+    )
+}
+
+# Takes the list rather than its buffer, since a raw VM array arrives as a
+# List across a Raku signature.  Callers hand over a concrete List whose
+# buffer is a flat VM array holding every value.
+my sub REDUCE-PLUS-REIFIED(\values) is raw is implementation-detail {
+    # Summing can run code that reaches the list it is summing.  Which slots
+    # are summed and what sits in each is settled here, so shortening the list
+    # cannot read past its end.  A value assigned into a container a slot
+    # already holds is still read when that slot is summed.
+    my \reified := nqp::clone(nqp::getattr(values,List,'$!reified'));
+    my int $elems = nqp::elems(reified);
+
+    # A hole warns under the name it has in its list, which pulling the
+    # values gives it and the buffer alone does not, so any hole sends the
+    # whole list to the fold that pulls.
+    my int $i = -1;
+    nqp::while(
+      nqp::islt_i(++$i,$elems)
+        && nqp::not_i(nqp::isnull(nqp::atpos(reified,$i))),
+      nqp::null
+    );
+    nqp::if(
+      nqp::islt_i($i,$elems),
+      REDUCE-PLUS-VALUES(values),
+      nqp::if(
+        $elems,
+        nqp::stmts(
+          (my $result := nqp::atpos(reified,0)),
+          nqp::if(
+            nqp::iseq_i($elems,1),
+            infix:<+>($result),        # call with 1 param
+            nqp::stmts(
+              (my int $j = 0),
+              nqp::while(
+                nqp::islt_i(++$j,$elems),
+                ($result := infix:<+>($result,nqp::atpos(reified,$j)))
+              ),
+              $result                  # final result
+            )
+          )
+        ),
+        infix:<+>()                    # identity
+      )
+    )
+}
+
+# Range.sum decides for a Range with Real endpoints that goes on producing
+# values.  Other endpoint types have no answer to take and are folded.  A sole
+# list holding nothing left to produce has its values in a buffer already, so
+# they are summed from there.  The reductions of min and max keep their own
+# copies of the probe for one, since a shared probe would cost a call where
+# most of its tests cost less.
+my sub REDUCE-LEFT-SUM(|args) is raw is implementation-detail {
+    my \list := nqp::getattr(nqp::decont(args),Capture,'@!list');
+    nqp::if(
+      nqp::not_i(nqp::isnull(list)) && nqp::iseq_i(nqp::elems(list),1),
+      nqp::if(
+        nqp::not_i(nqp::iscont(my \first := nqp::atpos(list,0)))
+          && nqp::istype(first,List)
+          && nqp::isconcrete(first)
+          && nqp::eqaddr(nqp::tryfindmethod(first,'list'),nqp::findmethod(List,'list'))
+          && nqp::not_i(nqp::isconcrete(nqp::getattr(first,List,'$!todo')))
+          && nqp::isconcrete(my \reified := nqp::getattr(first,List,'$!reified'))
+          && nqp::iseq_s(nqp::reprname(reified),'VMArray'),
+        REDUCE-PLUS-REIFIED(first),
+        nqp::if(
+          nqp::istype(first,Range)
+            && REDUCE-ENDLESS-RANGE(first)
+            && nqp::istype(first.min,Real)
+            && nqp::istype(first.max,Real),
+          first.sum,
+          REDUCE-PLUS-VALUES(|args))),
+      REDUCE-PLUS-VALUES(|args))
+}
+
 proto sub METAOP_REDUCE_LEFT(|) is implementation-detail {*}
 multi sub METAOP_REDUCE_LEFT(\op, \triangle) {
 
@@ -295,25 +479,11 @@ multi sub METAOP_REDUCE_LEFT(\op) {
 
              $result
          }
-      !! sub (+values) is raw {  # cannot be a block because of "is raw"
-             my $iterator := values.iterator;
-             nqp::if(
-               nqp::eqaddr((my $result := $iterator.pull-one),IterationEnd),
-               op.(),                         # identity
-               nqp::if(
-                 nqp::eqaddr((my $value := $iterator.pull-one),IterationEnd),
-                 op.($result),                # call with 1 param
-                 nqp::stmts(
-                   ($result := op.($result,$value)),
-                   nqp::until(
-                     nqp::eqaddr(($value := $iterator.pull-one),IterationEnd),
-                     ($result := op.($result,$value))
-                   ),
-                   $result                    # final result
-                 )
-               )
-             )
-         }
+      !! nqp::isconcrete(my \settled := REDUCE-SETTLED(op))
+        ?? REDUCE-LEFT-SETTLING(op, settled)
+        !! nqp::eqaddr(nqp::decont(op),nqp::decont(&infix:<+>))
+          ?? &REDUCE-LEFT-SUM
+          !! REDUCE-LEFT-FOLD(op)
 }
 
 proto sub METAOP_REDUCE_RIGHT(|) is implementation-detail {*}
@@ -470,6 +640,120 @@ multi sub METAOP_REDUCE_RIGHT(\op) {
     )
 }
 
+# Reports whether any value sits in the buffer as a Slip.  Takes the list
+# rather than its buffer for the reason REDUCE-PLUS-REIFIED does.
+my sub REDUCE-LIST-HOLDS-SLIP(\values) is implementation-detail {
+    my \reified := nqp::getattr(values,List,'$!reified');
+    my int $elems = nqp::elems(reified);
+    my int $i     = -1;
+    nqp::while(
+      nqp::islt_i(++$i,$elems)
+        && nqp::not_i(nqp::istype(nqp::atpos(reified,$i),Slip)),
+      nqp::null
+    );
+    nqp::islt_i($i,$elems)
+}
+
+# Spreading a pair over an argument list is what reaches the candidates the
+# operator declares for two values.  Any more reach the one candidate taking
+# them all whether spread or not, and handing them over whole is the cheaper
+# way there and carries more values than an argument list could, so only what
+# a Slip rules out is spread.  Values still producing answer neither how many
+# there are nor the operator taking them whole, and values that keep no buffer
+# of their own leave REDUCE-LIST-HOLDS-SLIP nothing to look through, so both
+# of those are spread whatever their length.  Counting the values first is
+# what fills that buffer.  min and max each keep their own copy of this
+# choice, naming their operator rather than reaching it through a reference.
+my sub REDUCE-MIN-VALUES(+values) is implementation-detail {
+    nqp::if(
+      values.is-lazy
+        || nqp::islt_i(values.elems,3)
+        || nqp::not_i(nqp::istype(values,List))
+        || REDUCE-LIST-HOLDS-SLIP(values),
+      infix:<min>(|values),
+      infix:<min>(values))
+}
+
+my sub REDUCE-MAX-VALUES(+values) is implementation-detail {
+    nqp::if(
+      values.is-lazy
+        || nqp::islt_i(values.elems,3)
+        || nqp::not_i(nqp::istype(values,List))
+        || REDUCE-LIST-HOLDS-SLIP(values),
+      infix:<max>(|values),
+      infix:<max>(values))
+}
+
+# A sole argument holding nothing left to produce keeps its values in a flat
+# buffer, and they go to the operator straight from there.  A list that
+# answers list for itself decides what its values are, so only one answering
+# it the way a List does has its buffer read.
+# A Range of Reals never steps below where it starts, so its start is the
+# smallest value it produces.  One climbing through values that are not Reals
+# can step below its start, the way a Str rolls over from z to aa, so it is
+# folded.
+my sub REDUCE-LIST-MIN(|args) is implementation-detail {
+    my \list := nqp::getattr(nqp::decont(args),Capture,'@!list');
+    nqp::if(
+      nqp::not_i(nqp::isnull(list)) && nqp::iseq_i(nqp::elems(list),1),
+      nqp::if(
+        nqp::not_i(nqp::iscont(my \first := nqp::atpos(list,0)))
+          && nqp::istype(first,List)
+          && nqp::isconcrete(first)
+          && nqp::eqaddr(nqp::tryfindmethod(first,'list'),nqp::findmethod(List,'list'))
+          && nqp::not_i(nqp::isconcrete(nqp::getattr(first,List,'$!todo')))
+          && nqp::isconcrete(my \reified := nqp::getattr(first,List,'$!reified'))
+          && nqp::iseq_s(nqp::reprname(reified),'VMArray'),
+        nqp::if(
+          nqp::islt_i(nqp::elems(reified),3)
+            || REDUCE-LIST-HOLDS-SLIP(first),
+          infix:<min>(|first),
+          infix:<min>(first)),
+        nqp::if(
+          nqp::istype(first,Range)
+            && REDUCE-ENDLESS-RANGE(first)
+            && nqp::istype(first.min,Real),
+          first.head,
+          REDUCE-MIN-VALUES(|args))),
+      REDUCE-MIN-VALUES(|args))
+}
+
+# An Int or a Rational climbs by one without bound, so a Range of either
+# towards Inf exceeds every value it produces, though one with nothing to
+# divide by stays put, which misplaces the answer only at -Inf.  A Num stops
+# climbing once a step of one is below its precision, and other values never
+# approach the Inf the endpoint names, so Ranges of all of those are folded.
+# So is one whose endpoint is a NaN, which no amount of climbing reaches.
+my sub REDUCE-LIST-MAX(|args) is implementation-detail {
+    my \list := nqp::getattr(nqp::decont(args),Capture,'@!list');
+    nqp::if(
+      nqp::not_i(nqp::isnull(list)) && nqp::iseq_i(nqp::elems(list),1),
+      nqp::if(
+        nqp::not_i(nqp::iscont(my \first := nqp::atpos(list,0)))
+          && nqp::istype(first,List)
+          && nqp::isconcrete(first)
+          && nqp::eqaddr(nqp::tryfindmethod(first,'list'),nqp::findmethod(List,'list'))
+          && nqp::not_i(nqp::isconcrete(nqp::getattr(first,List,'$!todo')))
+          && nqp::isconcrete(my \reified := nqp::getattr(first,List,'$!reified'))
+          && nqp::iseq_s(nqp::reprname(reified),'VMArray'),
+        nqp::if(
+          nqp::islt_i(nqp::elems(reified),3)
+            || REDUCE-LIST-HOLDS-SLIP(first),
+          infix:<max>(|first),
+          infix:<max>(first)),
+        nqp::if(
+          nqp::istype(first,Range)
+            && REDUCE-ENDLESS-RANGE(first)
+            && (nqp::istype((my \low := first.min),Int)
+                  || nqp::istype(low,Rational))
+            && low != -Inf
+            && nqp::istype((my \high := first.max),Real)
+            && high == Inf,
+          Inf,
+          REDUCE-MAX-VALUES(|args))),
+      REDUCE-MAX-VALUES(|args))
+}
+
 proto sub METAOP_REDUCE_LIST(|) is implementation-detail {*}
 multi sub METAOP_REDUCE_LIST(\op, \triangle) {
 
@@ -505,8 +789,14 @@ multi sub METAOP_REDUCE_LIST(\op, \triangle) {
         Seq.new: nqp::create(TriangleList).SET-SELF(op, values)
     }
 }
+
 multi sub METAOP_REDUCE_LIST(&op) {
-    -> +values { op(|values) }
+    my \candidate := nqp::decont(&op);
+    nqp::eqaddr(candidate,nqp::decont(&infix:<min>))
+      ?? &REDUCE-LIST-MIN
+      !! nqp::eqaddr(candidate,nqp::decont(&infix:<max>))
+        ?? &REDUCE-LIST-MAX
+        !! -> +values { op(|values) }
 }
 
 proto sub METAOP_REDUCE_LISTINFIX(|) is implementation-detail {*}

--- a/t/02-rakudo/range-int-bounds-failure.t
+++ b/t/02-rakudo/range-int-bounds-failure.t
@@ -1,0 +1,107 @@
+use lib 't/packages/Test-Helpers';
+use Test;
+use Test::Helpers;
+
+plan 16;
+
+# Asking a Range for integer bounds can reach .Int on an endpoint that has no
+# integer value, and .Int hands back a Failure for those.  The garbage collector
+# is what reports a Failure nothing marks handled, so each of these needs enough
+# iterations to collect what its loop discards.
+
+# .sum reaches the candidate taking two arguments.  An Inf endpoint is ruled out
+# before .Int is asked, and a NaN low endpoint fails the test for being its own
+# floor before that.
+is-run 'for ^5000 { my $ignored = (0..Inf).sum }; print "done"',
+  :out<done>,
+  'a high endpoint of Inf leaves no unhandled Failure behind';
+
+is-run 'for ^5000 { my $ignored = (-Inf..0).sum }; print "done"',
+  :out<done>,
+  'a low endpoint of -Inf leaves no unhandled Failure behind';
+
+# Range.minmax reaches the candidate taking no arguments, but only where the
+# bounds are already integers, so drive its guard directly.  .sum reaches a NaN
+# high endpoint but never returns for one, so drive that directly too.  The
+# argless candidate returns a Failure by contract.  Marking that one handled
+# leaves stderr carrying only what nothing accounted for.
+is-run 'for ^5000 {
+            my $a; my $b; (0..NaN).int-bounds($a, $b);
+            my $ignored = (0..Inf).int-bounds; $ignored.defined;
+        }; print "done"',
+  :out<done>,
+  'a NaN endpoint and the argless bounds leave no unhandled Failure behind';
+
+# An endpoint with no integer value need not be an Inf or a NaN.  A Rational
+# with nothing to divide by reaches .Int as well.
+is-run 'for ^5000 { my $ignored = (0..<1/0>).sum }; print "done"',
+  :out<done>,
+  'a Rational endpoint with a zero denominator leaves no unhandled Failure behind';
+
+is-run 'for ^5000 { my $ignored = (0..<1/0>).int-bounds; $ignored.defined }; print "done"',
+  :out<done>,
+  'the argless bounds of a Rational with a zero denominator leave nothing behind';
+
+# The bounds a Range reports are values rather than the containers they were
+# written through.
+{
+    my $bounds := (0e0..3e0).int-bounds;
+    dies-ok { $bounds[0] = 99 }, 'a Range of Nums reports bounds that cannot be written to';
+}
+
+# An endpoint that is not an integer still has integer bounds to read, and the
+# guard against a Failure has to leave those alone.
+is-deeply (0e0..3e0).int-bounds, (0, 3), 'a Range of Nums reads its integer bounds';
+is (0e0..3e0).sum, 6, 'a Range of Nums sums its values through its integer bounds';
+is (2e0^..^5e0).sum, 7, 'a Range of Nums excluding both ends sums its values';
+is-deeply (0..<7/2>).int-bounds, (0, 3), 'a Range ending at a Rational reads its integer bounds';
+{
+    my $from; my $to;
+    ok (0e0..3e0).int-bounds($from, $to), 'a Range of Nums reports having integer bounds';
+    is-deeply ($from, $to), (0, 3), 'a Range of Nums writes its integer bounds';
+}
+
+# The argless candidate reaches .Int for a Rational with a zero denominator, and
+# has to report having no bounds rather than let that Failure escape.
+{
+    my $bounds := (0..<1/0>).int-bounds;
+    is $bounds.exception.message, 'Cannot determine integer bounds',
+      'a Range ending at a Rational with a zero denominator reports no bounds';
+    $bounds.so;
+}
+
+# .Int may answer a Failure that is a type object, which has no handled flag to
+# set.  Ruling that out is what leaves the endpoint reported as having no
+# integer bounds rather than throwing.
+{
+    my class NoIntType does Real {
+        method Int()    { Failure }
+        method floor()  { 2       }
+        method Bridge() { 2e0     }
+    }
+    my $bounds := Range.new(NoIntType.new, 5).int-bounds;
+    is $bounds.exception.message, 'Cannot determine integer bounds',
+      'a Range whose endpoint answers .Int with a Failure type object reports no bounds';
+    $bounds.so;
+    my $from; my $to;
+    nok Range.new(NoIntType.new, 5).int-bounds($from, $to),
+      'a Range whose endpoint answers .Int with a Failure type object reports having none';
+}
+
+# An endpoint that answers .Int for itself reaches the marking at both endpoints
+# and through both candidates, which no Range of setting types does.
+is-run 'my class Unmarked is Failure { method Bool() { True } }
+        my class NoInt does Real {
+            method Int()    { Unmarked.new(X::AdHoc.new(payload => "no integer value")) }
+            method floor()  { self }
+            method Bridge() { 0e0 }
+        }
+        for ^5000 {
+            my $a; my $b; Range.new(NoInt.new, 5).int-bounds($a, $b);
+            my $ignored = Range.new(0, NoInt.new).int-bounds; $ignored.defined;
+        }
+        print "done"',
+  :out<done>,
+  'an endpoint answering .Int for itself leaves nothing behind at either end';
+
+# vim: expandtab shiftwidth=4

--- a/t/02-rakudo/reduce-endless-sequence.t
+++ b/t/02-rakudo/reduce-endless-sequence.t
@@ -1,0 +1,464 @@
+use Test;
+
+plan 142;
+
+# Reductions that already have their answer must not keep walking the values.
+# A short-circuit operator has one as soon as its result settles, and a Range
+# that goes on producing values has one for the operators that know it.
+
+# --- folding that reaches the end -------------------------------------------
+
+is ([||] 0, 0, 5, 7), 5, '[||] returns the first true value';
+is ([||] Nil, 0, ""), "", '[||] with no true value returns the last one';
+is ([||] 5), 5, '[||] on a single value returns that value';
+is-deeply ([||]), False, '[||] with no values returns False';
+
+is ([&&] 1, 2, 3), 3, '[&&] with no false value returns the last one';
+is ([&&] 1, 0, 3), 0, '[&&] returns the first false value';
+is-deeply ([&&]), True, '[&&] with no values returns True';
+
+is ([//] Nil, 7, 9), 7, '[//] returns the first defined value';
+is-deeply ([//]), Any, '[//] with no values returns Any';
+
+is ([+] 1..5), 15, '[+] on a bounded Range sums its values';
+is ([+] 1, 2, 3), 6, '[+] on separate values sums them';
+is ([+] ()), 0, '[+] with no values returns the identity';
+is ([+] (7,)), 7, '[+] on a sole List of one value returns that value';
+is ([+] (3, 4)), 7, '[+] on a sole List of two values sums them';
+is ([+] (3, 4, 5)), 12, '[+] on a sole List of three values sums them';
+{
+    my @two = 3, 4;
+    is ([+] @two), 7, '[+] on an Array of two values sums them';
+}
+{
+    my @counted = 3, 4, 5;
+    @counted.elems;
+    is ([+] @counted), 12, '[+] on an Array of values it has counted sums them';
+}
+is ([min] (3, 1, 2)), 1, '[min] on a sole List returns the smallest';
+is ([max] (3, 1, 2)), 3, '[max] on a sole List returns the largest';
+is-deeply ([min] (1, 1.0)), 1.0, '[min] on a sole List of a pair applies the operator to a pair';
+{
+    my @spoken = 1, 2, 3;
+    @spoken.elems;
+    @spoken does role { method list() { (100, 200) } };
+    is ([+] @spoken), 300, '[+] on a list that answers list for itself takes that answer';
+    is ([min] @spoken), 100, '[min] on a list that answers list for itself takes that answer';
+    is ([max] @spoken), 200, '[max] on a list that answers list for itself takes that answer';
+}
+{
+    my @pair = 5, 6;
+    @pair.elems;
+    @pair does role { method list() { (100, 200) } };
+    is ([min] @pair), 100, '[min] on a pair answering list for itself takes that answer';
+    is ([max] @pair), 200, '[max] on a pair answering list for itself takes that answer';
+}
+
+# A list holding values it has yet to produce keeps only some of them in its
+# buffer, so reading that buffer alone would answer from a part of the list.
+{
+    my \partial = (gather { take 5; take 3; take 9 }).List;
+    partial[0];
+    is ([+] partial), 17, '[+] on a list still producing values sums the ones it has yet to produce';
+}
+{
+    my \pending = (1..70000).reverse.map({ $_ }).List;
+    pending[0];
+    is ([min] pending), 1, '[min] on a list still producing values reaches the ones it has yet to produce';
+}
+{
+    my \pending = (1..70000).map({ $_ }).List;
+    pending[0];
+    is ([max] pending), 70000, '[max] on a list still producing values reaches the ones it has yet to produce';
+}
+
+# A Slip stands for the values it holds once it reaches an argument list, so a
+# list holding one goes to the operator spread however long it is.
+{
+    my @three = 1, 2, 3;   @three[0] = (7, 1).Slip;
+    is ([min] @three), 1, '[min] on three values holding a Slip reads the values it holds';
+    is ([max] @three), 7, '[max] on three values holding a Slip reads the values it holds';
+}
+{
+    my @empty = 1, 2, 3;
+    @empty[0] = Empty;
+    is ([min] @empty), 2, '[min] on values holding a Slip of nothing passes it over';
+}
+{
+    my @counted = 1, 2, 3;
+    @counted.elems;
+    @counted[2] = (0, 9).Slip;
+    is ([min] @counted), 0,
+      '[min] on counted values holding a Slip after the first reads the values it holds';
+    is ([max] @counted), 9,
+      '[max] on counted values holding a Slip after the first reads the values it holds';
+}
+{
+    my @shaped[3] = 1, 2, 3;
+    @shaped[0] = (7, 1).Slip;
+    is ([min] @shaped), 1, '[min] on a shaped array holding a Slip reads the values it holds';
+}
+
+# A Slip is spread however many values are alongside it, so more of them than
+# an argument list carries reports that rather than counting the Slip as one.
+{
+    my @big[70000];
+    @big = 1..70000;
+    @big[500] = (99999, 4).Slip;
+    dies-ok { [max] @big },
+      '[max] on more values than an argument list holds spreads a Slip among them';
+}
+{
+    my @slipped = 1, 2, 3;
+    @slipped[0] = (7, 1).Slip;
+    is ([min] @slipped.Seq), 1, '[min] on pulled values holding a Slip reads the values it holds';
+}
+{
+    my @slipped = 1, 2, 3;
+    @slipped[0] = (7, 1).Slip;
+    is ([max] @slipped.Seq), 7, '[max] on pulled values holding a Slip reads the values it holds';
+}
+
+{
+    my $itemized = (30, 40);
+    is-deeply ([+] $itemized), 2, '[+] on an itemized List counts it as one value';
+    is-deeply ([min] $itemized), (30, 40), '[min] on an itemized List returns that List';
+    is-deeply ([max] $itemized), (30, 40), '[max] on an itemized List returns that List';
+}
+{
+    my $itemized = [30, 40];
+    is-deeply ([+] $itemized), 2, '[+] on an itemized Array counts it as one value';
+}
+
+# A hole in a list warns under the name it has there, which pulling the
+# values gives it.
+{
+    my @holed;
+    @holed[3] = 5;
+    my @warnings;
+    my $sum = do {
+        CONTROL { when CX::Warn { @warnings.push(.message); .resume } }
+        [+] @holed;
+    };
+    is $sum, 5, '[+] on an Array with holes sums the values it does hold';
+    like @warnings[0], /'@holed[0]'/,
+      '[+] on an Array with holes warns under the name a hole has in its list';
+}
+{
+    my @gapped = 1, 2;
+    @gapped[4] = 5;
+    @gapped.elems;
+    my @warnings;
+    my $sum = do {
+        CONTROL { when CX::Warn { @warnings.push(.message); .resume } }
+        [+] @gapped;
+    };
+    is $sum, 8, '[+] on an Array whose holes follow its values sums the values it holds';
+    like @warnings[0], /'@gapped[2]'/,
+      '[+] on an Array whose holes follow its values names the first of them';
+}
+
+# Summing a list can run code that shortens that same list, and the slots
+# summed are the ones it held when the summing started.  Asking for the count
+# first puts the values where that reading of them applies.
+{
+    my @shrinking;
+    my class Shrinker { method Numeric() { @shrinking.pop; @shrinking.pop; 1 } }
+    @shrinking = Shrinker.new, Shrinker.new, 5, 6, 7;
+    @shrinking.elems;
+    is ([+] @shrinking), 20, '[+] on an Array that shortens as it sums holds on to its values';
+}
+
+{
+    my @none = ();
+    is ([+] @none), 0, '[+] on an Array of no values returns the identity';
+}
+is ([min] ()), Inf, '[min] on a sole List of no values returns the identity of min';
+is ([max] ()), -Inf, '[max] on a sole List of no values returns the identity of max';
+is ([min] (7,)), 7, '[min] on a sole List of one value returns that value';
+is ([max] (7,)), 7, '[max] on a sole List of one value returns that value';
+is ([min] 3, 1, 2), 1, '[min] on separate values returns the smallest';
+is ([max] 3, 1, 2), 3, '[max] on separate values returns the largest';
+is ([min] 1..5), 1, '[min] on a bounded Range returns the smallest';
+is ([max] 1..5), 5, '[max] on a bounded Range returns the largest';
+is ([max] my @long = ^100000), 99999, '[max] on more values than an argument list holds works';
+
+# More values than an argument list holds are handed to the operator whole.
+is ([min] 1..100000), 1, '[min] on more values than an argument list holds works';
+is ([max] 1..100000), 100000, '[max] on more values than an argument list holds works';
+is ([min] my @big = ^100000), 0, '[min] on a long Array works';
+dies-ok { [min] (1..70000).Seq },
+  '[min] on more values than an argument list holds pulled one at a time reports that limit';
+dies-ok { [max] (1..70000).Seq },
+  '[max] on more values than an argument list holds pulled one at a time reports that limit';
+is ([min] (3, 1, 2).lazy), 1, '[min] on a lazy list works';
+is ([max] (3, 1, 2).lazy), 3, '[max] on a lazy list works';
+
+# Two values reach the candidates the operator declares for a pair, which answer
+# a tie with the second.  More reach the candidate taking them all, which answers
+# a tie with the first.
+is-deeply ([min] 1, 1.0), 1.0, '[min] on a pair applies the operator to a pair';
+is-deeply ([max] 1, 1.0), 1.0, '[max] on a pair applies the operator to a pair';
+is-deeply ([min] 1, 1.0, 2), 1, '[min] on three values hands them over at once';
+is-deeply ([max] 1, 1.0, 0), 1, '[max] on three values hands them over at once';
+
+# --- operators of the same name declared in scope ---------------------------
+
+# The answers above belong to the setting's operators, which are matched by
+# address.
+# An operator declared in scope must fold like any other.
+{
+    my sub infix:<+>(\a, \b) { a * b }
+    is ([+] 1..4), 24, '[+] on a + declared in scope folds with that operator';
+}
+{
+    my sub infix:<||>(\a, \b) { a + b }
+    is ([||] 1, 2, 3), 6, '[||] on a || declared in scope folds with that operator';
+}
+{
+    my sub infix:<&&>(\a, \b) { a - b }
+    is ([&&] 1, 1, 5), -5, '[&&] on an && declared in scope folds with that operator';
+}
+{
+    my sub infix:<//>(\a, \b) { a + b }
+    is ([//] 1, 2, 3), 6, '[//] on a // declared in scope folds with that operator';
+}
+{
+    my sub infix:<or>(\a, \b) { a + b }
+    is ([or] 1, 2, 3), 6, '[or] on an or declared in scope folds with that operator';
+}
+{
+    my sub infix:<and>(\a, \b) { a - b }
+    is ([and] 1, 1, 5), -5, '[and] on an and declared in scope folds with that operator';
+}
+# A list-associative reduction hands every value over at once, so these need
+# to accept them all.
+{
+    my sub infix:<min>(|c) { c.elems }
+    is ([min] 1, 2, 3), 3, '[min] on a min declared in scope hands it the values apart';
+}
+{
+    my sub infix:<max>(|c) { c.elems }
+    is ([max] 1, 2, 3), 3, '[max] on a max declared in scope hands it the values apart';
+}
+
+# --- values the operator alone may inspect ----------------------------------
+
+# A reduction of one value never applies the operator to a pair, so nothing
+# may ask that value whether it is true.
+{
+    my $calls = 0;
+    my class Counted { method Bool() { $calls++; True } }
+    my $ignored := ([||] Counted.new);
+    is $calls, 0, '[||] on a single value does not ask it whether it is true';
+}
+{
+    my $calls = 0;
+    my class Counted { method Bool() { $calls++; False } }
+    my $ignored := ([||] Counted.new, Counted.new, Counted.new);
+    is $calls, 3, '[||] asks a result it does not settle on once per further value';
+}
+
+# Asking a Failure whether it is defined marks it handled, which suppresses
+# the error it carries.
+{
+    sub risky() { fail "boom" }
+    my $result := ([//] Nil, risky());
+    my $handled = $result.handled;
+    $result.so;                      # mark it, so it stays quiet at exit
+    is-deeply $handled, False, '[//] leaves a Failure result unhandled';
+}
+{
+    sub risky() { fail "boom" }
+    my $threw;
+    { sink ([||] risky()); CATCH { default { $threw = $_ } } }
+    is $threw.?message, 'boom', '[||] on a lone Failure still throws where the result is used';
+}
+
+# The test for having settled takes a result of any type.  One standing for
+# several answers it for all of them at once, so a true one settles || and
+# leaves && unsettled.
+is ([//] Mu, Mu, 3, Mu, 5), 3, '[//] carries a Mu result through to a defined one';
+is ([||] Mu, Mu, 0, 3, Mu, 5), 3, '[||] carries a Mu result through to a true one';
+is-deeply ([&&] Mu, Mu, 0, 3, Mu, 5), Mu, '[&&] on values starting with Mu returns Mu';
+is ([&&] 1, (0|1), 5), 5, '[&&] does not settle on a Junction that is not all false';
+
+# --- Ranges that produce values of their own choosing -----------------------
+
+# The answers read off the endpoints belong to the values a Range produces for
+# itself, so one that produces others is folded like any other list.
+{
+    my \spoken = (1..Inf) but role { method iterator() { (9, 8, 7).iterator } };
+    is ([min] spoken), 7, '[min] on a Range producing its own values returns their smallest';
+    is ([max] spoken), 9, '[max] on a Range producing its own values returns their largest';
+    is ([+] spoken), 24, '[+] on a Range producing its own values sums them';
+}
+{
+    my $both = -Inf..Inf;
+    is ([+] $both), Inf, '[+] on an itemized Range counts it as one value';
+}
+
+# --- Ranges that report themselves infinite but produce nothing -------------
+
+is ([+] Inf..Inf), 0, '[+] on an empty Range returns the identity of +';
+is ([min] NaN..5), Inf, '[min] on a Range starting at NaN returns the identity of min';
+is ([max] NaN..Inf), -Inf, '[max] on a Range starting at NaN returns the identity of max';
+is ([min] Inf^..Inf), Inf, '[min] on an empty Range excluding its start returns the identity';
+
+# An undefined list has no values to read and no buffer to look at.
+{
+    my @warnings;
+    my $sum = do {
+        CONTROL { when CX::Warn { @warnings.push(.message); .resume } }
+        [+] Array;
+    };
+    is $sum, 0, '[+] on an undefined Array returns the identity';
+    like @warnings[0], /'uninitialized value'/,
+      '[+] on an undefined Array warns that it has no values';
+}
+is ([min] List), Inf, '[min] on an undefined List returns the identity of min';
+
+# A shaped array keeps its values in a buffer of its own kind, which no
+# reduction reads.
+{
+    my @shaped[2;2] = (1,2),(3,4);
+    is ([+] @shaped), 10, '[+] on a shaped array sums its values';
+    is ([min] @shaped), 1, '[min] on a shaped array returns the smallest';
+    is ([max] @shaped), 4, '[max] on a shaped array returns the largest';
+}
+
+# --- an itemized argument counts as one value -------------------------------
+
+{
+    my $endless = 1..Inf;
+    is-deeply ([min] $endless), (1..Inf), '[min] on an itemized Range returns that Range';
+    is-deeply ([max] $endless), (1..Inf), '[max] on an itemized Range returns that Range';
+}
+is-deeply ([min] $(1..Inf)), (1..Inf), '[min] on an itemized Range term returns that Range';
+
+# --- an undefined Range has no endpoints to read ----------------------------
+
+is ([min] Range), Inf, '[min] on an undefined Range returns the identity of min';
+is ([max] Range), -Inf, '[max] on an undefined Range returns the identity of max';
+{
+    my Range $unset;
+    is ([min] $unset), Inf, '[min] on an itemized undefined Range returns the identity';
+}
+
+# --- values that never run out ----------------------------------------------
+
+# Each reduction below answers without reaching the end of its values, so a
+# fault here is an endless loop.  Run them apart from the main thread, and
+# report both a timeout and a throw, since neither shows up on its own.
+my Bool $complete = False;
+my $work = start {
+    is ([||] flat(0, 0, 5, 1..Inf)), 5,
+      '[||] on endless values returns the first true one';
+    is ([||] flat(0, (0|1), 1..Inf)).gist, 'any(0, 1)',
+      '[||] settles on a Junction that is not all false';
+    is ([or] flat(0, 0, 5, 1..Inf)), 5,
+      '[or] on endless values returns the first true one';
+    is ([||] flat(5, 1..Inf)), 5,
+      '[||] settles on a first value that is already true';
+    is ([&&] flat(1, 0, 1..Inf)), 0,
+      '[&&] on endless values returns the first false one';
+    is ([and] flat(1, 0, 1..Inf)), 0,
+      '[and] on endless values returns the first false one';
+    is ([//] flat(Nil, 7, 1..Inf)), 7,
+      '[//] on endless values returns the first defined one';
+    is ([//] flat(Nil, 0, 1..Inf)), 0,
+      '[//] settles on a defined value that is false';
+
+    # The value that settles the result is pulled, then one more, which is
+    # what tells the reduction the result is not the last value.
+    {
+        my $pulled = 0;
+        my $values := lazy gather {
+            for flat(0, 7, 1..Inf) { $pulled++; take $_ }
+        }
+        is ([||] $values), 7, '[||] returns the value it settled on';
+        is $pulled, 3, '[||] pulls one value past the one it settled on';
+    }
+    {
+        my $pulled = 0;
+        my $values := lazy gather {
+            for flat(1, 0, 1..Inf) { $pulled++; take $_ }
+        }
+        is ([&&] $values), 0, '[&&] returns the value it settled on';
+        is $pulled, 3, '[&&] pulls one value past the one it settled on';
+    }
+
+    is ([+] 0..Inf), Inf, '[+] on a Range without an end returns Inf';
+    is ([+] 1..*), Inf, '[+] on a Range ending in Whatever returns Inf';
+    is ([+] 0^..Inf), Inf, '[+] on an endless Range excluding its start returns Inf';
+    is ([+] -Inf..0), -Inf, '[+] on a Range starting at -Inf returns -Inf';
+    is ([+] -Inf..Inf), NaN, '[+] on a Range unbounded both ways returns NaN';
+    is ((0..Inf).reduce(&[+])), Inf, '.reduce(&[+]) on an endless Range returns Inf';
+
+    # Only a Range of Reals has a sum to take.  Anything else has to fold, so
+    # that the operator raises what it raises on a bounded Range of the same.
+    {
+        my $threw;
+        { my $ignored = [+] 'a'..*; CATCH { default { $threw = $_ } } }
+        isa-ok $threw, X::Str::Numeric,
+          "[+] on an endless Range of strings raises the operator's error";
+    }
+
+    is ([min] 0..Inf), 0, '[min] on a Range without an end returns the smallest value it produces';
+    is ([min] 0^..Inf), 1,
+      '[min] on an endless Range excluding its start skips that start';
+    is ([min] 0..NaN), 0, '[min] on a Range ending at NaN returns the smallest value it produces';
+    is-deeply ([min] -Inf..0), -Inf, '[min] on a Range starting at -Inf returns the smallest value it produces';
+    is-deeply ([min] 1.5..Inf), 1.5, '[min] on an endless Range of Rationals returns the smallest value it produces';
+    is ([max] 1.5..Inf), Inf, '[max] on an endless Range of Rationals returns Inf';
+
+    # A Range of Strs climbs through .succ, which rolls past the last letter
+    # and reaches values below its start, so its start is not the smallest
+    # value it produces.
+    is ('y'..*).min, 'y', 'a Range of Strs reports a start that is not its smallest value';
+    is ('y'..*).head(4).List.min, 'aa', 'a Range of Strs reaches values below its start';
+
+    # A Num stops climbing once a step of one is below its precision, and a
+    # Rational with nothing to divide by never climbs at all.
+    ok (2e0 ** 53).succ == 2e0 ** 53, 'a Num at the width of its kind does not climb';
+    ok <-1/0> + 1 == <-1/0>, 'a Rational with a zero denominator does not climb';
+
+    # A Whatever endpoint reports a Range infinite whatever its start, so one
+    # starting at a value that climbs its own way is folded, where its climb
+    # runs out loudly rather than answering from an endpoint.
+    {
+        my class Climb {
+            has $.n;
+            method succ() { $!n >= 3 ?? die "climbed off" !! Climb.new(n => $!n + 1) }
+        }
+        throws-like { [min] Climb.new(n => 1)..* }, X::AdHoc, message => 'climbed off',
+          '[min] on an endless Range of values that climb their own way reads the values';
+        throws-like { [max] Climb.new(n => 1)..* }, X::AdHoc, message => 'climbed off',
+          '[max] on an endless Range of values that climb their own way reads the values';
+    }
+
+    # Folding an endless Range with a scoped operator reaches that operator on
+    # the first pair, where taking Range.sum would never reach it at all.
+    {
+        my sub infix:<+>(\a, \b) { die "scoped + folded" }
+        my $folded = False;
+        { my $ignored = [+] 0..Inf; CATCH { default { $folded = .message eq "scoped + folded" } } }
+        ok $folded, '[+] on a + declared in scope folds an endless Range with that operator';
+    }
+    is ([max] 0..Inf), Inf, '[max] on a Range without an end returns Inf';
+    is ([max] 1..*), Inf, '[max] on a Range ending in Whatever returns Inf';
+    is ((0..Inf).reduce(&[min])), 0, '.reduce(&[min]) on an endless Range returns the smallest value it produces';
+    is ((0..Inf).reduce(&[max])), Inf, '.reduce(&[max]) on an endless Range returns Inf';
+    is (flat(0, 0, 5, 1..Inf).reduce(&[||])), 5,
+      '.reduce(&[||]) on endless values returns the first true one';
+
+    is-deeply ([\+] 1..Inf).head(3).List, (1, 3, 6),
+      '[\+] on a Range without an end stays lazy';
+
+    $complete = True;
+};
+await Promise.anyof($work, Promise.in(60));
+diag "reduction threw: {$work.cause.gist}" if $work.status ~~ Broken;
+ok $complete, 'every reduction over endless values finished';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously a reduction folded its values one at a time until they ran out, so a reduction over values that never run out never returned. Some reductions have their answer well before the end, and this teaches them to take it.

    say [+] 0..Inf;                  # Inf   (previously never returned)
    say [min] 0..Inf;                # 0
    say [max] 0..Inf;                # Inf
    say [||] flat(0, 0, 5, 1..Inf);  # 5
    say [min] 1..1000000;            # 1     (previously "argument lists are limited to 65535")

Two independent mechanisms do the work.

**Short-circuit operators settle.** `[||]` and `[or]` stop folding once the result is true, `[&&]` and `[and]` once it is false, `[//]` once it is defined. This works on any sequence, not just Ranges. The settle test runs only after a further value has been pulled, which is exactly when the operator itself would have inspected the result, so a Failure the fold would have left unhandled stays unhandled and a Junction result comes through untouched.

**Endless Ranges answer from their endpoints.** `[+]` takes the answer `Range.sum` gives. `[min]` takes the first value produced. `[max]` is `Inf` for a Range climbing towards `Inf`. These answers are taken only where the values are known to back them. The Range must be exactly `Range`, so a subclass or mixin producing its own values folds. The start must be a type whose stepping is known: an `Int` or `Rational` climbs by one without bound, while a `Num` stops climbing once a step of one is below its precision and a `Str` rolls over past `z` to `aa`, producing values below its start, so those fold like before.

Keeping the endless check off the common path led to a direct route for the most common argument, a sole fully reified list, and two things fell out of it.

Performance, against the same tree without this change: `[min] $a, $b` about 2.2x faster, `[+] $a, $b` about 3.6x, `[+]` over ten values about 5x, `[min]`/`[max]` over a hundred values about 20% faster, `[min] 1..100` about 50% faster.

The argument list limit. `[min]`, `[max]` and `[+]` over more values than an argument list holds previously died with the 65535 limit error. A fully reified list is now handed to the operator whole, so they answer. A `Slip` among the values still stands for what it holds, so a list holding one keeps spreading, and values still being produced keep pulling, exactly as before.

The first commit is a prerequisite. Summing an endless Range asks `int-bounds` about endpoints with no integer value, and the Failure that produced was never marked handled, so the garbage collector reported it at exit. `Inf` and `NaN` endpoints are now ruled out before `.Int` is asked, and anything else that fails there is marked handled.

`[*]`, `[~]`, `[,]` and the list-associative short-circuits like `[orelse]` still fold forever over endless values. They have no answer to take before the end.

Fixes #1210 
