### PR TITLE
RakuAST: report worries once and render them readably during the setting build

### DIFF
--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -3166,11 +3166,18 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
               :$scope, :$type, :$sigil, :$twigil, :desigilname($ast),
               :$shape, :$forced-dynamic, :$where;
 
-            if ($scope eq 'my' || $scope eq 'state' || $scope eq 'our')
-                && $*R.declare-lexical($decl)
-            {
-                $/.typed-worry('X::Redeclaration', :symbol($name));
-                $decl.set-already-declared;
+            if $scope eq 'my' || $scope eq 'state' || $scope eq 'our' {
+                my $prev := $*R.declare-lexical($decl);
+                if $prev {
+                    # The setting declares $_, $/ and $! itself for the legacy
+                    # frontend, which does not provide them. Here they are
+                    # already implicit.
+                    my $shadows-implicit := $*COMPILING_CORE_SETTING
+                      && nqp::istype($prev, Nodify('VarDeclaration::Implicit::Special'));
+                    $/.typed-worry('X::Redeclaration', :symbol($name))
+                      unless $shadows-implicit;
+                    $decl.set-already-declared;
+                }
             }
 
             self.set-declarand($/, $decl);

--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -694,10 +694,69 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
                 $exception.throw;
             }
             else {
-                # Only potential difficulties, just print them.
-                try stderr().print($exception.gist);
+                # Only potential difficulties, just print them. The gist of
+                # the group is setting code, which cannot run yet while the
+                # setting itself compiles, so fall back to a plain rendering.
+                my $text;
+                my $failure;
+                try {
+                    $text := $exception.gist;
+                    CATCH { $failure := $_ }
+                }
+                stderr().print(nqp::defined($text)
+                    ?? $text
+                    !! self.render-worries(nqp::isconcrete($failure)
+                        ?? self.exception-reason($failure)
+                        !! 'the gist returned no text'));
             }
         }
+    }
+
+    method render-worries($reason) {
+        my @lines := ['Potential difficulties:'];
+        for Nodify('Node').IMPL-UNWRAP-LIST($*R.all-worries) -> $worry {
+            my $text;
+            my $error;
+            try {
+                my $message := $worry.message;
+                $text := ~$message if nqp::defined($message);
+                if nqp::defined($text) && nqp::can($worry, 'line') && nqp::can($worry, 'filename') {
+                    my $line-number := $worry.line;
+                    $text := $text ~ ' at ' ~ $worry.filename ~ ':' ~ $line-number
+                        if nqp::defined($line-number);
+                }
+                CATCH { $error := $_ }
+            }
+            my $line := nqp::defined($text)
+                ?? $text
+                !! $worry.HOW.name($worry) ~ ', message unavailable: '
+                     ~ (nqp::isconcrete($error)
+                         ?? self.exception-reason($error)
+                         !! 'the message was empty');
+            nqp::push(@lines, '    ' ~ $line);
+        }
+        nqp::push(@lines, 'The full rendering of these failed: ' ~ $reason);
+        nqp::join("\n", @lines) ~ "\n"
+    }
+
+    # A Raku exception carries its message on the payload, not on the VM
+    # exception.
+    method exception-reason($exception) {
+        return 'no exception' unless nqp::isconcrete($exception);
+        my str $message := nqp::getmessage($exception);
+        return $message unless nqp::isnull_s($message) || nqp::chars($message) == 0;
+        my $payload := nqp::getpayload($exception);
+        my $reason;
+        my $inner;
+        try {
+            my $text := $payload.message;
+            $reason := ~$text if nqp::defined($text);
+            CATCH { $inner := $_ }
+        }
+        nqp::defined($reason)
+            ?? $reason
+            !! $payload.HOW.name($payload) ~ ' thrown, its message unavailable'
+                ~ (nqp::isconcrete($inner) ?? ': ' ~ self.exception-reason($inner) !! '')
     }
 
     # Throws the errors found so far, with any worries inside the group.

--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -700,6 +700,12 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
         }
     }
 
+    # Throws the errors found so far, with any worries inside the group.
+    # Worries alone do not throw and are printed at the end of the unit.
+    method throw-errors() {
+        $*R.produce-compilation-exception.throw if $*R.has-compilation-errors;
+    }
+
     # Action method to load any modules specified with -M
     method load-M-modules($/) {
         my $M := %*OPTIONS<M>;
@@ -2930,7 +2936,7 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
         );
 
         $package.to-parse-time($*R, $*CU.context);
-        self.report-problems();
+        self.throw-errors();
 
         self.set-declarand($/, $*PACKAGE := $package);
 

--- a/src/Raku/ast/compunit.rakumod
+++ b/src/Raku/ast/compunit.rakumod
@@ -879,6 +879,11 @@ class RakuAST::CtxSave
         nqp::create(self)
     }
 
+    # The term is there for its effect, so a sunk one is not a useless use.
+    method PERFORM-CHECK(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
+        True
+    }
+
     method PERFORM-PARSE(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
         $resolver.find-attach-target('compunit').set-explicit-ctxsave;
     }

--- a/src/Raku/ast/compunit.rakumod
+++ b/src/Raku/ast/compunit.rakumod
@@ -1113,25 +1113,66 @@ class RakuAST::LiteralBuilder {
     }
 }
 
+# Stands in for a Raku exception type that cannot be used yet, which is
+# the case while the setting defining it is still compiling. gist takes
+# the named arguments the group gist passes along, and returns a Raku
+# string since the group gist calls methods on it.
 class RakuAST::BOOTException {
     has Str $!message;
     has Hash $!opts;
+    has Str $!filename;
+    has Mu $!line;
     method new(Str $message, %opts) {
         my $obj := nqp::create(self);
         nqp::bindattr($obj, RakuAST::BOOTException, '$!message', $message);
         nqp::bindattr($obj, RakuAST::BOOTException, '$!opts', %opts);
         $obj
     }
-    method message() {
-        my $message := $!message;
-        $message := "$message(";
+    method SET_FILE_LINE($filename, $line) {
+        nqp::bindattr(self, RakuAST::BOOTException, '$!filename', $filename);
+        nqp::bindattr(self, RakuAST::BOOTException, '$!line', $line);
+    }
+    # There is no sort op, and the NQP setting's sorted_keys is out of reach
+    # here, so the keys are put in order by hand.
+    method IMPL-SORTED-KEYS() {
+        my @keys;
         for $!opts {
-            $message := $message ~ $_.key ~ " => " ~ ((try $_.value.gist) // (try $_.value.Str) // '<unknown>') ~ ", ";
+            nqp::push(@keys, $_.key);
         }
-        $message := "$message)";
+        my int $n := nqp::elems(@keys);
+        my int $i := 1;
+        while $i < $n {
+            my str $key := @keys[$i];
+            my int $j := $i - 1;
+            while $j >= 0 && nqp::isgt_s(@keys[$j], $key) {
+                @keys[$j + 1] := @keys[$j];
+                $j := $j - 1;
+            }
+            @keys[$j + 1] := $key;
+            $i := $i + 1;
+        }
+        @keys
+    }
+    method message() {
+        my @opts;
+        for self.IMPL-SORTED-KEYS() -> $key {
+            my $value := $!opts{$key};
+            # A boxed native has no methods to call.
+            my $rendered := nqp::isconcrete($value)
+              && (nqp::isstr($value) || nqp::isint($value) || nqp::isnum($value))
+                ?? $value
+                !! ((try $value.gist) // (try $value.Str) // ('<' ~ $value.HOW.name($value) ~ '>'));
+            nqp::push(@opts, $key ~ ' => ' ~ $rendered);
+        }
+        my $message := nqp::elems(@opts)
+            ?? $!message ~ '(' ~ nqp::join(', ', @opts) ~ ')'
+            !! $!message;
+        $message := $message ~ ' at ' ~ $!filename ~ ':' ~ $!line if $!filename;
         $message
     }
+    method gist(*%_) { nqp::hllizefor(self.message, 'Raku') }
+    method Str(*%_) { self.gist }
     method throw() {
-        nqp::die($!message);
+        nqp::die(self.message);
     }
 }

--- a/src/Raku/ast/resolver.rakumod
+++ b/src/Raku/ast/resolver.rakumod
@@ -797,7 +797,7 @@ class RakuAST::Resolver {
                     nqp::push(@others, $stubbed);
                 }
                 $sorries := RakuAST::Node.IMPL-WRAP-LIST(@others);
-                $num-sorries := $sorries.elems;
+                $num-sorries := nqp::elems(@others);
             }
         }
 
@@ -833,7 +833,9 @@ class RakuAST::Resolver {
     }
 
     # Returns True if there are any compilation errors (worries don't count).
-    method has-compilation-errors() { self.all-sorries.Bool }
+    method has-compilation-errors() {
+        nqp::elems(RakuAST::Node.IMPL-UNWRAP-LIST(self.all-sorries)) ?? True !! False
+    }
 
     # Gathers all sorries (from check time, if performed, and any specific to
     # a given resolver).

--- a/src/Raku/ast/resolver.rakumod
+++ b/src/Raku/ast/resolver.rakumod
@@ -710,11 +710,7 @@ class RakuAST::Resolver {
 
         # Could not find or use exception type, so build a fake
         # (typically happens during CORE.setting compilation).
-        my $message := $type-name;
-        for %opts {
-            $message := $message ~ $_.key ~ " => " ~ ((try $_.value.gist) // (try $_.value.Str) // '<unknown>') ~ ", ";
-        }
-        RakuAST::BOOTException.new($message, %opts);
+        RakuAST::BOOTException.new($type-name, %opts);
     }
 
     method convert-exception(Mu $ex) {

--- a/t/05-messages/10-warnings.t
+++ b/t/05-messages/10-warnings.t
@@ -3,7 +3,7 @@ use nqp;
 use Test;
 use Test::Helpers;
 
-plan 18;
+plan 21;
 
 subtest 'Supply.interval with negative value warns' => {
     plan 2;
@@ -136,5 +136,22 @@ is-run ｢print do given 5 { when 5 { 42; 43 } }｣,
     'the last statement of a when block in value position stays wanted',
     :out<43>,
     :err{ .contains('constant integer 42') && !.contains('constant integer 43') };
+
+is-run ｢my $_; class A { }; class B { }; print "ran"｣,
+    'a worry followed by package declarations is printed once',
+    :out<ran>, :err{ .comb('Potential difficulties').elems == 1 && .comb('Redeclaration').elems == 1 };
+
+is-run ｢my $_; my Int:X $x; class B { }; class C { }; BEGIN note "later"; print "ran"｣,
+    'an error known at a package declaration is thrown there with the earlier worry inside it once',
+    :out(''), :exitcode(1),
+    :err{ !.contains('later')
+        && .comb('Invalid type smiley').elems == 1
+        && .comb('potential difficulties').elems == 1
+        && .comb('Redeclaration').elems == 1 };
+
+is-run ｢my $_; class A { }; foo()｣,
+    'a worry before a package declaration survives an error at the end of the unit',
+    :exitcode(1),
+    :err{ .comb('Redeclaration').elems == 1 && .contains('Undeclared routine') };
 
 # vim: expandtab shiftwidth=4

--- a/t/05-messages/10-warnings.t
+++ b/t/05-messages/10-warnings.t
@@ -3,7 +3,7 @@ use nqp;
 use Test;
 use Test::Helpers;
 
-plan 21;
+plan 23;
 
 subtest 'Supply.interval with negative value warns' => {
     plan 2;
@@ -153,5 +153,15 @@ is-run ｢my $_; class A { }; foo()｣,
     'a worry before a package declaration survives an error at the end of the unit',
     :exitcode(1),
     :err{ .comb('Redeclaration').elems == 1 && .contains('Undeclared routine') };
+
+{
+    my $setting := make-temp-dir.add('yah.setting');
+    $setting.spurt(｢{YOU_ARE_HERE}; print "ran"｣);
+    my $proc := run $*EXECUTABLE, $setting, :out, :err;
+    is $proc.out.slurp(:close), 'ran',
+      'a setting file with {YOU_ARE_HERE} as a statement runs';
+    is $proc.err.slurp(:close), '',
+      'a sunk {YOU_ARE_HERE} is not a useless use';
+}
 
 # vim: expandtab shiftwidth=4

--- a/t/12-rakuast/errors.rakutest
+++ b/t/12-rakuast/errors.rakutest
@@ -1,7 +1,8 @@
 use v6.e.PREVIEW;
 use Test;
+use nqp;
 
-plan 2;
+plan 4;
 
 throws-like { EVAL(RakuAST::Term::Self.new) },
     X::Syntax::Self::WithoutObject;
@@ -12,4 +13,107 @@ throws-like { EVAL(RakuAST::Term::Self.new) },
         X::Undeclared::Symbols,
         message => *.contains(Q[Did you mean 'hello']),
         'an undeclared routine in a synthesized AST is reported with a suggestion';
+}
+
+subtest 'a stand-in exception for a setting still compiling renders readably' => {
+    plan 9;
+
+    my $with-string := RakuAST::BOOTException.new('X::Redeclaration', nqp::hash('symbol', '$_'));
+    is $with-string.message, 'X::Redeclaration(symbol => $_)',
+      'a string option renders as its value';
+
+    my $with-int := RakuAST::BOOTException.new('X::Comp', nqp::hash('line', 3));
+    is $with-int.message, 'X::Comp(line => 3)',
+      'an integer option renders as its value';
+
+    my $bare := RakuAST::BOOTException.new('X::AdHoc', nqp::hash());
+    is $bare.message, 'X::AdHoc',
+      'no options renders just the type name';
+
+    is $with-string.gist(:!sorry, :!expect), $with-string.message,
+      'the gist takes the named arguments a compile-time exception gist takes';
+    is $with-string.Str, $with-string.message,
+      'the Str is the message';
+    isa-ok $with-string.gist, Str,
+      'the gist is a Raku Str';
+
+    my $with-two := RakuAST::BOOTException.new('X::Comp', nqp::hash('line', 3, 'filename', 'foo.raku'));
+    is $with-two.message, 'X::Comp(filename => foo.raku, line => 3)',
+      'options render in key order';
+
+    my $with-five := RakuAST::BOOTException.new('X::Comp', nqp::hash('c', 1, 'a', 2, 'b', 3, 'z', 4, 'aa', 5));
+    is $with-five.message, 'X::Comp(a => 2, aa => 5, b => 3, c => 1, z => 4)',
+      'five options render sorted by key';
+
+    $with-string.SET_FILE_LINE('bar.raku', 7);
+    is $with-string.message, 'X::Redeclaration(symbol => $_) at bar.raku:7',
+      'a file and line set on the stand-in render after the options';
+}
+
+if nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' {
+    subtest 'worries render plainly when the group gist cannot' => {
+        plan 8;
+
+        my $actions := nqp::getcomp('Raku').parseactions;
+        sub vm-exception(&code) {
+            my $exception;
+            try {
+                code();
+                CATCH { default { $exception := nqp::getattr($_, Exception, '$!ex') } }
+            }
+            $exception
+        }
+        my class MessageDies  is Exception { method message() { die 'inner reason' } }
+        my class MessageFails is Exception { method message() { fail 'soft' } }
+        my class MessageNil   is Exception { method message() { Nil } }
+        my class Unprintable { method Str() { die 'no Str' } }
+        my class MessageUnprintable is Exception { method message() { Unprintable.new } }
+
+        is $actions.exception-reason(vm-exception({ die 'boom' })), 'boom',
+          'a Raku exception reports the message of its payload';
+        is $actions.exception-reason(vm-exception({ nqp::die('vm boom') })), 'vm boom',
+          'a VM exception reports its own message';
+        is $actions.exception-reason(vm-exception({ MessageDies.new.throw })),
+          'MessageDies thrown, its message unavailable: inner reason',
+          'a payload whose message dies reports the inner reason';
+
+        my $*R := class :: {
+            has @.worries;
+            method all-worries() { @!worries }
+        }.new(worries => [
+            X::Redeclaration.new(symbol => '$x'),
+            RakuAST::BOOTException.new('X::Comp', nqp::hash('line', 3)),
+            MessageDies.new,
+            MessageNil.new,
+            MessageUnprintable.new,
+        ]);
+        my $text := $actions.render-worries('the gist broke');
+        is $text, q:to/END/, 'every worry renders on its own line with the reason last';
+            Potential difficulties:
+                Redeclaration of symbol '$x'.
+                X::Comp(line => 3)
+                MessageDies, message unavailable: inner reason
+                MessageNil, message unavailable: the message was empty
+                MessageUnprintable, message unavailable: no Str
+            The full rendering of these failed: the gist broke
+            END
+        isa-ok $text, Str, 'the plain rendering is a Raku Str';
+
+        $*R.worries = [MessageFails.new];
+        ok $actions.render-worries('the gist broke').contains('soft'),
+          'a message that is a Failure still renders with its reason';
+
+        my $located := X::Redeclaration.new(symbol => '$y');
+        $located.SET_FILE_LINE('foo.raku', 3);
+        $*R.worries = [$located];
+        is $actions.render-worries('the gist broke').lines[1],
+          q[    Redeclaration of symbol '$y'. at foo.raku:3],
+          'a worry with a location renders it after the message';
+        is $actions.exception-reason(vm-exception({ MessageUnprintable.new.throw })),
+          'MessageUnprintable thrown, its message unavailable: no Str',
+          'a payload whose message cannot be stringified reports why';
+    }
+}
+else {
+    skip 'the plain rendering belongs to the RakuAST frontend';
 }


### PR DESCRIPTION
Previously a package declaration reported every problem found so far, so under the RakuAST frontend a worry followed by package declarations was printed again at each of them. `raku -e 'my $_; class A { }; class B { }'` printed the redeclaration worry three times where the legacy frontend prints it once. The same repeated reporting is what made the CORE.c build print `Potential difficulties: RakuAST::BOOTException.new` after 6604 started optimizing code compiled ahead of the unit, since the group gist that prints worries is code of the setting being compiled and had only been dying silently before that.

This makes a package declaration throw only for errors and leaves worries to the single report at the end of the unit, which is what the legacy frontend does. It also makes worries readable while the setting itself compiles. The stand-in exception used when the real type cannot be used yet now renders as its type name, options and location, and when the group gist cannot run the compiler falls back to a plain rendering that says why. The two worries the setting build was actually producing were noise and are gone, i.e. the `my $!; my $/; my $_;` in `traits.rakumod` that the legacy setting mainline needs but RakuAST already declares implicitly, and the sunk `{YOU_ARE_HERE}` term.

One visible difference from the current RakuAST frontend: a worry followed by a BEGIN time failure (e.g. `BEGIN die`, or a missing module) is no longer printed. That matches the legacy frontend, which never printed it either, and the old output only appeared because of the repeated reporting.

The plain rendering and the setting specific skips are verified by the CORE build being silent and by compiling CORE.c with the skip removed, as such they are not covered by the test suite beyond the direct tests of the renderer.
