### PR TITLE
RakuAST: look up routines the syntax calls by a static lookup

### DIFF
--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -719,6 +719,8 @@ class RakuAST::Node {
         my int $conditional-stmt := nqp::istype($expr, RakuAST::Statement::IfWith)
             || nqp::istype($expr, RakuAST::Statement::Unless);
         my int $loop-stmt        := nqp::istype($expr, RakuAST::Statement::Loop);
+        my int $list-infix       := nqp::istype($expr, RakuAST::ApplyListInfix);
+        my int $routine-lookup   := nqp::isconcrete(self.IMPL-ROUTINE-LOOKUP($expr));
 
         # The rewrites, and the marks the unit's walk cannot settle again,
         # wait for that walk when the resolver reports a walk ahead of
@@ -802,14 +804,16 @@ class RakuAST::Node {
             if ($apply-infix || $apply-prefix || $apply-postfix || $call-name
                 || $stmt-expression || $conditional-stmt || $loop-stmt
                 || $dot-assign || $stmt-for || $term-name || $routine
-                || $var-decl || $stmt-when || $parameter)
+                || $var-decl || $stmt-when || $parameter
+                || $list-infix || $routine-lookup)
                 && self.IMPL-IN-SOFT-SCOPE($resolver) {
                 self.IMPL-WITHDRAW-IDENTITY-MARKS($expr);
             }
             elsif $apply-infix || $apply-prefix || $apply-postfix || $call-name
                 || $stmt-expression || $conditional-stmt || $loop-stmt
                 || $dot-assign || $stmt-for || $term-name || $routine
-                || $var-decl || $stmt-when || $parameter {
+                || $var-decl || $stmt-when || $parameter
+                || $list-infix || $routine-lookup {
                 self.IMPL-MARK-NATIVE-INCDEC($resolver, $expr)
                     if $apply-postfix || $apply-prefix;
                 if $apply-infix {
@@ -830,6 +834,10 @@ class RakuAST::Node {
                     if $apply-prefix;
                 self.IMPL-MARK-STATIC-POSTFIX($resolver, $expr)
                     if $apply-postfix;
+                self.IMPL-MARK-STATIC-LIST-INFIX($resolver, $expr)
+                    if $list-infix;
+                self.IMPL-MARK-STATIC-LOOKUP($resolver, $expr)
+                    if $routine-lookup;
                 self.IMPL-MARK-CONSTANT-TERM($resolver, $expr)
                     if $term-name;
                 self.IMPL-MARK-NEGATE-NOT($resolver, $expr)
@@ -958,12 +966,17 @@ class RakuAST::Node {
             elsif nqp::istype($infix, RakuAST::MetaInfix::Negate) {
                 $infix.IMPL-CLEAR-NEGATE-NOT();
             }
-            elsif nqp::istype($infix, RakuAST::Infix) {
+            $infix := $infix.infix while nqp::istype($infix, RakuAST::MetaInfix);
+            if nqp::istype($infix, RakuAST::Infix) {
                 $infix.IMPL-SET-CALLSTATIC(0);
                 $infix.IMPL-SET-CHAINSTATIC(0);
                 $infix.IMPL-SET-LOWERED-ARRAY-INIT(0);
                 $infix.IMPL-CLEAR-CT-INLINE-CANDIDATE();
             }
+        }
+        elsif nqp::istype($expr, RakuAST::ApplyListInfix) {
+            my $infix := $expr.infix;
+            $infix.IMPL-SET-CALLSTATIC(0) if nqp::istype($infix, RakuAST::Infix);
         }
         elsif nqp::istype($expr, RakuAST::Call::Name) {
             $expr.IMPL-SET-CALLSTATIC(0);
@@ -984,6 +997,8 @@ class RakuAST::Node {
         elsif nqp::istype($expr, RakuAST::VarDeclaration::Simple) {
             $expr.IMPL-SET-LOWERED-ARRAY-INIT(0);
         }
+        my $lookup := self.IMPL-ROUTINE-LOOKUP($expr);
+        $lookup.IMPL-SET-STATIC-LOOKUP(0) if nqp::isconcrete($lookup);
         Nil
     }
 
@@ -1348,10 +1363,12 @@ class RakuAST::Node {
     }
 
     # Mark a chaining comparison whose operator's lexical is bound once for a
-    # static callee lookup at code generation.
+    # static callee lookup at code generation. The operator beneath a
+    # meta-op takes the mark, which the meta-ops that call it by name use.
     method IMPL-MARK-STATIC-CHAIN(RakuAST::Resolver $resolver, Mu $expr) {
         return Nil unless nqp::istype($expr, RakuAST::ApplyInfix);
         my $infix := $expr.infix;
+        $infix := $infix.infix while nqp::istype($infix, RakuAST::MetaInfix);
         return Nil unless nqp::istype($infix, RakuAST::Infix)
             && $infix.is-resolved
             && $infix.properties.chain;
@@ -1368,6 +1385,7 @@ class RakuAST::Node {
     method IMPL-MARK-STATIC-INFIX(RakuAST::Resolver $resolver, Mu $expr) {
         return Nil unless nqp::istype($expr, RakuAST::ApplyInfix);
         my $infix := $expr.infix;
+        $infix := $infix.infix while nqp::istype($infix, RakuAST::MetaInfix);
         return Nil unless nqp::istype($infix, RakuAST::Infix)
             && $infix.is-resolved
             && !$infix.properties.chain;
@@ -1400,6 +1418,60 @@ class RakuAST::Node {
         $postfix.IMPL-SET-CALLSTATIC(
             self.IMPL-RESOLUTION-BOUND-ONCE($resolver, $postfix.resolution,
                 '&postfix' ~ $resolver.IMPL-CANONICALIZE-PAIR($postfix.operator)) ?? 1 !! 0);
+        Nil
+    }
+
+    # Mark a list operator whose lexical is bound once for a static
+    # callee lookup at code generation.
+    method IMPL-MARK-STATIC-LIST-INFIX(RakuAST::Resolver $resolver, Mu $expr) {
+        return Nil unless nqp::istype($expr, RakuAST::ApplyListInfix);
+        my $infix := $expr.infix;
+        return Nil unless nqp::istype($infix, RakuAST::Infix)
+            && $infix.is-resolved;
+        my $resolution := $infix.resolution;
+        $infix.IMPL-SET-CALLSTATIC(
+            self.IMPL-RESOLUTION-BOUND-ONCE($resolver, $resolution,
+                $resolution.lexical-name) ?? 1 !! 0);
+        Nil
+    }
+
+    # The lookup of the routine an expression calls without a call node
+    # of its own, or Nil. A capture variable reads the match through the
+    # subscript its implicit lookup names.
+    method IMPL-ROUTINE-LOOKUP(Mu $expr) {
+        my $postfix := nqp::istype($expr, RakuAST::ApplyPostfix)
+            ?? $expr.postfix
+            !! nqp::istype($expr, RakuAST::ApplyDottyInfix)
+                ?? $expr.right
+                !! nqp::istype($expr, RakuAST::Term::TopicCall)
+                    ?? $expr.call
+                    !! Nil;
+        if nqp::isconcrete($postfix) {
+            return nqp::istype($postfix, RakuAST::Postcircumfix)
+                && nqp::istype($postfix, RakuAST::Lookup)
+                ?? $postfix
+                !! Nil;
+        }
+        return $expr if nqp::istype($expr, RakuAST::Circumfix::ArrayComposer)
+            || nqp::istype($expr, RakuAST::Circumfix::HashComposer)
+            || nqp::istype($expr, RakuAST::Term::Named)
+            || nqp::istype($expr, RakuAST::Term::EmptySet)
+            || nqp::istype($expr, RakuAST::Term::Rand);
+        return self.IMPL-UNWRAP-LIST($expr.get-implicit-lookups)[0]
+            if nqp::istype($expr, RakuAST::Var::PositionalCapture)
+            || nqp::istype($expr, RakuAST::Var::NamedCapture);
+        Nil
+    }
+
+    # Mark the lookup IMPL-ROUTINE-LOOKUP yields, when its lexical is
+    # bound once, for a static callee lookup at code generation.
+    method IMPL-MARK-STATIC-LOOKUP(RakuAST::Resolver $resolver, Mu $expr) {
+        my $lookup := self.IMPL-ROUTINE-LOOKUP($expr);
+        return Nil unless nqp::isconcrete($lookup) && $lookup.is-resolved;
+        my $resolution := $lookup.resolution;
+        $lookup.IMPL-SET-STATIC-LOOKUP(
+            self.IMPL-RESOLUTION-BOUND-ONCE($resolver, $resolution,
+                $resolution.lexical-name) ?? 1 !! 0);
         Nil
     }
 

--- a/src/Raku/ast/call.rakumod
+++ b/src/Raku/ast/call.rakumod
@@ -561,6 +561,8 @@ class RakuAST::Call::Name
         nqp::bindattr_i(self, RakuAST::Call::Name, '$!callstatic', $on)
     }
 
+    method IMPL-CALL-OP() { $!callstatic ?? 'callstatic' !! 'call' }
+
     # Set by the optimize pass when the argument types decide the dispatch
     # at compile time: the routine, for a multi the chosen candidate, whose
     # inline info, when it has any, is spliced in place of the call.

--- a/src/Raku/ast/circumfix.rakumod
+++ b/src/Raku/ast/circumfix.rakumod
@@ -179,7 +179,7 @@ class RakuAST::Circumfix::ArrayComposer
     method IMPL-EXPR-QAST(RakuAST::IMPL::QASTContext $context) {
         my $name := self.resolution.lexical-name;
         QAST::Op.new(
-            :op('call'), :$name,
+            :op(self.IMPL-CALL-OP), :$name,
             $!semilist.IMPL-TO-QAST($context)
         )
     }
@@ -252,7 +252,7 @@ class RakuAST::Circumfix::HashComposer
         my $name := self.resolution.lexical-name;
         my $expression := $!expression;
 
-        my $op := QAST::Op.new(:op<call>, :$name);
+        my $op := QAST::Op.new(:op(self.IMPL-CALL-OP), :$name);
         if $expression {
             $op.push($expression.IMPL-TO-QAST($context))
         }

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -584,6 +584,11 @@ class RakuAST::Infix
         nqp::bindattr_i(self, RakuAST::Infix, '$!callstatic', $on)
     }
 
+    # The op of a plain call to this operator by name.
+    method IMPL-CALL-OP() {
+        $!callstatic || $!chainstatic ?? 'callstatic' !! 'call'
+    }
+
     # Set by the optimize pass when the operand types decide the dispatch at
     # compile time: the routine, for a multi the chosen candidate, whose
     # inline info, when it has any, is spliced in place of the operator call.
@@ -857,7 +862,7 @@ class RakuAST::Infix
             # platform that wants to optimize this somewhat can).
             $past := QAST::Op.new( :op('p6assign'), $lhs_ast, $rhs_ast );
         }
-        elsif nqp::istype($lhs_ast, QAST::Op) && $lhs_ast.op eq 'call' &&
+        elsif nqp::istype($lhs_ast, QAST::Op) && ($lhs_ast.op eq 'call' || $lhs_ast.op eq 'callstatic') &&
               ((my $lhs_ast_name := $lhs_ast.name) eq '&postcircumfix:<[ ]>' ||
                $lhs_ast_name eq '&postcircumfix:<{ }>' ||
                $lhs_ast_name eq '&postcircumfix:<[; ]>') &&
@@ -867,7 +872,7 @@ class RakuAST::Infix
             $past.nosink(1);
         }
         elsif nqp::istype($lhs_ast, QAST::Op) && $lhs_ast.op eq 'hllize' &&
-                nqp::istype($lhs_ast[0],QAST::Op) && $lhs_ast[0].op eq 'call' &&
+                nqp::istype($lhs_ast[0],QAST::Op) && ($lhs_ast[0].op eq 'call' || $lhs_ast[0].op eq 'callstatic') &&
                 ($lhs_ast[0].name eq '&postcircumfix:<[ ]>' || $lhs_ast[0].name eq '&postcircumfix:<{ }>') &&
                 +@($lhs_ast[0]) == 2 { # no adverbs
             $lhs_ast[0].push($rhs_ast);
@@ -886,7 +891,9 @@ class RakuAST::Infix
                               Mu $right-qast
     ) {
         QAST::Op.new(
-            :op(self.properties.chain ?? 'chain' !! 'call'),
+            :op(self.properties.chain
+                ?? ($!chainstatic ?? 'chainstatic' !! 'chain')
+                !! self.IMPL-CALL-OP),
             :name(self.resolution.lexical-name),
             $left-qast,
             $right-qast
@@ -941,7 +948,7 @@ class RakuAST::Infix
         self.IMPL-TEMPORARIZE-TOPIC(
             $left.IMPL-TO-QAST($context),
             QAST::Op.new(
-                :op<call>, :$name,
+                :op(self.IMPL-CALL-OP), :$name,
                 QAST::Var.new( :name<$_>, :scope<lexical> ),
                 $right.IMPL-TO-QAST($context)))
     }
@@ -967,7 +974,7 @@ class RakuAST::Infix
             else {
                 $name := '&infix' ~ RakuAST::Resolver.IMPL-CANONICALIZE-PAIR($!operator);
             }
-            my $op := QAST::Op.new( :op('call'), :$name );
+            my $op := QAST::Op.new( :op(self.IMPL-CALL-OP), :$name );
             for $operands {
                 $op.push($_);
             }
@@ -1688,7 +1695,7 @@ class RakuAST::MetaInfix::Assign
                     QAST::Op.new(:op<decont>,
                         QAST::Var.new(:scope<local>, :name($temp)))),
                 QAST::Var.new(:scope<local>, :name($temp)),
-                QAST::Op.new(:op<call>, :name($!infix.resolution.lexical-name)));
+                QAST::Op.new(:op($!infix.IMPL-CALL-OP), :name($!infix.resolution.lexical-name)));
             $effect := QAST::Op.new(:op($store),
                 QAST::Var.new(:scope<local>, :name($temp)),
                 $!infix.IMPL-INFIX-QAST($context, $left, $right-qast));
@@ -3272,6 +3279,8 @@ class RakuAST::Prefix
         nqp::bindattr_i(self, RakuAST::Prefix, '$!callstatic', $on)
     }
 
+    method IMPL-CALL-OP() { $!callstatic ?? 'callstatic' !! 'call' }
+
     method IMPL-PREFIX-QAST(RakuAST::IMPL::QASTContext $context, Mu $operand-qast) {
         my $name;
         if self.is-resolved || !$*COMPILING_CORE_SETTING {
@@ -3601,6 +3610,8 @@ class RakuAST::Postfix
     method IMPL-SET-CALLSTATIC(int $on) {
         nqp::bindattr_i(self, RakuAST::Postfix, '$!callstatic', $on)
     }
+
+    method IMPL-CALL-OP() { $!callstatic ?? 'callstatic' !! 'call' }
 
     method IMPL-POSTFIX-QAST(
       RakuAST::IMPL::QASTContext $context,
@@ -3937,7 +3948,7 @@ class RakuAST::Postcircumfix::ArrayIndex
                 $fast := QAST::Op.new( :op($ref-op), $operand-qast, $fast-index );
             }
             return $fast if $literal;
-            my $slow := QAST::Op.new( :op('call'), :$name, $operand-qast );
+            my $slow := QAST::Op.new( :op(self.IMPL-CALL-OP), :$name, $operand-qast );
             $slow.push(self.IMPL-INDEX-QAST($context));
             $slow.push($!assignee.IMPL-TO-QAST($context)) if $!assignee;
             return QAST::Op.new(
@@ -3950,7 +3961,7 @@ class RakuAST::Postcircumfix::ArrayIndex
             );
         }
 
-        my $op := QAST::Op.new( :op('call'), :$name, $operand-qast );
+        my $op := QAST::Op.new( :op(self.IMPL-CALL-OP), :$name, $operand-qast );
         $op.push(self.IMPL-INDEX-QAST($context)) unless $!index.is-empty;
         $op.push($!assignee.IMPL-TO-QAST($context)) if $!assignee;
         self.IMPL-ADD-COLONPAIRS-TO-OP($context, $op);
@@ -3960,7 +3971,7 @@ class RakuAST::Postcircumfix::ArrayIndex
     method IMPL-BIND-POSTFIX-QAST(RakuAST::IMPL::QASTContext $context,
             RakuAST::Expression $operand, QAST::Node $source-qast) {
         my $name := self.resolution.lexical-name;
-        my $op := QAST::Op.new( :op('call'), :$name, $operand.IMPL-TO-QAST($context) );
+        my $op := QAST::Op.new( :op(self.IMPL-CALL-OP), :$name, $operand.IMPL-TO-QAST($context) );
         $op.push(self.IMPL-INDEX-QAST($context)) unless $!index.is-empty;
         my $bind := $source-qast;
         $bind.named('BIND');
@@ -4037,7 +4048,7 @@ class RakuAST::Postcircumfix::HashIndex
 
     method IMPL-POSTFIX-QAST(RakuAST::IMPL::QASTContext $context, Mu $operand-qast) {
         my $name := self.is-resolved ?? self.resolution.lexical-name !! self.IMPL-LEXICAL-NAME;
-        my $op := QAST::Op.new( :op('call'), :$name, $operand-qast );
+        my $op := QAST::Op.new( :op(self.IMPL-CALL-OP), :$name, $operand-qast );
         $op.push(self.IMPL-INDEX-QAST($context)) unless $!index.is-empty;
         self.IMPL-ADD-COLONPAIRS-TO-OP($context, $op);
         $op
@@ -4046,7 +4057,7 @@ class RakuAST::Postcircumfix::HashIndex
     method IMPL-BIND-POSTFIX-QAST(RakuAST::IMPL::QASTContext $context,
             RakuAST::Expression $operand, QAST::Node $source-qast) {
         my $name := self.resolution.lexical-name;
-        my $op := QAST::Op.new( :op('call'), :$name, $operand.IMPL-TO-QAST($context) );
+        my $op := QAST::Op.new( :op(self.IMPL-CALL-OP), :$name, $operand.IMPL-TO-QAST($context) );
         $op.push(self.IMPL-INDEX-QAST($context)) unless $!index.is-empty;
         self.IMPL-ADD-COLONPAIRS-TO-OP($context, $op);
         my $bind := $source-qast;
@@ -4133,7 +4144,7 @@ class RakuAST::Postcircumfix::LiteralHashIndex
 
     method IMPL-POSTFIX-QAST(RakuAST::IMPL::QASTContext $context, Mu $operand-qast) {
         my $name := self.resolution.lexical-name;
-        my $op := QAST::Op.new( :op('call'), :$name, $operand-qast );
+        my $op := QAST::Op.new( :op(self.IMPL-CALL-OP), :$name, $operand-qast );
         $op.push($!index.IMPL-TO-QAST($context)) unless $!index.is-empty-words;
         $op.push($!assignee.IMPL-TO-QAST($context)) if $!assignee;
         self.IMPL-ADD-COLONPAIRS-TO-OP($context, $op);
@@ -4152,7 +4163,7 @@ class RakuAST::Postcircumfix::LiteralHashIndex
     method IMPL-BIND-POSTFIX-QAST(RakuAST::IMPL::QASTContext $context,
             RakuAST::Expression $operand, QAST::Node $source-qast) {
         my $name := self.resolution.lexical-name;
-        my $op := QAST::Op.new( :op('call'), :$name, $operand.IMPL-TO-QAST($context) );
+        my $op := QAST::Op.new( :op(self.IMPL-CALL-OP), :$name, $operand.IMPL-TO-QAST($context) );
         $op.push($!index.IMPL-TO-QAST($context)) unless $!index.is-empty-words;
         self.IMPL-ADD-COLONPAIRS-TO-OP($context, $op);
         my $bind := $source-qast;

--- a/src/Raku/ast/scoping.rakumod
+++ b/src/Raku/ast/scoping.rakumod
@@ -1036,6 +1036,18 @@ class RakuAST::Lookup
         nqp::bindattr_i(self, RakuAST::Lookup, '$!value-args', $on)
     }
 
+    # Set by the optimize pass when the name is bound once, so a call
+    # through this lookup finds its callee by a static lookup, which the
+    # VM may resolve a single time. An operator or call lookup keeps its
+    # own mark and answers the call op from that.
+    has int $!static-lookup;
+
+    method IMPL-SET-STATIC-LOOKUP(int $on) {
+        nqp::bindattr_i(self, RakuAST::Lookup, '$!static-lookup', $on)
+    }
+
+    method IMPL-CALL-OP() { $!static-lookup ?? 'callstatic' !! 'call' }
+
     method needs-resolution() { True }
 
     method is-resolved() {

--- a/src/Raku/ast/term.rakumod
+++ b/src/Raku/ast/term.rakumod
@@ -338,7 +338,7 @@ class RakuAST::Term::Named
     }
 
     method IMPL-EXPR-QAST(RakuAST::IMPL::QASTContext $context) {
-        my $call := QAST::Op.new( :op('call'), :name(self.resolution.lexical-name) );
+        my $call := QAST::Op.new( :op(self.IMPL-CALL-OP), :name(self.resolution.lexical-name) );
         $!args.IMPL-ADD-QAST-ARGS($context, $call);
         $call
     }
@@ -363,7 +363,7 @@ class RakuAST::Term::EmptySet
     }
 
     method IMPL-EXPR-QAST(RakuAST::IMPL::QASTContext $context) {
-        QAST::Op.new( :op('call'), :name(self.resolution.lexical-name) )
+        QAST::Op.new( :op(self.IMPL-CALL-OP), :name(self.resolution.lexical-name) )
     }
 }
 
@@ -386,7 +386,7 @@ class RakuAST::Term::Rand
     }
 
     method IMPL-EXPR-QAST(RakuAST::IMPL::QASTContext $context) {
-        QAST::Op.new( :op('call'), :name(self.resolution.lexical-name) )
+        QAST::Op.new( :op(self.IMPL-CALL-OP), :name(self.resolution.lexical-name) )
     }
 
     method PERFORM-CHECK(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {

--- a/src/Raku/ast/variable-access.rakumod
+++ b/src/Raku/ast/variable-access.rakumod
@@ -928,7 +928,7 @@ class RakuAST::Var::PositionalCapture
         my $index := $!index;
         $context.ensure-sc($index);
         my $op := QAST::Op.new(
-            :op('call'),
+            :op($lookups[0].IMPL-CALL-OP),
             :name($lookups[0].is-resolved ?? $lookups[0].resolution.lexical-name !! '&postcircumfix:<[ ]>'),
             $lookups[1].IMPL-TO-QAST($context),
             QAST::WVal.new( :value($index) )
@@ -983,7 +983,7 @@ class RakuAST::Var::NamedCapture
     method IMPL-EXPR-QAST(RakuAST::IMPL::QASTContext $context) {
         my $lookups := self.IMPL-UNWRAP-LIST(self.get-implicit-lookups);
         my $op := QAST::Op.new(
-            :op('call'),
+            :op($lookups[0].IMPL-CALL-OP),
             :name($lookups[0].resolution.lexical-name),
             $lookups[1].IMPL-TO-QAST($context),
         );

--- a/t/08-performance/18-rakuast-callstatic.t
+++ b/t/08-performance/18-rakuast-callstatic.t
@@ -3,7 +3,7 @@ use Test::Helpers::QAST;
 use Test;
 use QAST:from<NQP>;
 use nqp;
-plan 43;
+plan 96;
 
 # A call to a named setting routine compiles its callee lookup as a static
 # one, which the VM may resolve a single time. So does a call to a routine
@@ -113,6 +113,123 @@ qast-is 'my &prefix:<-> = sub ($a) { 99 }; my $x = 5; my $y = -$x', -> \v {
     not qast-op-named(v, 'callstatic', '&prefix:<->')
 }, 'a prefix bound through an operator variable keeps the plain callee lookup';
 
+# A routine the syntax calls without a call node of its own compiles the
+# same static lookup: a subscript, an array or hash composer, a term that
+# names a routine, a list operator, the subscript a capture variable
+# reads the match with, and the operator beneath an assignment or reverse
+# meta-op.
+qast-is 'my @a = 1, 2; my $x = @a[0]', -> \v {
+        qast-op-named(v, 'callstatic', '&postcircumfix:<[ ]>')
+    and not qast-op-named(v, 'call', '&postcircumfix:<[ ]>')
+}, 'an array subscript compiles to a static callee lookup';
+
+qast-is 'my %h = a => 1; my $x = %h{"a"}', -> \v {
+        qast-op-named(v, 'callstatic', '&postcircumfix:<{ }>')
+    and not qast-op-named(v, 'call', '&postcircumfix:<{ }>')
+}, 'a hash subscript compiles to a static callee lookup';
+
+qast-is 'my %h = a => 1; my $x = %h<a>', -> \v {
+        qast-op-named(v, 'callstatic', '&postcircumfix:<{ }>')
+    and not qast-op-named(v, 'call', '&postcircumfix:<{ }>')
+}, 'a literal hash subscript compiles to a static callee lookup';
+
+qast-is 'my @a = 1, 2; my $x = @a.[0]', -> \v {
+        qast-op-named(v, 'callstatic', '&postcircumfix:<[ ]>')
+    and not qast-op-named(v, 'call', '&postcircumfix:<[ ]>')
+}, 'a subscript applied with a dot compiles to a static callee lookup';
+
+qast-is '$_ = [1, 2]; my $x = .[0]', -> \v {
+        qast-op-named(v, 'callstatic', '&postcircumfix:<[ ]>')
+    and not qast-op-named(v, 'call', '&postcircumfix:<[ ]>')
+}, 'a subscript applied to the topic compiles to a static callee lookup';
+
+qast-is 'my int @a = 1, 2; my int $i = 0; my $x = @a[$i]', -> \v {
+        qast-op-named(v, 'callstatic', '&postcircumfix:<[ ]>')
+    and not qast-op-named(v, 'call', '&postcircumfix:<[ ]>')
+}, 'the general call behind a native subscript compiles to a static callee lookup';
+
+qast-is 'sub postcircumfix:<[ ]>(\a, \i) { 2 }; my @a = 1; my $x = @a[0]', -> \v {
+        qast-op-named(v, 'callstatic', '&postcircumfix:<[ ]>')
+    and not qast-op-named(v, 'call', '&postcircumfix:<[ ]>')
+}, 'a subscript against a routine declared in the outermost scope compiles to a static callee lookup';
+
+qast-is '{ my sub postcircumfix:<[ ]>(\a, \i) { 2 }; my @a = 1; my $x = @a[0] }', :full, -> \v {
+    not qast-op-named(v, 'callstatic', '&postcircumfix:<[ ]>')
+}, 'a subscript against a nested user routine keeps the plain callee lookup';
+
+qast-is 'my &postcircumfix:<[ ]> = sub (\a, \i) { 1 }; my @a = 1; my $x = @a[0]', -> \v {
+    not qast-op-named(v, 'callstatic', '&postcircumfix:<[ ]>')
+}, 'a subscript bound through a routine variable keeps the plain callee lookup';
+
+qast-is 'my &rand = sub { 1 }; my $x = rand', -> \v {
+    not qast-op-named(v, 'callstatic', '&rand')
+}, 'the rand term bound through a routine variable keeps the plain callee lookup';
+
+qast-is 'my %h = a => 1; %h{"a"} := 5', -> \v {
+        qast-op-named(v, 'callstatic', '&postcircumfix:<{ }>')
+    and not qast-op-named(v, 'call', '&postcircumfix:<{ }>')
+}, 'a bind into a hash subscript compiles to a static callee lookup';
+
+qast-is 'my %h = a => 1; %h<a> := 5', -> \v {
+        qast-op-named(v, 'callstatic', '&postcircumfix:<{ }>')
+    and not qast-op-named(v, 'call', '&postcircumfix:<{ }>')
+}, 'a bind into a literal hash subscript compiles to a static callee lookup';
+
+qast-is 'my $x = 1; my $h = :{ a => $x }', -> \v {
+        qast-op-named(v, 'callstatic', '&circumfix:<:{ }>')
+    and not qast-op-named(v, 'call', '&circumfix:<:{ }>')
+}, 'an object hash composer compiles to a static callee lookup';
+
+qast-is 'my @a = 1, 2; @a[0] := 5', -> \v {
+        qast-op-named(v, 'callstatic', '&postcircumfix:<[ ]>')
+    and not qast-op-named(v, 'call', '&postcircumfix:<[ ]>')
+}, 'a bind into an array subscript compiles to a static callee lookup';
+
+qast-is 'my $x = 1; my $a = [$x, 2]', -> \v {
+        qast-op-named(v, 'callstatic', '&circumfix:<[ ]>')
+    and not qast-op-named(v, 'call', '&circumfix:<[ ]>')
+}, 'an array composer compiles to a static callee lookup';
+
+qast-is 'my $x = 1; my $h = { a => $x }', -> \v {
+        qast-op-named(v, 'callstatic', '&circumfix:<{ }>')
+    and not qast-op-named(v, 'call', '&circumfix:<{ }>')
+}, 'a hash composer compiles to a static callee lookup';
+
+qast-is 'my $x = rand', -> \v {
+        qast-op-named(v, 'callstatic', '&rand')
+    and not qast-op-named(v, 'call', '&rand')
+}, 'the rand term compiles to a static callee lookup';
+
+qast-is 'my $x = time', -> \v {
+        qast-op-named(v, 'callstatic', '&term:<time>')
+    and not qast-op-named(v, 'call', '&term:<time>')
+}, 'a named term compiles to a static callee lookup';
+
+qast-is 'my $x = 1; my $l = ($x, 2)', -> \v {
+        qast-op-named(v, 'callstatic', '&infix:<,>')
+    and not qast-op-named(v, 'call', '&infix:<,>')
+}, 'a list operator compiles to a static callee lookup';
+
+qast-is 'my $s = 0; my $x = 2; $s += $x', -> \v {
+        qast-op-named(v, 'callstatic', '&infix:<+>')
+    and not qast-op-named(v, 'call', '&infix:<+>')
+}, 'the operator beneath an assignment meta-op compiles to a static callee lookup';
+
+qast-is 'my $x = 1; my $y = 2; my $z = $x R- $y', -> \v {
+        qast-op-named(v, 'callstatic', '&infix:<->')
+    and not qast-op-named(v, 'call', '&infix:<->')
+}, 'the operator beneath a reverse meta-op compiles to a static callee lookup';
+
+qast-is '"ab" ~~ /(a)/; my $x = $0', -> \v {
+        qast-op-named(v, 'callstatic', '&postcircumfix:<[ ]>')
+    and not qast-op-named(v, 'call', '&postcircumfix:<[ ]>')
+}, 'a positional capture variable compiles to a static callee lookup';
+
+qast-is '"ab" ~~ /$<x>=(a)/; my $x = $<x>', -> \v {
+        qast-op-named(v, 'callstatic', '&postcircumfix:<{ }>')
+    and not qast-op-named(v, 'call', '&postcircumfix:<{ }>')
+}, 'a named capture variable compiles to a static callee lookup';
+
 # The soft pragma promises late rebinding, so this frontend declines
 # the mark under it, while the legacy optimizer still pins a setting
 # callee that is not itself soft.
@@ -123,9 +240,46 @@ if nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' {
     qast-is 'sub sfoo() { 1 }; BEGIN &sfoo does role { method soft(--> True) { } }; sfoo()', :full, -> \v {
         not qast-op-named(v, 'callstatic', '&sfoo')
     }, 'a call to a routine marked soft keeps the plain callee lookup';
+    # The legacy frontend compiles the empty set term to a shape of its
+    # own.
+    qast-is 'my $x = ∅', -> \v {
+            qast-op-named(v, 'callstatic', '&set')
+        and not qast-op-named(v, 'call', '&set')
+    }, 'the empty set term compiles to a static callee lookup';
+    # The legacy frontend compiles a smartmatch to a shape of its own.
+    qast-is 'sub f() { 2 }; my $x = 1; my $y = $x ~~ f()', -> \v {
+            qast-op-named(v, 'callstatic', '&infix:<~~>')
+        and not qast-op-named(v, 'call', '&infix:<~~>')
+    }, 'a smartmatch compiles to a static callee lookup';
+    qast-is 'use soft; my @a = 1; my $x = @a[0]', -> \v {
+        not qast-op-named(v, 'callstatic', '&postcircumfix:<[ ]>')
+    }, 'an array subscript under the soft pragma keeps the plain callee lookup';
+    qast-is 'use soft; my $x = rand', -> \v {
+        not qast-op-named(v, 'callstatic', '&rand')
+    }, 'the rand term under the soft pragma keeps the plain callee lookup';
+    qast-is 'use soft; my $x = 1; my $l = ($x, 2)', -> \v {
+        not qast-op-named(v, 'callstatic', '&infix:<,>')
+    }, 'a list operator under the soft pragma keeps the plain callee lookup';
+    # A routine declared after the use takes the name at run time, so
+    # the lookup the use resolved to is not the one to pin.
+    qast-is 'my $x = rand; sub rand() { 1 }', -> \v {
+        not qast-op-named(v, 'callstatic', '&rand')
+    }, 'the rand term shadowed by a later routine keeps the plain callee lookup';
+    qast-is 'my @a = 1; my $x = @a[0]; sub postcircumfix:<[ ]>(\a, \i) { 2 }', -> \v {
+        not qast-op-named(v, 'callstatic', '&postcircumfix:<[ ]>')
+    }, 'an array subscript shadowed by a later routine keeps the plain callee lookup';
+    qast-is '"ab" ~~ /(a)/; my $x = $0; sub postcircumfix:<[ ]>(\a, \i) { 2 }', -> \v {
+        not qast-op-named(v, 'callstatic', '&postcircumfix:<[ ]>')
+    }, 'a positional capture variable shadowed by a later routine keeps the plain callee lookup';
+    qast-is 'use soft; my $x = 1; my $a = [$x, 2]', -> \v {
+        not qast-op-named(v, 'callstatic', '&circumfix:<[ ]>')
+    }, 'an array composer under the soft pragma keeps the plain callee lookup';
+    qast-is 'use soft; my $x = 1; my $y = 2; my $z = $x R- $y', -> \v {
+        not qast-op-named(v, 'callstatic', '&infix:<->')
+    }, 'the operator beneath a reverse meta-op under the soft pragma keeps the plain callee lookup';
 }
 else {
-    skip 'the soft shape is specific to the RakuAST frontend', 2;
+    skip 'the soft shape is specific to the RakuAST frontend', 12;
 }
 
 # A routine marked soft promises late rebinding, so a wrapper
@@ -206,6 +360,70 @@ is 2 rt-mul 3, 6, 'a user infix declared in the outermost scope computes through
 sub prefix:<rt-neg>($a) { 0 - $a }
 &prefix:<rt-neg>.wrap(-> $a { 999 });
 is rt-neg 5, 999, 'a wrapped prefix in the outermost scope runs its wrapper through a static lookup';
+
+# Routines the syntax calls without a call node still behave through
+# static callee lookups, and so does the operator beneath a meta-op.
+{
+    my @a = 1, 2;
+    my %h = a => 3, b => 4;
+    is @a[1], 2, 'an array subscript through a static lookup reads the element';
+    is %h{'a'}, 3, 'a hash subscript through a static lookup reads the value';
+    is %h<b>, 4, 'a literal hash subscript through a static lookup reads the value';
+    @a[0] := 9;
+    is @a[0], 9, 'a bind into an array subscript through a static lookup binds the element';
+    my $x = 5;
+    is [$x, 2].elems, 2, 'an array composer through a static lookup composes the array';
+    is { a => $x }<a>, 5, 'a hash composer through a static lookup composes the hash';
+    ok 0 <= rand < 1, 'the rand term through a static lookup yields a number below one';
+    ok time > 0, 'a named term through a static lookup yields its value';
+    is ∅.elems, 0, 'the empty set term through a static lookup yields the empty set';
+    is ($x, 2).elems, 2, 'a list operator through a static lookup builds the list';
+    my $sum = 1;
+    $sum += $x;
+    is $sum, 6, 'an assignment meta-op through a static lookup steps the variable';
+    is 2 R- 5, 3, 'a reverse meta-op through a static lookup applies the reversed operator';
+    "ab" ~~ /(a)$<x>=(b)/;
+    is $0, 'a', 'a positional capture variable through a static lookup reads the match';
+    is $<x>, 'b', 'a named capture variable through a static lookup reads the match';
+}
+{
+    sub rt-rand() { 7 }
+    is rand, 7, 'the rand term reaches a routine declared in the outermost scope of its block';
+    sub rand() { rt-rand() }
+}
+{
+    sub rt-mk($n) { my sub postcircumfix:<[ ]>(\a, \i) { $n }; my @a = 1; @a[0] }
+    is rt-mk(5), 5, 'a subscript reaches a nested routine on the first entry';
+    is rt-mk(6), 6, 'a subscript reaches the fresh clone of a nested routine on the next entry';
+}
+{
+    my &rand = sub { 1 };
+    my $first = rand;
+    &rand = sub { 2 };
+    is rand, 2, 'the rand term sees a routine variable rebound after an earlier use';
+}
+# An assignment into a subscript goes to the subscripted object's assign
+# method, which decides the assignment when the read would not yield a
+# container.
+{
+    class RtKeyed {
+        has %.s;
+        method AT-KEY($k) { %!s{$k} // 'none' }
+        method ASSIGN-KEY($k, $v) { %!s{$k} = "set-$v" }
+    }
+    my $c = RtKeyed.new;
+    my $k = 'a';
+    $c{$k} = 5;
+    is $c.s<a>, 'set-5', 'an assignment into a hash subscript reaches the assign method';
+    class RtIndexed {
+        has $.got;
+        method AT-POS(*@i) { 'none' }
+        method ASSIGN-POS(*@i) { $!got = @i.join(',') }
+    }
+    my $d = RtIndexed.new;
+    $d[0; 1] = 5;
+    is $d.got, '0,1,5', 'an assignment into a multi-dimensional subscript reaches the assign method';
+}
 
 # The fatalize pass recognizes a static callee lookup both as a call whose
 # Failure it promotes and as a boolifying consumer that disarms its argument.


### PR DESCRIPTION
Previously the static callee mark covered calls by name and infix, prefix, and postfix operators. A subscript, an array or hash composer, a term that names a routine, a list operator, a capture variable, a smartmatch, and the operator beneath an assignment, reverse, or sequence meta-op still compiled as a call by name. The VM resolves such a call through the frame chain on every evaluation, and inside a loop body the walk reaches the setting each iteration. A nested for loop in a sub ran 30% slower than under the legacy frontend because of it.

This marks those lookups for a static callee lookup at code generation when their lexical is bound once, under the rule the existing marks follow. The soft pragma withdraws the mark, and a routine declared after the use keeps the plain lookup. The subscript assignment rewrite accepts the static call, so an assignment into a subscript still reaches the assign method. A small loop over a subscript, rand, a list, and a composer went from 0.61s to 0.38s, past the legacy frontend's 0.42s.