### PR TITLE
Draft: RakuAST: don't lower in a frame whose signature needs the binder

### DIFF
--- a/src/Raku/ast/var-lowering.rakumod
+++ b/src/Raku/ast/var-lowering.rakumod
@@ -864,6 +864,14 @@ class RakuAST::IMPL::VarLowering {
             return Nil;
         }
         my $frame := self.IMPL-ENTER($body, 1);
+        # Same rule as the general walk: a signature that needs the runtime
+        # binder binds by name into the frame, so nothing here may become a
+        # local. Without this the parameter of a `for` body - a flatten
+        # candidate, so it never reaches the general walk - was lowered to a
+        # local that p6bindsig, binding the lexical of the same name, never
+        # wrote, and the body read an empty container.
+        $frame.poison()
+            if nqp::istype($body, RakuAST::Code) && $body.custom-args;
         $frame.mark-flatten-candidate();
         $frame.mark-flatten-arg() if $arg;
         self.IMPL-REGISTER-IMPLICIT-LOOKUPS($body);


### PR DESCRIPTION
The general lex2local walk poisons a frame — refuses to turn any of its
lexicals into locals — when the code it belongs to has `custom-args`,
because the runtime binder binds by name into the frame.
`IMPL-WALK-FLATTEN-CANDIDATE` enters a frame of its own and skipped that
rule, so the one kind of block that never reaches the general walk — a
`for` body walked as a flatten candidate — was exempt.

When that combination is hit, the body's parameter is lowered to a local
while `p6bindsig` goes on binding the lexical of the same name, and the
body reads an empty container.

On MoarVM the combination is currently latent: a body only becomes a
flatten *candidate with argument* when its single parameter is fully
plain (`IMPL-FLATTEN-ARG-PARAMETER` rejects types, defaults, `where`,
traits, …), and such a signature does not set `custom-args`. The fix
matters for backends where `custom-args` is on more broadly: on the JVM
backend (RakuAST frontend work on the `truffle-grammar-engine` branch,
where custom-args is on for everything) this broke every `for` whose
body took an explicit parameter and used it — including the
`for Rakudo::Internals.INCLUDE -> $specs` in RepositoryRegistry, so
`use` of any module died with a type-check failure on `$specs`.

Applying the general walk's rule in the flatten-candidate walk closes
the hole for every backend; on MoarVM today it changes nothing
observable (verified: clean build at 1386f7bbd + this commit, sanity
and lex2local-sensitive tests pass, with the lowering decisions
otherwise identical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UqdbHPLfm48GriNCvuimvm
