### PR TITLE
Sort, slip and split without work the answer does not need

### DIFF
--- a/src/core.c/Rakudo/SlippyIterator.rakumod
+++ b/src/core.c/Rakudo/SlippyIterator.rakumod
@@ -4,11 +4,17 @@
 my role Rakudo::SlippyIterator does Iterator is implementation-detail {
     has Mu $!slipper;  # iterator of the Slip we're iterating, null if none
 
+    # Every multi here takes the Slip raw and decontainerizes it in the
+    # body.  Bound to a `$` parameter, a Slip that arrived as a map or
+    # grep block's result reaches slip-all inside a container, and the
+    # nqp::eqaddr that recognizes Empty compares that container instead.
+
     proto method start-slip(|) {*}
-    multi method start-slip(Slip:U $slip) {
-        $slip
+    multi method start-slip(Slip:U \slip) {
+        nqp::decont(slip)
     }
-    multi method start-slip(Slip:D $slip) {
+    multi method start-slip(Slip:D \slip) {
+        my $slip := nqp::decont(slip);
         nqp::if(
           nqp::eqaddr($slip,Empty),
           IterationEnd,                  # we know there's nothing
@@ -74,10 +80,11 @@ my role Rakudo::SlippyIterator does Iterator is implementation-detail {
     }
 
     proto method slip-all(|) {*}
-    multi method slip-all(Slip:U $slip, \target) {
-        target.push($slip)
+    multi method slip-all(Slip:U \slip, \target) {
+        target.push(nqp::decont(slip))
     }
-    multi method slip-all(Slip:D $slip, \target) {
+    multi method slip-all(Slip:D \slip, \target) {
+        my $slip := nqp::decont(slip);
         nqp::unless(
           nqp::eqaddr($slip,Empty),
           $slip.iterator.push-all(target)

--- a/src/core.c/Rakudo/Sorting.rakumod
+++ b/src/core.c/Rakudo/Sorting.rakumod
@@ -1,13 +1,36 @@
 my class Rakudo::Sorting is implementation-detail {
 
+    # Classifying costs a walk before a single comparison is made, which a
+    # shorter list does not do enough comparisons to repay.  Sorting
+    # elements and sorting by an extracted key cross over alike here.
+    my constant SORT-CLASSIFY-FROM = 16;
+
+    # helper sub to report whether reading a slot runs no code of its own,
+    # which is true of a plain value and of a Scalar, and not of a
+    # container that answers with a FETCH, such as a Proxy.  The slot is
+    # taken as Mu so that binding it does not read it either.
+    sub slot-reads-the-same(Mu \slot) {
+        nqp::not_i(nqp::iscont(slot))
+          || nqp::eqaddr(nqp::what_nd(slot),Scalar)
+    }
+
     # https://en.wikipedia.org/wiki/Merge_sort#Bottom-up_implementation
     # The parameter is the HLL List to be sorted *in place* using simple cmp.
     method MERGESORT-REIFIED-LIST(\list) {
+        # $A has the items to sort; $B is a work array
+        my $A := nqp::getattr(list,List,'$!reified');
+        my int $n = nqp::elems($A);
+
+        my int $kind = nqp::isge_i($n,SORT-CLASSIFY-FROM)
+          ?? self!SORT-ELEMENT-KIND(list)
+          !! 0;
+        return self!MERGESORT-REIFIED-LIST-Int(list)
+          if nqp::iseq_i($kind,1);
+        return self!MERGESORT-REIFIED-LIST-Str(list)
+          if nqp::iseq_i($kind,2);
+
         nqp::if(
-          nqp::isgt_i((my int $n = nqp::elems(
-            # $A has the items to sort; $B is a work array
-            my $A := nqp::getattr(list,List,'$!reified')
-          )),2),
+          nqp::isgt_i($n,2),
           nqp::stmts(     # we actually need to sort
             (my $B := nqp::setelems(nqp::create(IterationBuffer),$n)),
 
@@ -83,6 +106,196 @@ my class Rakudo::Sorting is implementation-detail {
               Order::More
             ),
             nqp::push($A,nqp::shift($A))  # wrong order, so swap
+          )
+        );
+
+        nqp::p6bindattrinvres(list,List,'$!reified',$A)
+    }
+
+    # Report which specialized merge, if any, may sort the given HLL List:
+    # 1 for a list of Int, 2 for a list of Str, 0 for anything else.  Every
+    # element has to be concrete and of exactly that type: an Allomorph
+    # carries both a numeric and a string value and picks the infix:<cmp>
+    # candidate that breaks a numeric tie on the string, where nqp::cmp_I
+    # calls the pair equal, so it would sort differently rather than
+    # complain.
+    method !SORT-ELEMENT-KIND(\list) {
+        # The reified buffer is fetched here rather than passed in.  A list
+        # built from a literal reifies into a bare VM array rather than an
+        # IterationBuffer, and a bare VM array handed to a method call
+        # arrives HLLized into a List, which nqp::elems cannot count.
+        my $A := nqp::getattr(list,List,'$!reified');
+        my int $n = nqp::elems($A);
+        my int $kind = 0;
+
+        # The first slot only says which type to expect.  Every element,
+        # that one included, is then checked by the loop.
+        nqp::if(
+          nqp::isgt_i($n,2)
+            && nqp::isgt_i(
+                 ($kind = nqp::eqaddr(
+                   (my $wanted := slot-reads-the-same(
+                     my $slot := nqp::ifnull(nqp::atpos($A,0),Mu)
+                   ) ?? nqp::what($slot) !! Mu),Int)
+                   ?? 1
+                   !! nqp::eqaddr($wanted,Str) ?? 2 !! 0),
+                 0
+               ),
+          nqp::stmts(
+            (my int $i = -1),
+            nqp::while(
+              nqp::islt_i(++$i,$n)
+                && slot-reads-the-same(
+                     $slot := nqp::ifnull(nqp::atpos($A,$i),Mu)
+                   )
+                && nqp::isconcrete(my $value := nqp::decont($slot))
+                && nqp::eqaddr(nqp::what($value),$wanted),
+              nqp::null
+            ),
+            nqp::unless(nqp::iseq_i($i,$n),($kind = 0))
+          )
+        );
+
+        $kind
+    }
+
+    # Takes the HLL List to be sorted *in place*, every element of which is
+    # exactly an Int, so cmp reduces to nqp::cmp_I on the two values, which
+    # a Scalar element is decontainerized for.  The left run always sits
+    # entirely before the right, so taking the left of an equal pair is
+    # what the general merge's explicit tie-break amounts to.
+    method !MERGESORT-REIFIED-LIST-Int(\list) {
+        # $A has the items to sort; $B is a work array
+        my $A := nqp::getattr(list,List,'$!reified');
+        my int $n = nqp::elems($A);
+        my $B := nqp::setelems(nqp::create(IterationBuffer),$n);
+
+        # Each 1-element run in $A is already "sorted"
+        # Make successively longer sorted runs of length 2, 4, 8, 16...
+        # until $A is wholly sorted
+        my int $width = 1;
+        nqp::while(
+          nqp::islt_i($width,$n),
+          nqp::stmts(
+            (my int $l = 0),
+
+            # $A is full of runs of length $width
+            nqp::while(
+              nqp::islt_i($l,$n),
+
+              nqp::stmts(
+                (my int $left  = $l),
+                (my int $right = nqp::add_i($l,$width)),
+                nqp::if(nqp::isge_i($right,$n),($right = $n)),
+                (my int $end = nqp::add_i($l,nqp::add_i($width,$width))),
+                nqp::if(nqp::isge_i($end,$n),($end = $n)),
+
+                (my int $i = $left),
+                (my int $j = $right),
+                (my int $k = nqp::sub_i($left,1)),
+
+                # Merge two runs: $A[i       .. i+width-1] and
+                #                 $A[i+width .. i+2*width-1]
+                # to $B or copy $A[i..n-1] to $B[] ( if(i+width >= n) )
+                nqp::while(
+                  nqp::islt_i(++$k,$end),
+                  nqp::if(
+                    nqp::islt_i($i,$right) && (
+                      nqp::isge_i($j,$end)
+                        || nqp::isle_i(nqp::cmp_I(
+                             nqp::decont(nqp::atpos($A,$i)),
+                             nqp::decont(nqp::atpos($A,$j))
+                           ),0)
+                    ),
+                    nqp::stmts(
+                      (nqp::bindpos($B,$k,nqp::atpos($A,$i))),
+                      ++$i
+                    ),
+                    nqp::stmts(
+                      (nqp::bindpos($B,$k,nqp::atpos($A,$j))),
+                      ++$j
+                    )
+                  )
+                ),
+                ($l = nqp::add_i($l,nqp::add_i($width,$width)))
+              )
+            ),
+
+            # Now work array $B is full of runs of length 2*width.
+            (my $temp := $B),($B := $A),($A := $temp),   # swap
+            # Now array $A is full of runs of length 2*width.
+
+            ($width = nqp::add_i($width,$width))
+          )
+        );
+
+        nqp::p6bindattrinvres(list,List,'$!reified',$A)
+    }
+
+    # As MERGESORT-REIFIED-LIST-Int, for a list of exactly Str, where cmp
+    # reduces to nqp::cmp_s on the unboxed strings.
+    method !MERGESORT-REIFIED-LIST-Str(\list) {
+        # $A has the items to sort; $B is a work array
+        my $A := nqp::getattr(list,List,'$!reified');
+        my int $n = nqp::elems($A);
+        my $B := nqp::setelems(nqp::create(IterationBuffer),$n);
+
+        # Each 1-element run in $A is already "sorted"
+        # Make successively longer sorted runs of length 2, 4, 8, 16...
+        # until $A is wholly sorted
+        my int $width = 1;
+        nqp::while(
+          nqp::islt_i($width,$n),
+          nqp::stmts(
+            (my int $l = 0),
+
+            # $A is full of runs of length $width
+            nqp::while(
+              nqp::islt_i($l,$n),
+
+              nqp::stmts(
+                (my int $left  = $l),
+                (my int $right = nqp::add_i($l,$width)),
+                nqp::if(nqp::isge_i($right,$n),($right = $n)),
+                (my int $end = nqp::add_i($l,nqp::add_i($width,$width))),
+                nqp::if(nqp::isge_i($end,$n),($end = $n)),
+
+                (my int $i = $left),
+                (my int $j = $right),
+                (my int $k = nqp::sub_i($left,1)),
+
+                # Merge two runs: $A[i       .. i+width-1] and
+                #                 $A[i+width .. i+2*width-1]
+                # to $B or copy $A[i..n-1] to $B[] ( if(i+width >= n) )
+                nqp::while(
+                  nqp::islt_i(++$k,$end),
+                  nqp::if(
+                    nqp::islt_i($i,$right) && (
+                      nqp::isge_i($j,$end)
+                        || nqp::isle_i(nqp::cmp_s(
+                             nqp::unbox_s(nqp::decont(nqp::atpos($A,$i))),
+                             nqp::unbox_s(nqp::decont(nqp::atpos($A,$j)))
+                           ),0)
+                    ),
+                    nqp::stmts(
+                      (nqp::bindpos($B,$k,nqp::atpos($A,$i))),
+                      ++$i
+                    ),
+                    nqp::stmts(
+                      (nqp::bindpos($B,$k,nqp::atpos($A,$j))),
+                      ++$j
+                    )
+                  )
+                ),
+                ($l = nqp::add_i($l,nqp::add_i($width,$width)))
+              )
+            ),
+
+            # Now work array $B is full of runs of length 2*width.
+            (my $temp := $B),($B := $A),($A := $temp),   # swap
+            # Now array $A is full of runs of length 2*width.
+
+            ($width = nqp::add_i($width,$width))
           )
         );
 
@@ -311,11 +524,42 @@ my class Rakudo::Sorting is implementation-detail {
             (my $A := nqp::setelems(nqp::list_i,$n)),       # indexes to sort
             (my $B := nqp::setelems(nqp::list_i,$n)),       # work array
             (my int $s = -1),
+            # $kind reports the one type every key came out as, as
+            # !SORT-ELEMENT-KIND reports it for elements, and stays -1
+            # until the first key is seen.  A key inside a container does
+            # not qualify at all, whatever it holds: the mapper runs over
+            # the whole list before any comparison, so a later call to it
+            # can still change a key already classified.
+            (my int $kind = nqp::isge_i($n,SORT-CLASSIFY-FROM) ?? -1 !! 0),
             nqp::while(  # set up the Schwartz and the initial indexes
               nqp::islt_i(($s = nqp::add_i($s,1)),$n),
-              nqp::bindpos($S,nqp::bindpos_i($A,$s,$s),
-                mapper(nqp::atpos($O,$s)))
+              nqp::stmts(
+                nqp::bindpos($S,nqp::bindpos_i($A,$s,$s),
+                  (my $key := mapper(nqp::atpos($O,$s)))),
+                nqp::unless(
+                  nqp::iseq_i($kind,0),
+                  nqp::stmts(
+                    (my $keytype := nqp::isconcrete_nd($key)
+                      ?? nqp::what_nd($key)
+                      !! Mu),
+                    (my int $this = nqp::eqaddr($keytype,Int)
+                      ?? 1
+                      !! nqp::eqaddr($keytype,Str) ?? 2 !! 0),
+                    nqp::if(
+                      nqp::iseq_i($kind,-1),
+                      ($kind = $this),
+                      nqp::unless(nqp::iseq_i($kind,$this),($kind = 0))
+                    )
+                  )
+                )
+              )
             ),
+            nqp::if(
+              nqp::isgt_i($kind,0),
+              nqp::iseq_i($kind,1)
+                ?? self!MERGESORT-AS-Int(list,$S,$indices)
+                !! self!MERGESORT-AS-Str(list,$S,$indices),
+              nqp::stmts(
 
             # Each 1-element run in $A is already "sorted"
             # Make successively longer sorted runs of length 2, 4, 8, 16...
@@ -395,6 +639,8 @@ my class Rakudo::Sorting is implementation-detail {
               )
             ),
             nqp::bindattr(list,List,'$!reified',$S)
+              )
+            )
           ),
 
           # N <= 2
@@ -417,6 +663,186 @@ my class Rakudo::Sorting is implementation-detail {
 
         list   # we did changes in place
     }
+    # Sorts the index array against a Schwartz of Int keys, where cmp reduces to nqp::cmp_I. The left run always
+    # sits entirely before the right, so taking the left of an equal pair is
+    # what the general merge's explicit tie-break amounts to and leaves the
+    # result, or the indices that produced it, in that same buffer.
+    method !MERGESORT-AS-Int(\list, \S, $indices) {
+        my $O := nqp::getattr(list,List,'$!reified');   # Original
+        my int $n = nqp::elems(S);
+        my $A := nqp::setelems(nqp::list_i,$n);         # indexes to sort
+        my $B := nqp::setelems(nqp::list_i,$n);         # work array
+        my int $s = -1;
+        nqp::while(
+          nqp::islt_i(($s = nqp::add_i($s,1)),$n),
+          nqp::bindpos_i($A,$s,$s)
+        );
+
+        # Each 1-element run in $A is already "sorted"
+        # Make successively longer sorted runs of length 2, 4, 8, 16...
+        # until $A is wholly sorted
+        my int $width = 1;
+        nqp::while(
+          nqp::islt_i($width,$n),
+          nqp::stmts(
+            (my int $l = 0),
+
+            # $A is full of runs of length $width
+            nqp::while(
+              nqp::islt_i($l,$n),
+
+              nqp::stmts(
+                (my int $left  = $l),
+                (my int $right = nqp::add_i($l,$width)),
+                nqp::if(nqp::isge_i($right,$n),($right = $n)),
+                (my int $end = nqp::add_i($l,nqp::add_i($width,$width))),
+                nqp::if(nqp::isge_i($end,$n),($end = $n)),
+
+                (my int $i = $left),
+                (my int $j = $right),
+                (my int $k = nqp::sub_i($left,1)),
+
+                # Merge two runs: $A[i       .. i+width-1] and
+                #                 $A[i+width .. i+2*width-1]
+                # to $B or copy $A[i..n-1] to $B[] ( if(i+width >= n) )
+                nqp::while(
+                  nqp::islt_i(++$k,$end),
+                  nqp::if(
+                    nqp::islt_i($i,$right) && (
+                      nqp::isge_i($j,$end)
+                        || nqp::isle_i(
+                             nqp::cmp_I(
+                               nqp::atpos(S,nqp::atpos_i($A,$i)),
+                               nqp::atpos(S,nqp::atpos_i($A,$j))
+                             ),0)
+                    ),
+                    nqp::stmts(
+                      (nqp::bindpos_i($B,$k,nqp::atpos_i($A,$i))),
+                      ++$i
+                    ),
+                    nqp::stmts(
+                      (nqp::bindpos_i($B,$k,nqp::atpos_i($A,$j))),
+                      ++$j
+                    )
+                  )
+                ),
+                ($l = nqp::add_i($l,nqp::add_i($width,$width)))
+              )
+            ),
+
+            # Now work array $B is full of runs of length 2*width.
+            (my $temp := $B),($B := $A),($A := $temp),   # swap
+            # Now array $A is full of runs of length 2*width.
+
+            ($width = nqp::add_i($width,$width))
+          )
+        );
+
+        $s = -1;
+        # repurpose the Schwartz for the result
+        nqp::if(
+          $indices,
+          nqp::while(   # indices only
+            nqp::islt_i(++$s,$n),
+            nqp::bindpos(S,$s,nqp::atpos_i($A,$s))
+          ),
+          nqp::while(   # actual values
+            nqp::islt_i(++$s,$n),
+            nqp::bindpos(S,$s,nqp::atpos($O,nqp::atpos_i($A,$s)))
+          )
+        );
+        nqp::bindattr(list,List,'$!reified',S)
+    }
+
+    # Sorts the index array against a Schwartz of Str keys, where cmp reduces to nqp::cmp_s on the unboxed strings and leaves the
+    # result, or the indices that produced it, in that same buffer.
+    method !MERGESORT-AS-Str(\list, \S, $indices) {
+        my $O := nqp::getattr(list,List,'$!reified');   # Original
+        my int $n = nqp::elems(S);
+        my $A := nqp::setelems(nqp::list_i,$n);         # indexes to sort
+        my $B := nqp::setelems(nqp::list_i,$n);         # work array
+        my int $s = -1;
+        nqp::while(
+          nqp::islt_i(($s = nqp::add_i($s,1)),$n),
+          nqp::bindpos_i($A,$s,$s)
+        );
+
+        # Each 1-element run in $A is already "sorted"
+        # Make successively longer sorted runs of length 2, 4, 8, 16...
+        # until $A is wholly sorted
+        my int $width = 1;
+        nqp::while(
+          nqp::islt_i($width,$n),
+          nqp::stmts(
+            (my int $l = 0),
+
+            # $A is full of runs of length $width
+            nqp::while(
+              nqp::islt_i($l,$n),
+
+              nqp::stmts(
+                (my int $left  = $l),
+                (my int $right = nqp::add_i($l,$width)),
+                nqp::if(nqp::isge_i($right,$n),($right = $n)),
+                (my int $end = nqp::add_i($l,nqp::add_i($width,$width))),
+                nqp::if(nqp::isge_i($end,$n),($end = $n)),
+
+                (my int $i = $left),
+                (my int $j = $right),
+                (my int $k = nqp::sub_i($left,1)),
+
+                # Merge two runs: $A[i       .. i+width-1] and
+                #                 $A[i+width .. i+2*width-1]
+                # to $B or copy $A[i..n-1] to $B[] ( if(i+width >= n) )
+                nqp::while(
+                  nqp::islt_i(++$k,$end),
+                  nqp::if(
+                    nqp::islt_i($i,$right) && (
+                      nqp::isge_i($j,$end)
+                        || nqp::isle_i(
+                             nqp::cmp_s(
+                               nqp::unbox_s(nqp::atpos(S,nqp::atpos_i($A,$i))),
+                               nqp::unbox_s(nqp::atpos(S,nqp::atpos_i($A,$j)))
+                             ),0)
+                    ),
+                    nqp::stmts(
+                      (nqp::bindpos_i($B,$k,nqp::atpos_i($A,$i))),
+                      ++$i
+                    ),
+                    nqp::stmts(
+                      (nqp::bindpos_i($B,$k,nqp::atpos_i($A,$j))),
+                      ++$j
+                    )
+                  )
+                ),
+                ($l = nqp::add_i($l,nqp::add_i($width,$width)))
+              )
+            ),
+
+            # Now work array $B is full of runs of length 2*width.
+            (my $temp := $B),($B := $A),($A := $temp),   # swap
+            # Now array $A is full of runs of length 2*width.
+
+            ($width = nqp::add_i($width,$width))
+          )
+        );
+
+        $s = -1;
+        # repurpose the Schwartz for the result
+        nqp::if(
+          $indices,
+          nqp::while(   # indices only
+            nqp::islt_i(++$s,$n),
+            nqp::bindpos(S,$s,nqp::atpos_i($A,$s))
+          ),
+          nqp::while(   # actual values
+            nqp::islt_i(++$s,$n),
+            nqp::bindpos(S,$s,nqp::atpos($O,nqp::atpos_i($A,$s)))
+          )
+        );
+        nqp::bindattr(list,List,'$!reified',S)
+    }
+
 
     # Takes the HLL List to be sorted *in place* using the comparator
     # and always produce indices

--- a/src/core.c/Str.rakumod
+++ b/src/core.c/Str.rakumod
@@ -1995,7 +1995,15 @@ my class Str does Stringy { # declared in BOOTSTRAP
 
     method !ensure-split-sanity($v, $k, $kv, $p) {
         # cannot combine these
-        my int $any = $v.Bool + $k.Bool + $kv.Bool + $p.Bool;
+        my int $any = nqp::eqaddr(nqp::decont($v),Any)
+          && nqp::eqaddr(nqp::decont($k),Any)
+          && nqp::eqaddr(nqp::decont($kv),Any)
+          && nqp::eqaddr(nqp::decont($p),Any)
+          ?? 0
+          !! $v.Bool + $k.Bool + $kv.Bool + $p.Bool;
+        # An adverb nobody passed holds the Any type object, which
+        # boolifies false, so four of those sum to zero without asking.
+        # Every split pays for this check and almost none pass an adverb.
         X::Adverb.new(
           what   => 'split',
           source => 'Str',

--- a/t/02-rakudo/slip-control-payload-6.e.t
+++ b/t/02-rakudo/slip-control-payload-6.e.t
@@ -1,0 +1,22 @@
+use v6.e.PREVIEW;
+use Test;
+
+# From 6.e a loop control statement may carry a payload, which the iterator
+# unpacks through the same start-slip and slip-all that an ordinary block
+# result goes through.  This needs its own file because the language
+# version has to be set before anything else.
+
+plan 5;
+
+is-deeply (1..4).map({ next slip($_,-$_) if $_ %% 2; $_ }).List, (1,2,-2,3,4,-4),
+  'next with a Slip payload contributes each of its elements';
+is-deeply (1..4).map({ next Empty if $_ %% 2; $_ }).List, (1,3),
+  'next with an Empty payload contributes no element';
+is-deeply (1..3).map({ next Slip if $_ == 2; $_ }).List, (1, Slip, 3),
+  'next with the Slip type object contributes it as a value';
+is-deeply (1..4).map({ last slip(8,9) if $_ == 3; $_ }).List, (1,2,8,9),
+  'last with a Slip payload contributes each of its elements';
+is-deeply (1..100).map({ next slip($_,-$_) if $_ %% 2; $_ }).head(4).List, (1,2,-2,3),
+  'next with a Slip payload flattens when pulled one value at a time';
+
+# vim: expandtab shiftwidth=4

--- a/t/02-rakudo/slip-empty-identity.t
+++ b/t/02-rakudo/slip-empty-identity.t
@@ -1,0 +1,76 @@
+use Test;
+use nqp;
+
+# The SlippyIterator role recognizes Empty by identity so that a block
+# returning it contributes nothing.  The iterators these cases use reach
+# slip-all when the result is consumed whole and start-slip when it is
+# pulled one value at a time, so the cases below do both.
+
+plan 18;
+
+is-deeply (1..4).map({ $_ %% 2 ?? Empty !! $_ }).List, (1,3),
+  'a block returning Empty contributes no element';
+is-deeply (1..3).map({ slip($_, $_) }).List, (1,1,2,2,3,3),
+  'a block returning a Slip contributes each of its elements';
+is-deeply (1..3).map({ $_ == 2 ?? slip() !! $_ }).List, (1,3),
+  'an empty Slip contributes no element';
+is-deeply (1..3).map({ Empty }).List, (),
+  'a block returning Empty for every element yields an empty list';
+is-deeply ((1..3).map({ $_ == 2 ?? Slip !! $_ }).List), (1, Slip, 3),
+  'the Slip type object is passed through as a value';
+is-deeply (1..4).grep({ $_ %% 2 }).map({ slip($_, -$_) }).List, (2,-2,4,-4),
+  'a Slip returned downstream of a grep still flattens';
+
+is-deeply (1..100).map({ slip($_, $_) }).head(3).List, (1,1,2),
+  'a Slip flattens when the result is pulled one value at a time';
+is-deeply (1..Inf).map({ $_ %% 3 ?? slip($_, -$_) !! Empty }).head(4).List, (3,-3,6,-6),
+  'Empty and Slip interleave when pulled from a lazy source';
+is-deeply (1..3).map({ $_ == 2 ?? Slip !! $_ }).head(3).List, (1, Slip, 3),
+  'the Slip type object is pulled through as a value';
+my $sunk = 0;
+sink (1..6).map({ $sunk++; $_ %% 2 ?? Empty !! $_ });
+is $sunk, 6, 'sinking a mapped list still runs the block for every element';
+
+# The Slip arrives from a variable rather than as a literal term, so it
+# reaches the iterator inside a container.
+my $held-empty = Empty;
+is-deeply (1..3).map({ $_ == 2 ?? $held-empty !! $_ }).List, (1,3),
+  'an Empty held in a container contributes no element';
+my $held-slip = slip(7,8);
+is-deeply (1..3).map({ $_ == 2 ?? $held-slip !! $_ }).List, (1,7,8,3),
+  'a Slip held in a container contributes each of its elements';
+my Slip $held-type;
+is-deeply (1..3).map({ $_ == 2 ?? $held-type !! $_ }).List, (1, Slip, 3),
+  'a Slip type object held in a container is passed through as a value';
+
+# Taking the Slip out of the container rather than passing the container
+# on is what keeps the source variable from staying aliased into the
+# reified result.
+my Slip $aliased;
+my $reified := (1..3).map({ $_ == 2 ?? $aliased !! $_ }).List;
+$reified.elems;
+$aliased = slip(9);
+is-deeply $reified, (1, Slip, 3),
+  'a Slip type object taken from a container is not left aliased to it';
+
+# --- what recognizing Empty leaves behind ------------------------------
+# This one does not show up in any value a map or grep produces.
+# start-slip returns early for Empty, and a slip already in progress is
+# not its to discard.
+
+my class Driver does Rakudo::SlippyIterator {
+    method pull-one() { IterationEnd }
+}
+my $driver := Driver.new;
+is $driver.start-slip(slip(1,2,3)), 1,
+  'starting a slip yields its first value';
+nok nqp::isnull(nqp::getattr($driver, Driver, '$!slipper')),
+  'and leaves the rest of it queued';
+is $driver.start-slip(Empty), IterationEnd,
+  'starting an Empty yields IterationEnd';
+my $rest := nqp::create(IterationBuffer);
+$driver.push-rest($rest);
+is nqp::elems($rest), 2,
+  'and leaves the queued slip untouched';
+
+# vim: expandtab shiftwidth=4

--- a/t/02-rakudo/sort-classifier-invariants.t
+++ b/t/02-rakudo/sort-classifier-invariants.t
@@ -1,0 +1,51 @@
+use Test;
+use nqp;
+use MONKEY-SEE-NO-EVAL;
+
+# Properties the specializations in Rakudo::Sorting rest on, neither of
+# which shows up in the value a sort returns, so neither is reachable by
+# asserting what a sort produces.
+
+plan 5;
+
+# --- what the setting's scope gains ------------------------------------
+# A sub written beside a class rather than inside it becomes a name every
+# Raku program can see and none can use.
+
+sub visible($name) { (try EVAL("\&$name")).defined || (try EVAL($name)).defined }
+
+ok visible('ORDER'),
+  'a sub the setting means to publish is reachable, so this check can fail';
+nok visible('slot-reads-the-same'),
+  'the sort helper stays out of the scope every program compiles in';
+nok visible('SORT-CLASSIFY-FROM'),
+  'the length the sort classifies from stays out of it too';
+
+# --- what a refused container costs ------------------------------------
+# The classifier refuses a container that answers with code of its own,
+# and has to reach that verdict without running that code.  Reading the
+# slot to decide, or binding it through a parameter that reads it, adds
+# a fetch per element to the very containers being kept out.
+
+sub fetches-sorting(int $n) {
+    my $reads = 0;
+    my @list;
+    for ^$n -> $i {
+        if $i == 3 {
+            @list[$i] := Proxy.new(
+              FETCH => method () { $reads++; 99 }, STORE => method ($x) {});
+        }
+        else {
+            @list[$i] = $i;
+        }
+    }
+    @list.sort.List;
+    $reads
+}
+
+is fetches-sorting(15), 25,
+  'a Proxy in a list too short to classify is read only by the merge';
+is fetches-sorting(20), 35,
+  'a Proxy in a list long enough to classify is read no more often';
+
+# vim: expandtab shiftwidth=4

--- a/t/02-rakudo/sort-element-kinds.t
+++ b/t/02-rakudo/sort-element-kinds.t
@@ -1,0 +1,249 @@
+use Test;
+
+# A list that is all Int, or all Str, sorts through a comparison built from
+# a single VM op instead of the general infix:<cmp> dispatch.  Every case
+# below pins a value or an ordering that specialization has to reproduce,
+# not the specialization itself.
+#
+# Classifying a list only pays for itself on a list long enough to sort for
+# a while, so it is only done above a length, and a case built from three
+# or four elements would never reach the code it means to test.  The two
+# helpers append values whose keys sort after everything being asserted on,
+# so a case can be written at the length that reads well and still reach
+# the classifying path.  The first element is classified apart from the
+# rest, so the cases where position could change the answer are written
+# with their disqualifying element in more than one place.
+
+plan 63;
+
+sub enough-int(*@head) { (|@head, |(4000 .. 4020)) }
+sub enough-str(*@head) { (|@head, |("zzz00" .. "zzz20")) }
+
+# --- lists that qualify -------------------------------------------------
+
+is-deeply enough-int(5,3,9,1,7).sort.head(5).List, (1,3,5,7,9),
+  'a list of Int sorts ascending';
+is-deeply enough-str(<pear apple fig cherry>).sort.head(4).List,
+  <apple cherry fig pear>.List,
+  'a list of Str sorts by codepoint';
+is-deeply (my @a = enough-int(5,3,9,1,7)).sort.head(5).List, (1,3,5,7,9),
+  'an Array of Int sorts through its element containers';
+is-deeply (|(2**70, 5, 2**80, 1), |(2**90 .. 2**90 + 20)).sort.head(4).List,
+  (1, 5, 2**70, 2**80),
+  'Int elements too large for a machine word keep their order';
+is-deeply enough-int(-3, 0, -7, 4).sort.head(4).List, (-7, -3, 0, 4),
+  'negative Int elements sort below zero';
+is-deeply enough-str("b", "", "a").sort.head(3).List, ("", "a", "b"),
+  'an empty Str sorts before every other Str';
+is-deeply enough-str("Z", "a", "A").sort.head(3).List, ("A", "Z", "a"),
+  'Str sorting is by codepoint, not case-insensitive';
+is-deeply (%(<a b c d e f g h i j k l m n o p q r s t>.map({ $_ => 1 })).keys.sort.List),
+  <a b c d e f g h i j k l m n o p q r s t>.List,
+  'the keys of a hash sort as Str';
+is-deeply ("c\na\nb\n" ~ ("zzz00" .. "zzz20").join("\n")).lines.sort.head(3).List,
+  ("a","b","c"),
+  'the lines of a string sort as Str';
+
+# --- lists long enough to merge at more than a few widths ---------------
+# The element merges are hand written copies of one skeleton and the key
+# merge shares one loop, so drive both wide enough that a slip in a run
+# bound shows up, and check them against a two argument comparator, which
+# is a different merge entirely.
+
+my @wide-int = (^400).map({ ($_ * 2654435761) % 997 });
+is-deeply @wide-int.sort.List, @wide-int.sort(-> $a, $b { $a cmp $b }).List,
+  'four hundred Int sort as a two argument comparator sorts them';
+my @wide-str = (^400).map({ "k" ~ ($_ * 2654435761) % 997 });
+is-deeply @wide-str.sort.List, @wide-str.sort(-> $a, $b { $a cmp $b }).List,
+  'four hundred Str sort as a two argument comparator sorts them';
+is-deeply @wide-int.sort(*.Str).List,
+          @wide-int.sort(-> $a, $b { $a.Str cmp $b.Str }).List,
+  'four hundred Str keys order as a two argument comparator orders them';
+is-deeply @wide-str.sort(*.chars).List,
+          @wide-str.sort(-> $a, $b { $a.chars cmp $b.chars }).List,
+  'four hundred Int keys order as a two argument comparator orders them';
+
+# --- the fast comparison must stay stable -------------------------------
+# Equal Int and Str elements are indistinguishable by value, so stability
+# of the element merges is only visible through object identity.  Bind the
+# elements rather than assigning them: assigning these variables would put
+# each value behind its own Scalar, and =:= would then compare containers.
+
+my $int-first := Int.new(1);
+my $int-later := Int.new(1);
+my $ints := enough-int($int-first, $int-later, Int.new(0)).sort.List;
+ok $ints[1] =:= $int-first, 'the earlier of two equal Int elements stays first';
+ok $ints[2] =:= $int-later, 'the later of two equal Int elements stays second';
+
+my $str-first := Str.new(value => "m");
+my $str-later := Str.new(value => "m");
+my $strs := enough-str($str-first, $str-later, Str.new(value => "a")).sort.List;
+ok $strs[1] =:= $str-first, 'the earlier of two equal Str elements stays first';
+ok $strs[2] =:= $str-later, 'the later of two equal Str elements stays second';
+
+is-deeply enough-int(3,1,3,1,2).sort.head(5).List, (1,1,2,3,3),
+  'duplicate Int elements sort without losing any of them';
+is-deeply enough-str(<bb aa cc dd>).sort(*.chars).head(4).List, <bb aa cc dd>.List,
+  'equal extracted keys keep the input order of their elements';
+
+# --- element types that must NOT take the fast comparison ---------------
+# An Allomorph is the case that would give a wrong answer rather than a
+# crash: it is both a number and a string, and its infix:<cmp> candidate
+# breaks a numeric tie on the string, where nqp::cmp_I calls the pair
+# equal.
+
+is-deeply enough-int(IntStr.new(1,"b"), IntStr.new(1,"a"), IntStr.new(1,"c"))
+    .sort.head(3).map(*.Str).List,
+  ("a","b","c"), 'IntStr elements that tie numerically order by their string';
+is-deeply enough-int(IntStr.new(10,"10"), IntStr.new(9,"9"), IntStr.new(100,"100"))
+    .sort.head(3).map(*.Int).List,
+  (9, 10, 100), 'IntStr among plain Int sort by numeric value, not by string';
+is-deeply enough-int(RatStr.new(1/2,"0.5"), RatStr.new(1/4,"0.25"),
+                     RatStr.new(1/8,"0.125")).sort.head(3).map(*.Rat).List,
+  (0.125, 0.25, 0.5), 'RatStr among plain Int sort by numeric value, not by string';
+is-deeply enough-int(IntStr.new(3,"z"), 1, 2).sort.head(3).List,
+  (1, 2, IntStr.new(3,"z")),
+  'an IntStr among plain Int sorts by its numeric value';
+
+my @proxied;
+for ^20 -> $i {
+    my $value = (37 * $i) % 20;
+    @proxied[$i] := Proxy.new(
+      FETCH => method () { $value }, STORE => method ($x) {});
+}
+is-deeply @proxied.sort.List, (^20).List,
+  'a list of Proxy elements sorts by the value each one fetches';
+
+# The comparison the fast merges use would take the first read for the
+# type of every later one, so a container that answers with a different
+# type the second time has to keep them out.
+my @flip;
+for ^20 -> $i {
+    my $value = (37 * $i) % 20;
+    my $reads = 0;
+    @flip[$i] := Proxy.new(
+      FETCH => method () { $reads++ ?? "s$value" !! $value },
+      STORE => method ($x) {});
+}
+my $flipped;
+lives-ok { $flipped = @flip.sort.List },
+  'a container answering with a different type on a later read still sorts';
+is $flipped.elems, 20, 'and it keeps every element';
+
+is-deeply enough-int(1, 2, 1.5).sort.head(3).List, (1, 1.5, 2),
+  'a Rat after the first element still sorts by numeric value';
+is-deeply enough-int(1, 2, IntStr.new(5,"b"), IntStr.new(5,"a"))
+    .sort.head(4).map(*.Str).List, ("1","2","a","b"),
+  'an IntStr later in a list of Int still breaks a numeric tie on its string';
+
+# Padding a case with Int is what refuses it when the head is an Allomorph,
+# so one list has to be nothing but Allomorphs for the first element's own
+# type test to be the thing that decides.
+my @all-allomorph = (^20).map({ IntStr.new($_ div 2, ("b","a")[$_ % 2] ~ $_) });
+is-deeply @all-allomorph.sort.map(*.Str).head(6).List,
+  ("a1","b0","a3","b2","a5","b4"),
+  'a list that is all IntStr breaks each numeric tie on the string';
+is-deeply enough-int(1.5, 2, 3).sort.head(3).List, (1.5, 2, 3),
+  'a Rat in the first position still sorts by numeric value';
+quietly is enough-int(1, 2, Int).sort.head(3).map({ .defined ?? .Str !! .^name }).join(","),
+  "Int,1,2",
+  'an Int type object after the first element sorts through the general comparison';
+quietly is enough-int(Int, 2, 1).sort.head(3).map({ .defined ?? .Str !! .^name }).join(","),
+  "Int,1,2",
+  'an Int type object in the first position sorts through the general comparison';
+
+my @holed = enough-int(1, 2); @holed[30] = 3;
+dies-ok { @holed.sort.List },
+  'a list with a hole does not reach a comparison that would accept it';
+my @front-hole; @front-hole[1] = 2; @front-hole[$_] = $_ for 3 .. 20;
+dies-ok { @front-hole.sort.List },
+  'a hole in the first position does not reach a comparison that would accept it';
+
+my class MyInt is Int { }
+is enough-int(1, 2, MyInt.new(3)).sort.head(3).join(","), "1,2,3",
+  'a subclass of Int sorts by value alongside plain Int';
+my class MyStr is Str { }
+is enough-str("a", "c", MyStr.new(value => "b")).sort.head(3).join(","), "a,b,c",
+  'a subclass of Str sorts alongside plain Str';
+
+is-deeply enough-int(3e0, 1e0, 2e0).sort.head(3).List, (1e0, 2e0, 3e0),
+  'Num among plain Int sort by numeric value';
+is-deeply (3e0, NaN, 1e0, 2e0).sort.List, (1e0, 2e0, 3e0, NaN),
+  'NaN sorts after every ordinary Num';
+my @lists = (1,0),(0,1),(1,1);
+@lists.push((2,$_)) for ^21;
+is-deeply @lists.sort.head(3).List, ($(0,1), $(1,0), $(1,1)),
+  'a list of Lists still sorts through the general comparison';
+
+# --- around the length at which classifying starts ----------------------
+# One length below the gate, the gate itself, where the run widths divide
+# the list exactly, and one above, which is the shortest ragged case.
+
+for 15, 16, 17 -> $n {
+    my @i = (^$n).map({ ($_ * 37) % 11 });
+    my @s = @i.map({ "k" ~ $_ });
+    is-deeply @i.sort.List, @i.sort(-> $a, $b { $a cmp $b }).List,
+      "$n Int sort as a two argument comparator sorts them";
+    is-deeply @s.sort.List, @s.sort(-> $a, $b { $a cmp $b }).List,
+      "$n Str sort as a two argument comparator sorts them";
+}
+is-deeply (|(1 .. 15), 0.5).sort.head(2).List, (0.5, 1),
+  'a disqualifying element last in the shortest classified list is still seen';
+is-deeply (^20).map({ (17 * $_) % 20 }).List.sort(*.self, :k).head(5).List,
+  (0, 13, 6, 19, 12),
+  'the :k form reports indices when the keys took the fast comparison';
+
+# --- sizes below the point where a merge sort starts --------------------
+
+is-deeply ().sort.List, (), 'an empty list sorts to an empty list';
+is-deeply (1,).sort.List, (1,), 'a one element list sorts to itself';
+is-deeply (2,1).sort.List, (1,2), 'a two element list of Int swaps';
+is-deeply (1,2).sort.List, (1,2), 'a sorted two element list is left alone';
+is-deeply <b a>.sort.List, <a b>.List, 'a two element list of Str swaps';
+is-deeply (5,3,9,1,7).sort.List, (1,3,5,7,9),
+  'a list too short to classify sorts through the general comparison';
+is-deeply <pear apple fig>.sort.List, <apple fig pear>.List,
+  'a short list of Str sorts through the general comparison';
+
+# --- the key extracting form --------------------------------------------
+
+is-deeply enough-str(<bbb a cc dddd>).sort(*.chars).head(4).List,
+  <a cc bbb dddd>.List,
+  'an Int key extractor orders by the extracted key';
+is-deeply enough-int(3,1,2).sort(*.Str).head(3).List, (1,2,3),
+  'a Str key extractor orders by the extracted key';
+is-deeply enough-str("a","b","c").sort({ $_ eq "c" ?? 3 !! $_ }).head(3).List,
+  ("c", "a", "b"),
+  'a key that is not a Str after the first orders through the general comparison';
+is-deeply enough-int(1,2,3).sort({
+    $_ >= 4000 ?? "zzz" !! $_ %% 2 ?? "x" !! 9
+}).head(3).List, (1,3,2),
+  'keys of mixed types order through the general comparison';
+
+# A key inside a container is refused outright, because the mapper runs
+# over the whole list before any comparison and a later call can still
+# reach back and change a key that was already classified.
+my @src = flat (3,1,2), (10 .. 30);
+is-deeply (^24).sort({ @src[$_] }).head(3).List, (1,2,0),
+  'a key extractor returning a container orders by the contained value';
+my @boxes := Array.new; @boxes[$_] = 0 for ^24;
+is-deeply (^24).sort({
+    @boxes[$_] = 100 - $_; @boxes[0] = "zz" if $_ == 23; @boxes[$_]
+}).head(3).List, (23, 22, 21),
+  'a mapper that changes an already extracted key still orders by cmp';
+
+# An undefined key is the shape .sort(*.attr) produces whenever the
+# attribute was never assigned.
+class Aged { has Int $.age }
+my @aged = flat (Aged.new(age => 3), Aged.new, Aged.new(age => 1)),
+                (10 .. 30).map({ Aged.new(age => $_) });
+quietly is-deeply @aged.sort(*.age).head(3).map({ .age.defined ?? .age !! 0 }).List,
+  (0, 1, 3),
+  'an undefined Int key orders through the general comparison';
+quietly is-deeply enough-str("bb","a","ccc").sort({ .chars == 1 ?? Str !! $_ }).head(3).List,
+  ("a","bb","ccc"),
+  'an undefined Str key orders through the general comparison';
+is-deeply <c a b>.sort(*.self, :k).List, (1,2,0),
+  'the :k form reports the indices the sorted elements came from';
+
+# vim: expandtab shiftwidth=4

--- a/t/02-rakudo/split-adverb-count.t
+++ b/t/02-rakudo/split-adverb-count.t
@@ -1,0 +1,59 @@
+use Test;
+
+# Str.split counts how many of :v, :k, :kv and :p were passed, and uses the
+# count both to reject a combination and to pick the mapping it applies.
+
+plan 17;
+
+is-deeply "a1b".split(/\d/, :k).List, ("a", 0, "b"),
+  'the :k adverb reports the index of each separator';
+throws-like { "abc".split("b", :v, :k) }, X::Adverb,
+  'combining two split adverbs is rejected';
+is-deeply "abc".split("b", :v, :k(False)).List, ("a","b","c"),
+  'an adverb that boolifies false does not count towards the limit';
+is-deeply "a1b2c".split(<1 2>, :v).List, ("a","1","b","2","c"),
+  'splitting on a list of needles keeps the separators with :v';
+is-deeply "a,b,c".split(",", 2).List, ("a", "b,c"),
+  'a split limit stops after the requested number of pieces';
+is-deeply "a,,b".split(",", :skip-empty).List, ("a","b"),
+  'skip-empty drops the empty piece between adjacent separators';
+
+# The adverbs are untyped, so an argument may boolify to anything at all and
+# the count is what has to cope with it.
+my class Zero  { method Bool { "0" } }
+my class Word  { method Bool { "yes" } }
+my class Nilly { method Bool { Nil } }
+is-deeply "a,b,c".split(",", :v(Zero.new)).List, ("a","b","c"),
+  'an adverb whose Bool is a string that numifies to zero does not count';
+throws-like { "a,b,c".split(",", :v(Word.new)) }, X::Str::Numeric,
+  'an adverb whose Bool is a non-numeric string reports the string';
+quietly is-deeply "a,b,c".split(",", :v(Nilly.new)).List, ("a","b","c"),
+  'an adverb whose Bool is Nil does not count';
+is-deeply "a,b,c".split(",").List, ("a","b","c"),
+  'splitting with no adverb at all keeps every piece';
+
+# An adverb may be given a type object, whose Bool a class is free to
+# define, so being undefined is not the same as being absent.
+my class TruthyType { method Bool { True } }
+is-deeply "a,b".split(",", :v(TruthyType)).List, ("a", ",", "b"),
+  'a type object whose Bool is True counts as a :v adverb';
+throws-like { "a,b".split(",", :v(TruthyType), :k(TruthyType)) }, X::Adverb,
+  'two type objects whose Bool is True are still rejected as a combination';
+is-deeply "a,b".split(",", :v(Any)).List, ("a","b"),
+  'an adverb given Any counts no more than one left out';
+
+# The count is reached from every split, and the adverb free path is
+# the one every ordinary call takes.
+is-deeply "a1b2c".split(/\d/).List, ("a","b","c"),
+  'splitting on a regex with no adverb keeps every piece';
+is-deeply "a1b2c".split(<1 2>).List, ("a","b","c"),
+  'splitting on a list of needles with no adverb keeps every piece';
+
+# Each of the four adverbs is counted separately, and the count picks the
+# mapping as well as rejecting a combination.
+is-deeply "a,b".split(",", :kv).List, ("a", 0, ",", "b"),
+  'the :kv adverb reports the index and the separator';
+is-deeply "a,b".split(",", :p).List, ("a", 0 => ",", "b"),
+  'the :p adverb pairs the index with the separator';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Three unrelated changes in the setting, each removing work that was being done to reach the same answer:

`.sort` compared every pair through the `infix:<cmp>` multi dispatch, which hands back an `Order` the merge then tests by identity. For a list that is all `Int` or all `Str` that whole step is one VM op, so a walk decides whether it is and the merge runs against `nqp::cmp_I` or `nqp::cmp_s` directly. Sorting by an extracted key does the same for the keys. Both pick a merge once rather than testing the kind inside the comparison, so a sort that cannot use one pays nothing for it. Only the exact types qualify, since an `IntStr` breaks a numeric tie on its string where `nqp::cmp_I` calls the pair equal, and the walk only happens from sixteen elements up, which is where it starts paying for itself. A million `Int` goes 3.57s to 2.75s and six hundred thousand strings by an extracted key 2.33s to 1.33s, while sorting `Num`, `Rat`, `Version` or `Instant`, by value or by key, stays where it was.

`SlippyIterator` recognizes `Empty` with `nqp::eqaddr`, but a `$` parameter binds the Slip through a container, so reached the way an iterator reaches it, with a map or grep block's result, `slip-all` compared the container and never matched. Every element such a block rejected built an iterator over `Empty` and pushed from it to push nothing. A grep over two million rejected elements goes 0.63s to 0.49s.

```
use nqp; sub f(Slip:D $s) { nqp::eqaddr($s, Empty) }; say f(Empty)   # False
```

`Str.split` checked its `:v`/`:k`/`:kv`/`:p` adverbs by adding four boolifications together, on a call that almost never passes one. An adverb nobody passed still holds `Any`, which boolifies false, so four of those sum to zero without asking.