### PR TITLE
RakuAST: make native arguments behave like container arguments

### DIFF
--- a/lib/NativeCall/Dispatcher.rakumod
+++ b/lib/NativeCall/Dispatcher.rakumod
@@ -180,20 +180,24 @@ my sub marshal-and-delegate-native-call(Mu $capture is raw) {
 
     while $i < $pos-args {
 
+        # With variadic C functions / a **@vararg slurpy parameter, the
+        # $params list ends early. The slurpy is detected ahead of the
+        # argument's kind: a native argument skips the boxed handling
+        # below, and a slurpy found only there would go undetected when a
+        # native arrives at its position, so the next boxed argument would
+        # read $params past its end.
+        my $param;
+        unless $variadic {
+            $param := nqp::atpos($params, $i);
+            # Detect the **@vararg param. If found the var args start and
+            # we have to work without params from now on.
+            if $param.slurpy && nqp::istype($param.type, Positional) {
+                $variadic = True;
+            }
+        }
+
         # If it should be passed read only, and it's an object...
         unless nqp::captureposprimspec($args, $i) {
-
-            # With variadic C functions / a **@vararg slurpy parameter, the
-            # $params list ends early.
-            my $param;
-            unless $variadic {
-                $param := nqp::atpos($params, $i);
-                # Detect the **@vararg param. If found the var args start and
-                # we have to work without params from now on.
-                if $param.slurpy && nqp::istype($param.type, Positional) {
-                    $variadic = True;
-                }
-            }
 
             # If it's in a Scalar container...
             my $Tvalue := nqp::track('arg', $args, nqp::unbox_i($i));

--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -770,10 +770,11 @@ class RakuAST::Node {
         }
 
         if $apply-infix {
-            # The negate withdrawal runs before the gated marks: it is a
-            # retraction of an operand's mark, so neither a rewrite having
-            # replaced this node nor the soft pragma may skip it.
+            # The withdrawals run before the gated marks: each retracts an
+            # operand's mark, so neither a rewrite having replaced this node
+            # nor the soft pragma may skip them.
             self.IMPL-WITHDRAW-NEGATE-NOT($expr);
+            self.IMPL-WITHDRAW-LONE-LINK($expr);
 
             # A bind statement replaces its target's container, so it
             # withdraws native subscript eligibility from the target's
@@ -848,8 +849,6 @@ class RakuAST::Node {
                 self.IMPL-MARK-JUNCTION-FOLD($resolver, $expr)
                     if ($loop-stmt || $conditional-stmt || $stmt-expression
                         || $apply-prefix) && !$ahead-of-unit;
-                self.IMPL-MARK-CHAIN-LINKS($resolver, $expr)
-                    if $apply-infix;
                 self.IMPL-DROP-UNREACHABLE($resolver, $expr)
                     if $stmt-expression && !$ahead-of-unit;
                 self.IMPL-MARK-PARAM-WHERE-JUNCTION($resolver, $expr)
@@ -862,6 +861,8 @@ class RakuAST::Node {
             && ($apply-infix
                 || nqp::istype($expr, RakuAST::ApplyListInfix)
                 || nqp::istype($expr, RakuAST::Term::Reduce));
+        self.IMPL-MARK-CHAIN-LINKS($resolver, $expr)
+            if $result =:= $expr && $apply-infix;
 
         # A replacement stands where the original stood, so it must carry the
         # original's sunk state for any sink-sensitive code generation.
@@ -1324,7 +1325,8 @@ class RakuAST::Node {
 
     # Mark an infix operator whose lexical is bound once for a static
     # callee lookup at code generation. A chaining one is the chain mark's
-    # business, since it compiles to a chain op instead.
+    # business, which decides its static lookup whether it compiles to a
+    # chain op or to a call.
     method IMPL-MARK-STATIC-INFIX(RakuAST::Resolver $resolver, Mu $expr) {
         return Nil unless nqp::istype($expr, RakuAST::ApplyInfix);
         my $infix := $expr.infix;
@@ -1398,6 +1400,23 @@ class RakuAST::Node {
             $_.infix.IMPL-CLEAR-NEGATE-NOT()
                 if nqp::istype($_, RakuAST::ApplyInfix)
                 && nqp::istype($_.infix, RakuAST::MetaInfix::Negate)
+                && $_.infix.properties.chain;
+        }
+        Nil
+    }
+
+    # Withdraw the lone link mark from an operand that turns out to be a
+    # link of a longer chain, since a link must never emit as a plain
+    # call. Unconditional for the reason the negate withdrawal is.
+    method IMPL-WITHDRAW-LONE-LINK(Mu $expr) {
+        return Nil unless nqp::istype($expr, RakuAST::ApplyInfix);
+        my $infix := $expr.infix;
+        return Nil unless nqp::istype($infix, RakuAST::Infixish)
+            && $infix.properties.chain;
+        for [$expr.left, $expr.right] {
+            $_.infix.IMPL-SET-LONE-LINK(0)
+                if nqp::istype($_, RakuAST::ApplyInfix)
+                && nqp::istype($_.infix, RakuAST::Infix)
                 && $_.infix.properties.chain;
         }
         Nil
@@ -2921,25 +2940,31 @@ class RakuAST::Node {
     }
 
     # The links of a longer chain take part in the chain op protocol, so
-    # none of them may compile to anything but a chain op. The reduced
-    # smartmatch marks decide per node and cannot see the enclosing
-    # chain, whose own offering comes only after its operands were
-    # visited, so the enclosing chain withdraws any decision its operand
-    # links took.
+    # none of them may compile to anything but a chain op, while a chain
+    # of one link compiles as a call. The reduced smartmatch marks decide
+    # per node and cannot see the enclosing chain, whose own visit comes
+    # only after its operands were visited, so the enclosing chain
+    # withdraws the smartmatch decision its operand links took. A chain
+    # with no operand link is a chain of one link and takes the lone
+    # link mark. The marks sit outside the soft gate, since a lone
+    # link's call dispatches the operator as the chain op does, and
+    # pins nothing.
     method IMPL-MARK-CHAIN-LINKS(RakuAST::Resolver $resolver, Mu $expr) {
         return Nil unless nqp::istype($expr, RakuAST::ApplyInfix)
             && nqp::istype($expr.infix, RakuAST::Infixish)
             && $expr.infix.properties.chain;
-        my $left := $expr.left;
-        $left.infix.IMPL-CLEAR-SMARTMATCH-MARKS()
-            if nqp::istype($left, RakuAST::ApplyInfix)
-            && nqp::istype($left.infix, RakuAST::Infix)
-            && $left.infix.properties.chain;
-        my $right := $expr.right;
-        $right.infix.IMPL-CLEAR-SMARTMATCH-MARKS()
-            if nqp::istype($right, RakuAST::ApplyInfix)
-            && nqp::istype($right.infix, RakuAST::Infix)
-            && $right.infix.properties.chain;
+        my int $linked := 0;
+        for [$expr.left, $expr.right] -> $operand {
+            if nqp::istype($operand, RakuAST::ApplyInfix)
+                && nqp::istype($operand.infix, RakuAST::Infixish)
+                && $operand.infix.properties.chain {
+                $linked := 1;
+                $operand.infix.IMPL-CLEAR-SMARTMATCH-MARKS()
+                    if nqp::istype($operand.infix, RakuAST::Infix);
+            }
+        }
+        $expr.infix.IMPL-SET-LONE-LINK($linked ?? 0 !! 1)
+            if nqp::istype($expr.infix, RakuAST::Infix);
         Nil
     }
 

--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -861,6 +861,9 @@ class RakuAST::Node {
             && ($apply-infix
                 || nqp::istype($expr, RakuAST::ApplyListInfix)
                 || nqp::istype($expr, RakuAST::Term::Reduce));
+        self.IMPL-MARK-VALUE-ARGS($resolver, $expr)
+            if $result =:= $expr
+            && ($apply-infix || $apply-prefix || $apply-postfix || $call-name);
         self.IMPL-MARK-CHAIN-LINKS($resolver, $expr)
             if $result =:= $expr && $apply-infix;
 
@@ -890,6 +893,41 @@ class RakuAST::Node {
             nqp::istype($base.resolution, RakuAST::Declaration::External::Setting)
             && !self.IMPL-IN-SOFT-SCOPE($resolver)
             && self.IMPL-OPERATOR-RESOLUTION-CURRENT($resolver, $base) ?? 1 !! 0);
+        Nil
+    }
+
+    # Mark a lookup whose name still reaches the declaration it resolved
+    # to, so a native argument may pass by value on that declaration's
+    # word. The mark is written on every visit, so the unit's walk
+    # settles what a walk ahead of it decided. It sits outside the soft
+    # gate, since it pins no routine identity.
+    method IMPL-MARK-VALUE-ARGS(RakuAST::Resolver $resolver, Mu $expr) {
+        my $lookup;
+        my int $current := 0;
+        if nqp::istype($expr, RakuAST::ApplyInfix) {
+            $lookup := $expr.infix;
+            $lookup := $lookup.infix while nqp::istype($lookup, RakuAST::MetaInfix);
+            $current := self.IMPL-OPERATOR-RESOLUTION-CURRENT($resolver, $lookup)
+                if nqp::istype($lookup, RakuAST::Infix);
+        }
+        elsif nqp::istype($expr, RakuAST::ApplyPrefix) {
+            $lookup := $expr.prefix;
+            $current := self.IMPL-OPERATOR-RESOLUTION-CURRENT($resolver, $lookup)
+                if nqp::istype($lookup, RakuAST::Prefix);
+        }
+        elsif nqp::istype($expr, RakuAST::ApplyPostfix) {
+            $lookup := $expr.postfix;
+            $current := self.IMPL-OPERATOR-RESOLUTION-CURRENT($resolver, $lookup)
+                if nqp::istype($lookup, RakuAST::Postfix);
+        }
+        elsif nqp::istype($expr, RakuAST::Call::Name) {
+            $lookup := $expr;
+            $current := self.IMPL-DECLARATION-CURRENT($resolver,
+                '&' ~ $expr.name.canonicalize, $expr.resolution)
+                if $expr.is-resolved && $expr.name.is-identifier;
+        }
+        $lookup.IMPL-SET-VALUE-ARGS($current)
+            if nqp::istype($lookup, RakuAST::Lookup);
         Nil
     }
 

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -547,9 +547,20 @@ class RakuAST::Infix
 
     method IMPL-HOP-CONSTANT() { $!hop-constant }
 
+    # Set by the optimize pass on a chaining operator whose application is
+    # a chain of one link, so it compiles as a plain call. The chain op
+    # serves the protocol between links, and boxes its operands for it,
+    # where a call passes a native operand as it is.
+    has int $!lone-link;
+
+    method IMPL-SET-LONE-LINK(int $on) {
+        nqp::bindattr_i(self, RakuAST::Infix, '$!lone-link', $on)
+    }
+
     # Set by the optimize pass when the resolved operator's lexical is bound
     # once, so a chaining operator's callee lookup can be compiled as a
-    # static one the VM resolves a single time.
+    # static one the VM resolves a single time. A lone link compiles as a
+    # call and takes its static lookup from this mark as well.
     has int $!chainstatic;
 
     method IMPL-SET-CHAINSTATIC(int $on) {
@@ -743,13 +754,14 @@ class RakuAST::Infix
             return $inlined unless nqp::isnull($inlined);
         }
 
+        my str $call-op := self.properties.chain && !$!lone-link
+            ?? ($!chainstatic ?? 'chainstatic' !! 'chain')
+            !! (($!callstatic || $!chainstatic) ?? 'callstatic' !! 'call');
+
         # A comparison in boolean position with a junction operand
         # unfolds to short-circuit comparisons per eigenstate.
         if $!junction-fold {
-            my $folded := self.IMPL-JUNCTION-FOLD-QAST($context,
-                self.properties.chain
-                    ?? ($!chainstatic ?? 'chainstatic' !! 'chain')
-                    !! ($!callstatic ?? 'callstatic' !! 'call'),
+            my $folded := self.IMPL-JUNCTION-FOLD-QAST($context, $call-op,
                 $name, $left-qast, $right-qast,
                 $!junction-fold, $!junction-fold-junction);
             return $folded unless nqp::isnull($folded);
@@ -758,9 +770,7 @@ class RakuAST::Infix
         # Otherwise, it's called by finding the lexical sub to call, and
         # compiling it as chaining if required.
         self.IMPL-SIMPLIFY-REF-ARGS(QAST::Op.new(
-            :op(self.properties.chain
-                  ?? ($!chainstatic ?? 'chainstatic' !! 'chain')
-                  !! ($!callstatic ?? 'callstatic' !! 'call')),
+            :op($call-op),
             :$name,
             $left-qast,
             $right-qast

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -531,6 +531,14 @@ class RakuAST::Infix
                 my $val-ast := $adverb.named-arg-value.IMPL-TO-QAST($context);
                 $val-ast.named($adverb.named-arg-name);
                 $qast.push($val-ast);
+                # The adverb is an argument of the call, evaluated after
+                # the positional ones, so the reference analysis runs
+                # again with it in place.
+                if nqp::istype($qast, QAST::Op) {
+                    my str $qop := $qast.op;
+                    $qast := self.IMPL-SIMPLIFY-REF-ARGS($qast)
+                        if $qop eq 'call' || $qop eq 'callstatic';
+                }
             }
             $qast
         }

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -1929,23 +1929,29 @@ class RakuAST::MetaInfix::Negate
     }
 
     method IMPL-INFIX-QAST(RakuAST::IMPL::QASTContext $context, Mu $left-qast, Mu $right-qast) {
+        # The negated operator's own lookup decides its reference
+        # arguments. A meta-op standing in for it has no lookup.
+        my int $own-lookup := nqp::istype($!infix, RakuAST::Infix);
         if $!negate-not {
             $context.ensure-sc($!negate-not-op);
+            my $call := QAST::Op.new(
+                :op('call'),
+                $!infix.IMPL-HOP-INFIX-QAST($context),
+                $left-qast,
+                $right-qast
+            );
+            $call := $!infix.IMPL-SIMPLIFY-REF-ARGS($call) if $own-lookup;
             return QAST::Op.new:
                 :op('call'),
                 QAST::WVal.new( :value($!negate-not-op) ),
-                QAST::Op.new(
-                    :op('call'),
-                    $!infix.IMPL-HOP-INFIX-QAST($context),
-                    $left-qast,
-                    $right-qast
-                );
+                $call;
         }
-        QAST::Op.new:
+        my $op := QAST::Op.new:
             :op($!infix.properties.chain ?? 'chain' !! 'call'),
             self.IMPL-HOP-INFIX-QAST($context),
             $left-qast,
-            $right-qast
+            $right-qast;
+        $own-lookup ?? $!infix.IMPL-SIMPLIFY-REF-ARGS($op) !! $op
     }
 
     method IMPL-HOP-INFIX-QAST(RakuAST::IMPL::QASTContext $context) {

--- a/src/Raku/ast/scoping.rakumod
+++ b/src/Raku/ast/scoping.rakumod
@@ -1026,6 +1026,16 @@ class RakuAST::Lookup
 {
     has RakuAST::Declaration $!resolution;
 
+    # Set by the optimize pass when the name still reaches the declaration
+    # the lookup resolved to, so a native argument may pass by value on
+    # that declaration's word. A declaration parsed after the use takes
+    # the call at run time, and the reference stays without the mark.
+    has int $!value-args;
+
+    method IMPL-SET-VALUE-ARGS(int $on) {
+        nqp::bindattr_i(self, RakuAST::Lookup, '$!value-args', $on)
+    }
+
     method needs-resolution() { True }
 
     method is-resolved() {
@@ -1104,15 +1114,16 @@ class RakuAST::Lookup
 
     # Native variable arguments compile to lexicalref/attributeref scope so
     # a callee with an "is rw" parameter can write back through them. When
-    # this lookup resolves to a routine and no candidate the call can reach
-    # declares the matching parameter rw, the argument is compiled as a
-    # value read instead. Otherwise a reference bound to a raw parameter, such as the
-    # value of infix:«=>», would be stored as a live view of the variable
-    # rather than a snapshot of it, and a reference read by the callee
-    # would see a write a later argument made to the variable, where the
-    # value read happens in argument order.
+    # this lookup resolves to a routine the name still reaches and no
+    # candidate the call can reach declares the matching parameter rw,
+    # the argument is compiled as a value read instead. Otherwise a
+    # reference bound to a raw parameter, such as the value of
+    # infix:«=>», would be stored as a live view of the variable rather
+    # than a snapshot of it, and a reference read by the callee would see
+    # a write a later argument made to the variable, where the value read
+    # happens in argument order.
     method IMPL-SIMPLIFY-REF-ARGS(Mu $call) {
-        unless $*COMPILING_CORE_SETTING {
+        if $!value-args && !$*COMPILING_CORE_SETTING {
             if self.is-resolved
                 && nqp::istype(self.resolution, RakuAST::CompileTimeValue) {
                 my $routine := self.resolution.compile-time-value;

--- a/src/Raku/ast/scoping.rakumod
+++ b/src/Raku/ast/scoping.rakumod
@@ -524,11 +524,11 @@ class RakuAST::LexicalScope
             elsif nqp::existskey(BOOLIFY_FIRST_CHILD_OPS, $op) ||
                     ($op eq 'call' || $op eq 'callstatic')
                     && nqp::existskey(BOOLIFY_FIRST_CHILD_CALLS, $qast.name) {
-                my int $first := 1;
+                my int $first-read := 1;
                 for @($qast) {
-                    if $first {
+                    if $first-read {
                         self.IMPL-FATALIZE-QAST($_, 1);
-                        $first := 0;
+                        $first-read := 0;
                     }
                     else {
                         self.IMPL-FATALIZE-QAST($_, 0);
@@ -1115,58 +1115,205 @@ class RakuAST::Lookup
     # Native variable arguments compile to lexicalref/attributeref scope so
     # a callee with an "is rw" parameter can write back through them. When
     # this lookup resolves to a routine the name still reaches and no
-    # candidate the call can reach declares the matching parameter rw,
-    # the argument is compiled as a value read instead. Otherwise a
-    # reference bound to a raw parameter, such as the value of
-    # infix:«=>», would be stored as a live view of the variable rather
-    # than a snapshot of it, and a reference read by the callee would see
-    # a write a later argument made to the variable, where the value read
-    # happens in argument order.
+    # candidate the call can reach declares the matching parameter rw, the
+    # argument is compiled as a value read instead, which spares the
+    # reference object and lets the dispatch see the native. A container
+    # argument is read when the callee binds it, after every argument
+    # was evaluated, so a later argument that writes the variable is
+    # seen by the callee. A value read where the argument
+    # stands would not be, so an impure argument after the read is
+    # evaluated into a temporary in the read's own slot, ahead of the
+    # read. A chain op evaluates a later link's operand only when the
+    # earlier links hold, so no operand may move across a link: a link
+    # whose right operand is impure keeps its references instead, and
+    # restores the reference of the middle operand it shares with the
+    # link before it.
     method IMPL-SIMPLIFY-REF-ARGS(Mu $call) {
-        if $!value-args && !$*COMPILING_CORE_SETTING {
-            if self.is-resolved
-                && nqp::istype(self.resolution, RakuAST::CompileTimeValue) {
-                my $routine := self.resolution.compile-time-value;
-                if nqp::isconcrete($routine) && nqp::istype($routine, Code) {
-                    # The callee is the first child when the call is not
-                    # made by name.
-                    my int $child := $call.name ?? 0 !! 1;
-                    my int $n := nqp::elems($call.list);
-                    # The positional count decides which candidates the
-                    # call can reach. A flattened argument makes it, and
-                    # the positions of the arguments after it, unknowable
-                    # at compile time.
-                    my int $positionals := 0;
-                    my int $flat := 0;
-                    my int $scan := $child;
-                    while $scan < $n {
-                        my $arg := $call.list[$scan];
-                        $flat := 1 if $arg.flat;
-                        ++$positionals unless $arg.named || $arg.flat;
-                        ++$scan;
+        return $call if $*COMPILING_CORE_SETTING || !$!value-args;
+        return $call unless self.is-resolved
+            && nqp::istype(self.resolution, RakuAST::CompileTimeValue);
+        my $routine := self.resolution.compile-time-value;
+        return $call unless nqp::isconcrete($routine)
+            && nqp::istype($routine, Code);
+
+        # The callee is the first child when the call is not made by name.
+        my int $start := $call.name ?? 0 !! 1;
+        my int $n := nqp::elems($call.list);
+        # The positional count decides which candidates the call can
+        # reach. A flattened argument makes it, and the positions of the
+        # arguments after it, unknowable at compile time.
+        my int $positionals := 0;
+        my int $flat := 0;
+        my int $scan := $start;
+        while $scan < $n {
+            my $arg := $call.list[$scan];
+            $flat := 1 if $arg.flat;
+            ++$positionals unless $arg.named;
+            ++$scan;
+        }
+        $positionals := -1 if $flat;
+
+        # The named arguments are evaluated after every positional one,
+        # whatever their place in the list. A value read an earlier pass
+        # settled counts as a read here, so the analysis may run again
+        # when a later argument joins the call. The first argument needs
+        # no impure note, as nothing reads before it.
+        my @reads;
+        my @hoist;
+        my @named;
+        my int $impure := 0;
+        my int $first-read := -1;
+        my int $past-flat := 0;
+        my int $pos := 0;
+        my int $child := $start;
+        while $child < $n {
+            my $arg := $call.list[$child];
+            $past-flat := 1 if $arg.flat;
+            if $arg.named {
+                nqp::push(@named, $child) unless self.IMPL-ARG-IS-PURE($arg);
+            }
+            else {
+                if !$past-flat && nqp::istype($arg, QAST::Var)
+                    && nqp::objprimspec($arg.returns) {
+                    my str $scope := $arg.scope;
+                    if ($scope eq 'lexicalref' || $scope eq 'attributeref')
+                        && self.IMPL-PARAM-NEVER-RW($routine, $pos, $positionals) {
+                        $arg.scope($scope eq 'lexicalref' ?? 'lexical' !! 'attribute');
+                        $arg.annotate('native-value-read', 1);
+                        nqp::push(@reads, $arg);
+                        $first-read := $child if $first-read < 0;
                     }
-                    $positionals := -1 if $flat;
-                    my int $pos := 0;
-                    while $child < $n {
-                        my $arg := $call.list[$child];
-                        last if $arg.flat;
-                        unless $arg.named {
-                            if nqp::istype($arg, QAST::Var)
-                                && nqp::objprimspec($arg.returns) {
-                                my str $scope := $arg.scope;
-                                if ($scope eq 'lexicalref' || $scope eq 'attributeref')
-                                    && self.IMPL-PARAM-NEVER-RW($routine, $pos, $positionals) {
-                                    $arg.scope($scope eq 'lexicalref' ?? 'lexical' !! 'attribute');
-                                }
-                            }
-                            ++$pos;
-                        }
-                        ++$child;
+                    elsif $scope eq 'lexical' || $scope eq 'attribute' {
+                        nqp::push(@reads, $arg);
+                        $first-read := $child if $first-read < 0;
                     }
                 }
+                elsif !$past-flat && self.IMPL-ARG-IS-SLOT($arg) {
+                    nqp::push(@reads, $arg.list[nqp::elems($arg.list) - 1]);
+                    $first-read := $child if $first-read < 0;
+                }
+                elsif $child > $start && !self.IMPL-ARG-IS-PURE($arg) {
+                    # The hoist list notes what may move, while the note
+                    # of impurity also serves a chain link whose read
+                    # sits in the link before it.
+                    $impure := 1;
+                    nqp::push(@hoist, $child) if $first-read >= 0;
+                }
+                ++$pos;
+            }
+            ++$child;
+        }
+        my str $op := $call.op;
+        my int $chained := $op eq 'chain' || $op eq 'chainstatic';
+        if $chained && $impure {
+            # No operand may move across a link, so the link keeps its
+            # references, and takes back the middle operand it shares
+            # with the link before it.
+            for @reads {
+                self.IMPL-RESTORE-REF($_);
+            }
+            my $left := $call.list[$start];
+            if nqp::istype($left, QAST::Op)
+                && ($left.op eq 'chain' || $left.op eq 'chainstatic') {
+                self.IMPL-RESTORE-REF($left.list[nqp::elems($left.list) - 1]);
+            }
+        }
+        elsif !$chained && $first-read >= 0 {
+            nqp::splice(@hoist, @named, nqp::elems(@hoist), 0);
+            # A native reference cannot survive a value temporary, so a
+            # call with one among the arguments to move keeps all its
+            # references instead, and the callee reads them as it binds.
+            for @hoist -> int $k {
+                if self.IMPL-ARG-RESULT-REF($call.list[$k]) {
+                    for @reads {
+                        self.IMPL-RESTORE-REF($_);
+                    }
+                    return $call;
+                }
+            }
+            if nqp::elems(@hoist) {
+                # A slot an earlier pass built keeps its read last, so
+                # the new temporaries go in ahead of it.
+                my $slot;
+                my $read;
+                if self.IMPL-ARG-IS-SLOT($call.list[$first-read]) {
+                    $slot := $call.list[$first-read];
+                    $read := nqp::pop($slot.list);
+                }
+                else {
+                    $slot := QAST::Stmts.new();
+                    $read := $call.list[$first-read];
+                }
+                for @hoist -> int $k {
+                    my $arg := $call.list[$k];
+                    my $use := self.IMPL-BIND-TEMPORARY($slot, '_native_read_', $arg);
+                    $use.named($arg.named) if $arg.named;
+                    $use.flat(1) if $arg.flat;
+                    $call.list[$k] := $use;
+                }
+                $slot.push($read);
+                $call.list[$first-read] := $slot;
             }
         }
         $call
+    }
+
+    # Whether the given argument code may keep its place while another
+    # moves across it: it writes nothing, and what it yields does not
+    # depend on where it runs, as a variable argument is read when the
+    # callee binds it anyway.
+    method IMPL-ARG-IS-PURE(Mu $node) {
+        if nqp::istype($node, QAST::Var) {
+            return !$node.decl;
+        }
+        if nqp::istype($node, QAST::Stmts) || nqp::istype($node, QAST::Stmt) {
+            for $node.list {
+                return 0 unless self.IMPL-ARG-IS-PURE($_);
+            }
+            return 1;
+        }
+        if nqp::istype($node, QAST::Want) {
+            my int $i := 0;
+            my int $n := nqp::elems($node.list);
+            while $i < $n {
+                return 0 unless self.IMPL-ARG-IS-PURE($node.list[$i]);
+                $i := $i + 2;
+            }
+            return 1;
+        }
+        nqp::istype($node, QAST::IVal) || nqp::istype($node, QAST::NVal)
+            || nqp::istype($node, QAST::SVal) || nqp::istype($node, QAST::WVal)
+    }
+
+
+    # Whether the given argument code is a temporary slot this pass
+    # built: a statement list ending in a settled value read.
+    method IMPL-ARG-IS-SLOT(Mu $node) {
+        return 0 unless nqp::istype($node, QAST::Stmts)
+            && nqp::elems($node.list);
+        my $last := $node.list[nqp::elems($node.list) - 1];
+        nqp::istype($last, QAST::Var) && $last.ann('native-value-read') ?? 1 !! 0
+    }
+
+    # Whether the given argument code's result is a native reference,
+    # behind any statement wrappers.
+    method IMPL-ARG-RESULT-REF(Mu $node) {
+        $node := self.IMPL-ARG-RESULT-NODE($node);
+        nqp::istype($node, QAST::Var) && nqp::objprimspec($node.returns)
+            && ($node.scope eq 'lexicalref' || $node.scope eq 'attributeref')
+    }
+
+    # Put a native variable read this pass settled back to its reference
+    # form. A value read that never was a reference, the lookup of a
+    # read-only native parameter among them, stays as it is.
+    method IMPL-RESTORE-REF(Mu $node) {
+        if nqp::istype($node, QAST::Var) && nqp::objprimspec($node.returns)
+            && $node.ann('native-value-read') {
+            my str $scope := $node.scope;
+            $node.scope('lexicalref') if $scope eq 'lexical';
+            $node.scope('attributeref') if $scope eq 'attribute';
+        }
+        Nil
     }
 
     # Whether the parameter binding positional argument $i is known to be
@@ -1232,8 +1379,8 @@ class RakuAST::Lookup
             return 0 if $pflags +& nqp::const::SIG_ELEM_IS_RW;
             # A slurpy that keeps its arguments' containers keeps the
             # reference, as a container argument stays a live view of the
-            # variable there. A native sub takes no reference, since the
-            # native call has no container to keep.
+            # variable there. A native sub's slurpy takes the value, since
+            # the native call has no container to keep.
             if ($pflags +& (nqp::const::SIG_ELEM_SLURPY_LOL
                     +| nqp::const::SIG_ELEM_SLURPY_ONEARG)
                 || $pflags +& nqp::const::SIG_ELEM_SLURPY_POS
@@ -1246,13 +1393,79 @@ class RakuAST::Lookup
         1
     }
 
+    # The node the given argument code yields, behind any statement
+    # wrappers.
+    method IMPL-ARG-RESULT-NODE(Mu $node) {
+        while nqp::istype($node, QAST::Stmts) || nqp::istype($node, QAST::Stmt) {
+            my int $n := nqp::elems($node.list);
+            return $node unless $n;
+            my $rc := $node.resultchild;
+            $node := $node.list[nqp::defined($rc) ?? $rc !! $n - 1];
+        }
+        $node
+    }
+
+    # The native type the given code yields in argument position, or Mu
+    # when it yields an object or the kind cannot be read off the code:
+    # a declared return, the result of a statement list, or a raw op by
+    # the kind its name ends in. A Want yields its object default there,
+    # which carries a Failure or a Nil the native alternatives cannot.
+    method IMPL-ARG-NATIVE-TYPE(Mu $node) {
+        my $returns := $node.returns;
+        return $returns if nqp::objprimspec($returns);
+        my $result := self.IMPL-ARG-RESULT-NODE($node);
+        return self.IMPL-ARG-NATIVE-TYPE($result)
+            unless nqp::eqaddr($result, $node);
+        if nqp::istype($node, QAST::Op) {
+            # Only an op whose kind suffix names its result speaks for
+            # the temporary: the raw assignment and arithmetic ops a
+            # native assignment or an inlined operator body compiles to.
+            # A comparison op's suffix names its operands, and a box or
+            # reference op's result is an object, so anything else is
+            # left to the boxed default.
+            my str $op := $node.op;
+            if nqp::eqat($op, 'assign_', 0) || nqp::eqat($op, 'add_', 0)
+                || nqp::eqat($op, 'sub_', 0) || nqp::eqat($op, 'mul_', 0)
+                || nqp::eqat($op, 'div_', 0) || nqp::eqat($op, 'mod_', 0)
+                || nqp::eqat($op, 'neg_', 0) || nqp::eqat($op, 'pow_', 0) {
+                return int  if nqp::eqat($op, '_i', -2);
+                return uint if nqp::eqat($op, '_u', -2);
+                return num  if nqp::eqat($op, '_n', -2);
+                return str  if nqp::eqat($op, '_s', -2);
+            }
+        }
+        Mu
+    }
+
+    # Bind the given argument code to a temporary in the given statement
+    # list, and return the temporary's read, of the argument's native kind
+    # where it has one.
+    method IMPL-BIND-TEMPORARY(Mu $stmts, str $prefix, Mu $arg) {
+        my str $name := QAST::Node.unique($prefix);
+        my $type := self.IMPL-ARG-NATIVE-TYPE($arg);
+        my $decl := QAST::Var.new( :$name, :scope('local'), :decl('var') );
+        my $use  := QAST::Var.new( :$name, :scope('local') );
+        if nqp::objprimspec($type) {
+            $decl.returns($type);
+            $use.returns($type);
+        }
+        else {
+            $decl.returns($arg.returns);
+            $use.returns($arg.returns);
+        }
+        $stmts.push(QAST::Op.new( :op('bind'), $decl, $arg ));
+        $use
+    }
+
     # Splice the given routine's inline info in place of a call to it, with
     # the argument code standing in for the parameter placeholders, or null
     # when the routine carries no inline info. An argument used other than
     # exactly once in the body is bound to a temporary first, so its code
     # runs once regardless. A native reference argument bound to a
     # never-rw parameter is downgraded to a value read, as the reference
-    # would only re-box on every use in the spliced body.
+    # would only re-box on every use in the spliced body. A value read
+    # followed by an impure argument puts every impure argument into a
+    # temporary, in order, so the body reads the variable after them.
     method IMPL-CT-INLINE-QAST(RakuAST::IMPL::QASTContext $context, Mu $routine, Mu @args-qast) {
         my $info := nqp::getattr($routine, Routine, '$!inline_info');
         return nqp::null() unless nqp::isconcrete($info) && nqp::istype($info, QAST::Node);
@@ -1267,6 +1480,7 @@ class RakuAST::Lookup
         $info.count_inline_placeholder_usages(@usages);
         my $inlined := QAST::Stmts.new();
         my @fillers;
+        my @args;
         my int $n := nqp::elems(@args-qast);
         my int $i := -1;
         while ++$i < $n {
@@ -1302,18 +1516,37 @@ class RakuAST::Lookup
                     }
                 }
             }
+            nqp::push(@args, $arg);
+        }
+        my int $reorder := 0;
+        my int $read := 0;
+        for @args {
+            if nqp::istype($_, QAST::Var) && nqp::objprimspec($_.returns)
+                && ($_.scope eq 'lexical' || $_.scope eq 'attribute') {
+                $read := 1;
+            }
+            elsif $read && !self.IMPL-ARG-IS-PURE($_) {
+                $reorder := 1;
+            }
+        }
+        # An impure argument's temporary comes ahead of every other, so a
+        # read bound to a temporary for its several uses still follows it.
+        if $reorder {
+            $i := -1;
+            while ++$i < $n {
+                my $arg := nqp::atpos(@args, $i);
+                nqp::bindpos(@fillers, $i, self.IMPL-BIND-TEMPORARY($inlined, '_inline_arg_', $arg))
+                    unless self.IMPL-ARG-IS-PURE($arg);
+            }
+        }
+        $i := -1;
+        while ++$i < $n {
+            next unless nqp::isnull(nqp::atpos(@fillers, $i));
+            my $arg := nqp::atpos(@args, $i);
             my $usage := nqp::atpos(@usages, $i);
-            if !nqp::isnull($usage) && $usage == 1 {
-                nqp::push(@fillers, $arg);
-            }
-            else {
-                my str $name := QAST::Node.unique('_inline_arg_');
-                $inlined.push(QAST::Op.new(
-                    :op('bind'),
-                    QAST::Var.new( :name($name), :scope('local'), :returns($arg.returns), :decl('var') ),
-                    $arg));
-                nqp::push(@fillers, QAST::Var.new( :name($name), :scope('local'), :returns($arg.returns) ));
-            }
+            nqp::bindpos(@fillers, $i, !nqp::isnull($usage) && $usage == 1
+                ?? $arg
+                !! self.IMPL-BIND-TEMPORARY($inlined, '_inline_arg_', $arg));
         }
         $inlined.push($info.substitute_inline_placeholders(@fillers));
         # The routine's return type, read raw: a method dispatch on the
@@ -1552,7 +1785,7 @@ class RakuAST::PackageInstaller {
             my @parts := nqp::clone(self.IMPL-UNWRAP-LIST($name.parts));
             $final := nqp::pop(@parts).name;
             nqp::shift(@parts) if nqp::istype(@parts[0], RakuAST::Name::Part::Empty);
-            my $first := @parts[0].name;
+            my $first-read := @parts[0].name;
             my $resolved := $resolver.partially-resolve-name-constant(RakuAST::Name.new(|@parts));
 
             # In 6.e and later, detect when the resolved path would
@@ -1589,12 +1822,12 @@ class RakuAST::PackageInstaller {
                 # caller declared, is a plain redeclaration and must still
                 # reach the collision check.
                 if $resolved[2] eq 'lexical' {
-                    if nqp::isconcrete($resolver.resolve-lexical-constant-in-scopes($first)) {
+                    if nqp::isconcrete($resolver.resolve-lexical-constant-in-scopes($first-read)) {
                         $setting-resolved-target := $target;
                     }
                     else {
-                        my $lexical-first := $resolver.resolve-lexical-constant($first);
-                        my $in-setting := $resolver.resolve-lexical-constant-in-setting($first);
+                        my $lexical-first := $resolver.resolve-lexical-constant($first-read);
+                        my $in-setting := $resolver.resolve-lexical-constant-in-setting($first-read);
                         $setting-resolved-target := $target
                             if nqp::isconcrete($lexical-first)
                             && nqp::isconcrete($in-setting)
@@ -1610,8 +1843,8 @@ class RakuAST::PackageInstaller {
                 # into this unit's GLOBALish, which every consumer merges
                 # in.
                 if $scope eq 'our' && nqp::elems(@parts) >= 1 && $resolved[2] eq 'lexical'
-                    && nqp::isconcrete($resolver.resolve-lexical-constant-in-scopes($first)) {
-                    ($resolver.get-global.WHO){$first} := $resolver.resolve-lexical($first).compile-time-value;
+                    && nqp::isconcrete($resolver.resolve-lexical-constant-in-scopes($first-read)) {
+                    ($resolver.get-global.WHO){$first-read} := $resolver.resolve-lexical($first-read).compile-time-value;
                 }
                 my $parts  := $resolved[1];
                 @parts := self.IMPL-UNWRAP-LIST($parts);
@@ -1629,24 +1862,24 @@ class RakuAST::PackageInstaller {
                 }
             }
             else {
-                my $first := nqp::shift(@parts).name;
-                $target := Perl6::Metamodel::PackageHOW.new_type(name => $first);
+                my $first-read := nqp::shift(@parts).name;
+                $target := Perl6::Metamodel::PackageHOW.new_type(name => $first-read);
                 $target.HOW.compose($target);
                 $resolver.current-scope.merge-generated-lexical-declaration:
                     :$resolver,
                     RakuAST::Declaration::LexicalPackage.new:
-                        :lexical-name($first),
+                        :lexical-name($first-read),
                         :compile-time-value($target),
                         :package(self);
                 if $scope eq 'our' {
                     # The slot is empty: the partial resolution above covers
                     # the lexical scopes, GLOBAL, and the enclosing package's
                     # stash, and an occupied slot takes the resolved branch.
-                    self.IMPL-STASH-BIND($current-package, $first, $target);
+                    self.IMPL-STASH-BIND($current-package, $first-read, $target);
                 }
                 $scope := 'our'; # Ensure we install the package into the generated stub
 
-                my $longname := $first;
+                my $longname := $first-read;
                 for @parts {
                     $longname := $longname ~ '::' ~ $_.name;
                     my $package := Perl6::Metamodel::PackageHOW.new_type(name => $longname);

--- a/src/Raku/ast/scoping.rakumod
+++ b/src/Raku/ast/scoping.rakumod
@@ -1104,11 +1104,13 @@ class RakuAST::Lookup
 
     # Native variable arguments compile to lexicalref/attributeref scope so
     # a callee with an "is rw" parameter can write back through them. When
-    # this lookup resolves to a routine and no candidate declares the
-    # matching parameter rw, the argument is compiled as a value read
-    # instead. Otherwise a reference bound to a raw parameter, such as the
+    # this lookup resolves to a routine and no candidate the call can reach
+    # declares the matching parameter rw, the argument is compiled as a
+    # value read instead. Otherwise a reference bound to a raw parameter, such as the
     # value of infix:«=>», would be stored as a live view of the variable
-    # rather than a snapshot of it.
+    # rather than a snapshot of it, and a reference read by the callee
+    # would see a write a later argument made to the variable, where the
+    # value read happens in argument order.
     method IMPL-SIMPLIFY-REF-ARGS(Mu $call) {
         unless $*COMPILING_CORE_SETTING {
             if self.is-resolved
@@ -1119,18 +1121,30 @@ class RakuAST::Lookup
                     # made by name.
                     my int $child := $call.name ?? 0 !! 1;
                     my int $n := nqp::elems($call.list);
+                    # The positional count decides which candidates the
+                    # call can reach. A flattened argument makes it, and
+                    # the positions of the arguments after it, unknowable
+                    # at compile time.
+                    my int $positionals := 0;
+                    my int $flat := 0;
+                    my int $scan := $child;
+                    while $scan < $n {
+                        my $arg := $call.list[$scan];
+                        $flat := 1 if $arg.flat;
+                        ++$positionals unless $arg.named || $arg.flat;
+                        ++$scan;
+                    }
+                    $positionals := -1 if $flat;
                     my int $pos := 0;
                     while $child < $n {
                         my $arg := $call.list[$child];
-                        # A flattened argument makes the positions of the
-                        # remaining arguments unknowable at compile time.
                         last if $arg.flat;
                         unless $arg.named {
                             if nqp::istype($arg, QAST::Var)
                                 && nqp::objprimspec($arg.returns) {
                                 my str $scope := $arg.scope;
                                 if ($scope eq 'lexicalref' || $scope eq 'attributeref')
-                                    && self.IMPL-PARAM-NEVER-RW($routine, $pos) {
+                                    && self.IMPL-PARAM-NEVER-RW($routine, $pos, $positionals) {
                                     $arg.scope($scope eq 'lexicalref' ?? 'lexical' !! 'attribute');
                                 }
                             }
@@ -1145,13 +1159,25 @@ class RakuAST::Lookup
     }
 
     # Whether the parameter binding positional argument $i is known to be
-    # non-rw in every candidate of $routine. Any candidate that cannot be
-    # introspected, or whose signature has optional, slurpy, or capture
-    # parameters, means the reference must be kept.
-    method IMPL-PARAM-NEVER-RW(Mu $routine, int $i) {
+    # non-rw in every candidate of $routine the call can reach. A call of
+    # $positionals positional arguments reaches no candidate that requires
+    # more or admits fewer, so such a candidate has no say. A count of -1
+    # is one the call cannot know. Every candidate has its say then, and
+    # one whose arity and count differ keeps the reference, since whether
+    # the run time count reaches it cannot be checked. Any candidate
+    # that cannot be introspected, or that has no positional parameter
+    # at the position, means the reference must be kept. A slurpy positional
+    # binds its own position and every one after it.
+    method IMPL-PARAM-NEVER-RW(Mu $routine, int $i, int $positionals) {
+        # The routine and its candidates are read through their attributes:
+        # a method lookup on a mixin type, which a candidate with a typed
+        # return has, can miss where its method cache is not published.
+        # A dispatcher holds a dispatchee list, and the flag bit is the one
+        # the onlystar method reads.
         my @candidates;
-        if nqp::can($routine, 'is_dispatcher') && $routine.is_dispatcher {
-            return 0 unless nqp::can($routine, 'onlystar') && $routine.onlystar;
+        if nqp::istype($routine, Routine)
+            && nqp::defined(nqp::getattr($routine, Routine, '@!dispatchees')) {
+            return 0 unless nqp::getattr_i($routine, Routine, '$!flags') +& 0x04;
             for nqp::getattr($routine, Routine, '@!dispatchees') {
                 nqp::push(@candidates, $_);
             }
@@ -1160,10 +1186,19 @@ class RakuAST::Lookup
             nqp::push(@candidates, $routine);
         }
         for @candidates {
-            return 0 unless nqp::can($_, 'signature');
-            my $sig := $_.signature;
-            return 0 unless nqp::isconcrete($sig)
-                && nqp::iseq_n($sig.arity, $sig.count);
+            return 0 unless nqp::istype($_, Code);
+            my $sig := nqp::getattr($_, Code, '$!signature');
+            return 0 unless nqp::isconcrete($sig);
+            # The count is Inf for a slurpy, so the compares are numeric.
+            my int $arity := nqp::getattr_i($sig, Signature, '$!arity');
+            my $count := nqp::getattr($sig, Signature, '$!count');
+            if $positionals >= 0 {
+                next if nqp::islt_n($positionals, $arity)
+                    || nqp::isgt_n($positionals, $count);
+            }
+            else {
+                return 0 unless nqp::iseq_n($arity, $count);
+            }
             my $param;
             my int $pos := 0;
             for nqp::getattr($sig, Signature, '@!params') {
@@ -1171,7 +1206,10 @@ class RakuAST::Lookup
                 unless nqp::getattr($_, Parameter, '@!named_names')
                     || $flags +& (nqp::const::SIG_ELEM_SLURPY_NAMED
                         +| nqp::const::SIG_ELEM_IS_CAPTURE) {
-                    if $pos == $i {
+                    if $pos == $i
+                        || $flags +& (nqp::const::SIG_ELEM_SLURPY_POS
+                            +| nqp::const::SIG_ELEM_SLURPY_LOL
+                            +| nqp::const::SIG_ELEM_SLURPY_ONEARG) {
                         $param := $_;
                         last;
                     }
@@ -1179,8 +1217,20 @@ class RakuAST::Lookup
                 }
             }
             return 0 unless nqp::isconcrete($param);
-            return 0 if nqp::getattr_i($param, Parameter, '$!flags')
-                +& nqp::const::SIG_ELEM_IS_RW;
+            my int $pflags := nqp::getattr_i($param, Parameter, '$!flags');
+            return 0 if $pflags +& nqp::const::SIG_ELEM_IS_RW;
+            # A slurpy that keeps its arguments' containers keeps the
+            # reference, as a container argument stays a live view of the
+            # variable there. A native sub takes no reference, since the
+            # native call has no container to keep.
+            if ($pflags +& (nqp::const::SIG_ELEM_SLURPY_LOL
+                    +| nqp::const::SIG_ELEM_SLURPY_ONEARG)
+                || $pflags +& nqp::const::SIG_ELEM_SLURPY_POS
+                    && $pflags +& nqp::const::SIG_ELEM_IS_RAW)
+                && nqp::isnull(nqp::how_nd($_).find_method($_,
+                    'CUSTOM-DISPATCHER', :no_fallback)) {
+                return 0;
+            }
         }
         1
     }
@@ -1236,7 +1286,7 @@ class RakuAST::Lookup
                 if nqp::istype($arg, QAST::Var) && nqp::objprimspec($arg.returns) {
                     my str $scope := $arg.scope;
                     if ($scope eq 'lexicalref' || $scope eq 'attributeref')
-                        && self.IMPL-PARAM-NEVER-RW($routine, $i) {
+                        && self.IMPL-PARAM-NEVER-RW($routine, $i, $n) {
                         $arg.scope($scope eq 'lexicalref' ?? 'lexical' !! 'attribute');
                     }
                 }

--- a/t/04-nativecall/26-varargs.t
+++ b/t/04-nativecall/26-varargs.t
@@ -4,7 +4,7 @@ use NativeCall;
 use Test;
 use nqp;
 
-plan 15;
+plan 17;
 
 compile_test_lib('26-varargs');
 
@@ -53,6 +53,14 @@ sub va5(int32, **@varargs) returns int32 is native('./26-varargs') { * }
 my $a1 = "Köln";
 ok va5(0, $a1), 'can pass strings';
 ok va5(0, "Köln"), 'can pass strings inline';
+if nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' {
+    my str $s = "Köln";
+    ok va5(0, $s), 'a native string variable in the variadic position';
+    ok va5(0, $s, "x"), 'a native string variable in the variadic position followed by an object';
+}
+else {
+    skip 'a native string reaches a variadic native sub on the RakuAST frontend only', 2;
+}
 }
 
 {

--- a/t/04-nativecall/26-varargs.t
+++ b/t/04-nativecall/26-varargs.t
@@ -4,7 +4,7 @@ use NativeCall;
 use Test;
 use nqp;
 
-plan 14;
+plan 15;
 
 compile_test_lib('26-varargs');
 
@@ -14,6 +14,9 @@ ok va1(0, 1), 'Can pass plain ints';
 
 my $a1 = 1;
 ok va1(0, $a1), 'Can pass Int';
+
+my int32 $n = 1;
+ok va1(0, $n, "trailing"), 'a native variable in the variadic position followed by an object';
 }
 
 {

--- a/t/08-performance/39-rakuast-native-arg-value.t
+++ b/t/08-performance/39-rakuast-native-arg-value.t
@@ -3,7 +3,7 @@ use Test::Helpers::QAST;
 use Test;
 use QAST:from<NQP>;
 use nqp;
-plan 37;
+plan 91;
 
 # A native variable passed to a routine none of whose reachable
 # candidates take that position rw is passed as a value, so a raw
@@ -138,6 +138,7 @@ plan 37;
     is $i, 43, 'a prefix operator declared later in the scope receives the reference';
     multi sub prefix:<->(int $a is rw) { $a = 43; 'RW' }
 }
+# The outer g exists for the block below to shadow.
 sub g(int $x) { }
 {
     my int $i = 1;
@@ -146,6 +147,124 @@ sub g(int $x) { }
     sub g(int $x is rw) { $x = 9 }
 }
 
+# A later argument that writes a native variable is seen by the callee,
+# as it is when the variable is a container, which is read when the
+# callee binds it.
+{
+    sub f(*@a) { @a.join(',') }
+    my Int $a = 1; my int $b = 1;
+    is f($b, ($b = 7)), f($a, ($a = 7)), 'a native argument to a slurpy parameter is read at bind time, as a container is';
+}
+{
+    sub f(**@a) { @a.join(',') }
+    my Int $a = 1; my int $b = 1;
+    is f(0, $b, ($b = 7)), f(0, $a, ($a = 7)), 'a native argument after the position a slurpy starts at is read at bind time, as a container is';
+}
+{
+    my Int $a = 4; my int $b = 4;
+    is $b !%% ($b = 3), $a !%% ($a = 3), 'a native operand of a negated operator is read at bind time, as a container is';
+}
+{
+    my Int $a = 1; my int $b = 1;
+    is (0 < $b < ($b = 7)), (0 < $a < ($a = 7)), 'the middle operand of a chain is read at the bind of each link, as a container is';
+    is (0 !> $b < ($b = 7)), (0 !> $a < ($a = 7)), 'the middle operand after a negated link is read at the bind of each link, as a container is';
+}
+
+# The named and flattened arguments take part in the evaluation order
+# the reads follow.
+{
+    sub f($x, :$n) { "$x,$n" }
+    my Int $a = 1; my int $b = 1;
+    is f($b, :n($b = 7)), f($a, :n($a = 7)), 'a named argument that writes the variable is evaluated ahead of the native read';
+    my Int $c = 1; my int $d = 1;
+    is f(:n($d = 7), $d), f(:n($c = 7), $c), 'a named argument ahead of the positional that writes the variable is evaluated ahead of the native read';
+}
+{
+    sub f($x, $y, :$n) { "$x,$y,$n" }
+    my int $b = 1;
+    is f($b, :n($b = 7), ($b = 9)), '7,9,7', 'the positional arguments are evaluated before the named ones, and the native read after them all';
+}
+{
+    sub f($x, $y, $z) { "$x,$y,$z" }
+    my Int $a = 1; my int $b = 1; my @one = 0;
+    is f($b, |@one, ($b = 7)), f($a, |@one, ($a = 7)), 'an argument after a flattened one that writes the variable is evaluated ahead of the native read';
+}
+{
+    sub f(int $c, $d) { "$c,$d" }
+    my int $b = 1;
+    sub g() { $b = 7; 5 }
+    is f($b, |(g(),)), '7,5', 'a flattened argument that writes the variable is evaluated ahead of the native read';
+}
+{
+    sub f($x, $y, $z) { "$y,$z" }
+    my Int $a = 1; my int $b = 1;
+    sub ha() { $a = 5; 100 }
+    sub hb() { $b = 5; 100 }
+    is f(0, hb(), $b), f(0, ha(), $a), 'an impure argument ahead of the native read stays where it is';
+}
+{
+    sub g(--> int) { fail "no" }
+    sub f(int $x, $y) { $y.^name }
+    my int $b = 1;
+    is f($b, g()), 'Failure', 'a Failure returned by an argument after the native read reaches the callee';
+}
+{
+    sub f(int $x is rw, $y) { $x = $x + $y; $y }
+    my int $b = 1;
+    is f($b, ($b = 7)), 7, 'an rw parameter followed by an impure argument still receives the argument';
+    is $b, 14, 'an rw parameter followed by an impure argument still writes back through the reference';
+}
+{
+    my Int $a = 2; my int $b = 2;
+    is (0 < 1 < $b < ($b = 7)), (0 < 1 < $a < ($a = 7)), 'the middle operand of a chain of three links is read at the bind of its link, as a container is';
+}
+
+{
+    my int $i = 1;
+    sub f() { $i = 7; 5 }
+    $i max= f();
+    is $i, 7, 'a native compound assignment reads its target after the argument that writes it';
+}
+# The temporary an impure argument binds keeps the kind its code
+# yields.
+{
+    my class MyInt is Int { }
+    sub f($x, $y) { $y.^name }
+    my int $i = 1;
+    sub g() { $i = 7; 3 }
+    is f($i, nqp::box_i(g(), MyInt)), 'MyInt', 'a boxing op after the native read keeps its boxed type';
+}
+{
+    multi sub d(Int $x, Int $y) { "Int/Int" }
+    multi sub d(Int $x, Str $y) { "Int/Str" }
+    my int $b = 1;
+    is d($b, nqp::iseq_s("a","a")), 'Int/Int', 'a comparison op result after a native read keeps its integer kind';
+}
+{
+    sub f(int $x, :$n) { "$x,$n" }
+    my Int $a = 1; my int $b = 1;
+    is f($b, :n(my int $t = ($b = 7))), f($a, :n(my int $u = ($a = 7))), 'a native typed named argument that writes the variable is evaluated ahead of the native read';
+}
+
+# An operator's adverb and a wrapped operand join the call like any
+# other argument.
+{
+    sub infix:<nn>($a, $b, :$n) { "$a,$b,$n" }
+    my Int $a = 1; my int $b = 1;
+    is ($b nn 0 :n($b = 7)), ($a nn 0 :n($a = 7)), 'an infix adverb that writes the variable is evaluated ahead of the native read';
+}
+{
+    sub f($x, int $y is rw) { $y = 99 }
+    my int $b = 1; my int $q = 1;
+    f($b, ($q));
+    is $q, 99, 'a parenthesized native argument to an rw parameter still passes the reference';
+}
+{
+    sub infix:<nn>($a, $b, :$n) { "$a,$b,$n" }
+    sub imp() { 3 }
+    my Int $a = 1; my int $b = 1;
+    is ($b nn imp() :n($b = 9)), ($a nn imp() :n($a = 9)), 'an infix adverb joins the temporaries of an impure operand ahead of the native read';
+}
 # The scope of the first argument of a named call, or the node's type
 # name when that argument is not a variable.
 sub qast-first-arg-scope(Mu $qast, str $callee --> Str) {
@@ -184,6 +303,51 @@ sub qast-count-calls(Mu $qast, str $op, str $callee --> Int) {
         $count += qast-count-calls($_, $op, $callee) for $qast.list;
     }
     $count
+}
+# Whether any temporary a native read or an inlined body binds appears.
+sub qast-has-temporary(Mu $qast --> Bool) {
+    return True if nqp::istype($qast, QAST::Var)
+        && ($qast.name.starts-with('_native_read_') || $qast.name.starts-with('_inline_arg_'));
+    if qast-descendable $qast {
+        for $qast.list {
+            return True if qast-has-temporary($_);
+        }
+    }
+    False
+}
+# The scope of the last operand of the innermost chain op, or ''.
+sub qast-chain-middle-scope(Mu $qast --> Str) {
+    if nqp::istype($qast, QAST::Op) && $qast.op eq 'chain' | 'chainstatic' {
+        my $inner = qast-chain-middle-scope($qast.list[0]);
+        return $inner if $inner;
+        my $last = $qast.list[*-1];
+        return nqp::istype($last, QAST::Var) ?? $last.scope !! '';
+    }
+    if qast-descendable $qast {
+        for $qast.list {
+            my $found = qast-chain-middle-scope($_);
+            return $found if $found;
+        }
+    }
+    ''
+}
+# Whether the named call's first argument is a statement list ending in
+# the given variable's value read, with a temporary as the argument after.
+sub qast-reads-last(Mu $qast, str $callee, str $var --> Bool) {
+    if nqp::istype($qast, QAST::Op) && $qast.name eq $callee {
+        my @args = $qast.list;
+        my $slot = @args[0];
+        return nqp::istype($slot, QAST::Stmts)
+            && nqp::istype($slot.list[*-1], QAST::Var)
+            && $slot.list[*-1].name eq $var && $slot.list[*-1].scope eq 'lexical'
+            && nqp::istype(@args[1], QAST::Var) && @args[1].scope eq 'local';
+    }
+    if qast-descendable $qast {
+        for $qast.list {
+            return True if qast-reads-last($_, $callee, $var);
+        }
+    }
+    False
 }
 
 # What follows holds under this frontend only.
@@ -231,9 +395,129 @@ if nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' {
         is $i, 43, 'a comparison declared later in the scope receives the reference';
         multi sub infix:«<»(int $a is rw, int $b) { $a = 43; 'RW' }
     }
+    # The legacy frontend reads a native operand where it stands.
+    {
+        sub f($x, $y, $z) { "$x,$y,$z" }
+        my Int $a = 1; my int $b = 1;
+        is f($b, ($b), ++$b), f($a, ($a), ++$a), 'a parenthesized native argument is read at bind time, as a container is';
+    }
+    {
+        my Int $a = 1; my int $b = 1;
+        is $b + ($b = 7), $a + ($a = 7), 'a native left operand is read after a later operand writes it, as a container is';
+    }
+    {
+        my Str $a = 'a'; my str $b = 'a';
+        is $b ~ ($b = 'b'), $a ~ ($a = 'b'), 'a native string operand is read after a later operand writes it, as a container is';
+    }
+    {
+        my Int $a = 1; my int $b = 1;
+        is infix:<+>($b, ($b = 7)), infix:<+>($a, ($a = 7)), 'a native argument to an operator called by name is read at bind time, as a container is';
+    }
+    {
+        my Int $a = 1; my int $b = 1;
+        is $b - ($b = 7), $a - ($a = 7), 'a native operand of subtraction is read at bind time, as a container is';
+    }
+    {
+        class C { has Int $.a = 1; has int $.b = 1; method m { ($!b + ($!b = 7), $!a + ($!a = 7)) } }
+        my ($native, $boxed) = C.new.m;
+        is $native, $boxed, 'a native attribute operand is read at bind time, as a container is';
+    }
+    {
+        sub f(\x, $y) { x }
+        my Int $a = 1; my int $b = 1;
+        is f($b, ($b = 7)), f($a, ($a = 7)), 'a native argument to a raw parameter is read at bind time, as a container is';
+    }
+    {
+        sub f($x, $y) { $x }
+        my Int $a = 1; my int $b = 1;
+        is f($b, ($b = 7)), f($a, ($a = 7)), 'a native argument to a plain parameter is read at bind time, as a container is';
+    }
+    {
+        sub h(int $x, $y) { $x }
+        my Int $a = 1; my int $b = 1;
+        is h($b, ($b = 7)), h($a, ($a = 7)), 'a native argument to a native parameter is read at bind time, as a container is';
+    }
+    {
+        sub o(\x, $y?) { x }
+        my Int $a = 1; my int $b = 1;
+        is o($b, ($b = 7)), o($a, ($a = 7)), 'a native argument to an optional parameter is read at bind time, as a container is';
+    }
+    {
+        my Int $a = 1; my int $b = 1;
+        is ($b < ($b = 7)), ($a < ($a = 7)), 'a lone native comparison reads its operand at bind time, as a container is';
+    }
+    {
+        my Int $a = 1; my int $b = 1;
+        is ($b !< ($b = 7)), ($a !< ($a = 7)), 'a negated native comparison reads its operand at bind time, as a container is';
+    }
+    {
+        my Int $a = 1; my int $b = 1;
+        is ($b < ($b = 7) < 9), ($a < ($a = 7) < 9), 'the first operand of a chain is read at the bind of its link, as a container is';
+    }
+    {
+        my Int $a = 1; my int $b = 1;
+        is $b + $b++, $a + $a++, 'a native operand is read after a later operand increments it, as a container is';
+    }
+    {
+        use soft;
+        my Int $a = 1; my int $b = 1;
+        is $b + ($b = 7), $a + ($a = 7), 'a native operand is read at bind time under the soft pragma, as a container is';
+    }
+    {
+        my int $b = 1;
+        is $b + ($b = 7), 14, 'a native left operand reads 7 after the later operand writes it';
+        my int $c = 1;
+        is infix:<+>($c, ($c = 7)), 14, 'a native argument to an operator called by name reads 7 after the later argument writes it';
+    }
+    {
+        my Int $a = 1; my int $b = 1;
+        is $b + ++$b, $a + ++$a, 'a native operand of an inlined operator is read after a later operand increments it, as a container is';
+        my int $c = 1;
+        is $c + ++$c, 4, 'a native operand of an inlined operator reads 2 after the later operand increments it';
+    }
+    {
+        my Str $a = 'a'; my str $b = 'a';
+        is $b ~ (my str $d = ($b = 'b')), $a ~ (my Str $c = ($a = 'b')), 'a native string operand of an inlined operator is read after a later operand writes it, as a container is';
+    }
+    # EVAL compiles a unit of its own, where the callee is settled and
+    # its body splices.
+    is EVAL('sub w(int $a, int $b) { $a * $a + $b }; my int $b = 1; w($b, ++$b)'), 6,
+        'a native argument used twice in an inlined body is read after a later argument increments it';
+    {
+        my uint $b = 1;
+        is $b + ($b = 7), 14, 'a native unsigned operand reads 7 after the later operand writes it';
+    }
+    {
+        sub f($x, $y) { "$x,$y" }
+        my num $b = 1e0;
+        is f($b, ($b = 7e0)), '7,7', 'a native num argument reads 7 after the later argument writes it';
+    }
+    {
+        sub f($x, $y, $z) { "$x,$y,$z" }
+        my int $b = 1;
+        is f($b, ($b = 7), $b), '7,7,7', 'both reads around a writing argument read after it';
+    }
+    qast-is 'sub f($x, $y) { }; my int $i = 1; f($i, ($i = 7));', :full, -> \v { qast-has-temporary(v) },
+        'a writing argument after a native read binds a temporary in sink context';
+    qast-is 'my int $i = 1; sub f() { 2 }; my $r = $i + f()', :full, -> \v {
+        qast-reads-last(v, '&infix:<+>', '$i')
+    }, 'an impure operand after a native read is evaluated into a temporary ahead of the read';
+    qast-is 'my int $i; my $r = $i + 1', -> \v { not qast-has-temporary(v) },
+        'a literal operand after a native read needs no temporary';
+    qast-is 'my int $i; my int $n; my $r = $i < $n', -> \v { not qast-has-temporary(v) },
+        'a native variable operand after a native read needs no temporary';
+    qast-is 'my int $b = 1; my $r = $b + ++$b', :full, -> \v { qast-has-temporary(v) },
+        'an impure operand of an inlined operator binds a temporary';
+    qast-is 'sub infix:<nn>($a,$b,:$n){}; my int $b = 1; my $r = $b nn 0 :n(5)', :full,
+        -> \v { not qast-has-temporary(v) }, 'a pure adverb after a native read needs no temporary';
+    qast-is 'sub f(int $x) { my $r = 0 < $x < g() }; sub g() { 9 }', :full,
+        -> \v { qast-chain-middle-scope(v) eq 'lexical' },
+        'a read-only native parameter in a chain is not promoted to a reference';
+    qast-is 'my int $b; my $r = 0 < $b < ($b = 7)', -> \v { qast-chain-middle-scope(v) eq 'lexicalref' },
+        'the middle operand of a chain whose last operand is impure stays a reference';
 }
 else {
-    skip 'argument passing shapes are specific to the RakuAST frontend', 10;
+    skip 'argument passing shapes are specific to the RakuAST frontend', 42;
 }
 
 # vim: expandtab shiftwidth=4

--- a/t/08-performance/39-rakuast-native-arg-value.t
+++ b/t/08-performance/39-rakuast-native-arg-value.t
@@ -3,7 +3,7 @@ use Test::Helpers::QAST;
 use Test;
 use QAST:from<NQP>;
 use nqp;
-plan 30;
+plan 37;
 
 # A native variable passed to a routine none of whose reachable
 # candidates take that position rw is passed as a value, so a raw
@@ -123,6 +123,29 @@ plan 30;
     is 1 < $n < 3, False, 'a native operand of a longer chain keeps the chain';
 }
 
+# A routine declared after the use in the same scope takes the call, so
+# the reference stays where such a declaration could take it rw.
+{
+    my int $i = 1;
+    my int $j = 2;
+    is $i + $j, 'RW', 'an operator declared later in the scope takes the call';
+    is $i, 43, 'an operator declared later in the scope receives the reference';
+    multi sub infix:<+>(int $a is rw, int $b) { $a = 43; 'RW' }
+}
+{
+    my int $i = 1;
+    is -$i, 'RW', 'a prefix operator declared later in the scope takes the call';
+    is $i, 43, 'a prefix operator declared later in the scope receives the reference';
+    multi sub prefix:<->(int $a is rw) { $a = 43; 'RW' }
+}
+sub g(int $x) { }
+{
+    my int $i = 1;
+    g($i);
+    is $i, 9, 'a sub declared later in the scope, shadowing an outer one, receives the reference';
+    sub g(int $x is rw) { $x = 9 }
+}
+
 # The scope of the first argument of a named call, or the node's type
 # name when that argument is not a variable.
 sub qast-first-arg-scope(Mu $qast, str $callee --> Str) {
@@ -201,9 +224,16 @@ if nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' {
             and qast-count-calls(v, 'callstatic', '&infix:«<»') == 0
             and qast-count-calls(v, 'call', '&infix:«<»') == 0
     }, 'every link of a chain of two compiles to a chain op';
+    {
+        my int $i = 1;
+        my int $j = 2;
+        is $i < $j, 'RW', 'a comparison declared later in the scope takes the call';
+        is $i, 43, 'a comparison declared later in the scope receives the reference';
+        multi sub infix:«<»(int $a is rw, int $b) { $a = 43; 'RW' }
+    }
 }
 else {
-    skip 'argument passing shapes are specific to the RakuAST frontend', 8;
+    skip 'argument passing shapes are specific to the RakuAST frontend', 10;
 }
 
 # vim: expandtab shiftwidth=4

--- a/t/08-performance/39-rakuast-native-arg-value.t
+++ b/t/08-performance/39-rakuast-native-arg-value.t
@@ -1,0 +1,157 @@
+use lib <t/packages/Test-Helpers>;
+use Test::Helpers::QAST;
+use Test;
+use QAST:from<NQP>;
+use nqp;
+plan 19;
+
+# A native variable passed to a routine none of whose reachable
+# candidates take that position rw is passed as a value, so a raw
+# parameter holds a snapshot of the variable rather than a live view.
+# A candidate the argument count cannot reach has no say.
+{
+    sub f(\x, $y) { -> { x } }
+    my int $i = 1;
+    my &c = f($i, 0); $i = 7;
+    is c(), 1, 'a native argument to a raw parameter is a snapshot of the variable';
+}
+{
+    multi sub h(int $x is rw) { $x = 5 }
+    multi sub h(\x, $y) { -> { x } }
+    my int $i = 1;
+    my &c = h($i, 0); $i = 7;
+    is c(), 1, 'an rw candidate that admits fewer positionals than the call passes has no say';
+}
+{
+    multi sub h(int $x is rw, $y, $z) { $x = 5 }
+    multi sub h(\x, $y) { -> { x } }
+    my int $i = 1;
+    my &c = h($i, 0); $i = 7;
+    is c(), 1, 'an rw candidate that requires more positionals than the call passes has no say';
+}
+{
+    sub f(int $x is rw) { $x = 5 }
+    my int $i = 1; f($i);
+    is $i, 5, 'a native argument to an rw parameter still passes the reference';
+}
+{
+    multi sub g(int $x is rw) { $x = 5 }
+    multi sub g(Str) { }
+    my int $i = 1; g($i);
+    is $i, 5, 'a native argument passes the reference when a reachable candidate takes it rw';
+}
+{
+    multi sub k(int $x is rw, $y?) { $x = 5 }
+    multi sub k(\x, $y, $z) { x }
+    my int $i = 1; k($i, 0);
+    is $i, 5, 'an rw candidate the call reaches through its optional parameter keeps the reference';
+}
+{
+    sub nm(int $x is rw, :$z) { $x = 5 }
+    my int $i = 1; nm($i, :z);
+    is $i, 5, 'a named argument after the positional does not count toward the positionals';
+    my int $j = 1; nm(:z, $j);
+    is $j, 5, 'a named argument before the positional does not count toward the positionals';
+}
+{
+    multi sub h(int $x is rw, $y, $z) { $x = 5 }
+    multi sub h(\x) { x }
+    my int $i = 1; my @two = 0, 0; h($i, |@two);
+    is $i, 5, 'a flattened argument keeps the reference for an rw candidate the run time count reaches';
+}
+{
+    proto sub p(|) { {*} }
+    multi sub p(\x, $y) { -> { x } }
+    my int $i = 1;
+    my &c = p($i, 0); $i = 7;
+    is c(), 7, 'a proto with a body keeps the reference';
+}
+{
+    sub c(|c) { -> { c[0] } }
+    my int $i = 1;
+    my &r = c($i); $i = 7;
+    is r(), 7, 'a capture parameter keeps the reference';
+}
+{
+    sub f(*@a) { @a }
+    my int $i = 1;
+    my $r = f($i); $i = 7;
+    is $r[0], 1, 'a slurpy parameter holds a snapshot of a native argument';
+}
+
+# A slurpy that keeps its arguments' containers keeps a native
+# argument's reference, so it holds a live view of the variable as it
+# does of a container.
+{
+    sub f(**@a) { @a }
+    my int $i = 1;
+    my $r = f($i); $i = 7;
+    is $r[0], 7, 'a double-star slurpy holds a live view of a native argument';
+}
+{
+    sub f(+@a) { @a }
+    my int $i = 1;
+    my $r = f($i); $i = 7;
+    is $r[0], 7, 'a plus slurpy holds a live view of a native argument';
+}
+{
+    sub f(*@a is raw) { @a }
+    my int $i = 1;
+    my $r = f($i); $i = 7;
+    is $r[0], 7, 'a raw slurpy holds a live view of a native argument';
+}
+
+# The scope of the first argument of a named call, or the node's type
+# name when that argument is not a variable.
+sub qast-first-arg-scope(Mu $qast, str $callee --> Str) {
+    if nqp::istype($qast, QAST::Op) && $qast.name eq $callee {
+        for $qast.list {
+            return nqp::istype($_, QAST::Var) ?? $_.scope !! $_.^name;
+        }
+    }
+    if qast-descendable $qast {
+        for $qast.list {
+            my $found = qast-first-arg-scope($_, $callee);
+            return $found if $found;
+        }
+    }
+    ''
+}
+# The scope of the variable of the given name where a call passes it.
+sub qast-call-arg-scope(Mu $qast, str $var --> Str) {
+    if nqp::istype($qast, QAST::Op) && $qast.op eq 'call' | 'callstatic' {
+        for $qast.list {
+            return $_.scope if nqp::istype($_, QAST::Var) && $_.name eq $var;
+        }
+    }
+    if qast-descendable $qast {
+        for $qast.list {
+            my $found = qast-call-arg-scope($_, $var);
+            return $found if $found;
+        }
+    }
+    ''
+}
+
+# The shapes are this frontend's.
+if nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' {
+    {
+        sub o(\x, $y?) { -> { x } }
+        my int $i = 1;
+        my &c = o($i, 0); $i = 7;
+        is c(), 1, 'an optional parameter holds a snapshot of a native argument';
+    }
+    qast-is 'my int $i; my $y; my $z = $i + $y', -> \v {
+        qast-first-arg-scope(v, '&infix:<+>') eq 'lexical'
+    }, 'a native operand of an operator passes as a value';
+    qast-is 'sub f(int $x is rw) { }; my int $i; f($i)', :full, -> \v { qast-first-arg-scope(v, '&f') eq 'lexicalref' },
+        'a native argument to an rw parameter passes as a reference';
+    qast-is 'my int $a; my int $b; my $c = $a !< $b', -> \v {
+        qast-call-arg-scope(v, '$a') eq 'lexical'
+    }, 'a native operand of a negated comparison passes as a value';
+}
+else {
+    skip 'argument passing shapes are specific to the RakuAST frontend', 4;
+}
+
+# vim: expandtab shiftwidth=4

--- a/t/08-performance/39-rakuast-native-arg-value.t
+++ b/t/08-performance/39-rakuast-native-arg-value.t
@@ -3,7 +3,7 @@ use Test::Helpers::QAST;
 use Test;
 use QAST:from<NQP>;
 use nqp;
-plan 19;
+plan 30;
 
 # A native variable passed to a routine none of whose reachable
 # candidates take that position rw is passed as a value, so a raw
@@ -101,6 +101,28 @@ plan 19;
     is $r[0], 7, 'a raw slurpy holds a live view of a native argument';
 }
 
+# The links of a longer chain keep the chain protocol: the middle
+# operand is evaluated once and a false link ends the chain.
+{
+    my $a = 2;
+    is-deeply (1 < $a < 3 < 2, 0 < 0.5 < 1 < 2), (False, True),
+        'a chain of several links answers as a chain';
+    my $n = 0;
+    sub f() { $n++; 2 }
+    is 5 < f() < 3, False, 'a false first link ends the chain';
+    is $n, 1, 'the middle operand of a chain is evaluated once';
+    my $m = 0;
+    sub g() { $m++; 9 }
+    is 1 < 0 < g(), False, 'a later link is not evaluated after a false one';
+    is $m, 0, 'a later link is not evaluated after a false one, with its operand untouched';
+}
+{
+    my $a = 5;
+    is 1 !< $a < 3, False, 'a false negated first link ends the chain';
+    my int $n = 5;
+    is 1 < $n < 3, False, 'a native operand of a longer chain keeps the chain';
+}
+
 # The scope of the first argument of a named call, or the node's type
 # name when that argument is not a variable.
 sub qast-first-arg-scope(Mu $qast, str $callee --> Str) {
@@ -132,8 +154,16 @@ sub qast-call-arg-scope(Mu $qast, str $var --> Str) {
     }
     ''
 }
+# How many ops of the given op name call the given callee name.
+sub qast-count-calls(Mu $qast, str $op, str $callee --> Int) {
+    my $count = nqp::istype($qast, QAST::Op) && $qast.op eq $op && $qast.name eq $callee ?? 1 !! 0;
+    if qast-descendable $qast {
+        $count += qast-count-calls($_, $op, $callee) for $qast.list;
+    }
+    $count
+}
 
-# The shapes are this frontend's.
+# What follows holds under this frontend only.
 if nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' {
     {
         sub o(\x, $y?) { -> { x } }
@@ -149,9 +179,31 @@ if nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' {
     qast-is 'my int $a; my int $b; my $c = $a !< $b', -> \v {
         qast-call-arg-scope(v, '$a') eq 'lexical'
     }, 'a native operand of a negated comparison passes as a value';
+    # A lone comparison dispatching on native operands is this frontend's
+    # shape.
+    {
+        multi sub infix:«<»(int $a, int $b) is default { $a <= 1 }
+        sub count(int $n) { my int $i = 0; my int $c = 0; while $i < $n { $i++; $c++ }; $c }
+        is count(3), 2, 'a lone native comparison dispatches on the native operands';
+    }
+    {
+        use soft;
+        multi sub infix:«<»(int $a, int $b) is default { $a <= 1 }
+        sub count(int $n) { my int $i = 0; my int $c = 0; while $i < $n { $i++; $c++ }; $c }
+        is count(3), 2, 'a lone native comparison dispatches on the native operands under the soft pragma';
+    }
+    qast-is 'my $a; my $b; my $c = $a < $b', -> \v {
+        qast-count-calls(v, 'callstatic', '&infix:«<»') == 1
+            and not qast-contains-op(v, 'chainstatic') and not qast-contains-op(v, 'chain')
+    }, 'a lone comparison compiles to a call';
+    qast-is 'my $a; my $d = 1 < $a < 3', -> \v {
+        qast-count-calls(v, 'chainstatic', '&infix:«<»') == 2
+            and qast-count-calls(v, 'callstatic', '&infix:«<»') == 0
+            and qast-count-calls(v, 'call', '&infix:«<»') == 0
+    }, 'every link of a chain of two compiles to a chain op';
 }
 else {
-    skip 'argument passing shapes are specific to the RakuAST frontend', 4;
+    skip 'argument passing shapes are specific to the RakuAST frontend', 8;
 }
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously a native variable passed to a routine compiled to a reference unless every candidate of the routine was known to take that position by value, and a candidate that binds the position to no parameter of its own, the zero and one argument identity candidates of an operator such as `+`, counted against that. So a native operand of most setting operators went by reference: the call allocated a reference object, the dispatch weighed a reference beside a native differently from two natives, a raw parameter held a live view of the variable where a container argument gives a snapshot, and a native string never survived the trip to a variadic native sub.

This passes a native argument by value wherever no candidate the call can reach takes it rw, and reads it where a container argument is read: when the callee binds it, after every argument was evaluated. An impure argument after the read is evaluated into a temporary ahead of it, the named arguments and an operator's adverb among them, and a chain link keeps its references instead, since no operand may move across a link. So `my int $i = 1; $i + ($i = 7)` is 14, as it is for `my Int $i`, with and without the optimize pass. An `is rw` parameter still receives the reference, as does a slurpy that keeps its arguments' containers, and a routine declared after the use in the same scope takes the call and receives the reference as well.

A comparison whose application is a chain of one link compiles as a plain call, so it dispatches on the native operands: with a `multi sub infix:«<»(int, int) is default` in scope, `$i < $n` now lands on the same candidate as `infix:«<»($i, $n)` and the legacy frontend. The links of a longer chain keep the chain op.

The native call dispatcher finds the `**@varargs` parameter before looking at the argument's kind, so a native argument at that position no longer walks the parameter list past its end, and together with the value passing a native `int` or `str` can be handed to a variadic native sub such as `printf`.

Passing the value also spares the reference object where a native operand meets a boxed one: `$i + $y` runs about 20% faster, a lone `$i == $y` comparison about 25% faster, and `$s ~ $y` on a native `str` about twice as fast.
