### PR TITLE
RakuAST: give a nested EVAL its enclosing compilation's package

### DIFF
--- a/src/Raku/ast/resolver.rakumod
+++ b/src/Raku/ast/resolver.rakumod
@@ -216,14 +216,18 @@ class RakuAST::Resolver {
     }
 
     # Obtains the current package. This is not a RakuAST::Package node, but
-    # rather the type object of the package we are currently in.
+    # rather the type object of the package we are currently in. The walk
+    # over the outer contexts ends at the first one declaring $?PACKAGE, at
+    # the setting itself, or when the contexts run out, and falls back to
+    # GLOBAL. A context reached by walking is a fresh object, so the
+    # setting check only matches when the outer context is the setting.
     method current-package() {
         if nqp::elems($!packages) {
             $!packages[nqp::elems($!packages) - 1].compile-time-value
         }
         else {
             my $current := $!outer;
-            until nqp::eqaddr($current, $!setting) {
+            until nqp::isnull($current) || nqp::eqaddr($current, $!setting) {
                 return nqp::atkey($current, '$?PACKAGE')
                   if nqp::existskey($current, '$?PACKAGE');
                 $current := nqp::ctxouterskipthunks($current);
@@ -1500,13 +1504,23 @@ class RakuAST::Resolver::Compile
         # first, but lexicals living in an already-running caller frame
         # (like $/ and $!) are only reachable through the runtime context
         # chain, which also ends in the setting.
-        self.new(
+        my $obj := self.new(
             :$setting,
             :outer($context),
             :$global,
             :scopes($resolver ?? nqp::clone(nqp::getattr($resolver, RakuAST::Resolver::Compile, '$!scopes')) !! Mu),
             :attach-targets($resolver ?? $resolver.IMPL-CLONE-ATTACH-TARGETS !! Mu),
-        )
+        );
+        # The EVAL is in the package its context declares, and otherwise in
+        # the package of the enclosing compilation, which a setting context
+        # cannot name.
+        if $resolver {
+            my $package := $obj.resolve-lexical-constant-in-outer('$?PACKAGE');
+            nqp::bindattr($obj, RakuAST::Resolver, '$!packages', $package
+                ?? [$package]
+                !! nqp::clone(nqp::getattr($resolver, RakuAST::Resolver, '$!packages')));
+        }
+        $obj
     }
 
     method clone() {

--- a/t/02-rakudo/21-begin-time-eval-context.t
+++ b/t/02-rakudo/21-begin-time-eval-context.t
@@ -1,7 +1,7 @@
 use MONKEY-SEE-NO-EVAL;
 use Test;
 
-plan 9;
+plan 15;
 
 # Each EVAL below runs at BEGIN time, while this file is still being
 # compiled, so the EVAL'd unit is nested inside the file's compilation.
@@ -47,5 +47,28 @@ class OurSubFromEval {
 }
 is OurSubFromEval::from-eval(), 'made-in-eval',
     'our-scoped sub EVALed at BEGIN time lands in the caller package';
+
+# A setting context declares no package, so the EVAL takes the package
+# of the compilation it runs inside.
+my $core-call;
+BEGIN { $core-call = EVAL Q[my sub inner() { 42 }; inner()], :context(CORE::) }
+is $core-call, 42,
+    'BEGIN-time string EVAL with the CORE:: context resolves a call';
+
+BEGIN { EVAL Q[our sub from-core-eval() { "made-in-core-eval" }; our $from-core-eval = 7], :context(CORE::) }
+is GLOBAL::<&from-core-eval>(), 'made-in-core-eval',
+    'our-scoped sub EVALed at BEGIN time with the CORE:: context lands in GLOBAL';
+is GLOBAL::<$from-core-eval>, 7,
+    'our-scoped variable EVALed at BEGIN time with the CORE:: context lands in GLOBAL';
+
+class OurFromCoreEval {
+    BEGIN { EVAL Q[our $in-class = 8; class Inner { }], :context(CORE::) }
+}
+is OurFromCoreEval::<$in-class>, 8,
+    'our-scoped variable EVALed at BEGIN time with the CORE:: context lands in the caller package';
+ok OurFromCoreEval::<Inner>:exists,
+    'class EVALed at BEGIN time with the CORE:: context lands in the caller package';
+nok GLOBAL::<Inner>:exists,
+    'class EVALed at BEGIN time with the CORE:: context does not leak into GLOBAL';
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously the resolver found the current package of an EVAL by walking from the EVAL's outer context until it met a context declaring $?PACKAGE or the setting object it holds. A context reached by walking is a fresh object, so the setting check only matches when the outer context is the setting itself, and a setting frame declares no package. An EVAL compiled while another compilation runs, with a setting context such as the one CORE:: holds as its outer, walked past the end of the chain and died on its first call by name, and had it survived it would have put its declarations in GLOBAL rather than the package of the code that ran it.

This has a textual EVAL compiled inside another compilation start in the package its context declares, and otherwise in the packages of the enclosing compilation, which is what the legacy frontend does. The walk also ends when the contexts run out, falling back to GLOBAL as a walk that reaches the setting does.