### PR TITLE
RakuAST: assign a native compound assignment's result without the metaop

### DIFF
--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -1754,7 +1754,14 @@ class RakuAST::Node {
             return Nil;
         }
 
+        # A routine declared after the use shadows the setting's the node
+        # resolved to and dispatches every use in its scope, so the
+        # dispatch is decided against the declaration the scope holds.
         my $resolution := $target.resolution;
+        if nqp::istype($resolution, RakuAST::Declaration::External::Setting) {
+            my $current := $resolver.resolve-lexical($lexname);
+            $resolution := $current if nqp::isconcrete($current);
+        }
         return Nil unless self.IMPL-RESOLUTION-BOUND-ONCE($resolver, $resolution, $lexname);
         my $routine := self.IMPL-DECLARATION-VALUE($resolution);
         return Nil unless nqp::isconcrete($routine)
@@ -3274,14 +3281,14 @@ class RakuAST::Node {
         nqp::istrue($resolver.find-scope-property(-> $scope { $scope.soft }))
     }
 
-    # True when the operator resolves to the CORE routine itself. An operator
-    # bound to a lexical variable has no compile-time value, which declines
-    # the lowering. A user `multi` or `sub` that shadows or extends the
-    # operator produces a distinct routine object whose file may still read
-    # SETTING::, so the file alone is not enough and the name is resolved
-    # again. When that walk reaches no declaration at all, the origin check
-    # already vouched, by file for a loaded setting or by the marker while a
-    # core setting compiles itself.
+    # True when the operator resolves to the CORE routine itself, the one
+    # the setting binds to the name, and the name still reaches it from
+    # the node. An operator bound to a lexical variable has no compile-time
+    # value, which declines the lowering. A user `multi` derives its proto
+    # from the setting's, so the clone reports the setting's source file
+    # and a check by origin takes it for the setting's. While a core
+    # setting is itself being compiled there is no setting to compare
+    # with, and any resolved operator the name still reaches is core.
     method IMPL-OPERATOR-IS-CORE(RakuAST::Resolver $resolver, Mu $operator) {
         CATCH {
             return False;
@@ -3289,30 +3296,29 @@ class RakuAST::Node {
         return False unless $operator.is-resolved;
         my $routine := self.IMPL-DECLARATION-VALUE($operator.resolution);
         return False unless nqp::isconcrete($routine);
-        # A loaded setting stamps its symbols with a SETTING:: file. While
-        # a core setting is itself being compiled its own operators carry
-        # the plain source file instead, and every one of them is core.
-        # A structural walk skips the file probe.
-        unless $resolver.IMPL-STRUCTURAL-WALK {
-            return False
-              unless nqp::can($routine, 'file')
-                && ($routine.file.starts-with('SETTING::')
-                    || nqp::istrue(nqp::ifnull(
-                         nqp::getlexdyn('$*COMPILING_CORE_SETTING'), 0)));
+        my str $name := self.IMPL-OPERATOR-LEXICAL-NAME($resolver, $operator);
+        unless nqp::istrue(nqp::ifnull(nqp::getlexdyn('$*COMPILING_CORE_SETTING'), 0)) {
+            my $setting := $resolver.resolve-lexical-constant-in-setting($name);
+            return False unless nqp::isconcrete($setting)
+                && nqp::eqaddr(nqp::decont($routine), nqp::decont($setting.compile-time-value));
         }
-        self.IMPL-OPERATOR-RESOLUTION-CURRENT($resolver, $operator) ?? True !! False
+        self.IMPL-DECLARATION-CURRENT($resolver, $name, $operator.resolution) ?? True !! False
+    }
+
+    # The lexical name an operator node spells from its category and symbol.
+    method IMPL-OPERATOR-LEXICAL-NAME(RakuAST::Resolver $resolver, Mu $operator) {
+        my str $category := nqp::istype($operator, RakuAST::Postfix) ?? '&postfix'
+                         !! nqp::istype($operator, RakuAST::Prefix)  ?? '&prefix'
+                         !! '&infix';
+        $category ~ $resolver.IMPL-CANONICALIZE-PAIR($operator.operator)
     }
 
     # Whether an operator's name still resolves to the routine the operator
     # resolved to at parse time.
     method IMPL-OPERATOR-RESOLUTION-CURRENT(RakuAST::Resolver $resolver, Mu $operator) {
         return 0 unless $operator.is-resolved;
-        my str $category := nqp::istype($operator, RakuAST::Postfix) ?? '&postfix'
-                         !! nqp::istype($operator, RakuAST::Prefix)  ?? '&prefix'
-                         !! '&infix';
         self.IMPL-DECLARATION-CURRENT($resolver,
-            $category ~ $resolver.IMPL-CANONICALIZE-PAIR($operator.operator),
-            $operator.resolution)
+            self.IMPL-OPERATOR-LEXICAL-NAME($resolver, $operator), $operator.resolution)
     }
 
     # Whether a name still resolves, in the scope of the node being

--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -857,6 +857,12 @@ class RakuAST::Node {
             }
         }
 
+        self.IMPL-MARK-HOP-CONSTANT($resolver, $expr)
+            if $result =:= $expr
+            && ($apply-infix
+                || nqp::istype($expr, RakuAST::ApplyListInfix)
+                || nqp::istype($expr, RakuAST::Term::Reduce));
+
         # A replacement stands where the original stood, so it must carry the
         # original's sunk state for any sink-sensitive code generation.
         if !($result =:= $expr)
@@ -865,6 +871,25 @@ class RakuAST::Node {
             $result.mark-sunk();
         }
         $result
+    }
+
+    # Mark the base operator of a meta operator or a reduction for
+    # forming the meta-op once at compile time, when the base resolves to
+    # a setting routine the name still reaches from the node. The soft
+    # pragma keeps the formation at run time. The mark is written on
+    # every visit, so the unit's walk settles what a walk ahead of it
+    # decided.
+    method IMPL-MARK-HOP-CONSTANT(RakuAST::Resolver $resolver, Mu $expr) {
+        my $base := $expr.infix;
+        return Nil unless nqp::istype($base, RakuAST::MetaInfix)
+            || nqp::istype($expr, RakuAST::Term::Reduce);
+        $base := $base.infix while nqp::istype($base, RakuAST::MetaInfix);
+        return Nil unless nqp::istype($base, RakuAST::Infix) && $base.is-resolved;
+        $base.IMPL-SET-HOP-CONSTANT(
+            nqp::istype($base.resolution, RakuAST::Declaration::External::Setting)
+            && !self.IMPL-IN-SOFT-SCOPE($resolver)
+            && self.IMPL-OPERATOR-RESOLUTION-CURRENT($resolver, $base) ?? 1 !! 0);
+        Nil
     }
 
     # Withdraw the marks that bind a routine by identity or pin its

--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -1005,10 +1005,9 @@ class RakuAST::Node {
         my int $spec := nqp::objprimspec(self.IMPL-NATIVE-STEP-TARGET-TYPE($left));
         return Nil unless $spec == 1 || $spec == 2;
         # The right operand must be a native value: a native variable of the
-        # same flavour, or a float literal. An integer literal is an `Int`, so
-        # `$i += 1` is an int + Int step that overflows to a bignum the native
-        # cannot hold and throws, like `my int $r = $i + 1`; leave it to the
-        # metaop. A float literal never overflows that way.
+        # same flavour, or a float literal. An integer literal is an `Int`,
+        # so `$i += 1` is left to the operator call, which pairs the literal
+        # with the native target. A float literal never overflows that way.
         my $right := $expr.right;
         my int $rhs-ok := 0;
         if nqp::istype($right, RakuAST::Var::Attribute)

--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -1054,7 +1054,9 @@ class RakuAST::Node {
     # True when the left of a compound assignment is a boxed scalar the inline
     # may assign through: a plain scalar lexical, or another compound assignment
     # whose result is itself such a scalar. Grouping parentheses are seen
-    # through, so a parenthesized chain qualifies.
+    # through, so a parenthesized chain qualifies. A scalar declared by binding
+    # holds no container, so it is left to the metaop, whose store reports the
+    # immutability as an assignment does.
     method IMPL-SCALAR-METAOP-LHS-OK(Mu $lhs) {
         my $node := $lhs;
         while nqp::istype($node, RakuAST::Circumfix::Parentheses)
@@ -1064,7 +1066,9 @@ class RakuAST::Node {
             $node := $stmt.expression;
         }
         (nqp::istype($node, RakuAST::Var::Lexical) && $node.is-resolved
-          && nqp::eqat($node.name, '$', 0) && nqp::objprimspec($node.return-type) == 0)
+          && nqp::eqat($node.name, '$', 0) && nqp::objprimspec($node.return-type) == 0
+          && !(nqp::istype($node.resolution, RakuAST::VarDeclaration::Simple)
+              && nqp::istype($node.resolution.initializer, RakuAST::Initializer::Bind)))
         || (nqp::istype($node, RakuAST::ApplyInfix)
           && nqp::istype($node.infix, RakuAST::MetaInfix::Assign)
           && self.IMPL-SCALAR-METAOP-LHS-OK($node.left))

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -1645,14 +1645,19 @@ class RakuAST::MetaInfix::Assign
     # surrounding compound assignment can assign through in turn. For a test
     # operator (// || &&) the assignment is the right operand of the base
     # operator, which selects it only when the left side does not, keeping the
-    # assignment conditional.
+    # assignment conditional. A plain scalar variable takes the scalar assign
+    # op. Any other left, such as a nested compound assignment, may yield a
+    # value that is no container, so it stores through p6store, whose STORE
+    # fallback reports the immutability as the metaop does.
     method IMPL-INLINE-METAOP-QAST(RakuAST::IMPL::QASTContext $context, Mu $left-qast, Mu $right-qast) {
         my str $temp := QAST::Node.unique('inline_metaop');
+        my str $store := nqp::istype($left-qast, QAST::Var) && nqp::eqat($left-qast.name, '$', 0)
+            ?? 'p6assign' !! 'p6store';
         my $effect;
         if self.IMPL-IS-TEST {
             $effect := $!infix.IMPL-INFIX-QAST($context,
                 QAST::Var.new(:scope<local>, :name($temp)),
-                QAST::Op.new(:op<p6assign>,
+                QAST::Op.new(:op($store),
                     QAST::Var.new(:scope<local>, :name($temp)), $right-qast));
         }
         else {
@@ -1666,7 +1671,7 @@ class RakuAST::MetaInfix::Assign
                         QAST::Var.new(:scope<local>, :name($temp)))),
                 QAST::Var.new(:scope<local>, :name($temp)),
                 QAST::Op.new(:op<call>, :name($!infix.resolution.lexical-name)));
-            $effect := QAST::Op.new(:op<p6assign>,
+            $effect := QAST::Op.new(:op($store),
                 QAST::Var.new(:scope<local>, :name($temp)),
                 $!infix.IMPL-INFIX-QAST($context, $left, $right-qast));
         }

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -1686,10 +1686,25 @@ class RakuAST::MetaInfix::Assign
     # The base assigns operands to QAST then calls IMPL-INFIX-QAST. When the
     # optimize pass marked a native compound assignment, emit the raw op
     # instead; that path needs the operand ASTs, not their QAST, to take the
-    # left as a lexicalref.
+    # left as a lexicalref. A native lexical or attribute target under a
+    # plain infix, with no adverb and no test or list meta, takes the
+    # operator's result by assignment, which needs the ASTs the same way.
+    # `^^` and `xor` compile to the `xor` QAST op, which yields a VMNull
+    # when neither operand is the result, where the metaop's routine call
+    # yields a Nil, so they are left to the metaop.
     method IMPL-INFIX-COMPILE(RakuAST::IMPL::QASTContext $context,
             RakuAST::Expression $left, RakuAST::Expression $right, RakuAST::ColonPairish :$adverb) {
         return self.IMPL-NATIVE-STEP-QAST($context, $left, $right) if $!native-step;
+        if !$adverb && nqp::istype($!infix, RakuAST::Infix) && !self.IMPL-IS-TEST
+            && !self.IMPL-WRAPS-LIST-META
+            && ((nqp::istype($left, RakuAST::Var::Lexical) && $left.is-resolved)
+                || nqp::istype($left, RakuAST::Var::Attribute)) {
+            my str $op := $!infix.operator;
+            if $op ne '^^' && $op ne 'xor' {
+                my int $spec := nqp::objprimspec(self.IMPL-NATIVE-ASSIGN-TARGET-TYPE($left));
+                return self.IMPL-NATIVE-ASSIGN-QAST($context, $left, $right, $spec) if $spec;
+            }
+        }
 
         my $qast := self.IMPL-INFIX-QAST($context, $left.IMPL-TO-QAST($context),
             $right.IMPL-TO-QAST($context));
@@ -1717,6 +1732,41 @@ class RakuAST::MetaInfix::Assign
         my $rhs     := $right.IMPL-TO-QAST($context);
         QAST::Op.new(:op($is-int ?? 'assign_i' !! 'assign_n'), :$returns, $var,
             QAST::Op.new(:op($op), :$returns, $var, $rhs))
+    }
+
+    # The type the store judges its target by: the type a native step
+    # judges by, and for an `is rw` native parameter, whose lexical is an
+    # alias of the caller's native, the parameter's declared type, since
+    # an assignment to the alias writes through where a raw op step would
+    # not.
+    method IMPL-NATIVE-ASSIGN-TARGET-TYPE(Mu $target) {
+        if nqp::istype($target, RakuAST::Var::Lexical) && $target.is-resolved {
+            my $resolution := $target.resolution;
+            if nqp::istype($resolution, RakuAST::ParameterTarget::Var) {
+                my $declaration := $resolution.declaration;
+                return $declaration.return-type if $declaration && $declaration.IMPL-IS-RW;
+            }
+        }
+        self.IMPL-NATIVE-STEP-TARGET-TYPE($target)
+    }
+
+    # A native target is always defined, so the metaop's identity value
+    # for an undefined left has no place, and it holds no container, so
+    # the compound assignment is a plain store of the operator's result,
+    # with the target passed to the operator as the native it is. The
+    # metaop takes the target by native reference and passes its value to
+    # the operator boxed, so the operator dispatch would see a boxed
+    # operand where the expanded form passes the native one. The store
+    # yields the value, as the raw op step does. The target is built the
+    # way an assignment builds its left, so an rw parameter's alias is
+    # written through.
+    method IMPL-NATIVE-ASSIGN-QAST(RakuAST::IMPL::QASTContext $context,
+            RakuAST::Expression $left, RakuAST::Expression $right, int $spec) {
+        my @assign := ['', 'assign_i', 'assign_n', 'assign_s', 'assign_i', 'assign_i',
+            'assign_i', 'assign_u', 'assign_u', 'assign_u', 'assign_u'];
+        my $var := $left.IMPL-ADJUST-QAST-FOR-LVALUE($left.IMPL-TO-QAST($context));
+        QAST::Op.new(:op(@assign[$spec]), :returns($var.returns), $var,
+            $!infix.IMPL-INFIX-COMPILE($context, $left, $right))
     }
 
     method IMPL-INFIX-QAST(RakuAST::IMPL::QASTContext $context, Mu $left-qast, Mu $right-qast) {

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -256,7 +256,8 @@ class RakuAST::Infixish
 
     # The given operator, or the meta-op a caller forms over it, as a
     # compile-time constant, or null when it cannot be one. A setting
-    # operator's lookup yields the same code object at run time, so the
+    # operator whose name the optimize pass found still resolving to it
+    # yields the same code object at every run time lookup, so the
     # value formed from it here serves every evaluation, which for a
     # meta-op spares the formation call and its closure on each one.
     # Anything else forms at run time, and so does everything while
@@ -267,6 +268,7 @@ class RakuAST::Infixish
         if nqp::istype($infix, RakuAST::Infix)
             && $infix.is-resolved
             && nqp::istype($infix.resolution, RakuAST::Declaration::External::Setting)
+            && $infix.IMPL-HOP-CONSTANT
             && !($*COMPILING_CORE_SETTING // 0) {
             my $meta-op := self.IMPL-HOP-INFIX;
             $context.ensure-sc($meta-op);
@@ -533,6 +535,17 @@ class RakuAST::Infix
             $qast
         }
     }
+
+    # Set by the optimize pass when the operator's name still resolves to
+    # the setting routine it resolved to, so a meta-op formed over it can
+    # be a compile-time constant.
+    has int $!hop-constant;
+
+    method IMPL-SET-HOP-CONSTANT(int $on) {
+        nqp::bindattr_i(self, RakuAST::Infix, '$!hop-constant', $on)
+    }
+
+    method IMPL-HOP-CONSTANT() { $!hop-constant }
 
     # Set by the optimize pass when the resolved operator's lexical is bound
     # once, so a chaining operator's callee lookup can be compiled as a

--- a/src/Raku/ast/term.rakumod
+++ b/src/Raku/ast/term.rakumod
@@ -599,9 +599,10 @@ class RakuAST::Term::Reduce
     }
 
     method IMPL-EXPR-QAST(RakuAST::IMPL::QASTContext $context) {
-        # A reduce of a setting operator forms its meta-op once at compile
-        # time: the operator lookup yields the same code object at run time,
-        # so the formed meta-op is a constant. This is skipped while
+        # A reduce of a setting operator whose name the optimize pass found
+        # still resolving to it forms its meta-op once at compile time: the
+        # operator lookup yields the same code object at every run time
+        # lookup, so the formed meta-op is a constant. This is skipped while
         # compiling a CORE setting itself, where compiler-formed closures
         # must not be serialized into the bootstrap. Anything else (lexical
         # operators, meta-infixes) makes a call to form the meta-op at run
@@ -610,6 +611,7 @@ class RakuAST::Term::Reduce
         if nqp::istype($!infix, RakuAST::Infix)
             && $!infix.is-resolved
             && nqp::istype($!infix.resolution, RakuAST::Declaration::External::Setting)
+            && $!infix.IMPL-HOP-CONSTANT
             && !($*COMPILING_CORE_SETTING // 0)
         {
             my $meta-op := self.IMPL-HOP-INFIX;

--- a/src/core.c/ForeignCode.rakumod
+++ b/src/core.c/ForeignCode.rakumod
@@ -164,6 +164,11 @@ $lang = 'Raku' if $lang eq 'perl6';
             |(%(:target('ast'), :compunit_ok(1)) if $rakuast-frontend),
             |(:optimize($_) with nqp::getcomp('Raku').cli-options<optimize>),
             |(%(:grammar($LANG<MAIN>), :actions($LANG<MAIN-actions>)) if $LANG);
+        # Stopping at the AST skips the optimize stage that sits between it
+        # and the QAST stage, so that stage runs here.
+        $result := $compiler.optimize($result,
+            |(:optimize($_) with nqp::getcomp('Raku').cli-options<optimize>))
+            if $rakuast-frontend;
         $compiled := $rakuast-frontend
             ?? compile-rakuast-comp-unit($result)
             !! $result;

--- a/t/08-performance/11-rakuast-constant-folding.t
+++ b/t/08-performance/11-rakuast-constant-folding.t
@@ -3,7 +3,7 @@ use Test::Helpers;
 use Test;
 use experimental :rakuast;
 
-plan 55;
+plan 56;
 
 # Constant folding rewrites a pure operator on constant operands into the
 # literal result. The helper deparses a source after optimizing it, so
@@ -171,6 +171,11 @@ ok optimized-deparse(Q[sub f() { 2 ** 3 }; multi sub infix:<**>(Int $a, Int $b) 
     is EVAL(q[use lib $dir; use FoldLateOp; &FoldLateOp::least()]), 'user',
         'a user list infix declared after a use in a sub is what the sub calls';
 }
+
+# A string EVAL runs the optimize pass too, so a folded string literal
+# is one object across calls where an unfolded concatenation is not.
+is-deeply EVAL(q[sub folded() { "ab" ~ "cd" }; folded() =:= folded()]), True,
+    'a string EVAL folds a constant like a compiled unit does';
 
 # Str.AST does not optimize, so the operator survives. The scenarios above
 # therefore test the optimize pass, not something upstream.

--- a/t/08-performance/15-rakuast-native-metaop.t
+++ b/t/08-performance/15-rakuast-native-metaop.t
@@ -2,7 +2,7 @@ use lib <t/packages/Test-Helpers>;
 use Test::Helpers::QAST;
 use Test;
 use nqp;
-plan 17;
+plan 37;
 
 # A native int or num `+=`/`-=`/`*=` with a native operand lowers to a raw op
 # instead of calling the metaop.
@@ -45,16 +45,99 @@ plan 17;
 qast-is 'my $a = 0; my $b = 1; $a += $b', -> \v { not qast-contains-op v, 'add_i' },
     'a non-native operand keeps the metaop call';
 
-# The remaining cases are RakuAST-frontend specific. The frontend leaves an
-# integer literal to the metaop, so `$i += 1` overflows to a bignum and throws
-# rather than wrapping, and it emits the native raw ops directly. The legacy
-# optimizer instead lowers an int literal to a wrapping op and reaches the
+# A native target takes the operator's result by assignment, with the
+# target passed to the operator as the native it is, so the compound
+# form agrees with its expansion on which candidate the operator
+# dispatch lands on.
+{
+    multi sub infix:<+>(int $a, int $b) is default { 42 }
+    my int $i = 1; $i += 1;
+    is $i, 42, 'a native int compound assignment dispatches on the native target';
+    my int $j = 1; $j = $j + 1;
+    is $j, 42, 'the expanded form of a native int compound assignment agrees';
+}
+{
+    multi sub infix:<~>(str $a, str $b) is default { 'nativeuser' }
+    my str $s = 'a'; $s ~= 'b';
+    is $s, 'nativeuser', 'a native str compound assignment dispatches on the native target';
+}
+{
+    multi sub infix:<+>(num $a, num $b) is default { 42e0 }
+    my num $n = 1e0; $n += 1e0;
+    is $n, 42e0, 'a native num compound assignment dispatches on the native target';
+}
+{
+    my class Counted { has int $!i = 1; method bump() { $!i += 1 } }
+    multi sub infix:<+>(int $a, int $b) is default { 42 }
+    is Counted.new.bump, 42, 'a native attribute compound assignment dispatches on the native target';
+}
+{
+    multi sub infix:<+>(int $a, int $b) is default { 42 }
+    sub bump(int $x is copy) { $x += 1; $x }
+    is bump(1), 42, 'a native copy parameter compound assignment dispatches on the native target';
+}
+{
+    sub bump(int $x is rw) { $x += 1 }
+    my int $v = 1; bump($v);
+    is $v, 2, 'a native rw parameter compound assignment writes through the reference';
+}
+{
+    multi sub infix:<+>(int $a, int $b) is default { 42 }
+    sub bump(int $x is rw) { $x += 1 }
+    my int $v = 1; bump($v);
+    is $v, 42, 'a native rw parameter compound assignment dispatches on the native it refers to';
+}
+dies-ok { sub bump(int $x) { $x += 1 }; bump(1) },
+    'a read-only native parameter compound assignment reports the mutability';
+{
+    use soft;
+    my $handle = &infix:<+>.wrap(-> |c { 100 });
+    my int $i = 1; my $x = 1; $i += $x;
+    $handle.restore;
+    is $i, 100, 'a native compound assignment under the soft pragma runs the wrapped operator';
+}
+{
+    my int $c = 1;
+    my @l = ($c += 1), ($c += 1);
+    is-deeply @l, [2, 3], 'a native compound assignment yields its value rather than the variable';
+}
+{
+    my int $i = 1; my $x = 1; ($i) += $x;
+    is $i, 2, 'a parenthesized native target compound-assigns through the metaop';
+}
+{
+    my int $j += 5;
+    is $j, 5, 'a native declaration as the target compound-assigns through the metaop';
+}
+throws-like { my int $i = 1; $i ^^= 1 }, Exception, message => /Nil/,
+    'a native exclusive-or compound assignment reports the Nil it cannot store';
+
+# An integer literal operand takes the operator call, which pairs the
+# literal with the native target, so `$i += 1` wraps as `$i + 1` does.
+{
+    my int $i = 9223372036854775807;
+    $i += 1;
+    is $i, -9223372036854775808, 'native int += an integer literal wraps like its expanded form';
+}
+
+# The remaining cases are RakuAST-frontend specific: the frontend emits
+# the native raw ops directly, where the legacy optimizer reaches the
 # native ops a different way, so these are pinned to RakuAST.
 if nqp::gethllsym('Raku', 'COMPILER-FRONTEND') eq 'rakuast' {
-    my int $i = 9223372036854775807;
-    dies-ok { $i += 1 }, 'native int += an integer literal throws on overflow';
-    qast-is 'my int $i; $i += 5', -> \v { not qast-contains-op v, 'add_i' },
-        'an integer literal keeps the metaop call';
+    qast-is 'my int $i; $i += 5', -> \v { not qast-contains-op(v, 'add_i') and qast-contains-call(v, '&infix:<+>') },
+        'an integer literal keeps the operator call';
+    qast-is 'my int $i; $i += 5', -> \v { qast-contains-op(v, 'assign_i') and not qast-contains-call(v, '&METAOP_ASSIGN') },
+        'an integer literal operand assigns the operator result to the native target';
+    qast-is 'my int $i; my $x; $i += $x', -> \v { qast-contains-op(v, 'assign_i') and not qast-contains-call(v, '&METAOP_ASSIGN') },
+        'a boxed operand assigns the operator result to the native target';
+    qast-is 'my uint $u; $u += 5', -> \v { qast-contains-op(v, 'assign_u') and not qast-contains-call(v, '&METAOP_ASSIGN') },
+        'an unsigned native target assigns the operator result';
+    qast-is 'my int $g; $g min= 3', -> \v { qast-contains-op(v, 'assign_i') and not qast-contains-call(v, '&METAOP_ASSIGN') },
+        'a list associative operator assigns its result to the native target';
+    qast-is 'sub f(int $x is rw) { my $y; $x += $y }', :full, -> \v { qast-contains-op(v, 'assign_i') and not qast-contains-call(v, '&METAOP_ASSIGN') },
+        'an rw native parameter target assigns the operator result through its alias';
+    qast-is 'my int $i; $i //= 5', -> \v { not qast-contains-op v, 'assign_i' },
+        'a test operator on a native target keeps the metaop';
     qast-is 'my int $i; my int $n; $i += $n', -> \v { qast-contains-op v, 'add_i' },
         'native int operands lower to a raw op';
     qast-is 'my num $a; $a += 1.5e0', -> \v { qast-contains-op v, 'add_n' },
@@ -71,7 +154,7 @@ if nqp::gethllsym('Raku', 'COMPILER-FRONTEND') eq 'rakuast' {
         'a native attribute read on the right lowers to a raw op';
 }
 else {
-    skip 'integer-literal and native lowering shape is RakuAST-specific', 9;
+    skip 'integer-literal and native lowering shape is RakuAST-specific', 14;
 }
 
 # vim: expandtab shiftwidth=4

--- a/t/08-performance/16-rakuast-scalar-metaop.t
+++ b/t/08-performance/16-rakuast-scalar-metaop.t
@@ -1,7 +1,8 @@
 use lib <t/packages/Test-Helpers>;
 use Test::Helpers::QAST;
 use Test;
-plan 16;
+use nqp;
+plan 21;
 
 # A compound assignment on a boxed scalar inlines to a direct assignment of the
 # operator's result, dropping the metaop dispatch.
@@ -85,8 +86,29 @@ plan 16;
     is $a, 999, 'a user-redefined operator is not inlined';
 }
 
+# A target that holds no container reports the immutability the way an
+# assignment does, whether the target is a scalar declared by binding or
+# a nested compound assignment that yields the bound value.
+throws-like 'my $a := 42; ($a //= 42) += 10', X::Assignment::RO,
+    'a compound assignment to a nested compound assignment on a bound scalar reports the immutability';
+
 # The inlining drops the metaop dispatch. This observes the emitted QAST.
 qast-is 'my $a; $a += 1', -> \v { not qast-contains-call v, /METAOP/ },
     'a compound assignment inlines the metaop away';
+qast-is 'my $a; $a += 1', -> \v { qast-contains-op(v, 'p6assign') and not qast-contains-op(v, 'p6store') },
+    'a plain scalar target stores through the scalar assign op';
+qast-is 'my $a; ($a //= 42) += 10', -> \v { qast-contains-op(v, 'p6store') },
+    'a nested compound assignment target stores through the fallback store';
+# The legacy frontend's answer for a scalar declared by binding depends on
+# the block the assignment sits in, so the case is pinned for this frontend.
+if nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' {
+    throws-like 'my $a := 42; $a += 10', X::Assignment::RO,
+        'a compound assignment to a scalar declared by binding reports the immutability';
+    qast-is 'my $a := 42; $a += 1', -> \v { qast-contains-call v, /METAOP/ },
+        'a scalar declared by binding keeps the metaop';
+}
+else {
+    skip 'the declined inline for a bound scalar is specific to the RakuAST frontend', 2;
+}
 
 # vim: expandtab shiftwidth=4

--- a/t/08-performance/22-rakuast-ct-dispatch.t
+++ b/t/08-performance/22-rakuast-ct-dispatch.t
@@ -4,7 +4,7 @@ use Test::Helpers::QAST;
 use Test;
 use QAST:from<NQP>;
 use nqp;
-plan 23;
+plan 27;
 
 # A call whose argument types decide the dispatch at compile time is
 # replaced by the chosen routine's recorded body, with the argument
@@ -65,6 +65,34 @@ qast-is 'my int $i = 3; my $b = $i < 5; sub infix:«<»($a, $b) { "user" }; say 
 qast-is 'my int $i = 3; my int $j = $i + 1; { sub infix:<+>(int $a, int $b) { 42 } }; say $j', :full, -> \v {
     qast-contains-op(v, 'add_i')
 }, 'a user infix in an inner block leaves a use outside it lowered';
+
+# The dispatch is decided against the candidates the scope holds, so a
+# user candidate that cannot take the operands leaves the splice in
+# place wherever it is declared.
+qast-is 'my class Later { }; my int $i = 3; my int $j = $i + 1; say $j; multi sub infix:<+>(Later $a, Later $b) { 1 }', :full, -> \v {
+    qast-contains-op(v, 'add_i')
+}, 'a user multi candidate declared after the use that cannot take native ints leaves the splice';
+qast-is 'my class Earlier { }; multi sub infix:<+>(Earlier $a, Earlier $b) { 1 }; my int $i = 3; my int $j = $i + 1; say $j', :full, -> \v {
+    qast-contains-op(v, 'add_i')
+}, 'a user multi candidate declared before the use that cannot take native ints leaves the splice';
+
+# A user multi candidate derives its proto from the setting's. The
+# lowerings that need the setting's own routine stand down for it, and
+# the dispatch lands on the candidate it adds.
+{
+    my $dir = make-temp-dir;
+    $dir.add('DispatchMultiOp.rakumod').spurt: q:to/END/;
+        unit module DispatchMultiOp;
+        multi sub infix:<..>(Int $a, Int $b) is default { (100,) }
+        our sub total() { my $s = 0; for 1..3 { $s = $s + $_ }; $s }
+        our sub add(int $a, int $b) { $a + $b }
+        multi sub infix:<+>(int $a, int $b) is default { 42 }
+        END
+    is EVAL(q[use lib $dir; use DispatchMultiOp; &DispatchMultiOp::total()]), 100,
+        'a user multi candidate for the range operator keeps a range loop a dispatch';
+    is EVAL(q[use lib $dir; use DispatchMultiOp; &DispatchMultiOp::add(1, 2)]), 42,
+        'a user multi candidate declared after the use is what a native dispatch lands on';
+}
 {
     my $dir = make-temp-dir;
     $dir.add('DispatchLateOp.rakumod').spurt: q:to/END/;

--- a/t/08-performance/28-rakuast-metaop-hoist.t
+++ b/t/08-performance/28-rakuast-metaop-hoist.t
@@ -1,16 +1,18 @@
 use lib <t/packages/Test-Helpers>;
+use Test::Helpers;
 use Test::Helpers::QAST;
 use Test;
 use QAST:from<NQP>;
 use nqp;
-plan 55;
+plan 72;
 
-# A meta-op over a setting operator is formed once at compile time and
-# emitted as a constant, since the operator lookup yields the same code
-# object at run time. A meta-op formed at run time makes the formation
-# call and allocates a closure per evaluation, which stays the path for
-# a lexical operator and for a meta-op operand. The shapes the
-# assertions pin down are this frontend's.
+# A meta-op over a setting operator whose name no later declaration
+# shadows is formed once at compile time and emitted as a constant,
+# since the operator lookup yields the same code object at run time. A
+# meta-op formed at run time makes the formation call and allocates a
+# closure per evaluation, which stays the path for a lexical operator,
+# for a meta-op operand, and for a setting operator a later declaration
+# shadows. The shapes the assertions pin down are this frontend's.
 
 sub qast-wval-callee (Mu $qast --> Bool:D) {
     if nqp::istype($qast, QAST::Op)
@@ -29,7 +31,7 @@ sub qast-wval-callee (Mu $qast --> Bool:D) {
 }
 
 sub qast-var-named (Mu $qast, Str:D $name --> Bool:D) {
-    if nqp::istype($qast, QAST::Var) && $qast.name eq $name {
+    if nqp::istype($qast, QAST::Var) && $qast.name eq $name && !$qast.decl {
         return True;
     }
     if qast-descendable $qast {
@@ -99,9 +101,79 @@ if nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' {
     qast-is 'use soft; my $x = 1; my $y = 2; say $x !== $y', :full, -> \v {
         qast-contains-op(v, 'chain')
     }, 'a negated comparison under the soft pragma keeps its meta-op';
+
+    # A user operator declared after the use shadows the setting's, so
+    # the meta-op forms at run time and finds the user's routine.
+    qast-is 'my @r = (1,2) Z+ (3,4); sub infix:<+>($a, $b) { "user" }', :full, -> \v {
+        qast-contains-call(v, '&METAOP_ZIP') and not qast-wval-callee(v)
+    }, 'a zip of an operator a later declaration shadows forms its meta-op at run time';
+    qast-is 'my $s = [+] 1, 2, 3; sub infix:<+>($a, $b) { "user" }', :full, -> \v {
+        qast-contains-call(v, '&METAOP_REDUCE_LEFT')
+    }, 'a reduce of an operator a later declaration shadows forms its meta-op at run time';
+    qast-is 'my $x = 1; $x += 2; sub infix:<+>($a, $b) { "user" }', :full, -> \v {
+        qast-var-named(v, '&infix:<+>')
+    }, 'a compound assignment with an operator a later declaration shadows looks the operator up at run time';
+    qast-is 'my @r = (1,2) Z+ (3,4) Z+ (5,6); sub infix:<+>($a, $b) { "user" }', :full, -> \v {
+        qast-contains-call(v, '&METAOP_ZIP') and not qast-wval-callee(v)
+    }, 'a zip chain of an operator a later declaration shadows forms its meta-op at run time';
+
+    # The soft pragma keeps the formation at run time, so the routine
+    # the meta-op runs stays wrappable.
+    qast-is 'use soft; my @r = (1,2) Z+ (3,4)', :full, -> \v {
+        qast-contains-call(v, '&METAOP_ZIP') and not qast-wval-callee(v)
+    }, 'a zip under the soft pragma forms its meta-op at run time';
+    qast-is 'use soft; my $s = [+] 1, 2, 3', :full, -> \v {
+        qast-contains-call(v, '&METAOP_REDUCE_LEFT')
+    }, 'a reduce under the soft pragma forms its meta-op at run time';
 }
 else {
-    skip 'the formation shapes are specific to the RakuAST frontend', 11;
+    skip 'the formation shapes are specific to the RakuAST frontend', 17;
+}
+
+# A user operator declared after the use is the one every meta-op runs.
+{
+    my $dir = make-temp-dir;
+    $dir.add('MetaLateOp.rakumod').spurt: q:to/END/;
+        unit module MetaLateOp;
+        our sub assign() { my $x = 1; $x += 2; $x }
+        our sub reduce() { [+] 1, 2, 3 }
+        our sub triangle() { [\+] 1, 2 }
+        our sub zip() { (1, 2) Z+ (3, 4) }
+        our sub cross() { (1, 2) X~ (3, 4) }
+        our sub negate() { 1 !eq 2 }
+        our sub hyper() { (1, 2, 3) >>+>> (10, 20) }
+        our sub zip-assign() { my @a = 1, 2; @a Z+= (3, 4); @a }
+        our sub chain() { (1, 2) Z+ (3, 4) Z+ (5, 6) }
+        our sub most() { [max] 1, 2, 3 }
+        my role RM { method z() { (1, 2) Z+ (3, 4) } }
+        class CM does RM is export { }
+        sub infix:<+>($a, $b) { 'user' }
+        sub infix:<~>($a, $b) { 'user' }
+        sub infix:<eq>($a, $b) { True }
+        sub infix:<max>(*@a) { 'user' }
+        END
+    is EVAL(q[use lib $dir; use MetaLateOp; &MetaLateOp::assign()]), 'user',
+        'a compound assignment runs a user infix declared after the use';
+    is EVAL(q[use lib $dir; use MetaLateOp; &MetaLateOp::reduce()]), 'user',
+        'a reduce runs a user infix declared after the use';
+    is EVAL(q[use lib $dir; use MetaLateOp; &MetaLateOp::triangle()]).join(' '), '1 user',
+        'a triangle reduce runs a user infix declared after the use';
+    is EVAL(q[use lib $dir; use MetaLateOp; &MetaLateOp::zip()]).join(' '), 'user user',
+        'a zip runs a user infix declared after the use';
+    is EVAL(q[use lib $dir; use MetaLateOp; &MetaLateOp::cross()]).join(' '), 'user user user user',
+        'a cross runs a user infix declared after the use';
+    is-deeply EVAL(q[use lib $dir; use MetaLateOp; &MetaLateOp::negate()]), False,
+        'a negated comparison runs a user infix declared after the use';
+    is EVAL(q[use lib $dir; use MetaLateOp; &MetaLateOp::hyper()]).join(' '), 'user user user',
+        'a hyper runs a user infix declared after the use';
+    is EVAL(q[use lib $dir; use MetaLateOp; &MetaLateOp::zip-assign()]).join(' '), 'user user',
+        'a zip assignment runs a user infix declared after the use';
+    is EVAL(q[use lib $dir; use MetaLateOp; &MetaLateOp::chain()]).join(' '), 'user user',
+        'a zip chain runs a user infix declared after the use';
+    is EVAL(q[use lib $dir; use MetaLateOp; &MetaLateOp::most()]), 'user',
+        'a list reduce runs a user infix declared after the use';
+    is EVAL(q[use lib $dir; use MetaLateOp; CM.new.z]).join(' '), 'user user',
+        'a zip in a precompiled role method runs a user infix declared after the role';
 }
 
 # Behavior stays identical.

--- a/t/08-performance/30-rakuast-native-attr-lvalues.t
+++ b/t/08-performance/30-rakuast-native-attr-lvalues.t
@@ -63,8 +63,10 @@ if nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' {
     }, 'an int attribute serves as the step value for a native lexical';
 
     qast-is 'my class C { has int $!s; method b() { $!s += 1 } }', :full, -> \v {
-        qast-contains-call(v, '&METAOP_ASSIGN')
-    }, 'a compound add of an Int literal keeps the metaop';
+        not qast-contains-op(v, 'add_i')
+        and qast-contains-op(v, 'assign_i')
+        and not qast-contains-call(v, '&METAOP_ASSIGN')
+    }, 'a compound add of an Int literal assigns the operator result to the attribute';
 
     qast-is 'my class C { has int8 $!t; method b() { my $v = $!t++; $v } }', :full, -> \v {
         qast-contains-call(v, '&postfix:<++>')
@@ -155,7 +157,7 @@ else {
     is $c.t-postfix, 101, 'a sized int postfix increment computes through the routine';
     is $c.t-prefix, 102, 'a sized int prefix increment yields the stepped value';
     is $c.boxed, 6, 'a boxed attribute increment computes through the routine';
-    is $c.int-literal, 51, 'a compound add of an Int literal computes through the metaop';
+    is $c.int-literal, 51, 'a compound add of an Int literal stores the operator result';
 }
 
 {


### PR DESCRIPTION
Previously a compound assignment on a native target that the native step lowering left alone, `$i += $x` with a boxed operand or with an operator that is not the setting's, called the metaop, which takes the target by native reference and passes its value to the operator boxed. The operator's dispatch then saw a boxed operand where the expanded form `$i = $i + $x` passes the native one, so the two forms disagreed on which candidate they landed on, at every optimize level:

```
$ RAKUDO_RAKUAST=1 raku -e 'multi sub infix:<+>(int $a, int $b) is default { 42 }; my int $i = 1; $i += 1; say $i'
2
$ RAKUDO_RAKUAST=1 raku -e 'multi sub infix:<+>(int $a, int $b) is default { 42 }; my int $i = 1; $i = $i + 1; say $i'
42
```

This stores the operator's result in the native target directly, passing the target to the operator as the native it is, so the compound form agrees with its expansion. An integer literal operand pairs with the native target the same way, so `$i += 1` at the top of the `int` range wraps as `$i + 1` does rather than throwing out of the metaop, and the store yields the value rather than the native reference, as the raw op step and the legacy frontend do. The metaop call and its closure leave that path with it: a compound assignment with a boxed operand in a loop runs about four times faster.