### PR TITLE
RakuAST: reduce a reversed operator with reversed associativity

### DIFF
--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -2018,7 +2018,7 @@ class RakuAST::MetaInfix::Reverse
 
     method action { 'reverse the args of' }
 
-    method reducer-name() { '&METAOP_REDUCE_LEFT' }
+    method reducer-name() { self.properties.reducer-name }
 
     method visit-children(Code $visitor) {
         $visitor($!infix);

--- a/t/12-rakuast/meta-operators.rakutest
+++ b/t/12-rakuast/meta-operators.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 14;
+plan 18;
 
 my $ast;
 my $deparsed;
@@ -283,6 +283,79 @@ subtest 'Triangle reduce meta-op on left associative operator' => {
 
     is-deeply $deparsed, '[\+] 1, 2, 3', 'deparse';
     is-deeply $_, (1,3,6), @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'Reduce meta-op on reversed left associative operator' => {
+    # [R-] 1, 2, 3
+    ast RakuAST::Term::Reduce.new(
+      infix => RakuAST::MetaInfix::Reverse.new(
+        RakuAST::Infix.new('-')
+      ),
+      args => RakuAST::ArgList.new(
+        RakuAST::IntLiteral.new(1),
+        RakuAST::IntLiteral.new(2),
+        RakuAST::IntLiteral.new(3)
+      )
+    );
+
+    is-deeply $deparsed, '[R-] 1, 2, 3', 'deparse';
+    is-deeply $_, 0, @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'Reduce meta-op on reversed right associative operator' => {
+    # [R**] 2, 3, 4
+    ast RakuAST::Term::Reduce.new(
+      infix => RakuAST::MetaInfix::Reverse.new(
+        RakuAST::Infix.new('**')
+      ),
+      args => RakuAST::ArgList.new(
+        RakuAST::IntLiteral.new(2),
+        RakuAST::IntLiteral.new(3),
+        RakuAST::IntLiteral.new(4)
+      )
+    );
+
+    is-deeply $deparsed, '[R**] 2, 3, 4', 'deparse';
+    is-deeply $_, 262144, @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'Reduce meta-op on reversed list associative operator' => {
+    # [R,] 1, 2, 3
+    ast RakuAST::Term::Reduce.new(
+      infix => RakuAST::MetaInfix::Reverse.new(
+        RakuAST::Infix.new(',')
+      ),
+      args => RakuAST::ArgList.new(
+        RakuAST::IntLiteral.new(1),
+        RakuAST::IntLiteral.new(2),
+        RakuAST::IntLiteral.new(3)
+      )
+    );
+
+    is-deeply $deparsed, '[R,] 1, 2, 3', 'deparse';
+    is-deeply $_, (3,2,1), @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'Triangle reduce meta-op on reversed left associative operator' => {
+    # [\R-] 1, 2, 3
+    ast RakuAST::Term::Reduce.new(
+      infix => RakuAST::MetaInfix::Reverse.new(
+        RakuAST::Infix.new('-')
+      ),
+      args => RakuAST::ArgList.new(
+        RakuAST::IntLiteral.new(1),
+        RakuAST::IntLiteral.new(2),
+        RakuAST::IntLiteral.new(3)
+      ),
+      triangle => True
+    );
+
+    is-deeply $deparsed, '[\R-] 1, 2, 3', 'deparse';
+    is-deeply $_, (3,1,0), @type[$++]
       for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
 }
 

--- a/t/12-rakuast/xx-fixed-in-rakuast.rakutest
+++ b/t/12-rakuast/xx-fixed-in-rakuast.rakutest
@@ -588,8 +588,7 @@ subtest 'use of &?ROUTINE and &?BLOCK' => {
     is-deeply ([foo]  1, 2, 3, 4), "(1,(2,(3,4)))", 'foo';
     is-deeply ([Rfoo] 1, 2, 3, 4), "(4,(3,(2,1)))", 'Rfoo';
     is-deeply ([bar]  1, 2, 3, 4), "(((1,2),3),4)", 'bar';
-    todo "gets associativity wrong" unless %*ENV<RAKUDO_RAKUAST>;
-    is-deeply ([Rbar] 1, 2, 3, 4), "(4,(3,(2,1)))", 'Rbar';
+    is-deeply ([Rbar] 1, 2, 3, 4), "(((4,3),2),1)", 'Rbar';
 }
 
 # https://github.com/rakudo/rakudo/issues/4797


### PR DESCRIPTION
Reversing an operator reverses its associativity, so a reduce of it folds the other way. Previously a reduce of any reversed operator folded left, which made [R-] 1, 2, 3 produce 2 instead of 0.

This takes the reducer from the reversed operator properties the node already computes, the way the cross and zip meta-operators take theirs. A left associative base operator now reduces right, a right associative one reduces left, and a list associative, chaining or list infix one keeps its own reducer.

[Rbar] on a left associative bar reduces right, so the value expected for it in the fixed-in-rakuast tests was the left folded one and is corrected here.