### PR TITLE
RakuAST: pass the paired literal of a negated operator natively

### DIFF
--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -840,8 +840,6 @@ class RakuAST::Node {
                     if $routine-lookup;
                 self.IMPL-MARK-CONSTANT-TERM($resolver, $expr)
                     if $term-name;
-                self.IMPL-MARK-NEGATE-NOT($resolver, $expr)
-                    if $apply-infix;
                 self.IMPL-MARK-NATIVE-INDEX($resolver, $expr)
                     if $apply-postfix;
                 self.IMPL-MARK-RETURN-DECONT($resolver, $expr)
@@ -873,6 +871,8 @@ class RakuAST::Node {
             if $result =:= $expr
             && ($apply-infix || $apply-prefix || $apply-postfix || $call-name);
         self.IMPL-MARK-CHAIN-LINKS($resolver, $expr)
+            if $result =:= $expr && $apply-infix;
+        self.IMPL-MARK-NEGATE-NOT($resolver, $expr)
             if $result =:= $expr && $apply-infix;
 
         # A replacement stands where the original stood, so it must carry the
@@ -962,9 +962,6 @@ class RakuAST::Node {
             if nqp::istype($infix, RakuAST::MetaInfix::Assign) {
                 $infix.IMPL-SET-NATIVE-STEP(0);
                 $infix.IMPL-SET-INLINE(0);
-            }
-            elsif nqp::istype($infix, RakuAST::MetaInfix::Negate) {
-                $infix.IMPL-CLEAR-NEGATE-NOT();
             }
             $infix := $infix.infix while nqp::istype($infix, RakuAST::MetaInfix);
             if nqp::istype($infix, RakuAST::Infix) {
@@ -1475,19 +1472,26 @@ class RakuAST::Node {
         Nil
     }
 
-    # Mark a standalone negated comparison for compiling as the setting
-    # prefix ! around the plain comparison call, which is what the
-    # meta-op computes for two arguments. A link of a longer chain keeps
-    # the meta-op, since the chain protocol needs a callee, so the
-    # enclosing link withdraws the mark its operand took.
+    # Mark a negated operator for compiling as the setting prefix !
+    # around the plain operator call, which is what the meta-op computes
+    # for two arguments. An adverbed application keeps the meta-op,
+    # since the adverb is pushed onto the emitted call and would land on
+    # prefix ! instead of the operator. A link of a longer chain keeps
+    # it too, since the chain protocol needs a callee, and the enclosing
+    # link withdraws the mark its operand took. The mark sits outside
+    # the soft gate: the operator is still looked up at run time and the
+    # setting's prefix ! is the one the meta-op applies, so it pins
+    # nothing the meta-op does not.
     method IMPL-MARK-NEGATE-NOT(RakuAST::Resolver $resolver, Mu $expr) {
         return Nil unless nqp::istype($expr, RakuAST::ApplyInfix);
         my $infix := $expr.infix;
-        return Nil unless nqp::istype($infix, RakuAST::MetaInfix::Negate)
-            && $infix.properties.chain;
-        for [$expr.left, $expr.right] {
-            return Nil if nqp::istype($_, RakuAST::ApplyInfix)
-                && $_.infix.properties.chain;
+        return Nil unless nqp::istype($infix, RakuAST::MetaInfix::Negate);
+        return Nil if nqp::elems($expr.colonpairs);
+        if $infix.properties.chain {
+            for [$expr.left, $expr.right] {
+                return Nil if nqp::istype($_, RakuAST::ApplyInfix)
+                    && $_.infix.properties.chain;
+            }
         }
         my $not := $resolver.resolve-lexical-constant-in-setting('&prefix:<!>');
         nqp::isconcrete($not) && nqp::istype($not, RakuAST::CompileTimeValue)
@@ -1524,10 +1528,13 @@ class RakuAST::Node {
         return Nil unless nqp::istype($infix, RakuAST::Infixish)
             && $infix.properties.chain;
         for [$expr.left, $expr.right] {
-            $_.infix.IMPL-SET-LONE-LINK(0)
-                if nqp::istype($_, RakuAST::ApplyInfix)
-                && nqp::istype($_.infix, RakuAST::Infix)
-                && $_.infix.properties.chain;
+            if nqp::istype($_, RakuAST::ApplyInfix)
+                && nqp::istype($_.infix, RakuAST::Infixish)
+                && $_.infix.properties.chain {
+                my $base := $_.infix;
+                $base := $base.infix while nqp::istype($base, RakuAST::MetaInfix);
+                $base.IMPL-SET-LONE-LINK(0) if nqp::istype($base, RakuAST::Infix);
+            }
         }
         Nil
     }
@@ -3056,9 +3063,10 @@ class RakuAST::Node {
     # only after its operands were visited, so the enclosing chain
     # withdraws the smartmatch decision its operand links took. A chain
     # with no operand link is a chain of one link and takes the lone
-    # link mark. The marks sit outside the soft gate, since a lone
-    # link's call dispatches the operator as the chain op does, and
-    # pins nothing.
+    # link mark, on the operator beneath any meta-op layers, since a
+    # reverse or sequence meta-op emits the operator's own call. The
+    # marks sit outside the soft gate, since a lone link's call
+    # dispatches the operator as the chain op does, and pins nothing.
     method IMPL-MARK-CHAIN-LINKS(RakuAST::Resolver $resolver, Mu $expr) {
         return Nil unless nqp::istype($expr, RakuAST::ApplyInfix)
             && nqp::istype($expr.infix, RakuAST::Infixish)
@@ -3073,8 +3081,10 @@ class RakuAST::Node {
                     if nqp::istype($operand.infix, RakuAST::Infix);
             }
         }
-        $expr.infix.IMPL-SET-LONE-LINK($linked ?? 0 !! 1)
-            if nqp::istype($expr.infix, RakuAST::Infix);
+        my $base := $expr.infix;
+        $base := $base.infix while nqp::istype($base, RakuAST::MetaInfix);
+        $base.IMPL-SET-LONE-LINK($linked ?? 0 !! 1)
+            if nqp::istype($base, RakuAST::Infix);
         Nil
     }
 

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -211,13 +211,26 @@ class RakuAST::Infixish
     # Override on infixes whose call returns a lazy producer (needs p6sink).
     method IMPL-RESULT-NEEDS-ITERATION() { False }
 
+    # The literal operand of an application that is passed in its native
+    # form, or null when none is.
+    method IMPL-NATIVE-PAIRED-OPERAND(RakuAST::Expression $left, RakuAST::Expression $right, Mu :$adverb) {
+        nqp::null()
+    }
+
     # A node can implement this if it wishes to have full control of the
     # compilation of nodes. Most implement IMPL-INFIX-QAST, which gets the
     # QAST of the operands.
     method IMPL-INFIX-COMPILE(RakuAST::IMPL::QASTContext $context,
             RakuAST::Expression $left, RakuAST::Expression $right, RakuAST::ColonPairish :$adverb) {
-        my $qast := self.IMPL-INFIX-QAST: $context, $left.IMPL-TO-QAST($context),
-            $right.IMPL-TO-QAST($context);
+        my $native-literal := self.IMPL-NATIVE-PAIRED-OPERAND($left, $right, :$adverb);
+        my $qast := self.IMPL-INFIX-QAST:
+            $context,
+            nqp::eqaddr($left, $native-literal)
+                ?? $left.IMPL-TO-QAST-ARG($context)
+                !! $left.IMPL-TO-QAST($context),
+            nqp::eqaddr($right, $native-literal)
+                ?? $right.IMPL-TO-QAST-ARG($context)
+                !! $right.IMPL-TO-QAST($context);
         if $adverb {
             my $val-ast := $adverb.named-arg-value.IMPL-TO-QAST($context);
             $val-ast.named($adverb.named-arg-name);
@@ -481,6 +494,17 @@ class RakuAST::Infix
         nqp::bindattr(self, RakuAST::Infix, '$!juncmatch-junction', $junction);
     }
 
+    # A literal beside a native operand takes that form, so runtime
+    # dispatch reaches the candidate the analysis counts on. A
+    # short-circuit operator yields an operand rather than dispatching
+    # on the pair, and an adverb turns into a named argument the
+    # analysis declines, so both keep the boxed form.
+    method IMPL-NATIVE-PAIRED-OPERAND(RakuAST::Expression $left, RakuAST::Expression $right, Mu :$adverb) {
+        $adverb || self.short-circuit
+            ?? nqp::null()
+            !! self.IMPL-NATIVE-PAIRED-LITERAL-OF($left, $right)
+    }
+
     method IMPL-INFIX-COMPILE(RakuAST::IMPL::QASTContext $context,
             RakuAST::Expression $left, RakuAST::Expression $right, RakuAST::ColonPairish :$adverb) {
         # Hash value is negation flag
@@ -508,15 +532,7 @@ class RakuAST::Infix
             self.IMPL-SMARTMATCH-QAST($context, $left, $right, nqp::atkey(OP-SMARTMATCH, $op));
         }
         else {
-            # A literal operand beside a native one is passed in its native
-            # form, so runtime dispatch reaches the candidate the analysis
-            # counts on. A short-circuit operator yields an operand rather
-            # than dispatching on the pair, and an adverb turns into a named
-            # argument the analysis declines, so both keep the boxed form.
-            my $native-literal := NQPMu;
-            unless $adverb || self.short-circuit {
-                $native-literal := self.IMPL-NATIVE-PAIRED-LITERAL-OF($left, $right);
-            }
+            my $native-literal := self.IMPL-NATIVE-PAIRED-OPERAND($left, $right, :$adverb);
             my $qast := self.IMPL-INFIX-QAST:
                 $context,
                 $op eq '='
@@ -891,7 +907,7 @@ class RakuAST::Infix
                               Mu $right-qast
     ) {
         QAST::Op.new(
-            :op(self.properties.chain
+            :op(self.properties.chain && !$!lone-link
                 ?? ($!chainstatic ?? 'chainstatic' !! 'chain')
                 !! self.IMPL-CALL-OP),
             :name(self.resolution.lexical-name),
@@ -1510,6 +1526,18 @@ class RakuAST::MetaInfix
   is RakuAST::Infixish
   is RakuAST::CheckTime
 {
+    # Whether this meta-op calls the operator on its two operands as the
+    # plain application does, so the pairing rule of what it wraps
+    # applies. A meta-op that hands the operands on through a capture
+    # boxes them on the way.
+    method IMPL-CALLS-OPERATOR() { False }
+
+    method IMPL-NATIVE-PAIRED-OPERAND(RakuAST::Expression $left, RakuAST::Expression $right, Mu :$adverb) {
+        self.IMPL-CALLS-OPERATOR
+            ?? self.infix.IMPL-NATIVE-PAIRED-OPERAND($left, $right, :$adverb)
+            !! nqp::null()
+    }
+
     method IMPL-HOP-INFIX() {
         self.IMPL-UNWRAP-LIST(self.get-implicit-lookups())[0].resolution.compile-time-value()(
             self.infix.IMPL-HOP-INFIX
@@ -1895,12 +1923,11 @@ class RakuAST::MetaInfix::Negate
 {
     has RakuAST::Infixish $.infix;
 
-    # Set by the optimize pass on a standalone application: the negation
-    # compiles as the setting prefix ! around the plain comparison call,
-    # which is what the meta-op computes for two arguments, sparing its
-    # formation and invocation. Holds the resolved prefix ! routine. A
-    # link of a longer chain keeps the meta-op, since the chain protocol
-    # needs a callee.
+    # Set by the optimize pass on an application that stands alone and
+    # carries no adverb: the negation compiles as the setting prefix !
+    # around the plain operator call, which is what the meta-op computes
+    # for two arguments, sparing its formation and invocation. The flag
+    # and the resolved prefix ! routine.
     has int $!negate-not;
     has Mu $!negate-not-op;
 
@@ -1953,19 +1980,21 @@ class RakuAST::MetaInfix::Negate
         self.IMPL-UNWRAP-LIST(self.get-implicit-lookups)[0].resolution.compile-time-value
     }
 
+    method IMPL-CALLS-OPERATOR() { $!negate-not ?? True !! False }
+
     method IMPL-INFIX-QAST(RakuAST::IMPL::QASTContext $context, Mu $left-qast, Mu $right-qast) {
         # The negated operator's own lookup decides its reference
         # arguments. A meta-op standing in for it has no lookup.
         my int $own-lookup := nqp::istype($!infix, RakuAST::Infix);
         if $!negate-not {
             $context.ensure-sc($!negate-not-op);
-            my $call := QAST::Op.new(
-                :op('call'),
-                $!infix.IMPL-HOP-INFIX-QAST($context),
-                $left-qast,
-                $right-qast
-            );
-            $call := $!infix.IMPL-SIMPLIFY-REF-ARGS($call) if $own-lookup;
+            my $call := $own-lookup
+                ?? $!infix.IMPL-SIMPLIFY-REF-ARGS(QAST::Op.new(
+                    :op('call'),
+                    $!infix.IMPL-HOP-INFIX-QAST($context),
+                    $left-qast,
+                    $right-qast))
+                !! $!infix.IMPL-INFIX-FOR-META-QAST($context, $left-qast, $right-qast);
             return QAST::Op.new:
                 :op('call'),
                 QAST::WVal.new( :value($!negate-not-op) ),
@@ -2033,6 +2062,8 @@ class RakuAST::MetaInfix::Reverse
     method IMPL-OPERATOR() {
         self.IMPL-UNWRAP-LIST(self.get-implicit-lookups)[0].resolution.compile-time-value
     }
+
+    method IMPL-CALLS-OPERATOR() { True }
 
     method IMPL-INFIX-QAST(RakuAST::IMPL::QASTContext $context, Mu $left-qast, Mu $right-qast) {
         $!infix.IMPL-INFIX-FOR-META-QAST($context, $right-qast, $left-qast)
@@ -2104,6 +2135,8 @@ class RakuAST::MetaInfix::Sequence
     method IMPL-HOP-INFIX() {
         self.infix.IMPL-HOP-INFIX
     }
+
+    method IMPL-CALLS-OPERATOR() { True }
 
     method IMPL-INFIX-QAST(RakuAST::IMPL::QASTContext $context, Mu $left-qast, Mu $right-qast) {
         $!infix.IMPL-INFIX-FOR-META-QAST($context, $left-qast, $right-qast)
@@ -2640,14 +2673,16 @@ class RakuAST::ApplyInfix
         my $left  := self.left;
         my $right := self.right;
 
+        # A meta-op that keeps the operator's properties declines the
+        # adverb as the plain application does.
+        my $base := $infix;
+        $base := $base.infix while nqp::istype($base, RakuAST::MetaInfix);
         if nqp::elems(self.colonpairs)
-          && nqp::istype($infix, RakuAST::Infix)
-          && ($infix.short-circuit
-                || nqp::chars($infix.properties.thunky)
-                || $infix.properties.chain) {
+          && nqp::istype($base, RakuAST::Infix)
+          && (nqp::chars($infix.properties.thunky) || $infix.properties.chain) {
             self.add-sorry:
               $resolver.build-exception: 'X::Syntax::Adverb',
-                what => '&infix' ~ RakuAST::Resolver.IMPL-CANONICALIZE-PAIR($infix.operator);
+                what => '&infix' ~ RakuAST::Resolver.IMPL-CANONICALIZE-PAIR($base.operator);
         }
 
         my constant WORRISOME-RANGE := nqp::hash(

--- a/t/02-rakudo/adverb-on-noncall-infix.t
+++ b/t/02-rakudo/adverb-on-noncall-infix.t
@@ -1,6 +1,9 @@
 use Test;
+use nqp;
 
-plan 5;
+plan 9;
+
+my $rakuast := nqp::gethllsym('Raku', 'COMPILER-FRONTEND') eq 'rakuast';
 
 # An adverb is tighter than most infixes, so in `EXPR OP term:adverb` it can bind
 # to OP rather than to the term. A short-circuit, thunky, or chaining operator
@@ -14,6 +17,22 @@ throws-like 'my %h; 1 == %h<a>:exists', X::Syntax::Adverb,
     "can't adverb a chaining infix";
 throws-like 'my %h; True ^^ %h<a>:exists', X::Syntax::Adverb,
     "can't adverb a thunky list infix";
+
+# A meta-op that keeps the operator's properties declines the adverb
+# the same way.
+throws-like 'my %h; 1 !== %h<a>:exists', X::Syntax::Adverb,
+    "can't adverb a negated chaining infix";
+if $rakuast {
+    throws-like 'my %h; 1 R== %h<a>:exists', X::Syntax::Adverb,
+        "can't adverb a reversed chaining infix";
+    throws-like 'my %h; True R&& %h<a>:exists', X::Syntax::Adverb,
+        "can't adverb a reversed short-circuit infix";
+    throws-like 'my %h; True !&& %h<a>:exists', X::Syntax::Adverb,
+        "can't adverb a negated short-circuit infix";
+}
+else {
+    skip 'the legacy frontend drops the adverb of these meta-ops', 3;
+}
 
 # The adverb still reaches the subscript when it binds there.
 my %h = a => 1;

--- a/t/02-rakudo/native-literal-dispatch.t
+++ b/t/02-rakudo/native-literal-dispatch.t
@@ -1,6 +1,9 @@
 use Test;
+use nqp;
 
-plan 24;
+plan 46;
+
+my $rakuast := nqp::gethllsym('Raku', 'COMPILER-FRONTEND') eq 'rakuast';
 
 # A literal carries no declared type, so its representation comes from its
 # context: beside an operand or argument whose type is a native kind the
@@ -134,6 +137,130 @@ my int $i = 3;
     multi pick-i(int $a, Int $b) { "Int" }
     my $f = &pick-i;
     is $f($i, 1), "int", 'an indirect call passes a paired literal natively';
+}
+
+# A negated operator dispatches on the operands the plain application
+# passes, so a literal beside a native operand reaches the native
+# candidate there too.
+{
+    my $picked;
+    multi sub infix:<%%>(int $a, int $b) is default { $picked = "int"; True }
+    multi sub infix:<%%>(int $a, Int $b) { $picked = "Int"; True }
+    multi sub infix:<%%>(Int $a, int $b) { $picked = "Int"; True }
+    my $r = $i !%% 1;
+    is $picked, "int", 'a negated operator passes a paired literal natively';
+    is $r, False, 'a negated operator negates the answer of the candidate the literal reached';
+    $picked = "none";
+    my $l = 1 !%% $i;
+    is $picked, "int", 'a negated operator passes a paired literal on the left natively';
+}
+{
+    my int $n = 1;
+    my $r = $n !< 5;
+    is $r, True, 'a negated comparison reaches a candidate declared after it';
+    is $n, 43, 'the rw candidate a negated comparison reaches writes its native operand';
+    multi sub infix:«<»(int $a is rw, int $b) { $a = 43; False }
+}
+{
+    my $rev;
+    multi sub infix:<+>(int $a, int $b) is default { $rev = "int"; 0 }
+    multi sub infix:<+>(int $a, Int $b) { $rev = "Int"; 0 }
+    multi sub infix:<+>(Int $a, int $b) { $rev = "Int"; 0 }
+    my $s = 1 R+ $i;
+    is $rev, "int", 'a reversed operator passes a paired literal natively';
+    $rev = "none";
+    my $t = $i R+ 1;
+    is $rev, "int", 'a reversed operator passes a paired literal on the right natively';
+}
+if $rakuast {
+    my $seq;
+    multi sub infix:<%%>(int $a, int $b) is default { $seq = "int"; True }
+    multi sub infix:<%%>(int $a, Int $b) { $seq = "Int"; True }
+    my $r = $i S%% 1;
+    is $seq, "int", 'a sequenced operator passes a paired literal natively';
+}
+else {
+    skip 'the sequenced operator does not run under the legacy frontend', 1;
+}
+if $rakuast {
+    my $picked;
+    multi sub infix:<eq>(int $a, int $b) { $picked = "int"; True }
+    multi sub infix:<eq>(int $a, Int $b) { $picked = "Int"; True }
+    my $r = $i !eq 1;
+    is $picked, "int", 'a negated comparison passes a paired literal natively';
+    my $left;
+    multi sub infix:<ne>(int $a, int $b) { $left = "int"; True }
+    multi sub infix:<ne>(Int $a, int $b) { $left = "Int"; True }
+    my $t = 1 !ne $i;
+    is $left, "int", 'a negated comparison passes a paired literal on the left natively';
+    is $t, False, 'a negated comparison negates the answer of the candidate the literal reached';
+}
+else {
+    skip 'the legacy frontend boxes the literal of a negated comparison', 3;
+}
+
+# A reversed or sequenced comparison standing alone dispatches on the
+# pair as the plain comparison does. A link of a longer chain takes part
+# in the chain protocol instead.
+{
+    my $picked;
+    multi sub infix:«<»(int $a, int $b) is default { $picked = "int"; True }
+    multi sub infix:«<»(int $a, Int $b) { $picked = "Int"; True }
+    multi sub infix:«<»(Int $a, int $b) { $picked = "Int"; True }
+    my $r = 5 R< $i;
+    is $picked, "int", 'a reversed comparison passes a paired literal natively';
+    if $rakuast {
+        $picked = "none";
+        my $s = $i S< 5;
+        is $picked, "int", 'a sequenced comparison passes a paired literal natively';
+        nok 3 S< 4 S< 2, 'a chain of sequenced comparisons fails through its second link';
+    }
+    else {
+        skip 'the sequenced operator does not run under the legacy frontend', 2;
+    }
+}
+
+# The soft pragma keeps routines wrappable and changes no dispatch.
+{
+    use soft;
+    my $picked;
+    multi sub infix:<%%>(int $a, int $b) is default { $picked = "int"; True }
+    multi sub infix:<%%>(int $a, Int $b) { $picked = "Int"; True }
+    my $r = $i !%% 1;
+    is $picked, "int", 'a negated operator under the soft pragma passes a paired literal natively';
+}
+
+# A negated operator still carries its adverb, which keeps the meta-op
+# and so the boxed form of its operands, and keeps the operator's own
+# evaluation of its operands.
+if $rakuast {
+    my $seen;
+    multi sub infix:<%%>($a, $b, :$flag) { $seen = $flag; True }
+    my $r = 4 !%% 2 :flag;
+    is $r, False, 'a negated operator with an adverb negates the answer';
+    is $seen, True, 'a negated operator with an adverb passes the adverb on';
+}
+else {
+    skip 'the legacy frontend drops the adverb of a negated operator', 2;
+}
+if $rakuast {
+    my $form;
+    multi sub infix:<%%>(int $a, int $b, :$flag) { $form = "int"; True }
+    multi sub infix:<%%>(Int $a, Int $b, :$flag) { $form = "Int"; True }
+    my $b = $i !%% 1 :flag;
+    is $form, "Int", 'a negated operator with an adverb keeps the boxed form of its operands';
+}
+else {
+    skip 'the legacy frontend drops the adverb of a negated operator', 1;
+}
+{
+    my $ran = 0;
+    my $t = 0 !&& ($ran = 1);
+    is $t, True, 'a negated short-circuit operator negates the answer';
+    is $ran, 0, 'a negated short-circuit operator does not evaluate the operand the operator skips';
+    my $u = 1 !&& ($ran = 2);
+    is $u, False, 'a negated short-circuit operator negates the operand the operator yields';
+    is $ran, 2, 'a negated short-circuit operator evaluates the operand the operator reaches';
 }
 
 # vim: expandtab shiftwidth=4

--- a/t/08-performance/28-rakuast-metaop-hoist.t
+++ b/t/08-performance/28-rakuast-metaop-hoist.t
@@ -4,7 +4,7 @@ use Test::Helpers::QAST;
 use Test;
 use QAST:from<NQP>;
 use nqp;
-plan 72;
+plan 76;
 
 # A meta-op over a setting operator whose name no later declaration
 # shadows is formed once at compile time and emitted as a constant,
@@ -25,6 +25,21 @@ sub qast-wval-callee (Mu $qast --> Bool:D) {
     if qast-descendable $qast {
         for $qast.list {
             qast-wval-callee $_ and return True;
+        }
+    }
+    False
+}
+
+sub qast-calls-not (Mu $qast --> Bool:D) {
+    if nqp::istype($qast, QAST::Op) && $qast.op eq 'call' {
+        for $qast.list {
+            return True if nqp::istype($_, QAST::WVal) && $_.value =:= &prefix:<!>;
+            last;
+        }
+    }
+    if qast-descendable $qast {
+        for $qast.list {
+            qast-calls-not $_ and return True;
         }
     }
     False
@@ -88,19 +103,41 @@ if nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' {
 
     # A standalone negated comparison compiles as the setting prefix !
     # around the plain comparison, so no chain op remains, while a link
-    # of a longer chain keeps the chain protocol.
+    # of a longer chain keeps the chain protocol. The soft pragma keeps
+    # the operator lookup at run time and nothing else, so the prefix !
+    # form stays.
     qast-is 'my $x = 1; my $y = 2; say $x !== $y', :full, -> \v {
-        not qast-contains-op(v, 'chain')
+        qast-calls-not(v) and not qast-contains-op(v, 'chain')
     }, 'a standalone negated comparison compiles without a chain op';
 
     qast-is 'my ($a,$b,$c) = 1,2,3; say $a !== $b !== $c', :full, -> \v {
         qast-contains-op(v, 'chain')
+        and not qast-calls-not(v)
         and not qast-contains-call(v, '&METAOP_NEGATE')
     }, 'a chained negated comparison keeps its chain over constant meta-ops';
 
     qast-is 'use soft; my $x = 1; my $y = 2; say $x !== $y', :full, -> \v {
-        qast-contains-op(v, 'chain')
-    }, 'a negated comparison under the soft pragma keeps its meta-op';
+        qast-calls-not(v) and not qast-contains-op(v, 'chain')
+    }, 'a negated comparison under the soft pragma compiles without a chain op';
+
+    # A negated operator that does not chain compiles the same way.
+    qast-is 'my int $i = 3; my $r = $i !%% 1', :full, -> \v {
+        qast-calls-not(v)
+    }, 'a standalone negated operator that does not chain compiles without its meta-op';
+    qast-is 'use soft; my int $i = 3; my $r = $i !%% 1', :full, -> \v {
+        qast-calls-not(v) and not qast-contains-call(v, '&METAOP_NEGATE')
+    }, 'a negated operator that does not chain compiles without its meta-op under the soft pragma';
+
+    # A reversed comparison standing alone compiles as the plain call
+    # the comparison does, while a link of a longer chain keeps the chain
+    # protocol.
+    qast-is 'my int $i = 3; my $r = 5 R< $i', :full, -> \v {
+        not qast-contains-op(v, 'chain')
+        and not qast-contains-op(v, 'chainstatic')
+    }, 'a standalone reversed comparison compiles without a chain op';
+    qast-is 'my $r = 3 R< 2 R< 1', :full, -> \v {
+        qast-contains-op(v, 'chain') or qast-contains-op(v, 'chainstatic')
+    }, 'a chained reversed comparison keeps its chain';
 
     # A user operator declared after the use shadows the setting's, so
     # the meta-op forms at run time and finds the user's routine.
@@ -127,7 +164,7 @@ if nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' {
     }, 'a reduce under the soft pragma forms its meta-op at run time';
 }
 else {
-    skip 'the formation shapes are specific to the RakuAST frontend', 17;
+    skip 'the formation shapes are specific to the RakuAST frontend', 21;
 }
 
 # A user operator declared after the use is the one every meta-op runs.


### PR DESCRIPTION
Previously a negated operator compiled its operands in their plain form, so a literal beside a native operand reached the operator boxed. The plain application of the same operator passes such a literal in its native form. The two forms of one comparison could reach different candidates as a result. With `my int $i`, `$i !< 5` picked the setting's candidate over a later `multi sub infix:«<»(int $a is rw, int $b)` that `$i < 5` reached. The reverse and sequence meta-ops boxed the literal the same way, so `1 R+ $i` promoted to a big integer at the native boundary where `$i + 1` wraps, as it does under the legacy frontend. A reversed or sequenced comparison standing alone also compiled as a chain op, which boxes its operands for the chain protocol, where the plain comparison compiles as a call.

This applies the operator's own pairing rule to a meta-op that calls the operator on the pair, through any such meta-op beneath it, so the application dispatches on the operands the plain one passes. The lone link mark goes to the operator beneath the meta-op layers and the emission a meta-op makes honours it, so a reversed or sequenced comparison standing alone compiles as a call too. A negated operator that does not chain now compiles as the setting prefix ! around the plain call as well, as a negated comparison already did, instead of forming the meta-op, whose capture boxes the literal. The mark sits outside the soft gate: the operator is still looked up at run time and the setting's prefix ! is the one the meta-op applies, so the pragma changes no dispatch. An adverbed application keeps the meta-op, which passes the adverb on, and a meta-op that keeps the operator's properties declines the adverb as the plain application does, so `4 !== 2 :flag` is rejected as `4 == 2 :flag` is.