### PR TITLE
RakuAST: set the read only mask on produced signatures

### DIFF
--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -4387,6 +4387,7 @@ class RakuAST::RegexThunk
         nqp::bindattr($signature, Signature, '@!params', nqp::list($parameter));
         nqp::bindattr_i($signature, Signature, '$!arity', 1);
         nqp::bindattr($signature, Signature, '$!count', nqp::box_i(1, Int));
+        nqp::bindattr_i($signature, Signature, '$!readonly', 1);
 
         # Create Regex object.
         my $regex := nqp::create(Regex);

--- a/src/Raku/ast/signature.rakumod
+++ b/src/Raku/ast/signature.rakumod
@@ -292,6 +292,24 @@ class RakuAST::Signature
         nqp::bindattr_i($signature, Signature, '$!arity', self.arity);
         nqp::bindattr($signature, Signature, '$!count', self.count);
 
+        # The mask of read only positionals. The invocation dispatcher
+        # reads it to pass such arguments outside their Scalar containers.
+        my int $n := nqp::elems(@parameters);
+        my int $i := -1;
+        my int $readonly;
+        while ++$i < $n {
+            my $param := @parameters[$i];
+            my int $flags := nqp::getattr_i($param, Parameter, '$!flags');
+            if !($flags +& nqp::const::SIG_ELEM_SLURPY_ARITY)
+              && !($flags +& nqp::const::SIG_ELEM_SLURPY_NAMED)
+              && nqp::isnull(nqp::getattr($param, Parameter, '@!named_names'))
+              && $i < 64
+              && !($flags +& (nqp::const::SIG_ELEM_IS_RW +| nqp::const::SIG_ELEM_IS_RAW)) {
+                $readonly := $readonly +| nqp::bitshiftl_i(1, $i);
+            }
+        }
+        nqp::bindattr_i($signature, Signature, '$!readonly', $readonly);
+
         # Figure out and set return type.
         nqp::bindattr($signature, Signature, '$!returns', $!returns
             ?? self.IMPL-RETURN-VALUE()

--- a/t/08-performance/37-rakuast-signature-readonly.t
+++ b/t/08-performance/37-rakuast-signature-readonly.t
@@ -1,0 +1,103 @@
+use Test;
+use nqp;
+plan 23;
+
+# The Signature meta-object carries a bit mask of its read only
+# positionals. The invocation dispatcher reads the mask to pass such
+# arguments outside their Scalar containers. These tests pin the mask
+# across parameter shapes and the argument passing behavior the mask
+# must not change.
+
+sub mask(Mu $routine) {
+    nqp::getattr_i(nqp::decont($routine.signature), Signature, '$!readonly')
+}
+
+sub two-plain($a, $b) { }
+is mask(&two-plain), 3, 'two plain positionals set both bits';
+
+sub first-rw($a is rw, $b) { }
+is mask(&first-rw), 2, 'an rw positional does not set its bit';
+
+sub first-raw(\a, $b) { }
+is mask(&first-raw), 2, 'a raw positional does not set its bit';
+
+sub first-copy($a is copy, $b) { }
+is mask(&first-copy), 3, 'an is copy positional keeps its bit';
+
+sub with-slurpy($a, *@rest) { }
+is mask(&with-slurpy), 1, 'a slurpy positional sets no bit of its own';
+
+sub with-named($a, :$n) { }
+is mask(&with-named), 1, 'a named parameter sets no bit of its own';
+
+sub with-capture(|c) { }
+is mask(&with-capture), 0, 'a capture parameter sets no bit';
+
+sub named-slurpy-only(*%h) { }
+is mask(&named-slurpy-only), 0, 'a named slurpy alone leaves the mask empty';
+
+sub optional-positional($a?) { }
+is mask(&optional-positional), 1, 'an optional positional keeps its bit';
+
+my class WithMethod {
+    method m($a) { }
+}
+is mask(WithMethod.^lookup('m')), 3,
+    'a method sets bits for the invocant and its positional';
+
+multi sub multi-case($a, $b) { }
+is mask(&multi-case.candidates[0]), 3,
+    'a multi candidate signature carries the mask';
+
+is mask(&infix:<+>.candidates.first({
+    .signature.params == 2 && .signature.params[0].type =:= Int
+})), 3, 'a setting operator candidate carries the mask';
+
+is mask(/ y /), 1, 'an anonymous regex sets the invocant bit';
+
+is mask({;$_}), 0, 'a bare block leaves its topic parameter unmasked';
+
+is mask(-> $a { }), 1, 'a pointy block positional sets its bit';
+
+my &wide = EVAL 'sub ('
+    ~ (^66).map({ $_ == 3 ?? "\$p$_ is rw" !! "\$p$_" }).join(', ')
+    ~ ') { }';
+is mask(&wide), -9,
+    'positionals beyond index 63 set no bits and rw still clears within range';
+
+# The mask must not change what a callee observes.
+sub sees-var($a) { $a.VAR.^name }
+my $contained = 5;
+is sees-var($contained), 'Scalar',
+    'a read only parameter still sees the caller container through VAR';
+
+multi sub multi-sees-var($a) { $a.VAR.^name }
+is multi-sees-var($contained), 'Scalar',
+    'a read only multi parameter still sees the caller container through VAR';
+
+multi sub writes-back($a is rw) { $a = 42 }
+my $target = 1;
+writes-back($target);
+is $target, 42, 'an rw multi parameter still writes back to the caller';
+
+multi sub raw-sees-var(\a) { a.VAR.^name }
+is raw-sees-var($contained), 'Scalar',
+    'a raw multi parameter still receives the caller container';
+
+multi sub copy-isolated($a is copy) { $a = 99 }
+my $kept = 5;
+copy-isolated($kept);
+is $kept, 5, 'an is copy multi parameter does not write back to the caller';
+
+multi sub resumed-write(Int $a is rw) { $a = 10; callsame }
+multi sub resumed-write($a is rw) { $a = $a + 1 }
+my $resumed = 1;
+resumed-write($resumed);
+is $resumed, 11, 'an rw parameter still writes back through a callsame resumption';
+
+sub sees-proxy($a) { $a.VAR.^name }
+my $proxy := Proxy.new(FETCH => -> $ { 5 }, STORE => -> $, $v { });
+is sees-proxy($proxy), 'Scalar',
+    'a Proxy argument still reaches the callee as a container';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously the signature meta-objects this frontend produced left the read only bit mask at zero. The invocation dispatcher reads that mask to pass read only object arguments outside their Scalar containers, so every call on contained arguments recorded a dispatch program that passed the container, with an extra value guard and a second container read in the callee on each call. A 2M iteration while loop over an untyped counter ran 1.3x slower than the legacy frontend compiled it.

This computes the mask the way the legacy frontend does. A positional that is not slurpy, not named, and neither rw nor raw sets its bit, and the dispatcher passes its argument decontainerized again. The anonymous regex signature sets the bit for its invocant. The while loop benchmark matches the legacy frontend after this.