### PR TITLE
RakuAST: Fix -n/-p loop wrapping issues

### DIFF
--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -169,9 +169,21 @@ sub hoist-loop-body-declarations($body, $compunit) {
             $node.set-hoisted-to-outer;
             $compunit.add-generated-lexical-declaration($node);
         }
+        # A list declaration bound with := goes through the runtime
+        # signature binder, which writes into the declaring frame's
+        # lexicals by name, so its targets must keep their slots in the
+        # loop body. The bind re-runs each line, so nothing persists to
+        # hoist anyway.
+        if nqp::istype($node, Nodify('VarDeclaration::Signature'))
+          && nqp::isconcrete($node.initializer)
+          && $node.initializer.is-binding {
+            0
+        }
         # Descend through everything except inner lexical scopes, which own
         # their own declarations; always descend into the loop body itself.
-        $node =:= $body || !nqp::istype($node, Nodify('LexicalScope'))
+        else {
+            $node =:= $body || !nqp::istype($node, Nodify('LexicalScope'))
+        }
     }
 }
 

--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -108,6 +108,51 @@ sub move-loop-phasers-to-body($compunit, $body) {
     }
 }
 
+# Move the CATCH/CONTROL handlers onto the per-line loop body the same way,
+# so a handled exception ends only that line's iteration and the loop
+# continues with the next line.
+sub move-exception-handlers-to-body($compunit, $body) {
+    my $LexicalScope := Nodify('LexicalScope');
+    my $handlers := nqp::getattr($compunit, $LexicalScope, '$!catch-handlers');
+    if $handlers {
+        for $handlers {
+            $body.attach-catch-handler($_);
+        }
+        nqp::bindattr($compunit, $LexicalScope, '$!catch-handlers', nqp::null());
+    }
+    $handlers := nqp::getattr($compunit, $LexicalScope, '$!control-handlers');
+    if $handlers {
+        for $handlers {
+            $body.attach-control-handler($_);
+        }
+        nqp::bindattr($compunit, $LexicalScope, '$!control-handlers', nqp::null());
+    }
+}
+
+# Move the succeed handler the program's when/default statements required
+# onto the per-line loop body, so a matched when ends only that line's
+# iteration. Their succeed scope moves too, keeping sink decisions on the
+# scope that takes the payload.
+sub move-succeed-handler-to-body($compunit, $body) {
+    my $LexicalScope := Nodify('LexicalScope');
+    return 0 unless nqp::getattr_i($compunit, $LexicalScope, '$!need-succeed-handler');
+    nqp::bindattr_i($compunit, $LexicalScope, '$!need-succeed-handler', 0);
+    $body.require-succeed-handler();
+    my $When    := Nodify('Statement::When');
+    my $Default := Nodify('Statement::Default');
+    $body.visit-dfs: -> $node {
+        if nqp::istype($node, $When)
+          && nqp::eqaddr(nqp::getattr($node, $When, '$!succeed-scope'), $compunit) {
+            nqp::bindattr($node, $When, '$!succeed-scope', $body);
+        }
+        elsif nqp::istype($node, $Default)
+          && nqp::eqaddr(nqp::getattr($node, $Default, '$!succeed-scope'), $compunit) {
+            nqp::bindattr($node, $Default, '$!succeed-scope', $body);
+        }
+        1
+    }
+}
+
 # Move the -n/-p program's lexical declarations from the per-line loop body
 # into the compunit mainline, so they persist across iterations and are
 # visible to BEGIN/END and friends, matching the legacy frontend. The loop
@@ -591,6 +636,8 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
             $statement-list := @wrapped[0];
             hoist-loop-body-declarations(@wrapped[1], $COMPUNIT);
             move-loop-phasers-to-body($COMPUNIT, @wrapped[1]);
+            move-exception-handlers-to-body($COMPUNIT, @wrapped[1]);
+            move-succeed-handler-to-body($COMPUNIT, @wrapped[1]);
             # Give the wrapper nodes a chance to do BEGIN time effects
             $statement-list.IMPL-BEGIN($RESOLVER, $COMPUNIT.context);
         }

--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -90,6 +90,24 @@ sub wrap-in-for-loop($ast) {
     nqp::list($statement-list, $body)
 }
 
+# Move the loop phasers the program's statements attached to the compilation
+# unit onto the per-line loop body, where they fire as loop phasers of the
+# -n/-p wrapper loop. The statements attached them before the wrapping, when
+# the compilation unit was the enclosing attach target. Block phasers such
+# as ENTER and LEAVE stay on the mainline.
+sub move-loop-phasers-to-body($compunit, $body) {
+    my $ScopePhaser := Nodify('ScopePhaser');
+    for ['FIRST', 'NEXT', 'LAST'] -> $type {
+        my $list := nqp::getattr($compunit, $ScopePhaser, '$!' ~ $type);
+        if $list {
+            for $list {
+                $body.add-phaser($type, $_);
+            }
+            nqp::bindattr($compunit, $ScopePhaser, '$!' ~ $type, nqp::null());
+        }
+    }
+}
+
 # Move the -n/-p program's lexical declarations from the per-line loop body
 # into the compunit mainline, so they persist across iterations and are
 # visible to BEGIN/END and friends, matching the legacy frontend. The loop
@@ -572,6 +590,7 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
             my @wrapped := wrap-in-for-loop($statement-list);
             $statement-list := @wrapped[0];
             hoist-loop-body-declarations(@wrapped[1], $COMPUNIT);
+            move-loop-phasers-to-body($COMPUNIT, @wrapped[1]);
             # Give the wrapper nodes a chance to do BEGIN time effects
             $statement-list.IMPL-BEGIN($RESOLVER, $COMPUNIT.context);
         }

--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -101,8 +101,8 @@ sub hoist-loop-body-declarations($body, $compunit) {
     $body.visit-dfs: -> $node {
         if nqp::istype($node, Nodify('Declaration'))
           && !nqp::istype($node, Nodify('VarDeclaration::Implicit'))
-          && $node.lexical-name ne '$_'
-          && $node.is-simple-lexical-declaration {
+          && $node.is-simple-lexical-declaration
+          && $node.lexical-name ne '$_' {
             $node.set-hoisted-to-outer;
             $compunit.add-generated-lexical-declaration($node);
         }

--- a/src/Raku/ast/statementprefixes.rakumod
+++ b/src/Raku/ast/statementprefixes.rakumod
@@ -977,7 +977,8 @@ class RakuAST::StatementPrefix::Phaser::First
 
         my $True := RakuAST::Term::Name.new(RakuAST::Name.from-identifier('True'));
 
-        my $attach-block := $resolver.find-attach-target('block');
+        my $attach-block := $resolver.find-attach-target('block')
+            // $resolver.find-attach-target('compunit');
 
         my $value-name := QAST::Node.unique('!first_block_value');
         my $value-var := RakuAST::VarDeclaration::Implicit::State.new: $value-name;

--- a/src/Raku/ast/var-lowering.rakumod
+++ b/src/Raku/ast/var-lowering.rakumod
@@ -787,7 +787,13 @@ class RakuAST::IMPL::VarLowering {
 
         my str $declined := '';
         my str $sigil := $decl.sigil;
-        if $decl.twigil ne '' {
+        if $decl.is-hoisted-to-outer {
+            # The declaration's lexpad slot is provided by an outer scope,
+            # as -n/-p do with the compunit mainline, so every access from
+            # the declaring scope crosses a frame boundary.
+            $declined := 'hoisted';
+        }
+        elsif $decl.twigil ne '' {
             $declined := 'twigil';
         }
         elsif $decl.forced-dynamic {

--- a/t/02-rakudo/n-flag-mainline-scope.t
+++ b/t/02-rakudo/n-flag-mainline-scope.t
@@ -1,8 +1,11 @@
 use lib <t/packages/Test-Helpers>;
 use Test;
 use Test::Helpers;
+use nqp;
 
-plan 7;
+my $rakuast = nqp::gethllsym('Raku', 'COMPILER-FRONTEND') eq 'rakuast';
+
+plan 12;
 
 # Under -n/-p the program runs once per input line, but its lexical
 # declarations live in the compunit mainline, so they persist across lines and
@@ -47,5 +50,38 @@ is-run 'my ($a, $b) = 1, 2; say $a + $b',
 is-run 's/a/A/',
     '-p modifies the topic each line',
     :compiler-args['-p'], :in($in), :out("A b\nc d e\n");
+
+# The program's FIRST/NEXT/LAST phasers become loop phasers of the wrapper
+# loop. The legacy frontend never runs them under -n.
+if $rakuast {
+    # FIRST runs during the first line's iteration, seeing its topic.
+    is-run 'FIRST .say',
+        'FIRST under -n runs with the first line as topic',
+        :compiler-args['-n'], :in($in), :out("a b\n");
+
+    # NEXT runs after every line's iteration.
+    is-run 'NEXT .say',
+        'NEXT under -n runs after each line',
+        :compiler-args['-n'], :in($in), :out($in);
+
+    # LAST runs once after the final line's iteration.
+    is-run 'LAST .say',
+        'LAST under -n runs with the last line as topic',
+        :compiler-args['-n'], :in($in), :out("c d e\n");
+
+    # FIRST assigns into a mainline-hoisted variable that then accumulates.
+    is-run 'my $c; FIRST $c = 10; $c++; LAST say $c',
+        'a FIRST-assigned variable persists and accumulates',
+        :compiler-args['-n'], :in($in), :out("12\n");
+
+    # The FIRST value variable lives on the compilation unit when no block
+    # encloses the phaser, so mainline FIRST keeps its return value.
+    is-run 'my $v = FIRST 42; say $v',
+        'FIRST at the compilation unit mainline produces its value',
+        :out("42\n");
+}
+else {
+    skip '-n loop phasers need the RakuAST frontend', 5;
+}
 
 # vim: expandtab shiftwidth=4

--- a/t/02-rakudo/n-flag-mainline-scope.t
+++ b/t/02-rakudo/n-flag-mainline-scope.t
@@ -5,7 +5,7 @@ use nqp;
 
 my $rakuast = nqp::gethllsym('Raku', 'COMPILER-FRONTEND') eq 'rakuast';
 
-plan 16;
+plan 17;
 
 # Under -n/-p the program runs once per input line, but its lexical
 # declarations live in the compunit mainline, so they persist across lines and
@@ -97,13 +97,19 @@ if $rakuast {
         'FIRST at the compilation unit mainline produces its value',
         :out("42\n");
 
+    # A bound list declaration keeps its slots in the loop body, where the
+    # runtime signature binder writes them, and rebinds each line.
+    is-run 'my ($a, $b) := $_, .uc; say "$a $b"',
+        'a my list declaration bound with := works under -n',
+        :compiler-args['-n'], :in($in), :out("a b A B\nc d e C D E\n");
+
     # A default statement sees the line as its topic.
     is-run 'when "a b" { say "isAB" }; default { say "d-$_" }',
         'a default statement sees each line as topic',
         :compiler-args['-n'], :in($in), :out("isAB\nd-c d e\n");
 }
 else {
-    skip '-n loop phasers need the RakuAST frontend', 6;
+    skip '-n loop phasers need the RakuAST frontend', 7;
 }
 
 # vim: expandtab shiftwidth=4

--- a/t/02-rakudo/n-flag-mainline-scope.t
+++ b/t/02-rakudo/n-flag-mainline-scope.t
@@ -2,7 +2,7 @@ use lib <t/packages/Test-Helpers>;
 use Test;
 use Test::Helpers;
 
-plan 6;
+plan 7;
 
 # Under -n/-p the program runs once per input line, but its lexical
 # declarations live in the compunit mainline, so they persist across lines and
@@ -37,6 +37,11 @@ is-run 'BEGIN my $w = 0; BEGIN my $n = 0; $w += .words.elems; $n++; END say "$w 
 is-run 'my $x = 1; say $x',
     'a declared and used variable compiles and runs each line',
     :compiler-args['-n'], :in($in), :out("1\n1\n");
+
+# A signature declaration hoists through its parameter targets.
+is-run 'my ($a, $b) = 1, 2; say $a + $b',
+    'a my list declaration works under -n',
+    :compiler-args['-n'], :in($in), :out("3\n3\n");
 
 # -p modifies and prints the (writable) topic each line.
 is-run 's/a/A/',

--- a/t/02-rakudo/n-flag-mainline-scope.t
+++ b/t/02-rakudo/n-flag-mainline-scope.t
@@ -5,7 +5,7 @@ use nqp;
 
 my $rakuast = nqp::gethllsym('Raku', 'COMPILER-FRONTEND') eq 'rakuast';
 
-plan 12;
+plan 16;
 
 # Under -n/-p the program runs once per input line, but its lexical
 # declarations live in the compunit mainline, so they persist across lines and
@@ -51,6 +51,23 @@ is-run 's/a/A/',
     '-p modifies the topic each line',
     :compiler-args['-p'], :in($in), :out("A b\nc d e\n");
 
+# A CATCH handler covers one line's iteration: a handled exception ends that
+# line and the loop continues with the next one.
+is-run 'CATCH { default { say "caught" } }; die "x" if $_ eq "a b"; say $_',
+    'a handled exception continues with the next line',
+    :compiler-args['-n'], :in($in), :out("caught\nc d e\n");
+
+# A CONTROL handler covers one line's iteration the same way.
+is-run 'CONTROL { when CX::Warn { say "ctl" } }; warn "w" if $_ eq "a b"; say $_',
+    'a handled control exception continues with the next line',
+    :compiler-args['-n'], :in($in), :out("ctl\nc d e\n");
+
+# A matched when succeeds out of one line's iteration only, so the loop
+# continues with the next line.
+is-run 'when "a b" { say "matched" }; say "not-$_"',
+    'a matched when ends only that line',
+    :compiler-args['-n'], :in($in), :out("matched\nnot-c d e\n");
+
 # The program's FIRST/NEXT/LAST phasers become loop phasers of the wrapper
 # loop. The legacy frontend never runs them under -n.
 if $rakuast {
@@ -79,9 +96,14 @@ if $rakuast {
     is-run 'my $v = FIRST 42; say $v',
         'FIRST at the compilation unit mainline produces its value',
         :out("42\n");
+
+    # A default statement sees the line as its topic.
+    is-run 'when "a b" { say "isAB" }; default { say "d-$_" }',
+        'a default statement sees each line as topic',
+        :compiler-args['-n'], :in($in), :out("isAB\nd-c d e\n");
 }
 else {
-    skip '-n loop phasers need the RakuAST frontend', 5;
+    skip '-n loop phasers need the RakuAST frontend', 6;
 }
 
 # vim: expandtab shiftwidth=4

--- a/t/02-rakudo/n-flag-mainline-scope.t
+++ b/t/02-rakudo/n-flag-mainline-scope.t
@@ -2,7 +2,7 @@ use lib <t/packages/Test-Helpers>;
 use Test;
 use Test::Helpers;
 
-plan 5;
+plan 6;
 
 # Under -n/-p the program runs once per input line, but its lexical
 # declarations live in the compunit mainline, so they persist across lines and
@@ -31,6 +31,12 @@ is-run 'my $w = 0; $w += .words.elems; END say $w',
 is-run 'BEGIN my $w = 0; BEGIN my $n = 0; $w += .words.elems; $n++; END say "$w $n"',
     'separate BEGIN-declared variables both persist',
     :compiler-args['-n'], :in($in), :out("5 2\n");
+
+# A hoisted declaration's slot lives in the mainline, so the lexical-to-local
+# lowering must leave it addressable by name from the loop body.
+is-run 'my $x = 1; say $x',
+    'a declared and used variable compiles and runs each line',
+    :compiler-args['-n'], :in($in), :out("1\n1\n");
 
 # -p modifies and prints the (writable) topic each line.
 is-run 's/a/A/',


### PR DESCRIPTION
Under RakuAST the `-n`/`-p` program is parsed before it gets wrapped in the `for lines()` loop, so anything the statements attach to their enclosing scope at parse/begin time lands on the compilation unit instead of the loop body. Several things broke from that mismatch, some as compile failures and some as wrong runtime behavior. This makes the wrapped program behave like the equivalent written-out `for lines() { ... }` loop.

Previously:

```
$ raku -n -e 'my $x = 1; say $x'
Cannot reference undeclared local '$__lowered_x_1'

$ raku -n -e 'my ($a, $b) = 1, 2; say $a + $b'
No such method 'lexical-name' for invocant of type 'RakuAST::VarDeclaration::Signature'

$ echo "foo" | raku -n -e 'FIRST .say'
Cannot modify an immutable 'Mu' type object

$ raku -n -e 'my ($a, $b) := 3, 4; say $a + $b'
Lexical with name '$a' does not exist in this frame
```

A `CATCH`/`CONTROL` handler or a matched `when` also unwound the whole loop instead of ending just that line's iteration, since the handler was registered on the compilation unit.

Now the lexical-to-local lowering leaves hoisted declarations addressable by name, list declarations hoist through their parameter targets (with `:=` bound ones staying in the loop body where the runtime binder writes them), `FIRST`/`NEXT`/`LAST` are transplanted onto the loop body so they run as real loop phasers, and `CATCH`/`CONTROL`/`when`/`default` handlers cover one line's iteration. The `FIRST` value variable also gets the same compunit fallback the phaser attachment already used, which fixes `my $v = FIRST 42` at the mainline without `-n` as well.

The three todo'd tests in S19-command-line-options/02-dash-n.t (`FIRST .say` prints the first line, `LAST .say` the last, `NEXT .say` every line) now pass and can be unfudged.
