### PR TITLE
RakuAST: fix package naming and version parsing for Inline::Perl5

### DIFF
--- a/src/Raku/Grammar.nqp
+++ b/src/Raku/Grammar.nqp
@@ -4643,7 +4643,7 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
         <?before v\d+\w*
             [ '.' \d
               || <!{ $*R.resolve-lexical(~$/) }> ]>
-        'v' $<vstr>=[<vnum>+ % '.' ['+' | '-']? ]
+        'v' $<vstr>=[<vnum>+ % '.' ['+' | '-' <!before \w>]? ]
         <!before '-'|\'> # cheat because of LTM fail
     }
 

--- a/src/Raku/ast/package.rakumod
+++ b/src/Raku/ast/package.rakumod
@@ -218,9 +218,18 @@ class RakuAST::Package
                     self.stubbed-meta-object(:$resolver, :$context)
                 );
                 my $full-name := self.IMPL-FULL-NAME($resolver);
+                # A HOW written in Raku receives the name its type is created
+                # with through a Raku signature, which boxes it, and its own
+                # methods read the attribute back expecting a value they can
+                # call methods on. Rename it with the flavour it already holds
+                # rather than always with a raw VM string.
+                my $current-name := $type-object.HOW.name($type-object);
+                my str $full-name-str := $full-name.canonicalize(:colonpairs(0));
                 $type-object.HOW.set_name(
                     $type-object,
-                    $full-name.canonicalize(:colonpairs(0))
+                    nqp::istype($current-name, Str)
+                      ?? nqp::box_s($full-name-str, Str)
+                      !! $full-name-str
                 );
 
                 # Update the Stash's name, too.

--- a/t/02-rakudo/custom-declarator-naming.t
+++ b/t/02-rakudo/custom-declarator-naming.t
@@ -1,0 +1,23 @@
+use lib <t/02-rakudo/test-packages>;
+use Test;
+use RakuLevelNameHOW;
+
+plan 4;
+
+rakuname Alpha { }
+rakuname GLOBAL::Gamma { }
+module Wrap { rakuname Beta { } }
+
+is Alpha.HOW.name-chars(Alpha), 5,
+  'a HOW written in Raku can use the name of a package declared at unit scope';
+
+is Gamma.HOW.name-chars(Gamma), 5,
+  'a HOW written in Raku can use the name of a package declared with a GLOBAL:: prefix';
+
+is Wrap::Beta.HOW.name-chars(Wrap::Beta), 10,
+  'a HOW written in Raku can use the name of a package declared inside another package';
+
+is Wrap::Beta.^name, 'Wrap::Beta',
+  'a package declared inside another package is still named with the enclosing package';
+
+# vim: expandtab shiftwidth=4

--- a/t/02-rakudo/leading-use-version-like-name.t
+++ b/t/02-rakudo/leading-use-version-like-name.t
@@ -1,0 +1,24 @@
+use lib <t/02-rakudo/test-packages>;
+use Test;
+use MONKEY-SEE-NO-EVAL;
+use nqp;
+
+my $rakuast := nqp::gethllsym('Raku', 'COMPILER-FRONTEND') eq 'rakuast';
+
+plan 3;
+
+ok EVAL('use v5-dashed; dashed-module-loaded()'),
+  'a leading `use` of a module whose name starts with a version-like part loads the module';
+
+is EVAL('use v6; v1.2+.raku'), 'v1.2+',
+  'a version may still be given a + adverb';
+
+if $rakuast {
+    is EVAL('use v6; v1.2-.raku'), 'v1.2-',
+      'a version may still be given a - adverb';
+}
+else {
+    skip 'the - version adverb is only supported by the RakuAST frontend';
+}
+
+# vim: expandtab shiftwidth=4

--- a/t/02-rakudo/test-packages/RakuLevelNameHOW.rakumod
+++ b/t/02-rakudo/test-packages/RakuLevelNameHOW.rakumod
@@ -1,0 +1,32 @@
+# A meta-object written in Raku rather than in NQP, in the shape Inline::Perl5
+# uses: it composes Metamodel::Naming and names the type from its own new_type,
+# whose signature boxes the string it is handed. Its other methods then read
+# $!name back expecting a value they can call methods on.
+class MetamodelX::RakuLevelNameHOW
+    does Metamodel::Naming
+    does Metamodel::Stashing
+{
+    my $archetypes := Metamodel::Archetypes.new(:nominal(1));
+    method archetypes(Mu $?) { $archetypes }
+
+    method new_type(:$name) {
+        my $how = self.new;
+        my $type := Metamodel::Primitives.create_type($how);
+        $how.set_name($type, $name);
+        $how.add_stash($type);
+        Metamodel::Primitives.configure_type_checking($type, (Any, Mu), :authoritative);
+        $type
+    }
+
+    method compose(Mu $type) { $type }
+
+    method name-chars(Mu $type) { $!name.chars }
+}
+
+my package EXPORTHOW {
+    package DECLARE {
+        constant rakuname = MetamodelX::RakuLevelNameHOW;
+    }
+}
+
+# vim: expandtab shiftwidth=4

--- a/t/02-rakudo/test-packages/v5-dashed.rakumod
+++ b/t/02-rakudo/test-packages/v5-dashed.rakumod
@@ -1,0 +1,7 @@
+# Named so that a leading `use v5-dashed` puts a version-like part where the
+# compilation unit looks for a `use v6` language declaration.
+unit module v5-dashed;
+
+our sub dashed-module-loaded() is export { True }
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Getting Inline::Perl5 working under the RakuAST frontend turned up two unrelated compiler bugs. Both are RakuAST only, the legacy frontend does the right thing in each case, and each commit carries a test that runs on both frontends.

**Naming a package hands the meta-object a raw VM string.** Previously a package's meta-object was created with the name it was declared with and then renamed with its fully qualified name, always handing `set_name` a raw VM string. The legacy frontend passes the fully qualified name to `new_type` once and never renames. That matters for a HOW written in Raku rather than in NQP, e.g. `Inline::Perl5::ClassHOW`, which receives the name through a Raku signature, which boxes it, and then reads `$!name` back directly, which does not. After the rename it is holding a string with no methods on it, and the first use of the name dies with `No such method 'Stringy' for string 'Foo'`. An NQP HOW wants the raw string and does its own string ops on it, so we cannot just box it either way. This passes the rename the same kind of string the name already holds.

**A version adverb eats a module name.** Previously the optional `+` or `-` that may follow a version's numbers would take the hyphen out of a module name such as `v5-inline`. `vnum` is `\w+` and stops at the hyphen, so `v5-inline` matched as version `5-`, and the `<!before '-'>` guard after it cannot help because the hyphen has already been consumed by then. A compilation unit whose first statement is `use v5-inline` would fail with `No compiler available for Raku v5-`, as that is the slot `lang-setup` parses a `use v6` in. Inside a block LTM picks the longname instead, so this only shows up at the very start of a file. This only takes the hyphen when what follows it cannot continue an identifier. The `+` is left as it was, as is `v1.2-`, which a04661369b added and the legacy frontend does not have.

With both of these plus https://github.com/niner/Inline-Perl5/pull/194 Inline::Perl5's test suite passes in full under RAKUDO_RAKUAST=1, the same as it does on the legacy frontend.
