### PR TITLE
Key precompilation stores to the setting they bind to

### DIFF
--- a/src/core.c/Compiler.rakumod
+++ b/src/core.c/Compiler.rakumod
@@ -5,12 +5,18 @@ class Compiler does Systemic {
     my constant $backend = $compiler.backend;
     my constant $name    = $backend.name;
 
+    # The frontends serialize a setting differently from the same sources
+    my constant $core-frontend =
+      nqp::getlexdyn('$*CU') ?? 'rakuast' !! 'legacy';
+
     # This needs to be done at compile time to be able to access the correct
     # frontend specific dynamic variables
     my constant $compilation-base-id = nqp::box_s(
       nqp::sha1(
         (nqp::getlexdyn('$*CU') ?? $*CU.comp-unit-name !! $*W.handle.Str)
           ~ nqp::atkey($config,'source-digest')
+          ~ nqp::atkey($config,'version')
+          ~ $core-frontend
       ),
       Str
     );


### PR DESCRIPTION
Previously the compilation id keying a precompilation store derived from the compiler's sources and the frontend compiling the modules, while the setting a precompilation binds to also varies by the frontend that compiled it and by the version string it bakes in. Rebuilding the setting with the other frontend, or after a commit that moves the described version without touching a source, replaced the setting while every store stayed keyed as before, and loading from one fails with errors naming types that have nothing to do with the module asked for.

The compilation id now folds in the frontend that compiled the setting, baked in at setting compile time, and the version string the setting already bakes in beside it, so the stores move whenever the setting they bind to does.