### PR TITLE
Share unit lexicals between BEGIN code and the mainline

### DIFF
--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -2235,6 +2235,12 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
                           where => "in a subscope"
                         ) unless $outer =:= $*UNIT;
 
+                        # The body of a unit scoped package is entered once
+                        # from the mainline. A role body runs per
+                        # specialization, so it is left out.
+                        $*W.cur_lexpad().annotate('unit_body', 1)
+                            unless $*PKGDECL eq 'role';
+
                         $*begin_compunit := 0;
                     }
                     { $*IN_DECL := ''; }

--- a/src/Perl6/Optimizer.nqp
+++ b/src/Perl6/Optimizer.nqp
@@ -738,11 +738,17 @@ my class BlockVarOptimizer {
         return 0 if $!poisoned || $!uses_bindsig;
         return 0 unless nqp::istype($block[0], QAST::Stmts);
         for @!decls -> $qast {
-            # We're looking for lexical var/contvar decls.
+            # We're looking for lexical var/contvar decls. A unit container
+            # is declared static, and its block symbol carries a descriptor,
+            # which the other static decls lack, so it lowers as a contvar.
             my str $scope := $qast.scope;
             next unless $scope eq 'lexical';
             my str $decl := $qast.decl;
             my int $is_contvar := $decl eq 'contvar';
+            if $decl eq 'static' {
+                my %sym := $block.symbol($qast.name);
+                $is_contvar := nqp::ishash(%sym) && nqp::existskey(%sym, 'descriptor');
+            }
             next unless $is_contvar || $decl eq 'var' || $decl eq 'param';
 
             # Also ensure not dynamic or with an implicit lexical usage.

--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -1787,7 +1787,7 @@ class Perl6::World is HLL::World {
     # the type of container to install.
     method install_lexical_container($block, str $name, %cont_info, $descriptor,
             :$scope, :$package, :$cont = self.build_container_and_add_to_sc(%cont_info, $descriptor),
-            :$init_removal) {
+            :$init_removal, :$magical) {
         # Add to block, if needed. Note that it doesn't really have
         # a compile time value.
         my $var;
@@ -1851,7 +1851,15 @@ class Perl6::World is HLL::World {
 
         # Tweak var to have container.
         $var.value($cont);
-        $var.decl($scope eq 'state' ?? 'statevar' !! 'contvar');
+        # The unit block and the body of a unit scoped package each run once,
+        # so their containers stay the ones compile_in_context already hands
+        # to code run at BEGIN time. A magical stays cloned, since every
+        # block of the unit shares its master.
+        $var.decl($scope eq 'state'
+            ?? 'statevar'
+            !! ($block =:= $*UNIT || $block.ann('unit_body')) && !$magical
+                ?? 'static'
+                !! 'contvar');
 
         # Evaluate to the container.
         $cont
@@ -2194,7 +2202,7 @@ class Perl6::World is HLL::World {
         my %magical_cds := self.context().magical_cds();
 
         if nqp::atkey(%magical_cds, $name) -> @mcd {
-            self.install_lexical_container($block, $name, @mcd[0], @mcd[1], :cont(@mcd[2]));
+            self.install_lexical_container($block, $name, @mcd[0], @mcd[1], :cont(@mcd[2]), :magical);
         }
         else {
             my $Mu     := self.find_single_symbol_in_setting('Mu');
@@ -2215,7 +2223,7 @@ class Perl6::World is HLL::World {
             my $cont := self.build_container_and_add_to_sc(%info, $desc);
 
             %magical_cds{$name} := [%info, $desc, $cont];
-            self.install_lexical_container($block, $name, %info, $desc, :cont($cont));
+            self.install_lexical_container($block, $name, %info, $desc, :cont($cont), :magical);
         }
     }
 

--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -712,6 +712,7 @@ class RakuAST::VarDeclaration::Simple
     has Bool                 $!is-bindable;
     has Bool                 $!already-declared;
     has RakuAST::Code        $!block;
+    has RakuAST::Package     $!unit-package;
 
     has Mu $!container-initializer;
     has Mu $!package;
@@ -1046,6 +1047,14 @@ class RakuAST::VarDeclaration::Simple
             $block := $compunit.mainline if $compunit;
         }
         nqp::bindattr(self, RakuAST::VarDeclaration::Simple, '$!block', $block);
+
+        # The body of a unit scoped package is entered once from the
+        # mainline, so its declarations get the mainline treatment. A role
+        # body runs per specialization, so it is left out.
+        my $package := $resolver.find-attach-target('package');
+        if $package && $package.scope eq 'unit' && !nqp::istype($package, RakuAST::Role) {
+            nqp::bindattr(self, RakuAST::VarDeclaration::Simple, '$!unit-package', $package);
+        }
 
         if self.is-attribute {
             # $_ is the attribute's current value; type it Mu so a value
@@ -1623,6 +1632,13 @@ class RakuAST::VarDeclaration::Simple
         }
     }
 
+    # Whether the declaration belongs to the mainline block or to the body
+    # of a unit scoped package, each of which runs exactly once.
+    method IMPL-IS-UNIT-SCOPED() {
+        nqp::isconcrete($*CU) && nqp::eqaddr($!block, $*CU.mainline)
+          || nqp::isconcrete($!unit-package) && nqp::eqaddr($!block, $!unit-package.body)
+    }
+
     method IMPL-QAST-DECL(RakuAST::IMPL::QASTContext $context) {
         my str $scope := self.scope;
         my $of := $!where ?? $!type.meta-object !! self.IMPL-OF-TYPE;
@@ -1682,8 +1698,7 @@ class RakuAST::VarDeclaration::Simple
                 }
             }
             else {
-                # Need to vivify the object. Note: maybe we want to drop the
-                # contvar, though we'll need an alternative for BEGIN.
+                # Need to vivify the object.
                 my $container := self.meta-object;
                 $context.ensure-sc($container);
                 my str $local-name := self.IMPL-LOWERED-LOCAL-NAME;
@@ -1697,9 +1712,12 @@ class RakuAST::VarDeclaration::Simple
                     )
                 }
                 else {
+                    # A unit scoped container lives in a frame entered once,
+                    # so it stays the serialized one that code run at BEGIN
+                    # time already resolves the variable to.
                     my $qast := QAST::Var.new(
-                        :scope('lexical'), :decl('contvar'), :name(self.name),
-                        :value($container)
+                        :scope('lexical'), :name(self.name), :value($container),
+                        :decl(self.IMPL-IS-UNIT-SCOPED ?? 'static' !! 'contvar')
                     );
                     if self.IMPL-HAS-EXPLICIT-CONTAINER-BASE-TYPE {
                         $qast := QAST::Op.new( :op('bind'), $qast,

--- a/t/02-rakudo/begin-indirect-lexical.t
+++ b/t/02-rakudo/begin-indirect-lexical.t
@@ -27,8 +27,8 @@ is (BEGIN ::('&sprintf'))("%d", 3), '3',
 is (BEGIN ::('ScriptClass')).which, 'script-class',
     'a BEGIN indirect lookup finds a class declared in the compiling unit';
 
-is (BEGIN ::('$script-value')).^name, 'Any',
-    'a BEGIN indirect lookup of a scalar reaches its container, unassigned so far';
+is (BEGIN ::('$script-value')), 7,
+    'a BEGIN indirect lookup of a scalar reaches the container the unit assigns at run time';
 
 my constant $constant-sub = ::('&script-hex');
 is $constant-sub("b"), 'script-b',

--- a/t/02-rakudo/test-packages/UnitLexicalSharing.rakumod
+++ b/t/02-rakudo/test-packages/UnitLexicalSharing.rakumod
@@ -1,0 +1,19 @@
+unit module UnitLexicalSharing;
+
+# The trait, the phaser it adds, and the lexicals they touch all live in
+# the body of a unit scoped package, with a binding as the first read.
+
+my constant observed = class {};
+my @seen;
+multi sub trait_mod:<does>(Variable:D $v, observed) {
+    $v.block.add_phaser: 'LEAVE', $v.willdo: -> \var { @seen.push(var) };
+}
+sub traited() { my $fh does observed = 42 }
+
+my $scalar = 5;
+my &read-scalar = BEGIN { -> { $scalar } };
+
+my @bound := @seen;
+
+sub unit-seen() is export { traited(); @seen }
+sub unit-scalar() is export { read-scalar() }

--- a/t/02-rakudo/unit-lexical-begin-sharing.t
+++ b/t/02-rakudo/unit-lexical-begin-sharing.t
@@ -1,0 +1,95 @@
+use lib <t/02-rakudo/test-packages>;
+use Test;
+
+plan 16;
+
+# A closure created by code run at BEGIN time resolves a unit lexical to
+# the serialized container of the compiling unit. The unit frame runs
+# once, so it declares its containers static instead of cloning them on
+# first read, and the mainline and such closures share one container no
+# matter which side touches it first.
+
+my constant observed = class {};
+my @seen;
+multi sub trait_mod:<does>(Variable:D $v, observed) {
+    $v.block.add_phaser: 'LEAVE', $v.willdo: -> \var { @seen.push(var) };
+}
+sub traited() { my $fh does observed = 42 }
+
+my @bound := @seen;
+traited();
+is-deeply @seen, [42],
+    'a phaser added by a variable trait reaches the unit array that a binding read first';
+traited();
+is-deeply @seen, [42, 42],
+    'later phaser runs keep accumulating into the shared container';
+
+# Each program compiles and runs on its own, so the read it names is the
+# first read of the array in that unit.
+sub seen-after(Str:D $read) {
+    use MONKEY-SEE-NO-EVAL;
+    EVAL Q:to/PROGRAM/.subst('READ', $read);
+    my constant observed = class {};
+    my @seen;
+    multi sub trait_mod:<does>(Variable:D $v, observed) {
+        $v.block.add_phaser: 'LEAVE', $v.willdo: -> \var { @seen.push(var) };
+    }
+    sub traited() { my $fh does observed = 42 }
+    sub reader() { @seen.elems }
+    READ
+    traited();
+    @seen
+    PROGRAM
+}
+is-deeply seen-after('my @x := @seen;'), [42],
+    'a phaser added by a variable trait reaches the array of a unit whose first read is a binding';
+is-deeply seen-after('my $s = "@seen[]";'), [42],
+    'a phaser added by a variable trait reaches the array of a unit whose first read is an interpolation';
+is-deeply seen-after('reader();'), [42],
+    'a phaser added by a variable trait reaches the array of a unit whose first read is in a nested sub';
+is-deeply seen-after(''), [42],
+    'a phaser added by a variable trait reaches the array of a unit that never read it first';
+
+my $scalar = 5;
+my &read-scalar = BEGIN { -> { $scalar } };
+is read-scalar(), 5,
+    'a closure created at BEGIN time reads the value the mainline assigned';
+
+my @array;
+my &push-array = BEGIN { -> { @array.push('begin') } };
+@array.push('mainline');
+push-array();
+is-deeply @array, ['mainline', 'begin'],
+    'a closure created at BEGIN time pushes into the array the mainline uses';
+
+our @package;
+my &push-package = BEGIN { -> { @package.push('begin') } };
+@package.push('mainline');
+push-package();
+is-deeply @package, ['mainline', 'begin'],
+    'a closure created at BEGIN time pushes into the array an our declaration names';
+ok OUR::<@package> =:= @package,
+    'the lexical of an our declaration is the package slot container';
+
+my $assigned = 1;
+BEGIN { $assigned = 2 }
+is $assigned, 1,
+    'a mainline assignment still overwrites a BEGIN time assignment';
+
+my $unassigned;
+BEGIN { $unassigned = 3 }
+is $unassigned, 3,
+    'a BEGIN time assignment still shows in a variable the mainline never assigns';
+
+"aXa" ~~ /(X)/;
+sub own-match() { $/ }
+nok own-match().defined,
+    'a routine match variable stays fresh after the mainline matches';
+is ~$0, 'X',
+    'the mainline match variable keeps the mainline match';
+
+use UnitLexicalSharing;
+is-deeply unit-seen(), [42],
+    'a phaser added by a variable trait reaches an array in a unit scoped package body that a binding read first';
+is unit-scalar(), 5,
+    'a closure created at BEGIN time reads the value a unit scoped package body assigned';

--- a/t/08-performance/19-rakuast-lex2local.t
+++ b/t/08-performance/19-rakuast-lex2local.t
@@ -14,26 +14,33 @@ plan 26;
 # reach by name at runtime, keeps its ordinary lexical declaration. Both
 # frontends lower, so these assertions hold for either.
 
-sub qast-var-decl (Mu $qast, Str:D $name, Str:D $decl --> Bool:D) {
-    if nqp::istype($qast, QAST::Var) && $qast.name eq $name && $qast.decl eq $decl {
+sub qast-var-decl (Mu $qast, Str:D $name, Str:D $decl, &value-ok? --> Bool:D) {
+    if nqp::istype($qast, QAST::Var) && $qast.name eq $name && $qast.decl eq $decl
+      && (!&value-ok || value-ok($qast.value)) {
         return True;
     }
     if qast-descendable $qast {
         for $qast.list {
-            qast-var-decl $_, $name, $decl and return True;
+            qast-var-decl($_, $name, $decl, &value-ok) and return True;
         }
     }
     False
 }
 
-# The sentinel that replaces a lowered declaration's by-name symbol.
-sub lowered-away (Mu $qast, Str:D $name --> Bool:D) {
-    qast-var-decl($qast, $name, 'static')
+sub is-sentinel (Mu $value --> Bool:D) {
+    so nqp::eqaddr(nqp::decont($value), Rakudo::Internals::LoweredAwayLexical)
 }
 
-# An ordinary containerized lexical declaration.
+# The sentinel that replaces a lowered declaration's by-name symbol.
+sub lowered-away (Mu $qast, Str:D $name --> Bool:D) {
+    qast-var-decl($qast, $name, 'static', &is-sentinel)
+}
+
+# A declaration whose container stays under its name, whichever decl
+# carries it.
 sub kept-lexical (Mu $qast, Str:D $name --> Bool:D) {
     qast-var-decl($qast, $name, 'contvar')
+      or qast-var-decl($qast, $name, 'static', -> Mu $value { !is-sentinel($value) })
 }
 
 qast-is 'my $x = 1; say $x', :full, -> \v {

--- a/t/08-performance/20-rakuast-lex2local-flatten.t
+++ b/t/08-performance/20-rakuast-lex2local-flatten.t
@@ -11,26 +11,43 @@ plan 30;
 # as frame-confined and is lowered to a local. Both frontends flatten
 # and lower, so the shape assertions hold for either.
 
-sub qast-var-decl (Mu $qast, Str:D $name, Str:D $decl --> Bool:D) {
-    if nqp::istype($qast, QAST::Var) && $qast.name eq $name && $qast.decl eq $decl {
+sub qast-var-decl (Mu $qast, Str:D $name, Str:D $decl, &value-ok? --> Bool:D) {
+    if nqp::istype($qast, QAST::Var) && $qast.name eq $name && $qast.decl eq $decl
+      && (!&value-ok || value-ok($qast.value)) {
         return True;
     }
     if qast-descendable $qast {
         for $qast.list {
-            qast-var-decl $_, $name, $decl and return True;
+            qast-var-decl($_, $name, $decl, &value-ok) and return True;
         }
     }
     False
 }
 
+sub is-sentinel (Mu $value --> Bool:D) {
+    so nqp::eqaddr(nqp::decont($value), Rakudo::Internals::LoweredAwayLexical)
+}
+
+# The sentinel that replaces a lowered declaration's by-name symbol.
+sub lowered-away (Mu $qast, Str:D $name --> Bool:D) {
+    qast-var-decl($qast, $name, 'static', &is-sentinel)
+}
+
+# A declaration whose container stays under its name, whichever decl
+# carries it.
+sub kept-lexical (Mu $qast, Str:D $name --> Bool:D) {
+    qast-var-decl($qast, $name, 'contvar')
+      or qast-var-decl($qast, $name, 'static', -> Mu $value { !is-sentinel($value) })
+}
+
 qast-is 'my $sum = 0; my int $i = 0; while $i < 3 { $sum = $sum + 1; $i = $i + 1 }; say $sum',
     :full, -> \v {
-    qast-var-decl(v, '$sum', 'static')
+    lowered-away(v, '$sum')
 }, 'an accumulator used only from a flattenable loop body is lowered';
 
 qast-is 'my $x = 0; my int $i = 0; while $i < 3 { my $c = { $x }; $c(); $i = $i + 1 }; say $x',
     :full, -> \v {
-    qast-var-decl(v, '$x', 'contvar')
+    kept-lexical(v, '$x')
 }, 'a lexical captured by a closure inside the loop body keeps its lexical';
 
 # The smartmatch guard is this frontend's own conservatism: it reaches
@@ -40,7 +57,7 @@ qast-is 'my $x = 0; my int $i = 0; while $i < 3 { my $c = { $x }; $c(); $i = $i 
 if nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' {
     qast-is 'my $x = 0; my int $i = 0; while $i < 3 { $x = $x ~~ Int ?? 1 !! 2; $i = $i + 1 }; say $x',
         :full, -> \v {
-        qast-var-decl(v, '$x', 'contvar')
+        kept-lexical(v, '$x')
     }, 'a smartmatch in the loop body keeps the body a real frame';
 }
 else {
@@ -117,7 +134,7 @@ else {
 
 if nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' {
     qast-is 'my $x = 0; { $x = 5 }; say $x', :full, -> \v {
-        qast-var-decl(v, '$x', 'static')
+        lowered-away(v, '$x')
     }, 'a lexical used only from a flattenable bare block statement is lowered';
 }
 else {
@@ -140,7 +157,7 @@ else {
 
 qast-is 'my $sum = 0; my int $i = 0; while $i < 9 { if $i % 2 { $sum = $sum + $i } else { $sum = $sum - 1 }; $i = $i + 1 }; say $sum',
     :full, -> \v {
-    qast-var-decl(v, '$sum', 'static')
+    lowered-away(v, '$sum')
 }, 'an accumulator used from branch bodies inside a loop body is lowered';
 
 {
@@ -183,17 +200,17 @@ qast-is 'my $sum = 0; my int $i = 0; while $i < 9 { if $i % 2 { $sum = $sum + $i
 
 if nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' {
     qast-is 'my $sum = 0; for ^9 -> $x { $sum = $sum + $x }; say $sum', :full, -> \v {
-        qast-var-decl(v, '$sum', 'static')
-            and not qast-var-decl(v, '$x', 'contvar')
+        lowered-away(v, '$sum')
+            and not kept-lexical(v, '$x')
             and not qast-var-decl(v, '$x', 'var')
     }, 'a pointy for body flattens, lowering the accumulator and dissolving the parameter';
 
     qast-is 'my $n = 0; for ^5 { $n = $n + 1 }; say $n', :full, -> \v {
-        qast-var-decl(v, '$n', 'static')
+        lowered-away(v, '$n')
     }, 'a topic-free for body flattens and lowers the accumulator';
 
     qast-is 'my $x = 0; given 42 { $x = 1 }; say $x', :full, -> \v {
-        qast-var-decl(v, '$x', 'static')
+        lowered-away(v, '$x')
     }, 'a topic-free given body flattens';
 }
 else {


### PR DESCRIPTION
Previously a closure created by code run at BEGIN time, such as the phaser a variable trait adds through `Variable.willdo`, resolved a unit lexical to the serialized master container while the unit frame cloned that master on first read. Whether the phaser and the mainline ended up looking at the same storage depended on who touched the container first, so a read in the mainline before the traited routine was called left the phaser writing into a container nothing else could see:

```raku
my constant obs = class {};
my @seen;
multi sub trait_mod:<does>(Variable:D $v, obs) {
    $v.block.add_phaser: 'LEAVE', $v.willdo: -> \var { @seen.push(var) };
}
sub f() { my $fh does obs = 42 }
my @x := @seen;   # any executed read here breaks the sharing
f();
say @seen.raku;   # []  (prints [42] without the marked line)
```

The unit frame runs exactly once, and so does the body of a `unit` scoped package, so cloning their containers buys nothing. This declares those containers `static` in both frontends so the frame works on the master container itself, i.e. the same object BEGIN code resolves the variable to, and the outcome no longer depends on execution order. Role bodies and the magicals keep cloning, and the legacy optimizer is taught to lower a static declaration that carries a container the same way it lowers a contvar so unit lexicals keep being lowered to locals.

The first commit only adjusts the lex2local shape tests to tell a lowered declaration from a kept one by the sentinel value rather than by the decl kind, since a unit container is now also `static`.

Fixes #6600
