### PR TITLE
RakuAST: Compile the block without modifier via the without op

### DIFF
--- a/src/Raku/ast/statement-mods.rakumod
+++ b/src/Raku/ast/statement-mods.rakumod
@@ -217,31 +217,12 @@ class RakuAST::StatementModifier::Without
   is RakuAST::StatementModifier::Condition
 {
     method IMPL-WRAP-QAST(RakuAST::IMPL::QASTContext $context, Mu $statement-qast) {
-        if nqp::istype($statement-qast, QAST::Block && $statement-qast.code_object.count) {
-            my $code-obj := $statement-qast.code_object;
-            $context.ensure-sc($code-obj);
-            my $clone := QAST::Op.new(
-                :op('callmethod'), :name('clone'),
-                QAST::WVal.new( :value($code-obj) ).annotate_self('past_block', $statement-qast).annotate_self('code_object', $code-obj)
-            );
-            my $closure := QAST::Op.new( :op('p6capturelex'), $clone );
-
-            my $tested := QAST::Node.unique('without_tested');
+        if nqp::istype($statement-qast, QAST::Block) {
+            # It's a block, so just use the `without` compilation.
             QAST::Op.new(
-                :op('unless'),
-                QAST::Op.new(
-                    :op('callmethod'), :name('defined'),
-                    QAST::Op.new(
-                        :op('bind'),
-                        QAST::Var.new( :name($tested), :scope('local'), :decl('var') ),
-                        self.expression.IMPL-TO-QAST($context),
-                    ),
-                ),
-                QAST::Op.new(
-                    :op('call'),
-                    $closure,
-                    QAST::Var.new( :name($tested), :scope('local') ),
-                ),
+                :op('without'),
+                self.expression.IMPL-TO-QAST($context),
+                $statement-qast,
                 self.IMPL-EMPTY($context)
             )
         }

--- a/src/core.c/RakuAST/Raku.rakumod
+++ b/src/core.c/RakuAST/Raku.rakumod
@@ -203,6 +203,9 @@ augment class RakuAST::Node {
           'match-immediately', -> {
               :match-immediately if self.match-immediately
           },
+          'may-have-signature', -> {
+              :may-have-signature if self.may-have-signature
+          },
           'meta', -> {
               my $meta := self.meta;
               :$meta if $meta
@@ -347,7 +350,7 @@ augment class RakuAST::Node {
 
     multi method raku(RakuAST::Block:D: --> Str:D) {
         self!add-WHY: self!nameds:
-          <implicit-topic required-topic exception body>
+          <implicit-topic required-topic exception may-have-signature body>
     }
 
     multi method raku(RakuAST::Blockoid:D: --> Str:D) {

--- a/t/12-rakuast/statement-mods.rakutest
+++ b/t/12-rakuast/statement-mods.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 14;
+plan 20;
 
 my $ast;
 my $deparsed;
@@ -185,6 +185,215 @@ subtest 'The postfix "without" statement works with a type object' => {
 
     is-deeply $deparsed, '.Str without Int', 'deparse';
     is-deeply $_, "", @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'The postfix "without" statement runs a zero-parameter block' => {
+    # -> { 42 } without Any
+    ast RakuAST::Statement::Expression.new(
+      expression => RakuAST::PointyBlock.new(
+        body => RakuAST::Blockoid.new(
+          RakuAST::StatementList.new(
+            RakuAST::Statement::Expression.new(
+              expression => RakuAST::IntLiteral.new(42)
+            )
+          )
+        )
+      ),
+      condition-modifier => RakuAST::StatementModifier::Without.new(
+        RakuAST::Type::Simple.new(
+          RakuAST::Name.from-identifier('Any')
+        )
+      )
+    );
+
+    is-deeply $deparsed, q:to/CODE/.chomp, 'deparse';
+-> {
+    42
+} without Any
+CODE
+
+    is-deeply $_, 42, @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'The postfix "without" statement passes the tested value to a block parameter' => {
+    # -> $param { $param } without Int
+    ast RakuAST::Statement::Expression.new(
+      expression => RakuAST::PointyBlock.new(
+        signature => RakuAST::Signature.new(
+          parameters => (
+            RakuAST::Parameter.new(
+              target => RakuAST::ParameterTarget::Var.new(:name<$param>)
+            ),
+          )
+        ),
+        body => RakuAST::Blockoid.new(
+          RakuAST::StatementList.new(
+            RakuAST::Statement::Expression.new(
+              expression => RakuAST::Var::Lexical.new('$param')
+            )
+          )
+        )
+      ),
+      condition-modifier => RakuAST::StatementModifier::Without.new(
+        RakuAST::Type::Simple.new(
+          RakuAST::Name.from-identifier('Int')
+        )
+      )
+    );
+
+    is-deeply $deparsed, q:to/CODE/.chomp, 'deparse';
+-> $param {
+    $param
+} without Int
+CODE
+
+    is-deeply $_, Int, @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'The postfix "without" statement skips a block for a defined false value' => {
+    # -> $param { $param } without 0
+    ast RakuAST::Statement::Expression.new(
+      expression => RakuAST::PointyBlock.new(
+        signature => RakuAST::Signature.new(
+          parameters => (
+            RakuAST::Parameter.new(
+              target => RakuAST::ParameterTarget::Var.new(:name<$param>)
+            ),
+          )
+        ),
+        body => RakuAST::Blockoid.new(
+          RakuAST::StatementList.new(
+            RakuAST::Statement::Expression.new(
+              expression => RakuAST::Var::Lexical.new('$param')
+            )
+          )
+        )
+      ),
+      condition-modifier => RakuAST::StatementModifier::Without.new(
+        RakuAST::IntLiteral.new(0)
+      )
+    );
+
+    is-deeply $deparsed, q:to/CODE/.chomp, 'deparse';
+-> $param {
+    $param
+} without 0
+CODE
+
+    # cannot put Empty as an entity in a for
+    is-deeply EVAL($ast), Empty, @type[$++];
+    is-deeply EVAL($deparsed), Empty, @type[$++];
+    is-deeply EVAL(EVAL $raku), Empty, @type[$++];
+}
+
+subtest 'A zero-parameter block keeps the topic of its outer scope' => {
+    # $_ = 666; -> { $_ } without Any
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::ApplyInfix.new(
+          left  => RakuAST::Var::Lexical.new('$_'),
+          infix => RakuAST::Infix.new('='),
+          right => RakuAST::IntLiteral.new(666)
+        ),
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::PointyBlock.new(
+          body => RakuAST::Blockoid.new(
+            RakuAST::StatementList.new(
+              RakuAST::Statement::Expression.new(
+                expression => RakuAST::Var::Lexical.new('$_')
+              )
+            )
+          )
+        ),
+        condition-modifier => RakuAST::StatementModifier::Without.new(
+          RakuAST::Type::Simple.new(
+            RakuAST::Name.from-identifier('Any')
+          )
+        )
+      )
+    );
+
+    is-deeply $deparsed, q:to/CODE/.chomp, 'deparse';
+$_ = 666;
+-> {
+    $_
+} without Any
+CODE
+
+    is-deeply $_, 666, @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'A bare block topicalizes the tested value' => {
+    # $_ = 666; { $_ } without Any
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::ApplyInfix.new(
+          left  => RakuAST::Var::Lexical.new('$_'),
+          infix => RakuAST::Infix.new('='),
+          right => RakuAST::IntLiteral.new(666)
+        ),
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Block.new(
+          body => RakuAST::Blockoid.new(
+            RakuAST::StatementList.new(
+              RakuAST::Statement::Expression.new(
+                expression => RakuAST::Var::Lexical.new('$_')
+              )
+            )
+          )
+        ),
+        condition-modifier => RakuAST::StatementModifier::Without.new(
+          RakuAST::Type::Simple.new(
+            RakuAST::Name.from-identifier('Any')
+          )
+        )
+      )
+    );
+
+    is-deeply $deparsed, q:to/CODE/.chomp, 'deparse';
+$_ = 666;
+{
+    $_
+} without Any
+CODE
+
+    is-deeply $_, Any, @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'A placeholder block receives the tested value' => {
+    # { $^a } without Int
+    ast RakuAST::Statement::Expression.new(
+      expression => RakuAST::Block.new(
+        may-have-signature => True,
+        body => RakuAST::Blockoid.new(
+          RakuAST::StatementList.new(
+            RakuAST::Statement::Expression.new(
+              expression => RakuAST::VarDeclaration::Placeholder::Positional.new('$a')
+            )
+          )
+        )
+      ),
+      condition-modifier => RakuAST::StatementModifier::Without.new(
+        RakuAST::Type::Simple.new(
+          RakuAST::Name.from-identifier('Int')
+        )
+      )
+    );
+
+    is-deeply $deparsed, q:to/CODE/.chomp, 'deparse';
+{
+    $^a
+} without Int
+CODE
+
+    is-deeply $_, Int, @type[$++]
       for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
 }
 


### PR DESCRIPTION
The without statement modifier special-cased blocks by cloning the code object and calling it with the tested value, guarded by an arity check with a misplaced parenthesis. The check degraded to a bare block type test, so every block-shaped statement got called with the tested value:

```
$ RAKUDO_RAKUAST=1 raku -e '-> { say "ran" } without Any'
Too many positionals passed; expected 0 arguments but got 1
```

This drops the special case and compiles a block through the `without` QAST op, the same way the with modifier uses the `with` op (and the same op the legacy frontend already uses for this, which is why this only breaks under RAKUDO_RAKUAST=1). The op only passes the tested value to a block that takes a parameter, and it leaves the surrounding `$_` alone for blocks that don't.

Also includes a small fix for `RakuAST::Block.raku` dropping the `may-have-signature` flag, which meant EVALing the dump of a block using a placeholder variable rebuilt a block that rejects placeholders. The new tests roundtrip blocks through `.raku` and need it.
