### PR TITLE
Let make attach to a capture's own match in its code block

### DIFF
--- a/src/core.c/Match.rakumod
+++ b/src/core.c/Match.rakumod
@@ -443,12 +443,16 @@ multi sub infix:<eqv>(Match:D $a, Match:D $b) {
 }
 
 
-# Attach to the match of the nearest enclosing regex frame when there is
-# one. Its cursor cannot be disturbed by user code, however a match run
-# inside the regex's code block can overwrite $/. In a 6.e scope, where
-# $/ carries the isolation marker, the next candidate is the Match in
-# the immediate caller frame's own $/, i.e. the match that frame most
-# recently established. After that comes a Match topic, so a block
+# Inside a regex frame, attach to the caller's $/ when it belongs to the
+# parse the frame's cursor belongs to, and otherwise to the cursor's
+# match. In a capture group's code block the cursor the block sees can
+# be the enclosing regex's while $/ is the capture's own match, so $/ is
+# the one to attach to. A match run inside the code block overwrites $/
+# with a match of another parse, which leaves the cursor's match as the
+# target. Outside any regex frame, in a 6.e scope where $/ carries the
+# isolation marker, the next candidate is the Match in the immediate
+# caller frame's own $/, i.e. the match that frame most recently
+# established. After that comes a Match topic, so a block
 # iterating match results attaches to its topic even when it never set
 # up a $/ of its own. Everything else attaches to the caller's $/, as
 # in an action method, whose $/ parameter carries no marker in any
@@ -466,7 +470,14 @@ sub make(Mu \made) {
     my \slash-cont  := nqp::getlexcaller('$/');
     my $slash       := nqp::decont(slash-cont);
     nqp::isconcrete($cursor) && nqp::istype($cursor, NQPMatchRole)
-      ?? nqp::bindattr($cursor.MATCH, Match, '$!made', made)
+      ?? nqp::bindattr(
+           nqp::isconcrete($slash) && nqp::istype($slash, Match)
+             && nqp::eqaddr(
+                  nqp::getattr($slash,  Match, '$!shared'),
+                  nqp::getattr($cursor, Match, '$!shared'))
+             ?? $slash
+             !! $cursor.MATCH,
+           Match, '$!made', made)
       !! Rakudo::Internals.IS-ISOLATED-MATCH(nearby-cont)
            && nqp::isconcrete(my $nearby := nqp::decont(nearby-cont))
            && nqp::istype($nearby, NQPMatchRole)

--- a/t/02-rakudo/make-regex-frame.t
+++ b/t/02-rakudo/make-regex-frame.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 8;
+plan 15;
 
 # https://github.com/rakudo/rakudo/issues/1235
 
@@ -11,8 +11,8 @@ plan 8;
       'make with no match anywhere in reach throws';
 }
 
-# The make routine attaches to the match of the nearest enclosing regex
-# frame, so a match run inside a regex code block cannot redirect it.
+# Inside a regex code block, make attaches to the match of the parse in
+# progress, so a match run inside the block cannot redirect it.
 {
     grammar ClobberGrammar {
         token TOP { <letters> { if $<letters> ~~ /^a/ { make 42 } } }
@@ -39,6 +39,34 @@ plan 8;
       'make in a nested token attaches to that token, not the outer one';
     is $nested.made, "O",
       'make in the outer token is untouched by the inner make';
+}
+
+# In a capture group's code block, $/ is the capture's own match, and
+# that is where make attaches, whichever regex frame's cursor the block
+# can see.
+{
+    is-deeply ('ab' ~~ / (\w { make ~$/ }) (\w { make ~$/ }) /)[0, 1].map(*.made).List,
+      ('a', 'b'),
+      'make in a positional capture attaches to that capture';
+    is ('ab' ~~ / $<x>=(\w { make ~$/ }) /)<x>.made, 'a',
+      'make in a named capture attaches to that capture';
+    is-deeply ('abc' ~~ / ^ [ (\w { make ~$/ }) ]* $ /)[0].map(*.made).List,
+      ('a', 'b', 'c'),
+      'make in a quantified capture attaches to each match of it';
+    is-deeply ('abc' ~~ / ^ [ $<x>=(\w { make ~$/ }) ]* $ /)<x>.map(*.made).List,
+      ('a', 'b', 'c'),
+      'make in a quantified named capture attaches to each match of it';
+    is (BEGIN / ^ [ (\w { make ~$/ }) ]* $ { make $0>>.made.join('-') } /)
+         .ACCEPTS('abc').made, 'a-b-c',
+      'a later code block of a regex closure created at BEGIN time reads the made of each capture';
+
+    grammar CaptureGrammar { token TOP { (\w) { make 'token' } (\w { make 'capture' }) } }
+    class CaptureActions { method TOP($/) { make 'action:' ~ $1.made } }
+    my $parsed = CaptureGrammar.parse('ab', :actions(CaptureActions));
+    is $parsed[1].made, 'capture',
+      'make in a token capture attaches to the capture under an action class';
+    is $parsed.made, 'action:capture',
+      'make in the action method attaches to the token match after the capture made';
 }
 
 # Outside any regex frame, make attaches to the caller's $/.


### PR DESCRIPTION
Previously make attached to the match of the cursor in the nearest enclosing regex frame. In a capture group's code block the legacy frontend resolves that cursor to the enclosing regex, while `$/` is the capture's own match, so a make there landed on the enclosing match and the capture's made stayed empty. This attaches to the caller's `$/` when it is a match of the parse the cursor belongs to, and falls back to the cursor's match when `$/` has been overwritten by a match of another parse.