### PR TITLE
RakuAST: Show the source around a compile time problem

### DIFF
--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -62,6 +62,24 @@ class RakuAST::Node {
         nqp::bindattr(self, RakuAST::Node, '$!origin', $origin);
     }
 
+    # Attaches this node's file, line and source excerpt to an exception
+    # that can carry them. A node without a sourced origin, or a type
+    # object standing in for one, leaves the exception as it is.
+    method IMPL-LOCATE-EXCEPTION(Mu $exception) {
+        if nqp::isconcrete(self)
+          && nqp::isconcrete($!origin)
+          && nqp::isconcrete($!origin.source)
+          && nqp::can($exception, 'SET_FILE_LINE') {
+            my $match := $!origin.as-match;
+            $exception.SET_FILE_LINE($match.file, $match.line);
+            if nqp::can($exception, 'SET_PRE_POST') {
+                my @prepost := $!origin.source.prepost-of-pos($!origin.from);
+                $exception.SET_PRE_POST(@prepost[0], @prepost[1]);
+            }
+        }
+        Nil
+    }
+
     # Find the narrowest key origin node for an original position
     method locate-node(int $pos, int $to?, :$key) {
         return Nil unless nqp::isconcrete($!origin)

--- a/src/Raku/ast/begintime.rakumod
+++ b/src/Raku/ast/begintime.rakumod
@@ -69,12 +69,7 @@ class RakuAST::BeginTime
 
             # Alas, need to rethrow wil line info if possible
             else {
-                if nqp::can($ex,'SET_FILE_LINE')
-                  && self
-                  && my $origin := self.origin {
-                    my $origin-match := $origin.as-match;
-                    $ex.SET_FILE_LINE($origin-match.file, $origin-match.line);
-                }
+                self.IMPL-LOCATE-EXCEPTION($ex);
                 $ex.rethrow;
             }
         }

--- a/src/Raku/ast/checktime.rakumod
+++ b/src/Raku/ast/checktime.rakumod
@@ -27,10 +27,7 @@ class RakuAST::CheckTime
     # Add a sorry check-time problem (which will produce a SORRY output in the
     # compiler).
     method add-sorry(Any $exception) {
-        if nqp::can($exception, 'SET_FILE_LINE') && my $origin := self.origin {
-            my $origin-match := $origin.as-match;
-            $exception.SET_FILE_LINE($origin-match.file, $origin-match.line);
-        }
+        self.IMPL-LOCATE-EXCEPTION($exception);
         nqp::push(
           $!sorries // nqp::bindattr(self,RakuAST::CheckTime,'$!sorries',[]),
           $exception
@@ -41,10 +38,7 @@ class RakuAST::CheckTime
     # Add a worry check-time problem (which will produce a potential
     # difficulties output in the compiler).
     method add-worry(Any $exception) {
-        if nqp::can($exception, 'SET_FILE_LINE') && my $origin := self.origin {
-            my $origin-match := $origin.as-match;
-            $exception.SET_FILE_LINE($origin-match.file, $origin-match.line);
-        }
+        self.IMPL-LOCATE-EXCEPTION($exception);
         nqp::push(
           $!worries // nqp::bindattr(self,RakuAST::CheckTime,'$!worries',[]),
           $exception

--- a/src/Raku/ast/compunit.rakumod
+++ b/src/Raku/ast/compunit.rakumod
@@ -466,10 +466,8 @@ class RakuAST::CompUnit
                     my $coercer := $lookups[3].resolution.compile-time-value;
                     $exception := $coercer($_);
                     my $wrapped := $BeginTime.new(:$exception, :use-case('evaluating a CHECK'));
-                    if nqp::istype($check-phaser, RakuAST::StatementPrefix::Phaser::Check) && (my $origin := $check-phaser.origin) {
-                        my $origin-match := $origin.as-match;
-                        $wrapped.SET_FILE_LINE($origin-match.file, $origin-match.line);
-                    }
+                    $check-phaser.IMPL-LOCATE-EXCEPTION($wrapped)
+                        if nqp::istype($check-phaser, RakuAST::StatementPrefix::Phaser::Check);
                     $wrapped.throw;
                 }
             }
@@ -1128,6 +1126,8 @@ class RakuAST::BOOTException {
     has Hash $!opts;
     has Str $!filename;
     has Mu $!line;
+    has Str $!pre;
+    has Str $!post;
     method new(Str $message, %opts) {
         my $obj := nqp::create(self);
         nqp::bindattr($obj, RakuAST::BOOTException, '$!message', $message);
@@ -1137,6 +1137,10 @@ class RakuAST::BOOTException {
     method SET_FILE_LINE($filename, $line) {
         nqp::bindattr(self, RakuAST::BOOTException, '$!filename', $filename);
         nqp::bindattr(self, RakuAST::BOOTException, '$!line', $line);
+    }
+    method SET_PRE_POST($pre, $post) {
+        nqp::bindattr(self, RakuAST::BOOTException, '$!pre', $pre);
+        nqp::bindattr(self, RakuAST::BOOTException, '$!post', $post);
     }
     # There is no sort op, and the NQP setting's sorted_keys is out of reach
     # here, so the keys are put in order by hand.
@@ -1174,6 +1178,8 @@ class RakuAST::BOOTException {
             ?? $!message ~ '(' ~ nqp::join(', ', @opts) ~ ')'
             !! $!message;
         $message := $message ~ ' at ' ~ $!filename ~ ':' ~ $!line if $!filename;
+        # The marker X::Comp prints while the setting compiles.
+        $message := $message ~ "\n------> " ~ $!pre ~ '<HERE>' ~ $!post if $!pre;
         $message
     }
     method gist(*%_) { nqp::hllizefor(self.message, 'Raku') }

--- a/src/Raku/ast/origins.rakumod
+++ b/src/Raku/ast/origins.rakumod
@@ -203,6 +203,28 @@ class RakuAST::Origin::Source {
         self.location-of-pos($pos)[1]
     }
 
+    # The source on either side of a position, cut to the line the
+    # position is on and to a fixed width.
+    method prepost-of-pos(int $pos) {
+        my int $width := 40;
+        my int $chars := nqp::chars($!orig);
+        $pos := 0 if $pos < 0;
+        $pos := $chars if $pos > $chars;
+
+        my int $linestart := $pos - (self.original-line-column($pos)[1] - 1);
+        my int $prestart := $pos - $width;
+        $prestart := $linestart if $prestart < $linestart;
+        my str $pre := nqp::substr($!orig, $prestart, $pos - $prestart);
+        $pre := '<BOL>' if $pre eq '';
+
+        my int $postend := nqp::findcclass(nqp::const::CCLASS_NEWLINE,
+            $!orig, $pos, $pos + $width > $chars ?? $chars - $pos !! $width);
+        my str $post := nqp::substr($!orig, $pos, $postend - $pos);
+        $post := '<EOL>' if $post eq '';
+
+        [$pre, $post]
+    }
+
     # $from-to can be either NQPMatch, or Match, or RakuAST::Origin,
     # or anything else with .from/.to methods available
     method match-from($from-to) {

--- a/src/Raku/ast/pair.rakumod
+++ b/src/Raku/ast/pair.rakumod
@@ -408,15 +408,12 @@ class RakuAST::ColonPair::Value
         return $value if $!has-cached-value;
         # Not IMPL-INTERPRET-able; fall through to BEGIN-time evaluation.
         # The CATCH re-attaches the colonpair's source location because
-        # IMPL-BEGIN-TIME-EVALUATE attributes through self.origin, which
-        # is unset on the BeginTime type object we dispatch through.
+        # IMPL-BEGIN-TIME-EVALUATE locates through the BeginTime type
+        # object it is dispatched on, which has no origin.
         {
             CATCH {
                 my $ex := $resolver.convert-begin-time-exception($_);
-                if nqp::can($ex, 'SET_FILE_LINE') && my $origin := self.origin {
-                    my $origin-match := $origin.as-match;
-                    $ex.SET_FILE_LINE($origin-match.file, $origin-match.line);
-                }
+                self.IMPL-LOCATE-EXCEPTION($ex);
                 $ex.rethrow;
             }
             $value := RakuAST::BeginTime.IMPL-BEGIN-TIME-EVALUATE(

--- a/src/Raku/ast/statementprefixes.rakumod
+++ b/src/Raku/ast/statementprefixes.rakumod
@@ -715,10 +715,7 @@ class RakuAST::StatementPrefix::Phaser::Begin
         {
             CATCH {
                 my $ex := $resolver.convert-begin-time-exception($_);
-                if nqp::can($ex, 'SET_FILE_LINE') && my $origin := self.origin {
-                    my $origin-match := $origin.as-match;
-                    $ex.SET_FILE_LINE($origin-match.file, $origin-match.line);
-                }
+                self.IMPL-LOCATE-EXCEPTION($ex);
                 $ex.rethrow;
             }
             nqp::bindattr(self, RakuAST::StatementPrefix::Phaser::Begin,

--- a/src/Raku/ast/statements.rakumod
+++ b/src/Raku/ast/statements.rakumod
@@ -2679,10 +2679,7 @@ class RakuAST::Statement::Use
     method PERFORM-BEGIN(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {
         CATCH {
             my $ex := $resolver.convert-exception($_);
-            if nqp::can($ex, 'SET_FILE_LINE') && self && my $origin := self.origin {
-                my $origin-match := $origin.as-match;
-                $ex.SET_FILE_LINE($origin-match.file, $origin-match.line);
-            }
+            self.IMPL-LOCATE-EXCEPTION($ex);
             $ex.rethrow;
         }
         # Evaluate the argument to the module load, if any.

--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -518,10 +518,7 @@ class RakuAST::VarDeclaration::Constant
                     $ex := nqp::istype($ex, $XUndeclaredSymbols.compile-time-value)
                         ?? $ex
                         !! $resolver.convert-begin-time-exception($ex);
-                    if nqp::can($ex, 'SET_FILE_LINE') && my $origin := self.origin {
-                        my $origin-match := $origin.as-match;
-                        $ex.SET_FILE_LINE($origin-match.file, $origin-match.line);
-                    }
+                    self.IMPL-LOCATE-EXCEPTION($ex);
                     $ex.rethrow;
                 }
                 else {

--- a/src/core.c/Exception.rakumod
+++ b/src/core.c/Exception.rakumod
@@ -972,6 +972,10 @@ my role X::Comp is Exception {
         $!line     = $line;
         $!is-compile-time = True;
     }
+    method SET_PRE_POST($pre, $post) is implementation-detail {
+        $!pre  = $pre;
+        $!post = $post;
+    }
 }
 
 class X::Comp::Group is Exception {
@@ -1039,6 +1043,11 @@ my class X::Comp::BeginTime does X::Comp {
     multi method gist(::?CLASS:D: :$sorry = True) {
         my $r = $sorry ?? self.sorry_heading() !! "";
         $r ~= "$.message\nat $.filename():$.line";
+        if defined $.pre {
+            my ($red,$clear,$green,$yellow,$eject) =
+              Rakudo::Internals.error-rcgye;
+            $r ~= "\n------> $green$.pre$yellow$eject$red$.post$clear";
+        }
         for @.modules.reverse.skip {
             my $line = nqp::p6box_i($_<line>);
             $r ~= $_<module>.defined

--- a/t/05-messages/03-errors.t
+++ b/t/05-messages/03-errors.t
@@ -1,8 +1,9 @@
 use lib <t/packages/Test-Helpers>;
 use Test;
+use nqp;
 use Test::Helpers;
 
-plan 30;
+plan 31;
 
 subtest '.map does not explode in optimizer' => {
     plan 3;
@@ -228,6 +229,104 @@ subtest 'constraint failure on an unpassed optional parameter explains the impli
         X::TypeCheck::Binding::Parameter,
         message => { not .contains('was not passed') },
         'an explicit default failing the constraint does not claim the parameter has none';
+}
+
+subtest 'a compile time problem shows the source around it' => {
+    plan 14;
+
+    throws-like ｢sub f(Int $x) { }; f("str")｣,
+        X::TypeCheck::Argument,
+        pre  => 'sub f(Int $x) { }; ',
+        post => 'f("str")',
+        gist => *.contains('------> '),
+        'a check time sorry carries the source on either side of the problem';
+
+    throws-like ｢my $a = 1;
+sub f(Int $x) { }; f("str");
+my $b = 2｣,
+        X::TypeCheck::Argument,
+        line => 2,
+        pre  => 'sub f(Int $x) { }; ',
+        post => 'f("str");',
+        'the source shown is cut to the line the problem is on';
+
+    throws-like "my \$a = 1;\r\nsub f(Int \$x) \{ }; f(\"str\");\r\nmy \$b = 2",
+        X::TypeCheck::Argument,
+        line => 2,
+        pre  => 'sub f(Int $x) { }; ',
+        post => 'f("str");',
+        'a source with carriage return line endings is cut to the line too';
+
+    throws-like ｢my $aaaa = 1; my $bbbb = 2; my $cccc = 3; sub f(Int $x) { }; f("str"); my $dddd = 4; my $eeee = 5; my $ffff = 6｣,
+        X::TypeCheck::Argument,
+        pre  => { .chars == 40 && .ends-with('sub f(Int $x) { }; ') },
+        post => { .chars == 40 && .starts-with('f("str"); my $dddd') },
+        'each side of the source shown is cut to forty characters';
+
+    if nqp::gethllsym('Raku', 'COMPILER-FRONTEND') eq 'rakuast' {
+        throws-like ｢my $a = 1; $a xx 2 :foo｣,
+            X::Syntax::Adverb,
+            pre  => 'my $a = 1; ',
+            post => '$a xx 2 :foo',
+            'the source is split where the node reporting the problem starts';
+
+        throws-like ｢my $a = 1;
+$a xx 2 :foo｣,
+            X::Syntax::Adverb,
+            pre  => '<BOL>',
+            'a problem at the start of a line names the line start';
+
+        throws-like ｢my $a = 1; $a xx 2 :foo
+｣,
+            X::Syntax::Adverb,
+            post => '$a xx 2 :foo',
+            'the source after the problem stops at the line end';
+
+        throws-like ｢BEGIN die "boom"｣,
+            X::Comp::BeginTime,
+            pre  => '<BOL>',
+            post => 'BEGIN die "boom"',
+            gist => *.contains('------> '),
+            'a BEGIN time failure carries the source of the BEGIN';
+
+        throws-like ｢my $a = 1; CHECK die "boom"; my $b = 2｣,
+            X::Comp::BeginTime,
+            pre  => 'my $a = 1; ',
+            post => 'CHECK die "boom"; my $b = 2',
+            'a CHECK time failure carries the source of the CHECK';
+
+        throws-like ｢my $a = 1; use Nope::Missing; my $b = 2｣,
+            X::CompUnit::UnsatisfiedDependency,
+            pre  => 'my $a = 1; ',
+            post => 'use Nope::Missing; my $b = 2',
+            'a failed module load carries the source of the use';
+
+        throws-like ｢my $a = 1; constant x = die "boom"; my $b = 2｣,
+            X::Comp::BeginTime,
+            pre  => 'my $a = 1; ',
+            post => 'constant x = die "boom"; my $b = 2',
+            'a constant whose value fails carries the source of the constant';
+
+        throws-like ｢my $a = 1; no worries (die "boom"); my $b = 2｣,
+            X::AdHoc,
+            pre  => 'my $a = 1; ',
+            post => 'no worries (die "boom"); my $b = 2',
+            'a pragma argument that fails carries the source of the pragma';
+
+        throws-like ｢my $a = 1; class A:auth(do { die "boom" }) { }; my $b = 2｣,
+            X::Comp::BeginTime,
+            pre  => 'my $a = 1; class A',
+            post => ':auth(do { die "boom" }) { }; my $b = 2',
+            'a colonpair value that fails carries the source of the colonpair';
+
+        throws-like ｢my $a = 1; $a xx 2 :foo; $a xx 3 :bar｣,
+            X::Comp::Group,
+            gist => { .comb('------> ').elems == 2 },
+            'each problem in a group shows its own source';
+    }
+    else {
+        skip 'the source split is placed by the RakuAST frontend', 10;
+    }
 }
 
 # vim: expandtab shiftwidth=4

--- a/t/05-messages/10-warnings.t
+++ b/t/05-messages/10-warnings.t
@@ -3,7 +3,7 @@ use nqp;
 use Test;
 use Test::Helpers;
 
-plan 23;
+plan 24;
 
 subtest 'Supply.interval with negative value warns' => {
     plan 2;
@@ -162,6 +162,15 @@ is-run ｢my $_; class A { }; foo()｣,
       'a setting file with {YOU_ARE_HERE} as a statement runs';
     is $proc.err.slurp(:close), '',
       'a sunk {YOU_ARE_HERE} is not a useless use';
+}
+
+if nqp::gethllsym('Raku', 'COMPILER-FRONTEND') eq 'rakuast' {
+    is-run ｢my $a = 1; 1 == 2; print "ran"｣,
+        'a worry shows the source around the statement it is about',
+        :out<ran>, :err(/'Useless use' .*? '------> my $a = 1; <HERE>1 == 2;'/);
+}
+else {
+    skip 'the source split is placed by the RakuAST frontend', 1;
 }
 
 # vim: expandtab shiftwidth=4

--- a/t/12-rakuast/errors.rakutest
+++ b/t/12-rakuast/errors.rakutest
@@ -2,7 +2,7 @@ use v6.e.PREVIEW;
 use Test;
 use nqp;
 
-plan 4;
+plan 5;
 
 throws-like { EVAL(RakuAST::Term::Self.new) },
     X::Syntax::Self::WithoutObject;
@@ -16,7 +16,7 @@ throws-like { EVAL(RakuAST::Term::Self.new) },
 }
 
 subtest 'a stand-in exception for a setting still compiling renders readably' => {
-    plan 9;
+    plan 10;
 
     my $with-string := RakuAST::BOOTException.new('X::Redeclaration', nqp::hash('symbol', '$_'));
     is $with-string.message, 'X::Redeclaration(symbol => $_)',
@@ -48,6 +48,45 @@ subtest 'a stand-in exception for a setting still compiling renders readably' =>
     $with-string.SET_FILE_LINE('bar.raku', 7);
     is $with-string.message, 'X::Redeclaration(symbol => $_) at bar.raku:7',
       'a file and line set on the stand-in render after the options';
+
+    $with-string.SET_PRE_POST('my $_; my ', '$_;');
+    is $with-string.message,
+      "X::Redeclaration(symbol => \$_) at bar.raku:7\n------> my \$_; my <HERE>\$_;",
+      'the source around the problem renders on its own line after the location';
+}
+
+subtest 'the source excerpt around a position is cut to its line and width' => {
+    plan 12;
+
+    sub prepost(str $orig, int $pos) {
+        RakuAST::Origin::Source.new(:$orig).prepost-of-pos($pos).List
+    }
+
+    is-deeply prepost('abc', 1), ('a', 'bc'),
+      'a position inside one line splits it there';
+    is-deeply prepost('abc', 3), ('abc', '<EOL>'),
+      'a position at the end of the source marks the line end';
+    is-deeply prepost('abc', 0), ('<BOL>', 'abc'),
+      'a position at the start of the source marks the line start';
+    is-deeply prepost('', 0), ('<BOL>', '<EOL>'),
+      'an empty source marks both sides';
+    is-deeply prepost('abc', -5), ('<BOL>', 'abc'),
+      'a position before the source counts as its start';
+    is-deeply prepost('abc', 99), ('abc', '<EOL>'),
+      'a position past the source counts as its end';
+    is-deeply prepost("ab\ncd", 2), ('ab', '<EOL>'),
+      'a position before a newline stops the post side there';
+    is-deeply prepost("ab\ncd", 3), ('<BOL>', 'cd'),
+      'a position after a newline starts the pre side there';
+    is-deeply prepost("ab\r\ncd", 3), ('<BOL>', 'cd'),
+      'a carriage return newline pair is one line break';
+    is-deeply prepost("ab\rcd", 3), ('<BOL>', 'cd'),
+      'a lone carriage return is a line break';
+    is-deeply prepost("ab\x[2028]cd", 3), ('<BOL>', 'cd'),
+      'a unicode line separator is a line break';
+    my ($pre, $post) = prepost('x' x 100, 50);
+    ok $pre.chars == 40 && $post.chars == 40,
+      'each side is cut to forty characters';
 }
 
 if nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' {


### PR DESCRIPTION
Previously only the grammar's own errors carried the excerpt of source that renders as the `------>` line with the problem marked in it, since the cursor position was at hand when they were built. Every problem the frontend found after parsing rendered with a file and line and nothing of the source: check time sorries and worries, a BEGIN or CHECK block that died, a use statement that failed to load, a constant or colonpair value that failed to evaluate. The reader had to find the statement.

Every node that attaches a location to an exception now does so through one method, which sets the file and line and the source on either side of the node's start, cut to that line the way the grammar cuts it. X::Comp gains a setter for the excerpt, the BEGIN time wrapper renders it under the location, and the stand-in exception used while the setting compiles carries it in its message.