### PR TITLE
RakuAST: implement FOREIGN-LANG for Raku level slang grammars

### DIFF
--- a/src/Raku/Grammar.nqp
+++ b/src/Raku/Grammar.nqp
@@ -1267,13 +1267,42 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
     # This is like HLL::Grammar.LANG but it allows to call a token of a
     # Raku level grammar.  Takes the language (usually 'MAIN') and the
     # name of the regex to be executed.
-    method FOREIGN-LANG($langname, $regex) {
+    method FOREIGN-LANG($langname, $regex, *@args, *%named) {
         my $grammar := self.slang_grammar($langname);
+        self.panic("No language '" ~ $langname ~ "' is registered")
+          if nqp::isnull($grammar);
         if nqp::istype($grammar, NQPMatch) {
-            self.LANG($langname, $regex);
+            self.LANG($langname, $regex, |@args, |%named);
         }
         else {
-            nqp::die('FOREIGN-LANG non-NQP branch NYI')
+            # The foreign cursor cannot reuse this parse's shared state
+            # because regexes of a Raku level grammar expect their own
+            # shared type.
+            my $lang-cursor := $grammar.'!cursor_init'(self.orig, :p(self.pos));
+            $lang-cursor.clone_braid_from(self);
+            $lang-cursor.set_actions(self.slang_actions($langname));
+            my $ret := $lang-cursor."$regex"(|@args, |%named);
+
+            # Rebuild the Raku level match as an NQP one so the calling
+            # grammar can consume its extent and made value like any
+            # other subrule result.  Captures of the foreign parse stay
+            # behind, so values must cross the boundary through make.
+            my $Match := $*R.type-from-setting('Match');
+
+            # Transfer the extent the capture markers of the foreign
+            # regex determined, without reifying its captures.
+            $ret.CURSOR_CAPTURE_MARKERS;
+            my $new := nqp::create(NQPMatch);
+            nqp::bindattr($new, NQPMatch, '$!shared', self.'!shared'());
+            nqp::bindattr_i($new, NQPMatch, '$!from',
+              nqp::getattr_i($ret, $Match, '$!from'));
+            nqp::bindattr_i($new, NQPMatch, '$!pos',
+              nqp::getattr_i($ret, $Match, '$!pos'));
+            nqp::bindattr_i($new, NQPMatch, '$!to',
+              nqp::getattr_i($ret, $Match, '$!to'));
+            nqp::bindattr($new, NQPMatch, '$!made',
+              nqp::getattr($ret, $Match, '$!made'));
+            $new.set_braid_from(self)
         }
     }
 

--- a/t/02-rakudo/foreign-lang-slang.t
+++ b/t/02-rakudo/foreign-lang-slang.t
@@ -1,0 +1,81 @@
+use Test;
+use nqp;
+use experimental :rakuast;
+
+plan 6;
+
+unless nqp::gethllsym('Raku', 'COMPILER-FRONTEND') eq 'rakuast' {
+    skip-rest 'FOREIGN-LANG is the RakuAST frontend spelling';
+    exit;
+}
+
+grammar Digits::Lang {
+    token main-syntax { \d+ }
+    token exactly($n) { \d ** {$n} }
+    token trimmed { '#' <( \d+ )> '#' }
+    token based($n, :$hex) {
+        [ <?{ $hex }> <[0..9a..f]> ** {$n} | <?{ !$hex }> \d ** {$n} ]
+    }
+}
+class Digits::Actions {
+    method main-syntax($/) { make (~$/).Int }
+    method exactly($/)     { make (~$/).Int }
+}
+my sub value-of(Mu $/) { nqp::atkey($/.hash, 'value') }
+my role Digits::Slang {
+    token term:sym<digitize> {
+        <sym> \s* '{' \s* <value=.FOREIGN-LANG('Digits::Lang', 'main-syntax')> \s* '}'
+    }
+    token term:sym<two-digits> {
+        <sym> \s* '{' \s* <value=.FOREIGN-LANG('Digits::Lang', 'exactly', 2)> \s* '}'
+    }
+    token term:sym<trim-digits> {
+        <sym> \s* '{' \s* <value=.FOREIGN-LANG('Digits::Lang', 'trimmed')> \s* '}'
+    }
+    token term:sym<hex-digits> {
+        <sym> \s* '{' \s* <value=.FOREIGN-LANG('Digits::Lang', 'based', 2, :hex)> \s* '}'
+    }
+}
+my role Digits::SlangActions {
+    method term:sym<digitize>(Mu $/) {
+        self.attach: $/, RakuAST::IntLiteral.new(value-of($/).made);
+    }
+    method term:sym<two-digits>(Mu $/) {
+        self.attach: $/, RakuAST::IntLiteral.new(value-of($/).made);
+    }
+    method term:sym<trim-digits>(Mu $/) {
+        self.attach: $/, RakuAST::StrLiteral.new(value-of($/).Str);
+    }
+    method term:sym<hex-digits>(Mu $/) {
+        self.attach: $/, RakuAST::StrLiteral.new(value-of($/).Str);
+    }
+}
+
+my $setup = Q:to/SETUP/;
+    BEGIN {
+        $*LANG.define_slang('MAIN',
+          $*LANG.slang_grammar('MAIN').^mixin(Digits::Slang),
+          $*LANG.slang_actions('MAIN').^mixin(Digits::SlangActions));
+        $*LANG.define_slang('Digits::Lang', Digits::Lang, Digits::Actions);
+    }
+    SETUP
+
+is EVAL($setup ~ 'digitize { 42 }'), 42,
+    'the made value of the foreign parse reaches the calling action';
+
+is EVAL($setup ~ 'digitize { 42 } + 58'), 100,
+    'parsing continues after the region the foreign grammar consumed';
+
+is EVAL($setup ~ 'two-digits { 42 }'), 42,
+    'extra FOREIGN-LANG arguments are passed to the foreign regex';
+
+is EVAL($setup ~ 'trim-digits { #42# }'), "42",
+    'capture markers in the foreign token trim the matched text';
+
+is EVAL($setup ~ 'hex-digits { ab }'), "ab",
+    'named FOREIGN-LANG arguments are passed to the foreign regex';
+
+throws-like { EVAL($setup ~ 'digitize { nope }') }, X::Undeclared::Symbols,
+    'a failed foreign parse falls back to ordinary compile errors';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously FOREIGN-LANG died with an NYI error when the requested slang grammar was a Raku grammar rather than an NQP one, which prevented slang modules such as Slang::BNF from parsing a foreign syntax inside their package declarator. This ports the legacy frontend's non-NQP branch: run the Raku grammar's regex with the slang's actions and copy the result back into an NQP match that the calling grammar can use like any other subrule result. Positional and named arguments are passed through to the foreign regex, an unregistered language name dies with a message naming it, and the extent copy honors capture markers in the foreign regex.