### PR TITLE
RakuAST: drop a statement's match tree once its node exists

### DIFF
--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -699,6 +699,17 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
     method semilist($/) { self.collect-statements($/, 'SemiList')          }
     method sequence($/) { self.collect-statements($/, 'StatementSequence') }
 
+    # Nothing reads a finished statement's captures. Its consumers take the
+    # node, the position or the source text, so the match tree below it
+    # can go. The empty containers are shared because nothing writes to a
+    # statement's captures after its action.
+    my @EMPTY-LIST := nqp::list;
+    my %EMPTY-HASH := nqp::hash;
+    sub drop-captures($/) {
+        nqp::bindattr($/, NQPCapture, '@!list', @EMPTY-LIST);
+        nqp::bindattr($/, NQPCapture, '%!hash', %EMPTY-HASH);
+    }
+
     # Action method for handling an actual statement
     method statement($/) {
 
@@ -716,6 +727,7 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
             }
             $target.add-label($<label>.ast);
             make $ast;
+            drop-captures($/) if $*DROP-STATEMENT-CAPTURES;
             return;       # nothing left to do here
         }
 
@@ -755,6 +767,7 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
         $statement.attach-doc-blocks unless $*PARSING-DOC-BLOCK;
 
         self.attach: $/, $statement;
+        drop-captures($/) if $*DROP-STATEMENT-CAPTURES;
     }
 
     # Action method for handling labels attached to a statement

--- a/src/Raku/Grammar.nqp
+++ b/src/Raku/Grammar.nqp
@@ -1207,6 +1207,12 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
         # from there, otherwise from EVAL invocations.
         my %*OPTIONS := %*COMPILING<%?OPTIONS>;
 
+        # HLL::Compiler dumps the match tree for a parse target, spelled in
+        # any case, so that keeps the whole tree. Everything else reads only
+        # the nodes, so finished statements drop their captures.
+        my $*DROP-STATEMENT-CAPTURES :=
+          nqp::lc(nqp::atkey(%*OPTIONS, 'target')) ne 'parse';
+
         # Package declarator to meta-package mapping. Starts pretty much empty;
         # we get the mappings either imported or supplied by the setting. One
         # issue is that we may have no setting to provide them, e.g. when we

--- a/t/02-rakudo/parse-target-match-tree.t
+++ b/t/02-rakudo/parse-target-match-tree.t
@@ -1,0 +1,61 @@
+use v6;
+use nqp;
+use Test;
+
+plan 9;
+
+# A finished statement drops its captures once its node exists, except when
+# the compile targets the parse stage, whose output is the match tree.
+
+my $source = q:to/SRC/;
+FOO: for 1 { last FOO }
+my $y = 1;
+{ say 42; my $z = 3 }
+SRC
+
+sub statements-of(Mu $match) {
+    my $list := nqp::atkey($match.hash, 'statementlist');
+    nqp::atkey($list.hash, 'statement')
+}
+
+for <parse Parse> -> $target {
+    my $tree := nqp::getcomp('Raku').compile($source, :$target, :compunit_ok(1));
+    my $statements := statements-of($tree);
+    is nqp::elems($statements), 3,
+      "target $target keeps every statement of the statement list";
+    ok nqp::existskey(nqp::atpos($statements, 0).hash, 'label'),
+      "target $target keeps the label capture of a labelled statement";
+    ok nqp::existskey(nqp::atpos($statements, 1).hash, 'EXPR'),
+      "target $target keeps the EXPR capture of an expression statement";
+}
+
+my $frontend = nqp::gethllsym('Raku', 'COMPILER-FRONTEND');
+if $frontend eq 'rakuast' {
+    # The top level statement list restores its braid before its action
+    # runs, so the hook only sees the statement list of the nested block.
+    BEGIN $?LANG.refine_slang('MAIN', role {}, role {
+        method statementlist(Mu $/) {
+            my $statements := nqp::atkey($/.hash, 'statement');
+            if nqp::elems($statements) {
+                my $first := nqp::atpos($statements, 0);
+                nqp::bindcurhllsym('DROP-STATEMENT-CAPTURES-SEEN', nqp::list(
+                  nqp::elems($first.hash), $first.Str, $first.ast.^name));
+            }
+            nextsame
+        }
+    });
+    { say 42; my $z = 3 }
+
+    my $seen := nqp::getcurhllsym('DROP-STATEMENT-CAPTURES-SEEN');
+    is nqp::atpos($seen, 0), 0,
+      'a finished statement holds no captures once its node exists';
+    is nqp::atpos($seen, 1), 'say 42',
+      'a finished statement still stringifies from its source range';
+    is nqp::atpos($seen, 2), 'RakuAST::Statement::Expression',
+      'a finished statement still carries its node';
+}
+else {
+    skip 'statement captures are only dropped by the RakuAST frontend', 3;
+}
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously every statement's captures stayed reachable for the whole compilation. The statement list only ever reads a statement's node, yet each finished statement kept its capture list and hash, and through them every cursor, capture hash and array beneath it. A closure created while checking the compilation unit pins the frames of the parse, so the tree survived the parse stage as well. Compiling CORE.c.setting peaked at 2.4GB, growing about 15KB per source line through the parse stage.

This rebinds a statement's captures to shared empty containers at the end of its action. A parse target keeps them, since HLL::Compiler dumps the match tree for it. The CORE.c compile now peaks at 1.6GB and a 1000 line module keeps 11 cursors alive at the end of its compile instead of 15000.