### PR TITLE
RakuAST: stop forming discarded closure clones of declared routines

### DIFF
--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -2419,6 +2419,10 @@ class RakuAST::Routine
 
     method declaration-kind() { 'routine' }
 
+    # RakuAST::Code answers this too, but the method resolution order
+    # reaches RakuAST::Expression first for routines.
+    method needs-sink-call() { False }
+
     method attach-target-names() {
         self.IMPL-WRAP-LIST(['routine', 'block'])
     }
@@ -3079,11 +3083,11 @@ class RakuAST::Routine
                         )
                     )
                 }
-                else { # No need to replace the lexical with the closure clone if declared in the comp unit directly
-                    QAST::Stmts.new(
-                        QAST::Var.new( :decl<static>, :scope<lexical>, :$name, :value(self.meta-object) ),
-                        self.IMPL-CLOSURE-QAST($context),
-                    )
+                else {
+                    # The comp unit's frame runs once per load, so the
+                    # serialized routine works as the lexical's value as is.
+                    $context.ensure-sc(self.meta-object);
+                    QAST::Var.new( :decl<static>, :scope<lexical>, :$name, :value(self.meta-object) )
                 }
             }
         }

--- a/src/Raku/ast/statements.rakumod
+++ b/src/Raku/ast/statements.rakumod
@@ -1081,6 +1081,13 @@ class RakuAST::Statement::Expression
             $qast := $!condition-modifier.IMPL-WRAP-QAST($context,
                 $!expression.IMPL-TO-QAST($context, :immediate));
         }
+        elsif self.sunk && !$!condition-modifier && !$!loop-modifier
+                && nqp::istype($!expression, RakuAST::Routine)
+                && !$!expression.outer-most-thunk {
+            # Sunk, so the closure clone this would form is discarded. The
+            # declaration walk installs the routine and captures its frame.
+            $qast := QAST::Op.new( :op('null') );
+        }
         else {
             $qast := $!expression.IMPL-TO-QAST($context);
             if self.sunk && $!expression.needs-sink-call {

--- a/t/08-performance/38-rakuast-declaration-closures.t
+++ b/t/08-performance/38-rakuast-declaration-closures.t
@@ -1,0 +1,161 @@
+use lib <t/packages/Test-Helpers>;
+use Test::Helpers::QAST;
+use Test;
+use QAST:from<NQP>;
+use nqp;
+plan 20;
+
+# A routine declaration in statement position evaluates to a closure
+# clone of the routine, formed by a method dispatch on the serialized
+# code object plus a capture of the enclosing frame. When the statement
+# is sunk that clone is discarded, and the routine itself is installed
+# by the declaration walk, so the statement emits nothing. A routine
+# declared directly in the comp unit likewise keeps the serialized
+# routine as its lexical's value, with no clone formed beside it. The
+# elided chains would otherwise run on every load of the compilation
+# unit, once per declaration.
+
+# The file-scope routines the behavioral tests call. Declared at the
+# top level of this file so they take the comp unit branch, which a
+# routine under any enclosing block does not.
+sub wrap-target() { 'orig' }
+my $file-var = 10;
+sub reads-file-var() { $file-var + 1 }
+sub never-defined() { ... }
+sub stub-then-real() { ... }
+sub stub-then-real() { 'real' }
+
+my sub qast-count-callmethod (Mu $qast, $name --> Int:D) {
+    my int $count = 0;
+    $count = 1 if nqp::istype($qast, QAST::Op)
+        && $qast.op eq 'callmethod' && $qast.name ~~ $name;
+    if qast-descendable $qast {
+        $count += qast-count-callmethod($_, $name) for $qast.list;
+    }
+    $count
+}
+
+if nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' {
+    # A package body compiles as an immediate call with no clone of its
+    # own. The one clone each snippet keeps belongs to the body's final
+    # declaration statement: as the body block's return expression it is
+    # not sunk, so it still forms its closure.
+    qast-is 'my class SunkPlain { method m() { } }; 1', :full, -> \v {
+        qast-count-callmethod(v, 'clone') == 1
+    }, 'a sunk method declaration forms no closure clone of its own';
+
+    qast-is 'my class SunkMulti { multi method m() { }; multi method m(Int) { } }; 1', :full, -> \v {
+        qast-count-callmethod(v, 'clone') == 1
+    }, 'sunk multi method declarations form no closure clones of their own';
+
+    qast-is 'sub f() { }; 1', :full, -> \v {
+        not qast-contains-callmethod(v, 'clone')
+    }, 'a comp unit level sub keeps the serialized routine as its lexical value';
+
+    qast-is 'my grammar SunkG { token t { \d } }; 1', :full, -> \v {
+        qast-count-callmethod(v, 'clone') == 1
+    }, 'a sunk token declaration forms no closure clone of its own';
+
+    qast-is 'sub f() { }; 1', :full, -> \v {
+        not qast-contains-op(v, 'p6sink')
+    }, 'a sunk routine declaration statement is not sink called';
+
+    qast-is 'my $c = sub () { 42 }', :full, -> \v {
+        qast-contains-callmethod(v, 'clone')
+    }, 'a routine used as an expression still forms its closure clone';
+
+    qast-is 'my class BodySub { my sub h() { 1 }; method m() { h } }; 1', :full, -> \v {
+        qast-contains-callmethod(v, 'clone')
+    }, 'a lexical sub under a class body still rebinds its closure clone';
+}
+else {
+    skip 'shapes specific to the RakuAST frontend', 7;
+}
+
+# The declaration walk and the frame prologue's capture carry all the
+# behavior a per-statement clone would.
+
+{
+    my @subs;
+    for 1..3 -> $i {
+        my sub s() { $i }
+        @subs.push(&s);
+    }
+    is @subs.map({ .() }).join(','), '1,2,3',
+        'a lexical sub under a repeating block closes over each run';
+}
+
+{
+    my @closures;
+    for 1..2 -> $i {
+        @closures.push: do { my sub v() { $i } };
+    }
+    is @closures.map({ .() }).join(','), '1,2',
+        'a declaration as a block final value still yields a fresh closure';
+}
+
+{
+    my class InProcess {
+        my sub h() { 'helped' }
+        method m() { h() }
+    }
+    is InProcess.m, 'helped', 'a method reaches a lexical sub of its class body';
+}
+
+&wrap-target.wrap(sub () { 'wrapped-' ~ callsame });
+is wrap-target(), 'wrapped-orig', 'wrap works on a comp unit level sub';
+
+is reads-file-var(), 11, 'a comp unit level sub closes over comp unit lexicals';
+
+throws-like { never-defined() }, X::StubCode,
+    'calling a comp unit level stub reports the stub';
+
+is stub-then-real(), 'real',
+    'a comp unit level stub replaced by a definition calls the definition';
+
+{
+    my $caller-var = 5;
+    is EVAL('sub e() { $caller-var }; e()'), 5,
+        'a sub at the top of an EVAL unit closes over caller lexicals';
+}
+
+# The same holds when the unit is precompiled and its serialized
+# routines load in a fresh compilation. The fixture keeps its routines
+# at file scope, with no unit module wrapper, so they take the comp
+# unit branch too.
+{
+    my $dir = $*TMPDIR.add("rakuast-decl-closures-{$*PID}");
+    sub nuke(IO::Path $d) {
+        for $d.dir { $_.d ?? nuke($_) !! $_.unlink }
+        $d.rmdir;
+    }
+    LEAVE nuke($dir) if $dir.e;
+    $dir.mkdir;
+    $dir.add('DeclClosures.rakumod').spurt(q:to/END/);
+        my $unit-var = 5;
+        our sub uses-unit() { $unit-var * 2 }
+        our proto sub pm(|) {*}
+        multi sub pm(Int) { 'int' }
+        multi sub pm(Str) { 'str' }
+        our grammar PG { token TOP { \d+ } }
+        our class DC {
+            my sub helper() { 'H' }
+            method m() { helper() ~ $unit-var }
+            multi method mm() { 'zero' }
+            multi method mm(Int) { 'int' }
+        }
+        END
+    my $repo = CompUnit::Repository::FileSystem.new(:prefix($dir.Str));
+    CompUnit::RepositoryRegistry.use-repository($repo);
+    require ::('DeclClosures');
+    is ::('&uses-unit')(), 10,
+        'a precompiled comp unit level sub closes over its unit lexical';
+    is ::('&pm')(1) ~ ::('&pm')('x'), 'intstr',
+        'a precompiled comp unit level proto dispatches its multis';
+    is ::('PG').parse('123').Str, '123',
+        'a precompiled comp unit level grammar parses';
+    is ::('DC').m, 'H5',
+        'a precompiled method reaches its class body lexical sub';
+    is ::('DC').mm ~ ::('DC').mm(1), 'zeroint',
+        'precompiled multi methods dispatch';
+}


### PR DESCRIPTION
Previously every routine declaration emitted a closure clone of the routine, formed by a method dispatch on the serialized code object plus a capture dispatch of the enclosing frame. A sunk declaration statement discarded that clone. A routine declared directly in the comp unit discarded a second one built beside its lexical static value. These chains run on every load of a compilation unit. The core setting carried about fifteen thousand of them and re-dispatched roughly ten thousand at every startup of raku itself.

A sunk routine declaration statement now emits nothing. The declaration walk still places the routine block, and the frame prologue capture keeps its outer wired. A routine declared directly in the comp unit now keeps the serialized routine as its lexical value, matching what the traditional frontend emits. Routines also no longer take a sink call, since sinking a code object does nothing.

Startup of an empty program drops from 0.12s to 0.09s, and CORE.c.setting.moarvm shrinks by about 670KB.