### PR TITLE
RakuAST: fix issue with m:p/foo/ codegenning

### DIFF
--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -4807,7 +4807,8 @@ class RakuAST::Substitution
         }
         for self.IMPL-UNWRAP-LIST(self.adverbs) {
             my str $norm := self.IMPL-NORMALIZE-ADVERB($_.key);
-            if self.IMPL-IS-POSITION-ADVERB($norm) {
+            if nqp::istype($_,RakuAST::ColonPair::True)
+              && self.IMPL-IS-POSITION-ADVERB($norm) {
                 # These need to be passed the end of the last match.
                 $match-qast.push: QAST::Op.new:
                     :named($norm), :op<if>,

--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -4620,7 +4620,8 @@ class RakuAST::QuotedRegex
             my int $is-multiple-match;
             for self.IMPL-UNWRAP-LIST(self.adverbs) {
                 my str $norm := self.IMPL-NORMALIZE-ADVERB($_.key);
-                if self.IMPL-IS-POSITION-ADVERB($norm) {
+                if nqp::istype($_,RakuAST::ColonPair::True)
+                  && self.IMPL-IS-POSITION-ADVERB($norm) {
                     # These need to be passed the end of the last match.
                     $match-qast.push: QAST::Op.new:
                         :named($norm), :op<if>,


### PR DESCRIPTION
It appears that is was conflating the functionality of
  m:p/foo/
with
  m:p(2)/foo/

Fix this by only taking the special "to" codegenning path if the specified adverb represents True.