### PR TITLE
RakuAST: optimize code compiled ahead of the unit

### DIFF
--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -1884,18 +1884,7 @@ class RakuAST::Node {
         # The nearest scope declaring the name must be the outermost one, and
         # the declaration found there must be the resolution itself, so a
         # shadowing declaration the resolution predates turns the mark off.
-        my $nearest := nqp::null();
-        my $outermost := nqp::null();
-        $resolver.find-scope-property(-> $scope {
-            $outermost := $scope;
-            $nearest := $scope
-                if nqp::isnull($nearest)
-                && nqp::isconcrete($scope.find-lexical($name));
-            Nil
-        });
-        !nqp::isnull($nearest)
-            && nqp::eqaddr($nearest, $outermost)
-            && nqp::eqaddr($outermost.find-lexical($name), $decl)
+        $resolver.IMPL-DECLARED-ONLY-IN-OUTERMOST-SCOPE($name, $decl)
     }
 
     # A smartmatch against a compile-time-known type object reduces to a type
@@ -3197,8 +3186,8 @@ class RakuAST::Node {
     }
 
     # True when the operator resolves to the CORE routine itself. An operator
-    # bound to a lexical variable has no compile-time value and throws, which
-    # declines the lowering. A user `multi` or `sub` that shadows or extends the
+    # bound to a lexical variable has no routine as its compile-time value,
+    # which declines the lowering. A user `multi` or `sub` that shadows or extends the
     # operator produces a distinct routine object whose file may still read
     # SETTING::, so the file alone is not enough. The name is resolved again in
     # the scope of the node being offered: a lexical declaration is visible to
@@ -3212,7 +3201,9 @@ class RakuAST::Node {
         CATCH {
             return False;
         }
-        my $routine := $operator.resolution.compile-time-value;
+        return False unless $operator.is-resolved;
+        my $routine := self.IMPL-DECLARATION-VALUE($operator.resolution);
+        return False unless nqp::isconcrete($routine);
         # A loaded setting stamps its symbols with a SETTING:: file. While
         # a core setting is itself being compiled its own operators carry
         # the plain source file instead, and every one of them is core.
@@ -3226,9 +3217,21 @@ class RakuAST::Node {
                          !! '&infix';
         my $current := $resolver.resolve-lexical(
           $category ~ $resolver.IMPL-CANONICALIZE-PAIR($operator.operator));
-        nqp::isconcrete($current)
-          ?? nqp::eqaddr($routine, nqp::decont($current.compile-time-value))
-          !! True
+        return True unless nqp::isconcrete($current);
+        my $current-value := self.IMPL-DECLARATION-VALUE($current);
+        nqp::isconcrete($current-value)
+            && nqp::eqaddr($routine, nqp::decont($current-value))
+    }
+
+    # The compile-time value a declaration has to offer, or Mu when it
+    # has none: a compile-time value declaration answers directly, an
+    # external one may know its value, and any other has nothing.
+    method IMPL-DECLARATION-VALUE(Mu $decl) {
+        nqp::istype($decl, RakuAST::CompileTimeValue)
+            ?? $decl.compile-time-value
+            !! nqp::can($decl, 'maybe-compile-time-value')
+                ?? $decl.maybe-compile-time-value
+                !! Mu
     }
 
     # A ternary with a constant condition becomes the branch the condition

--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -720,44 +720,53 @@ class RakuAST::Node {
             || nqp::istype($expr, RakuAST::Statement::Unless);
         my int $loop-stmt        := nqp::istype($expr, RakuAST::Statement::Loop);
 
+        # The rewrites, and the marks the unit's walk cannot settle again,
+        # wait for that walk when the resolver reports a walk ahead of
+        # it. The compile time dispatch mark waits during a structural
+        # one. Each helper gates itself as well.
+        my int $ahead-of-unit := $resolver.IMPL-AHEAD-OF-UNIT-WALK;
+        my int $structural    := $resolver.IMPL-STRUCTURAL-WALK;
+
         my $result := $expr;
-        if nqp::istype($expr, RakuAST::Ternary) {
-            $result := self.IMPL-COLLAPSE-TERNARY($resolver, $expr);
-        }
-
-        if $apply-infix && $result =:= $expr {
-            $result := self.IMPL-COLLAPSE-SHORT-CIRCUIT($resolver, $expr);
-        }
-
-        if $result =:= $expr
-            && ($apply-infix || $apply-prefix
-                || nqp::istype($expr, RakuAST::ApplyListInfix)
-                || nqp::istype($expr, RakuAST::Circumfix::Parentheses)) {
-            $result := self.IMPL-FOLD-CONSTANT($resolver, $expr);
-        }
-
-        if $apply-infix {
-            if $result =:= $expr {
-                $result := self.IMPL-COLLAPSE-TYPEMATCH($resolver, $expr);
+        unless $ahead-of-unit {
+            if nqp::istype($expr, RakuAST::Ternary) {
+                $result := self.IMPL-COLLAPSE-TERNARY($resolver, $expr);
             }
-            if $result =:= $expr {
-                $result := self.IMPL-COLLAPSE-LITMATCH($resolver, $expr);
+
+            if $apply-infix && $result =:= $expr {
+                $result := self.IMPL-COLLAPSE-SHORT-CIRCUIT($resolver, $expr);
             }
-            if $result =:= $expr {
-                $result := self.IMPL-COLLAPSE-PAIRMATCH($resolver, $expr);
+
+            if $result =:= $expr
+                && ($apply-infix || $apply-prefix
+                    || nqp::istype($expr, RakuAST::ApplyListInfix)
+                    || nqp::istype($expr, RakuAST::Circumfix::Parentheses)) {
+                $result := self.IMPL-FOLD-CONSTANT($resolver, $expr);
             }
-        }
 
-        if ($conditional-stmt || $stmt-expression) && $result =:= $expr {
-            $result := self.IMPL-COLLAPSE-DEAD-BRANCH($resolver, $expr);
-        }
+            if $apply-infix {
+                if $result =:= $expr {
+                    $result := self.IMPL-COLLAPSE-TYPEMATCH($resolver, $expr);
+                }
+                if $result =:= $expr {
+                    $result := self.IMPL-COLLAPSE-LITMATCH($resolver, $expr);
+                }
+                if $result =:= $expr {
+                    $result := self.IMPL-COLLAPSE-PAIRMATCH($resolver, $expr);
+                }
+            }
 
-        if $apply-infix && $result =:= $expr {
-            $result := self.IMPL-REWRITE-SQUARE($resolver, $expr);
-        }
+            if ($conditional-stmt || $stmt-expression) && $result =:= $expr {
+                $result := self.IMPL-COLLAPSE-DEAD-BRANCH($resolver, $expr);
+            }
 
-        if $apply-postfix && $result =:= $expr {
-            $result := self.IMPL-UNROLL-SLICE($resolver, $expr);
+            if $apply-infix && $result =:= $expr {
+                $result := self.IMPL-REWRITE-SQUARE($resolver, $expr);
+            }
+
+            if $apply-postfix && $result =:= $expr {
+                $result := self.IMPL-UNROLL-SLICE($resolver, $expr);
+            }
         }
 
         if $apply-infix {
@@ -793,7 +802,13 @@ class RakuAST::Node {
                 || $stmt-expression || $conditional-stmt || $loop-stmt
                 || $dot-assign || $stmt-for || $term-name || $routine
                 || $var-decl || $stmt-when || $parameter)
-                && !self.IMPL-IN-SOFT-SCOPE($resolver) {
+                && self.IMPL-IN-SOFT-SCOPE($resolver) {
+                self.IMPL-WITHDRAW-IDENTITY-MARKS($expr);
+            }
+            elsif $apply-infix || $apply-prefix || $apply-postfix || $call-name
+                || $stmt-expression || $conditional-stmt || $loop-stmt
+                || $dot-assign || $stmt-for || $term-name || $routine
+                || $var-decl || $stmt-when || $parameter {
                 self.IMPL-MARK-NATIVE-INCDEC($resolver, $expr)
                     if $apply-postfix || $apply-prefix;
                 if $apply-infix {
@@ -825,20 +840,20 @@ class RakuAST::Node {
                 self.IMPL-MARK-ARRAY-INIT($resolver, $expr)
                     if $apply-infix || $var-decl;
                 self.IMPL-MARK-CT-DISPATCH($resolver, $expr)
-                    if $call-name || $apply-infix;
+                    if ($call-name || $apply-infix) && !$structural;
                 self.IMPL-MARK-NATIVE-CONDITION($resolver, $expr)
                     if $loop-stmt || $conditional-stmt || $stmt-expression;
                 self.IMPL-MARK-WHEN-TYPEMATCH($resolver, $expr)
-                    if $stmt-when || $stmt-expression;
+                    if ($stmt-when || $stmt-expression) && !$ahead-of-unit;
                 self.IMPL-MARK-JUNCTION-FOLD($resolver, $expr)
-                    if $loop-stmt || $conditional-stmt || $stmt-expression
-                        || $apply-prefix;
+                    if ($loop-stmt || $conditional-stmt || $stmt-expression
+                        || $apply-prefix) && !$ahead-of-unit;
                 self.IMPL-MARK-CHAIN-LINKS($resolver, $expr)
                     if $apply-infix;
                 self.IMPL-DROP-UNREACHABLE($resolver, $expr)
-                    if $stmt-expression;
+                    if $stmt-expression && !$ahead-of-unit;
                 self.IMPL-MARK-PARAM-WHERE-JUNCTION($resolver, $expr)
-                    if $parameter;
+                    if $parameter && !$ahead-of-unit;
             }
         }
 
@@ -850,6 +865,62 @@ class RakuAST::Node {
             $result.mark-sunk();
         }
         $result
+    }
+
+    # Withdraw the marks that bind a routine by identity or pin its
+    # lookup. The soft pragma keeps routines wrappable, and a walk ahead
+    # of the unit may have set such a mark before the pragma was parsed.
+    # The withdrawal reaches the frame the unit emits, which a
+    # precompiled unit loads.
+    method IMPL-WITHDRAW-IDENTITY-MARKS(Mu $expr) {
+        if nqp::istype($expr, RakuAST::ApplyPrefix) {
+            $expr.IMPL-SET-NATIVE-INCDEC(0);
+            my $prefix := $expr.prefix;
+            $prefix.IMPL-SET-CALLSTATIC(0) if nqp::istype($prefix, RakuAST::Prefix);
+        }
+        elsif nqp::istype($expr, RakuAST::ApplyPostfix) {
+            $expr.IMPL-SET-NATIVE-INCDEC(0);
+            my $postfix := $expr.postfix;
+            $postfix.IMPL-SET-CALLSTATIC(0) if nqp::istype($postfix, RakuAST::Postfix);
+            $postfix.IMPL-SET-NATIVE-INDEX(0, nqp::null)
+                if nqp::istype($postfix, RakuAST::Postcircumfix::ArrayIndex);
+        }
+        elsif nqp::istype($expr, RakuAST::ApplyInfix) {
+            my $infix := $expr.infix;
+            if nqp::istype($infix, RakuAST::MetaInfix::Assign) {
+                $infix.IMPL-SET-NATIVE-STEP(0);
+                $infix.IMPL-SET-INLINE(0);
+            }
+            elsif nqp::istype($infix, RakuAST::MetaInfix::Negate) {
+                $infix.IMPL-CLEAR-NEGATE-NOT();
+            }
+            elsif nqp::istype($infix, RakuAST::Infix) {
+                $infix.IMPL-SET-CALLSTATIC(0);
+                $infix.IMPL-SET-CHAINSTATIC(0);
+                $infix.IMPL-SET-LOWERED-ARRAY-INIT(0);
+                $infix.IMPL-CLEAR-CT-INLINE-CANDIDATE();
+            }
+        }
+        elsif nqp::istype($expr, RakuAST::Call::Name) {
+            $expr.IMPL-SET-CALLSTATIC(0);
+            $expr.IMPL-CLEAR-CT-INLINE-CANDIDATE();
+        }
+        elsif nqp::istype($expr, RakuAST::Term::Name) {
+            $expr.IMPL-SET-COMPILE-TO-VALUE(0);
+        }
+        elsif nqp::istype($expr, RakuAST::Statement::For) {
+            $expr.IMPL-SET-CAN-LOWER-RANGE(0);
+        }
+        elsif nqp::istype($expr, RakuAST::Statement::Expression) {
+            my $loop := $expr.loop-modifier;
+            $loop.IMPL-SET-CAN-LOWER-RANGE(0)
+                if nqp::isconcrete($loop)
+                && nqp::istype($loop, RakuAST::StatementModifier::For);
+        }
+        elsif nqp::istype($expr, RakuAST::VarDeclaration::Simple) {
+            $expr.IMPL-SET-LOWERED-ARRAY-INIT(0);
+        }
+        Nil
     }
 
     # Mark a native int or num increment or decrement on a simple lexical or
@@ -885,7 +956,7 @@ class RakuAST::Node {
         # reverse would not give the original back; leave those to the routine.
         # A prefix yields the stepped value directly, so it needs no such guard.
         return Nil if $is-postfix && nqp::objprimbits($target-type) != 64;
-        $expr.IMPL-SET-NATIVE-INCDEC($spec) if self.IMPL-OPERATOR-IS-CORE($resolver, $op-node);
+        $expr.IMPL-SET-NATIVE-INCDEC(self.IMPL-OPERATOR-IS-CORE($resolver, $op-node) ?? $spec !! 0);
         Nil
     }
 
@@ -926,7 +997,7 @@ class RakuAST::Node {
             $rhs-ok := 1;
         }
         return Nil unless $rhs-ok;
-        $infix.IMPL-SET-NATIVE-STEP($spec) if self.IMPL-OPERATOR-IS-CORE($resolver, $base);
+        $infix.IMPL-SET-NATIVE-STEP(self.IMPL-OPERATOR-IS-CORE($resolver, $base) ?? $spec !! 0);
         Nil
     }
 
@@ -951,7 +1022,7 @@ class RakuAST::Node {
         # which returns a Nil there, so leave them to it as well.
         return Nil if $op eq '^^' || $op eq 'xor';
         return Nil unless self.IMPL-SCALAR-METAOP-LHS-OK($expr.left);
-        $infix.IMPL-SET-INLINE if self.IMPL-OPERATOR-IS-CORE($resolver, $base);
+        $infix.IMPL-SET-INLINE(self.IMPL-OPERATOR-IS-CORE($resolver, $base) ?? 1 !! 0);
         Nil
     }
 
@@ -1052,9 +1123,9 @@ class RakuAST::Node {
             ?? $for.source
             !! $for.expression;
         my $operator := $for.IMPL-RANGE-FOR-OPERATOR($source);
-        $for.IMPL-SET-CAN-LOWER-RANGE()
-            if nqp::isconcrete($operator)
-            && self.IMPL-OPERATOR-IS-CORE($resolver, $operator);
+        $for.IMPL-SET-CAN-LOWER-RANGE(
+            nqp::isconcrete($operator)
+            && self.IMPL-OPERATOR-IS-CORE($resolver, $operator) ?? 1 !! 0);
         Nil
     }
 
@@ -1064,9 +1135,9 @@ class RakuAST::Node {
         return Nil unless nqp::istype($expr, RakuAST::Call::Name)
             && $expr.name.is-identifier
             && $expr.is-resolved;
-        $expr.IMPL-SET-CALLSTATIC()
-            if self.IMPL-RESOLUTION-BOUND-ONCE($resolver, $expr.resolution,
-                '&' ~ $expr.name.canonicalize);
+        $expr.IMPL-SET-CALLSTATIC(
+            self.IMPL-RESOLUTION-BOUND-ONCE($resolver, $expr.resolution,
+                '&' ~ $expr.name.canonicalize) ?? 1 !! 0);
         Nil
     }
 
@@ -1203,9 +1274,9 @@ class RakuAST::Node {
         return Nil unless nqp::istype($resolution, RakuAST::CompileTimeValue)
             && $resolution.has-compile-time-value;
         return Nil if nqp::iscont($resolution.compile-time-value);
-        $expr.IMPL-SET-COMPILE-TO-VALUE()
-            if self.IMPL-RESOLUTION-BOUND-ONCE($resolver, $resolution,
-                $expr.name.canonicalize);
+        $expr.IMPL-SET-COMPILE-TO-VALUE(
+            self.IMPL-RESOLUTION-BOUND-ONCE($resolver, $resolution,
+                $expr.name.canonicalize) ?? 1 !! 0);
         Nil
     }
 
@@ -1217,9 +1288,9 @@ class RakuAST::Node {
         return Nil unless nqp::istype($infix, RakuAST::Infix)
             && $infix.is-resolved
             && $infix.properties.chain;
-        $infix.IMPL-SET-CHAINSTATIC()
-            if self.IMPL-RESOLUTION-BOUND-ONCE($resolver, $infix.resolution,
-                '&infix' ~ $resolver.IMPL-CANONICALIZE-PAIR($infix.operator));
+        $infix.IMPL-SET-CHAINSTATIC(
+            self.IMPL-RESOLUTION-BOUND-ONCE($resolver, $infix.resolution,
+                '&infix' ~ $resolver.IMPL-CANONICALIZE-PAIR($infix.operator)) ?? 1 !! 0);
         Nil
     }
 
@@ -1232,9 +1303,9 @@ class RakuAST::Node {
         return Nil unless nqp::istype($infix, RakuAST::Infix)
             && $infix.is-resolved
             && !$infix.properties.chain;
-        $infix.IMPL-SET-CALLSTATIC()
-            if self.IMPL-RESOLUTION-BOUND-ONCE($resolver, $infix.resolution,
-                '&infix' ~ $resolver.IMPL-CANONICALIZE-PAIR($infix.operator));
+        $infix.IMPL-SET-CALLSTATIC(
+            self.IMPL-RESOLUTION-BOUND-ONCE($resolver, $infix.resolution,
+                '&infix' ~ $resolver.IMPL-CANONICALIZE-PAIR($infix.operator)) ?? 1 !! 0);
         Nil
     }
 
@@ -1245,9 +1316,9 @@ class RakuAST::Node {
         my $prefix := $expr.prefix;
         return Nil unless nqp::istype($prefix, RakuAST::Prefix)
             && $prefix.is-resolved;
-        $prefix.IMPL-SET-CALLSTATIC()
-            if self.IMPL-RESOLUTION-BOUND-ONCE($resolver, $prefix.resolution,
-                '&prefix' ~ $resolver.IMPL-CANONICALIZE-PAIR($prefix.operator));
+        $prefix.IMPL-SET-CALLSTATIC(
+            self.IMPL-RESOLUTION-BOUND-ONCE($resolver, $prefix.resolution,
+                '&prefix' ~ $resolver.IMPL-CANONICALIZE-PAIR($prefix.operator)) ?? 1 !! 0);
         Nil
     }
 
@@ -1258,9 +1329,9 @@ class RakuAST::Node {
         my $postfix := $expr.postfix;
         return Nil unless nqp::istype($postfix, RakuAST::Postfix)
             && $postfix.is-resolved;
-        $postfix.IMPL-SET-CALLSTATIC()
-            if self.IMPL-RESOLUTION-BOUND-ONCE($resolver, $postfix.resolution,
-                '&postfix' ~ $resolver.IMPL-CANONICALIZE-PAIR($postfix.operator));
+        $postfix.IMPL-SET-CALLSTATIC(
+            self.IMPL-RESOLUTION-BOUND-ONCE($resolver, $postfix.resolution,
+                '&postfix' ~ $resolver.IMPL-CANONICALIZE-PAIR($postfix.operator)) ?? 1 !! 0);
         Nil
     }
 
@@ -1279,9 +1350,9 @@ class RakuAST::Node {
                 && $_.infix.properties.chain;
         }
         my $not := $resolver.resolve-lexical-constant-in-setting('&prefix:<!>');
-        $infix.IMPL-SET-NEGATE-NOT($not.compile-time-value)
-            if nqp::isconcrete($not)
-            && nqp::istype($not, RakuAST::CompileTimeValue);
+        nqp::isconcrete($not) && nqp::istype($not, RakuAST::CompileTimeValue)
+            ?? $infix.IMPL-SET-NEGATE-NOT($not.compile-time-value)
+            !! $infix.IMPL-CLEAR-NEGATE-NOT();
         Nil
     }
 
@@ -1324,20 +1395,21 @@ class RakuAST::Node {
             # fallback, and both branches compile the operands, so an operand
             # declaring a lexical must keep the plain STORE.
             my $infix := $expr.infix;
-            $infix.IMPL-SET-LOWERED-ARRAY-INIT()
-                if nqp::istype($infix, RakuAST::Infix)
-                && $infix.operator eq '='
-                && nqp::istype($expr.left, RakuAST::Var::Lexical)
-                && $expr.left.is-resolved
-                && self.IMPL-PLAIN-ARRAY-DECL($expr.left.resolution)
-                && self.IMPL-CORE-COMMA-LIST($resolver, $expr.right)
-                && self.IMPL-DROPPABLE($expr.right);
+            if nqp::istype($infix, RakuAST::Infix) {
+                $infix.IMPL-SET-LOWERED-ARRAY-INIT(
+                    $infix.operator eq '='
+                    && nqp::istype($expr.left, RakuAST::Var::Lexical)
+                    && $expr.left.is-resolved
+                    && self.IMPL-PLAIN-ARRAY-DECL($expr.left.resolution)
+                    && self.IMPL-CORE-COMMA-LIST($resolver, $expr.right)
+                    && self.IMPL-DROPPABLE($expr.right) ?? 1 !! 0);
+            }
         }
         elsif nqp::istype($expr, RakuAST::VarDeclaration::Simple) {
-            $expr.IMPL-SET-LOWERED-ARRAY-INIT()
-                if self.IMPL-PLAIN-ARRAY-DECL($expr)
+            $expr.IMPL-SET-LOWERED-ARRAY-INIT(
+                self.IMPL-PLAIN-ARRAY-DECL($expr)
                 && nqp::istype($expr.initializer, RakuAST::Initializer::Assign)
-                && self.IMPL-CORE-COMMA-LIST($resolver, $expr.initializer.expression);
+                && self.IMPL-CORE-COMMA-LIST($resolver, $expr.initializer.expression) ?? 1 !! 0);
         }
         Nil
     }
@@ -1623,6 +1695,7 @@ class RakuAST::Node {
     # alone: a link inside a longer chain takes part in the chain op
     # protocol, which an inlined body no longer would.
     method IMPL-MARK-CT-DISPATCH(RakuAST::Resolver $resolver, Mu $expr) {
+        return Nil if $resolver.IMPL-STRUCTURAL-WALK;
         return Nil if nqp::istrue(nqp::ifnull(nqp::getlexdyn('$*NO-CT-DISPATCH'), 0));
         my $target;
         my @args;
@@ -1640,6 +1713,7 @@ class RakuAST::Node {
             }
             $target := $expr;
             $lexname := '&' ~ $expr.name.canonicalize;
+            $target.IMPL-CLEAR-CT-INLINE-CANDIDATE();
         }
         elsif nqp::istype($expr, RakuAST::ApplyInfix) {
             my $infix := $expr.infix;
@@ -1674,6 +1748,7 @@ class RakuAST::Node {
             nqp::push(@args, $right);
             $target := $infix;
             $lexname := '&infix' ~ $resolver.IMPL-CANONICALIZE-PAIR($infix.operator);
+            $target.IMPL-CLEAR-CT-INLINE-CANDIDATE();
         }
         else {
             return Nil;
@@ -1681,9 +1756,7 @@ class RakuAST::Node {
 
         my $resolution := $target.resolution;
         return Nil unless self.IMPL-RESOLUTION-BOUND-ONCE($resolver, $resolution, $lexname);
-        my $routine := nqp::istype($resolution, RakuAST::CompileTimeValue)
-            ?? $resolution.compile-time-value
-            !! $resolution.maybe-compile-time-value;
+        my $routine := self.IMPL-DECLARATION-VALUE($resolution);
         return Nil unless nqp::isconcrete($routine)
             && nqp::istype($routine, Code)
             && nqp::can($routine, 'signature');
@@ -1867,17 +1940,15 @@ class RakuAST::Node {
     method IMPL-RESOLUTION-BOUND-ONCE(RakuAST::Resolver $resolver, Mu $decl, str $name) {
         return 1 if nqp::istype($decl, RakuAST::Declaration::External::Setting);
 
-        return 0 unless nqp::istype($decl, RakuAST::CompileTimeValue)
-            || nqp::can($decl, 'maybe-compile-time-value');
-        my $routine := nqp::istype($decl, RakuAST::CompileTimeValue)
-            ?? $decl.compile-time-value
-            !! $decl.maybe-compile-time-value;
+        my $routine := self.IMPL-DECLARATION-VALUE($decl);
         return 0 unless nqp::isconcrete($routine);
         # The check fails open like the other soft guards. A Code that
         # cannot answer soft cannot be wrapped either, and the
         # published method cache of a mixin type in the setting under
         # compilation can miss the methods the setting itself adds.
-        if nqp::istype($routine, Code) {
+        # A structural walk skips the probe, since the setting's own
+        # routines are never soft.
+        if nqp::istype($routine, Code) && !$resolver.IMPL-STRUCTURAL-WALK {
             return 0 if nqp::can($routine, 'soft') && $routine.soft;
         }
 
@@ -1952,6 +2023,7 @@ class RakuAST::Node {
     # known topic decides the match now through the literal's own ACCEPTS.
     # Otherwise the reduced comparison is marked for code generation.
     method IMPL-COLLAPSE-LITMATCH(RakuAST::Resolver $resolver, Mu $expr) {
+        return $expr if $resolver.IMPL-AHEAD-OF-UNIT-WALK;
         CATCH {
             return $expr;
         }
@@ -2079,6 +2151,7 @@ class RakuAST::Node {
     # takes Any or narrower, so no candidate could have bound the
     # junction itself in place of autothreading.
     method IMPL-MARK-JUNCTION-FOLD(RakuAST::Resolver $resolver, Mu $expr) {
+        return Nil if $resolver.IMPL-AHEAD-OF-UNIT-WALK;
         CATCH {
             return Nil;
         }
@@ -2460,6 +2533,7 @@ class RakuAST::Node {
     # Junction argument autothreading qualifies, so the constraint never
     # sees a junction itself.
     method IMPL-MARK-PARAM-WHERE-JUNCTION(RakuAST::Resolver $resolver, Mu $expr) {
+        return Nil if $resolver.IMPL-AHEAD-OF-UNIT-WALK;
         CATCH {
             return Nil;
         }
@@ -2527,6 +2601,7 @@ class RakuAST::Node {
     # A smartmatch against a compile-time Pair asks the topic the method
     # the key names. Mark the reduced form for code generation.
     method IMPL-COLLAPSE-PAIRMATCH(RakuAST::Resolver $resolver, Mu $expr) {
+        return $expr if $resolver.IMPL-AHEAD-OF-UNIT-WALK;
         CATCH {
             return $expr;
         }
@@ -2646,6 +2721,7 @@ class RakuAST::Node {
     # phaser statement, whose begin-time registration outlives its
     # position but whose spot in the list is left alone all the same.
     method IMPL-DROP-UNREACHABLE(RakuAST::Resolver $resolver, Mu $expr) {
+        return Nil if $resolver.IMPL-AHEAD-OF-UNIT-WALK;
         CATCH {
             return Nil;
         }
@@ -2706,6 +2782,7 @@ class RakuAST::Node {
     # must be droppable. A with part tests definedness and topicalizes
     # its value, so only plain if parts collapse.
     method IMPL-COLLAPSE-DEAD-BRANCH(RakuAST::Resolver $resolver, Mu $expr) {
+        return $expr if $resolver.IMPL-AHEAD-OF-UNIT-WALK;
         CATCH {
             return $expr;
         }
@@ -2852,6 +2929,7 @@ class RakuAST::Node {
     # reduced smartmatch takes for a topic that turns out to be a
     # concrete Junction.
     method IMPL-MARK-WHEN-TYPEMATCH(RakuAST::Resolver $resolver, Mu $expr) {
+        return Nil if $resolver.IMPL-AHEAD-OF-UNIT-WALK;
         CATCH {
             return Nil;
         }
@@ -2933,6 +3011,7 @@ class RakuAST::Node {
     }
 
     method IMPL-COLLAPSE-TYPEMATCH(RakuAST::Resolver $resolver, Mu $expr) {
+        return $expr if $resolver.IMPL-AHEAD-OF-UNIT-WALK;
         # The checks introspect meta-objects the walk has no say over, so a
         # surprise from an unusual one declines rather than breaks the build.
         CATCH {
@@ -3045,6 +3124,7 @@ class RakuAST::Node {
     # The soft pragma turns the rewrite off, since it bypasses the power
     # routine that wrapping relies on.
     method IMPL-REWRITE-SQUARE(RakuAST::Resolver $resolver, Mu $expr) {
+        return $expr if $resolver.IMPL-AHEAD-OF-UNIT-WALK;
         CATCH {
             return $expr;
         }
@@ -3099,6 +3179,7 @@ class RakuAST::Node {
     # is the left operand of any parent keeps the call. The comma and the
     # postcircumfix operator must be the core ones in the node's scope.
     method IMPL-UNROLL-SLICE(RakuAST::Resolver $resolver, Mu $expr) {
+        return $expr if $resolver.IMPL-AHEAD-OF-UNIT-WALK;
         CATCH {
             return $expr;
         }
@@ -3186,8 +3267,8 @@ class RakuAST::Node {
     }
 
     # True when the operator resolves to the CORE routine itself. An operator
-    # bound to a lexical variable has no routine as its compile-time value,
-    # which declines the lowering. A user `multi` or `sub` that shadows or extends the
+    # bound to a lexical variable has no compile-time value, which declines
+    # the lowering. A user `multi` or `sub` that shadows or extends the
     # operator produces a distinct routine object whose file may still read
     # SETTING::, so the file alone is not enough. The name is resolved again in
     # the scope of the node being offered: a lexical declaration is visible to
@@ -3207,11 +3288,14 @@ class RakuAST::Node {
         # A loaded setting stamps its symbols with a SETTING:: file. While
         # a core setting is itself being compiled its own operators carry
         # the plain source file instead, and every one of them is core.
-        return False
-          unless nqp::can($routine, 'file')
-            && ($routine.file.starts-with('SETTING::')
-                || nqp::istrue(nqp::ifnull(
-                     nqp::getlexdyn('$*COMPILING_CORE_SETTING'), 0)));
+        # A structural walk skips the file probe.
+        unless $resolver.IMPL-STRUCTURAL-WALK {
+            return False
+              unless nqp::can($routine, 'file')
+                && ($routine.file.starts-with('SETTING::')
+                    || nqp::istrue(nqp::ifnull(
+                         nqp::getlexdyn('$*COMPILING_CORE_SETTING'), 0)));
+        }
         my str $category := nqp::istype($operator, RakuAST::Postfix) ?? '&postfix'
                          !! nqp::istype($operator, RakuAST::Prefix)  ?? '&prefix'
                          !! '&infix';
@@ -3223,9 +3307,7 @@ class RakuAST::Node {
             && nqp::eqaddr($routine, nqp::decont($current-value))
     }
 
-    # The compile-time value a declaration has to offer, or Mu when it
-    # has none: a compile-time value declaration answers directly, an
-    # external one may know its value, and any other has nothing.
+    # The compile-time value a declaration offers, or Mu when it has none.
     method IMPL-DECLARATION-VALUE(Mu $decl) {
         nqp::istype($decl, RakuAST::CompileTimeValue)
             ?? $decl.compile-time-value
@@ -3239,6 +3321,7 @@ class RakuAST::Node {
     # unselected branch is one the running program would not have evaluated. The
     # condition is removed as well, so it too must be droppable.
     method IMPL-COLLAPSE-TERNARY(RakuAST::Resolver $resolver, Mu $expr) {
+        return $expr if $resolver.IMPL-AHEAD-OF-UNIT-WALK;
         return $expr unless nqp::istype($expr, RakuAST::Ternary);
         my int $truth := self.IMPL-CONSTANT-TRUTH($resolver, $expr.condition);
         return $expr if $truth < 0;
@@ -3255,6 +3338,7 @@ class RakuAST::Node {
     # have evaluated, so its code is removed too. The left's constant truth
     # stands in for the runtime test only when the left is droppable.
     method IMPL-COLLAPSE-SHORT-CIRCUIT(RakuAST::Resolver $resolver, Mu $expr) {
+        return $expr if $resolver.IMPL-AHEAD-OF-UNIT-WALK;
         return $expr unless nqp::istype($expr, RakuAST::ApplyInfix);
         my $infix := $expr.infix;
         return $expr
@@ -3377,6 +3461,7 @@ class RakuAST::Node {
     # one-shot or failure-like results are not folded, and folding is declined
     # before the guard types are available (early bootstrap).
     method IMPL-FOLD-CONSTANT(RakuAST::Resolver $resolver, Mu $expr) {
+        return $expr if $resolver.IMPL-AHEAD-OF-UNIT-WALK;
         return $expr unless nqp::isconcrete($expr);
 
         # Grouping parentheses around a single constant are transparent, so a

--- a/src/Raku/ast/call.rakumod
+++ b/src/Raku/ast/call.rakumod
@@ -557,8 +557,8 @@ class RakuAST::Call::Name
     # resolves a single time.
     has int $!callstatic;
 
-    method IMPL-SET-CALLSTATIC() {
-        nqp::bindattr_i(self, RakuAST::Call::Name, '$!callstatic', 1)
+    method IMPL-SET-CALLSTATIC(int $on) {
+        nqp::bindattr_i(self, RakuAST::Call::Name, '$!callstatic', $on)
     }
 
     # Set by the optimize pass when the argument types decide the dispatch
@@ -568,6 +568,10 @@ class RakuAST::Call::Name
 
     method IMPL-SET-CT-INLINE-CANDIDATE(Mu $routine) {
         nqp::bindattr(self, RakuAST::Call::Name, '$!ct-inline-candidate', $routine)
+    }
+
+    method IMPL-CLEAR-CT-INLINE-CANDIDATE() {
+        nqp::bindattr(self, RakuAST::Call::Name, '$!ct-inline-candidate', nqp::null())
     }
 
     method IMPL-EXPR-QAST(RakuAST::IMPL::QASTContext $context) {

--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -252,10 +252,15 @@ class RakuAST::Code
         my $compiler-thunk := {
             my $*IMPL-COMPILE-DYNAMICALLY := 1;
             # This emission caches the QAST block before the unit's
-            # optimize phase has decided which lexicals become locals,
-            # and the unit's own emission reuses the cache. Decide for
-            # this code object now so both compilations agree.
-            RakuAST::IMPL::VarLowering.analyze-routine(self, $resolver);
+            # optimize phase has rewritten the tree and decided which
+            # lexicals become locals, and the unit's own emission reuses
+            # the cache. Optimize and decide for this code object here so
+            # both compilations agree. A block cached by an earlier
+            # formation is emitted as it is.
+            unless $!qast-block {
+                self.IMPL-OPTIMIZE-AHEAD-OF-UNIT($resolver, $context);
+                RakuAST::IMPL::VarLowering.analyze-routine(self, $resolver);
+            }
             my $block := self.IMPL-QAST-BLOCK($context, :blocktype<declaration_static>);
             $precomp := self.IMPL-COMPILE-DYNAMICALLY($resolver, $context, $block);
         };
@@ -573,6 +578,10 @@ class RakuAST::Code
             $var
         }
 
+        # A flattened body block lands in the frame as a statement list
+        # rather than a block of its own, and a run may skip it.
+        my int $flattened := 0;
+
         $visit-children := sub ($node) {
             my int $i := 0;
             my int $n := nqp::elems($node);
@@ -591,9 +600,10 @@ class RakuAST::Code
                                 $visit.name(nqp::null);
                                 $visit.unshift(QAST::WVal.new(:$value));
                             }
-                            elsif nqp::elems(@blocks) == 2 {
-                                # we're in top level block (excluding wrapper) and routines would
-                                # definitely get called. Can't do so if we couldn't find it.
+                            elsif nqp::elems(@blocks) == 2 && !$flattened {
+                                # we're in top level block (excluding wrapper) and not in a
+                                # flattened body, so routines would definitely get called.
+                                # Can't do so if we couldn't find it.
                                 $resolver.build-exception(
                                     'X::Undeclared::Symbols',
                                     :unk_routines(nqp::hllizefor(nqp::hash($visit.name, [self.origin ?? self.origin.as-match.line !! -1]), 'Raku'))
@@ -607,7 +617,10 @@ class RakuAST::Code
                     $visit-block($visit);
                 }
                 elsif nqp::istype($visit, QAST::Stmt) || nqp::istype($visit, QAST::Stmts) || nqp::istype($visit, QAST::ParamTypeCheck) {
+                    my int $body := $visit.ann('flattened-body') ?? 1 !! 0;
+                    $flattened := $flattened + 1 if $body;
                     $visit-children($visit);
+                    $flattened := $flattened - 1 if $body;
                 }
                 elsif nqp::istype($visit, QAST::Var) {
                     $node[$i] := $visit-var($visit);
@@ -619,6 +632,37 @@ class RakuAST::Code
         }
 
         $visit-block($block);
+    }
+
+    # The optimize walk over one code object compiled ahead of the
+    # unit's optimize phase, with the parse-time resolver, when one was
+    # recorded, so names resolve in the scope the code object was
+    # declared in.
+    method IMPL-OPTIMIZE-AHEAD-OF-UNIT(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
+        my $walk-resolver := $context.parse-time-resolver($!cuid) || $resolver;
+        # The check phase settles sink states only after this compilation,
+        # and the walk and the lowering read them.
+        self.IMPL-CALCULATE-SINK();
+        my $*NO-CT-DISPATCH := nqp::existskey(nqp::getenvhash(), 'RAKUDO_NO_CT_DISPATCH');
+        my int $enclosing-ahead      := $walk-resolver.IMPL-AHEAD-OF-UNIT-WALK;
+        my int $enclosing-structural := $walk-resolver.IMPL-STRUCTURAL-WALK;
+        my int $scope-depth          := $walk-resolver.IMPL-SCOPE-DEPTH;
+        my int $package-depth        := $walk-resolver.IMPL-PACKAGE-DEPTH;
+        $walk-resolver.IMPL-SET-AHEAD-OF-UNIT-WALK(1,
+            nqp::istrue(nqp::ifnull(nqp::getlexdyn('$*COMPILING_CORE_SETTING'), 0)) ?? 1 !! 0);
+        # The resolver outlives this walk, so its stacks and flags go back
+        # to what they were, whether the walk returns or throws.
+        {
+            CATCH {
+                $walk-resolver.IMPL-UNWIND-SCOPES($scope-depth);
+                $walk-resolver.IMPL-UNWIND-PACKAGES($package-depth);
+                $walk-resolver.IMPL-SET-AHEAD-OF-UNIT-WALK($enclosing-ahead, $enclosing-structural);
+                nqp::rethrow($_);
+            }
+            self.IMPL-OPTIMIZE($walk-resolver);
+        }
+        $walk-resolver.IMPL-SET-AHEAD-OF-UNIT-WALK($enclosing-ahead, $enclosing-structural);
+        Nil
     }
 
     method IMPL-COMPILE-DYNAMICALLY(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context, Mu $block) {
@@ -740,7 +784,7 @@ class RakuAST::Code
                 }
             }
         }
-        return 0 unless $has_nested_blocks;
+        return [] unless $has_nested_blocks;
 
         # Parse-time resolver from the QASTContext side table; this path
         # runs at compile time and the caller doesn't have its own
@@ -782,7 +826,7 @@ class RakuAST::Code
         $block[1].push($fixup);
 
         $lexical-fixup.set-block($c_block_ast, $fixup_list);
-        Nil
+        [$throwaway_block_past, $fixup]
     }
 
     method IMPL-APPEND-SIGNATURE-RETURN(RakuAST::IMPL::QASTContext $context, Mu $qast-stmts) {
@@ -1858,6 +1902,7 @@ class RakuAST::Block
         my $nested-blocks := self.IMPL-QAST-NESTED-BLOCK-DECLS($context);
         $stmts.push($nested-blocks) if nqp::elems($nested-blocks.list);
         $stmts.push($!body.IMPL-TO-QAST($context));
+        $stmts.annotate('flattened-body', 1);
         $stmts
     }
 
@@ -1878,6 +1923,7 @@ class RakuAST::Block
         my $nested-blocks := self.IMPL-QAST-NESTED-BLOCK-DECLS($context);
         $stmts.push($nested-blocks) if nqp::elems($nested-blocks.list);
         $stmts.push($!body.IMPL-TO-QAST($context));
+        $stmts.annotate('flattened-body', 1);
         $stmts
     }
 
@@ -3334,9 +3380,23 @@ class RakuAST::RoleBody
 {
     has RakuAST::LexicalFixup $.fixup;
 
-    # IMPL-FINISH-ROLE-BODY appends the lexical fixup nodes to the
-    # formed block, which a re-formation would not reproduce.
-    method IMPL-REBUILD-ELIGIBLE() { 0 }
+    # The lexical fixup nodes IMPL-FINISH-ROLE-BODY appended to the
+    # formed block. The throwaway block's outer annotation names the
+    # block object the graft keeps.
+    has Mu $!fixup-nodes;
+
+    # A re-formation reproduces the body's statements only, so the fixup
+    # nodes go back, and the accessor QAST the package splices in is
+    # spliced again once its marker, which the graft kept, is cleared.
+    method IMPL-REBUILD-BEGIN-TIME-CACHED-BLOCK(RakuAST::IMPL::QASTContext $context) {
+        nqp::findmethod(RakuAST::Code, 'IMPL-REBUILD-BEGIN-TIME-CACHED-BLOCK')(self, $context);
+        my $block := nqp::getattr(self, RakuAST::Code, '$!qast-block');
+        for $!fixup-nodes {
+            $block[1].push($_);
+        }
+        $block.annotate('accessor-qast-added', 0);
+        Nil
+    }
 
     method new(          str :$scope,
                          str :$multiness,
@@ -3357,6 +3417,7 @@ class RakuAST::RoleBody
         nqp::bindattr($obj, RakuAST::Sub, '$!body',
           $body // RakuAST::Blockoid.new);
         nqp::bindattr($obj, RakuAST::RoleBody, '$!fixup', RakuAST::LexicalFixup);
+        nqp::bindattr($obj, RakuAST::RoleBody, '$!fixup-nodes', []);
         $obj.set-WHY($WHY);
         $obj
     }
@@ -3385,8 +3446,16 @@ class RakuAST::RoleBody
         unless self.is-stub {
             self.IMPL-RESOLVE-FORWARD-LEXICALS($resolver);
             my $*IMPL-COMPILE-DYNAMICALLY := 1;
+            # The body compiles here ahead of the unit, so it takes the
+            # optimize walk and the lowering a BEGIN-time routine takes
+            # in its compiler thunk.
+            unless nqp::isconcrete(nqp::getattr(self, RakuAST::Code, '$!qast-block')) {
+                self.IMPL-OPTIMIZE-AHEAD-OF-UNIT($resolver, $context);
+                RakuAST::IMPL::VarLowering.analyze-routine(self, $resolver);
+            }
             my $body-qast := self.IMPL-QAST-BLOCK($context, :blocktype<immediate>);
-            self.IMPL-BEGIN-TIME-LEXICAL-FIXUP($context, $body-qast, $!fixup);
+            nqp::bindattr(self, RakuAST::RoleBody, '$!fixup-nodes',
+                self.IMPL-BEGIN-TIME-LEXICAL-FIXUP($context, $body-qast, $!fixup));
         }
     }
 

--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -582,7 +582,7 @@ class RakuAST::Code
                 $node[$i] := $visit;
                 if nqp::istype($visit, QAST::Op) {
                     my $op := $visit.op;
-                    if ($op eq 'call' || $op eq 'callstatic' || $op eq 'chain') && $visit.name {
+                    if ($op eq 'call' || $op eq 'callstatic' || $op eq 'chain' || $op eq 'chainstatic') && $visit.name {
                         if ! $declared-in-cu($visit.name) {
                             my $routine := $parse-time-resolver.resolve-lexical-constant($visit.name);
                             if $routine {

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -539,8 +539,8 @@ class RakuAST::Infix
     # static one the VM resolves a single time.
     has int $!chainstatic;
 
-    method IMPL-SET-CHAINSTATIC() {
-        nqp::bindattr_i(self, RakuAST::Infix, '$!chainstatic', 1)
+    method IMPL-SET-CHAINSTATIC(int $on) {
+        nqp::bindattr_i(self, RakuAST::Infix, '$!chainstatic', $on)
     }
 
     # Set by the optimize pass when the resolved operator's lexical is bound
@@ -548,8 +548,8 @@ class RakuAST::Infix
     # lookup as a static one the VM resolves a single time.
     has int $!callstatic;
 
-    method IMPL-SET-CALLSTATIC() {
-        nqp::bindattr_i(self, RakuAST::Infix, '$!callstatic', 1)
+    method IMPL-SET-CALLSTATIC(int $on) {
+        nqp::bindattr_i(self, RakuAST::Infix, '$!callstatic', $on)
     }
 
     # Set by the optimize pass when the operand types decide the dispatch at
@@ -622,8 +622,8 @@ class RakuAST::Infix
     # array variable, for lowering to a direct build of the list internals.
     has int $!lowered-array-init;
 
-    method IMPL-SET-LOWERED-ARRAY-INIT() {
-        nqp::bindattr_i(self, RakuAST::Infix, '$!lowered-array-init', 1)
+    method IMPL-SET-LOWERED-ARRAY-INIT(int $on) {
+        nqp::bindattr_i(self, RakuAST::Infix, '$!lowered-array-init', $on)
     }
 
     # Set by the optimize pass when this smartmatch reduces to a type check:
@@ -1621,8 +1621,8 @@ class RakuAST::MetaInfix::Assign
 
     method IMPL-NATIVE-STEP-SET() { $!native-step }
 
-    method IMPL-SET-INLINE() {
-        nqp::bindattr_i(self, RakuAST::MetaInfix::Assign, '$!inline', 1)
+    method IMPL-SET-INLINE(int $on) {
+        nqp::bindattr_i(self, RakuAST::MetaInfix::Assign, '$!inline', $on)
     }
 
     # A boxed scalar compound assignment the optimize pass marked: assign the
@@ -3176,8 +3176,8 @@ class RakuAST::Prefix
     # resolves a single time.
     has int $!callstatic;
 
-    method IMPL-SET-CALLSTATIC() {
-        nqp::bindattr_i(self, RakuAST::Prefix, '$!callstatic', 1)
+    method IMPL-SET-CALLSTATIC(int $on) {
+        nqp::bindattr_i(self, RakuAST::Prefix, '$!callstatic', $on)
     }
 
     method IMPL-PREFIX-QAST(RakuAST::IMPL::QASTContext $context, Mu $operand-qast) {
@@ -3506,8 +3506,8 @@ class RakuAST::Postfix
     # resolves a single time.
     has int $!callstatic;
 
-    method IMPL-SET-CALLSTATIC() {
-        nqp::bindattr_i(self, RakuAST::Postfix, '$!callstatic', 1)
+    method IMPL-SET-CALLSTATIC(int $on) {
+        nqp::bindattr_i(self, RakuAST::Postfix, '$!callstatic', $on)
     }
 
     method IMPL-POSTFIX-QAST(
@@ -4338,8 +4338,8 @@ class RakuAST::Statement::For
     # source to a native counting loop.
     has int $!can-lower-range;
 
-    method IMPL-SET-CAN-LOWER-RANGE() {
-        nqp::bindattr_i(self, RakuAST::Statement::For, '$!can-lower-range', 1)
+    method IMPL-SET-CAN-LOWER-RANGE(int $on) {
+        nqp::bindattr_i(self, RakuAST::Statement::For, '$!can-lower-range', $on)
     }
 
     method new(

--- a/src/Raku/ast/resolver.rakumod
+++ b/src/Raku/ast/resolver.rakumod
@@ -25,6 +25,18 @@ class RakuAST::Resolver {
     # The current comp unit's EXPORT package.
     has Mu $!export-package;
 
+    # Set while the optimize walk runs over a code object ahead of the
+    # unit's optimize phase. The scopes enclosing the code object are
+    # still being parsed then, so a rewrite, which cannot be undone,
+    # waits for the unit's own walk, and a mark is one that walk
+    # settles again.
+    has int $!ahead-of-unit-walk;
+
+    # Set while such a walk runs and the core setting is compiling
+    # itself. The setting's routines are stubs then, so the marks that
+    # probe one wait for the unit's own walk as well.
+    has int $!structural-walk;
+
     # In-source `our` package decls seen in this compunit's BEGIN
     # walk. Keyed by install target's `nqp::objectid` plus the final
     # name part so the same trailing name under different `my`-scoped
@@ -91,6 +103,8 @@ class RakuAST::Resolver {
     # Create a shallow clone, but deep clone attach targets and packages
     method clone() {
         my $clone := nqp::clone(self);
+        nqp::bindattr_i($clone, RakuAST::Resolver, '$!ahead-of-unit-walk', 0);
+        nqp::bindattr_i($clone, RakuAST::Resolver, '$!structural-walk', 0);
         nqp::bindattr($clone,RakuAST::Resolver,'$!attach-targets',
           nqp::clone($!attach-targets));
         nqp::bindattr($clone,RakuAST::Resolver,'$!packages',
@@ -169,6 +183,22 @@ class RakuAST::Resolver {
     }
 
     method get-global() { $!global }
+
+    method IMPL-AHEAD-OF-UNIT-WALK() { $!ahead-of-unit-walk }
+    method IMPL-STRUCTURAL-WALK() { $!structural-walk }
+    method IMPL-SET-AHEAD-OF-UNIT-WALK(int $ahead, int $structural) {
+        nqp::bindattr_i(self, RakuAST::Resolver, '$!ahead-of-unit-walk', $ahead);
+        nqp::bindattr_i(self, RakuAST::Resolver, '$!structural-walk', $structural);
+        Nil
+    }
+
+    # The package stack's depth, and a pop back to a depth recorded
+    # earlier, for a walk that may throw between its pushes and pops.
+    method IMPL-PACKAGE-DEPTH() { nqp::elems($!packages) }
+    method IMPL-UNWIND-PACKAGES(int $depth) {
+        self.pop-package() while nqp::elems($!packages) > $depth;
+        Nil
+    }
 
     # Set the EXPORT package when we're starting a fresh compilation unit.
     method set-export-package(Mu $package) {
@@ -1249,6 +1279,12 @@ class RakuAST::Resolver::EVAL
         0
     }
 
+    method IMPL-SCOPE-DEPTH() { nqp::elems($!scopes) }
+    method IMPL-UNWIND-SCOPES(int $depth) {
+        self.pop-scope() while nqp::elems($!scopes) > $depth;
+        Nil
+    }
+
     # Resolves a lexical to its declaration. The declaration need not have a
     # compile-time value.
     method resolve-lexical(Str $name, Bool :$current-scope-only) {
@@ -1595,6 +1631,12 @@ class RakuAST::Resolver::Compile
                 if nqp::isconcrete($found);
         }
         0
+    }
+
+    method IMPL-SCOPE-DEPTH() { nqp::elems($!scopes) }
+    method IMPL-UNWIND-SCOPES(int $depth) {
+        self.pop-scope() while nqp::elems($!scopes) > $depth;
+        Nil
     }
 
     # Add a lexical declaration. Used when the compiler produces the

--- a/src/Raku/ast/resolver.rakumod
+++ b/src/Raku/ast/resolver.rakumod
@@ -1236,6 +1236,19 @@ class RakuAST::Resolver::EVAL
         Nil
     }
 
+    # Whether the nearest active scope declaring the name is the outermost
+    # one and declares it as the given declaration.
+    method IMPL-DECLARED-ONLY-IN-OUTERMOST-SCOPE(Str $name, Mu $decl) {
+        my @scopes := $!scopes;
+        my int $i := nqp::elems(@scopes);
+        while $i-- {
+            my $found := @scopes[$i].find-lexical($name);
+            return nqp::eqaddr(@scopes[$i], @scopes[0]) && nqp::eqaddr($found, $decl) ?? 1 !! 0
+                if nqp::isconcrete($found);
+        }
+        0
+    }
+
     # Resolves a lexical to its declaration. The declaration need not have a
     # compile-time value.
     method resolve-lexical(Str $name, Bool :$current-scope-only) {
@@ -1565,6 +1578,23 @@ class RakuAST::Resolver::Compile
             return $res if nqp::isconcrete($res);
         }
         Nil
+    }
+
+    # Whether the nearest active scope declaring the name is the outermost
+    # one and declares it as the given declaration. A scope still being
+    # parsed answers from its live declaration map, so its AST lexical
+    # lookup table is not cached before its declarations are complete.
+    # The outermost scope can be on the stack twice, entered by the parse
+    # and pushed again by a batch walk, so scopes compare by node.
+    method IMPL-DECLARED-ONLY-IN-OUTERMOST-SCOPE(Str $name, Mu $decl) {
+        my @scopes := $!scopes;
+        my int $i := nqp::elems(@scopes);
+        while $i-- {
+            my $found := @scopes[$i].find-lexical($name);
+            return nqp::eqaddr(@scopes[$i].scope, @scopes[0].scope) && nqp::eqaddr($found, $decl) ?? 1 !! 0
+                if nqp::isconcrete($found);
+        }
+        0
     }
 
     # Add a lexical declaration. Used when the compiler produces the

--- a/src/Raku/ast/statement-mods.rakumod
+++ b/src/Raku/ast/statement-mods.rakumod
@@ -392,8 +392,8 @@ class RakuAST::StatementModifier::For
     # source to a native counting loop.
     has int $!can-lower-range;
 
-    method IMPL-SET-CAN-LOWER-RANGE() {
-        nqp::bindattr_i(self, RakuAST::StatementModifier::For, '$!can-lower-range', 1)
+    method IMPL-SET-CAN-LOWER-RANGE(int $on) {
+        nqp::bindattr_i(self, RakuAST::StatementModifier::For, '$!can-lower-range', $on)
     }
 
     method PRODUCE-IMPLICIT-LOOKUPS() {

--- a/src/Raku/ast/term.rakumod
+++ b/src/Raku/ast/term.rakumod
@@ -15,8 +15,8 @@ class RakuAST::Term::Name
     # name's lookup op keeps the surrounding frame from ever inlining.
     has int $!compile-to-value;
 
-    method IMPL-SET-COMPILE-TO-VALUE() {
-        nqp::bindattr_i(self, RakuAST::Term::Name, '$!compile-to-value', 1);
+    method IMPL-SET-COMPILE-TO-VALUE(int $on) {
+        nqp::bindattr_i(self, RakuAST::Term::Name, '$!compile-to-value', $on);
     }
 
     method new(RakuAST::Name $name) {

--- a/src/Raku/ast/var-lowering.rakumod
+++ b/src/Raku/ast/var-lowering.rakumod
@@ -140,7 +140,6 @@ class RakuAST::IMPL::VarLowering {
     has int $!debug;
     has int $!begin-context;
     has int $!topic-not-dynamic;
-    has int $!declarations-only;
 
     method IMPL-MAKE-ANALYZER(RakuAST::Resolver $resolver) {
         my $analyzer := nqp::create(self);
@@ -168,16 +167,12 @@ class RakuAST::IMPL::VarLowering {
     }
 
     # Scoped analysis for one code object compiled ahead of the unit's
-    # optimize phase for BEGIN-time use: its QAST is emitted and cached
-    # right away, so the unit-wide analysis comes too late to affect it.
+    # optimize phase, a BEGIN-time routine or a role body: its QAST is
+    # emitted and cached right away, so the unit-wide analysis comes too
+    # late to affect it.
     method analyze-routine(RakuAST::Code $routine, RakuAST::Resolver $resolver) {
         return Nil if nqp::atkey(nqp::getenvhash(), 'RAKUDO_NO_LEX2LOCAL');
         my $analyzer := self.IMPL-MAKE-ANALYZER($resolver);
-        # Only declarations: the flatten and unused-implicit rewrites
-        # change block shapes in ways the dynamic compilation's by-name
-        # fixup is not prepared for.
-        nqp::bindattr_i($analyzer, RakuAST::IMPL::VarLowering,
-            '$!declarations-only', 1);
         $analyzer.IMPL-WALK($routine);
         Nil
     }
@@ -576,9 +571,11 @@ class RakuAST::IMPL::VarLowering {
                 # serialized, and flattening dissolves the frame and
                 # takes the names with it. An approval here would
                 # flatten the emitted frame away from the names the
-                # serialized contexts rebind at load.
-                my int $approved := $!declarations-only
-                        || self.IMPL-IN-BEGIN-TIME-CACHED-CODE($frame)
+                # serialized contexts rebind at load. The analysis that
+                # ran ahead of the unit already settled which frames
+                # under it flatten, and that decision stands since
+                # nothing withdraws an approval.
+                my int $approved := self.IMPL-IN-BEGIN-TIME-CACHED-CODE($frame)
                     ?? 0
                     !! self.IMPL-FLATTEN-VERDICT($frame);
                 $flattened := $approved;
@@ -606,8 +603,7 @@ class RakuAST::IMPL::VarLowering {
                         !! self.IMPL-MARK-CAPTURED-ID($id);
                 }
             }
-            self.IMPL-DECIDE-IMPLICITS($frame)
-                unless $flattened || $!declarations-only;
+            self.IMPL-DECIDE-IMPLICITS($frame) unless $flattened;
         }
         Nil
     }

--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -736,8 +736,8 @@ class RakuAST::VarDeclaration::Simple
     has str $!lowered-local-name;
     has Mu $!lowered-away-sentinel;
 
-    method IMPL-SET-LOWERED-ARRAY-INIT() {
-        nqp::bindattr_i(self, RakuAST::VarDeclaration::Simple, '$!lowered-array-init', 1)
+    method IMPL-SET-LOWERED-ARRAY-INIT(int $on) {
+        nqp::bindattr_i(self, RakuAST::VarDeclaration::Simple, '$!lowered-array-init', $on)
     }
 
     # Set by the lexical-to-local lowering analysis on a method's unused

--- a/t/08-performance/36-rakuast-begin-compiled-remark.t
+++ b/t/08-performance/36-rakuast-begin-compiled-remark.t
@@ -3,14 +3,16 @@ use Test::Helpers::QAST;
 use Test;
 use QAST:from<NQP>;
 use nqp;
-plan 54;
+plan 114;
 
 # A routine invoked at BEGIN time compiles ahead of the unit's optimize
-# walk and caches its QAST. The unit emission re-forms the cached block
-# once the walk's marks are known, so such routines run at runtime with
-# the same lowerings as routines compiled in the ordinary order. The
-# behavioral tests hold on both frontends. The QAST shape tests are
-# specific to the RakuAST frontend.
+# walk and caches its QAST. That compilation runs its own optimize walk
+# and lowering first. The unit emission re-forms the cached block after
+# the unit's own walk, so a precompiled unit runs such routines with
+# the same lowerings as routines compiled in the ordinary order, while
+# a script runs the frames of the early compilation. The behavioral
+# tests hold on both frontends. The QAST shape tests are specific to
+# the RakuAST frontend.
 
 # Dynamic compilation is per code object, so each method the BEGIN
 # block invokes compiles ahead of the optimize walk.
@@ -44,6 +46,102 @@ is Counter.new.named-count(:a, :b), 2,
 is Counter.new.own-name, 'own-name',
     'a routine variable read still works after a BEGIN time use';
 
+# The early compilation carries the optimize walk's marks. A chained
+# comparison is one the walk marks for a static callee lookup, which
+# the dynamic compilation must resolve by value instead.
+my class Within {
+    method check($x) { 1 <= $x <= 3 }
+}
+BEGIN Within.new.check(2);
+is Within.new.check(2), True,
+    'a chained comparison in a method used at BEGIN time still holds at runtime';
+is Within.new.check(5), False,
+    'a chained comparison in a method used at BEGIN time still fails at runtime';
+
+# The walk ahead of the unit resolves names in scopes the parse is
+# still adding to, so a declaration made after the BEGIN time use must
+# still reach the unit's own emission. The BEGIN statement's own walk
+# consults the unit scope for the call to the sub.
+sub twice($x) { $x * 2 }
+BEGIN twice(1);
+my $declared-after = 5;
+is twice($declared-after), 10,
+    'a lexical declared after a BEGIN time call of a sub is declared in the unit';
+
+# A routine compiled ahead of the unit consults the unit scope for a
+# sub, a constant, and an enum value it uses.
+sub helper($x) { $x + 1 }
+my constant K = 100;
+enum Colour <Red Green>;
+sub uses-unit-symbols($x) { helper($x) + K + Green }
+BEGIN uses-unit-symbols(1);
+my $declared-after-too = 5;
+is uses-unit-symbols($declared-after-too), 107,
+    'a lexical declared after a BEGIN time call of a routine using unit symbols is declared in the unit';
+
+# A role body compiles at the end of the role declaration, before a
+# sub declared later in the unit exists, and a call to that sub from a
+# role method resolves once the unit is complete.
+my role Forward {
+    method call-later() { declared-later(1) }
+}
+my class UsesForward does Forward { }
+sub declared-later($x) { $x + 1 }
+is UsesForward.new.call-later, 2,
+    'a role method calling a sub declared later in the unit resolves the call';
+
+# The early compilation flattens an inner body block into its frame.
+my class Branch {
+    method m($b) { my $s = 0; if $b { my $t = $b + 1; $s = $t }; $s }
+}
+BEGIN Branch.new.m(1);
+is Branch.new.m(0), 0,
+    'an untaken flattened inner branch leaves the outer variable alone after a BEGIN time use';
+is Branch.new.m(41), 42,
+    'a taken flattened inner branch writes the outer variable after a BEGIN time use';
+
+# A stub role declared inside a role body, or inside a routine used at
+# BEGIN time, is formed with the enclosing block ahead of the unit and
+# has no fixup nodes to put back.
+my role Outer {
+    my role Inner { ... }
+    method m() { 1 }
+}
+my class UsesOuter does Outer { }
+is UsesOuter.new.m, 1,
+    'a stub role inside a role body compiles alongside the role';
+sub declares-stub() { my role Stubbed { ... }; 1 }
+BEGIN declares-stub();
+is declares-stub(), 1,
+    'a stub role inside a routine used at BEGIN time compiles alongside it';
+
+# A role body's lexicals are reached by name from its methods, which
+# are cloned per concretization with the body frame as their outer, so
+# the body's lowering keeps every captured one as a lexical.
+my role Tally {
+    my $count = 0;
+    my int $native = 0;
+    my $branch = 0;
+    if True { my $t = 5; $branch = $t }
+    method bump() { ++$count }
+    method nbump() { ++$native }
+    method branch() { $branch }
+    method nameds() { %_.elems }
+}
+my class Tallied does Tally { }
+BEGIN { Tallied.new.bump; Tallied.new.nbump }
+Tallied.new.bump;
+is Tallied.new.bump, 3,
+    'a role body lexical a method increments keeps its value after a BEGIN time use';
+is Tallied.new.nbump, 2,
+    'a native role body lexical a method increments keeps its value after a BEGIN time use';
+is Tallied.new.branch, 5,
+    'a role body lexical assigned in a body level block reads back from a method';
+is Tally.new.bump, 1,
+    'punning the role runs the body afresh with its own lexicals';
+is Tallied.new.nameds(:x, :y, :z), 3,
+    'a role method reading its implicit slurpy still collects named arguments';
+
 # The elided slurpy binding still accepts and discards stray nameds.
 # A call that fails its constraint reruns through the full binder,
 # which binds the parameters it reaches into the frame by name.
@@ -58,6 +156,14 @@ is Stray.new.n(5, :stray), 5,
     'a BEGIN used method with a constrained param still binds with stray nameds';
 throws-like { Stray.new.n(-1) }, X::TypeCheck::Binding::Parameter,
     'a call failing its constraint after a BEGIN use reports through the full binder';
+
+# A call the frame certainly reaches is reported at the BEGIN time
+# compilation when its routine is declared only later, whether it sits
+# under a statement modifier or a short circuit operator.
+throws-like { EVAL 'BEGIN { later-mod() if True }; sub later-mod() { 1 }' }, X::Undeclared::Symbols,
+    'a call under a statement modifier in a BEGIN block to a sub declared later is reported at compile time';
+throws-like { EVAL 'BEGIN { True && later-and() }; sub later-and() { 1 }' }, X::Undeclared::Symbols,
+    'a call under a short circuit in a BEGIN block to a sub declared later is reported at compile time';
 
 # The implicit marks decide what a re-formed frame elides, so an
 # implicit the routine reads must keep its full setup there.
@@ -82,8 +188,7 @@ BEGIN UsesBlock.new.m;
 is UsesBlock.new.m, 1,
     'a block variable read still works after a BEGIN time use';
 
-# A role body appends lexical fixup nodes to its formed block, so it
-# declines the re-formation. Its methods still take it.
+# A role body forms ahead of the unit, and its methods form with it.
 my role Countable {
     has int $!n;
     method tick() { ++$!n }
@@ -155,9 +260,9 @@ is typed("hi"), 'Str',
 is typed(1.5), 'Rat',
     'a second call instantiates the generic independently';
 
-# An inner bare block would flatten into the method frame in ordinary
-# compilation, and the lowering holds that off for a frame the early
-# compilation serialized.
+# An inner bare block flattens into the method frame in the early
+# compilation as it does in ordinary compilation, and the re-formation
+# keeps that shape.
 my class Inner {
     method m() { my $r; { my int $x = 1; $r = $x + 2; }; $r }
 }
@@ -247,6 +352,34 @@ is EVAL(q[my class E { has int $!i; method m() { ++$!i } }; my $e := E.new; BEGI
         }
         our $begin-inner;
         our sub check-inner() { $begin-inner() }
+        our sub flat($b) { my $r = 0; if $b { my $t = $b + 1; $r = $t }; $r }
+        our sub bump-late() { my int $i = 1; $i++; $i }
+        role RL {
+            my $count = 0;
+            my int $native = 0;
+            my $branch = 0;
+            if True { my $t = 5; $branch = $t }
+            method bump() { my int $i = 1; $i++; $i }
+            method count() { ++$count }
+            method ncount() { ++$native }
+            method branch() { $branch }
+            method nameds() { %_.elems }
+            method idx(int $i) { my int @a = 1,2,3; @a[$i] }
+            method via-sub() { soft-target(5) }
+        }
+        class RC does RL { }
+        role Gen[::T] { has T $.x; method t() { T.^name } }
+        class GenInt does Gen[Int] { }
+        our sub soft-target(int $a) { $a + 1 }
+        our sub soft-caller(int $i) { soft-target($i) }
+        our sub soft-index(int $i) { my int @a = 1,2,3; @a[$i] }
+        our sub guarded($b) { if $b { declared-below(1) } else { 0 } }
+        our sub g-unless($b) { my $r = 0; unless $b { $r = declared-below(1) }; $r }
+        our sub g-while($n) { my $i = 0; while $i < $n { $i = declared-below($i) }; $i }
+        our sub nested-role() { my role NR { my $c = 0; method m() { ++$c } }; my class NC does NR { }; NC.new.m }
+        our sub nested-role-attr() { my role NA { has $.a = 42; method m() { $!a + 1 } }; my class NCA does NA { }; NCA.new.m }
+        our $guarded-at-begin;
+        our sub var-op() { my $s = 0; for 1..3 { $s = $s + $_ }; $s }
         grammar PG { token TOP { ( "ab" | "a" | ( "b" ) ) } }
         BEGIN PG.parse("ab");
         class PC {
@@ -260,7 +393,22 @@ is EVAL(q[my class E { has int $!i; method m() { ++$!i } }; my $e := E.new; BEGI
             PC.new.named(:x);
             $begin-closure = adder(5);
             $begin-inner = inner-closure(41);
+            flat(1);
+            bump-late();
+            RC.new.count;
+            soft-caller(1);
+            soft-index(0);
+            $guarded-at-begin = guarded(0);
+            g-unless(1);
+            g-while(0);
+            nested-role();
+            nested-role-attr();
+            var-op();
         }
+        our sub declared-below($x) { $x + 1 }
+        sub postfix:<++>($a is rw) { $a = 100 }
+        use soft;
+        my &infix:<..> = sub ($a, $b) { (100,) };
         END
     my $repo = CompUnit::Repository::FileSystem.new(:prefix($dir.Str));
     CompUnit::RepositoryRegistry.use-repository($repo);
@@ -275,6 +423,52 @@ is EVAL(q[my class E { has int $!i; method m() { ++$!i } }; my $e := E.new; BEGI
         'a closure the precompiled BEGIN block minted runs correctly at runtime';
     is &::('PrecompRemark::check-inner')(), 42,
         'a closure minted inside an inner block at BEGIN keeps its frame chain across precompilation';
+    is &::('PrecompRemark::flat')(41), 42,
+        'a precompiled routine with a flattened inner branch used at BEGIN computes at runtime';
+    is &::('PrecompRemark::bump-late')(), 100,
+        'an operator declared after a BEGIN time use of a precompiled routine still shadows the core one in it';
+    is ::('PrecompRemark::RC').new.bump, 100,
+        'an operator declared after a precompiled role still shadows the core one in a role method';
+    is ::('PrecompRemark::RC').new.ncount, 1,
+        'a precompiled role body keeps a native lexical its method increments';
+    is ::('PrecompRemark::RC').new.branch, 5,
+        'a precompiled role body lexical assigned in a body level block reads back from a method';
+    is ::('PrecompRemark::RC').new.nameds(:a, :b), 2,
+        'a precompiled role method reading its implicit slurpy still collects named arguments';
+    is ::('PrecompRemark::GenInt').new(x => 1).t, 'Int',
+        'a precompiled parametric role instantiates its type parameter';
+    is ::('PrecompRemark::GenInt').new(x => 1).x, 1,
+        'a precompiled parametric role keeps the accessor of its generic attribute';
+    is $::('PrecompRemark::guarded-at-begin'), 0,
+        'a precompiled BEGIN time call leaves an untaken call to a sub declared later intact';
+    is &::('PrecompRemark::guarded')(1), 2,
+        'a precompiled routine used at BEGIN reaches a sub declared later through a branch at runtime';
+    is &::('PrecompRemark::g-unless')(0), 2,
+        'a precompiled routine used at BEGIN reaches a sub declared later through an unless body at runtime';
+    is &::('PrecompRemark::g-while')(3), 3,
+        'a precompiled routine used at BEGIN reaches a sub declared later through a while body at runtime';
+    is &::('PrecompRemark::nested-role')(), 2,
+        'a role declared in a precompiled routine used at BEGIN keeps its body lexical across calls';
+    is &::('PrecompRemark::nested-role-attr')(), 43,
+        'a role declared in a precompiled routine used at BEGIN reads its attribute in a method';
+    is &::('PrecompRemark::var-op')(), 100,
+        'an operator bound to a variable after a BEGIN time use shadows the core one in a precompiled routine';
+    &::('PrecompRemark::soft-target').wrap(-> | { 'wrapped' });
+    is &::('PrecompRemark::soft-caller')(5), 'wrapped',
+        'the soft pragma parsed after a BEGIN time use keeps a precompiled routine wrappable';
+    is ::('PrecompRemark::RC').new.via-sub, 'wrapped',
+        'the soft pragma parsed after a precompiled role keeps a sub its method calls wrappable';
+    my ($sub-index, $role-index);
+    {
+        my $index-wrap = &postcircumfix:<[ ]>.wrap(-> | { 'wrapped' });
+        LEAVE $index-wrap.restore;
+        $sub-index  = &::('PrecompRemark::soft-index')(1);
+        $role-index = ::('PrecompRemark::RC').new.idx(1);
+    }
+    is $sub-index, 'wrapped',
+        'the soft pragma parsed after a BEGIN time use keeps a native subscript in a precompiled routine wrappable';
+    is $role-index, 'wrapped',
+        'the soft pragma parsed after a precompiled role keeps a native subscript in its method wrappable';
     is ::('PrecompRemark::PG').parse("ab").Str, 'ab',
         'a precompiled grammar parsed at BEGIN still picks the longest alternative';
     is ::('PrecompRemark::PG').parse("a")[0].Str, 'a',
@@ -352,6 +546,18 @@ sub qast-deep-has-op(Mu $qast, str $op, %seen = {} --> Bool:D) {
     }
     for $qast.list {
         qast-deep-has-op($_, $op, %seen) and return True;
+    }
+    False
+}
+
+sub qast-deep-has-call(Mu $qast, str $name, %seen = {} --> Bool:D) {
+    return False unless nqp::istype($qast, QAST::Node);
+    my str $id = ~nqp::objectid($qast);
+    return False if %seen{$id};
+    %seen{$id} = True;
+    return True if nqp::istype($qast, QAST::Op) && $qast.name eq $name;
+    for $qast.list {
+        return True if qast-deep-has-call($_, $name, %seen);
     }
     False
 }
@@ -514,18 +720,151 @@ if nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' {
         qast-block-occurrences(v, 'POPULATE') == 1 && qast-block-occurrences(v, 'a') == 1
     }, 'control: the same class emits its generated methods once without a BEGIN use';
 
-    # The frame boundary of an inner body block is part of the shape the
-    # early compilation serialized, so it survives the re-formation
-    # while the control flattens it away.
+    # A role body forms its methods with it ahead of the unit, and the
+    # unit re-forms them once the marks are settled.
+    qast-is 'my role R1 { has int $!i; method m() { ++$!i } }; my class C1 does R1 { }; C1.new.m', :full, -> \v {
+        my \block = qast-find-block(v, 'm');
+        nqp::istype(block, QAST::Block) && qast-deep-has-op(block, 'add_i')
+    }, 'a native attribute increment in a role method lowers to add_i';
+
+    qast-is 'my role R2 { my $c = 0; my $u = 5; method m() { ++$c } }; my class C2 does R2 { }; C2.new.m', :full, -> \v {
+        my \body = qast-find-block(v, 'R2');
+        my \m = qast-find-block(v, 'm');
+        nqp::istype(body, QAST::Block) && nqp::istype(m, QAST::Block)
+            && qast-declares-lexical(body, '$c') && qast-uses-lexical(m, '$c')
+            && !qast-uses-lexical(body, '$u')
+    }, 'a role body keeps a lexical its methods capture and lowers one they do not';
+
+    # The early compilation lowers the routine before it caches the
+    # block, so the inner body block flattens there as it does in the
+    # control, and the re-formation keeps that shape.
     qast-is 'my class F1 { method m() { my $s = 0; if $s { my $t = 1; $s = $t }; $s } }; BEGIN F1.new.m; F1.new.m', :full, -> \v {
         my \block = qast-find-block(v, 'm');
-        nqp::istype(block, QAST::Block) && qast-counts-nested-blocks(block) > 0
-    }, 'an inner body block keeps its frame after a BEGIN time use';
+        nqp::istype(block, QAST::Block) && qast-counts-nested-blocks(block) == 0
+    }, 'an inner body block flattens after a BEGIN time use';
 
     qast-is 'my class F2 { method m() { my $s = 0; if $s { my $t = 1; $s = $t }; $s } }; F2.new.m', :full, -> \v {
         my \block = qast-find-block(v, 'm');
         nqp::istype(block, QAST::Block) && qast-counts-nested-blocks(block) == 0
     }, 'control: the same inner body block flattens without a BEGIN use';
+
+    # The shapes a method in a class takes, in a method of a role.
+    qast-is 'my role RW { method w() { my int $i = 0; while $i < 3 { $i++ }; $i } }; my class CW does RW { }; CW.new.w', :full, -> \v {
+        my \block = qast-find-block(v, 'w');
+        nqp::istype(block, QAST::Block) && qast-counts-nested-blocks(block) == 0 && qast-deep-has-op(block, 'islt_i')
+    }, 'a while loop in a role method flattens its body and lowers its native condition';
+    qast-is 'my role RC { method c($x) { 1 <= $x <= 3 } }; my class CC does RC { }; CC.new.c(2)', :full, -> \v {
+        my \block = qast-find-block(v, 'c');
+        nqp::istype(block, QAST::Block) && qast-deep-has-op(block, 'chainstatic')
+    }, 'a chained comparison in a role method takes the static chain lookup';
+    qast-is 'my role RS { method s() { unit-helper(1) } }; sub unit-helper($x) { $x }; my class CS does RS { }; CS.new.s', :full, -> \v {
+        my \block = qast-find-block(v, 's');
+        nqp::istype(block, QAST::Block) && qast-deep-has-op(block, 'callstatic')
+    }, 'a call from a role method to a sub of the unit takes the static call lookup';
+    qast-is 'my role RF { method f() { my int $t = 0; for 1..3 { $t = $t + $_ }; $t } }; my class CF does RF { }; CF.new.f', :full, -> \v {
+        my \block = qast-find-block(v, 'f');
+        nqp::istype(block, QAST::Block) && qast-deep-has-op(block, 'while')
+    }, 'a range loop in a role method lowers to a native counting loop';
+    qast-is 'sub w3() { my int $i = 0; while $i < 3 { $i++ }; $i }; BEGIN w3(); w3()', :full, -> \v {
+        my \block = qast-find-block(v, 'w3');
+        nqp::istype(block, QAST::Block) && qast-counts-nested-blocks(block) == 0
+    }, 'a while loop body in a sub used at BEGIN time flattens';
+
+    # The soft pragma parsed after the early walk withdraws each mark
+    # that binds a routine by identity from the frame the unit emits.
+    qast-is 'sub s1() { my int $i = 0; ++$i }; BEGIN s1(); use soft; s1()', :full, -> \v {
+        my \block = qast-find-block(v, 's1');
+        nqp::istype(block, QAST::Block) && !qast-deep-has-op(block, 'add_i')
+    }, 'the soft pragma parsed after a BEGIN time use withdraws the native increment lowering';
+    qast-is 'sub t1($x) { $x }; sub c1() { t1(1) }; BEGIN c1(); use soft; c1()', :full, -> \v {
+        my \block = qast-find-block(v, 'c1');
+        nqp::istype(block, QAST::Block) && !qast-deep-has-op(block, 'callstatic') && qast-deep-has-op(block, 'call')
+    }, 'the soft pragma parsed after a BEGIN time use withdraws the static call lookup';
+    qast-is 'sub t2($x) { $x }; sub c2() { t2(1) }; BEGIN c2(); c2()', :full, -> \v {
+        my \block = qast-find-block(v, 'c2');
+        nqp::istype(block, QAST::Block) && qast-deep-has-op(block, 'callstatic')
+    }, 'control: a call to a sub of the unit after a BEGIN time use takes the static call lookup';
+    qast-is 'sub r1() { my $s = 0; for 1..3 { $s = $s + $_ }; $s }; BEGIN r1(); use soft; r1()', :full, -> \v {
+        my \block = qast-find-block(v, 'r1');
+        nqp::istype(block, QAST::Block) && !qast-deep-has-op(block, 'while')
+    }, 'the soft pragma parsed after a BEGIN time use withdraws the range loop lowering';
+    qast-is 'sub r2() { my $s = 0; for 1..3 { $s = $s + $_ }; $s }; BEGIN r2(); r2()', :full, -> \v {
+        my \block = qast-find-block(v, 'r2');
+        nqp::istype(block, QAST::Block) && qast-deep-has-op(block, 'while')
+    }, 'control: a range loop after a BEGIN time use lowers to a native counting loop';
+    qast-is 'sub m1() { my $s = 0; $s = $s + $_ for 1..3; $s }; BEGIN m1(); use soft; m1()', :full, -> \v {
+        my \block = qast-find-block(v, 'm1');
+        nqp::istype(block, QAST::Block) && !qast-deep-has-op(block, 'while')
+    }, 'the soft pragma parsed after a BEGIN time use withdraws the range loop modifier lowering';
+    qast-is 'my role SR { method c() { my int $i = 0; ++$i } }; my class SC does SR { }; use soft; SC.new.c', :full, -> \v {
+        my \block = qast-find-block(v, 'c');
+        nqp::istype(block, QAST::Block) && !qast-deep-has-op(block, 'add_i')
+    }, 'the soft pragma parsed after a role withdraws the native increment lowering in its method';
+
+    # A role body's re-formation splices the generated accessor QAST
+    # back in exactly once.
+    qast-is 'my role RA { has $.a = 42 }; my class CA does RA { }; CA.new.a', :full, -> \v {
+        qast-block-occurrences(v, 'a') == 1
+    }, 'a role with a public attribute emits its generated accessor once';
+    qast-is 'sub k3() { my role RR { method m() { 1 } }; my class KC does RR { }; KC.new.m }; BEGIN k3(); k3()', :full, -> \v {
+        qast-block-occurrences(v, 'RR') == 1 && qast-block-occurrences(v, 'm') == 1
+    }, 'a role declared in a sub used at BEGIN emits its body and method once';
+
+    # A throw from the walk ahead of the unit, caught by the code that
+    # invoked the routine, must leave the unit's own walk intact.
+    my $early-throw = q:to/END/;
+        my constant &probe-dies = sub ($x) { $x } but role {
+            method soft() { state $n = 0; die 'probe' unless $n++; False }
+        };
+        sub calls-probe() { probe-dies(1) }
+        my $caught;
+        BEGIN { try calls-probe(); $caught = $!.message }
+        my $folded = 2 ** 10;
+        "$caught $folded"
+        END
+    is EVAL($early-throw), 'probe 1024',
+        'a throw from the walk ahead of the unit reaches the BEGIN block that invoked the routine';
+    qast-is $early-throw, :full, -> \v { !qast-deep-has-call(v, '&infix:<**>') },
+        'the unit walk still folds a constant after a caught throw from the walk ahead of the unit';
+
+    # An aborted walk ahead of the unit leaves none of the scopes or
+    # packages it entered behind on the resolver a retry compiles with.
+    my $retry-after-throw = q:to/END/;
+        my constant &probe-dies-once = sub ($x) { $x } but role {
+            method soft() { state $n = 0; die 'probe' unless $n++; False }
+        };
+        sub names-package() {
+            my class Inner { method m() { probe-dies-once(1) } }
+            Inner.new.m;
+            $?PACKAGE.^name
+        }
+        BEGIN { try names-package() }
+        names-package()
+        END
+    is EVAL($retry-after-throw), 'GLOBAL',
+        'a routine retried after a caught throw from the walk ahead of the unit compiles in its own package';
+
+    # A call in a flattened body to a sub declared later is left to the
+    # runtime lookup at BEGIN time.
+    lives-ok { EVAL 'BEGIN { my $b = False; if $b { later-if() } }; sub later-if() { 1 }' },
+        'a call in a flattened if body to a sub declared later compiles at BEGIN time';
+    lives-ok { EVAL 'BEGIN { my $b = False; unless !$b { later-unless() } }; sub later-unless() { 1 }' },
+        'a call in a flattened unless body to a sub declared later compiles at BEGIN time';
+    lives-ok { EVAL 'BEGIN { my $b = False; while $b { later-while() } }; sub later-while() { 1 }' },
+        'a call in a flattened while body to a sub declared later compiles at BEGIN time';
+
+    # The rewrites deferred ahead of the unit reach the re-formed frame.
+    qast-is 'sub p1() { 2 ** 10 }; BEGIN p1(); p1()', :full, -> \v {
+        my \block = qast-find-block(v, 'p1');
+        nqp::istype(block, QAST::Block) && !qast-deep-has-call(block, '&infix:<**>')
+    }, 'a constant expression in a sub used at BEGIN time folds in the re-formed frame';
+    qast-is 'sub p2() { return 1; my $x = 2; $x + 1 }; BEGIN p2(); p2()', :full, -> \v {
+        my \block = qast-find-block(v, 'p2');
+        nqp::istype(block, QAST::Block) && !qast-deep-has-call(block, '&infix:<+>')
+    }, 'statements after a return in a sub used at BEGIN time are dropped from the re-formed frame';
+    qast-is 'sub p3() { my role PR { method m() { 2 ** 10 } }; my class PC does PR { }; PC.new.m }; BEGIN p3(); p3()', :full, -> \v {
+        !qast-deep-has-call(v, '&infix:<**>')
+    }, 'a constant expression in a role method declared in a sub used at BEGIN time folds';
 }
 else {
     skip-rest 'QAST shapes specific to the RakuAST frontend';


### PR DESCRIPTION
Previously a role body, and any routine invoked at BEGIN time, was compiled before the unit's optimize walk and lexical lowering had run, and the code object kept that early frame. A method in a role therefore ran without any of the marks the same method in a class gets, i.e. no native operators, no static callee lookups, loop bodies as closures, nothing lowered to locals, and the unused implicit slurpy bound on every call. The same method body is over five times slower in a role than in a class:

```
$ RAKUDO_RAKUAST=1 raku -e 'my role R { method m($x) { my $s = 0; my int $i = 0; while $i < 2000 { $s = $s + $x; $i = $i + 1 }; $s } }; my class C does R {}; my $o = C.new; my $t = now; $o.m(1) for ^3000; say now - $t'
1.38
$ RAKUDO_RAKUAST=1 raku -e 'my class C { method m($x) { my $s = 0; my int $i = 0; while $i < 2000 { $s = $s + $x; $i = $i + 1 }; $s } }; my $o = C.new; my $t = now; $o.m(1) for ^3000; say now - $t'
0.25
```

Every role in the setting pays this too, e.g. `Rational.Num` and `Real.Bridge` allocated a Hash per call for the `*%_` nothing reads.

This runs the optimize walk and the full lowering over such a code object before its QAST is formed, in the compiler thunk and in `IMPL-FINISH-ROLE-BODY`. The scopes enclosing the code object are still being parsed at that point, so a later declaration could shadow an operator the early walk already decided on. As such the rewrites that cannot be undone wait for the unit's own walk, the marks that bind a routine by identity are set in both directions so the unit's walk can override the early decision, and a role body is re-formed at unit emission like a routine so a precompiled unit carries the settled marks. Where `use soft` is in effect the unit's walk withdraws those marks. While the core setting compiles itself its routines are stubs, so the compile time dispatch and the file and softness probes are skipped during the early walk.

The two smaller commits are prerequisites: the dynamic compilation fixup did not rewrite `chainstatic` callees, and the bound-once check called `find-lexical` on the still open compunit scope, which froze its lookup cache before later declarations were parsed.

With this the role method above runs in 0.25s, the same as the class, and a sub called at BEGIN time gets the same treatment. In the setting `Rational.Num` and `Real.Bridge` no longer allocate per call, which shows up as a few percent on numeric loops.