### PR TITLE
RakuAST: type check the source of a bind

### DIFF
--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -45,6 +45,13 @@ class RakuAST::Node {
     # and False otherwise.
     method can-be-bound-to() { False }
 
+    # Compiles a bind to this node, checking the source against the
+    # target's bind constraint. The default performs no check, so a node
+    # whose target carries a constraint must override this.
+    method IMPL-CHECKED-BIND-QAST(RakuAST::IMPL::QASTContext $context, Mu $source-qast) {
+        self.IMPL-BIND-QAST($context, $source-qast)
+    }
+
     # Builds the exception thrown when this cannot be bound to, but someone
     # tries to do so anyway.
     method build-bind-exception(RakuAST::Resolver $resolver) {

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -486,7 +486,7 @@ class RakuAST::Infix
         my str $op := $!operator;
         if $op eq ':=' || $op eq '≔' {
             if $left.can-be-bound-to {
-                $left.IMPL-BIND-QAST($context, $right.IMPL-TO-QAST($context))
+                $left.IMPL-CHECKED-BIND-QAST($context, $right.IMPL-TO-QAST($context))
             }
             else {
                 nqp::die('Cannot compile bind to ' ~ $left.HOW.name($left));

--- a/src/Raku/ast/signature.rakumod
+++ b/src/Raku/ast/signature.rakumod
@@ -2269,6 +2269,12 @@ class RakuAST::ParameterTarget::Var
         }
     }
 
+    method IMPL-CHECKED-BIND-QAST(RakuAST::IMPL::QASTContext $context, Mu $source-qast) {
+        $!attribute
+            ?? self.IMPL-BIND-QAST($context, $source-qast)
+            !! $!declaration.IMPL-CHECKED-BIND-QAST($context, $source-qast)
+    }
+
     method IMPL-LOOKUP-QAST(RakuAST::IMPL::QASTContext $context) {
         unless $!declaration {
             nqp::die('Cannot produce lookup QAST for attribute parameter target');

--- a/src/Raku/ast/variable-access.rakumod
+++ b/src/Raku/ast/variable-access.rakumod
@@ -126,6 +126,10 @@ class RakuAST::Var::Lexical
         self.resolution.IMPL-BIND-QAST($context, $source-qast)
     }
 
+    method IMPL-CHECKED-BIND-QAST(RakuAST::IMPL::QASTContext $context, QAST::Node $source-qast) {
+        self.resolution.IMPL-CHECKED-BIND-QAST($context, $source-qast)
+    }
+
     method IMPL-CAN-INTERPRET() {
         self.is-resolved
           && nqp::istype(self.resolution, RakuAST::CompileTimeValue)

--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -1989,6 +1989,25 @@ class RakuAST::VarDeclaration::Simple
         )
     }
 
+    # Parameter binding also compiles through IMPL-BIND-QAST but with
+    # values the signature binder has already checked, some of which are
+    # VM-level and would not survive the assertion, so the assertion
+    # lives here rather than there.
+    method IMPL-CHECKED-BIND-QAST(RakuAST::IMPL::QASTContext $context, QAST::Node $source-qast) {
+        my str $sigil := self.sigil;
+        if $sigil eq '@' || $sigil eq '%' {
+            $source-qast := QAST::Op.new( :op('decont'), $source-qast );
+        }
+        my $type := self.return-type;
+        unless nqp::eqaddr($type, Mu) || $type.HOW.archetypes($type).generic {
+            $context.ensure-sc($type);
+            $source-qast := QAST::Op.new(
+                :op('p6bindassert'),
+                $source-qast, QAST::WVal.new( :value($type) ));
+        }
+        self.IMPL-BIND-QAST($context, $source-qast)
+    }
+
     method IMPL-EXPR-QAST(RakuAST::IMPL::QASTContext $context) {
         self.IMPL-LOOKUP-QAST($context)
     }

--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -2005,11 +2005,24 @@ class RakuAST::VarDeclaration::Simple
             $source-qast := QAST::Op.new( :op('decont'), $source-qast );
         }
         my $type := self.return-type;
-        unless nqp::eqaddr($type, Mu) || $type.HOW.archetypes($type).generic {
-            $context.ensure-sc($type);
-            $source-qast := QAST::Op.new(
-                :op('p6bindassert'),
-                $source-qast, QAST::WVal.new( :value($type) ));
+        unless nqp::eqaddr($type, Mu) {
+            if $type.HOW.archetypes($type).generic {
+                # A generic constraint is an un-instantiated stub at compile
+                # time, which no value matches. A plain named type is a
+                # lexical holding the concrete type where the bind runs, so
+                # the assertion looks the type up instead of embedding it.
+                if $sigil eq '$' && $!type && nqp::istype($!type, RakuAST::Lookup) {
+                    $source-qast := QAST::Op.new(
+                        :op('p6bindassert'),
+                        $source-qast, $!type.IMPL-TO-QAST($context));
+                }
+            }
+            else {
+                $context.ensure-sc($type);
+                $source-qast := QAST::Op.new(
+                    :op('p6bindassert'),
+                    $source-qast, QAST::WVal.new( :value($type) ));
+            }
         }
         self.IMPL-BIND-QAST($context, $source-qast)
     }

--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -948,12 +948,7 @@ class RakuAST::VarDeclaration::Simple
             my str $sigil := self.sigil;
             return True if $sigil eq '@' || $sigil eq '%';
             return True unless $!type;
-            my $type := self.IMPL-UNWRAP-LIST(self.get-implicit-lookups)[0];
-            return True unless nqp::objprimspec(
-                # $type will be undefined if $!type is set by an Of trait.
-                # In that case we assume the trait type has been resolved
-                ($type // $!type).resolution.compile-time-value
-            );
+            return True unless nqp::objprimspec(self.IMPL-OF-TYPE);
         }
         False
     }

--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -273,6 +273,13 @@ class RakuAST::ContainerCreator {
                 $container-type := $explicit-base.HOW.parameterize(
                     $explicit-base, $value-type, $key-type);
             }
+            # An @ or % variable is bound to its container directly, so the
+            # explicit base constrains what can be bound. An `is` type on a
+            # scalar names its scalar container type, which the bound value
+            # never is.
+            if $sigil eq '@' || $sigil eq '%' {
+                $bind-constraint := $container-type;
+            }
         }
 
         nqp::bindattr(self, RakuAST::ContainerCreator, '$!initialized', True);
@@ -1572,10 +1579,9 @@ class RakuAST::VarDeclaration::Simple
               # An attribute with an explicit container base type (e.g.
               # `has Int @.a is Array`) needs the parameterized container as
               # its type, both for introspection and for REPRs that lay
-              # attributes out by type. The bind constraint is a bare Mu on
-              # that path. Only sigils whose base type is the container
-              # itself qualify. An `is` type on a scalar names its scalar
-              # container type rather than the value type.
+              # attributes out by type. Only sigils whose base type is the
+              # container itself qualify. An `is` type on a scalar names its
+              # scalar container type rather than the value type.
               type => self.IMPL-HAS-EXPLICIT-CONTAINER-BASE-TYPE
                   && ($scope eq 'HAS' || self.sigil eq '@' || self.sigil eq '%')
                 ?? self.IMPL-CONTAINER-TYPE($of)

--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -1393,6 +1393,15 @@ class RakuAST::VarDeclaration::Simple
             inner => self.IMPL-EXPLICIT-CONTAINER-BASE-TYPE,
         ) if self.IMPL-HAS-CONFLICTING-BASE-TYPE;
 
+        # A bind replaces the declared container, which would discard an
+        # array's shape, so a shaped array declaration cannot take a binding
+        # initializer. A keyed hash also sets the shape, but its keys live
+        # on the container type the bind checks, so it binds fine.
+        self.add-sorry(
+          $resolver.build-exception: 'X::Bind'
+        ) if $!shape && self.sigil eq '@'
+          && $!initializer && $!initializer.is-binding;
+
         if (self.initializer) {
             my @found := self.IMPL-UNWRAP-LIST(self.find-nodes(
                 RakuAST::Var::Lexical,
@@ -1834,19 +1843,10 @@ class RakuAST::VarDeclaration::Simple
                     my $init-qast := $!initializer.IMPL-TO-QAST($context, :invocant-qast($var-access));
                     my $perform-init-qast;
                     if $!initializer.is-binding {
-                        my $source := $sigil eq '@' || $sigil eq '%'
-                          ?? QAST::Op.new( :op('decont'), $init-qast)
-                          !! $init-qast;
-                        my $type := self.bind-constraint;
-                        $context.ensure-sc($type);
-                        if !nqp::eqaddr($type, Mu) {
-                            $source := QAST::Op.new(
-                                :op('p6bindassert'),
-                                $source, QAST::WVal.new( :value($type) ))
-                        }
-                        $perform-init-qast := QAST::Op.new(
-                          :op('bind'), $var-access, $source
-                        );
+                        # The bind replaces the declared container, so it
+                        # targets the variable itself rather than any
+                        # instantiate_generic wrap of the access.
+                        $perform-init-qast := self.IMPL-CHECKED-BIND-QAST($context, $init-qast);
                     }
                     else {
                         # Assignment. Case-analyze by sigil.

--- a/t/02-rakudo/bind-typecheck.t
+++ b/t/02-rakudo/bind-typecheck.t
@@ -7,13 +7,13 @@ use MONKEY-SEE-NO-EVAL;
 # sigil. The check covers types that wrap another type node, such as
 # definite, coercion, and parameterized types, and also applies when
 # the target is a typed is copy parameter rebound in the routine body.
-# A bind declaration checks the same way, works when the constraint
-# is generic, and is refused on a shaped array declaration, whose
-# shape the bind would discard.
+# A bind declaration checks the same way and is refused on a shaped
+# array declaration, whose shape the bind would discard. A generic
+# constraint is checked against the type it is instantiated with.
 
 my $rakuast := nqp::gethllsym('Raku', 'COMPILER-FRONTEND') eq 'rakuast';
 
-plan 44;
+plan 47;
 
 {
     my Int $y = 42;
@@ -203,6 +203,12 @@ throws-like {
 }
 
 throws-like {
+    my role R[::T] { method m(T $x is copy, $y) { $x := $y } }
+    R[Int].new.m(1, "s");
+}, X::TypeCheck::Binding,
+    'rebinding a generic typed is copy parameter to the wrong type throws';
+
+throws-like {
     my Int $x := "s";
 }, X::TypeCheck::Binding,
     'a bind declaration of a typed scalar checks the bound value';
@@ -283,9 +289,21 @@ if $rakuast {
         R[Int].new.m(5)
         CODE
         'a bind declaration with a generic type takes the bound value';
+
+    throws-like q:to/CODE/, X::TypeCheck::Binding,
+        my role R[::T] { method m($v) { my T $x := $v } }
+        R[Int].new.m("s")
+        CODE
+        'a bind declaration with a generic type checks the bound value';
+
+    is EVAL(q:to/CODE/), 2,
+        my role R[::T] { method m(T $x is copy, T $y) { $x := $y; $x } }
+        R[Int].new.m(1, 2)
+        CODE
+        'a generic typed is copy parameter can be rebound to a matching value';
 }
 else {
-    skip 'the legacy frontend does not compile a bind declaration with a generic type';
+    skip 'the legacy frontend asserts a generic bind against the un-instantiated type', 3;
 }
 
 # vim: expandtab shiftwidth=4

--- a/t/02-rakudo/bind-typecheck.t
+++ b/t/02-rakudo/bind-typecheck.t
@@ -1,0 +1,171 @@
+use Test;
+
+# An infix bind checks its source against the target container's bind
+# constraint and deconts the source when the target has the @ or %
+# sigil. The check covers types that wrap another type node, such as
+# definite, coercion, and parameterized types, and also applies when
+# the target is a typed is copy parameter rebound in the routine body.
+
+plan 25;
+
+{
+    my Int $y = 42;
+    my Int:D $x = 1;
+    $x := $y;
+    is $x, 42, 'can bind a defined value to a variable with a definite type';
+}
+
+throws-like {
+    my Int $y;
+    my Int:D $x = 1;
+    $x := $y;
+}, X::TypeCheck::Binding,
+    'binding an undefined value to a variable with a definite type throws';
+
+{
+    my $y = "9";
+    my Int(Str) $x = 5;
+    $x := $y;
+    is $x.^name, 'Str', 'can bind an accepted value to a variable with a coercion type';
+}
+
+throws-like {
+    my $y = 4.5;
+    my Int(Str) $x = 5;
+    $x := $y;
+}, X::TypeCheck::Binding,
+    'binding a value outside a coercion type to a variable with a coercion type throws';
+
+{
+    my @a := Array[Int].new(1, 2);
+    my Array[Int] $x;
+    $x := @a;
+    is-deeply $x, Array[Int].new(1, 2),
+        'can bind a matching value to a variable with a parameterized type';
+}
+
+throws-like {
+    my @a = 1, 2;
+    my Array[Int] $x;
+    $x := @a;
+}, X::TypeCheck::Binding,
+    'binding an untyped array to a variable with a parameterized type throws';
+
+throws-like {
+    my Int $x = 1;
+    $x := "s";
+}, X::TypeCheck::Binding,
+    'binding a value of the wrong type to a typed scalar throws';
+
+{
+    my Int $x = 1;
+    my $y = 5;
+    $x := $y;
+    is $x, 5, 'a valid bind to a typed scalar takes the new value';
+    $y = 7;
+    is $x, 7, 'a scalar bind aliases the source container';
+    $x = 9;
+    is $y, 9, 'assignment through a rebound scalar reaches the source container';
+}
+
+throws-like {
+    my @a;
+    @a := 5;
+}, X::TypeCheck::Binding,
+    'binding a non-Positional value to an @ sigil variable throws';
+
+throws-like {
+    my Int @a;
+    my @b = "x", "y";
+    @a := @b;
+}, X::TypeCheck::Binding,
+    'binding an untyped array to a typed @ sigil variable throws';
+
+{
+    my @b = 1, 2;
+    my $s = @b;
+    my @a;
+    @a := $s;
+    is @a.VAR.^name, 'Array',
+        'binding a Scalar-held array to an @ sigil variable deconts the source';
+}
+
+{
+    my @b = 1, 2;
+    my @a;
+    @a := @b;
+    @b.push(3);
+    is @a.elems, 3, 'binding an array to an @ sigil variable aliases it';
+}
+
+throws-like {
+    my %h;
+    %h := 5;
+}, X::TypeCheck::Binding,
+    'binding a non-Associative value to a % sigil variable throws';
+
+{
+    my %b = a => 1;
+    my $s = %b;
+    my %h;
+    %h := $s;
+    is %h.VAR.^name, 'Hash',
+        'binding a Scalar-held hash to a % sigil variable deconts the source';
+}
+
+throws-like {
+    my Int %h;
+    my %b = a => "x";
+    %h := %b;
+}, X::TypeCheck::Binding,
+    'binding an untyped hash to a typed % sigil variable throws';
+
+throws-like {
+    sub f(Int $x is copy) { $x := "s" }
+    f(42);
+}, X::TypeCheck::Binding,
+    'rebinding a typed is copy parameter to the wrong type throws';
+
+{
+    sub f(Int $x is copy) { $x := 99; $x }
+    is f(42), 99, 'a valid rebind of a typed is copy parameter takes the new value';
+}
+
+{
+    sub f($x is copy) { $x := "s"; $x }
+    is f(42), "s", 'an untyped is copy parameter can be rebound to any type';
+}
+
+throws-like {
+    sub f(Int @a is copy) { @a := ["x"] }
+    my Int @a = 1, 2;
+    f(@a);
+}, X::TypeCheck::Binding,
+    'rebinding a typed @ sigil is copy parameter to the wrong type throws';
+
+throws-like {
+    sub f() { state Int $x; $x := "s" }
+    f;
+}, X::TypeCheck::Binding,
+    'binding a value of the wrong type to a typed state variable throws';
+
+throws-like {
+    my UInt $x = 1;
+    my $y = -5;
+    $x := $y;
+}, X::TypeCheck::Binding,
+    'binding a value outside a subset type to a variable with a subset type throws';
+
+{
+    my UInt $x = 1;
+    my $y = 5;
+    $x := $y;
+    is $x, 5, 'can bind an accepted value to a variable with a subset type';
+}
+
+{
+    my role R[::T] { method m(T $x is copy, T $y) { $x := $y; $x } }
+    ok R[Int] ~~ R, 'a role body with a bind to a generic typed variable compiles';
+}
+
+# vim: expandtab shiftwidth=4

--- a/t/02-rakudo/bind-typecheck.t
+++ b/t/02-rakudo/bind-typecheck.t
@@ -1,12 +1,19 @@
+use nqp;
 use Test;
+use MONKEY-SEE-NO-EVAL;
 
 # An infix bind checks its source against the target container's bind
 # constraint and deconts the source when the target has the @ or %
 # sigil. The check covers types that wrap another type node, such as
 # definite, coercion, and parameterized types, and also applies when
 # the target is a typed is copy parameter rebound in the routine body.
+# A bind declaration checks the same way, works when the constraint
+# is generic, and is refused on a shaped array declaration, whose
+# shape the bind would discard.
 
-plan 27;
+my $rakuast := nqp::gethllsym('Raku', 'COMPILER-FRONTEND') eq 'rakuast';
+
+plan 44;
 
 {
     my Int $y = 42;
@@ -112,6 +119,20 @@ throws-like {
 }
 
 throws-like {
+    my %h is Hash[Int];
+    my %b = a => "x";
+    %h := %b;
+}, X::TypeCheck::Binding,
+    'binding an untyped hash to a % sigil variable with an explicit container base throws';
+
+{
+    my %h is Hash[Int];
+    %h := Hash[Int].new((a => 1));
+    is %h<a>, 1,
+        'can bind a matching hash to a % sigil variable with an explicit container base';
+}
+
+throws-like {
     my %h;
     %h := 5;
 }, X::TypeCheck::Binding,
@@ -179,6 +200,92 @@ throws-like {
 {
     my role R[::T] { method m(T $x is copy, T $y) { $x := $y; $x } }
     ok R[Int] ~~ R, 'a role body with a bind to a generic typed variable compiles';
+}
+
+throws-like {
+    my Int $x := "s";
+}, X::TypeCheck::Binding,
+    'a bind declaration of a typed scalar checks the bound value';
+
+{
+    my $y = 5;
+    my Int $x := $y;
+    is $x, 5, 'a valid bind declaration of a typed scalar takes the value';
+    $y = 7;
+    is $x, 7, 'a bind declaration of a scalar aliases the source container';
+}
+
+throws-like {
+    my Int @a := ["x"];
+}, X::TypeCheck::Binding,
+    'a bind declaration of a typed @ sigil variable checks the bound value';
+
+{
+    my Int @a := Array[Int].new(1, 2);
+    is-deeply @a, Array[Int].new(1, 2),
+        'a valid bind declaration of a typed @ sigil variable takes the value';
+}
+
+{
+    my @b = 1, 2;
+    my $s = @b;
+    my @a := $s;
+    is @a.VAR.^name, 'Array',
+        'a bind declaration of an @ sigil variable deconts the source';
+}
+
+throws-like {
+    my Int %h := { a => "x" };
+}, X::TypeCheck::Binding,
+    'a bind declaration of a typed % sigil variable checks the bound value';
+
+{
+    my Int %h := Hash[Int].new((a => 1));
+    is %h<a>, 1,
+        'a valid bind declaration of a typed % sigil variable takes the value';
+}
+
+throws-like {
+    my $x of Int;
+    $x := "s";
+}, X::TypeCheck::Binding,
+    'binding a value of the wrong type to a variable typed by an of trait throws';
+
+{
+    our $x := 5;
+    is $x, 5, 'a bind declaration of an our variable takes the value';
+}
+
+{
+    class WithKeys does Associative[Any, Int] { method AT-KEY($k) { 42 } }
+    my %h{Int} := WithKeys.new;
+    is %h{1}, 42, 'a keyed hash declaration can take a binding initializer';
+}
+
+{
+    class ShapedAttr { has @.a[2] }
+    is-deeply ShapedAttr.new.a.shape, (2,),
+        'a shaped attribute declaration without a binding initializer keeps its shape';
+}
+
+{
+    my @a[2] = 1, 2;
+    is @a[1], 2, 'a shaped array declaration with an assignment initializer works';
+}
+
+throws-like q[my @a[2] := [1,2]],
+    X::Bind,
+    'a bind declaration of a shaped variable is refused at compile time';
+
+if $rakuast {
+    is EVAL(q:to/CODE/), 5,
+        my role R[::T] { method m(T $v) { my T $x := $v; $x } }
+        R[Int].new.m(5)
+        CODE
+        'a bind declaration with a generic type takes the bound value';
+}
+else {
+    skip 'the legacy frontend does not compile a bind declaration with a generic type';
 }
 
 # vim: expandtab shiftwidth=4

--- a/t/02-rakudo/bind-typecheck.t
+++ b/t/02-rakudo/bind-typecheck.t
@@ -6,7 +6,7 @@ use Test;
 # definite, coercion, and parameterized types, and also applies when
 # the target is a typed is copy parameter rebound in the routine body.
 
-plan 25;
+plan 27;
 
 {
     my Int $y = 42;
@@ -96,6 +96,19 @@ throws-like {
     @a := @b;
     @b.push(3);
     is @a.elems, 3, 'binding an array to an @ sigil variable aliases it';
+}
+
+throws-like {
+    my @a is Array[Int];
+    @a := ["x"];
+}, X::TypeCheck::Binding,
+    'binding an untyped array to an @ sigil variable with an explicit container base throws';
+
+{
+    my @a is Array[Int];
+    @a := Array[Int].new(1, 2);
+    is-deeply @a, Array[Int].new(1, 2),
+        'can bind a matching array to an @ sigil variable with an explicit container base';
 }
 
 throws-like {


### PR DESCRIPTION
Previously the RakuAST frontend compiled `:=` to a bare bind of the source value, however the legacy frontend asserts the source against the target container's bind constraint and deconts it for `@` and `%` sigils. As such `my Int $x = 1; $x := "s"` succeeded where legacy throws `X::TypeCheck::Binding`, `my @a; @a := 5` bound an Int to an array variable, and `@a := $scalar` left the `Scalar` container behind the `@` sigil. A typed `is copy` parameter rebound in a routine body had the same gap. A bind to a variable whose type wraps another type node (`Int:D`, `Int(Str)`, `Array[Int]`) could not compile at all, dying with an internal `No such method 'resolution'` error in `can-be-bound-to`.

This adds an `IMPL-CHECKED-BIND-QAST` that deconts an `@` or `%` source and wraps it in a `p6bindassert` against the bind constraint, and compiles infix binds and bind declarations through it. The assertion can not live in `IMPL-BIND-QAST` itself since parameter binding also compiles through that method with values the signature binder has already checked, e.g. the VM-level hash behind the implicit `%_`.

Along the way this also sets the bind constraint for explicit container base declarations such as `my @a is Array[Int]`, which previously accepted any Positional, and fixes bind declarations whose constraint is generic, i.e. `my T $x := $v` in a role body died with an internal QAST error. A shaped array declaration like `my @a[2] := [1,2]` now reports the same bind operator error as legacy instead of that internal error.

A generic constraint is asserted against the type it is instantiated with rather than the compile time stub. Legacy embeds the stub and as such throws on valid binds inside instantiated role bodies, e.g. `role R[::T] { method m(T $x is copy, T $y) { $x := $y } }` dies with "expected T but got Int" on `R[Int]`, whereas this checks against `Int`.