### PR TITLE
RakuAST: Parse -M arguments as use statements

### DIFF
--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -770,23 +770,43 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
         my $M := %*OPTIONS<M>;
         return Nil unless nqp::defined($M); # nothing to do here
 
-        # shortcuts
-        my $R       := $*R;
-        my $context := $*CU.context;
-
-        # Create a RakuAST statement list with -use- statements
-        # of the specified module names and attach that
         my $ast := Nodify('StatementList').new;
-        for nqp::islist($M) ?? $M !! [$M] -> $longname {
-            my $use := Nodify('Statement::Use').new(
-              module-name => Nodify('Name').from-identifier-parts(
-                |nqp::split('::', $longname)
-              )
-            );
-            $use.ensure-begin-performed($R, $context);
-            $ast.add-statement: $use;
+        for nqp::islist($M) ?? $M !! [$M] -> $spec {
+            $ast.add-statement: self.parse-M-module($/, $spec);
         }
         self.attach: $/, $ast;
+    }
+
+    # Parse a -M argument as the use statement it stands for.  The cursor
+    # shares the braid of the compilation unit, so pragmas and the
+    # declarators and operators a module exports reach the code being
+    # compiled.  The newline makes the use rule settle any heredoc the
+    # argument starts before the program is parsed.  Diagnostics name
+    # -M as their source.
+    method parse-M-module($/, str $spec) {
+        my str $source := 'use ' ~ $spec ~ "\n";
+        my $cursor := $/.'!cursor_init'($source, :p(0));
+        $cursor.set_braid_from($/);
+
+        my %COMPILING := %*COMPILING;
+        my $match;
+        {
+            my $?FILES := '-M';
+            my %*COMPILING := nqp::clone(%COMPILING);
+            %*COMPILING<%?OPTIONS> := nqp::clone(%COMPILING<%?OPTIONS>);
+            %*COMPILING<%?OPTIONS><source-name> := '-M';
+            my $*ORIGIN-SOURCE := Nodify('Origin::Source').new(
+              :orig($cursor.target)
+            );
+            my $*LASTQUOTE := [0,0];
+            my $*LANG := $/;
+            $match := $cursor.'statement-control:sym<use>'().MATCH;
+            unless $match.pos == nqp::chars($source) {
+                $cursor.'!cursor_pos'($match.pos) if $match.pos >= 0;
+                $cursor.malformed('-M argument');
+            }
+        }
+        $match.ast
     }
 
     # Only needed for compiling CORE.setting

--- a/src/Raku/Grammar.nqp
+++ b/src/Raku/Grammar.nqp
@@ -622,6 +622,7 @@ role Raku::Common {
         }
         elsif !nqp::eqat($file,'/', 0)    # does not start with /
           &&  !nqp::eqat($file,'-e',0)    # and it's not -e
+          &&  !nqp::eqat($file,'-M',0)    # and it's not -M
           &&  !nqp::eqat($file,':', 1) {  # and no drive letter at start
             $file := nqp::cwd ~ '/' ~ $file;
         }

--- a/t/02-rakudo/m-flag-module-spec.t
+++ b/t/02-rakudo/m-flag-module-spec.t
@@ -1,0 +1,108 @@
+use lib <t/packages/Test-Helpers>;
+use Test;
+use Test::Helpers;
+use nqp;
+
+# A -M argument is parsed as the module part of a use statement, so it
+# takes the same adverbs and import lists as a use statement in source.
+
+plan 19;
+
+my @fixture = '-I', 't/packages/02-rakudo/m-flag-fixture';
+
+is-run 'say fixture-loaded',
+    'a plain -M loads the module and imports its default exports',
+    :compiler-args[|@fixture, '-M', 'MFlag::Fixture'], :out("MFlag::Fixture loaded\n");
+
+is-run 'say 1 mflag 2',
+    'an operator exported by a -M module parses in the program',
+    :compiler-args[|@fixture, '-M', 'MFlag::Fixture'], :out("1 mflag 2\n");
+
+is-run 'say EVAL "1 + 1"',
+    'a pragma given with -M applies to the program',
+    :compiler-args['-M', 'MONKEY-SEE-NO-EVAL'], :out("2\n");
+
+is-run 'declarer-class Foo { method m { "declared" } }; say Foo.m',
+    'a declarator exported through EXPORTHOW by a -M module parses in the program',
+    :compiler-args['-I', 't/packages/02-rakudo/lib', '-M', 'ExporthowDeclarer'],
+    :out("declared\n");
+
+if nqp::gethllsym('Raku', 'COMPILER-FRONTEND') eq 'rakuast' {
+    is-run 'say fixture-loaded',
+        'a -M with matching :ver, :auth and :api adverbs loads the module',
+        :compiler-args[|@fixture, '-M', 'MFlag::Fixture:ver<1.*>:auth<test:fixture>:api<2>'],
+        :out("MFlag::Fixture loaded\n");
+
+    is-run 'say fixture-loaded',
+        'a -M with a :ver<1.+> adverb loads the module',
+        :compiler-args[|@fixture, '-M', 'MFlag::Fixture:ver<1.+>'],
+        :out("MFlag::Fixture loaded\n");
+
+    is-run 'say fixture-loaded',
+        'a -M with a :ver adverb that matches no installed version fails to compile',
+        :compiler-args[|@fixture, '-M', 'MFlag::Fixture:ver<2.*>'],
+        :err(/'Could not find MFlag::Fixture:ver<2.*>'/), :exitcode(1);
+
+    is-run 'say fixture-loaded',
+        'a -M with a :auth adverb that matches nothing fails to compile',
+        :compiler-args[|@fixture, '-M', 'MFlag::Fixture:auth<nobody>'],
+        :err(/'Could not find MFlag::Fixture:auth<nobody>'/), :exitcode(1);
+
+    is-run 'say fixture-tagged',
+        'a -M with an import tag imports that tag',
+        :compiler-args[|@fixture, '-M', 'MFlag::Fixture :tagged'],
+        :out("MFlag::Fixture tagged\n");
+
+    is-run 'say fixture-loaded',
+        'a -M with an import tag does not import the default exports',
+        :compiler-args[|@fixture, '-M', 'MFlag::Fixture :tagged'],
+        :err(/'Undeclared routine'/), :exitcode(1);
+
+    is-run 'say fixture-loaded() ~ " " ~ EVAL q/"and evaluated"/',
+        'two -M arguments both apply',
+        :compiler-args[|@fixture, '-M', 'MFlag::Fixture', '-M', 'MONKEY-SEE-NO-EVAL'],
+        :out("MFlag::Fixture loaded and evaluated\n");
+
+    is-run 'say 1',
+        'a -M with trailing garbage is reported as malformed, located in the argument',
+        :compiler-args[|@fixture, '-M', 'MFlag::Fixture)'],
+        :err(/'Malformed -M argument' \s+ 'at -M:1' .* 'use MFlag::Fixture'/), :exitcode(1);
+
+    is-run 'say 1',
+        'an empty -M is reported as malformed',
+        :compiler-args['-M', ''],
+        :err(/'Malformed -M argument'/), :exitcode(1);
+
+    is-run 'say fixture-tagged',
+        'whitespace around a -M argument is ignored',
+        :compiler-args[|@fixture, '-M', ' MFlag::Fixture :tagged '],
+        :out("MFlag::Fixture tagged\n");
+
+    is-run "say 1;\nEND\nsay 2",
+        'a heredoc started in a -M argument does not take its body from the program',
+        :compiler-args[|@fixture, '-M', 'MFlag::Fixture :tagged, q:to/END/'],
+        :err(/'Ending delimiter END not found'/), :exitcode(1);
+
+    is-run "my \$a = 1;\nmy \$b = 1;\nmy \$c = 1 1;",
+        'a quote in a -M argument does not turn into a runaway quote hint for the program',
+        :compiler-args[|@fixture, '-M', 'MFlag::Fixture:ver<1.*>'],
+        :err(/'Two terms in a row' <!before ' (runaway'>/), :exitcode(1);
+
+    is-run 'say 1',
+        'a compile time error inside a -M argument names -M as its source',
+        :compiler-args[|@fixture, '-M', 'MFlag::Fixture :nosuchtag'],
+        :err(/'nosuchtag' .* 'at -M:1'/), :exitcode(1);
+
+    is-run 'say 1',
+        'a -M with an unterminated adverb is a compile error',
+        :compiler-args[|@fixture, '-M', 'MFlag::Fixture:ver<1.*'],
+        :err(/"couldn't find final '>'"/), :exitcode(1);
+
+    is-run 'say 1',
+        'a -M that is only a version is rejected like use v6 would be',
+        :compiler-args['-M', 'v6.d'],
+        :err(/'Too late'/), :exitcode(1);
+}
+else {
+    skip-rest 'adverbs on -M are only supported by the RakuAST frontend';
+}

--- a/t/packages/02-rakudo/m-flag-fixture/META6.json
+++ b/t/packages/02-rakudo/m-flag-fixture/META6.json
@@ -1,0 +1,10 @@
+{
+    "name": "MFlag::Fixture",
+    "ver": "1.5",
+    "auth": "test:fixture",
+    "api": "2",
+    "description": "Fixture distribution for -M module specification tests",
+    "provides": {
+        "MFlag::Fixture": "lib/MFlag/Fixture.rakumod"
+    }
+}

--- a/t/packages/02-rakudo/m-flag-fixture/lib/MFlag/Fixture.rakumod
+++ b/t/packages/02-rakudo/m-flag-fixture/lib/MFlag/Fixture.rakumod
@@ -1,0 +1,7 @@
+unit module MFlag::Fixture;
+
+sub fixture-loaded() is export(:DEFAULT, :loaded) { 'MFlag::Fixture loaded' }
+
+sub fixture-tagged() is export(:tagged) { 'MFlag::Fixture tagged' }
+
+sub infix:<mflag>($a, $b) is export { "$a mflag $b" }


### PR DESCRIPTION
Previously a -M argument was split on :: into a bare module name, so adverbs such as -M'Foo:ver<1.*>:auth<x>' were looked up as a module named `"Foo:ver<1.*>:auth<x>"` and never found. A pragma given with -M was looked up as a module as well.

This parses each -M argument with the grammar rule for a use statement, on a cursor that shares the braid of the compilation unit. Whatever a use statement accepts now works with -M: version, auth and api adverbs, :from, and import tags such as -M'Foo :tag'. Pragmas, exported operators and EXPORTHOW declarators reach the program the same way they do from a use statement in the source.

Parse state that would otherwise carry over into the program stays with the argument. A heredoc the argument starts is settled against the argument, quote positions do not feed the runaway quote hint for the program, and the language cursor is restored afterwards. Diagnostics raised while parsing an argument name -M as their source, and text left over after the use statement is reported as a malformed -M argument.