### PR TITLE
RakuAST: report variable trait errors when the argument needs a thunk

### DIFF
--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -381,7 +381,6 @@ class RakuAST::TraitTarget::Variable
   is RakuAST::Meta
   is RakuAST::ImplicitLookups
   is RakuAST::BeginTime
-  is RakuAST::CheckTime
 {
     has str $!name;
     has str $!scope;
@@ -406,10 +405,6 @@ class RakuAST::TraitTarget::Variable
     }
 
     method PERFORM-BEGIN(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
-    }
-
-    method PERFORM-CHECK(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
-        self.add-trait-sorries;
     }
 
     method PRODUCE-META-OBJECT(:$resolver, :$context) {
@@ -1324,9 +1319,8 @@ class RakuAST::VarDeclaration::Simple
             );
             # Get around RakuAST compiler deconting all arguments:
             nqp::bindattr($target, RakuAST::TraitTarget::Variable, '$!cont', $meta);
-            # No check time: the target's PERFORM-CHECK would only replay
-            # trait sorries, and the apply-traits call below records those
-            # on the declaration itself.
+            # The apply-traits call below records trait sorries on the
+            # declaration itself, so the target needs no check time.
             $target.to-begin-time($resolver, $context);
 
             if self.twigil eq '.' {

--- a/t/02-rakudo/trait-error-complex-arg.t
+++ b/t/02-rakudo/trait-error-complex-arg.t
@@ -1,0 +1,43 @@
+use Test;
+
+# An exception thrown by a trait handler must surface as a compile-time
+# error even when the trait argument cannot be interpreted at BEGIN time,
+# such as a declaration like `my $` or a call like `rand`. Such arguments
+# route the trait call through a compiled thunk, and the trait must still
+# both run and report its errors from there.
+
+plan 4;
+
+use MONKEY-SEE-NO-EVAL;
+
+throws-like q:to/CODE/,
+        multi sub trait_mod:<is>(Variable:D \v, :$foo! is raw) { die "oops" }
+        my @a is foo(my $);
+        CODE
+    Exception, message => /oops/,
+    'a dying variable trait with a declaration argument reports the error';
+
+throws-like q:to/CODE/,
+        multi sub trait_mod:<is>(Variable:D \v, :$foo! is raw) { die "oops" }
+        my @a is foo(rand);
+        CODE
+    Exception, message => /oops/,
+    'a dying variable trait with a call argument reports the error';
+
+is EVAL(q:to/CODE/), 'ran',
+        my $log;
+        multi sub trait_mod:<is>(Variable:D \v, :$foo! is raw) { $log = "ran" }
+        my @a is foo(my $);
+        $log
+        CODE
+    'a variable trait with a declaration argument still runs';
+
+is EVAL(q:to/CODE/), 'Num',
+        my $log;
+        multi sub trait_mod:<is>(Variable:D \v, :$foo! is raw) { $log = $foo.^name }
+        my @a is foo(rand);
+        $log
+        CODE
+    'a variable trait with a call argument receives the evaluated value';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously an exception thrown by a variable trait handler was silently discarded when the trait argument could not be interpreted at BEGIN time, such as `is foo(my $)` or `is foo(rand)`. Such arguments route the trait call through IMPL-BEGIN-TIME-EVALUATE, whose CATCH records the error as a sorry on the node it was invoked on when that node does check time. That node is the RakuAST::TraitTarget::Variable standing in for the declaration, and its check time is deliberately never run, so the sorry was never replayed and the program compiled as if the trait had succeeded.

This makes RakuAST::TraitTarget::Variable a begin-time only node. The evaluation now rethrows the exception, apply-traits records it on the declaration itself, and it surfaces as a compile-time error the same way it does for arguments that can be interpreted directly.