### PR TITLE
Fold the plus reduction over bare values

### DIFF
--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -1805,8 +1805,12 @@ class RakuAST::Node {
             ?? $decl.compile-time-value
             !! $decl.maybe-compile-time-value;
         return 0 unless nqp::isconcrete($routine);
+        # The check fails open like the other soft guards. A Code that
+        # cannot answer soft cannot be wrapped either, and the
+        # published method cache of a mixin type in the setting under
+        # compilation can miss the methods the setting itself adds.
         if nqp::istype($routine, Code) {
-            return 0 unless nqp::can($routine, 'soft') && !$routine.soft;
+            return 0 if nqp::can($routine, 'soft') && $routine.soft;
         }
 
         # The nearest scope declaring the name must be the outermost one, and

--- a/src/core.c/metaops.rakumod
+++ b/src/core.c/metaops.rakumod
@@ -293,7 +293,14 @@ my sub REDUCE-PLUS-REIFIED(\values) is raw is implementation-detail {
       nqp::if(
         $elems,
         nqp::stmts(
-          (my $result := nqp::atpos(reified,0)),
+          # Without the deconts the accumulator would start as the slot's
+          # container while every later iteration rebinds it to the
+          # operator's bare return, and a stored value would arrive as
+          # whatever its slot holds, so the operator's callsite would
+          # keep several shapes live. Bare values keep it to one shape,
+          # and no candidate of the plus operator writes to its
+          # arguments.
+          (my $result := nqp::decont(nqp::atpos(reified,0))),
           nqp::if(
             nqp::iseq_i($elems,1),
             infix:<+>($result),        # call with 1 param
@@ -301,7 +308,7 @@ my sub REDUCE-PLUS-REIFIED(\values) is raw is implementation-detail {
               (my int $j = 0),
               nqp::while(
                 nqp::islt_i(++$j,$elems),
-                ($result := infix:<+>($result,nqp::atpos(reified,$j)))
+                ($result := infix:<+>($result,nqp::decont(nqp::atpos(reified,$j))))
               ),
               $result                  # final result
             )

--- a/t/02-rakudo/reduce-endless-sequence.t
+++ b/t/02-rakudo/reduce-endless-sequence.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 142;
+plan 151;
 
 # Reductions that already have their answer must not keep walking the values.
 # A short-circuit operator has one as soon as its result settles, and a Range
@@ -460,5 +460,40 @@ my $work = start {
 await Promise.anyof($work, Promise.in(60));
 diag "reduction threw: {$work.cause.gist}" if $work.status ~~ Broken;
 ok $complete, 'every reduction over endless values finished';
+
+# The plus fast path starts its fold on a bare accumulator, while the
+# generic path hands the operator the list's own containers, since an
+# operator writing to its first value must reach the real container.
+{
+    my sub infix:<mut>($a is rw, $b) is raw { $a = $a + $b }
+    my @accumulated = 1, 2, 3;
+    is ([[&infix:<mut>]] @accumulated), 6,
+      'a reduction with an operator writing to its first value folds through it';
+    is-deeply @accumulated, [6, 2, 3],
+      'a reduction with an operator writing to its first value writes into that value';
+}
+is-deeply ([+] (1, 2.5, 3e0)), 6.5e0,
+  '[+] on a sole List of mixed numeric types sums through each type';
+{
+    my @one = (my $ = 5),;
+    is ([+] @one), 5,
+      '[+] over a single stored value gives that value';
+    ok !(([+] @one) =:= @one[0]),
+      'the single value result is a bare value, not the stored container';
+}
+is-deeply ([+] ("5",)), 5,
+  '[+] over a single stored string applies the operator, numifying it';
+is-deeply ([+] (1, |(2, 3),)), 6,
+  '[+] over slipped values sums through the pulling fold';
+{
+    my @slipped = 1, 2, 3;
+    @slipped[0] = (7, 1).Slip;
+    is ([+] @slipped), 7,
+      '[+] takes a Slip stored in the first slot as one seed value';
+    my @tail = 1, 2, 3;
+    @tail[1] = (7, 1).Slip;
+    is ([+] @tail), 6,
+      '[+] adds a Slip stored in a later slot as one value';
+}
 
 # vim: expandtab shiftwidth=4

--- a/t/08-performance/18-rakuast-callstatic.t
+++ b/t/08-performance/18-rakuast-callstatic.t
@@ -3,7 +3,7 @@ use Test::Helpers::QAST;
 use Test;
 use QAST:from<NQP>;
 use nqp;
-plan 40;
+plan 43;
 
 # A call to a named setting routine compiles its callee lookup as a static
 # one, which the VM may resolve a single time. So does a call to a routine
@@ -120,9 +120,24 @@ if nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' {
     qast-is 'use soft; my $x = 5; my $y = -$x', -> \v {
         not qast-op-named(v, 'callstatic', '&prefix:<->')
     }, 'a setting prefix under the soft pragma keeps the plain callee lookup';
+    qast-is 'sub sfoo() { 1 }; BEGIN &sfoo does role { method soft(--> True) { } }; sfoo()', :full, -> \v {
+        not qast-op-named(v, 'callstatic', '&sfoo')
+    }, 'a call to a routine marked soft keeps the plain callee lookup';
 }
 else {
-    skip 'the soft shape is specific to the RakuAST frontend', 1;
+    skip 'the soft shape is specific to the RakuAST frontend', 2;
+}
+
+# A routine marked soft promises late rebinding, so a wrapper
+# installed at runtime must take effect at a call site compiled
+# before it.
+{
+    sub swrapped() { 1 }
+    BEGIN &swrapped does role { method soft(--> True) { } };
+    is swrapped(), 1, 'a routine marked soft runs normally before any wrap';
+    &swrapped.wrap(sub () { 1 + callsame });
+    is swrapped(), 2,
+        'a wrapper installed at runtime takes effect at a call site compiled before it';
 }
 
 # These observe that statically looked up callees still behave.


### PR DESCRIPTION
`[+] @a` kept a polymorphic callsite in its fast path: the accumulator seeded as the first slot's container while later values arrived bare, and each stored value arrived as whatever its slot held. Deconting the seed and each stored value keeps the callsite to one argument shape. No `infix:<+>` candidate writes to its arguments, so nothing can observe the difference, and the generic reduction paths still hand rw operators the real containers.

The second commit fixes the one soft guard in the RakuAST static call mark that failed closed. The published method cache of a mixin type in the setting under compilation can miss the methods the setting itself adds, `soft` among them, which refused the static callee lookup at hundreds of setting call sites.

```raku
my @a = 1..10; my $s; $s = [+] @a for ^500_000; say now - ENTER now
```

drops from 0.97s to 0.56s with a CORE the RakuAST frontend compiled, and from 0.76s to 0.53s with one the legacy frontend compiled (the second commit only affects a RakuAST compiled CORE).
