### PR TITLE
RakuAST: re-form regex code with the optimize walk's marks

### DIFF
--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -4232,12 +4232,6 @@ class RakuAST::RegexDeclaration
     has RakuAST::Regex $.body;
     has            str $.source;
 
-    # Compiling the body stores caps and the NFA on the Regex code
-    # object, and one entry per alternation into a hash under a key
-    # minted fresh each compilation, so a re-formation would leave
-    # every alternation NFA in the serialized code object twice.
-    method IMPL-REBUILD-ELIGIBLE() { 0 }
-
     method new(          str :$scope,
                          str :$multiness,
                RakuAST::Name :$name,
@@ -4400,7 +4394,7 @@ class RakuAST::RegexThunk
             RakuAST::Expression :$expression) {
         my $slash := RakuAST::VarDeclaration::Implicit::Special.new(:name('$/'));
         my $thunk := self.IMPL-THUNKED-REGEX-QAST($context); # must be before nested blocks
-        my $nested-decls := $*IMPL-COMPILE-DYNAMICALLY
+        my $nested-decls := $*IMPL-COMPILE-DYNAMICALLY || $*EMIT-BEGIN-SHAPE
             ?? self.IMPL-NESTED-REGEX-THUNK-DECLS($context)
             !! QAST::Stmts.new;
         QAST::Block.new(

--- a/src/Raku/ast/compunit.rakumod
+++ b/src/Raku/ast/compunit.rakumod
@@ -229,7 +229,6 @@ class RakuAST::CompUnit
             && ($!setting-name eq 'NULL.c' || $!setting-name eq 'NULL.d'
                 || $!setting-name eq 'NULL.e')
             ?? 1 !! 0;
-        $!context.set-optimize-regex() if nqp::isconcrete($!context);
         $resolver.push-scope(self);
         $!mainline.IMPL-OPTIMIZE($resolver);
         self.IMPL-OPTIMIZE($resolver);

--- a/src/Raku/ast/impl.rakumod
+++ b/src/Raku/ast/impl.rakumod
@@ -27,16 +27,6 @@ class RakuAST::IMPL::QASTContext {
     has int $.is-nested;
     has Mu $.language-revision; # Same type as in CORE-SETTING-REV
 
-    # Set as the optimize stage begins on this unit, so regex code
-    # generation runs its QAST optimizations over the compiled regex.
-    # Code compiled before the stage runs, as a use at BEGIN time
-    # forces, keeps the plain compilation.
-    has int $.optimize-regex;
-
-    method set-optimize-regex() {
-        nqp::bindattr_i(self, RakuAST::IMPL::QASTContext, '$!optimize-regex', 1)
-    }
-
     # Set once the optimize stage has walked this unit, so emission can
     # tell a QAST block cached ahead of the walk from one that reflects
     # the marks the walk decided.

--- a/src/Raku/ast/regex.rakumod
+++ b/src/Raku/ast/regex.rakumod
@@ -54,10 +54,9 @@ class RakuAST::Regex
         }
 
         # The QAST regex optimizations run after the NFA is stored, so
-        # LTM sees the original shape. Gated on the optimize stage having
-        # run, like the marks on the AST. The level is pinned: this
-        # frontend's only optimization switch is whether the stage ran.
-        if $context.optimize-regex {
+        # LTM sees the original shape. The level is pinned: this
+        # frontend has no regex optimization switch.
+        {
             self.IMPL-SIMPLIFY-BEFORE-ASSERTIONS($wrap-qast);
             # The optimizer relocates a stubbed assertion block into
             # the block passed here. That path needs an assertion argument

--- a/src/Raku/ast/regex.rakumod
+++ b/src/Raku/ast/regex.rakumod
@@ -2,6 +2,8 @@
 class RakuAST::Regex
   is RakuAST::Node
 {
+    has str $!alt-nfa-prefix;
+
     # In a ratchet regex each atom position carries the ratchet on its
     # outermost compiled node, once any significant whitespace is attached, so
     # a quantifier inside can still give its match back across that whitespace
@@ -33,7 +35,7 @@ class RakuAST::Regex
         $code-object.SET_CAPS(QRegex::P6Regex::Actions.capnames($regex-qast, 0));
         QRegex::P6Regex::Actions.store_regex_caps($code-object, NQPMu, QRegex::P6Regex::Actions.capnames($regex-qast, 0));
         QRegex::P6Regex::Actions.store_regex_nfa($code-object, NQPMu, QRegex::NFA.new.addnode($regex-qast));
-        QRegex::P6Regex::Actions.alt_nfas($code-object, $regex-qast, $context.sc-handle);
+        self.IMPL-ALT-NFAS($code-object, $regex-qast, $context.sc-handle);
 
         # Wrap in scan/pass as appropriate.
         my $pass-qast := $name
@@ -70,6 +72,55 @@ class RakuAST::Regex
                 if nqp::elems($parking[0].list);
         }
         $wrap-qast
+    }
+
+    # Names each alternation and stores its NFAs on the code object,
+    # as QRegex::P6Regex::Actions.alt_nfas does, with the name derived
+    # from this regex's source origin and the walk position rather
+    # than a fresh counter. Forming the block again then stores the
+    # same entries under the same names instead of accreting a second
+    # set, and the same source builds the same names, which a
+    # reproducible build needs. The walk runs before the regex
+    # optimizer touches the tree, so the positions are the source's
+    # own and agree between formations. A synthetic regex without an
+    # origin mints a name once and keeps it, so forming it again still
+    # stores the same entries.
+    method IMPL-ALT-NFAS(Mu $code-object, Mu $ast, str $suffix) {
+        my str $prefix := $!alt-nfa-prefix;
+        unless $prefix {
+            my $origin := self.origin;
+            $prefix := nqp::isconcrete($origin)
+                ?? ~$origin.from
+                !! QAST::Node.unique('anon_');
+            nqp::bindattr_s(self, RakuAST::Regex, '$!alt-nfa-prefix', $prefix);
+        }
+        my @counter := nqp::list_i(0);
+        self.IMPL-ALT-NFAS-WALK($code-object, $ast, $suffix, $prefix, @counter);
+        Nil
+    }
+
+    method IMPL-ALT-NFAS-WALK(Mu $code-object, Mu $ast, str $suffix, str $prefix, Mu @counter) {
+        my str $rxtype := $ast.rxtype;
+        if $rxtype eq 'alt' {
+            my @alternatives;
+            for $ast.list {
+                self.IMPL-ALT-NFAS-WALK($code-object, $_, $suffix, $prefix, @counter);
+                nqp::push(@alternatives, QRegex::NFA.new.addnode($_));
+            }
+            my int $i := nqp::atpos_i(@counter, 0);
+            nqp::bindpos_i(@counter, 0, $i + 1);
+            $ast.name('alt_nfa_' ~ $prefix ~ '_' ~ $i ~ '_' ~ $suffix);
+            QRegex::P6Regex::Actions.store_regex_alt_nfa($code-object, $ast.name, @alternatives);
+        }
+        elsif $rxtype eq 'subcapture' || $rxtype eq 'quant' {
+            self.IMPL-ALT-NFAS-WALK($code-object, $ast[0], $suffix, $prefix, @counter);
+        }
+        elsif $rxtype eq 'concat' || $rxtype eq 'altseq' || $rxtype eq 'conj' || $rxtype eq 'conjseq' {
+            for $ast.list {
+                self.IMPL-ALT-NFAS-WALK($code-object, $_, $suffix, $prefix, @counter);
+            }
+        }
+        Nil
     }
 
     # A `before` assertion invokes its argument's thunk at match time: a

--- a/t/08-performance/36-rakuast-begin-compiled-remark.t
+++ b/t/08-performance/36-rakuast-begin-compiled-remark.t
@@ -3,7 +3,7 @@ use Test::Helpers::QAST;
 use Test;
 use QAST:from<NQP>;
 use nqp;
-plan 46;
+plan 54;
 
 # A routine invoked at BEGIN time compiles ahead of the unit's optimize
 # walk and caches its QAST. The unit emission re-forms the cached block
@@ -247,6 +247,8 @@ is EVAL(q[my class E { has int $!i; method m() { ++$!i } }; my $e := E.new; BEGI
         }
         our $begin-inner;
         our sub check-inner() { $begin-inner() }
+        grammar PG { token TOP { ( "ab" | "a" | ( "b" ) ) } }
+        BEGIN PG.parse("ab");
         class PC {
             has int $!i;
             method bump() { ++$!i }
@@ -273,6 +275,12 @@ is EVAL(q[my class E { has int $!i; method m() { ++$!i } }; my $e := E.new; BEGI
         'a closure the precompiled BEGIN block minted runs correctly at runtime';
     is &::('PrecompRemark::check-inner')(), 42,
         'a closure minted inside an inner block at BEGIN keeps its frame chain across precompilation';
+    is ::('PrecompRemark::PG').parse("ab").Str, 'ab',
+        'a precompiled grammar parsed at BEGIN still picks the longest alternative';
+    is ::('PrecompRemark::PG').parse("a")[0].Str, 'a',
+        'a precompiled grammar parsed at BEGIN still captures its alternation';
+    is ::('PrecompRemark::PG').parse("b")[0][0].Str, 'b',
+        'a capturing group nested in another group survives precompilation of a BEGIN used grammar';
     sub nuke(IO::Path $d) {
         for $d.dir { $_.d ?? nuke($_) !! $_.unlink }
         $d.rmdir;
@@ -289,6 +297,32 @@ BEGIN Alts.parse("yy");
     is (nqp::isnull(alt-nfas) ?? 0 !! nqp::elems(alt-nfas)), 1,
         'a token with alternations parsed at BEGIN stores one alternation NFA set';
 }
+
+# A capturing group compiles as its own regex code object through a
+# formation of its own, so its alternations take the same treatment.
+# The BEGIN parse runs the dynamically compiled regex itself, so its
+# capture pins that compilation directly.
+my grammar CapAlts { token TOP { ("aa" | "bb") "-" } }
+my $begin-cap;
+BEGIN $begin-cap = ~CapAlts.parse("aa-")[0];
+is $begin-cap, 'aa',
+    'the BEGIN time parse itself captures the matched alternative';
+is CapAlts.parse("bb-")[0].Str, 'bb',
+    'a captured alternation in a token parsed at BEGIN still captures at runtime';
+is CapAlts.parse("aa-")[0].Str, 'aa',
+    'the other alternative of the captured group still matches at runtime';
+
+# A quantified group takes the walk through the quant node into the
+# group, so its alternation still drives longest token matching.
+my grammar QuantAlts { token TOP { [ "a" | "ab" ]+ } }
+BEGIN QuantAlts.parse("a");
+{
+    my \alt-nfas = nqp::getattr(QuantAlts.^lookup('TOP'), Regex, '%!alt_nfas');
+    is (nqp::isnull(alt-nfas) ?? 0 !! nqp::elems(alt-nfas)), 1,
+        'a quantified alternation parsed at BEGIN stores one alternation NFA set';
+}
+is QuantAlts.parse("ab").Str, 'ab',
+    'a quantified alternation parsed at BEGIN still picks the longest alternative';
 
 # QAST is a DAG: a Want's alternatives share subtrees with its primary,
 # so a walk must remember visited nodes or it re-walks shared regions


### PR DESCRIPTION
A grammar or token a module uses at BEGIN time compiles ahead of the unit's optimize walk, and its serialized compilation kept that early form: the regex QAST optimizations never applied, so every load of the module ran the unreduced assertion path. Regex declarations had declined the re-formation the other BEGIN-compiled routines take because compiling a regex body stores one NFA entry per alternation under a name minted from a fresh counter, and a second formation stored a second set. The alternation names now derive from the regex's source origin and the walk position, so forming the body again stores the same entries under the same names, and a regex declaration takes the re-formation like any routine.

The second commit retires the `optimize-regex` flag. The regex QAST optimizations depend on nothing the optimize stage computes, and the NFA is stored before they run in either order, so LTM is unaffected. Every compiled regex now takes them, including the copy a BEGIN-time compilation itself executes.

```raku
my grammar G { token TOP { <line>+ }; token line { \w+ '=' \w+ \n } }
BEGIN G.parse("a=b\n");
```

Parsing with a grammar shaped like this matches the speed of one never used at BEGIN, both loaded from precompilation and in the compiling process itself, where it ran the plain compilation before.
