### PR TITLE
RakuAST: resolve an operator again before folding or deciding its dispatch

### DIFF
--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -1926,8 +1926,9 @@ class RakuAST::Node {
 
     # Whether a resolution's lexical is bound once, so the VM may resolve a
     # lookup of $name a single time and treat the result as a constant. Two
-    # kinds of binding qualify. A setting symbol: the setting binds each
-    # name once and user code cannot rebind it. And a compile-time-valued
+    # kinds of binding qualify. A setting symbol the name still reaches from
+    # the node: the setting binds each name once and user code cannot rebind
+    # it, though a routine declaration parsed after the use shadows it. And a compile-time-valued
     # binding in the outermost scope of the compilation unit, such as a
     # sub declaration, a constant, an enum value, or an import, since that
     # scope's frame is entered once per load and such a binding cannot be
@@ -1938,7 +1939,14 @@ class RakuAST::Node {
     # does a Code value compiled under the soft pragma, so it stays
     # wrappable.
     method IMPL-RESOLUTION-BOUND-ONCE(RakuAST::Resolver $resolver, Mu $decl, str $name) {
-        return 1 if nqp::istype($decl, RakuAST::Declaration::External::Setting);
+        # A routine's name is visible throughout its scope, so a user
+        # declaration parsed after the use shadows the setting's. Any
+        # other name is visible from its declaration on, so the stored
+        # resolution stands.
+        if nqp::istype($decl, RakuAST::Declaration::External::Setting) {
+            return 1 unless nqp::eqat($name, '&', 0);
+            return self.IMPL-DECLARATION-CURRENT($resolver, $name, $decl);
+        }
 
         my $routine := self.IMPL-DECLARATION-VALUE($decl);
         return 0 unless nqp::isconcrete($routine);
@@ -3270,14 +3278,10 @@ class RakuAST::Node {
     # bound to a lexical variable has no compile-time value, which declines
     # the lowering. A user `multi` or `sub` that shadows or extends the
     # operator produces a distinct routine object whose file may still read
-    # SETTING::, so the file alone is not enough. The name is resolved again in
-    # the scope of the node being offered: a lexical declaration is visible to
-    # that walk wherever it sits in its block, so a user operator declared after
-    # a use of the name still turns the lowering off, where the resolution
-    # stored on the node (made when the declaration had not been parsed yet)
-    # would still claim the CORE routine. When the walk reaches no declaration
-    # at all, the origin check above already vouched, by file for a loaded
-    # setting or by the marker while a core setting compiles itself.
+    # SETTING::, so the file alone is not enough and the name is resolved
+    # again. When that walk reaches no declaration at all, the origin check
+    # already vouched, by file for a loaded setting or by the marker while a
+    # core setting compiles itself.
     method IMPL-OPERATOR-IS-CORE(RakuAST::Resolver $resolver, Mu $operator) {
         CATCH {
             return False;
@@ -3296,15 +3300,40 @@ class RakuAST::Node {
                     || nqp::istrue(nqp::ifnull(
                          nqp::getlexdyn('$*COMPILING_CORE_SETTING'), 0)));
         }
+        self.IMPL-OPERATOR-RESOLUTION-CURRENT($resolver, $operator) ?? True !! False
+    }
+
+    # Whether an operator's name still resolves to the routine the operator
+    # resolved to at parse time.
+    method IMPL-OPERATOR-RESOLUTION-CURRENT(RakuAST::Resolver $resolver, Mu $operator) {
+        return 0 unless $operator.is-resolved;
         my str $category := nqp::istype($operator, RakuAST::Postfix) ?? '&postfix'
                          !! nqp::istype($operator, RakuAST::Prefix)  ?? '&prefix'
                          !! '&infix';
-        my $current := $resolver.resolve-lexical(
-          $category ~ $resolver.IMPL-CANONICALIZE-PAIR($operator.operator));
-        return True unless nqp::isconcrete($current);
+        self.IMPL-DECLARATION-CURRENT($resolver,
+            $category ~ $resolver.IMPL-CANONICALIZE-PAIR($operator.operator),
+            $operator.resolution)
+    }
+
+    # Whether a name still resolves, in the scope of the node being
+    # offered, to the value of the declaration stored on the node. A
+    # lexical declaration is visible to that walk wherever it sits in
+    # its block, so a user declaration parsed after the use, which the
+    # stored resolution predates, turns the answer off. A name the walk
+    # reaches no declaration for keeps the stored resolution. Asking a
+    # declaration without a compile-time value throws, and declining
+    # keeps the use at runtime.
+    method IMPL-DECLARATION-CURRENT(RakuAST::Resolver $resolver, str $name, Mu $decl) {
+        CATCH {
+            return 0;
+        }
+        my $value := self.IMPL-DECLARATION-VALUE($decl);
+        return 0 unless nqp::isconcrete($value);
+        my $current := $resolver.resolve-lexical($name);
+        return 1 unless nqp::isconcrete($current);
         my $current-value := self.IMPL-DECLARATION-VALUE($current);
         nqp::isconcrete($current-value)
-            && nqp::eqaddr($routine, nqp::decont($current-value))
+            && nqp::eqaddr(nqp::decont($value), nqp::decont($current-value)) ?? 1 !! 0
     }
 
     # The compile-time value a declaration offers, or Mu when it has none.
@@ -3488,7 +3517,8 @@ class RakuAST::Node {
                 && self.IMPL-PURE-ROUTINE($infix)
                 && !nqp::isconcrete($expr.args.arg-at-pos(2))
                 && self.IMPL-FOLDABLE-OPERAND($expr.left)
-                && self.IMPL-FOLDABLE-OPERAND($expr.right);
+                && self.IMPL-FOLDABLE-OPERAND($expr.right)
+                && self.IMPL-OPERATOR-RESOLUTION-CURRENT($resolver, $infix);
         }
         elsif nqp::istype($expr, RakuAST::ApplyPrefix) {
             my $prefix := $expr.prefix;
@@ -3500,7 +3530,8 @@ class RakuAST::Node {
                 && $prefix.is-resolved
                 && self.IMPL-PURE-ROUTINE($prefix)
                 && nqp::elems($prefix.colonpairs) == 0
-                && self.IMPL-FOLDABLE-OPERAND($expr.operand);
+                && self.IMPL-FOLDABLE-OPERAND($expr.operand)
+                && self.IMPL-OPERATOR-RESOLUTION-CURRENT($resolver, $prefix);
         }
         elsif nqp::istype($expr, RakuAST::ApplyListInfix) {
             my $infix := $expr.infix;
@@ -3520,6 +3551,8 @@ class RakuAST::Node {
                     for @operands {
                         $foldable := 0 unless self.IMPL-FOLDABLE-OPERAND($_);
                     }
+                    $foldable := 0
+                        if $foldable && !self.IMPL-OPERATOR-RESOLUTION-CURRENT($resolver, $infix);
                 }
             }
         }

--- a/t/08-performance/11-rakuast-constant-folding.t
+++ b/t/08-performance/11-rakuast-constant-folding.t
@@ -3,7 +3,7 @@ use Test::Helpers;
 use Test;
 use experimental :rakuast;
 
-plan 47;
+plan 55;
 
 # Constant folding rewrites a pure operator on constant operands into the
 # literal result. The helper deparses a source after optimizing it, so
@@ -134,6 +134,43 @@ ok optimized-deparse(Q[my $x = 3; my $y = $x * 2]).contains('$x * 2'),
     'a runtime variable keeps the operator';
 ok optimized-deparse(Q[class FoldPkg { }; my $y = FoldPkg:: eq "x"]).contains('eq'),
     'a stash reference keeps the operator';
+
+# A user operator declared after the use shadows the setting's, and the
+# resolution stored on the node predates the declaration, so the operator
+# survives and the user's runs. A declaration in an inner block reaches
+# no use outside it. The operator use sits in a module rather than in an
+# EVAL string, since an EVAL runs the user's routine either way.
+ok optimized-deparse(Q[my $y = 2 ** 3; sub infix:<**>($a, $b) { 'user' }]).contains('**'),
+    'a user infix declared after the use keeps the operator';
+ok optimized-deparse(Q[my $y = 2 min 3; sub infix:<min>($a, $b) { 'user' }]).contains('min'),
+    'a user list infix declared after the use keeps the operator';
+ok optimized-deparse(Q[my $y = 2 ** 3; my &infix:<**> = sub ($a, $b) { 'user' }]).contains('**'),
+    'an operator bound to a variable after the use keeps the operator';
+ok optimized-deparse(Q[sub f() { 2 ** 3 }; multi sub infix:<**>(Int $a, Int $b) is default { 'user' }]).contains('**'),
+    'a user multi declared after the use keeps the operator';
+{
+    my $t = optimized-deparse(Q[sub outer() { 2 ** 3 }; sub inner() { { sub infix:<**>($a, $b) { 'user' }; 2 ** 3 } }]);
+    ok $t.subst(/\s+/, ' ', :g).contains('sub outer () { 8 }') && $t.contains('2 ** 3'),
+        'a user infix in an inner block leaves a use outside it folding and keeps its own';
+}
+{
+    my $dir = make-temp-dir;
+    $dir.add('FoldLateOp.rakumod').spurt: q:to/END/;
+        unit module FoldLateOp;
+        our sub pow() { 2 ** 3 }
+        our sub neg() { -3 }
+        our sub least() { 2 min 3 }
+        sub infix:<**>($a, $b) { 'user' }
+        sub prefix:<->($a) { 'user' }
+        sub infix:<min>($a, $b) { 'user' }
+        END
+    is EVAL(q[use lib $dir; use FoldLateOp; &FoldLateOp::pow()]), 'user',
+        'a user infix declared after a use in a sub is what the sub calls';
+    is EVAL(q[use lib $dir; use FoldLateOp; &FoldLateOp::neg()]), 'user',
+        'a user prefix declared after a use in a sub is what the sub calls';
+    is EVAL(q[use lib $dir; use FoldLateOp; &FoldLateOp::least()]), 'user',
+        'a user list infix declared after a use in a sub is what the sub calls';
+}
 
 # Str.AST does not optimize, so the operator survives. The scenarios above
 # therefore test the optimize pass, not something upstream.

--- a/t/08-performance/22-rakuast-ct-dispatch.t
+++ b/t/08-performance/22-rakuast-ct-dispatch.t
@@ -1,9 +1,10 @@
 use lib <t/packages/Test-Helpers>;
+use Test::Helpers;
 use Test::Helpers::QAST;
 use Test;
 use QAST:from<NQP>;
 use nqp;
-plan 17;
+plan 23;
 
 # A call whose argument types decide the dispatch at compile time is
 # replaced by the chosen routine's recorded body, with the argument
@@ -44,6 +45,36 @@ else {
 qast-is 'use soft; sub g(int $a) { $a + 1 }; my int $i = 2; say g($i)', :full, -> \v {
     qast-contains-call(v, '&g')
 }, 'the soft pragma keeps the call so the routine stays wrappable';
+
+# A user operator declared after the use shadows the setting candidate
+# named by the resolution stored on the node, so the dispatch stays. A
+# declaration in an inner block reaches no use outside it. The module
+# shows the user's routine running.
+qast-is 'my int $i = 3; my int $j = $i + 1; sub infix:<+>(int $a, int $b) { 42 }; say $j', :full, -> \v {
+    not qast-contains-op(v, 'add_i')
+}, 'a user infix declared after the use keeps native int addition a dispatch';
+qast-is 'my int $i = 3; my int $j = $i + 1; multi sub infix:<+>(int $a, int $b) is default { 42 }; say $j', :full, -> \v {
+    not qast-contains-op(v, 'add_i')
+}, 'a user multi declared after the use keeps native int addition a dispatch';
+qast-is 'my int $i = 3; my int $j = $i + 1; my &infix:<+> = sub ($a, $b) { 42 }; say $j', :full, -> \v {
+    not qast-contains-op(v, 'add_i')
+}, 'an operator bound to a variable after the use keeps native int addition a dispatch';
+qast-is 'my int $i = 3; my $b = $i < 5; sub infix:«<»($a, $b) { "user" }; say $b', :full, -> \v {
+    not qast-contains-op(v, 'islt_i')
+}, 'a user infix declared after the use keeps a native comparison a dispatch';
+qast-is 'my int $i = 3; my int $j = $i + 1; { sub infix:<+>(int $a, int $b) { 42 } }; say $j', :full, -> \v {
+    qast-contains-op(v, 'add_i')
+}, 'a user infix in an inner block leaves a use outside it lowered';
+{
+    my $dir = make-temp-dir;
+    $dir.add('DispatchLateOp.rakumod').spurt: q:to/END/;
+        unit module DispatchLateOp;
+        our sub add(int $a, int $b) { $a + $b }
+        sub infix:<+>(int $a, int $b) { 42 }
+        END
+    is EVAL(q[use lib $dir; use DispatchLateOp; &DispatchLateOp::add(1, 2)]), 42,
+        'a user infix declared after a use in a sub is what the sub dispatches to';
+}
 
 # Behavior stays identical where the splice applies.
 

--- a/t/08-performance/31-rakuast-constant-terms.t
+++ b/t/08-performance/31-rakuast-constant-terms.t
@@ -3,7 +3,7 @@ use Test::Helpers::QAST;
 use Test;
 use QAST:from<NQP>;
 use nqp;
-plan 19;
+plan 20;
 
 # A term that resolves to a constant whose lexical is bound once
 # compiles to its value. The name lookup it replaces costs on every
@@ -97,6 +97,8 @@ else {
     ok $y =:= Int, 'a constant holding a type object reads the very type object';
 }
 
+sub nuke(IO::Path $p) { if $p.d { nuke($_) for $p.dir; $p.rmdir } else { $p.unlink } }
+
 # The folded value serializes as a reference into its own context, so
 # a precompiled module must produce the same objects when its store
 # compiles and when it loads. The imported container proves the
@@ -124,7 +126,21 @@ else {
         $proc.err.slurp(:close);
         is $out, '1|424242|light=1|Scalar', "the folded constants $stage";
     }
-    sub nuke(IO::Path $p) { if $p.d { nuke($_) for $p.dir; $p.rmdir } else { $p.unlink } }
+    nuke($dir);
+}
+
+# A constant declared after the use is visible only from its declaration
+# on, so the setting term stays the one the use compiles to.
+{
+    my $dir = $*TMPDIR.add("rakuast-constant-terms-late-{$*PID}");
+    $dir.mkdir;
+    $dir.add('LateTerm.rakumod').spurt: q:to/END/;
+        unit module LateTerm;
+        our sub setting-pi() { pi }
+        my constant pi = 3;
+        END
+    is EVAL(q[use lib $dir; use LateTerm; &LateTerm::setting-pi()]), pi,
+        'a constant declared after a use of a setting term leaves the use on the setting value';
     nuke($dir);
 }
 

--- a/t/08-performance/36-rakuast-begin-compiled-remark.t
+++ b/t/08-performance/36-rakuast-begin-compiled-remark.t
@@ -3,7 +3,7 @@ use Test::Helpers::QAST;
 use Test;
 use QAST:from<NQP>;
 use nqp;
-plan 114;
+plan 116;
 
 # A routine invoked at BEGIN time compiles ahead of the unit's optimize
 # walk and caches its QAST. That compilation runs its own optimize walk
@@ -366,6 +366,8 @@ is EVAL(q[my class E { has int $!i; method m() { ++$!i } }; my $e := E.new; BEGI
             method nameds() { %_.elems }
             method idx(int $i) { my int @a = 1,2,3; @a[$i] }
             method via-sub() { soft-target(5) }
+            method pow() { 2 ** 3 }
+            method rem(int $a, int $b) { $a % $b }
         }
         class RC does RL { }
         role Gen[::T] { has T $.x; method t() { T.^name } }
@@ -407,6 +409,8 @@ is EVAL(q[my class E { has int $!i; method m() { ++$!i } }; my $e := E.new; BEGI
         }
         our sub declared-below($x) { $x + 1 }
         sub postfix:<++>($a is rw) { $a = 100 }
+        sub infix:<**>($a, $b) { 'user' }
+        sub infix:<%>(int $a, int $b) { 42 }
         use soft;
         my &infix:<..> = sub ($a, $b) { (100,) };
         END
@@ -427,6 +431,10 @@ is EVAL(q[my class E { has int $!i; method m() { ++$!i } }; my $e := E.new; BEGI
         'a precompiled routine with a flattened inner branch used at BEGIN computes at runtime';
     is &::('PrecompRemark::bump-late')(), 100,
         'an operator declared after a BEGIN time use of a precompiled routine still shadows the core one in it';
+    is ::('PrecompRemark::RC').new.pow, 'user',
+        'an operator declared after a precompiled role shadows the core one in a constant expression of its method';
+    is ::('PrecompRemark::RC').new.rem(7, 4), 42,
+        'an operator declared after a precompiled role shadows the core one in a native dispatch of its method';
     is ::('PrecompRemark::RC').new.bump, 100,
         'an operator declared after a precompiled role still shadows the core one in a role method';
     is ::('PrecompRemark::RC').new.ncount, 1,


### PR DESCRIPTION
Previously the optimize walk trusted the resolution stored on an operator node when folding a constant expression or deciding a dispatch at compile time. That resolution is made when the operator is parsed, so a user operator declared later in the unit, which shadows the setting's, was never seen: `2 ** 3` folded to 8 with a user `**` declared below it, and `$a + $b` on native ints inlined the setting's addition past a user `+`, where the legacy frontend calls the user's in both cases. The core operator check already resolves the name again in the scope of the node for this reason.

This does the same for constant folding and for the bound once check, which passed a setting resolution outright, through one helper that asks whether a name still resolves to the declaration stored on the node. A routine's name is visible throughout its scope, so a routine declared after the use shadows the setting's, where a constant or type declared after a use of a setting term is visible only from its declaration on and the use keeps the setting's value. A method in a role, which takes the unit's marks in a precompiled unit, honours a later operator there as a plain sub does.