### PR TITLE
Refuse a regex or branch made up of modifiers alone from 6.e

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -11754,6 +11754,64 @@ class Perl6::QActions is HLL::Actions does STDActions {
 
 class Perl6::RegexActions is QRegex::P6Regex::Actions does STDActions {
 
+    method nibbler($/) {
+        self.reject-modifier-only($<termseq><termaltseq>, 0);
+        make $<termseq>.ast;
+    }
+
+    method termaltseq($/) {
+        self.reject-modifier-only-branches($/, 'termconjseq');
+        nqp::findmethod(QRegex::P6Regex::Actions, 'termaltseq')(self, $/)
+    }
+    method termconjseq($/) {
+        self.reject-modifier-only-branches($/, 'termalt');
+        nqp::findmethod(QRegex::P6Regex::Actions, 'termconjseq')(self, $/)
+    }
+    method termalt($/) {
+        self.reject-modifier-only-branches($/, 'termconj');
+        nqp::findmethod(QRegex::P6Regex::Actions, 'termalt')(self, $/)
+    }
+    method termconj($/) {
+        self.reject-modifier-only-branches($/, 'termish');
+        nqp::findmethod(QRegex::P6Regex::Actions, 'termconj')(self, $/)
+    }
+
+    # A lone part is not a branch. The nibbler checks it as the whole regex.
+    method reject-modifier-only-branches($/, str $key) {
+        my @parts := nqp::atkey($/, $key);
+        if nqp::elems(@parts) > 1 {
+            for @parts { self.reject-modifier-only($_, 1) }
+        }
+    }
+
+    # Internal modifiers are not atoms, so a regex, or a branch of an
+    # alternation or conjunction, holding nothing but modifiers would match
+    # the empty string. Walk down through the levels that hold a single part
+    # to the termish and refuse it when every noun is a modifier, from 6.e
+    # on. Earlier revisions compile it as that empty match.
+    method reject-modifier-only($branch, int $in-branch) {
+        return 0 if nqp::getcomp('Raku').language_revision < 3;
+        my $termish := $branch;
+        until $termish<noun> {
+            my $inner := $termish<termconjseq> || $termish<termalt>
+                || $termish<termconj> || $termish<termish>;
+            return 0 unless $inner && nqp::elems($inner) == 1;
+            $termish := $inner[0];
+        }
+        my @modifiers;
+        for $termish<noun> {
+            my $metachar := $_<atom><metachar>;
+            return 0 unless $metachar && $metachar<mod_internal>;
+            @modifiers.push(~$metachar);
+        }
+        my $pos := $termish.pos;
+        $termish.'!clear_highwater'();
+        $termish.'!cursor_pos'($termish.from);
+        $termish.typed_sorry('X::Syntax::Regex::SolitaryModifier',
+            :modifiers($*W.p6ize_recursive(@modifiers)), :branch($in-branch));
+        $termish.'!cursor_pos'($pos);
+    }
+
     # Duplicates the QRegex::P6Regex::Actions base, adding the 6.e gate below.
     # It lives here, not in the base, so NQP's own regexes stay ungated. Keep
     # the c/w handling in sync with the base.

--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -4951,11 +4951,37 @@ Please use $worry.";
 class Raku::RegexActions is HLL::Actions does Raku::CommonActions {
 
     method nibbler($/) {
+        self.reject-modifier-only($<termseq><termaltseq>, 0);
         self.attach: $/, $<termseq>.ast;
     }
 
     method termseq($/) {
         self.attach: $/, $<termaltseq>.ast;
+    }
+
+    # Internal modifiers are not atoms, so a regex, or a branch of an
+    # alternation or conjunction, holding nothing but modifiers would match
+    # the empty string. Walk down through the levels that hold a single part
+    # to the termish and refuse it when every noun is a modifier, from 6.e
+    # on. Earlier revisions compile it as that empty match.
+    method reject-modifier-only($branch, int $in-branch) {
+        return 0 if nqp::getcomp('Raku').language_revision < 3;
+        my $termish := $branch;
+        until $termish<noun> {
+            my $inner := $termish<termconjseq> || $termish<termalt>
+              || $termish<termconj> || $termish<termish>;
+            return 0 unless $inner && nqp::elems($inner) == 1;
+            $termish := $inner[0];
+        }
+        my @modifiers;
+        for $termish<noun> {
+            my $metachar := $_<atom><metachar>;
+            return 0 unless $metachar && $metachar<modifier>;
+            @modifiers.push(~$metachar);
+        }
+        $termish.typed-sorry-at($termish.from,
+          'X::Syntax::Regex::SolitaryModifier',
+          :modifiers(p6ize_recursive(@modifiers)), :branch($in-branch));
     }
 
     # helper method to handle regex sequences
@@ -4970,6 +4996,9 @@ class Raku::RegexActions is HLL::Actions does Raku::CommonActions {
             my @branches;
             for @parts {
                 @branches.push($_.ast);
+            }
+            unless $class eq 'Sequence' {
+                for @parts { self.reject-modifier-only($_, 1) }
             }
             $ast := Nodify('Regex::' ~ $class).new(|@branches);
         }

--- a/src/Raku/ast/regex.rakumod
+++ b/src/Raku/ast/regex.rakumod
@@ -286,9 +286,11 @@ class RakuAST::Regex::Branching
         my $qast := QAST::Regex.new(:rxtype(self.IMPL-QAST-REGEX-TYPE));
         for $!branches {
             my $branch-qast := $_.IMPL-REGEX-QAST($context, %mods);
-            # An internal modifier (e.g. :i) as a sole branch compiles to
-            # Nil. Emit an empty concat so the alternation has a real QAST
-            # child for the NFA and capnames helpers.
+            # A branch that is a bare internal modifier compiles to Nil. The
+            # parser refuses that from 6.e on, but earlier revisions and the
+            # RakuAST API still build it. Emit an empty concat so the
+            # alternation has a real QAST child for the NFA and capnames
+            # helpers.
             $branch-qast := QAST::Regex.new(:rxtype<concat>) unless $branch-qast;
             $branch-qast.backtrack('r') if %mods<r> && !$branch-qast.backtrack;
             $qast.push($branch-qast);

--- a/src/core.c/Exception.rakumod
+++ b/src/core.c/Exception.rakumod
@@ -2290,6 +2290,25 @@ my class X::Syntax::Regex::NullRegex does X::Syntax {
     method message() { "Null regex not allowed.  Please use .comb if you wanted to produce a sequence of characters from a string.".naive-word-wrapper }
 }
 
+my class X::Syntax::Regex::SolitaryModifier is X::Syntax::Regex::NullRegex {
+    has @.modifiers;
+    has Bool $.branch;
+    submethod BUILD(:@!modifiers, Bool() :$!branch) {}
+    method message() {
+        my $modifiers = @!modifiers.join(' ');
+        my $plural = @!modifiers > 1;
+        my $message = $plural
+          ?? "The regex modifiers $modifiers do not match anything by themselves"
+          !! "The regex modifier $modifiers does not match anything by itself";
+        ("Null regex not allowed. $message" ~ ($!branch
+          ?? ", so this branch would match the empty string. To apply "
+               ~ ($plural ?? 'them' !! 'it')
+               ~ " to every branch, put the branches in a group: $modifiers [ ... ]"
+          !! '.'
+        )).naive-word-wrapper
+    }
+}
+
 my class X::Syntax::Regex::MalformedRange does X::Syntax {
     method message() {
         'Malformed Range. If attempting to use variables for end points, '

--- a/t/02-rakudo/regex-modifier-alt-branch.t
+++ b/t/02-rakudo/regex-modifier-alt-branch.t
@@ -1,70 +1,148 @@
+use v6.e.PREVIEW;
 use lib <t/packages/Test-Helpers>;
 use Test;
 use Test::Helpers;
+use nqp;
 
-plan 5;
+plan 40;
 
-# An internal regex modifier (`:i`, `:m`, `:r`, `:s`) alone as a top-level
-# branch of an alternation or conjunction applies to the surrounding
-# construct and compiles to an empty branch.
+# An internal regex modifier such as `:i` or `:dba` is not an atom. A
+# regex, or a branch of an alternation or conjunction, made up of nothing
+# but modifiers would match the empty string, so from 6.e on it is refused
+# at compile time. Earlier language revisions keep the empty match.
 
+throws-like ｢'BAZ' ~~ / :i | foo | bar /｣, X::Syntax::Regex::SolitaryModifier,
+    :modifiers<:i>, :branch({ .so }),
+    ':i as the first branch of `|` alternation is refused';
+throws-like ｢'BAZ' ~~ / :i | foo | bar /｣, X::Syntax::Regex::NullRegex,
+    ':i as the first branch is refused as a null regex';
+throws-like ｢'BAZ' ~~ / :i || foo || bar /｣, X::Syntax::Regex::SolitaryModifier,
+    :modifiers<:i>, :branch({ .so }),
+    ':i as the first branch of `||` alternation is refused';
+throws-like ｢'A' ~~ / :i & <[ A..Z ]> & a /｣, X::Syntax::Regex::SolitaryModifier,
+    :modifiers<:i>, :branch({ .so }),
+    ':i as the first branch of `&` conjunction is refused';
+throws-like ｢'A' ~~ / :i && <[ A..Z ]> && a /｣, X::Syntax::Regex::SolitaryModifier,
+    :modifiers<:i>, :branch({ .so }),
+    ':i as the first branch of `&&` conjunction is refused';
+throws-like ｢'ZZZ' ~~ / a | :i | b /｣, X::Syntax::Regex::SolitaryModifier,
+    :modifiers<:i>, :branch({ .so }),
+    ':i as a middle branch is refused';
+throws-like ｢'ZZZ' ~~ / a | b | :i /｣, X::Syntax::Regex::SolitaryModifier,
+    :modifiers<:i>, :branch({ .so }),
+    ':i as the last branch is refused';
+throws-like ｢'ZZZ' ~~ / :i :r | foo | bar /｣, X::Syntax::Regex::SolitaryModifier,
+    :modifiers<:i :r>, :branch({ .so }),
+    'several modifiers as a branch are refused and all named';
+throws-like ｢'foo' ~~ / :!i | foo | bar /｣, X::Syntax::Regex::SolitaryModifier,
+    :modifiers<:!i>, :branch({ .so }),
+    'a negated modifier as a branch is refused';
+throws-like ｢'foo' ~~ / :i(0) | foo | bar /｣, X::Syntax::Regex::SolitaryModifier,
+    :modifiers<:i(0)>, :branch({ .so }),
+    'a modifier with an argument as a branch is refused and named as written';
+throws-like ｢'foo' ~~ / :ignorecase | foo | bar /｣, X::Syntax::Regex::SolitaryModifier,
+    :modifiers<:ignorecase>, :branch({ .so }),
+    'a long form modifier as a branch is refused';
+throws-like ｢'foo' ~~ / :i: | foo | bar /｣, X::Syntax::Regex::SolitaryModifier,
+    :modifiers<:i>, :branch({ .so }),
+    'a modifier with a backtrack marker as a branch is refused';
+todo 'the legacy frontend parses :dba(...) as :dba and a capture group'
+    unless nqp::gethllsym('Raku', 'COMPILER-FRONTEND') eq 'rakuast';
+throws-like ｢'ZZZ' ~~ / :dba('branches') | foo | bar /｣, X::Syntax::Regex::SolitaryModifier,
+    :modifiers([":dba('branches')"]), :branch({ .so }),
+    ':dba as a branch is refused';
+throws-like ｢'ZZZ' ~~ / :i | foo & <[ a..z ]>+ | bar /｣, X::Syntax::Regex::SolitaryModifier,
+    :modifiers<:i>, :branch({ .so }),
+    ':i as a branch of an alternation over conjunctions is refused';
+throws-like ｢'ZZZ' ~~ / [ :i | foo | bar ] /｣, X::Syntax::Regex::SolitaryModifier,
+    :modifiers<:i>, :branch({ .so }),
+    ':i as a branch inside a group is refused';
+throws-like ｢grammar G { token t { :i | foo | bar } }｣, X::Syntax::Regex::SolitaryModifier,
+    :modifiers<:i>, :branch({ .so }),
+    ':i as a branch in a grammar token is refused';
+throws-like ｢grammar R { rule r { :i | foo | bar } }｣, X::Syntax::Regex::SolitaryModifier,
+    :modifiers<:i>, :branch({ .so }),
+    ':i as a branch in a grammar rule is refused';
+throws-like ｢'foo' ~~ / :i /｣, X::Syntax::Regex::SolitaryModifier,
+    :modifiers<:i>, :branch({ !.so }),
+    'a regex holding only :i is refused';
+throws-like ｢'foo' ~~ / :i: /｣, X::Syntax::Regex::SolitaryModifier,
+    :modifiers<:i>, :branch({ !.so }),
+    'a regex holding only a modifier with a backtrack marker is refused';
+throws-like ｢'foo' ~~ / :i :s /｣, X::Syntax::Regex::SolitaryModifier,
+    :modifiers<:i :s>, :branch({ !.so }),
+    'a regex holding only modifiers is refused';
+todo 'the legacy frontend parses :dba(...) as :dba and a capture group'
+    unless nqp::gethllsym('Raku', 'COMPILER-FRONTEND') eq 'rakuast';
+throws-like ｢'foo' ~~ / :dba('two words') /｣, X::Syntax::Regex::SolitaryModifier,
+    :modifiers([":dba('two words')"]), :branch({ !.so }),
+    message => { .contains('modifier :dba') },
+    'a regex holding only :dba is refused as a single modifier';
+throws-like ｢'foo' ~~ / [ :i ] foo /｣, X::Syntax::Regex::SolitaryModifier,
+    :modifiers<:i>, :branch({ !.so }),
+    'a group holding only :i is refused';
+throws-like ｢'foo' ~~ / ( :i ) foo /｣, X::Syntax::Regex::SolitaryModifier,
+    :modifiers<:i>, :branch({ !.so }),
+    'a capture group holding only :i is refused';
+throws-like ｢'foo' ~~ / foo <?before :i> /｣, X::Syntax::Regex::SolitaryModifier,
+    :modifiers<:i>, :branch({ !.so }),
+    'a lookahead holding only :i is refused';
+
+{
+    try EVAL ｢'foo' ~~ / :i | :s /｣;
+    isa-ok $!, X::Comp::Group,
+        'branches that are all modifiers are each refused';
+    like $!.message, / ':i [ ... ]' .* ':s [ ... ]' /,
+        'each of the modifier-only branches is named in its own sorry';
+}
+
+{
+    try EVAL ｢'foo' ~~ / foo | /｣;
+    isa-ok $!, X::Syntax::Regex::NullRegex,
+        'an empty branch is refused as a null regex';
+    unlike $!.message, / 'regex modifier' /,
+        'an empty branch is not reported as a modifier';
+}
+
+is 'foo' ~~ / :my $x; | foo | bar /, 'foo',
+    'a declaration alone as a branch is an atom and compiles';
+is 'foo' ~~ / { } | foo | bar /, 'foo',
+    'a code block alone as a branch is an atom and compiles';
+is 'foo' ~~ / :i { } | foo | bar /, 'foo',
+    'a modifier followed by a code block is not modifier only';
+is 'FOO' ~~ m:i/ | foo | bar /, 'FOO',
+    'an external adverb with a leading | is not a modifier only branch';
+is 'FOO' ~~ / :i foo | bar /, 'FOO',
+    'a modifier followed by an atom in the first branch compiles';
+
+like X::Syntax::Regex::SolitaryModifier.new(:modifiers[':i'], :branch).message,
+    / ':i [ ... ]' /,
+    'the branch message shows how to apply the modifier to every branch';
+like X::Syntax::Regex::SolitaryModifier.new(:modifiers[':i', ':s'], :branch).message,
+    / 'modifiers :i :s do not' .* 'apply' \s+ 'them' /,
+    'the branch message is plural for several modifiers';
+unlike X::Syntax::Regex::SolitaryModifier.new(:modifiers[':i'], :!branch).message,
+    / '[ ... ]' /,
+    'the whole regex message does not talk about branches';
+
+is-deeply 'BAZ' ~~ / :i [ | foo | bar ] /, Nil,
+    ':i before a grouped alternation does not match the empty string';
+is 'BAR' ~~ / :i [ | foo | bar ] /, 'BAR',
+    ':i before a grouped alternation applies to every branch';
+
+# A `use v6.d` inside an EVAL does not lower the language revision on
+# every frontend, so the 6.d behaviour gets its own process.
 is-run q:to/CODE/,
-    grammar G {
-        token irregular {
-            :i
-            | 'en-GB-oed'
-            | 'i-ami'
-        }
-    }
-    say G.parse('EN-GB-OED', :rule<irregular>) // 'no';
-    say G.parse('i-ami',     :rule<irregular>) // 'no';
-    say G.parse('zzz',       :rule<irregular>) // 'no';
+    use v6.d;
+    print 'BAZ' ~~ / :i | foo | bar /;
     CODE
-    :out("｢EN-GB-OED｣\n｢i-ami｣\nno\n"),
-    ':i as the first branch of `|` alternation matches with the modifier applied';
-
+    :out(''),
+    'under 6.d a modifier-only branch compiles and matches the empty string';
 is-run q:to/CODE/,
-    grammar G {
-        token middle { 'a' | :i | 'B' }
-    }
-    say G.parse('a', :rule<middle>) // 'no';
-    say G.parse('b', :rule<middle>) // 'no';
+    use v6.d;
+    print 'foo' ~~ / :i /;
     CODE
-    :out("｢a｣\n｢b｣\n"),
-    ':i in a non-first branch position applies to subsequent branches';
-
-is-run q:to/CODE/,
-    grammar G {
-        token nego { :!i | 'foo' | 'bar' }
-    }
-    say G.parse('foo', :rule<nego>) // 'no';
-    say G.parse('FOO', :rule<nego>) // 'no';
-    CODE
-    :out("｢foo｣\nno\n"),
-    ':!i as the first branch of `|` alternation keeps case-sensitive matching';
-
-is-run q:to/CODE/,
-    grammar G {
-        token seqalt {
-            :i
-            || 'foo'
-            || 'bar'
-        }
-    }
-    G.parse('FOO', :rule<seqalt>);
-    say 'compiled';
-    CODE
-    :out("compiled\n"),
-    ':i as the first branch of `||` alternation compiles';
-
-is-run q:to/CODE/,
-    grammar G {
-        token conjAtom { :i & <[ a..z A..Z ]> & 'A' }
-    }
-    G.parse('A', :rule<conjAtom>);
-    say 'compiled';
-    CODE
-    :out("compiled\n"),
-    ':i as the first branch of `&` conjunction compiles';
+    :out(''),
+    'under 6.d a modifier-only regex compiles and matches the empty string';
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously a branch of a regex alternation or conjunction made up of nothing but internal modifiers, such as the `:i` in `/ :i | foo | bar /`, compiled to an empty branch. That branch matches the empty string, so the regex matched every input. A regex or group holding only modifiers, such as `/ :i /`, matched the empty string the same way.

Internal modifiers are not atoms, so a regex or branch with nothing else in it is a null regex. From 6.e on this refuses it at compile time with X::Syntax::Regex::SolitaryModifier, a NullRegex that names the modifiers as written in the source and, for a branch, shows how to apply them to every branch instead. Earlier language revisions keep compiling it as the empty match, as the other 6.e regex errors do. Both frontends walk the parse tree at the nibbler and at each alternation and conjunction level, so groups, captures and lookaheads are covered too, and the error points at the modifiers.

Fixes #5667