### PR TITLE
RakuAST: don't set the caller's $/ in 6.e

### DIFF
--- a/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
+++ b/src/Perl6/bootstrap.c/BOOTSTRAP.nqp
@@ -1550,6 +1550,13 @@ class ContainerDescriptor does Perl6::Metamodel::Explaining {
 # descriptor is used as a marker
 class ContainerDescriptor::Untyped is ContainerDescriptor { }
 
+#- ContainerDescriptor::IsolatedMatch ------------------------------------------
+# Container descriptor for the implicit $/ of a 6.e scope. The type is used
+# as a marker: method forms such as .match and .subst leave a container with
+# this descriptor alone instead of writing the match into their caller's $/,
+# while operator forms assign through it as with any other container.
+class ContainerDescriptor::IsolatedMatch is ContainerDescriptor::Untyped { }
+
 #- ContainerDescriptor::Whence -------------------------------------------------
 # Role for container descriptors that need to bind the container to some place
 # (hence the "whence") on first assignment.  Most commonly used for elements
@@ -2449,7 +2456,8 @@ BEGIN {
                         }
                         my $what := $desc.WHAT;
                         unless nqp::eqaddr($what, ContainerDescriptor) ||
-                               nqp::eqaddr($what, ContainerDescriptor::Untyped) {
+                               nqp::eqaddr($what, ContainerDescriptor::Untyped) ||
+                               nqp::eqaddr($what, ContainerDescriptor::IsolatedMatch) {
                             $desc.assigned($cont)
                                 unless nqp::eqaddr($what, ContainerDescriptor::UninitializedAttribute);
                             nqp::bindattr($cont, Scalar, '$!descriptor', $desc.next);
@@ -2475,7 +2483,8 @@ BEGIN {
                 my $desc := nqp::getattr($cont, Scalar, '$!descriptor');
                 my $what := $desc.WHAT;
                 unless nqp::eqaddr($what, ContainerDescriptor) ||
-                       nqp::eqaddr($what, ContainerDescriptor::Untyped) {
+                       nqp::eqaddr($what, ContainerDescriptor::Untyped) ||
+                       nqp::eqaddr($what, ContainerDescriptor::IsolatedMatch) {
                     $desc.assigned($cont)
                         unless nqp::eqaddr($what, ContainerDescriptor::UninitializedAttribute);
                     nqp::bindattr($cont, Scalar, '$!descriptor', $desc.next);

--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -748,6 +748,7 @@ class RakuAST::Code
         my $resolver := $context.parse-time-resolver($!cuid);
         my $throwaway_block_ast := RakuAST::Block.new(:!implicit-topic);
         $throwaway_block_ast.set-implicit-topic(0);
+        $throwaway_block_ast.set-no-implicit-match();
         $throwaway_block_ast.to-begin-time($resolver, $context);
         my $throwaway_block_past := $throwaway_block_ast.IMPL-QAST-BLOCK($context, :blocktype<declaration>);
         $throwaway_block_past.name('!LEXICAL_FIXUP');
@@ -762,6 +763,7 @@ class RakuAST::Code
 
         # Set up capturing code.
         my $c_block_ast := RakuAST::Block.new(:!implicit-topic);
+        $c_block_ast.set-no-implicit-match();
         $c_block_ast.to-begin-time($resolver, $context);
         my $c_block := $c_block_ast.IMPL-QAST-BLOCK($context, :blocktype<declaration_static>);
         $c_block.name('!LEXICAL_FIXUP_CSCOPE');
@@ -1615,6 +1617,11 @@ class RakuAST::Block
     # Should this block declare a fresh implicit `$/`?
     has int $!fresh-match;
 
+    # Set on blocks whose QAST merges into a frame that already declares
+    # the implicit specials, such as the compilation unit mainline, so
+    # they must not declare an implicit `$/` of their own.
+    has int $!no-implicit-match;
+
     # Should this block declare a fresh implicit `$!`?
     has int $!fresh-exception;
 
@@ -1936,6 +1943,11 @@ class RakuAST::Block
         nqp::bindattr_i(self, RakuAST::Block, '$!fresh-exception', $exception ?? 1 !! 0);
     }
 
+    method set-no-implicit-match() {
+        nqp::bindattr_i(self, RakuAST::Block, '$!no-implicit-match', 1);
+        Nil
+    }
+
     method attach-target-names() {
         self.IMPL-WRAP-LIST(['block'])
     }
@@ -1967,7 +1979,11 @@ class RakuAST::Block
                     :exception);
             }
         }
-        if $!fresh-match {
+        if nqp::getcomp('Raku').language_revision >= 3 && !$!no-implicit-match {
+            nqp::push(@implicit, RakuAST::VarDeclaration::Implicit::BlockMatch.new(:name('$/')))
+                unless self.IMPL-HAS-PARAMETER('$/');
+        }
+        elsif $!fresh-match {
             nqp::push(@implicit, RakuAST::VarDeclaration::Implicit::Special.new(:name('$/')));
         }
         if $!fresh-exception {

--- a/src/Raku/ast/compunit.rakumod
+++ b/src/Raku/ast/compunit.rakumod
@@ -66,6 +66,7 @@ class RakuAST::CompUnit
 
         my $mainline := RakuAST::Block.new();
         $mainline.set-implicit-topic(0);
+        $mainline.set-no-implicit-match();
         nqp::bindattr($obj, RakuAST::CompUnit, '$!mainline', $mainline);
 
         nqp::bindattr($obj, RakuAST::CompUnit, '$!comp-unit-name',

--- a/src/Raku/ast/impl.rakumod
+++ b/src/Raku/ast/impl.rakumod
@@ -362,9 +362,19 @@ class RakuAST::IMPL::Archetypes {
 # nominals so STORE accepts NQP-typed values. Emulates create_container_descriptor
 # in src/Perl6/World.nqp.
 class RakuAST::IMPL::Containers {
-    method create-descriptor(Mu :$of!, Mu :$default, int :$dynamic, :$name) {
+    method create-descriptor(Mu :$of!, Mu :$default, int :$dynamic, :$name, int :$isolated-match) {
         my $d := nqp::eqaddr($default, Mu) ?? $of !! $default;
-        my $cd-type := nqp::eqaddr($of, Mu) ?? ContainerDescriptor::Untyped !! ContainerDescriptor;
+        # An untyped $/ in a 6.e scope is isolated no matter how it was
+        # declared: an explicit `my $/` gets the same marker descriptor as
+        # the implicit one, so method forms treat both alike. The marker
+        # is untyped, so a typed declaration such as `my Match $/` keeps
+        # the plain descriptor even when the flag is passed, and method
+        # forms write into it as they do for earlier revisions.
+        my $cd-type := nqp::eqaddr($of, Mu)
+            ?? $isolated-match
+                ?? ContainerDescriptor::IsolatedMatch
+                !! ContainerDescriptor::Untyped
+            !! ContainerDescriptor;
         $cd-type.new(:$of, :default($d), :$dynamic, :$name)
     }
 }

--- a/src/Raku/ast/scoping.rakumod
+++ b/src/Raku/ast/scoping.rakumod
@@ -162,7 +162,9 @@ class RakuAST::LexicalScope
                     if nqp::istype($node, RakuAST::ImplicitDeclarations) {
                         for self.IMPL-UNWRAP-LIST($node.get-implicit-declarations()) -> $decl {
                             if $decl.is-simple-lexical-declaration {
-                                if nqp::istype($decl, RakuAST::VarDeclaration::Implicit::BlockTopic) && $decl.IMPL-NOT-IF-DUPLICATE {
+                                if (nqp::istype($decl, RakuAST::VarDeclaration::Implicit::BlockTopic)
+                                      && $decl.IMPL-NOT-IF-DUPLICATE)
+                                  || nqp::istype($decl, RakuAST::VarDeclaration::Implicit::BlockMatch) {
                                     nqp::push(@not-if-duplicate, $decl);
                                 }
                                 elsif !%declarations-seen{nqp::objectid($decl)} {
@@ -181,8 +183,9 @@ class RakuAST::LexicalScope
             }
             for @not-if-duplicate -> $decl {
                 my $found := 0;
+                my str $name := $decl.lexical-name;
                 for @declarations {
-                    if $_.lexical-name eq '$_' && !($_ =:= $decl) {
+                    if $_.lexical-name eq $name && !($_ =:= $decl) {
                         $found := 1;
                         last;
                     }
@@ -190,9 +193,17 @@ class RakuAST::LexicalScope
                 unless $found {
                     # Implicits are declared right at the start of a lexical scope anyway,
                     # so it should be safe to unshift them. We need them to be declared before
-                    # they are first used.
-                    nqp::unshift(@declarations, $decl);
-                    nqp::unshift(@variables, $decl);
+                    # they are first used. A block's $/ instead goes at the end: its entry
+                    # initialization reads the topic, so it must run after the topic
+                    # parameter has bound.
+                    if nqp::istype($decl, RakuAST::VarDeclaration::Implicit::BlockMatch) {
+                        nqp::push(@declarations, $decl);
+                        nqp::push(@variables, $decl);
+                    }
+                    else {
+                        nqp::unshift(@declarations, $decl);
+                        nqp::unshift(@variables, $decl);
+                    }
                 }
             }
             nqp::bindattr(self, RakuAST::LexicalScope, '$!declarations-cache', @declarations);

--- a/src/Raku/ast/var-lowering.rakumod
+++ b/src/Raku/ast/var-lowering.rakumod
@@ -653,6 +653,23 @@ class RakuAST::IMPL::VarLowering {
                     self.IMPL-MARK-MAGICAL-USED('$_');
                 }
             }
+            elsif nqp::istype($decl, RakuAST::VarDeclaration::Implicit::BlockMatch) {
+                if $used || $poisoned {
+                    # A kept block match reads the enclosing $/ by name
+                    # at entry.
+                    self.IMPL-MARK-MAGICAL-USED('$/');
+                }
+                else {
+                    # Unlike a routine's $/, a block only sets its own
+                    # match variable up when the block itself mentions
+                    # it, so a callee reaching $/ by name sees the
+                    # nearest frame that kept one. Keeping it whenever
+                    # the frame makes a call would cost a container
+                    # clone and an initialization on almost every block
+                    # entry.
+                    $decl.IMPL-SET-UNUSED();
+                }
+            }
             elsif nqp::istype($decl, RakuAST::VarDeclaration::Implicit::Special) {
                 my str $name := $decl.name;
                 if $name eq '$_' {

--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -289,9 +289,12 @@ class RakuAST::ContainerCreator {
         # type itself as a value.
         $default := RakuAST::Type.IMPL-NOMINALIZE-FOR-DEFAULT($of) if self.type;
         my int $dynamic := self.twigil eq '*' ?? 1 !! self.forced-dynamic ?? 1 !! 0;
+        my int $isolated-match := self.lexical-name eq '$/'
+            && nqp::getcomp('Raku').language_revision >= 3;
         nqp::bindattr(self, RakuAST::ContainerCreator, '$!container-descriptor',
             RakuAST::IMPL::Containers.create-descriptor(
-                :$of, :$default, :$dynamic, :name(self.lexical-name)));
+                :$of, :$default, :$dynamic, :name(self.lexical-name),
+                :$isolated-match));
 
         Nil
     }
@@ -2725,7 +2728,10 @@ class RakuAST::VarDeclaration::Implicit::Special
             ),
             nqp::hash(  # 6.e
                 '$_', ContainerDescriptor::Untyped.new(:of(Mu), :default(Any), :!dynamic, :name('$_')),
-                '$/', ContainerDescriptor::Untyped.new(:of(Mu), :default(Nil), :dynamic, :name('$/')),
+                # The IsolatedMatch type marks the container so method forms
+                # such as .match leave it alone instead of writing the match
+                # into their caller's $/.
+                '$/', ContainerDescriptor::IsolatedMatch.new(:of(Mu), :default(Nil), :dynamic, :name('$/')),
                 '$!', ContainerDescriptor::Untyped.new(:of(Mu), :default(Nil), :dynamic, :name('$!'))
             )
         );

--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -2759,6 +2759,56 @@ class RakuAST::VarDeclaration::Implicit::Special
     }
 }
 
+# The implicit match variable of a 6.e block: a fresh container per
+# invocation, initialized at entry from the topic when the topic is a
+# Match, and otherwise from the value of the enclosing $/. A regex
+# operator in the block then writes the block's own container, so
+# matching in one block never disturbs the match state of another frame,
+# and a block invoked with a Match reads that Match's captures.
+class RakuAST::VarDeclaration::Implicit::BlockMatch
+  is RakuAST::VarDeclaration::Implicit::Special
+{
+    # The declaration is emitted after the topic parameter so its entry
+    # initialization can read the topic, while lookups of $/ anywhere in
+    # the block are its uses. That order is not a post-declaration worth
+    # reporting.
+    method report-redeclaration() {
+        False
+    }
+
+    method IMPL-QAST-DECL(RakuAST::IMPL::QASTContext $context) {
+        return self.IMPL-UNUSED-DECL-QAST() if self.IMPL-UNUSED;
+        my $container := self.meta-object;
+        $context.ensure-sc($container);
+        # The topic check is against NQPMatchRole rather than Match: the
+        # role is resolvable here at compile time, while a lexical lookup
+        # of the name Match would bind to any user type of that name.
+        QAST::Stmts.new(
+            QAST::Var.new(
+                :scope('lexical'), :decl('contvar'), :name(self.name),
+                :value($container)
+            ),
+            QAST::Op.new(
+                :op('p6assign'),
+                QAST::Var.new( :scope('lexical'), :name(self.name) ),
+                QAST::Op.new(
+                    :op('if'),
+                    QAST::Op.new(
+                        :op('istype'),
+                        QAST::Op.new(
+                            :op('decont'),
+                            QAST::Var.new( :scope('lexical'), :name('$_') )
+                        ),
+                        QAST::WVal.new( :value(NQPMatchRole) )
+                    ),
+                    QAST::Var.new( :scope('lexical'), :name('$_') ),
+                    QAST::Op.new( :op('getlexouter'), QAST::SVal.new( :value(self.name) ) )
+                )
+            )
+        )
+    }
+}
+
 # Implicit block topic declaration. By default it is an optional parameter,
 # but can be configured to be either a non-parameter (always from outer), a
 # required parameter, or to obtain the current exception (for when it is a

--- a/src/core.c/Grammar.rakumod
+++ b/src/core.c/Grammar.rakumod
@@ -22,7 +22,8 @@ my class Grammar is Match {
           $cursor := $cursor.'!cursor_next'()
         );
 
-        nqp::getlexcaller('$/') = $cursor
+        Rakudo::Internals.SLASH-WRITE-TARGET(nqp::getlexcaller('$/'))
+          = $cursor
           ?? $cursor.Match::MATCH
           !! Nil
     }
@@ -32,13 +33,15 @@ my class Grammar is Match {
         $grammar.set_actions($actions)
           unless nqp::eqaddr(nqp::decont($actions),Mu);
 
-        nqp::getlexcaller('$/') = $args
+        Rakudo::Internals.SLASH-WRITE-TARGET(nqp::getlexcaller('$/'))
+          = $args
           ?? $grammar."$rule"(|$args.Capture).Match::MATCH
           !! $grammar."$rule"().Match::MATCH
       }
 
     method parsefile(Str(Cool) $filename, :$enc) {
-        nqp::getlexcaller('$/') = nqp::elems(nqp::getattr(%_,Map,'$!storage'))
+        Rakudo::Internals.SLASH-WRITE-TARGET(nqp::getlexcaller('$/'))
+          = nqp::elems(nqp::getattr(%_,Map,'$!storage'))
           ?? self.parse($filename.IO.slurp(:$enc), :$filename, |%_)
           !! self.parse($filename.IO.slurp(:$enc), :$filename)
     }

--- a/src/core.c/Match.rakumod
+++ b/src/core.c/Match.rakumod
@@ -443,9 +443,16 @@ multi sub infix:<eqv>(Match:D $a, Match:D $b) {
 }
 
 
+# Attach to the match of the nearest enclosing regex frame when there is
+# one: its cursor cannot be disturbed by user code, while $/ can have been
+# overwritten by a match run inside the regex's code block. Outside of a
+# regex frame, such as in an action method, the caller's $/ is the match.
 sub make(Mu \made) {
-    my $slash := nqp::decont(nqp::getlexcaller('$/'));
-    nqp::istype($slash, NQPMatchRole)
+    my $cursor := nqp::decont(nqp::getlexcaller('$¢'));
+    my $slash  := nqp::decont(nqp::getlexcaller('$/'));
+    nqp::isconcrete($cursor) && nqp::istype($cursor, NQPMatchRole)
+      ?? nqp::bindattr($cursor.MATCH, Match, '$!made', made)
+      !! nqp::istype($slash, NQPMatchRole)
         ?? nqp::bindattr($slash,Match,'$!made',made)
         !! X::Make::MatchRequired.new(:got($slash)).throw
 }

--- a/src/core.c/Match.rakumod
+++ b/src/core.c/Match.rakumod
@@ -444,17 +444,40 @@ multi sub infix:<eqv>(Match:D $a, Match:D $b) {
 
 
 # Attach to the match of the nearest enclosing regex frame when there is
-# one: its cursor cannot be disturbed by user code, while $/ can have been
-# overwritten by a match run inside the regex's code block. Outside of a
-# regex frame, such as in an action method, the caller's $/ is the match.
+# one. Its cursor cannot be disturbed by user code, however a match run
+# inside the regex's code block can overwrite $/. In a 6.e scope, where
+# $/ carries the isolation marker, the next candidate is the Match in
+# the immediate caller frame's own $/, i.e. the match that frame most
+# recently established. After that comes a Match topic, so a block
+# iterating match results attaches to its topic even when it never set
+# up a $/ of its own. Everything else attaches to the caller's $/, as
+# in an action method, whose $/ parameter carries no marker in any
+# revision. The caller lookups must stay at routine level. From inside
+# a nested block they would see this routine's own frame as the caller
+# and find its own $/. The topic lookup must stay behind the marker
+# check. A native $_ in the caller chain makes the lexical walk itself
+# die, so callers outside a 6.e scope must never trigger it.
 sub make(Mu \made) {
-    my $cursor := nqp::decont(nqp::getlexcaller('$¢'));
-    my $slash  := nqp::decont(nqp::getlexcaller('$/'));
+    my $cursor      := nqp::decont(nqp::getlexcaller('$¢'));
+    my \pad         := nqp::ctxlexpad(nqp::ctxcallerskipthunks(nqp::ctx()));
+    my \nearby-cont := nqp::existskey(pad,'$/')
+      ?? nqp::atkey(pad,'$/')
+      !! nqp::null();
+    my \slash-cont  := nqp::getlexcaller('$/');
+    my $slash       := nqp::decont(slash-cont);
     nqp::isconcrete($cursor) && nqp::istype($cursor, NQPMatchRole)
       ?? nqp::bindattr($cursor.MATCH, Match, '$!made', made)
-      !! nqp::istype($slash, NQPMatchRole)
-        ?? nqp::bindattr($slash,Match,'$!made',made)
-        !! X::Make::MatchRequired.new(:got($slash)).throw
+      !! Rakudo::Internals.IS-ISOLATED-MATCH(nearby-cont)
+           && nqp::isconcrete(my $nearby := nqp::decont(nearby-cont))
+           && nqp::istype($nearby, NQPMatchRole)
+        ?? nqp::bindattr($nearby, Match, '$!made', made)
+        !! Rakudo::Internals.IS-ISOLATED-MATCH(slash-cont)
+             && nqp::isconcrete(my $topic := nqp::decont(nqp::getlexcaller('$_')))
+             && nqp::istype($topic, NQPMatchRole)
+          ?? nqp::bindattr($topic, Match, '$!made', made)
+          !! nqp::istype($slash, NQPMatchRole)
+            ?? nqp::bindattr($slash,Match,'$!made',made)
+            !! X::Make::MatchRequired.new(:got($slash)).throw
 }
 
 # A concrete Match matcher is a match result already, so the smartmatch

--- a/src/core.c/Rakudo/Internals.rakumod
+++ b/src/core.c/Rakudo/Internals.rakumod
@@ -447,6 +447,35 @@ my class Rakudo::Internals is implementation-detail {
         )
     }
 
+    # The container to write a match into on behalf of a caller. An
+    # untyped $/ compiled by the RakuAST frontend in a 6.e scope carries
+    # the IsolatedMatch descriptor, which asks method forms not to write
+    # into it; a throwaway container takes the write instead, so shared
+    # write paths need no other check. Anything else passes through
+    # untouched: an unmarked container, a non-container from a rebound
+    # $/, and a non-Scalar container such as a native reference, which
+    # has no descriptor to inspect.
+    method SLASH-WRITE-TARGET(Mu \cont) is raw {
+        nqp::if(
+          Rakudo::Internals.IS-ISOLATED-MATCH(cont),
+          nqp::p6scalarfromdesc(nqp::null),
+          cont
+        )
+    }
+
+    # Whether the given value is a container carrying the IsolatedMatch
+    # descriptor, the $/ of a 6.e scope.
+    method IS-ISOLATED-MATCH(Mu \cont) {
+        nqp::hllbool(
+          nqp::eqaddr(nqp::what_nd(cont),Scalar)
+            && nqp::isrwcont(cont)
+            && nqp::eqaddr(
+                 nqp::what_nd(nqp::ifnull(
+                   nqp::getattr(cont,Scalar,'$!descriptor'),Mu)),
+                 ContainerDescriptor::IsolatedMatch)
+        )
+    }
+
     method TRANSPOSE(str $string, str $original, str $final) {
         nqp::join($final,nqp::split($original,$string))
     }

--- a/src/core.c/Str.rakumod
+++ b/src/core.c/Str.rakumod
@@ -1175,7 +1175,9 @@ my class Str does Stringy { # declared in BOOTSTRAP
     # All of these !match methods take a nqp::getlexcaller value for the $/
     # to be set as the first parameter.  The second parameter is usually
     # the Match object to be used (or something from which a Match can
-    # be made).
+    # be made).  Each writing method routes that value through
+    # Rakudo::Internals.SLASH-WRITE-TARGET, so a 6.e caller's $/ is left
+    # alone.
 
     # Generic fallback for matching with a pattern
     method !match-pattern(Mu \slash, $pattern, str $name, $value, \opts) {
@@ -1264,7 +1266,7 @@ my class Str does Stringy { # declared in BOOTSTRAP
 
     # Match object at given position
     method !match-one(Mu \slash, \cursor) {
-        slash
+        Rakudo::Internals.SLASH-WRITE-TARGET(slash)
           = my $match := nqp::isge_i(nqp::getattr_i(cursor,Match,'$!pos'),0)
           ?? cursor.MATCH
           !! Nil;
@@ -1273,7 +1275,7 @@ my class Str does Stringy { # declared in BOOTSTRAP
 
     # Some object at given position
     method !match-as-one(Mu \slash, \cursor, \as) {
-        slash = my $match := nqp::if(
+        Rakudo::Internals.SLASH-WRITE-TARGET(slash) = my $match := nqp::if(
           nqp::isge_i(nqp::getattr_i(cursor,Match,'$!pos'),0),
           nqp::if(nqp::istype(as,Str), &POST-STR, &POST-MATCH)(cursor),
           Nil
@@ -1283,7 +1285,7 @@ my class Str does Stringy { # declared in BOOTSTRAP
 
     # Create list from the appropriate Sequence given the move
     method !match-list(Mu \slash, \cursor, \move, \post) {
-        slash
+        Rakudo::Internals.SLASH-WRITE-TARGET(slash)
           = my $match := nqp::isge_i(nqp::getattr_i(cursor,Match,'$!pos'),0)
             ?? Seq.new(POST-ITERATOR.new(cursor, move, post)).list
             !! List.new;
@@ -1336,7 +1338,7 @@ my class Str does Stringy { # declared in BOOTSTRAP
 
     # Give back the nth match found
     method !match-nth-int(Mu \slash, \cursor, \move, \post, int $nth) {
-        slash
+        Rakudo::Internals.SLASH-WRITE-TARGET(slash)
           = my $match := nqp::isge_i(nqp::getattr_i(cursor,Match,'$!pos'),0)
           ?? nqp::eqaddr(
               (my $pulled := POST-ITERATOR.new(cursor, move, post)
@@ -1351,7 +1353,7 @@ my class Str does Stringy { # declared in BOOTSTRAP
 
     # Give back the N-tail match found
     method !match-nth-tail(Mu \slash, \cursor, \move, int $tail) {
-        slash = my $match := nqp::eqaddr(
+        Rakudo::Internals.SLASH-WRITE-TARGET(slash) = my $match := nqp::eqaddr(
           (my $pulled := Rakudo::Iterator.LastNValues(
             CURSOR-ITERATOR.new(cursor, move), $tail, 'match', 1
           ).pull-one),
@@ -1362,7 +1364,7 @@ my class Str does Stringy { # declared in BOOTSTRAP
 
     # Give last value of given iterator, or Nil if none
     method !match-last(Mu \slash, \cursor, \move) {
-        slash = my $match := nqp::eqaddr(
+        Rakudo::Internals.SLASH-WRITE-TARGET(slash) = my $match := nqp::eqaddr(
           (my $pulled := Rakudo::Iterator.LastValue(
             CURSOR-ITERATOR.new(cursor, move), 'match')
           ),
@@ -1374,7 +1376,7 @@ my class Str does Stringy { # declared in BOOTSTRAP
     # These !match methods take an iterator instead of a cursor.
     # Give list with matches found given a range with :nth
     method !match-nth-range(Mu \slash, \iterator, $min, $max) {
-        slash = my $match := nqp::stmts(
+        Rakudo::Internals.SLASH-WRITE-TARGET(slash) = my $match := nqp::stmts(
           (my int $skip = $min),
           nqp::if(
             nqp::islt_i($skip,1),
@@ -1427,7 +1429,7 @@ my class Str does Stringy { # declared in BOOTSTRAP
 
     # Give list with matches found given an iterator with :nth
     method !match-nth-iterator(Mu \slash, \source, \indexes) {
-        slash = my $match := nqp::stmts(
+        Rakudo::Internals.SLASH-WRITE-TARGET(slash) = my $match := nqp::stmts(
           Seq.new(Rakudo::Iterator.MonotonicIndexes(
             source, indexes, 1,
             -> $got,$next {
@@ -1465,7 +1467,7 @@ my class Str does Stringy { # declared in BOOTSTRAP
               nqp::istype($x,Range),
               self!match-x-range(slash, $iterator, $x.min, $x.max),
               nqp::stmts(
-                (slash = Nil),
+                (Rakudo::Internals.SLASH-WRITE-TARGET(slash) = Nil),
                 X::Str::Match::x.new(:got($x)).Failure
               )
             )
@@ -1475,7 +1477,7 @@ my class Str does Stringy { # declared in BOOTSTRAP
 
     # Give list with matches found given a range with :x
     method !match-x-range(Mu \slash, $iterator, $min, $max) {
-        slash = my $match := nqp::stmts(
+        Rakudo::Internals.SLASH-WRITE-TARGET(slash) = my $match := nqp::stmts(
           (my int $todo = nqp::if($max == Inf, 0x7fffffff, $max)),
           (my $matches := nqp::create(IterationBuffer)),
           nqp::until(
@@ -1639,7 +1641,8 @@ my class Str does Stringy { # declared in BOOTSTRAP
       :ii(:$samecase), :ss(:$samespace), :mm(:$samemark), *%options
     ) {
         my $global = %options<g> || %options<global>;
-        my \caller_dollar_slash := nqp::getlexcaller('$/');
+        my \caller_dollar_slash :=
+          Rakudo::Internals.SLASH-WRITE-TARGET(nqp::getlexcaller('$/'));
         my $SET_DOLLAR_SLASH     = nqp::istype($matcher, Regex);
         my $word_by_word = so $samespace || %options<s> || %options<sigspace>;
 
@@ -1670,7 +1673,9 @@ my class Str does Stringy { # declared in BOOTSTRAP
         my $result := nqp::if(
           (my $opts := nqp::getattr(%options,Map,'$!storage'))
             && nqp::isgt_i(nqp::elems($opts),1),
-          self!SUBST(nqp::getlexcaller('$/'),$original,$final,|%options),
+          self!SUBST(
+            Rakudo::Internals.SLASH-WRITE-TARGET(nqp::getlexcaller('$/')),
+            $original,$final,|%options),
           nqp::if(
             nqp::elems($opts),
             nqp::if(                                      # one named
@@ -1679,7 +1684,9 @@ my class Str does Stringy { # declared in BOOTSTRAP
               nqp::if(                                    # no trueish g/global
                 nqp::existskey($opts,'g') || nqp::existskey($opts,'global'),
                 Rakudo::Internals.TRANSPOSE-ONE(self, $original, $final),
-                self!SUBST(nqp::getlexcaller('$/'),$original,$final,|%options)
+                self!SUBST(
+                  Rakudo::Internals.SLASH-WRITE-TARGET(nqp::getlexcaller('$/')),
+                  $original,$final,|%options)
               )
             ),
             Rakudo::Internals.TRANSPOSE-ONE(self, $original, $final) # no nameds
@@ -1693,7 +1700,7 @@ my class Str does Stringy { # declared in BOOTSTRAP
     multi method subst(Str:D: $matcher, $replacement = "", *%options) {
         nqp::istype(
           (my $result := self!SUBST(
-            nqp::getlexcaller('$/'),
+            Rakudo::Internals.SLASH-WRITE-TARGET(nqp::getlexcaller('$/')),
             $matcher,
             $replacement,
             |%options
@@ -3213,7 +3220,7 @@ my class Str does Stringy { # declared in BOOTSTRAP
         invalid-trans-arg(@specs.are) unless @specs.are(Pair);
 
         # Make sure we have a writable $/
-        $/ := nqp::getlexcaller('$/');
+        $/ := Rakudo::Internals.SLASH-WRITE-TARGET(nqp::getlexcaller('$/'));
         $/ := my $ unless nqp::iscont($/);
 
         # Set up needles and pins
@@ -3279,7 +3286,7 @@ my class Str does Stringy { # declared in BOOTSTRAP
     my sub trans-with-nameds(Str:D $string, @specs, %_) {
 
         # Make sure we have access to the caller's lexical $/
-        $/ := nqp::getlexcaller('$/');
+        $/ := Rakudo::Internals.SLASH-WRITE-TARGET(nqp::getlexcaller('$/'));
 
         # Get the named arguments manually
         my int $complement = %_<c> // %_<complement> // 0;
@@ -3404,7 +3411,7 @@ my class Str does Stringy { # declared in BOOTSTRAP
               && self.chars;
 
         # Callables need access to the lexically visible $/ of the caller
-        $/ := nqp::getlexcaller('$/');
+        $/ := Rakudo::Internals.SLASH-WRITE-TARGET(nqp::getlexcaller('$/'));
 
         # Slow path for any nameds
         if nqp::elems(nqp::getattr(%_,Map,'$!storage')) {

--- a/src/vm/moar/dispatchers.nqp
+++ b/src/vm/moar/dispatchers.nqp
@@ -741,7 +741,8 @@ sub guard-type-concreteness($tracker) {
             }
 
             # A container assignment without type information
-            elsif nqp::eqaddr($desc-WHAT, ContainerDescriptor::Untyped) {
+            elsif nqp::eqaddr($desc-WHAT, ContainerDescriptor::Untyped)
+               || nqp::eqaddr($desc-WHAT, ContainerDescriptor::IsolatedMatch) {
                 if nqp::eqaddr($value, Nil) {
                     # Nil case is NYI.
                 }

--- a/t/02-rakudo/block-scoped-match-var.t
+++ b/t/02-rakudo/block-scoped-match-var.t
@@ -1,0 +1,204 @@
+use v6.e.PREVIEW;
+use nqp;
+use Test;
+
+plan 31;
+
+# https://github.com/rakudo/rakudo/issues/1235
+
+# A method form finding a non-Scalar container in the caller's $/ leaves
+# it alone rather than inspecting it for the isolation marker.
+{
+    sub with-native-slash($/ is rw) { "ab".subst("a", "x", :g, :ii) }
+    my int $native = 1;
+    is with-native-slash($native), "xb",
+      'a subst with a native reference bound to $/ works';
+}
+
+# The 6.e block-scoped $/ is a RakuAST frontend behavior.
+if nqp::gethllsym('Raku', 'COMPILER-FRONTEND') eq 'rakuast' {
+    {
+        is "42".subst(/(\d)/, { $0 * 2 }, :g), "84",
+          'a zero-arg subst callback reads the captures of its own match';
+    }
+    {
+        $/ := "meow";
+        is "42".subst(/(\d)/, { $0 * 2 }, :g), "84",
+          'a subst callback works when the surrounding $/ is bound to a plain value';
+    }
+    {
+        is "ab".match(/(\w)/, :g).map({ ~$0 }).join(","), "a,b",
+          'a block invoked with a Match reads that Match through $0';
+    }
+    {
+        "abc" ~~ /(b)/;
+        for 1 { "xyz" ~~ /(x)/ }
+        is ~$0, "b",
+          'a match inside a block does not disturb $/ in the enclosing scope';
+    }
+    {
+        my $got = do if "abc" ~~ /(b)/ { ~$0 };
+        is $got, "b",
+          'a block with no match of its own reads the enclosing $/';
+    }
+    {
+        "abc" ~~ /(b)/;
+        is ~$0, "b",
+          'the match operator still sets $/ in its own scope';
+    }
+    {
+        my sub f { { my $/; "abc" ~~ /(b)/; ~$0 } }
+        is f(), "b",
+          'an explicit my $/ in a block replaces the implicit one';
+    }
+    {
+        "abc" ~~ /(b)/;
+        is (try ~$0), "b",
+          'a try block reads the enclosing $/';
+    }
+    {
+        is (^200).race(:2batch).map({ S/ (.*) /$0/ }).unique.elems, 200,
+          'a substitution in a racing block keeps its match state per frame';
+    }
+    {
+        "old" ~~ /(old)/;
+        "abc".match(/(b)/);
+        is ~$0, "old",
+          'the match method does not write into the surrounding $/';
+    }
+    {
+        "old" ~~ /(old)/;
+        "abc".match(/(\w)/, :g);
+        is ~$0, "old",
+          'the match method with :g does not write into the surrounding $/';
+    }
+    {
+        "old" ~~ /(old)/;
+        "abc".match(/(\w)/, :x(2));
+        is ~$0, "old",
+          'the match method with :x does not write into the surrounding $/';
+    }
+    {
+        "old" ~~ /(old)/;
+        grammar P { token TOP { \w+ } }
+        P.parse("abc");
+        is ~$/, "old",
+          'the parse method does not write into the surrounding $/';
+    }
+    {
+        "old" ~~ /(old)/;
+        grammar SP { token TOP { \w+ } }
+        SP.subparse("abc");
+        is ~$/, "old",
+          'the subparse method does not write into the surrounding $/';
+    }
+    {
+        "old" ~~ /(old)/;
+        "42".subst(/(\d)/, "x");
+        is ~$0, "old",
+          'the subst method does not write into the surrounding $/';
+    }
+    {
+        "old" ~~ /(old)/;
+        "a1c".trans(/(\d)/ => { "x" });
+        is ~$0, "old",
+          'the trans method with a regex pair does not write into the surrounding $/';
+    }
+    {
+        my int $stable = 0;
+        for ^500 {
+            "abc" ~~ /(b)/;
+            "xyz".match(/(x)/);
+            $stable++ if ~$0 eq "b";
+        }
+        is $stable, 500,
+          'method isolation of $/ survives repeated operator writes to the container';
+    }
+    {
+        my @r;
+        for "ab".match(/(\w)/, :g).list { @r.push(~$0) }
+        is @r.join(","), "a,b",
+          'a for block whose topic is a Match reads that Match through $0';
+    }
+    {
+        my $/;
+        "old" ~~ /(old)/;
+        "abc".match(/(b)/);
+        is ~$0, "old",
+          'an explicit my $/ at mainline is as isolated as the implicit one';
+    }
+    {
+        my sub f { { my $/; "old" ~~ /(old)/; "abc".match(/(b)/); ~$0 } }
+        is f(), "old",
+          'an explicit my $/ in a block is as isolated as the implicit one';
+    }
+    {
+        my class Match { has $.x }
+        "o" ~~ /(o)/;
+        my @r;
+        for (Match.new(:x(1)),) { @r.push(~$0) }
+        is @r.join, "o",
+          'a user type named Match as the topic does not become $/';
+    }
+    {
+        grammar Q { token TOP { \w+ } }
+        class QA { method TOP($/) { make $/.Str.subst(/a/, "X") } }
+        is Q.parse("abc", :actions(QA)).made, "Xbc",
+          'subst works inside an action method with a $/ parameter';
+    }
+    {
+        my @m = "ab".match(/./, :g).list;
+        @m.map({ make "X" }).eager;
+        is @m.map({ .made // "Nil" }).join(","), "X,X",
+          'make in a block whose topic is a Match attaches to that Match';
+    }
+    {
+        my @m = "ab".match(/./, :g).list;
+        @m.map({ my $probe := $/; make "Y" }).eager;
+        is @m.map({ .made // "Nil" }).join(","), "Y,Y",
+          'make attaches to the same Match whether or not the block mentions $/';
+    }
+    {
+        "zz" ~~ /(z)/;
+        my @m = "ab".match(/./, :g).list;
+        @m.map({ make "X" }).eager;
+        is @m.map({ .made // "Nil" }).join(",") ~ "|" ~ ($/.made // "Nil"),
+          "X,X|Nil",
+          'make prefers the Match topic over a Match in the enclosing $/';
+    }
+    {
+        my @m = "ab".match(/./, :g).list;
+        my @r;
+        for @m { "zz" ~~ /(z)/; make "F"; @r.push($/.made // "Nil") }
+        is @r.join(",") ~ "|" ~ @m.map({ .made // "Nil" }).join(","),
+          "F,F|Nil,Nil",
+          'make prefers a match the block itself established over the topic';
+    }
+    {
+        my Match $/;
+        "old" ~~ /(old)/;
+        "abc".match(/(b)/);
+        is ~$0, "b",
+          'a typed my Match $/ keeps accepting method-form writes';
+    }
+    {
+        my $got = do with "abc".match(/(b)/) { ~$0 };
+        is $got, "b",
+          'a with block whose topic is a Match reads that Match through $0';
+    }
+    {
+        my $got = do given "xy" { when /(y)/ { ~$0 } };
+        is $got, "y",
+          'a when block reads the match its own regex condition produced';
+    }
+    {
+        with "abc" { /b/.Bool }
+        is $/.defined, False,
+          'a bare regex match inside a with block does not leak into the enclosing $/';
+    }
+}
+else {
+    skip-rest 'block-scoped $/ needs the RakuAST frontend';
+}
+
+# vim: expandtab shiftwidth=4

--- a/t/02-rakudo/make-regex-frame.t
+++ b/t/02-rakudo/make-regex-frame.t
@@ -1,0 +1,61 @@
+use Test;
+
+plan 8;
+
+# https://github.com/rakudo/rakudo/issues/1235
+
+# First, before anything in this file has produced a match: make with
+# nothing to attach to throws.
+{
+    throws-like { make 5 }, X::Make::MatchRequired,
+      'make with no match anywhere in reach throws';
+}
+
+# The make routine attaches to the match of the nearest enclosing regex
+# frame, so a match run inside a regex code block cannot redirect it.
+{
+    grammar ClobberGrammar {
+        token TOP { <letters> { if $<letters> ~~ /^a/ { make 42 } } }
+        token letters { \w+ }
+    }
+    is ClobberGrammar.parse("abcd").made, 42,
+      'make targets the token match after a smartmatch inside its code block';
+
+    grammar ActionGrammar { token TOP { \d+ } }
+    class ActionClass { method TOP($/) { make 3 * 3 } }
+    is ActionGrammar.parse("42", :actions(ActionClass)).made, 9,
+      'make in an action method attaches to the $/ parameter';
+
+    grammar InlineGrammar { token TOP { \w+ { make "hi" } } }
+    is InlineGrammar.parse("x").made, "hi",
+      'make in a plain regex code block attaches to the token match';
+
+    grammar NestedGrammar {
+        token TOP { <in> { make "O" } }
+        token in { \w { make "I" } }
+    }
+    my $nested = NestedGrammar.parse("x");
+    is $nested<in>.made, "I",
+      'make in a nested token attaches to that token, not the outer one';
+    is $nested.made, "O",
+      'make in the outer token is untouched by the inner make';
+}
+
+# Outside any regex frame, make attaches to the caller's $/.
+{
+    my $/ = Match.new;
+    make "plain";
+    is $/.made, "plain",
+      'make outside a regex frame attaches to the Match in the caller $/';
+}
+
+# The topic plays no part here: even with a Match as the topic, the
+# caller's $/ receives the value.
+{
+    my $/ = Match.new;
+    given Match.new { make "T" }
+    is $/.made, "T",
+      'make ignores a Match topic and attaches to the caller $/';
+}
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously the method forms of matching (`.match`, `.subst`, `.trans`, `Grammar.parse` and friends) reached into their caller's frame and wrote the match into its `$/`. That is the behavior #1235 describes as too invasive. It breaks when the caller's `$/` is bound or read-only, which is the normal state of affairs inside grammar actions, and it makes matching in threaded code unsafe since every block shares the enclosing scope's one container:

```raku
say (^1000).race.map({ S/ (.*) /$0/ }).unique.elems;  # ~915 instead of 1000

$/ := "meow";
say "42".subst(/(\d)/, { $0 * 2 }, :g);  # dies trying to numify "meow"
```

As jnthn noted in the issue, simply not setting `$/` would break the very common `$str.subst(/(\d+)/, { $0 * 2 })` idiom, since the replacement block reads its captures through the caller's `$/`. However, bare blocks already receive the match as their topic. As such, under `v6.e.PREVIEW` every block now declares its own `$/`, initialized at block entry from the topic when the topic is a Match and from the enclosing `$/` value otherwise. A regex operator inside a block writes the block's own container, a subst callback reads the captures of the match it was invoked with, `"ab".match(/(\w)/, :g).map({ ~$0 })` gives per item captures, and a block with no match of its own still sees the enclosing one.

With that in place the method forms no longer need to write the caller's `$/` at all. An untyped `$/` compiled by the RakuAST frontend in a 6.e scope carries a marker container descriptor (`ContainerDescriptor::IsolatedMatch`) and the method side write points leave such a container alone. The operator forms (`~~`, `m//`, `s///`, `S///`, `tr///`) still set `$/` in their own scope. The visible migration item is that 6.e code calling `.match` and then reading `$0` should use the return value instead, e.g. `with $str.match(/re/) { ~$0 }`. Callers on 6.d and earlier keep the old behavior in full, as their containers carry no marker, and the legacy frontend is unchanged.

The first commit stands somewhat apart and applies to every language revision. `make` now attaches to the match of the nearest enclosing regex frame through its `$¢` rather than through the caller's `$/`, which user code can clobber. Previously a `~~` inside a token's code block would redirect `make` to the wrong Match and `.made` on the parse result came back `Nil`. Two corner cases change with this in older revisions, however: a closure that escapes a regex frame and calls `make` later now attaches to that frame's cursor instead of throwing, and an explicit `$/ = $other` inside a regex code block is no longer honored.

Fixes #1235
