### PR TITLE
RakuAST: attach doc blocks to the statement that follows them

### DIFF
--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -197,6 +197,24 @@ role Raku::CommonActions {
     # this was done with the "r" method.  Since it is apparently impossible
     # to reliably export Nodify, this interface is kept alive.
     method r(str $class) { Nodify($class) }
+
+    # A statement parsed outside of any statement list, as in the argument
+    # of a statement prefix or a regex :my declaration, is a dead end for
+    # doc blocks it claimed, since it is never added to a statement list.
+    # Hand them back for the enclosing statement to claim into its own
+    # statement list.
+    method reclaim-doc-blocks($ast) {
+        if nqp::istype($ast, Nodify('Statement')) {
+            my $blocks := $ast.take-doc-blocks;
+            if nqp::islist($blocks) {
+                for $blocks {
+                    $*DOC-BLOCKS-COLLECTED.push(
+                      nqp::list($*STATEMENT-ID - 1, $_, -1)
+                    );
+                }
+            }
+        }
+    }
 }
 
 #-------------------------------------------------------------------------------
@@ -541,6 +559,14 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
 
         # Do any requested wrapping (-n or -p)
         my $statement-list := $<statementlist>.ast;
+
+        # Doc blocks no statement claimed reach the compilation unit here.
+        # A stale statement mark must never drop a block, so add whatever
+        # is still pending to the outermost statement list.
+        for $*DOC-BLOCKS-COLLECTED {
+            $statement-list.add-doc-block(nqp::atpos($_, 1));
+        }
+        $*DOC-BLOCKS-COLLECTED := [];
         if (my $add-print-topic := nqp::existskey(%OPTIONS,'p')) || nqp::existskey(%OPTIONS,'n') {
             $statement-list.add-statement(print-topic()) if $add-print-topic;
             my @wrapped := wrap-in-for-loop($statement-list);
@@ -654,13 +680,21 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
     method statementlist($/) {
         my $statements := self.collect-statements($/, 'StatementList');
 
-        # Add any uncollected doc blocks.  This can happen if there
-        # are no statements in a statementlist, e.g. in a rakudoc
-        # only file.
-        for $*DOC-BLOCKS-COLLECTED {
-            $statements.add-doc-block($_);
+        # Add any uncollected doc blocks that were parsed inside this
+        # statement list.  This can happen if no statement follows them,
+        # e.g. in a rakudoc only file or with trailing doc blocks.  Blocks
+        # parsed before an enclosing statement started stay collected for
+        # that statement to claim.  A statement list parsed inside a doc
+        # block configuration is discarded, so it must not take anything.
+        unless $*PARSING-DOC-BLOCK {
+            my @keep;
+            for $*DOC-BLOCKS-COLLECTED {
+                nqp::atpos($_, 0) >= $*STATEMENT-LIST-MARK
+                  ?? $statements.add-doc-block(nqp::atpos($_, 1))
+                  !! nqp::push(@keep, $_);
+            }
+            $*DOC-BLOCKS-COLLECTED := @keep;
         }
-        $*DOC-BLOCKS-COLLECTED := [];
     }
     method semilist($/) { self.collect-statements($/, 'SemiList')          }
     method sequence($/) { self.collect-statements($/, 'StatementSequence') }
@@ -1240,7 +1274,11 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
 # Statement prefixes
 
     # Helper method to normalize a blorst
-    method blorst($/) { self.attach: $/, $<block>.ast }
+    method blorst($/) {
+        my $ast := $<block>.ast;
+        self.reclaim-doc-blocks($ast);
+        self.attach: $/, $ast
+    }
 
     # Helper method for setting up simple prefix that just take a blorst
     method SP-prefix($/, $name) {
@@ -3244,8 +3282,9 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
                 # attachment to the following declaration, else it never reaches
                 # $=pod. The repr value is the remaining code statement.
                 for $ast.IMPL-UNWRAP-LIST($ast.semilist.statements) {
-                    $*DOC-BLOCKS-COLLECTED.push($_)
-                        if nqp::istype($_, Nodify('Doc::Block'));
+                    $*DOC-BLOCKS-COLLECTED.push(
+                      nqp::list($*STATEMENT-ID - 1, $_, -1)
+                    ) if nqp::istype($_, Nodify('Doc::Block'));
                 }
                 $repr := $ast.semilist.code-statements[0];
             }
@@ -4330,9 +4369,22 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
         if $docs > 1 {
             nqp::die("Found $docs doc blocks instead of just one");
         }
-        else {
+        elsif $docs {
             for $*SEEN {
-                $*DOC-BLOCKS-COLLECTED.push($_.value);
+                $*DOC-BLOCKS-COLLECTED.push(
+                  nqp::list($*NEXT-STATEMENT-ID, $_.value, $/.from)
+                );
+            }
+        }
+        else {
+            # A block seen on an earlier pass is not collected anew.
+            # Statements inside its configuration have
+            # advanced the statement counter on this pass, so refresh the
+            # mark of the pending block at this source position to keep it
+            # claimable by the statement that follows it.
+            for $*DOC-BLOCKS-COLLECTED {
+                nqp::bindpos($_, 0, $*NEXT-STATEMENT-ID)
+                  if nqp::atpos($_, 2) == $/.from;
             }
         }
     }
@@ -4976,7 +5028,9 @@ class Raku::RegexActions is HLL::Actions does Raku::CommonActions {
     }
 
     method metachar:sym<:my>($/) {
-        self.attach: $/, Nodify('Regex::Statement').new($<statement>.ast);
+        my $ast := $<statement>.ast;
+        self.reclaim-doc-blocks($ast);
+        self.attach: $/, Nodify('Regex::Statement').new($ast);
     }
 
     method metachar:sym<{ }>($/) {

--- a/src/Raku/Grammar.nqp
+++ b/src/Raku/Grammar.nqp
@@ -1232,8 +1232,13 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
         # of doc blocks to statements that will not actually be CHECKed
         my $*PARSING-DOC-BLOCK;
 
-        # RakuDoc blocks collected so far, to be included with next statement
-        # into its statement list.
+        # RakuDoc blocks collected so far, each stored with a statement id
+        # mark and its source position.  A statement claims blocks marked
+        # at or above its own statement list's mark and below its own id.
+        # That makes the
+        # statement that follows a block in the same statement list claim
+        # it, rather than the first statement completed inside a nested
+        # statement list.
         my $*DOC-BLOCKS-COLLECTED := [];
 
         # RakuDoc aliases (=alias -> A<>) collected so far
@@ -1333,6 +1338,7 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
     # Parsing zero or more statements, e.g. inside a (pointy) block
     rule statementlist {
         :dba('statement list')
+        :my $*STATEMENT-LIST-MARK := $*NEXT-STATEMENT-ID;
         <.ws>
         :my $*LANG;              # Define this scope to be a new language
         <!!{ $*LANG := $/.clone_braid_from(self); 1 }>
@@ -1351,6 +1357,7 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
     # Parsing zero or more statements in an expression, e.g @a[10;20]
     rule semilist {
         :dba('list composer')
+        :my $*STATEMENT-LIST-MARK := $*NEXT-STATEMENT-ID;
         ''
         [
           | <?before <.[)\]}]> >  # bumping into  ) ] }
@@ -1364,6 +1371,7 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
     # Parsing zero or more statements in a contextualizer, e.g $(10;20)
     rule sequence {
         :dba('sequence of statements')
+        :my $*STATEMENT-LIST-MARK := $*NEXT-STATEMENT-ID;
         ''
         [
           | <?before <.[)\]}]> >  # bumping into  ) ] }

--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -3213,9 +3213,10 @@ class RakuAST::Sub
     }
 
     method is-stub() {
-        my $statement-list := self.body.statement-list;
-        $statement-list.IMPL-IS-SINGLE-EXPRESSION
-            && nqp::istype(self.IMPL-UNWRAP-LIST($statement-list.statements)[0].expression, RakuAST::Stub)
+        my @code := self.body.statement-list.code-statements;
+        nqp::elems(@code) == 1
+            && nqp::istype(@code[0], RakuAST::Statement::Expression)
+            && nqp::istype(@code[0].expression, RakuAST::Stub)
     }
 
     method PERFORM-CHECK(Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
@@ -3657,15 +3658,16 @@ class RakuAST::Method
     }
 
     method is-stub() {
-        my $statement-list := self.body.statement-list;
-        $statement-list.IMPL-IS-SINGLE-EXPRESSION
-            && nqp::istype(self.IMPL-UNWRAP-LIST($statement-list.statements)[0].expression, RakuAST::Stub)
+        my @code := self.body.statement-list.code-statements;
+        nqp::elems(@code) == 1
+            && nqp::istype(@code[0], RakuAST::Statement::Expression)
+            && nqp::istype(@code[0].expression, RakuAST::Stub)
     }
 
     method IMPL-COMPILE-BODY(RakuAST::IMPL::QASTContext $context) {
         # If our first expression is a stub object (!!!, ..., ???),
         # set the yada bit on the Method itself
-        if (my $first-statement := self.IMPL-UNWRAP-LIST($!body.statement-list.statements)[0])
+        if (my $first-statement := nqp::atpos($!body.statement-list.code-statements, 0))
             && nqp::istype($first-statement, RakuAST::Statement::Expression)
             && nqp::istype($first-statement.expression, RakuAST::Stub)
         {

--- a/src/Raku/ast/statements.rakumod
+++ b/src/Raku/ast/statements.rakumod
@@ -98,13 +98,38 @@ class RakuAST::Statement
     }
     method labels() { self.IMPL-WRAP-LIST($!labels) }
 
-    # Attach any collected RakuDoc blocks to this statement
+    # Attach any collected RakuDoc blocks that this statement owns: those
+    # parsed after the enclosing statement list started and before this
+    # statement started.  Statement actions run innermost first, so blocks
+    # parsed before an outer statement must be left for that statement
+    # rather than claimed by the first statement completed inside it.
     method attach-doc-blocks() {
         my @collected := $*DOC-BLOCKS-COLLECTED;
         if nqp::elems(@collected) {
-            nqp::bindattr(self, RakuAST::Statement, '$!doc-blocks', @collected);
-            $*DOC-BLOCKS-COLLECTED := [];
+            my $list-mark := $*STATEMENT-LIST-MARK;
+            my $my-id     := self.statement-id;
+            my @mine;
+            my @keep;
+            for @collected {
+                my $mark := nqp::atpos($_, 0);
+                $mark >= $list-mark && $mark < $my-id
+                  ?? nqp::push(@mine, nqp::atpos($_, 1))
+                  !! nqp::push(@keep, $_);
+            }
+            if nqp::elems(@mine) {
+                nqp::bindattr(self, RakuAST::Statement, '$!doc-blocks', @mine);
+                $*DOC-BLOCKS-COLLECTED := @keep;
+            }
         }
+    }
+
+    # Hand back any claimed doc blocks.  Used when this statement was
+    # parsed outside of any statement list, as in the argument of a
+    # statement prefix, where claimed blocks would never reach one.
+    method take-doc-blocks() {
+        my $blocks := $!doc-blocks;
+        nqp::bindattr(self, RakuAST::Statement, '$!doc-blocks', nqp::null);
+        $blocks
     }
 
     # Add any RakuDoc blocks attached to this statement to the given

--- a/t/02-rakudo/doc-block-statement-owner.t
+++ b/t/02-rakudo/doc-block-statement-owner.t
@@ -1,0 +1,152 @@
+use Test;
+
+plan 15;
+
+# A doc block belongs to the statement that follows it in the same statement
+# list. A doc block preceding a package declaration must not end up inside
+# the package body, where it would sit in a stub method's statement list and
+# stop the method from registering as a stub with the yada bit.
+
+sub role-code(Str:D $name) {
+    qq:to/CODE/;
+    =begin pod
+    documentation
+    =end pod
+    my role $name \{
+        method dispatch(\$event) \{ ... }
+    }
+    CODE
+}
+
+is EVAL(role-code('SinkA') ~ 'SinkA').^lookup('dispatch').yada, True,
+    'a stub method in a role preceded by a doc block keeps its yada bit';
+
+throws-like { EVAL(role-code('SinkB') ~ 'SinkB.new.dispatch("x")') },
+    Exception,
+    message => /'must be implemented'/,
+    'punning such a role reports the unimplemented required method';
+
+throws-like { EVAL(role-code('SinkC') ~ 'class C does SinkC { }') },
+    Exception,
+    message => /'must be implemented'/,
+    'composing such a role without the method fails composition';
+
+is EVAL(q:to/CODE/), 'first,second', 'doc blocks before and after a role reach $=pod in order';
+=begin pod
+first
+=end pod
+my role SinkD {
+    method dispatch($event) { ... }
+}
+=begin pod
+second
+=end pod
+$=pod.map({ .contents[0].contents[0].Str }).join(",")
+CODE
+
+is EVAL(q:to/CODE/), 'between', 'a doc block between class members attaches inside the class body';
+class MembersA {
+    has $.a;
+    =begin pod
+    between
+    =end pod
+    method m() { 42 }
+}
+MembersA.new.m;
+$=pod[0].contents[0].contents[0].Str
+CODE
+
+is EVAL(q:to/CODE/), '42,1', 'a trailing doc block inside a method body reaches $=pod';
+class TrailA {
+    method m() {
+        42;
+        =begin pod
+        tail
+        =end pod
+    }
+}
+TrailA.new.m ~ ',' ~ $=pod.elems
+CODE
+
+lives-ok { EVAL "=begin pod\nonly\n=end pod\n" },
+    'a compilation unit holding only a doc block compiles';
+
+is EVAL(q:to/CODE/), 1, 'a doc block before a statement-prefixed loop expression reaches $=pod';
+=begin pod
+prefixed
+=end pod
+my @r = do for 1..3 { $_ * 2 };
+$=pod.elems
+CODE
+
+is EVAL(q:to/CODE/), 1, 'a doc block before a simple do prefix expression reaches $=pod';
+=begin pod
+prefixed
+=end pod
+my $x = do 42;
+$=pod.elems
+CODE
+
+is EVAL(q:to/CODE/), 1, 'a leading doc block with a parenthesized config value reaches $=pod';
+=begin pod :kind("Type")
+configured
+=end pod
+my $x = 42;
+$=pod.elems
+CODE
+
+is EVAL(q:to/CODE/), 'A,B', 'a doc block before one with a block config value reaches $=pod';
+say "";
+=begin pod
+A
+=end pod
+=begin pod :x{a => 1}
+B
+=end pod
+$=pod.map({ .contents[0].contents[0].Str }).join(",")
+CODE
+
+is EVAL(q:to/CODE/), 'A,B', 'doc blocks interleave in order across a statement prefix';
+=begin pod
+A
+=end pod
+my $x = do 42;
+=begin pod
+B
+=end pod
+my $y = 1;
+$=pod.map({ .contents[0].contents[0].Str }).join(",")
+CODE
+
+is EVAL(q:to/CODE/), '1,1', 'a doc block before a phaser argument inside a sub reaches $=pod';
+sub p() {
+    ENTER
+=begin pod
+phased
+=end pod
+    42;
+    1
+}
+p() ~ ',' ~ $=pod.elems
+CODE
+
+is EVAL(q:to/CODE/), 'first,second', 'two leading doc blocks where the second has a parenthesized config reach $=pod in order';
+=begin pod
+first
+=end pod
+=begin pod :kind("Type")
+second
+=end pod
+my $x = 42;
+$=pod.map({ .contents[0].contents[0].Str }).join(",")
+CODE
+
+is EVAL(q:to/CODE/), 1, 'a doc block before a regex with a :my declaration reaches $=pod';
+=begin pod
+rx
+=end pod
+my $r = / :my $q = 1; abc /;
+$=pod.elems
+CODE
+
+# vim: expandtab shiftwidth=4

--- a/t/02-rakudo/doc-block-statement-owner.t
+++ b/t/02-rakudo/doc-block-statement-owner.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 15;
+plan 18;
 
 # A doc block belongs to the statement that follows it in the same statement
 # list. A doc block preceding a package declaration must not end up inside
@@ -147,6 +147,39 @@ rx
 =end pod
 my $r = / :my $q = 1; abc /;
 $=pod.elems
+CODE
+
+is EVAL(q:to/CODE/), True, 'a doc block inside a stub method body keeps the stub a stub';
+my role SinkE {
+    method dispatch($event) {
+=begin pod
+internal
+=end pod
+        ...
+    }
+}
+SinkE.^lookup('dispatch').yada
+CODE
+
+is EVAL(q:to/CODE/), True, 'a doc block inside a stub sub body keeps the stub a stub';
+sub f() {
+=begin pod
+internal
+=end pod
+    ...
+}
+&f.yada
+CODE
+
+is EVAL(q:to/CODE/), 42, 'a stub sub with an inline doc block can be redeclared';
+sub g() {
+=begin pod
+internal
+=end pod
+    ...
+}
+sub g() { 42 }
+g()
 CODE
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously a parsed doc block was claimed by the first statement action to run after it. Statement actions run innermost first, so a doc block directly before a `role` or `class` was claimed by the first statement completed inside the package body rather than the declaration itself. For a role whose first member was a stub method the doc block landed in the stub's body statement list, the method no longer read as a stub, and it lost its yada bit. That silently turned off required method enforcement:

```raku
=begin pod
docs
=end pod
role Sink {
    method dispatch($event) { ... }
}
Sink.new.dispatch("x") # "Stub code executed" instead of "Method 'dispatch' must be implemented..."
```

(found via blin, JobQueue's test suite expects the must be implemented error)

This stores a statement id mark with each collected doc block so a block is claimed by the statement that follows it in the same statement list. Statements parsed outside any statement list, i.e. the argument of a statement prefix such as `do` or a regex `:my` declaration, hand claimed blocks back for the enclosing statement. Backtracked parses refresh the mark, since a config value such as `:kind("Type")` advances the statement counter on every pass. Anything still unclaimed is added to the outermost statement list when the compilation unit is assembled, so a doc block can never be silently dropped from `$=pod`. A second commit makes stub detection itself ignore doc blocks, so a pod block inside a stub body does not defeat the yada bit either.
