### PR TITLE
Settle a channel's closed promise even when the marker is in flight

### DIFF
--- a/src/core.c/Channel.rakumod
+++ b/src/core.c/Channel.rakumod
@@ -23,6 +23,12 @@ my class Channel does Awaitable {
     # Flag for if the channel is closed to senders.
     has int $!closed;
 
+    # The first CHANNEL_CLOSE or CHANNEL_FAIL marker, bound before it is
+    # pushed onto the queue. A reader that shifted the marker and is about
+    # to push it back leaves the queue momentarily empty, so a reader that
+    # finds the queue empty consults this instead.
+    has $!terminal;
+
     # We use a Supplier to send async notifications that there may be a new
     # message to read from the channel (there may be many things competing
     # over them).
@@ -34,6 +40,7 @@ my class Channel does Awaitable {
 
     submethod BUILD(--> Nil) {
         $!queue := nqp::create(Queue);
+        $!terminal := Mu;
         $!closed_promise = Promise.new;
         $!closed_promise_vow = $!closed_promise.vow;
         $!async-notify = Supplier.new;
@@ -56,12 +63,14 @@ my class Channel does Awaitable {
           nqp::istype(msg,CHANNEL_CLOSE),
           nqp::stmts(
             nqp::push($!queue, msg),    # make sure other readers see it
+            self!settle(msg),
             X::Channel::ReceiveOnClosed.new(channel => self).throw
           ),
           nqp::if(
             nqp::istype(msg,CHANNEL_FAIL),
             nqp::stmts(
               nqp::push($!queue,msg),   # make sure other readers see it
+              self!settle(msg),
               msg.error.rethrow
             ),
             nqp::stmts(
@@ -75,17 +84,22 @@ my class Channel does Awaitable {
     method poll(Channel:D:) {
         nqp::if(
           nqp::isnull(my \msg := nqp::queuepoll($!queue)),
-          Nil,
+          nqp::stmts(
+            nqp::if($!closed, self!settle($!terminal)),
+            Nil
+          ),
           nqp::if(
             nqp::istype(msg, CHANNEL_CLOSE),
             nqp::stmts(
               nqp::push($!queue, msg),
+              self!settle(msg),
               Nil
             ),
             nqp::if(
               nqp::istype(msg, CHANNEL_FAIL),
               nqp::stmts(
                 nqp::push($!queue, msg),
+                self!settle(msg),
                 Nil
               ),
               nqp::stmts(
@@ -97,22 +111,33 @@ my class Channel does Awaitable {
         )
     }
 
+    # Settles the closed promise from an end marker. A reader passes the
+    # marker it shifted, or $!terminal after finding the queue empty. Every
+    # value sent before the close was pushed ahead of the marker, so an
+    # empty queue on a closed channel means they have all been taken.
+    method !settle(Channel:D: Mu \marker --> Nil) {
+        if nqp::eqaddr($!closed_promise.status, Planned) {
+            if nqp::istype(marker, CHANNEL_CLOSE) {
+                try $!closed_promise_vow.keep(Nil);
+            }
+            elsif nqp::istype(marker, CHANNEL_FAIL) {
+                try $!closed_promise_vow.break(marker.error);
+            }
+        }
+    }
+
     method !peek(Channel:D:) {
         my \msg := nqp::atpos($!queue, 0);
         if nqp::isnull(msg) {
+            self!settle($!terminal) if $!closed;
             Nil
-        } else {
-            if nqp::istype(msg, CHANNEL_CLOSE) {
-                try $!closed_promise_vow.keep(Nil);
-                Nil
-            }
-            elsif nqp::istype(msg, CHANNEL_FAIL) {
-                try $!closed_promise_vow.break(msg.error);
-                Nil
-            }
-            else {
-                msg
-            }
+        }
+        elsif nqp::istype(msg, CHANNEL_CLOSE) || nqp::istype(msg, CHANNEL_FAIL) {
+            self!settle(msg);
+            Nil
+        }
+        else {
+            msg
         }
     }
 
@@ -277,13 +302,26 @@ my class Channel does Awaitable {
         }
     }
 
-    method close(--> Nil) {
+    method !end(Channel:D: \marker --> Nil) {
         $!closed = 1;
-        nqp::push($!queue, CHANNEL_CLOSE);
+        unless nqp::istype($!terminal, CHANNEL_CLOSE)
+          || nqp::istype($!terminal, CHANNEL_FAIL) {
+#?if moar
+            nqp::atomicbindattr(self, Channel, '$!terminal', marker);
+#?endif
+#?if !moar
+            nqp::bindattr(self, Channel, '$!terminal', marker);
+#?endif
+        }
+        nqp::push($!queue, marker);
         # if $!queue is otherwise empty, make sure that $!closed_promise
         # learns about the new value
         self!peek();
         $!async-notify.emit(True);
+    }
+
+    method close(--> Nil) {
+        self!end(CHANNEL_CLOSE)
     }
 
     multi method elems(Channel:D:) {
@@ -291,11 +329,8 @@ my class Channel does Awaitable {
     }
 
     method fail($error is copy) {
-        $!closed = 1;
         $error = X::AdHoc.new(payload => $error) unless nqp::istype($error, Exception);
-        nqp::push($!queue, CHANNEL_FAIL.new(:$error));
-        self!peek();
-        $!async-notify.emit(True);
+        self!end(CHANNEL_FAIL.new(:$error));
         Nil
     }
 

--- a/t/02-rakudo/26-channel-closed-promise-race.t
+++ b/t/02-rakudo/26-channel-closed-promise-race.t
@@ -1,0 +1,94 @@
+use Test;
+
+plan 10;
+
+# A reader that shifts the close or fail marker off a channel's queue pushes
+# it straight back, which leaves the queue empty for a moment. A reader that
+# takes the last value during that moment sees nothing behind it and must
+# still settle the closed promise, or an await on the channel never returns.
+
+# Each channel holds one value and is already closed or failed when several
+# threads race to drain it, so the last value and the marker are shifted
+# concurrently often enough to hit that moment.
+sub drain-raced(&end, &take) {
+    my @channels = (^10000).map: {
+        my $c = Channel.new;
+        $c.send(1);
+        end($c);
+        $c
+    }
+    my @threads = (^4).map: {
+        Thread.start({ for @channels { take($_); take($_) } })
+    }
+    .finish for @threads;
+    @channels
+}
+
+sub unsettled(@channels) {
+    +@channels.grep({ .closed.status == Planned })
+}
+
+sub not-failed(@channels) {
+    +@channels.grep({ .closed.status != Broken || .closed.cause.message ne 'nope' })
+}
+
+{
+    my @channels = drain-raced({ .close }, { .poll });
+    is unsettled(@channels), 0,
+      'closed promise is kept for every closed channel drained by poll';
+
+    my $awaited = start { for @channels { try await $_ } }
+    await Promise.anyof($awaited, Promise.in(30));
+    is $awaited.status, Kept,
+      'await on every drained closed channel returns';
+}
+
+{
+    my @channels = drain-raced({ .close }, { try .receive });
+    is unsettled(@channels), 0,
+      'closed promise is kept for every closed channel drained by receive';
+}
+
+{
+    my @channels = drain-raced({ .fail('nope') }, { .poll });
+    is not-failed(@channels), 0,
+      'closed promise is broken with the failure for every failed channel drained by poll';
+}
+
+{
+    my @channels = drain-raced({ .fail('nope') }, { try .receive });
+    is not-failed(@channels), 0,
+      'closed promise is broken with the failure for every failed channel drained by receive';
+}
+
+{
+    my $c = Channel.new;
+    is $c.poll, Nil, 'poll on an open empty channel returns Nil';
+    is $c.closed.status, Planned,
+      'poll on an open empty channel leaves the closed promise planned';
+}
+
+# The first marker to reach the queue decides how the channel ends.
+{
+    my $c = Channel.new;
+    $c.send(1);
+    $c.fail('first');
+    $c.close;
+    $c.poll;
+    is $c.closed.status, Broken,
+      'closed promise is broken when a fail comes before a close';
+    is $c.closed.cause.message, 'first',
+      'closed promise carries the failure when a fail comes before a close';
+}
+
+{
+    my $c = Channel.new;
+    $c.send(1);
+    $c.close;
+    $c.fail('late');
+    $c.poll;
+    is $c.closed.status, Kept,
+      'closed promise is kept when a fail comes after a close';
+}
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously the closed promise of a Channel was kept or broken only by a reader that saw the close or fail marker at the head of the queue after taking a value, or by close itself when the queue was already empty. A reader that shifts the marker pushes it straight back, which leaves the queue empty for a moment. A reader taking the last value in that moment saw nothing behind it, so nothing settled the closed promise. After that every poll shifted and pushed the marker again without settling it and no further notification was emitted, so every non-blocking await on the channel hung. That is what made the closed channel case of S17-promise/nonblocking-await.t time out on CI under load.

This records the first marker in the channel before it is pushed and settles the closed promise whenever a reader holds a marker or finds the queue empty on a closed channel. Every value sent before the close sits ahead of the marker, so an empty queue on a closed channel means they have all been taken. A reader that holds a marker settles from that marker, and the recorded one is the first pushed, so a fail followed by a close still breaks the promise with the failure as it did when only the queue head decided.