### PR TITLE
RakuAST: keep a slurpy for body off the statement form

### DIFF
--- a/src/Raku/ast/statements.rakumod
+++ b/src/Raku/ast/statements.rakumod
@@ -434,7 +434,10 @@ class RakuAST::ForLoopImplementation
         my $count := nqp::getattr(
             nqp::getattr($body.meta-object, Code, '$!signature'),
             Signature, '$!count');
-        nqp::isconcrete($count) && $count == 1 && !$body.has-loop-phasers
+        # A slurpy positional or capture parameter makes the count a boxed
+        # Inf, and NQP's == compares as integers.
+        nqp::istype($count, Int) && nqp::isconcrete($count) && $count == 1
+            && !$body.has-loop-phasers
     }
 
     # The iterator-driven form for a sunk statement-level `for` loop.

--- a/t/02-rakudo/for-statement-iterator-protocol.t
+++ b/t/02-rakudo/for-statement-iterator-protocol.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 12;
+plan 20;
 
 # A sunk statement-level `for` loop drives the source's iterator directly
 # rather than calling its `map` method, so an object that overrides `map`
@@ -65,4 +65,40 @@ my class OverridesMap does Iterable {
     my @seen = do for $source<> -> $x { $x * 2 };
     is-deeply @seen, [2, 4, 6], 'an expression do-for still collects its values';
     is $source.map-calls.elems, 1, 'an expression do-for still dispatches to a user map override';
+}
+
+# A body whose signature takes any number of arguments has no fixed
+# count, so the statement form does not apply and the loop goes
+# through map.
+
+{
+    my $source = OverridesMap.new;
+    my @seen;
+    for $source<> -> *@r { @seen.push(@r) }
+    is-deeply @seen, [[1], [2], [3]], 'a slurpy body receives each value as a one element array';
+    is $source.map-calls.elems, 1, 'a slurpy body dispatches to a user map override';
+}
+
+{
+    my $source = OverridesMap.new;
+    my @seen;
+    for $source<> -> $x, *@rest { @seen.push($x) }
+    is-deeply @seen, [1, 2, 3], 'a positional plus slurpy body receives each value';
+    is $source.map-calls.elems, 1, 'a positional plus slurpy body dispatches to a user map override';
+}
+
+{
+    my $source = OverridesMap.new;
+    my @seen;
+    for $source<> -> $x, |c { @seen.push($x) }
+    is-deeply @seen, [1, 2, 3], 'a positional plus capture body receives each value';
+    is $source.map-calls.elems, 1, 'a positional plus capture body dispatches to a user map override';
+}
+
+{
+    my $source = OverridesMap.new;
+    my @seen;
+    -> *@r { @seen.push(@r) } for $source<>;
+    is-deeply @seen, [[1], [2], [3]], 'a slurpy block modifier for receives each value as a one element array';
+    is $source.map-calls.elems, 1, 'a slurpy block modifier for dispatches to a user map override';
 }


### PR DESCRIPTION
Previously a sunk for loop whose body took a slurpy or capture parameter failed to compile with "This type cannot unbox to a native integer". The count of such a signature is a boxed Inf, and the statement form check compared it to 1 with an NQP ==, which unboxes through .Int. This checks that the count is an Int before comparing, so such a body goes through map like any other body without a fixed count.