### PR TITLE
Keep a unit lexical container out of a dependent's serialization

### DIFF
--- a/src/Perl6/Optimizer.nqp
+++ b/src/Perl6/Optimizer.nqp
@@ -823,6 +823,17 @@ my class BlockVarOptimizer {
                     # as it is bound immediately.
                     $qast.decl('var');
                     unless $qast.ann('our_decl') {
+                        # The container is now created on each frame entry,
+                        # so a unit declaration's mark against repossession
+                        # has nothing left to protect.
+                        my @kept;
+                        for @($block[0]) {
+                            @kept.push($_) unless nqp::istype($_, QAST::Op)
+                                && $_.op eq 'neverrepossess'
+                                && nqp::istype($_[0], QAST::Var)
+                                && $_[0].name eq $name;
+                        }
+                        $block[0].set_children(@kept);
                         my $type := nqp::what_nd($qv);
                         my $setup := QAST::Op.new(
                             :op('create'),

--- a/src/Perl6/World.nqp
+++ b/src/Perl6/World.nqp
@@ -1861,6 +1861,17 @@ class Perl6::World is HLL::World {
                 ?? 'static'
                 !! 'contvar');
 
+        # A static container is the serialized one, so a module that uses
+        # the unit and changes it while precompiling repossesses it, and
+        # loading that module hands back the state its precompilation saw.
+        # The neverrepossess mark is not serialized, so it is set at unit
+        # entry. A package scoped container is bound from the stash at
+        # entry, as the RakuAST frontend declares it, and is left alone.
+        if $var.decl eq 'static' && $scope ne 'our' {
+            $block[0].push(QAST::Op.new( :op('neverrepossess'),
+                QAST::Var.new( :name($name), :scope('lexical') ) ));
+        }
+
         # Evaluate to the container.
         $cont
     }

--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -1715,13 +1715,27 @@ class RakuAST::VarDeclaration::Simple
                     # A unit scoped container lives in a frame entered once,
                     # so it stays the serialized one that code run at BEGIN
                     # time already resolves the variable to.
+                    my int $unit-scoped := self.IMPL-IS-UNIT-SCOPED;
                     my $qast := QAST::Var.new(
                         :scope('lexical'), :name(self.name), :value($container),
-                        :decl(self.IMPL-IS-UNIT-SCOPED ?? 'static' !! 'contvar')
+                        :decl($unit-scoped ?? 'static' !! 'contvar')
                     );
                     if self.IMPL-HAS-EXPLICIT-CONTAINER-BASE-TYPE {
                         $qast := QAST::Op.new( :op('bind'), $qast,
                           self.IMPL-EXPLICIT-CONTAINER-VIVIFY-QAST($context, $of) );
+                    }
+                    # The static container is the serialized one, so a
+                    # module that uses the unit and changes it while
+                    # precompiling repossesses it, and loading that module
+                    # hands back the state its precompilation saw. The
+                    # neverrepossess mark is not serialized, so it is set
+                    # at unit entry.
+                    if $unit-scoped {
+                        $qast := QAST::Stmts.new(
+                            $qast,
+                            QAST::Op.new( :op('neverrepossess'),
+                                QAST::Var.new( :scope('lexical'), :name(self.name) ) )
+                        );
                     }
                     $qast
                 }

--- a/t/02-rakudo/test-packages/RegistryFile.rakumod
+++ b/t/02-rakudo/test-packages/RegistryFile.rakumod
@@ -1,0 +1,7 @@
+# The same registry held in the mainline of a file without a package
+# declaration.
+
+my @in-order;
+
+sub register-in-file(Str:D $name) is export { @in-order.push($name) }
+sub registered-in-file() is export { @in-order }

--- a/t/02-rakudo/test-packages/RegistryUnit.rakumod
+++ b/t/02-rakudo/test-packages/RegistryUnit.rakumod
@@ -1,0 +1,9 @@
+unit module RegistryUnit;
+
+# A registry held in a unit lexical, filled by the modules that use it as
+# they load.
+
+my @in-order;
+
+sub register(Str:D $name) is export { @in-order.push($name) }
+sub registered() is export { @in-order }

--- a/t/02-rakudo/test-packages/RegistryUnitBoth.rakumod
+++ b/t/02-rakudo/test-packages/RegistryUnitBoth.rakumod
@@ -1,0 +1,2 @@
+use RegistryUnitFirst;
+use RegistryUnitSecond;

--- a/t/02-rakudo/test-packages/RegistryUnitFirst.rakumod
+++ b/t/02-rakudo/test-packages/RegistryUnitFirst.rakumod
@@ -1,0 +1,4 @@
+use RegistryUnit;
+use RegistryFile;
+register('first');
+register-in-file('first');

--- a/t/02-rakudo/test-packages/RegistryUnitLater.rakumod
+++ b/t/02-rakudo/test-packages/RegistryUnitLater.rakumod
@@ -1,0 +1,1 @@
+use RegistryUnitSecond;

--- a/t/02-rakudo/test-packages/RegistryUnitSecond.rakumod
+++ b/t/02-rakudo/test-packages/RegistryUnitSecond.rakumod
@@ -1,0 +1,4 @@
+use RegistryUnit;
+use RegistryFile;
+register('second');
+register-in-file('second');

--- a/t/02-rakudo/unit-lexical-precomp-repossess.t
+++ b/t/02-rakudo/unit-lexical-precomp-repossess.t
@@ -1,0 +1,24 @@
+use lib <t/02-rakudo/test-packages>;
+use Test;
+
+plan 2;
+
+# A unit lexical container is serialized with its module, and a module
+# that uses it can change it while precompiling. Loading such a module
+# must not bring back the state its precompilation saw, so the registry
+# keeps what every loaded module registered.
+#
+# RegistryUnitBoth precompiles with both registrations made, and
+# RegistryUnitLater with only the second one made.
+
+use RegistryUnitBoth;
+use RegistryUnitLater;
+use RegistryUnit;
+use RegistryFile;
+
+is-deeply registered(), ['first', 'second'],
+  'a unit module array keeps every registration after a later module loads';
+is-deeply registered-in-file(), ['first', 'second'],
+  'a mainline array keeps every registration after a later module loads';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously a module that changed a unit lexical container while precompiling repossessed the container into its own serialization, since the container is declared static and the unit frame works on the serialized one itself. Loading that module then handed back the state its precompilation saw, so a registry filled by several modules ended up holding only what the last loaded module's precompilation had seen registered. This marks the container as never repossessed at unit entry, for the lexically scoped declarations of both frontends. The legacy optimizer drops the mark from a container it lowers to a local, which is created on each frame entry.