### PR TITLE
RakuAST: link an EVAL's code objects inside the compiler

### DIFF
--- a/src/Perl6/Compiler.nqp
+++ b/src/Perl6/Compiler.nqp
@@ -234,6 +234,32 @@ class Perl6::Compiler is HLL::Compiler {
         $super(self, |@args, |%options);
     }
 
+    # An EVAL's code objects live in the enclosing compilation's
+    # serialization context, so the coderefs the backend produces for them
+    # have to be linked back once the pipeline has run, or an enclosing
+    # precompilation serializes code its loader cannot find. The stage
+    # that lowers the tree records the comp unit when that unit is an
+    # EVAL. A compile that starts past that stage records nothing: its
+    # caller built the QAST and owns the linking. Only a compile that runs
+    # to the final stage hands back a compilation unit to link.
+    method compile($source, :$from, *%adverbs) {
+        my $*RAKUAST-EVAL-COMP-UNIT := NQPMu;
+        my %options := nqp::clone(%adverbs);
+        %options<compunit_ok> := 1;
+        my $super := nqp::findmethod(HLL::Compiler, 'compile');
+        my $result := $super(self, $source, :$from, |%options);
+
+        my $comp-unit := $*RAKUAST-EVAL-COMP-UNIT;
+        my str $target := nqp::lc(%adverbs<target>);
+        my @stages := self.stages();
+        if nqp::isconcrete($comp-unit)
+          && ($target eq '' || $target eq @stages[nqp::elems(@stages) - 1]) {
+            $comp-unit.context.IMPL-FIXUP-COMPILED-CODEREFS(
+                nqp::compunitcodes($result));
+        }
+        %adverbs<compunit_ok> ?? $result !! self.backend.compunit_mainline($result)
+    }
+
     # The stage whose output is the finished QAST tree. Compilation that
     # starts with an already-built QAST tree passes this as the :from stage.
     # The legacy frontend produces its final QAST in its optimize stage, the
@@ -297,7 +323,21 @@ class Perl6::Compiler is HLL::Compiler {
         # such EVALs don't compile into an ephemeral context that breaks
         # precompilation.
         my $*CU := $rakuast;
-        my $comp_unit := $rakuast.IMPL-TO-QAST-COMP-UNIT;
+        $*RAKUAST-EVAL-COMP-UNIT := $rakuast
+            if $rakuast.is-eval && !nqp::isnull(nqp::getlexdyn('$*RAKUAST-EVAL-COMP-UNIT'));
+        # The cleanup nulls the compiler state stubbed code objects carry.
+        # An EVAL's code objects sit in the enclosing compilation's
+        # serialization context, so a lowering that throws still runs it,
+        # and a failure in the cleanup itself must not hide the error
+        # that got here.
+        my $comp_unit;
+        {
+            $comp_unit := $rakuast.IMPL-TO-QAST-COMP-UNIT;
+            CATCH {
+                try { $rakuast.cleanup() }
+                nqp::rethrow($_);
+            }
+        }
         $rakuast.cleanup();
         $comp_unit;
     }

--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -1290,11 +1290,14 @@ class RakuAST::ScopePhaser {
         self.IMPL-ADD-PHASER-TO-LEAVE-ORDER('UNDO', $phaser);
     }
 
-    method add-enter-phaser(RakuAST::StatementPrefix::Phaser $phaser) {
+    # The scope names the phaser's result lexical here. A phaser node
+    # added outside a parse never reaches begin time, so it has to supply
+    # its own meta-object.
+    method add-enter-phaser(RakuAST::StatementPrefix::Phaser::Enter $phaser) {
         self.add-phaser('ENTER', $phaser);
-        my $result-name := '__enter_phaser_result_' ~ $!next-enter-phaser-result;
+        $phaser.set-result-name('__enter_phaser_result_' ~ $!next-enter-phaser-result);
         nqp::bindattr_i(self, RakuAST::ScopePhaser, '$!next-enter-phaser-result', $!next-enter-phaser-result + 1);
-        $result-name
+        Nil
     }
 
     method set-needs-result(Bool $needs-result) {
@@ -1484,7 +1487,7 @@ class RakuAST::ScopePhaser {
             my %seen;
             if $!ENTER {
                 for $!ENTER {
-                    my $result-name := $_.IMPL-RESULT-NAME;
+                    my $result-name := $_.result-name;
                     $enter-setup.push(
                       QAST::Op.new(
                         :op<bind>,

--- a/src/Raku/ast/statementprefixes.rakumod
+++ b/src/Raku/ast/statementprefixes.rakumod
@@ -849,16 +849,21 @@ class RakuAST::StatementPrefix::Phaser::Enter
     }
 
     method PERFORM-BEGIN(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
-        nqp::bindattr_s(self, RakuAST::StatementPrefix::Phaser::Enter, '$!result-name',
-            ($resolver.find-attach-target('block')
-              // $resolver.find-attach-target('compunit')
-            ).add-enter-phaser(self)
-        );
+        ($resolver.find-attach-target('block')
+          // $resolver.find-attach-target('compunit')
+        ).add-enter-phaser(self);
         self.IMPL-STUB-CODE($resolver, $context);
     }
 
-    method IMPL-RESULT-NAME() {
+    # The name of the lexical the enclosing scope declares for this
+    # phaser's result, handed over when the scope takes the phaser.
+    method result-name() {
         $!result-name
+    }
+
+    method set-result-name(str $name) {
+        nqp::bindattr_s(self, RakuAST::StatementPrefix::Phaser::Enter, '$!result-name', $name);
+        Nil
     }
 
     # Call the phaser's code object directly rather than a fresh clone per

--- a/src/core.c/ForeignCode.rakumod
+++ b/src/core.c/ForeignCode.rakumod
@@ -59,9 +59,13 @@ $lang = 'Raku' if $lang eq 'perl6';
     my $eval_ctx := nqp::getattr(nqp::decont($context), PseudoStash, '$!ctx');
 
     # Compile a RakuAST comp-unit the rest of the way to a code object.
-    # IMPL-TO-QAST-COMP-UNIT runs outside the compiler's qast stage here,
-    # so bind the dynamic that stage provides, and run the comp-unit's
-    # cleanup even when a later stage throws.
+    # Only the RakuAST frontend's pipeline has a stage that lowers a
+    # RakuAST tree, and this runs under either frontend, so the lowering
+    # happens here with the $*COMPILING_CORE_SETTING that stage would
+    # bind, and compilation resumes after the last stage that produces
+    # QAST. Link the code objects to their coderefs as the compiler does
+    # for a unit it lowers itself, and run the comp-unit's cleanup even
+    # when a later stage throws.
     my sub compile-rakuast-comp-unit($comp-unit) {
         LEAVE $comp-unit.cleanup;
         my $*COMPILING_CORE_SETTING := 0;
@@ -151,27 +155,13 @@ $lang = 'Raku' if $lang eq 'perl6';
 
         my $LANG := $context<%?LANG>:exists ?? $context<%?LANG> !! Nil;
         my $*INSIDE-EVAL := 1;
-        # The RakuAST frontend (the only frontend with a qast stage) stops
-        # at the AST so the comp-unit can take the same finishing path as
-        # AST EVAL, fixing up code objects to survive an enclosing
-        # compilation's precomp and wrapping nested EVAL output.
-        my $rakuast-frontend := $compiler.exists_stage('qast');
-        my $result := $compiler.compile:
+        $compiled := $compiler.compile:
             $code,
             :outer_ctx($eval_ctx),
             :global(GLOBAL),
             :language_version(nqp::getcomp('Raku').language_version),
-            |(%(:target('ast'), :compunit_ok(1)) if $rakuast-frontend),
             |(:optimize($_) with nqp::getcomp('Raku').cli-options<optimize>),
             |(%(:grammar($LANG<MAIN>), :actions($LANG<MAIN-actions>)) if $LANG);
-        # Stopping at the AST skips the optimize stage that sits between it
-        # and the QAST stage, so that stage runs here.
-        $result := $compiler.optimize($result,
-            |(:optimize($_) with nqp::getcomp('Raku').cli-options<optimize>))
-            if $rakuast-frontend;
-        $compiled := $rakuast-frontend
-            ?? compile-rakuast-comp-unit($result)
-            !! $result;
     }
 
     if $check {

--- a/t/02-rakudo/21-begin-time-compile-sub.t
+++ b/t/02-rakudo/21-begin-time-compile-sub.t
@@ -1,0 +1,12 @@
+use lib <t/packages/02-rakudo/lib>;
+use Test;
+
+plan 2;
+
+use CompilerEvalSubAtBegin;
+is foo(), 'from-precomped-compiler-eval',
+    'precompiling a module returning a Sub compiled through the compiler object from BEGIN works';
+is bar(), 'from-precomped-compiler-unit',
+    'the same with the compilation unit kept and its mainline taken by the caller';
+
+# vim: expandtab shiftwidth=4

--- a/t/12-rakuast/statement-phaser.rakutest
+++ b/t/12-rakuast/statement-phaser.rakutest
@@ -1,7 +1,8 @@
 use v6.e.PREVIEW;
 use Test;
+use nqp;
 
-plan 36; # Do not change this file to done-testing because of END block tests
+plan 39; # Do not change this file to done-testing because of END block tests
 
 my $ast;
 my $deparsed;
@@ -1666,6 +1667,72 @@ CODE
           phaser  => "POST",
           "$type: POST phaser throws";
         is-deeply $post, $result, "$type: POST actually ran";
+    }
+}
+
+subtest 'ENTER phaser subclass added to a scope outside a parse' => {
+    plan 2;
+
+    # The scope declares a lexical for each ENTER phaser's result under a
+    # name it hands the phaser when taking it, so two phasers added this
+    # way need two names.
+    my class MyEnter is RakuAST::StatementPrefix::Phaser::Enter {
+        has $.code is rw;
+        method meta-object() { $!code }
+    }
+    my @ran;
+    my $block = RakuAST::Block.new(
+      body => RakuAST::Blockoid.new(
+        RakuAST::StatementList.new(
+          RakuAST::Statement::Expression.new(
+            expression => RakuAST::IntLiteral.new(42)
+          )
+        )
+      )
+    );
+    for <first second> -> $tag {
+        my $phaser = MyEnter.new(RakuAST::Block.new);
+        $phaser.code = { @ran.push($tag) };
+        $block.add-enter-phaser($phaser);
+    }
+    is EVAL(RakuAST::StatementPrefix::Do.new($block)), 42,
+      'block with two subclass ENTER phasers returns its value';
+    is-deeply @ran, [<first second>],
+      'each subclass phaser meta-object was called';
+}
+
+subtest 'two ENTER phasers in one scope keep their own values' => {
+    plan 1;
+    is-deeply EVAL(q[{ my $a = ENTER 'a'; my $b = ENTER 'b'; ($a, $b) }()]),
+      ('a', 'b'),
+      'each ENTER result reads back its own lexical';
+}
+
+subtest 'ENTER phaser subclass added to the compilation unit at BEGIN' => {
+    plan 1;
+    # A string compiles with the running frontend, and only the RakuAST
+    # frontend has a compilation unit node to add to.
+    if nqp::gethllsym('Raku', 'COMPILER-FRONTEND') ne 'rakuast' {
+        skip 'the legacy frontend has no RakuAST compilation unit', 1;
+    }
+    else {
+    my $code = q:to/CODE/;
+        use experimental :rakuast;
+        my class UnitEnter is RakuAST::StatementPrefix::Phaser::Enter {
+            has $.code is rw;
+            method meta-object() { $!code }
+        }
+        my @ran;
+        BEGIN {
+            my $phaser = UnitEnter.new(RakuAST::Block.new);
+            $phaser.code = { @ran.push('unit') };
+            $*CU.add-enter-phaser($phaser);
+        }
+        my $mine = ENTER 'mine';
+        ($mine, @ran)
+        CODE
+    is-deeply EVAL($code), ('mine', ['unit']),
+      'the added phaser ran and the parsed ENTER kept its own value';
     }
 }
 

--- a/t/packages/02-rakudo/lib/CompilerEvalSubAtBegin.rakumod
+++ b/t/packages/02-rakudo/lib/CompilerEvalSubAtBegin.rakumod
@@ -1,0 +1,22 @@
+use nqp;
+# Pins the compiler linking an EVAL's code objects to their coderefs on its
+# own: a Sub compiled at BEGIN time through the compiler object, the way a
+# module embedding another language compiles the Raku code it hosts, must
+# survive its outer module's precomp. The outer context marks the compile
+# as an EVAL, which nests it in the unit being compiled.
+our &foo;
+our &bar;
+BEGIN {
+    my $ctx := nqp::getattr(CORE::, PseudoStash, '$!ctx');
+    my $compiler := nqp::getcomp('Raku');
+
+    my $compiled := $compiler.compile('sub () { "from-precomped-compiler-eval" }', :outer_ctx($ctx));
+    nqp::forceouterctx(nqp::getattr($compiled, ForeignCode, '$!do'), $ctx);
+    &foo = $compiled();
+
+    # A caller keeping the compilation unit takes the mainline itself.
+    my $unit := $compiler.compile('sub () { "from-precomped-compiler-unit" }', :outer_ctx($ctx), :compunit_ok(1));
+    my $mainline := $compiler.backend.compunit_mainline($unit);
+    nqp::forceouterctx(nqp::getattr($mainline, ForeignCode, '$!do'), $ctx);
+    &bar = $mainline();
+}


### PR DESCRIPTION
Previously a compile nested in an enclosing compilation had to stop at the AST and finish by hand: lower the unit to QAST, compile from the qast stage, and call `IMPL-FIXUP-COMPILED-CODEREFS` on the result so the enclosing precompilation could serialize the code objects it produced. String EVAL did this in `ForeignCode`, and any module that compiles Raku code at BEGIN time through the compiler object (Inline::Perl5 for its `raku { }` blocks) had to copy the same IMPL- dance or fail to precompile with `Serialization Error: missing static code ref for closure`.

This makes `Perl6::Compiler.compile` do that itself. The stage that lowers the tree records the unit when it is an EVAL, and once the pipeline has produced a compilation unit the compiler links the code objects to their coderefs before handing back the mainline. String EVAL is a plain `compile` call again under both frontends, and an embedder only needs `compile($code, :outer_ctx($ctx))`. AST EVAL keeps its manual tail since the legacy pipeline has no stage that lowers a RakuAST tree.

The first commit is a small API change the same embedder needed. An ENTER phaser node built outside a parse never reaches begin time, which is where the phaser used to store the result name the scope hands it through an IMPL- method. Now the scope sets that name on the phaser when it takes it, so adding a phaser node to a scope is enough for every kind of phaser.
