### PR TITLE
Scope the language revision to the compilation unit

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -18,7 +18,7 @@ my int $?BITS := nqp::isgt_i(nqp::add_i(2147483648, 1), 0) ?? 64 !! 32;
 sub block_closure($code, :$regex) {
     my $clone := QAST::Op.new( :op('callmethod'), :name('clone'), $code );
     if $regex {
-        if nqp::getcomp('Raku').language_revision < 2 {
+        if $*LANGUAGE-REVISION < 2 {
             my $marker := $*W.find_symbol(['Rakudo', 'Internals', 'RegexBoolification6cMarker']);
             $clone.push(QAST::WVal.new( :value($marker), :named('topic') ));
         }
@@ -1435,7 +1435,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
               QAST::WVal.new(:value($main<value>)),
               $mainline             # run the mainline and get its result
             );
-            unless nqp::getcomp('Raku').language_revision < 2 {
+            unless $*LANGUAGE-REVISION < 2 {
                 $mainline.push(
                   QAST::WVal.new( # $*IN as $*ARGSFILES
                     value => $world.find_symbol(['Bool','True'], :setting-only),
@@ -1632,7 +1632,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
                 my $ast := $statements[0].ast;
 
                 # an op and 6e or higher?
-                if nqp::istype($ast,QAST::Op) && nqp::getcomp('Raku').language_revision >= 3 {
+                if nqp::istype($ast,QAST::Op) && $*LANGUAGE-REVISION >= 3 {
                     sub is-pipe-pipe($ast) {
                         nqp::istype($ast,QAST::Op)
                           && $ast.name eq '&prefix:<|>'
@@ -2572,7 +2572,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
 
     sub single_top_level_whenever($block) {
         if $*WHENEVER_COUNT == 1
-        && nqp::getcomp('Raku').language_revision > 1 {
+        && $*LANGUAGE-REVISION > 1 {
             my $stmts := $block[1];
             if nqp::istype($stmts, QAST::Stmts) {
                 my @stmts := $stmts.list;
@@ -2657,7 +2657,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
             QAST::WVal.new( :value($world.find_single_symbol_in_setting('Promise')) ),
             $<blorst>.ast
         );
-        if nqp::getcomp('Raku').language_revision > 1 {
+        if $*LANGUAGE-REVISION > 1 {
             $qast.push(QAST::WVal.new(
                 :value($world.find_symbol(['Bool', 'True'])),
                 :named('report-broken-if-sunk')
@@ -3017,7 +3017,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
 
     method contextualizer($/) {
         my $past := $<coercee>.ast;
-        my $has_magic := nqp::getcomp('Raku').language_revision < 2 && $<coercee> eq '';
+        my $has_magic := $*LANGUAGE-REVISION < 2 && $<coercee> eq '';
         my $sigil := ~$<sigil>;
 
         if $has_magic && $sigil eq '$' { # for '$()'
@@ -3081,7 +3081,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
 
         if nqp::existskey(%variable_deprecations, $name)
             && nqp::isge_i(
-                nqp::getcomp('Raku').language_revision,
+                $*LANGUAGE-REVISION,
                 %variable_deprecations{$name}[0])
         {
             @deprecation := nqp::clone(%variable_deprecations{$name});
@@ -3178,7 +3178,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
             # under 6.e so that an if/while/etc. CONDITION (which is
             # parsed in the outer pad, before the body's new pad gets
             # pushed) doesn't try to redeclare an explicit *@_ parameter.
-            if (nqp::getcomp('Raku').language_revision < 3
+            if ($*LANGUAGE-REVISION < 3
                 && $world.nearest_signatured_block_declares('@_'))
               || +$world.cur_lexpad().symbol('@_') {
                 $past.scope('lexical');
@@ -3191,7 +3191,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
         elsif $name eq '%_' {
             # Same 6.e gate as @_ above. The $*METHODTYPE check stays
             # unconditional: methods auto-have *%_ in every revision.
-            if (nqp::getcomp('Raku').language_revision < 3
+            if ($*LANGUAGE-REVISION < 3
                 && $world.nearest_signatured_block_declares('%_'))
               || +$world.cur_lexpad().symbol('%_')
               || $*METHODTYPE {
@@ -4194,7 +4194,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
 
     sub decontrv_op() {
 #?if moar
-        nqp::getcomp('Raku').language_revision < 2
+        $*LANGUAGE-REVISION < 2
           ?? 'p6decontrv_6c'
           !! 'p6decontrv'
 #?endif
@@ -5544,7 +5544,7 @@ class Perl6::Actions is HLL::Actions does STDActions {
         }
         if $sigil eq '%' {
             nqp::defined($*OFTYPE) && $world.throw: $/, 'X::ParametricConstant';
-            nqp::getcomp('Raku').language_revision < 2
+            $*LANGUAGE-REVISION < 2
               ?? check-type($world.find_symbol: ['Associative'])
               !! check-type-maybe-coerce('Map', $world.find_symbol: ['Associative'])
         }
@@ -11773,7 +11773,7 @@ class Perl6::RegexActions is QRegex::P6Regex::Actions does STDActions {
         else {
             # Any name other than w/c is a typo: an error from 6.e. Before then
             # $qast stays null, which the base matches as the empty string.
-            if nqp::getcomp('Raku').language_revision >= 3 {
+            if $*LANGUAGE-REVISION >= 3 {
                 $/.typed_panic('X::Syntax::Regex::UnrecognizedBoundary', :boundary($name));
             }
         }

--- a/src/Perl6/Compiler.nqp
+++ b/src/Perl6/Compiler.nqp
@@ -279,6 +279,8 @@ class Perl6::Compiler is HLL::Compiler {
             my $optimize := %adverbs<optimize>;
             unless nqp::defined($optimize)
               && ($optimize eq 'off' || $optimize eq '0') {
+                # The parse frame that declared this is gone by now
+                my $*LANGUAGE-REVISION := $past.language-revision.Int;
                 $past.optimize($past.resolver,
                     :interactive(%adverbs<interactive> ?? 1 !! 0));
             }
@@ -323,6 +325,7 @@ class Perl6::Compiler is HLL::Compiler {
         # such EVALs don't compile into an ephemeral context that breaks
         # precompilation.
         my $*CU := $rakuast;
+        my $*LANGUAGE-REVISION := $rakuast.language-revision.Int;
         $*RAKUAST-EVAL-COMP-UNIT := $rakuast
             if $rakuast.is-eval && !nqp::isnull(nqp::getlexdyn('$*RAKUAST-EVAL-COMP-UNIT'));
         # The cleanup nulls the compiler state stubbed code objects carry.

--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -350,7 +350,7 @@ role STD {
         <?{ $*COMPILING_CORE_SETTING
             || ((try $*W.find_single_symbol('EXPERIMENTAL-' ~ nqp::uc($feature)))
                 && ($feature ne 'macros'
-                    || nqp::getcomp('Raku').language_revision < 3)) }>
+                    || $*LANGUAGE-REVISION < 3)) }>
         || <.typed_panic('X::Experimental', :$feature)>
     }
 
@@ -848,9 +848,13 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         # for runaway detection
         :my $*LASTQUOTE := [0,0];
 
+        # Revision checks read this rather than the compiler object, which
+        # every unit compiled in the process writes to
+        :my $*LANGUAGE-REVISION;
         {
             nqp::getcomp('Raku').reset_language_version();
-            $*W.comp_unit_stage0($/)
+            $*W.comp_unit_stage0($/);
+            $*LANGUAGE-REVISION := nqp::getcomp('Raku').language_revision;
         }
 
         <.bom>?
@@ -1212,7 +1216,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
     rule statement_control:sym<whenever> {
         <sym><.kok>
         [
-        || <?{ nqp::getcomp('Raku').language_revision == 1 || $*WHENEVER_COUNT >= 0 }>
+        || <?{ $*LANGUAGE-REVISION == 1 || $*WHENEVER_COUNT >= 0 }>
         || <.typed_panic('X::Comp::WheneverOutOfScope')>
         ]
         { $*WHENEVER_COUNT++ }
@@ -2496,7 +2500,7 @@ grammar Perl6::Grammar is HLL::Grammar does STD {
         || ';'
             {
                 # Allow all subs with ; but require "unit" scope from 6.e
-                if nqp::getcomp('Raku').language_revision >= 3 {
+                if $*LANGUAGE-REVISION >= 3 {
                     $/.typed_panic("X::UnitScope::MustHaveUnit", :what<sub>)
                       unless $*SCOPE eq 'unit';
                 }
@@ -3123,7 +3127,7 @@ sub, perhaps you accidentally placed a semicolon after routine's definition?"
     token term:sym<time> { <sym> <.tok> }
 
     token term:sym<nano> {
-        <?{ (nqp::getcomp('Raku').language_revision >= 3)
+        <?{ ($*LANGUAGE-REVISION >= 3)
             || $*W.is_name(['&term:<nano>']) }>
         <sym> <.tok>
     }
@@ -3566,7 +3570,7 @@ sub, perhaps you accidentally placed a semicolon after routine's definition?"
     }
 
     token quote:sym</null/> {
-        :my $rev := nqp::getcomp('Raku').language_revision;
+        :my $rev := $*LANGUAGE-REVISION;
           <?{ $rev < 3 }>
           '/' \s* '/' <.typed_panic: "X::Syntax::Regex::NullRegex">
         | <?{ $rev >= 3 }>
@@ -4159,7 +4163,7 @@ sub, perhaps you accidentally placed a semicolon after routine's definition?"
     }
     token prefix:sym<⚛>   { <sym>  <O(|%symbolic_unary)> }
     token prefix:sym<//>  {
-        <?{ nqp::getcomp('Raku').language_revision >= 3 }>
+        <?{ $*LANGUAGE-REVISION >= 3 }>
         <sym> <O(|%symbolic_unary)>
     }
 
@@ -4675,7 +4679,7 @@ sub, perhaps you accidentally placed a semicolon after routine's definition?"
             self.typed_panic(
                 'X::Syntax::Extension::Category', :$category
             ) if nqp::iseq_s($subname, "$category:<$opname>")
-              || nqp::iseq_s($subname, "$category:sym<$opname>") && nqp::getcomp('Raku').language_revision < 2;
+              || nqp::iseq_s($subname, "$category:sym<$opname>") && $*LANGUAGE-REVISION < 2;
 
             self.typed_panic(
                 'X::Syntax::Reserved', :reserved(':sym<> colonpair')

--- a/src/Perl6/Metamodel/LanguageRevision.nqp
+++ b/src/Perl6/Metamodel/LanguageRevision.nqp
@@ -30,11 +30,16 @@ role Perl6::Metamodel::LanguageRevision
             # may not represent the CORE's revision. But the World's
             # instance knows it.
             # TODO RakuAST needs different approach.
+            # The revision of the unit declaring the type, or of the unit
+            # composing it at runtime
+            my $unit-rev := nqp::getlexdyn('$*LANGUAGE-REVISION');
+            $unit-rev := nqp::getlexcaller('$?LANGUAGE-REVISION')
+                if nqp::isnull($unit-rev);
             nqp::push(
                 @lang-ver,
                 $*COMPILING_CORE_SETTING
                 ?? $*W ?? $*W.setting_revision !! $*COMPILING_CORE_SETTING
-                !! $comp.language_revision
+                !! nqp::isnull($unit-rev) ?? $comp.language_revision !! $unit-rev
             );
         }
         else {

--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -541,7 +541,14 @@ class Perl6::World is HLL::World {
         }
     }
 
+    # !load-lang-ver returns early on several paths, so the unit's
+    # revision is recorded here
     method load-lang-ver($ver-match, $comp) {
+        self.'!load-lang-ver'($ver-match, $comp);
+        $*LANGUAGE-REVISION := $comp.language_revision;
+    }
+
+    method !load-lang-ver($ver-match, $comp) {
         if $*INSIDE-EVAL && $!have_outer {
             # XXX Calling typed_panic is the desirable behavior. But it breaks some code. Just ignore version change for
             # now.
@@ -810,8 +817,8 @@ class Perl6::World is HLL::World {
             $*UNIT, '$=pod', $*POD_PAST.compile_time_value
         );
 
-        # Install $?LANGUAGE-REVISION to whatever the current compiler version is
-        self.install_lexical_symbol($*UNIT, '$?LANGUAGE-REVISION', nqp::getcomp('Raku').language_revision);
+        # Install $?LANGUAGE-REVISION as the revision of this compilation unit
+        self.install_lexical_symbol($*UNIT, '$?LANGUAGE-REVISION', $*LANGUAGE-REVISION);
 
         # Tag UNIT with a magical lexical unless it is CORE.
         self.add_unit_marker($/, '!UNIT_MARKER') unless $*COMPILING_CORE_SETTING;
@@ -1657,7 +1664,7 @@ class Perl6::World is HLL::World {
                 # legacy silent-replace behavior where the new package
                 # simply overwrites the module in the outer stash via
                 # steal_WHO below.
-                my $use-nested := nqp::getcomp('Raku').language_revision >= 3
+                my $use-nested := $*LANGUAGE-REVISION >= 3
                     && +@parts == 1
                     && nqp::existskey($resolved_pkg.WHO, $name)
                     && ($resolved_pkg.WHO){$name} =:= $package;
@@ -1724,7 +1731,7 @@ class Perl6::World is HLL::World {
     # kind on pre-6.e code. All gating lives here so the installer
     # call site stays readable.
     method maybe_worry_same_name_as_enclosing($/, $existing, $symbol, $pkgdecl, $package) {
-        if nqp::getcomp('Raku').language_revision < 3
+        if $*LANGUAGE-REVISION < 3
           && $existing =:= $package {
             my $existing-how := $existing.HOW.HOW.name($existing.HOW);
             my $enclosing-kind :=
@@ -1825,7 +1832,7 @@ class Perl6::World is HLL::World {
             elsif $prim == 2 {
                 $init := QAST::Op.new( :op('bind'),
                     QAST::Var.new( :scope('lexical'), :name($name) ),
-                    nqp::getcomp('Raku').language_revision < 2
+                    $*LANGUAGE-REVISION < 2
                       ?? QAST::Op.new(:op<nan>)
                       !! QAST::NVal.new(:value(0e0))
                 );
@@ -2081,7 +2088,7 @@ class Perl6::World is HLL::World {
             }
             if $shape {
                 @value_type[0] := self.find_single_symbol_in_setting(
-                    nqp::getcomp('Raku').language_revision >= 3 ?? 'Mu' !! 'Any'
+                    $*LANGUAGE-REVISION >= 3 ?? 'Mu' !! 'Any'
                 ) unless +@value_type;
                 my $shape_ast := $shape[0].ast;
                 if nqp::istype($shape_ast, QAST::Stmts) {
@@ -2176,7 +2183,7 @@ class Perl6::World is HLL::World {
     method maybe-definite-how-base($v) {
         # returns the value itself, unless it's a DefiniteHOW, in which case,
         # it returns its base type. Behaviour available in 6.d and later only.
-        nqp::getcomp('Raku').language_revision >= 2
+        $*LANGUAGE-REVISION >= 2
             && nqp::eqaddr($v.HOW, self.find_symbol(['Metamodel','DefiniteHOW'], :setting-only))
             ?? $v.HOW.base_type: $v
             !! $v
@@ -2189,7 +2196,7 @@ class Perl6::World is HLL::World {
         !$v-how.archetypes($v).coercive
             && (nqp::can($v-how, 'language_revision')
                     ?? $v-how.language_revision($v) < 3
-                    !! nqp::getcomp('Raku').language_revision < 3)
+                    !! $*LANGUAGE-REVISION < 3)
             ?? self.maybe-definite-how-base($v)
             !! ($v-how.archetypes($v).nominalizable
                 ?? $v-how.nominalize($v)
@@ -2217,7 +2224,7 @@ class Perl6::World is HLL::World {
                 'default_value',   $WHAT,
                 'scalar_value',    $WHAT,
             );
-            my $dynamic := nqp::getcomp('Raku').language_revision < 2 || $name ne '$_';
+            my $dynamic := $*LANGUAGE-REVISION < 2 || $name ne '$_';
             my $desc := self.create_container_descriptor($Mu, $name, $WHAT, $dynamic);
 
             my $cont := self.build_container_and_add_to_sc(%info, $desc);

--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -349,6 +349,9 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
         my $context       := %OPTIONS<outer_ctx>;
         my $resolver-type := Nodify('Resolver::Compile');
 
+        # Start from the revision the compile options select
+        nqp::getcomp('Raku').reset_language_version();
+
         my $setting-name := %OPTIONS<setting>;
         if nqp::eqat($setting-name, 'NULL.', 0) {
             my $comp := nqp::getcomp('Raku');
@@ -362,6 +365,8 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
                     ?? $setting_revision
                     !! $default_revision );
         }
+
+        $*LANGUAGE-REVISION := nqp::getcomp('Raku').language_revision;
 
         my $RESOLVER := $*R := nqp::isconcrete($context)
           ?? $resolver-type.from-context(
@@ -565,6 +570,8 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
         elsif !$is-EVAL && !$*COMPILING_CORE_SETTING {
             resolver-from-revision();
         }
+
+        $*LANGUAGE-REVISION := $language-revision;
 
         # Locate an EXPORTHOW and set those mappings on our current language.
         my $EXPORTHOW := $RESOLVER.resolve-lexical-constant('EXPORTHOW');
@@ -2690,7 +2697,7 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
                 # block, shadowing the outer one. See:
                 #   https://github.com/Raku/roast/commit/0b8c717e6
                 #   https://github.com/Raku/old-issue-tracker/issues/1488
-                if nqp::getcomp('Raku').language_revision < 3
+                if $*LANGUAGE-REVISION < 3
                   && $*R.resolve-lexical($name) {
                     $ast := Nodify('Var::Lexical').new(:$sigil, :$desigilname);
                 }
@@ -2820,7 +2827,7 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
         # In 6.c an empty contextualizer operates on $/. `$()` yields the
         # smartmatch result of $/ (its made AST if any, else its matched
         # string), while `@()` and `%()` coerce $/ itself.
-        if nqp::getcomp('Raku').language_revision < 2 && $<coercee> eq '' {
+        if $*LANGUAGE-REVISION < 2 && $<coercee> eq '' {
             if $sigil eq '$' {
                 self.attach: $/, Nodify('Ternary').new(
                     condition => self.IMPL-MATCH-VAR-METHOD-CALL('ast'),
@@ -5318,7 +5325,7 @@ class Raku::RegexActions is HLL::Actions does Raku::CommonActions {
             # Only `w` and `c` are real boundaries, so any other name is a typo.
             # Pre-6.e code already compiles it as a silent no-op, so the error is
             # gated on 6.e to keep that working.
-            if nqp::getcomp('Raku').language_revision >= 3 {
+            if $*LANGUAGE-REVISION >= 3 {
                 $/.typed-panic: 'X::Syntax::Regex::UnrecognizedBoundary', :boundary($name);
             }
             else {

--- a/src/Raku/Grammar.nqp
+++ b/src/Raku/Grammar.nqp
@@ -52,7 +52,7 @@ role Raku::Common {
     token fatty { \h* [ '=>' | '⇒' ] }
 
     # The current language revision (1 = 6.c, 2 = 6.d, 3 = 6.e)
-    method language-revision() { nqp::getcomp('Raku').language_revision }
+    method language-revision() { $*LANGUAGE-REVISION }
 
     # Helper method for chars of match
     method leading-char()   { nqp::substr(self.orig, self.from,     1) }
@@ -1323,6 +1323,7 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
         :my $*ORIGIN-SOURCE;   # current RakuAST::Origin::Source object
         :my @*ORIGIN-NESTINGS := [];  # handling nested origins
         :my $*R;               # current RakuAST::Resolver::xxx object
+        :my $*LANGUAGE-REVISION;  # language revision of this compilation unit
         :my $*LITERALS;        # current RakuAST::LiteralBuilder object
         :my &*DD;              # debug helper to dd()
         {
@@ -4247,7 +4248,7 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
           || ';'
              {
                  # Allow all subs with ; but require "unit" scope from 6.e
-                 if nqp::getcomp('Raku').language_revision >= 3 {
+                 if $*LANGUAGE-REVISION >= 3 {
                      $/.typed_panic("X::UnitScope::MustHaveUnit","sub")
                        unless $*SCOPE eq 'unit';
                  }

--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -453,6 +453,16 @@ class RakuAST::Node {
         nqp::die('Missing IMPL-INTERPRET implementation on ' ~ self.HOW.name(self))
     }
 
+    # The revision of the compilation unit in dynamic scope, or the
+    # compiler's for a tree compiled outside one, as through the RakuAST
+    # API at runtime
+    method IMPL-LANGUAGE-REVISION() {
+        my $revision := nqp::getlexdyn('$*LANGUAGE-REVISION');
+        nqp::isnull($revision)
+          ?? nqp::getcomp('Raku').language_revision
+          !! $revision
+    }
+
     method IMPL-WRAP-LIST(Mu $vm-array) {
         if nqp::istype($vm-array, List) {
             # It already is a list

--- a/src/Raku/ast/code.rakumod
+++ b/src/Raku/ast/code.rakumod
@@ -2179,7 +2179,7 @@ class RakuAST::Block
                     :exception);
             }
         }
-        if nqp::getcomp('Raku').language_revision >= 3 && !$!no-implicit-match {
+        if self.IMPL-LANGUAGE-REVISION >= 3 && !$!no-implicit-match {
             nqp::push(@implicit, RakuAST::VarDeclaration::Implicit::BlockMatch.new(:name('$/')))
                 unless self.IMPL-HAS-PARAMETER('$/');
         }

--- a/src/Raku/ast/compunit.rakumod
+++ b/src/Raku/ast/compunit.rakumod
@@ -661,7 +661,7 @@ class RakuAST::CompUnit
               QAST::WVal.new(:value($main.meta-object)),
               QAST::Stmts.new(|$top-level.list) # run the mainline and get its result
             );
-            unless nqp::getcomp('Raku').language_revision < 2 {
+            unless $!language-revision.Int < 2 {
                 $run-main.push(
                   QAST::WVal.new( # $*IN as $*ARGSFILES
                     value => True,

--- a/src/Raku/ast/scoping.rakumod
+++ b/src/Raku/ast/scoping.rakumod
@@ -1819,7 +1819,7 @@ class RakuAST::PackageInstaller {
             # In 6.d and earlier, let $resolved stand so the legacy
             # silent-replace path below does the ModuleHOW steal_WHO
             # overwrite, matching the traditional grammar.
-            if $resolved && nqp::getcomp('Raku').language_revision >= 3 {
+            if $resolved && self.IMPL-LANGUAGE-REVISION >= 3 {
                 my $check := self.IMPL-UNWRAP-LIST($resolved);
                 my $check-target := $check[0];
                 my $check-remaining := self.IMPL-UNWRAP-LIST($check[1]);
@@ -1968,7 +1968,7 @@ class RakuAST::PackageInstaller {
     # the setting), matching legacy `install_package`.
     method IMPL-SHOULD-SILENT-REPLACE(Mu $existing, Mu $current-package, RakuAST::Name $name, str $orig-scope, int $target-from-setting) {
         nqp::istype($existing.HOW, Perl6::Metamodel::PackageHOW)
-        || (nqp::getcomp('Raku').language_revision < 3
+        || (self.IMPL-LANGUAGE-REVISION < 3
             && nqp::istype($existing.HOW, Perl6::Metamodel::ModuleHOW)
             && $existing =:= $current-package)
         || $name.is-identifier
@@ -1981,7 +1981,7 @@ class RakuAST::PackageInstaller {
     # kind on pre-6.e code. All gating lives here so the installer
     # call site stays readable.
     method IMPL-MAYBE-WORRY-SAME-NAME-AS-ENCLOSING($resolver, $existing, $type-object, $current-package, $name) {
-        if nqp::getcomp('Raku').language_revision < 3
+        if self.IMPL-LANGUAGE-REVISION < 3
           && !$name.is-identifier
           && $existing =:= $current-package {
             my $enclosing-kind :=

--- a/src/Raku/ast/type.rakumod
+++ b/src/Raku/ast/type.rakumod
@@ -45,7 +45,7 @@ class RakuAST::Type
     method IMPL-MAYBE-DEFINITE-HOW-BASE($v) {
         # returns the value itself, unless it's a DefiniteHOW, in which case,
         # it returns its base type. Behaviour available in 6.d and later only.
-        nqp::getcomp('Raku').language_revision >= 2
+        self.IMPL-LANGUAGE-REVISION >= 2
             && nqp::eqaddr($v.HOW, Perl6::Metamodel::DefiniteHOW)
             ?? $v.HOW.base_type: $v
             !! $v
@@ -57,7 +57,7 @@ class RakuAST::Type
         my $v-how := $v.HOW;
         (nqp::can($v-how, 'language_revision')
                 ?? $v-how.language_revision($v) < 3
-                !! nqp::getcomp('Raku').language_revision < 3)
+                !! self.IMPL-LANGUAGE-REVISION < 3)
             ?? self.IMPL-MAYBE-DEFINITE-HOW-BASE($v)
             !! $v-how.archetypes($v).nominalizable ?? $v-how.nominalize($v) !! $v
     }
@@ -71,7 +71,7 @@ class RakuAST::Type
         !$v-how.archetypes($v).coercive
             && (nqp::can($v-how, 'language_revision')
                     ?? $v-how.language_revision($v) < 3
-                    !! nqp::getcomp('Raku').language_revision < 3)
+                    !! self.IMPL-LANGUAGE-REVISION < 3)
             ?? self.IMPL-MAYBE-DEFINITE-HOW-BASE($v)
             !! $v-how.archetypes($v).nominalizable ?? $v-how.nominalize($v) !! $v
     }

--- a/src/Raku/ast/var-lowering.rakumod
+++ b/src/Raku/ast/var-lowering.rakumod
@@ -161,7 +161,7 @@ class RakuAST::IMPL::VarLowering {
         # From 6.d the topic is not a dynamic variable, so a callee
         # cannot reach an unused one and its declaration can go.
         nqp::bindattr_i($analyzer, RakuAST::IMPL::VarLowering, '$!topic-not-dynamic',
-            nqp::getcomp('Raku').language_revision >= 2 ?? 1 !! 0);
+            RakuAST::Node.IMPL-LANGUAGE-REVISION >= 2 ?? 1 !! 0);
 
         # The sentinel type that stands in for a lowered lexical's
         # by-name symbol. Without it (very early bootstrap) nothing is

--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -236,7 +236,7 @@ class RakuAST::ContainerCreator {
                             $bind-constraint, $of, $key-type);
                     }
                     else {
-                        my $value-default := nqp::getcomp('Raku').language_revision >= 3 ?? Mu !! Any;
+                        my $value-default := self.IMPL-LANGUAGE-REVISION >= 3 ?? Mu !! Any;
                         $container-type := Hash.HOW.parameterize(
                             Hash, $value-default, $key-type);
                         $bind-constraint := $bind-constraint.HOW.parameterize(
@@ -269,7 +269,7 @@ class RakuAST::ContainerCreator {
             else {
                 my $value-type := self.type
                     ?? $of
-                    !! (nqp::getcomp('Raku').language_revision >= 3 ?? Mu !! Any);
+                    !! (self.IMPL-LANGUAGE-REVISION >= 3 ?? Mu !! Any);
                 $container-type := $explicit-base.HOW.parameterize(
                     $explicit-base, $value-type, $key-type);
             }
@@ -297,7 +297,7 @@ class RakuAST::ContainerCreator {
         $default := RakuAST::Type.IMPL-NOMINALIZE-FOR-DEFAULT($of) if self.type;
         my int $dynamic := self.twigil eq '*' ?? 1 !! self.forced-dynamic ?? 1 !! 0;
         my int $isolated-match := self.lexical-name eq '$/'
-            && nqp::getcomp('Raku').language_revision >= 3;
+            && self.IMPL-LANGUAGE-REVISION >= 3;
         nqp::bindattr(self, RakuAST::ContainerCreator, '$!container-descriptor',
             RakuAST::IMPL::Containers.create-descriptor(
                 :$of, :$default, :$dynamic, :name(self.lexical-name),
@@ -2777,7 +2777,7 @@ class RakuAST::VarDeclaration::Implicit::Special
                 '$!', ContainerDescriptor::Untyped.new(:of(Mu), :default(Nil), :dynamic, :name('$!'))
             )
         );
-        my $cont-desc := COMMON[nqp::getcomp('Raku').language_revision]{self.name} //
+        my $cont-desc := COMMON[self.IMPL-LANGUAGE-REVISION]{self.name} //
             RakuAST::IMPL::Containers.create-descriptor(
                 :of(Mu), :default(Any), :dynamic(0), :name(self.name));
         my $container := nqp::create(Scalar);

--- a/src/core.c/ForeignCode.rakumod
+++ b/src/core.c/ForeignCode.rakumod
@@ -120,8 +120,11 @@ $lang = 'Raku' if $lang eq 'perl6';
             RakuAST::CompUnit.new:
                 :outer-cu($*CU // RakuAST::CompUnit),
                 :eval, :$statement-list,
-                :comp-unit-name($filename // 'EVAL_' ~ Rakudo::Internals::EvalIdSource.next-id)
+                :comp-unit-name($filename // 'EVAL_' ~ Rakudo::Internals::EvalIdSource.next-id),
+                :language-revision(Rakudo::Internals.LANGUAGE-REVISION-OF-CONTEXT($eval_ctx))
         }
+
+        my $*LANGUAGE-REVISION := $comp-unit.language-revision.Int;
 
         # Perform symbol resolution, then compile to QAST and in turn bytecode.
         # When called from a BEGIN block the captured outer-context chain may
@@ -154,12 +157,14 @@ $lang = 'Raku' if $lang eq 'perl6';
         my $?FILES   := $filename // 'EVAL_' ~ Rakudo::Internals::EvalIdSource.next-id;
 
         my $LANG := $context<%?LANG>:exists ?? $context<%?LANG> !! Nil;
+
         my $*INSIDE-EVAL := 1;
         $compiled := $compiler.compile:
             $code,
             :outer_ctx($eval_ctx),
             :global(GLOBAL),
-            :language_version(nqp::getcomp('Raku').language_version),
+            # the revision of the unit calling EVAL, not the compiler's
+            :language_version(Rakudo::Internals.LANGUAGE-VERSION-OF-CONTEXT($eval_ctx)),
             |(:optimize($_) with nqp::getcomp('Raku').cli-options<optimize>),
             |(%(:grammar($LANG<MAIN>), :actions($LANG<MAIN-actions>)) if $LANG);
     }

--- a/src/core.c/REPL.rakumod
+++ b/src/core.c/REPL.rakumod
@@ -494,6 +494,10 @@ do {
                     my $exception,
                     $previous-evals.List,
                     :outer_ctx($!save_ctx),
+                    # the revision of the saved context, not the compiler's
+                    :language_version(
+                      Rakudo::Internals.LANGUAGE-VERSION-OF-CONTEXT($!save_ctx)
+                    ),
                     |%adverbs);
 
                 if self.input-incomplete($output) {

--- a/src/core.c/Rakudo/Internals.rakumod
+++ b/src/core.c/Rakudo/Internals.rakumod
@@ -476,6 +476,26 @@ my class Rakudo::Internals is implementation-detail {
         )
     }
 
+    # The revision of the unit a context belongs to, or the compiler's
+    # for a context without one
+    method LANGUAGE-REVISION-OF-CONTEXT(Mu \ctx) {
+        my \context  := nqp::decont(ctx);
+        my \revision := nqp::isconcrete(context)
+          ?? nqp::getlexrel(context, '$?LANGUAGE-REVISION')
+          !! nqp::null;
+        nqp::isnull(revision)
+          ?? nqp::getcomp('Raku').language_revision
+          !! nqp::unbox_i(revision)
+    }
+
+    # The same as the language version string a compile takes, without a
+    # modifier, which the compiler does not keep after a pragma either
+    method LANGUAGE-VERSION-OF-CONTEXT(Mu \ctx) {
+        '6.' ~ nqp::getcomp('Raku').lvs.p6rev(
+          self.LANGUAGE-REVISION-OF-CONTEXT(ctx)
+        )
+    }
+
     method TRANSPOSE(str $string, str $original, str $final) {
         nqp::join($final,nqp::split($original,$string))
     }

--- a/src/core.c/core_epilogue.rakumod
+++ b/src/core.c/core_epilogue.rakumod
@@ -817,7 +817,7 @@ augment class Cool {
           self.Str,
           :outer_ctx($eval_ctx),
           :global(GLOBAL),
-          :language_version($compiler.language_version),
+          :language_version(Rakudo::Internals.LANGUAGE-VERSION-OF-CONTEXT($eval_ctx)),
           |(:optimize($_) with $compiler.cli-options<optimize>),
           :target<ast>, :compunit_ok(1), :$grammar, :$actions;
 

--- a/t/02-rakudo/language-revision-per-unit.t
+++ b/t/02-rakudo/language-revision-per-unit.t
@@ -1,0 +1,205 @@
+use lib <t/packages/Test-Helpers t/packages/02-rakudo/lib>;
+use Test;
+use Test::Helpers;
+use nqp;
+
+plan 22;
+
+# The language revision belongs to the compilation unit. Compiling another
+# unit in the same process, through EVAL or by loading a module that is
+# not precompiled, must not change the revision the enclosing unit keeps
+# compiling under, and an EVAL starts from the revision of the unit that
+# calls it. The unrecognized regex boundary <|x> is an error from 6.e on
+# and compiles silently before, so it tells the revisions apart, as does
+# the value default of a typed hash, which is Mu from 6.e on and Any
+# before.
+
+my $lib = make-temp-dir;
+$lib.add('ModC.rakumod').spurt: q:to/CODE/;
+    use v6.c;
+    unit module ModC;
+    sub callee() { CALLER::<$_> }
+    our sub outer() { callee() }
+    CODE
+$lib.add('ModD.rakumod').spurt: q:to/CODE/;
+    use v6.d;
+    unit module ModD;
+    our sub boundary() { EVAL q["x" ~~ / <|x> /; 'compiled'] }
+    CODE
+$lib.add('ModE.rakumod').spurt: q:to/CODE/;
+    use v6.e.PREVIEW;
+    unit module ModE;
+    our sub revision() { $?LANGUAGE-REVISION }
+    CODE
+
+# Compiling a 6.e unit in-process from this 6.d unit
+BEGIN CompUnit::Loader.load-source(q:to/SRC/.encode);
+    use v6.e.PREVIEW;
+    unit module LangRevSixEBegin;
+    SRC
+my %h{Str};
+is %h.of.^name, 'Any',
+    'a typed hash declared after a 6.e unit compiled in-process keeps the 6.d value default';
+is $?LANGUAGE-REVISION, 2,
+    'a unit keeps its own $?LANGUAGE-REVISION after a 6.e unit compiled in-process';
+CompUnit::Loader.load-source(q:to/SRC/.encode);
+    use v6.e.PREVIEW;
+    unit module LangRevSixERuntime;
+    SRC
+is EVAL(q[$?LANGUAGE-REVISION]), 2,
+    'an EVAL starts from the revision of the calling unit after a 6.e unit compiled in-process';
+lives-ok { EVAL q["x" ~~ / <|x> /] },
+    'an EVAL in a 6.d unit compiles an unrecognized boundary after a 6.e unit compiled in-process';
+is Q[$?LANGUAGE-REVISION].AST.EVAL, 2,
+    'Str.AST parses under the revision of the calling unit after a 6.e unit compiled in-process';
+
+# Precompiled modules of another revision
+use LangRevSixD;
+use LangRevSixE;
+is LangRevSixE::revision(), 3,
+    'an EVAL in a precompiled 6.e module starts from 6.e when called from a 6.d unit';
+throws-like { LangRevSixE::boundary() }, X::Syntax::Regex::UnrecognizedBoundary,
+    'an EVAL in a precompiled 6.e module rejects an unrecognized boundary when called from a 6.d unit';
+is LangRevSixD::boundary(), 'compiled',
+    'an EVAL in a precompiled 6.d module compiles an unrecognized boundary';
+
+is-run q:to/CODE/,
+    use v6.e.PREVIEW;
+    use LangRevSixD;
+    print LangRevSixD::boundary();
+    CODE
+    :compiler-args['-It/packages/02-rakudo/lib'],
+    :out('compiled'),
+    'an EVAL in a precompiled 6.d module starts from 6.d when called from a 6.e unit';
+
+is-run q:to/CODE/,
+    use v6.e.PREVIEW;
+    BEGIN EVAL q[use v6.d; 1];
+    "x" ~~ / <|x> /;
+    CODE
+    :err(/'Unrecognized regex boundary'/), :exitcode(1),
+    'an EVAL at BEGIN time that lowers the revision does not lower the rest of the calling unit';
+
+is-run q:to/CODE/,
+    use v6.e.PREVIEW;
+    EVAL q[use v6.d; 1];
+    EVAL q["x" ~~ / <|x> /];
+    CODE
+    :err(/'Unrecognized regex boundary'/), :exitcode(1),
+    'an EVAL that lowers the revision does not lower the revision of later EVALs';
+
+todo 'the legacy frontend does not isolate $/ in a .match call'
+    unless nqp::gethllsym('Raku', 'COMPILER-FRONTEND') eq 'rakuast';
+is-run q:to/CODE/,
+    use v6.e.PREVIEW;
+    BEGIN EVAL q[use v6.d; 1];
+    "b" ~~ /b/;
+    "a".match(/a/);
+    print $/;
+    CODE
+    :out('b'),
+    'an EVAL at BEGIN time that lowers the revision does not stop the calling unit isolating $/';
+
+{
+    temp %*ENV<RAKUDO_NO_PRECOMPILATION> = 1;
+
+    is-run q:to/CODE/,
+        use v6.e.PREVIEW;
+        use ModD;
+        "x" ~~ / <|x> /;
+        CODE
+        :compiler-args["-I$lib"],
+        :err(/'Unrecognized regex boundary'/), :exitcode(1),
+        'compiling a 6.d module in-process keeps the 6.e unit that uses it at 6.e';
+
+    is-run q:to/CODE/,
+        use v6.e.PREVIEW;
+        use ModD;
+        my %h{Str};
+        print %h.of.^name;
+        CODE
+        :compiler-args["-I$lib"],
+        :out('Mu'),
+        'compiling a 6.d module in-process keeps the 6.e value default of a typed hash';
+
+    is-run q:to/CODE/,
+        use ModE;
+        "x" ~~ / <|x> /;
+        print 'compiled';
+        CODE
+        :compiler-args["-I$lib"],
+        :out('compiled'),
+        'compiling a 6.e module in-process keeps the 6.d unit that uses it at 6.d';
+
+    is-run q:to/CODE/,
+        use ModE;
+        print $?LANGUAGE-REVISION;
+        print ModE::revision();
+        CODE
+        :compiler-args["-I$lib"],
+        :out('23'),
+        'each unit keeps its own $?LANGUAGE-REVISION after an in-process module compile';
+
+    is-run q:to/CODE/,
+        use ModE;
+        class Foo { }
+        print Foo.HOW.language_revision;
+        CODE
+        :compiler-args["-I$lib"],
+        :out('2'),
+        'a class declared after a 6.e module compiled in-process is stamped with the unit revision';
+
+    is-run q:to/CODE/,
+        use v6.e.PREVIEW;
+        use ModD;
+        BEGIN print EVAL q[$?LANGUAGE-REVISION];
+        print $?LANGUAGE-REVISION;
+        CODE
+        :compiler-args["-I$lib"],
+        :out('33'),
+        'an EVAL at BEGIN time starts from the revision of the calling unit after an in-process module compile';
+
+    is-run q:to/CODE/,
+        use v6.e.PREVIEW;
+        use ModD;
+        Q["x" ~~ / <|x> /].AST;
+        CODE
+        :compiler-args["-I$lib"],
+        :err(/'Unrecognized regex boundary'/), :exitcode(1),
+        'Str.AST parses under the revision of the calling unit after an in-process module compile';
+
+    is-run q:to/CODE/,
+        use v6.e.PREVIEW;
+        use ModC;
+        $_ = 'top';
+        print ModC::outer().raku;
+        CODE
+        :compiler-args["-I$lib"],
+        :out('Any'),
+        'a 6.c module compiled in-process keeps its dynamic topic when used from a 6.e unit';
+
+    is-run q:to/CODE/,
+        use v6.c;
+        use ModD;
+        sub callee() { CALLER::<$_> }
+        sub outer() { callee() }
+        $_ = 'top';
+        print outer().raku;
+        CODE
+        :compiler-args["-I$lib"],
+        :out('Any'),
+        'a 6.c unit keeps its dynamic topic after a 6.d module compiled in-process';
+
+    is-run q:to/CODE/,
+        use v6.c;
+        use ModE;
+        my \type := Metamodel::ClassHOW.new_type(:name<Rt>);
+        type.^compose;
+        print type.HOW.language_revision;
+        CODE
+        :compiler-args["-I$lib"],
+        :out('1'),
+        'a class composed at runtime is stamped with the revision of the unit composing it';
+}
+
+# vim: expandtab shiftwidth=4

--- a/t/packages/02-rakudo/lib/LangRevSixD.rakumod
+++ b/t/packages/02-rakudo/lib/LangRevSixD.rakumod
@@ -1,0 +1,3 @@
+use v6.d;
+unit module LangRevSixD;
+our sub boundary() { EVAL q["x" ~~ / <|x> /; 'compiled'] }

--- a/t/packages/02-rakudo/lib/LangRevSixE.rakumod
+++ b/t/packages/02-rakudo/lib/LangRevSixE.rakumod
@@ -1,0 +1,4 @@
+use v6.e.PREVIEW;
+unit module LangRevSixE;
+our sub revision() { EVAL q[$?LANGUAGE-REVISION] }
+our sub boundary() { EVAL q["x" ~~ / <|x> /] }


### PR DESCRIPTION
Previously every compile-time check of the language revision read it from the compiler object, which holds a single value for the whole process. Any unit compiled in that process wrote to it: a `use v6.x` pragma, a module compiled in-process because it was not precompiled, or an EVAL. The legacy frontend reset it at the start of each unit, the RakuAST frontend did not, and neither restored it when a nested compile returned. So a 6.e unit went on parsing as 6.d after loading a 6.d module in-process, a 6.d unit picked up 6.e errors after loading a 6.e module, a class declared after such a load was stamped with the module's revision, and on the RakuAST frontend an EVAL of `use v6.d` lowered every later EVAL in the process. EVAL and Str.AST made this worse by handing the inner compile whatever the global happened to be at runtime rather than the revision of the unit that contains them.

This gives each compilation unit a `$*LANGUAGE-REVISION` dynamic. The comp unit rule of both grammars declares it, set from the compile options and updated when the version pragma is processed, and the optimize and qast stages and the EVAL of a tree declare it again from the unit's own revision, since they run after the parse frame is gone. Every compile-time check in the grammars, actions, World and the metamodel's type stamping reads it, and RakuAST node code reads it through IMPL-LANGUAGE-REVISION, which falls back to the compiler's value for a tree built through the RakuAST API outside any compilation. A type composed at runtime is stamped from the `$?LANGUAGE-REVISION` of the unit composing it. Being dynamic, an inner compile's value goes out of scope with it. The RakuAST frontend now also resets the compiler's value at the start of a unit, so the compile options decide the starting revision as they do in the legacy frontend. EVAL, Str.AST and the REPL pass the calling context's `$?LANGUAGE-REVISION` as the language version of the inner compile, and the EVAL of a tree builds its unit with that revision.

Installing `$?LANGUAGE-REVISION` from the unit's own revision also puts revision-gated multi dispatch right on the legacy frontend, which reads that lexical from the caller: a 6.c unit that loaded a 6.e module in-process used to dispatch to the 6.e candidates.