### PR TITLE
Make Signature.new and Parameter.new match what the compiler builds

### DIFF
--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -2478,7 +2478,7 @@ class Perl6::World is HLL::World {
                 unless nqp::can($package.HOW, 'hidden') && $package.HOW.hidden($package) {
                     @params.push(hash(
                         variable_name => '%_',
-                        type => self.find_single_symbol_in_setting('Mu'),
+                        type => self.find_single_symbol_in_setting('Associative'),
                         named_slurpy => 1,
                         is_multi_invocant => 1,
                         sigil => '%'

--- a/src/core.c/Parameter.rakumod
+++ b/src/core.c/Parameter.rakumod
@@ -136,6 +136,13 @@ my class Parameter { # declared in BOOTSTRAP
         if %args.EXISTS-KEY('type') {
             my $type := %args.AT-KEY('type');
             $type := $type.WHAT if $type.DEFINITE;
+            # Definedness lives in the flags, the type being the base type
+            if nqp::istype($type.HOW,Metamodel::DefiniteHOW) {
+                $flags +|= $type.^definite
+                  ?? nqp::const::SIG_ELEM_DEFINED_ONLY
+                  !! nqp::const::SIG_ELEM_UNDEFINED_ONLY;
+                $type := $type.^base_type;
+            }
             $!type := nqp::eqaddr($sigil-type,Mu)
               ?? $type
               !! $sigil-type.^parameterize($type);

--- a/src/core.c/Parameter.rakumod
+++ b/src/core.c/Parameter.rakumod
@@ -72,8 +72,8 @@ my class Parameter { # declared in BOOTSTRAP
             }
             elsif $sigil eq Q/+/ {
                 $name  = $name.substr(1);
-                $sigil = $name.substr(-1,1);
-                $flags +|= nqp::const::SIG_ELEM_IS_RAW +| nqp::const::SIG_ELEM_SLURPY_ONEARG;
+                $sigil = $name.substr(0,1);
+                $flags +|= nqp::const::SIG_ELEM_SLURPY_ONEARG;
             }
 
             if $name.ends-with(Q/)/) {
@@ -91,10 +91,6 @@ my class Parameter { # declared in BOOTSTRAP
                 $name  = $name.substr(1);
                 $sigil = $name.substr(0,1);
 
-                if %args.EXISTS-KEY('type') {
-                    die "Slurpy named parameters with type constraints are not supported|"
-                }
-
                 if $sigil eq Q/*/ {                  # is it a double slurpy?
                     $name  = $name.substr(1);
                     $sigil = $name.substr(0,1);
@@ -106,6 +102,11 @@ my class Parameter { # declared in BOOTSTRAP
                 elsif $sigil eq Q/%/ {               # a slurpy hash?
                     $flags +|= nqp::const::SIG_ELEM_SLURPY_NAMED;
                 }
+            }
+
+            if %args.EXISTS-KEY('type')
+              && $flags +& nqp::const::SIG_ELEM_IS_SLURPY {
+                die "Slurpy { $sigil eq Q/%/ ?? 'named' !! 'positional' } parameters with type constraints are not supported"
             }
 
             if $name.substr(1,1) -> $twigil {

--- a/src/core.c/Parameter.rakumod
+++ b/src/core.c/Parameter.rakumod
@@ -52,6 +52,7 @@ my class Parameter { # declared in BOOTSTRAP
         --> Nil
       ) {
 
+        my $sigil = '';
         if $name {                                 # specified a name?
 
             if $name.ends-with(Q/!/) {
@@ -63,7 +64,7 @@ my class Parameter { # declared in BOOTSTRAP
                 $optional = True;
             }
 
-            my $sigil = $name.substr(0,1);
+            $sigil = $name.substr(0,1);
 
             if $sigil eq Q/:/ {
                 $name  = $name.substr(1);
@@ -81,6 +82,7 @@ my class Parameter { # declared in BOOTSTRAP
                     my $start = $name.index(Q/(/); # XXX handle multiple
                     @!named_names := nqp::list_s($name.substr(0,$start));
                     $name := $name.substr($start + 1, *-1);
+                    $sigil = $name.substr(0,1);
                 }
                 else {
                     die "Can only specify alternative names on named parameters: $name";
@@ -122,12 +124,24 @@ my class Parameter { # declared in BOOTSTRAP
             $name = $name.substr(1) if $sigil eq Q/\/ || $sigil eq Q/|/;
         }
 
+        # The sigil implies a role, which a given type parameterizes the
+        # way the compiler stores `Int @a` as Positional[Int]
+        my $sigil-type := $sigil eq Q/@/
+          ?? Positional
+          !! $sigil eq Q/%/
+            ?? Associative
+            !! $sigil eq Q/&/
+              ?? Callable
+              !! Mu;
         if %args.EXISTS-KEY('type') {
             my $type := %args.AT-KEY('type');
-            $!type := $type.DEFINITE ?? $type.WHAT !! $type;
+            $type := $type.WHAT if $type.DEFINITE;
+            $!type := nqp::eqaddr($sigil-type,Mu)
+              ?? $type
+              !! $sigil-type.^parameterize($type);
         }
         else {
-            $!type := Any;
+            $!type := nqp::eqaddr($sigil-type,Mu) ?? Any !! $sigil-type;
         }
 
         if %args.EXISTS-KEY('default') {

--- a/src/core.c/Signature.rakumod
+++ b/src/core.c/Signature.rakumod
@@ -75,11 +75,14 @@ my class Signature { # declared in BOOTSTRAP
         my $r-named-sink := False;
 
         for @r-params -> $r-param is raw {
-            if $r-param.positional {
-                if $r-param.slurpy {
-                    $r-pos-sink := True;
-                }
-                elsif $todo {
+            if $r-param.capture {
+                $r-pos-sink := $r-named-sink := True;
+            }
+            elsif $r-param.slurpy && !$r-param.named {
+                $r-pos-sink := True;
+            }
+            elsif $r-param.positional {
+                if $todo {
                     # When a required or optional positional parameter exists
                     # in a signature, it will be prepended. Typechecks can be
                     # predicted when such parameters exist in the topic too.
@@ -104,18 +107,18 @@ my class Signature { # declared in BOOTSTRAP
                     %r-named-queue{$_} := $r-param for $r-param.named_names;
                 }
             }
-            else {
-                $r-pos-sink := $r-named-sink := True;
-            }
         }
 
         for @l-params.tail: $todo -> $l-param is raw {
             state %r-to-l-named{Mu};
-            if $l-param.positional {
-                if $l-param.slurpy {
-                    return False unless $r-pos-sink;
-                }
-                elsif @r-pos-queue {
+            if $l-param.capture {
+                return False unless $r-pos-sink && $r-named-sink;
+            }
+            elsif $l-param.slurpy && !$l-param.named {
+                return False unless $r-pos-sink;
+            }
+            elsif $l-param.positional {
+                if @r-pos-queue {
                     return False unless $l-param ~~ @r-pos-queue.shift;
                 }
                 else {
@@ -144,9 +147,6 @@ my class Signature { # declared in BOOTSTRAP
                 else {
                     return False unless $r-named-sink;
                 }
-            }
-            else {
-                return False unless $r-pos-sink && $r-named-sink;
             }
         }
 

--- a/src/core.c/Signature.rakumod
+++ b/src/core.c/Signature.rakumod
@@ -40,7 +40,9 @@ my class Signature { # declared in BOOTSTRAP
     }
 
     method !SET-SELF(@params, Mu $returns, $arity, $count) {
-        nqp::bind(@!params,nqp::getattr(@params,List,'$!reified'));
+        my $params := nqp::list;
+        nqp::push($params, nqp::decont($_)) for @params;
+        nqp::bind(@!params, $params);
         $!returns := nqp::decont($returns);
         $!arity    = $arity;
         $!count   := $count;

--- a/src/core.c/Signature.rakumod
+++ b/src/core.c/Signature.rakumod
@@ -12,10 +12,31 @@ my class Signature { # declared in BOOTSTRAP
     multi method new(Signature:U:
             :@params,
          Mu :$returns,
-      Int:D :$arity = @params.elems,
-      Num:D :$count = $arity.Num
+        Int :$arity,
+        Num :$count
     ) {
-        nqp::create(self)!SET-SELF(@params, $returns, $arity, $count)
+        # Arity is the required positionals and count all of them, or Inf
+        # once a slurpy positional or a capture is present. Count never
+        # drops below an explicit arity.
+        my int $required;
+        my int $positionals;
+        my int $unbounded;
+        for @params {
+            if .positional {
+                ++$positionals;
+                ++$required unless .optional;
+            }
+            elsif !.named {
+                $unbounded = 1;
+            }
+        }
+        my $arity-used := $arity // $required;
+        nqp::create(self)!SET-SELF(
+          @params,
+          $returns,
+          $arity-used,
+          $count // ($unbounded ?? Inf !! ($positionals max $arity-used).Num)
+        )
     }
 
     method !SET-SELF(@params, Mu $returns, $arity, $count) {

--- a/src/core.c/Signature.rakumod
+++ b/src/core.c/Signature.rakumod
@@ -20,7 +20,7 @@ my class Signature { # declared in BOOTSTRAP
 
     method !SET-SELF(@params, Mu $returns, $arity, $count) {
         nqp::bind(@!params,nqp::getattr(@params,List,'$!reified'));
-        $!returns := $returns;
+        $!returns := nqp::decont($returns);
         $!arity    = $arity;
         $!count   := $count;
         self

--- a/src/core.c/Signature.rakumod
+++ b/src/core.c/Signature.rakumod
@@ -22,6 +22,12 @@ my class Signature { # declared in BOOTSTRAP
         my int $positionals;
         my int $unbounded;
         for @params {
+            X::TypeCheck.new(
+              operation => 'constructing a Signature',
+              got       => $_,
+              expected  => Parameter
+            ).throw unless nqp::istype(nqp::decont($_),Parameter)
+                        && nqp::isconcrete(nqp::decont($_));
             if .positional {
                 ++$positionals;
                 ++$required unless .optional;

--- a/t/02-rakudo/signature-new-method-parity.t
+++ b/t/02-rakudo/signature-new-method-parity.t
@@ -1,0 +1,150 @@
+use Test;
+
+plan 47;
+
+class Foo {
+    method bar(Str $a, Int $b) { }
+}
+my $method-sig := Foo.^lookup('bar').signature;
+
+sub params() {
+    Parameter.new(type => Foo, :invocant),
+    Parameter.new(name => '$a', type => Str),
+    Parameter.new(name => '$b', type => Int),
+    Parameter.new(name => '*%_'),
+}
+
+# returns
+{
+    my $sig := Signature.new(params => params);
+    ok $sig.returns =:= Mu,
+      'unspecified return type is the Mu type object itself';
+    is $sig.raku, ':(Foo $:: Str $a, Int $b, *%_)',
+      'unspecified return type does not print as --> Mu';
+    ok Signature.new(params => params, returns => Mu).returns =:= Mu,
+      'explicit Mu return type is the Mu type object itself';
+    nok $method-sig.ACCEPTS(Signature.new(params => params, returns => Nil)),
+      'a different return type still makes the signatures differ';
+}
+
+# arity and count
+{
+    my $sig := Signature.new(params => params);
+    is $sig.arity, 3, 'arity counts invocant and required positionals only';
+    is $sig.count, 3, 'count leaves out the slurpy hash';
+    is Signature.new(params => (Parameter.new(name => '$a'), Parameter.new(name => '$b?'))).arity, 1,
+      'arity leaves out optional positionals';
+    is Signature.new(params => (Parameter.new(name => '$a'), Parameter.new(name => '$b?'))).count, 2,
+      'count includes optional positionals';
+    is Signature.new(params => (Parameter.new(name => '$a'), Parameter.new(name => '*@b'))).count, Inf,
+      'count is Inf with a slurpy positional';
+    is Signature.new(params => (Parameter.new(name => '**@a'),)).count, Inf,
+      'count is Inf with a double slurpy positional';
+    is Signature.new(params => (Parameter.new(name => '|c'),)).count, Inf,
+      'count is Inf with a capture';
+    is Signature.new(params => (Parameter.new(name => ':$x'),)).count, 0,
+      'count leaves out named parameters';
+    is Signature.new(params => (Parameter.new(name => '$a'),), arity => 2).count, 2,
+      'count is never below an explicit arity';
+}
+
+# the parameter list
+{
+    my @array = params;
+    my $sig := Signature.new(params => @array);
+    ok $method-sig.ACCEPTS($sig),
+      'constructed signature matches when the parameters come from an Array';
+    @array[0] = Parameter.new(name => '$z');
+    is $sig.raku, ':(Foo $:: Str $a, Int $b, *%_)',
+      'assigning into the Array afterwards does not change the signature';
+    @array.push: Parameter.new(name => '$c');
+    is $sig.params.elems, 4,
+      'pushing to the Array afterwards does not change the signature';
+    is Signature.new(params => (1..2).map({ Parameter.new(name => "\$a$_") }), arity => 2, count => 2e0).params.elems, 2,
+      'parameters from a lazy list are all kept when arity and count are given';
+    throws-like { Signature.new(params => (1,)) }, X::TypeCheck,
+      'a parameter that is not a Parameter is rejected';
+    throws-like { Signature.new(params => (Parameter.new(name => '$a'), Nil)) }, X::TypeCheck,
+      'a Nil parameter is rejected';
+}
+
+# matching a method signature
+{
+    ok $method-sig.ACCEPTS(Signature.new(params => params)),
+      'constructed signature matches the method signature';
+    ok $method-sig eqv Signature.new(params => params),
+      'constructed signature is eqv to the method signature';
+    ok $method-sig.params.tail.type =:= Associative,
+      'implicit slurpy hash of a method is typed Associative';
+    ok $method-sig.params.tail eqv Parameter.new(name => '*%_'),
+      'implicit slurpy hash of a method is eqv to a constructed one';
+}
+
+# sigil implied types
+{
+    ok Parameter.new(name => '@a').type =:= Positional,
+      'array sigil implies Positional';
+    ok Parameter.new(name => '%h').type =:= Associative,
+      'hash sigil implies Associative';
+    ok Parameter.new(name => '&c').type =:= Callable,
+      'code sigil implies Callable';
+    ok Parameter.new(name => '@a', type => Int).type =:= Positional[Int],
+      'array sigil with a type gives the parameterized Positional';
+    ok Parameter.new(name => '%h', type => Int).type =:= Associative[Int],
+      'hash sigil with a type gives the parameterized Associative';
+    ok Parameter.new(name => '&c', type => Int).type =:= Callable[Int],
+      'code sigil with a type gives the parameterized Callable';
+    ok Parameter.new(name => '@a', type => Int) eqv :(Int @a).params[0],
+      'typed array parameter is eqv to the compiled one';
+    ok Parameter.new(name => ':foo(@x)').type =:= Positional,
+      'array sigil behind an alternative name implies Positional';
+    ok Parameter.new(name => ':foo(@x)') eqv :(:foo(@x)).params[0],
+      'aliased array parameter is eqv to the compiled one';
+}
+
+# definite types
+{
+    ok Parameter.new(name => '$a', type => Int:D).type =:= Int,
+      'definite type is stored as its base type';
+    is Parameter.new(name => '$a', type => Int:D).raku, 'Int:D $a',
+      'definite type is kept as the definedness of the parameter';
+    ok Parameter.new(name => '$a', type => Int:D) eqv :(Int:D $a).params[0],
+      'defined only parameter is eqv to the compiled one';
+    ok Parameter.new(name => '$a', type => Int:U) eqv :(Int:U $a).params[0],
+      'undefined only parameter is eqv to the compiled one';
+    ok Parameter.new(name => '@a', type => Int:D) eqv :(Int:D @a).params[0],
+      'defined only array parameter is eqv to the compiled one';
+}
+
+# slurpies
+{
+    ok Parameter.new(name => '+@a') eqv :(+@a).params[0],
+      'single argument slurpy is eqv to the compiled one';
+    nok Parameter.new(name => '+@a').raw,
+      'single argument slurpy is not raw';
+    throws-like { Parameter.new(name => '*@a', type => Int) }, Exception,
+      message => 'Slurpy positional parameters with type constraints are not supported',
+      'typed slurpy positional is rejected as a positional';
+    throws-like { Parameter.new(name => '+@a', type => Int) }, Exception,
+      message => 'Slurpy positional parameters with type constraints are not supported',
+      'typed single argument slurpy is rejected as a positional';
+    throws-like { Parameter.new(name => '*%h', type => Int) }, Exception,
+      message => 'Slurpy named parameters with type constraints are not supported',
+      'typed slurpy named is rejected as a named';
+}
+
+# smartmatching with slurpies
+{
+    nok :(:$x) ~~ :(*@a),
+      'slurpy positional does not accept named arguments';
+    nok :(*%h) ~~ :(*@a),
+      'slurpy positional does not accept a slurpy hash';
+    nok :(|c) ~~ :(*@a),
+      'slurpy positional does not accept everything a capture accepts';
+    ok :(*@a) ~~ :(|c),
+      'capture accepts everything a slurpy positional accepts';
+    ok :(**@a) ~~ :(*@a),
+      'slurpy positional accepts everything a double slurpy accepts';
+}
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously a signature built at runtime with `Signature.new` and `Parameter.new` could not match the signature of a method, or of most routines, even when it described the same parameters. `$m.ACCEPTS($s)` and `$m eqv $s` were False, and it was hard to see why since both printed the same. The main cause was `Signature.new` binding the Scalar holding its `:$returns` argument into `$!returns`, so the unspecified case held a container around Mu rather than Mu itself. The identity check at the end of ACCEPTS then failed for every method signature, and `.raku` printed a spurious `--> Mu`.

Once that was out of the way the remaining differences were all of the same kind, the constructors filling in something the compiler fills in differently. The arity and count defaulted to the number of parameters, counting the invocant, named parameters and slurpies alike. The parameter list was the Array's own storage, so it held Scalar containers rather than Parameters and changed along with the Array. `Parameter.new` gave every parameter the type Any where the compiler gives `@`, `%` and `&` parameters Positional, Associative and Callable, and stores `Int @a` as `Positional[Int]`. A definite type such as `Int:D` was stored as the type itself, where the compiler stores Int and records the definedness in the flags. A `+@a` name died in substr, and a type on a slurpy was only rejected for `*` names, with a message that always said "named". The legacy frontend typed the implicit `*%_` of a method as Mu while RakuAST types it Associative, so a constructed `*%_` could match under one frontend and not the other.

This makes each of those agree with what the compiler builds, and derives the defaults from the parameters the way the compiler does. `Signature.new` also now rejects anything in `params` that is not a Parameter, since a stray value used to surface later as a missing method on it, or in the case of Nil quietly turned the count into Inf.

`Signature.ACCEPTS(Signature)` had a related problem that showed up while comparing constructed signatures. `.positional` is False for a slurpy positional, so a `*@a` on the accepting side fell into the branch meant for captures and was treated as accepting named arguments as well. `:(:$x) ~~ :(*@a)` was True. Captures, slurpy positionals and plain positionals are now told apart on both sides.

```
$ raku -e 'class A { method m(Str $a) { } }; my $s = Signature.new(params => (Parameter.new(type => A, :invocant), Parameter.new(name => q[$a], type => Str), Parameter.new(name => q[*%_]))); say $s.raku; say A.^lookup("m").signature ~~ $s'
:(A $:: Str $a, *%_ --> Mu)
False
```

With this branch that prints `:(A $:: Str $a, *%_)` and True.

Two things are visible to code that introspects constructed parameters. The type of an `@`, `%` or `&` parameter is now the sigil role rather than Any, and the type of a parameter given `Int:D` is now Int with `.modifier` answering `:D`, which is what compiled parameters have always answered. The docs for `Parameter.new` say the type assumes Any when not specified, which needs updating for the sigil cases. The script in the issue also passes type names as strings, which 11be008b9d removed on purpose, so it needs type objects to pass.

Fixes #5591
