### PR TITLE
RakuAST: bind a BEGIN-called routine to the running compilation

### DIFF
--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -163,9 +163,21 @@ class RakuAST::Code
         );
         self.IMPL-TWEAK-REGEX-CLONE($context, $clone) if $regex;
         my $closure := QAST::Op.new( :op('p6capturelex'), $clone );
-        $!dynamically-compiled && !$context.is-precompilation-mode
-            ?? QAST::Stmts.new(self.IMPL-DYNAMIC-DO-REBIND-QAST($context), $closure)
-            !! $closure
+        if $!dynamically-compiled && !$context.is-precompilation-mode {
+            my $stmts := QAST::Stmts.new(self.IMPL-DYNAMIC-DO-REBIND-QAST($context));
+            # A block clone copies its NEXT, LAST, QUIT and CLOSE
+            # phasers, so those bind here. The block's own declarations
+            # run after the clone has taken its copy.
+            if nqp::istype(self, RakuAST::ScopePhaser) {
+                my $phaser-binds := self.IMPL-PHASER-DO-REBINDS($context, :captured);
+                $stmts.push($phaser-binds) if nqp::elems($phaser-binds.list);
+            }
+            $stmts.push($closure);
+            $stmts
+        }
+        else {
+            $closure
+        }
     }
 
     # A dynamic compilation binds the do it produced, whose outer is a
@@ -1487,34 +1499,48 @@ class RakuAST::ScopePhaser {
 
     # A phaser fires as the code object the routine holds, with no
     # closure site of its own, so a routine compiled dynamically binds
-    # each phaser's do to the running compilation on entry. A phaser
-    # node that is not code itself, such as QUIT, hands its blorst out
-    # as the code object.
-    method IMPL-PHASER-DO-REBINDS(RakuAST::IMPL::QASTContext $context) {
+    # each phaser's do to the running compilation at whichever site
+    # reaches the phaser. A thunked phaser shares its blorst's code
+    # object when the blorst is code, and a phaser that is not code
+    # itself, such as QUIT, hands its blorst out the same way. A
+    # thunked phaser whose blorst is a bare statement is itself the
+    # code object. In each case the rebind reads the node the dynamic
+    # compilation marked.
+    method IMPL-PHASER-DO-REBINDS(RakuAST::IMPL::QASTContext $context, :$captured) {
         my $stmts := QAST::Stmts.new;
         my @nodes;
-        for '$!ENTER', '$!FIRST', '$!NEXT', '$!LAST', '$!QUIT', '$!PRE', '$!POST', '$!CLOSE' {
+        # A block clone copies its NEXT, LAST, QUIT and CLOSE phasers,
+        # so a clone site binds those ahead of the clone. Entering the
+        # block binds them all, which is the only site a loop body that
+        # runs immediate, with no clone of its own, ever reaches. The
+        # captured names are the ones BOOTSTRAP !clone_phasers copies
+        # and !capture_phasers walks, and have to stay in step with them.
+        my @names := $captured
+            ?? ['$!NEXT', '$!LAST', '$!QUIT', '$!CLOSE']
+            !! ['$!ENTER', '$!FIRST', '$!NEXT', '$!LAST', '$!QUIT',
+                '$!CLOSE', '$!PRE', '$!POST'];
+        for @names {
             my $list := nqp::getattr(self, RakuAST::ScopePhaser, $_);
             if $list {
                 nqp::push(@nodes, $_) for $list;
             }
         }
-        if $!LEAVE-ORDER {
-            nqp::push(@nodes, $_[1]) for $!LEAVE-ORDER;
+        unless $captured {
+            if $!LEAVE-ORDER {
+                nqp::push(@nodes, $_[1]) for $!LEAVE-ORDER;
+            }
+            nqp::push(@nodes, $!let) if $!let;
+            nqp::push(@nodes, $!temp) if $!temp;
         }
-        nqp::push(@nodes, $!let) if $!let;
-        nqp::push(@nodes, $!temp) if $!temp;
         for @nodes {
-            # A thunked phaser with a block body shares that block's code
-            # object, so the block is the node the dynamic compilation
-            # marked. A phaser that is not code itself, such as QUIT,
-            # hands its blorst out as the code object too.
-            my $code := nqp::can($_, 'blorst') && nqp::istype($_.blorst, RakuAST::Code)
+            my $code := nqp::can($_, 'blorst') && nqp::istype($_.blorst, RakuAST::Block)
                 ?? $_.blorst
                 !! nqp::istype($_, RakuAST::Code) ?? $_ !! Mu;
+            # A phaser that is not code and holds no code blorst has no
+            # do of its own to rebind.
             next unless nqp::isconcrete($code);
-            $code.IMPL-QAST-BLOCK($context, :blocktype<declaration_static>);
             if nqp::getattr_i($code, RakuAST::Code, '$!dynamically-compiled') {
+                $code.IMPL-QAST-BLOCK($context, :blocktype<declaration_static>);
                 $stmts.push($code.IMPL-DYNAMIC-DO-REBIND-QAST($context));
             }
         }

--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -107,6 +107,10 @@ class RakuAST::Code
     # record that the cache was formed early, and with what arguments,
     # so the block can be re-formed once the marks are known.
     has int $!begin-time-cached;
+    # Set when a dynamic compilation forms this block, so the sites that
+    # hand out a closure of it or declare it bind its do to the running
+    # compilation.
+    has int $!dynamically-compiled;
     has str $!begin-cache-blocktype;
     has Mu $!begin-cache-expression;
 
@@ -158,7 +162,66 @@ class RakuAST::Code
             QAST::WVal.new( :value($code-obj) ).annotate_self('past_block', $!qast-block).annotate_self('code_object', $code-obj)
         );
         self.IMPL-TWEAK-REGEX-CLONE($context, $clone) if $regex;
-        QAST::Op.new( :op('p6capturelex'), $clone )
+        my $closure := QAST::Op.new( :op('p6capturelex'), $clone );
+        $!dynamically-compiled && !$context.is-precompilation-mode
+            ?? QAST::Stmts.new(self.IMPL-DYNAMIC-DO-REBIND-QAST($context), $closure)
+            !! $closure
+    }
+
+    # A dynamic compilation binds the do it produced, whose outer is a
+    # snapshot of the compile-time scope. A unit run as a script emits the
+    # same block again, and a closure captured at BEGIN time keeps running
+    # the dynamic frame, so both compilations stay live at runtime. Each
+    # site that clones the code object first binds its do to the block of
+    # the compilation that is running, so the clone captures that frame.
+    # A clone registered before the dynamic compilation never captured a
+    # frame, so it gets a fresh do from that block as well. A precompiled
+    # unit needs none of this: loading it binds every do to its own
+    # frames.
+    method IMPL-DYNAMIC-DO-REBIND-QAST(RakuAST::IMPL::QASTContext $context) {
+        my $code-obj := self.meta-object;
+        my $block := $!qast-block;
+        nqp::die('IMPL-DYNAMIC-DO-REBIND-QAST needs the QAST block formed first')
+            unless $block;
+        my $stmts := QAST::Stmts.new(
+            QAST::Op.new(
+                :op('bindattr'),
+                QAST::WVal.new( :value($code-obj) ),
+                QAST::WVal.new( :value(Code) ),
+                QAST::SVal.new( :value('$!do') ),
+                QAST::BVal.new( :value($block) )
+            )
+        );
+        my %clones := $context.sub-id-to-cloned-code-objects();
+        if nqp::existskey(%clones, $!cuid) {
+            for %clones{$!cuid} -> $clone {
+                $context.ensure-sc($clone);
+                my $tmp := $stmts.unique('dynamic_do');
+                $stmts.push(QAST::Stmt.new(
+                    QAST::Op.new(
+                        :op('bind'),
+                        QAST::Var.new( :name($tmp), :scope('local'), :decl('var') ),
+                        QAST::Op.new( :op('clone'), QAST::BVal.new( :value($block) ) )
+                    ),
+                    # The fresh do takes its code object before the clone
+                    # binds it, so a call racing this rebind never runs a
+                    # do that answers for the original.
+                    QAST::Op.new(
+                        :op('setcodeobj'),
+                        QAST::Var.new( :name($tmp), :scope('local') ),
+                        QAST::WVal.new( :value($clone) )
+                    ),
+                    QAST::Op.new(
+                        :op('bindattr'),
+                        QAST::WVal.new( :value($clone) ),
+                        QAST::WVal.new( :value(Code) ),
+                        QAST::SVal.new( :value('$!do') ),
+                        QAST::Var.new( :name($tmp), :scope('local') )
+                    )
+                ));
+            }
+        }
+        $stmts
     }
 
     method IMPL-QAST-BLOCK(RakuAST::IMPL::QASTContext $context, str :$blocktype,
@@ -193,6 +256,7 @@ class RakuAST::Code
         nqp::bindattr(self, RakuAST::Code, '$!qast-block', $block);
         if nqp::ifnull(nqp::getlexdyn('$*IMPL-COMPILE-DYNAMICALLY'), 0) {
             nqp::bindattr_i(self, RakuAST::Code, '$!begin-time-cached', 1);
+            nqp::bindattr_i(self, RakuAST::Code, '$!dynamically-compiled', 1);
             if self.IMPL-REBUILD-ELIGIBLE {
                 nqp::bindattr_s(self, RakuAST::Code, '$!begin-cache-blocktype', $blocktype);
                 nqp::bindattr(self, RakuAST::Code, '$!begin-cache-expression', $expression);
@@ -666,6 +730,7 @@ class RakuAST::Code
     }
 
     method IMPL-COMPILE-DYNAMICALLY(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context, Mu $block) {
+        nqp::bindattr_i(self, RakuAST::Code, '$!dynamically-compiled', 1);
         my $wrapper := QAST::Block.new(QAST::Stmts.new(), nqp::clone($block));
         $wrapper.annotate('DYN_COMP_WRAPPER', 1);
 
@@ -718,7 +783,12 @@ class RakuAST::Code
         ));
 
         for self.IMPL-EXTRA-BEGIN-TIME-DECLS($resolver, $context) {
-            if nqp::istype($_, RakuAST::CompileTimeValue) {
+            # A code node the compiled block takes a closure of, declared
+            # here as the scope enclosing that block would in a unit.
+            if nqp::istype($_, RakuAST::Code) && !nqp::istype($_, RakuAST::Declaration) {
+                $wrapper[0].push($_.IMPL-QAST-DECL-CODE($context));
+            }
+            elsif nqp::istype($_, RakuAST::CompileTimeValue) {
                 my $value := $_.compile-time-value;
                 $context.ensure-sc($value);
                 $wrapper[0].push(QAST::Var.new(
@@ -897,6 +967,10 @@ class RakuAST::ExpressionThunk
     # content (a loop's NEXT phasers) is only known once the body compiles.
     has Mu $!prelude-producer;
 
+    # The expression the block was formed around, for a compilation of
+    # the thunk on its own.
+    has RakuAST::Expression $!formed-expression;
+
     method new() {
         nqp::create(self)
     }
@@ -933,6 +1007,15 @@ class RakuAST::ExpressionThunk
     # into the passed `$target`. If there is a next thunk in `$!next` then it
     # should be compiled recursively and the expression passed along; otherwise,
     # the expression itself should be compiled and used as the body.
+    # An expression that is itself a code node, as `try` of a bare
+    # statement is, has the thunk body take a closure of it, and the
+    # scope enclosing the thunk is what declares its block. A thunk
+    # compiled on its own, as a constant's value is, has that
+    # compilation's wrapper declare the block instead.
+    method IMPL-EXTRA-BEGIN-TIME-DECLS(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
+        nqp::istype($!formed-expression, RakuAST::Code) ?? [$!formed-expression] !! []
+    }
+
     method IMPL-THUNK-CODE-QAST(RakuAST::IMPL::QASTContext $context, Mu $target,
             RakuAST::Expression $expression) {
 
@@ -943,6 +1026,7 @@ class RakuAST::ExpressionThunk
 
     method IMPL-QAST-FORM-BLOCK(RakuAST::IMPL::QASTContext $context,
             str :$blocktype, RakuAST::Expression :$expression!) {
+        nqp::bindattr(self, RakuAST::ExpressionThunk, '$!formed-expression', $expression);
         # From the block, compiling the signature.
         my $signature := self.IMPL-GET-OR-PRODUCE-SIGNATURE;
         my $stmts := QAST::Stmts.new();
@@ -1401,9 +1485,50 @@ class RakuAST::ScopePhaser {
         }
     }
 
+    # A phaser fires as the code object the routine holds, with no
+    # closure site of its own, so a routine compiled dynamically binds
+    # each phaser's do to the running compilation on entry. A phaser
+    # node that is not code itself, such as QUIT, hands its blorst out
+    # as the code object.
+    method IMPL-PHASER-DO-REBINDS(RakuAST::IMPL::QASTContext $context) {
+        my $stmts := QAST::Stmts.new;
+        my @nodes;
+        for '$!ENTER', '$!FIRST', '$!NEXT', '$!LAST', '$!QUIT', '$!PRE', '$!POST', '$!CLOSE' {
+            my $list := nqp::getattr(self, RakuAST::ScopePhaser, $_);
+            if $list {
+                nqp::push(@nodes, $_) for $list;
+            }
+        }
+        if $!LEAVE-ORDER {
+            nqp::push(@nodes, $_[1]) for $!LEAVE-ORDER;
+        }
+        nqp::push(@nodes, $!let) if $!let;
+        nqp::push(@nodes, $!temp) if $!temp;
+        for @nodes {
+            # A thunked phaser with a block body shares that block's code
+            # object, so the block is the node the dynamic compilation
+            # marked. A phaser that is not code itself, such as QUIT,
+            # hands its blorst out as the code object too.
+            my $code := nqp::can($_, 'blorst') && nqp::istype($_.blorst, RakuAST::Code)
+                ?? $_.blorst
+                !! nqp::istype($_, RakuAST::Code) ?? $_ !! Mu;
+            next unless nqp::isconcrete($code);
+            $code.IMPL-QAST-BLOCK($context, :blocktype<declaration_static>);
+            if nqp::getattr_i($code, RakuAST::Code, '$!dynamically-compiled') {
+                $stmts.push($code.IMPL-DYNAMIC-DO-REBIND-QAST($context));
+            }
+        }
+        $stmts
+    }
+
     method add-phasers-handling-code(RakuAST::IMPL::Context $context, Mu $qast) {
         my $block := nqp::istype(self, RakuAST::Code) ?? self.meta-object !! NQPMu;
         my $phasers := nqp::isconcrete($block) ?? nqp::getattr($block, Block, '$!phasers') !! NQPMu;
+
+        unless $context.is-precompilation-mode {
+            my $rebinds := self.IMPL-PHASER-DO-REBINDS($context);
+            $qast[0].push($rebinds) if nqp::elems($rebinds.list);
+        }
 
         if $!has-exit-handler || self.needs-result > 1 || $phasers && (nqp::istype($phasers, Code) || nqp::existskey($phasers, 'LEAVE') || nqp::existskey($phasers, 'POST')) {
             $qast.has_exit_handler(1);
@@ -3123,6 +3248,15 @@ class RakuAST::Routine
             return $stmts;
         }
 
+        # A multi candidate has no lexical of its own, so its placement in
+        # the enclosing block is where its do gets bound to the running
+        # compilation.
+        if self.multiness eq 'multi'
+          && nqp::getattr_i(self, RakuAST::Code, '$!dynamically-compiled')
+          && !$context.is-precompilation-mode {
+            return QAST::Stmts.new($block, self.IMPL-DYNAMIC-DO-REBIND-QAST($context));
+        }
+
         $block
     }
 
@@ -3152,7 +3286,11 @@ class RakuAST::Routine
                     # The comp unit's frame runs once per load, so the
                     # serialized routine works as the lexical's value as is.
                     $context.ensure-sc(self.meta-object);
-                    QAST::Var.new( :decl<static>, :scope<lexical>, :$name, :value(self.meta-object) )
+                    my $decl := QAST::Var.new( :decl<static>, :scope<lexical>, :$name, :value(self.meta-object) );
+                    nqp::getattr_i(self, RakuAST::Code, '$!dynamically-compiled')
+                      && !$context.is-precompilation-mode
+                        ?? QAST::Stmts.new($decl, self.IMPL-DYNAMIC-DO-REBIND-QAST($context))
+                        !! $decl
                 }
             }
         }

--- a/src/Raku/ast/statementprefixes.rakumod
+++ b/src/Raku/ast/statementprefixes.rakumod
@@ -255,6 +255,15 @@ class RakuAST::StatementPrefix::Thunky
                    $context, :$blocktype, :$expression)
     }
 
+    # A thunk with a block body hands out that block's code object, so
+    # the block is also the node carrying the dynamic compilation mark
+    # and the QAST block a closure of it binds.
+    method IMPL-CLOSURE-QAST(RakuAST::IMPL::QASTContext $context, Bool :$regex) {
+        nqp::istype(self.blorst, RakuAST::Block)
+            ?? self.blorst.IMPL-CLOSURE-QAST($context, :$regex)
+            !! nqp::findmethod(RakuAST::Code, 'IMPL-CLOSURE-QAST')(self, $context, :$regex)
+    }
+
     method IMPL-QAST-DECL-CODE(RakuAST::IMPL::QASTContext $context) {
         if nqp::istype(self.blorst, RakuAST::Block) {
             # Block already, so we need add nothing.

--- a/src/Raku/ast/statementprefixes.rakumod
+++ b/src/Raku/ast/statementprefixes.rakumod
@@ -273,14 +273,7 @@ class RakuAST::StatementPrefix::Thunky
             QAST::Op.new( :op('call'), self.blorst.IMPL-TO-QAST($context) )
         }
         else {
-            my $block := self.meta-object;
-            $context.ensure-sc($block);
-            my $clone := QAST::Op.new(
-                :op('callmethod'), :name('clone'),
-                QAST::WVal.new( :value($block) ).annotate_self('past_block', self.IMPL-QAST-BLOCK($context, :blocktype('declaration_static'))).annotate_self('code_object', $block)
-            );
-            my $closure := QAST::Op.new( :op('p6capturelex'), $clone );
-            QAST::Op.new( :op('call'), $closure)
+            QAST::Op.new( :op('call'), self.IMPL-CLOSURE-QAST($context) )
         }
     }
 }

--- a/t/02-rakudo/begin-called-block-routine.t
+++ b/t/02-rakudo/begin-called-block-routine.t
@@ -1,0 +1,283 @@
+use Test;
+use nqp;
+
+plan 32;
+
+# The bind belongs to the RakuAST frontend, so the legacy frontend runs
+# none of this.
+unless nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' {
+    skip-rest 'the BEGIN-time compilation bind is specific to the RakuAST frontend';
+    exit;
+}
+
+# A routine called at BEGIN time is compiled ahead of the unit, in a
+# compilation of its own whose outer is a snapshot of the compile-time
+# scope. A unit run as a script binds such a routine to the block of its
+# own compilation where the routine is declared, so a routine declared in
+# a block closes over the frame of the block at runtime and not over that
+# snapshot. Each case reads a lexical of an enclosing bare block, which
+# is what tells the two compilations apart. A lexical at unit scope
+# reads the same either way and would assert nothing.
+
+{
+    my $x = 5;
+    sub c() { $x }
+    BEGIN c();
+    $x = 7;
+    is c(), 7, 'a sub in a block reads the runtime value of a block lexical';
+}
+
+{
+    my $x = 5;
+    multi c() { $x }
+    BEGIN c();
+    $x = 7;
+    is c(), 7, 'a multi in a block reads the runtime value of a block lexical';
+}
+
+{
+    my $x = 5;
+    my $cl = sub c() { $x }
+    BEGIN c();
+    $x = 7;
+    is $cl(), 7, 'the closure a sub declaration evaluates to reads the runtime value';
+}
+
+{
+    my $x = 5;
+    sub c() { $x }
+    sub d() { c() }
+    BEGIN d();
+    $x = 7;
+    is d(), 7, 'a sub reached through another sub called at BEGIN time reads the runtime value';
+}
+
+{
+    my $x = 5;
+    sub c() { -> { $x } }
+    BEGIN c()();
+    $x = 7;
+    is c()(), 7, 'a closure taken inside a sub called at BEGIN time reads the runtime value';
+}
+
+{
+    my $x = 5;
+    sub c() { $x }
+    my &saved = BEGIN { c(); &c };
+    $x = 7;
+    is saved(), 7, 'the routine object a BEGIN block hands out reads the runtime value';
+    is c(), 7, 'the block lexical for that routine reads the runtime value';
+}
+
+{
+    my @seen;
+    for 1, 2 {
+        my $x = $_;
+        sub c() { $x }
+        BEGIN c();
+        @seen.push(c());
+    }
+    is-deeply @seen, [1, 2], 'each entry of a loop body clones the sub over its own lexical';
+}
+
+{
+    my @closures;
+    for 1, 2 {
+        my $x = $_;
+        my &cl = sub c() { $x }
+        BEGIN c();
+        @closures.push(&cl);
+    }
+    is-deeply @closures.map({ .() }).list, (1, 2), 'closures kept from each loop entry read their own lexical';
+}
+
+{
+    use soft;
+    sub s() { 1 }
+    sub c() { s() }
+    BEGIN c();
+    &s.wrap(-> { 42 });
+    is c(), 42, 'a runtime wrap of a sub is seen by a caller that ran at BEGIN time';
+}
+
+{
+    my $x = 5;
+    sub c() { $x }
+    BEGIN c();
+    &c.wrap(-> { 'w' ~ callsame });
+    $x = 7;
+    is c(), 'w7', 'a runtime wrap of a sub called at BEGIN time wraps its runtime clone';
+}
+
+{
+    use soft;
+    sub s() { 1 }
+    sub c() { s() }
+    BEGIN { &c.wrap(-> { 'w' ~ callsame }); c() }
+    &s.wrap(-> { 42 });
+    is c(), 'w42', 'a sub wrapped and called at BEGIN time still sees a runtime wrap of its callee';
+}
+
+{
+    sub c() { state $n = 0; ++$n }
+    BEGIN c();
+    is c(), 1, 'a state variable in a block sub starts fresh at runtime';
+}
+
+sub unit-state() { state $n = 0; ++$n }
+BEGIN unit-state();
+is unit-state(), 1, 'a state variable in a unit sub starts fresh at runtime';
+
+sub unit-wrapped() { 1 }
+sub unit-caller() { unit-wrapped() }
+BEGIN unit-caller();
+&unit-wrapped.wrap(-> { 42 });
+is unit-caller(), 42, 'a runtime wrap of a unit sub is seen by a unit caller that ran at BEGIN time';
+
+{
+    my $x = 5;
+    sub with-default($y = { $x }) { $y }
+    BEGIN with-default();
+    $x = 7;
+    is with-default().(), 7,
+        'a closure a parameter default builds reads the runtime value';
+}
+
+{
+    my $x = 5;
+    sub default-expr($n = $x) { $n }
+    BEGIN default-expr();
+    $x = 7;
+    is default-expr(), 7,
+        'an expression a parameter default evaluates reads the runtime value';
+}
+
+{
+    my $x = 5;
+    sub with-try() { try $x }
+    BEGIN with-try();
+    $x = 7;
+    is with-try(), 7,
+        'a statement prefix thunk in a sub called at BEGIN time reads the runtime value';
+}
+
+{
+    my $x = 5;
+    my $seen;
+    sub with-enter() { ENTER { $seen = $x }; 1 }
+    BEGIN with-enter();
+    $x = 7;
+    with-enter();
+    is $seen, 7, 'an ENTER phaser with a block body reads the runtime value';
+}
+
+{
+    my $x = 5;
+    my $seen;
+    sub with-leave() { LEAVE { $seen = $x }; 1 }
+    BEGIN with-leave();
+    $x = 7;
+    with-leave();
+    is $seen, 7, 'a LEAVE phaser with a block body reads the runtime value';
+}
+
+{
+    my $x = 5;
+    my $seen;
+    sub with-keep() { KEEP { $seen = $x }; 1 }
+    BEGIN with-keep();
+    $x = 7;
+    with-keep();
+    is $seen, 7, 'a KEEP phaser with a block body reads the runtime value';
+}
+
+our $temporized = 1;
+{
+    my $x = 5;
+    my $seen;
+    sub with-temp() { temp $temporized = $x; $seen = $temporized; 1 }
+    BEGIN with-temp();
+    $x = 7;
+    with-temp();
+    is $seen, 7, 'a temp in a sub called at BEGIN time assigns the runtime value';
+}
+
+{
+    my $x = 5;
+    my regex matcher { $x }
+    sub with-regex() { so 'q' ~~ &matcher }
+    BEGIN with-regex();
+    $x = 'q';
+    is with-regex(), True,
+        'a regex a sub called at BEGIN time matches interpolates the runtime value';
+}
+
+{
+    my $x = 5;
+    sub outer-routine() { sub inner-routine() { $x }; inner-routine() }
+    BEGIN outer-routine();
+    $x = 7;
+    is outer-routine(), 7,
+        'a sub nested in a sub called at BEGIN time reads the runtime value';
+}
+
+{
+    my $x = 5;
+    proto explicit-proto(|) {*}
+    multi explicit-proto() { $x }
+    BEGIN explicit-proto();
+    $x = 7;
+    is explicit-proto(), 7,
+        'a candidate of an explicit proto reads the runtime value';
+}
+
+{
+    my $x = 5;
+    sub read-from-thread() { $x }
+    BEGIN read-from-thread();
+    $x = 7;
+    is await(start read-from-thread()), 7,
+        'a sub called at BEGIN time reads the runtime value on another thread';
+}
+
+{
+    sub hands-out-closure() { -> $y { { $y } } }
+    my &saved = BEGIN hands-out-closure();
+    is saved(9), 9,
+        'a closure a BEGIN-called sub handed out still runs once the sub is bound again';
+}
+
+# A constant's value runs in a compilation of its own that holds the
+# thunk around the value and nothing else, so a statement prefix of a
+# bare statement, which that thunk takes a closure of, is declared by
+# the thunk rather than by an enclosing scope.
+
+{
+    constant $tried = try 42;
+    is $tried, 42, 'a constant whose value is a try of a bare statement';
+}
+
+{
+    constant @gathered = gather take 1;
+    is-deeply @gathered, (1,), 'a constant whose value is a gather of a bare statement';
+}
+
+{
+    constant $started = start 42;
+    is $started.result, 42, 'a constant whose value is a start of a bare statement';
+}
+
+{
+    constant $onced = once 42;
+    is $onced, 42, 'a constant whose value is a once of a bare statement';
+}
+
+# A thunk with an enclosing scope leaves that declaration to the scope.
+# Declared inside the thunk as well, the thunk's frame would capture a
+# block whose outer is the scope.
+
+{
+    my $modified = 'a';
+    s/(.)/x/ for $modified;
+    is $modified, 'x', 'a substitution under a for modifier runs from its enclosing scope';
+}

--- a/t/02-rakudo/begin-called-block-routine.t
+++ b/t/02-rakudo/begin-called-block-routine.t
@@ -1,7 +1,7 @@
 use Test;
 use nqp;
 
-plan 32;
+plan 53;
 
 # The bind belongs to the RakuAST frontend, so the legacy frontend runs
 # none of this.
@@ -13,11 +13,11 @@ unless nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast'
 # A routine called at BEGIN time is compiled ahead of the unit, in a
 # compilation of its own whose outer is a snapshot of the compile-time
 # scope. A unit run as a script binds such a routine to the block of its
-# own compilation where the routine is declared, so a routine declared in
-# a block closes over the frame of the block at runtime and not over that
-# snapshot. Each case reads a lexical of an enclosing bare block, which
-# is what tells the two compilations apart. A lexical at unit scope
-# reads the same either way and would assert nothing.
+# own compilation where the routine is declared, so a routine declared
+# in a block closes over the frame of the block at runtime and not over
+# that snapshot. The cases that read a lexical read one of an enclosing
+# bare block, which is what tells the two compilations apart. A lexical
+# at unit scope reads the same either way and would assert nothing.
 
 {
     my $x = 5;
@@ -244,7 +244,228 @@ our $temporized = 1;
     sub hands-out-closure() { -> $y { { $y } } }
     my &saved = BEGIN hands-out-closure();
     is saved(9), 9,
-        'a closure a BEGIN-called sub handed out still runs once the sub is bound again';
+        'a closure handed out by a sub called at BEGIN time still runs once the sub is bound again';
+}
+
+# A loop clones its body block, and the clone copies that block's NEXT,
+# LAST, QUIT and CLOSE phasers, so such a phaser binds before the clone.
+
+{
+    my $x = 5;
+    my $seen;
+    sub with-next() { for 1..2 { NEXT $seen = $x }; 1 }
+    BEGIN with-next();
+    $x = 7;
+    with-next();
+    is $seen, 7, 'a NEXT phaser of a loop in a sub called at BEGIN time reads the runtime value';
+}
+
+{
+    my $x = 5;
+    my $seen;
+    sub with-last() { for 1..2 { LAST $seen = $x }; 1 }
+    BEGIN with-last();
+    $x = 7;
+    with-last();
+    is $seen, 7, 'a LAST phaser of a loop in a sub called at BEGIN time reads the runtime value';
+}
+
+{
+    my $x = 5;
+    sub with-start() { start { $x } }
+    BEGIN with-start();
+    $x = 7;
+    is await(with-start()), 7,
+        'a start block in a sub called at BEGIN time reads the runtime value';
+}
+
+{
+    my $x = 5;
+    sub with-react() {
+        my @seen;
+        react { whenever supply { emit $x } -> $v { @seen.push($v); done } }
+        @seen[0]
+    }
+    BEGIN with-react();
+    $x = 7;
+    is with-react(), 7,
+        'a whenever block in a sub called at BEGIN time reads the runtime value';
+}
+
+{
+    my $x = 5;
+    my $seen;
+    sub with-while-next() { my $i = 0; while $i++ < 2 { NEXT $seen = $x }; 1 }
+    BEGIN with-while-next();
+    $x = 7;
+    with-while-next();
+    is $seen, 7,
+        'a NEXT phaser of a while loop in a sub called at BEGIN time reads the runtime value';
+}
+
+{
+    my $x = 5;
+    my $seen;
+    sub with-quit() {
+        react { whenever supply { die 'stop' } { QUIT { $seen = $x; done; True } } }
+        1
+    }
+    BEGIN { try with-quit() }
+    $x = 7;
+    try with-quit();
+    is $seen, 7, 'a QUIT phaser in a sub called at BEGIN time reads the runtime value';
+}
+
+# A statement prefix with a block body hands that block out as its code
+# object, so each prefix reaches the block through the same closure.
+
+{
+    my $x = 5;
+    sub with-gather() { gather { take $x } }
+    BEGIN with-gather().list;
+    $x = 7;
+    is with-gather().list[0], 7,
+        'a gather block in a sub called at BEGIN time takes the runtime value';
+}
+
+{
+    my $x = 5;
+    sub with-do() { do { $x } }
+    BEGIN with-do();
+    $x = 7;
+    is with-do(), 7, 'a do block in a sub called at BEGIN time reads the runtime value';
+}
+
+{
+    my $x = 5;
+    sub with-try-block() { try { $x } }
+    BEGIN with-try-block();
+    $x = 7;
+    is with-try-block(), 7,
+        'a try block in a sub called at BEGIN time reads the runtime value';
+}
+
+{
+    my $x = 5;
+    sub with-once() { once { $x } }
+    BEGIN with-once();
+    $x = 7;
+    is with-once(), 7, 'a once block in a sub called at BEGIN time reads the runtime value';
+}
+
+# A loop body that runs immediate has no clone of its own, so entering
+# the block is the only site its phasers bind at.
+
+{
+    my $x = 5;
+    my $seen;
+    sub with-until-next() { my $i = 0; until $i++ >= 2 { NEXT $seen = $x }; 1 }
+    BEGIN with-until-next();
+    $x = 7;
+    with-until-next();
+    is $seen, 7,
+        'a NEXT phaser of an until loop in a sub called at BEGIN time reads the runtime value';
+}
+
+{
+    my $x = 5;
+    my $seen;
+    sub with-repeat-next() { my $i = 0; repeat { NEXT $seen = $x } while $i++ < 1; 1 }
+    BEGIN with-repeat-next();
+    $x = 7;
+    with-repeat-next();
+    is $seen, 7,
+        'a NEXT phaser of a repeat loop in a sub called at BEGIN time reads the runtime value';
+}
+
+{
+    my $x = 5;
+    my $seen;
+    sub with-loop-last() { loop (my $i = 0; $i < 2; $i++) { LAST $seen = $x }; 1 }
+    BEGIN with-loop-last();
+    $x = 7;
+    with-loop-last();
+    is $seen, 7,
+        'a LAST phaser of a loop statement in a sub called at BEGIN time reads the runtime value';
+}
+
+{
+    my $x = 5;
+    my $seen;
+    sub with-first-in-loop() { for 1..2 { FIRST $seen = $x }; 1 }
+    BEGIN with-first-in-loop();
+    $x = 7;
+    with-first-in-loop();
+    is $seen, 7,
+        'a FIRST phaser of a loop in a sub called at BEGIN time reads the runtime value';
+}
+
+our $let-restored = 1;
+{
+    my $x = 5;
+    my $seen;
+    sub with-let() { let $let-restored = $x; $seen = $let-restored; fail 'undo' }
+    BEGIN { try with-let() }
+    $x = 7;
+    try with-let();
+    is $seen, 7, 'a let in a sub called at BEGIN time assigns the runtime value';
+}
+
+{
+    my $x = 5;
+    my $seen;
+    sub with-close() {
+        my $tap = (supply { CLOSE { $seen = $x }; emit 1 }).tap;
+        $tap.close;
+        1
+    }
+    BEGIN with-close();
+    $x = 7;
+    $seen = Nil;
+    with-close();
+    is $seen, 7, 'a CLOSE phaser of a supply in a sub called at BEGIN time reads the runtime value';
+}
+
+# PRE and POST walk the same rebind list as the other phasers, and
+# UNDO rides the LEAVE order.
+
+{
+    my $x = 5;
+    my $seen;
+    sub with-pre() { PRE { $seen = $x; True }; 1 }
+    BEGIN with-pre();
+    $x = 7;
+    with-pre();
+    is $seen, 7, 'a PRE phaser in a sub called at BEGIN time reads the runtime value';
+}
+
+{
+    my $x = 5;
+    my $seen;
+    sub with-post() { POST { $seen = $x; True }; 1 }
+    BEGIN with-post();
+    $x = 7;
+    with-post();
+    is $seen, 7, 'a POST phaser in a sub called at BEGIN time reads the runtime value';
+}
+
+{
+    my $x = 5;
+    my $seen;
+    sub with-undo() { UNDO $seen = $x; fail 'undo' }
+    BEGIN { try with-undo() }
+    $x = 7;
+    try with-undo();
+    is $seen, 7, 'an UNDO phaser in a sub called at BEGIN time reads the runtime value';
+}
+
+{
+    my $x = 5;
+    my class WithMethod { method m() { $x } }
+    BEGIN WithMethod.m;
+    $x = 7;
+    is WithMethod.m, 7,
+        'a method of a class in a block called at BEGIN time reads the runtime value';
 }
 
 # A constant's value runs in a compilation of its own that holds the
@@ -281,3 +502,13 @@ our $temporized = 1;
     s/(.)/x/ for $modified;
     is $modified, 'x', 'a substitution under a for modifier runs from its enclosing scope';
 }
+
+# A runtime EVAL is itself a dynamic compilation.
+
+is EVAL(q[
+    my $x = 5;
+    sub evaled() { $x }
+    BEGIN evaled();
+    $x = 7;
+    evaled();
+]), 7, 'a sub called at BEGIN time inside a runtime EVAL reads the runtime value';

--- a/t/08-performance/36-rakuast-begin-compiled-remark.t
+++ b/t/08-performance/36-rakuast-begin-compiled-remark.t
@@ -3,16 +3,16 @@ use Test::Helpers::QAST;
 use Test;
 use QAST:from<NQP>;
 use nqp;
-plan 116;
+plan 117;
 
 # A routine invoked at BEGIN time compiles ahead of the unit's optimize
 # walk and caches its QAST. That compilation runs its own optimize walk
 # and lowering first. The unit emission re-forms the cached block after
 # the unit's own walk, so a precompiled unit runs such routines with
-# the same lowerings as routines compiled in the ordinary order, while
-# a script runs the frames of the early compilation. The behavioral
-# tests hold on both frontends. The QAST shape tests are specific to
-# the RakuAST frontend.
+# the same lowerings as routines compiled in the ordinary order, and a
+# script binds such routines to the unit's own frames where they are
+# declared. The behavioral tests hold on both frontends. The QAST shape
+# tests are specific to the RakuAST frontend.
 
 # Dynamic compilation is per code object, so each method the BEGIN
 # block invokes compiles ahead of the optimize walk.
@@ -307,17 +307,19 @@ with-leave();
 is $left, 1,
     'a LEAVE phaser in a sub used at BEGIN fires once per runtime call';
 
-# On both frontends a FIRST phaser in a sub invoked at BEGIN fires
-# during that call, so a runtime call finds the trigger container
-# already set. This pins that the runtime frame consults the container
-# the BEGIN compilation minted, not a fresh one from a later formation.
+# A FIRST phaser in a sub invoked at BEGIN fires during that call. Under
+# the RakuAST frontend the script binds the sub to the unit's own
+# compilation at load, whose trigger container starts unset, so the
+# first runtime call fires the phaser again, as a precompiled unit does.
+# The legacy frontend keeps the trigger state of the BEGIN compilation.
 our $first-runs = 0;
 sub with-first() { FIRST $first-runs++; 'x' }
 BEGIN { with-first(); with-first() }
 with-first();
 with-first();
-is $first-runs, 0,
-    'the runtime frame consults the FIRST trigger container the BEGIN compilation minted';
+is $first-runs,
+    nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' ?? 1 !! 0,
+    'a FIRST phaser in a sub used at BEGIN fires once at runtime under the RakuAST frontend and not at all under the legacy frontend';
 
 # A placeholder signature takes the reset on its own signature object.
 sub ph { $^a + 1 }
@@ -382,6 +384,14 @@ is EVAL(q[my class E { has int $!i; method m() { ++$!i } }; my $e := E.new; BEGI
         our sub nested-role-attr() { my role NA { has $.a = 42; method m() { $!a + 1 } }; my class NCA does NA { }; NCA.new.m }
         our $guarded-at-begin;
         our sub var-op() { my $s = 0; for 1..3 { $s = $s + $_ }; $s }
+        our &block-held;
+        {
+            my $bx = 5;
+            sub block-lexical() { $bx }
+            BEGIN block-lexical();
+            &block-held = &block-lexical;
+            $bx = 7;
+        }
         grammar PG { token TOP { ( "ab" | "a" | ( "b" ) ) } }
         BEGIN PG.parse("ab");
         class PC {
@@ -483,6 +493,8 @@ is EVAL(q[my class E { has int $!i; method m() { ++$!i } }; my $e := E.new; BEGI
         'a precompiled grammar parsed at BEGIN still captures its alternation';
     is ::('PrecompRemark::PG').parse("b")[0][0].Str, 'b',
         'a capturing group nested in another group survives precompilation of a BEGIN used grammar';
+    is &::('PrecompRemark::block-held')(), 7,
+        'a sub scoped to a bare block used at BEGIN reads the value the block assigns at load time';
     sub nuke(IO::Path $d) {
         for $d.dir { $_.d ?? nuke($_) !! $_.unlink }
         $d.rmdir;


### PR DESCRIPTION
Previously a routine called at BEGIN time kept the do of its dynamic compilation when the unit later ran as a script. That do closes over a snapshot of the compile-time scope, so a sub declared in a block read the snapshot instead of the block's runtime frame:

```raku
{ my $x = 5; sub c() { $x }; BEGIN c(); $x = 7; say c() }  # (Any), expected 7
```

A precompiled unit was unaffected, as loading it binds every do to the unit's own frames. Restoring the load-time fixup the dynamic compilation drops would be wrong in the other direction however, since a closure captured at BEGIN time keeps running the dynamic frame at runtime. Both compilations stay live, so instead each site that hands out a closure of a dynamically compiled routine binds its do to the block of the compilation that is running, ahead of the clone. Routines with no clone of their own get the same bind where they are declared, a unit-level sub and a multi candidate among them. The second commit extends the bind to the phasers a block clone copies and to statement prefix thunks such as `start`, whose block body is the code object the thunk hands out.

A FIRST phaser in a sub used at BEGIN now fires once at runtime, as it does from a precompiled unit.

This only changes the RakuAST frontend, and the new test file skips under the legacy frontend. It needs the nqp change in ugexe/bval-frame-of-own-compilation, since the `QAST::BVal` a bind site emits can precede the block in the unit's own compilation and the frame table is shared with the dynamic compilations.
