### PR TITLE
RakuAST: drop marker flags from character class subtraction

### DIFF
--- a/src/Raku/ast/regex.rakumod
+++ b/src/Raku/ast/regex.rakumod
@@ -1734,9 +1734,14 @@ class RakuAST::Regex::Assertion::Lookahead
 
     method IMPL-REGEX-QAST(RakuAST::IMPL::QASTContext $context, %mods) {
         my $qast := $!assertion.IMPL-REGEX-QAST($context, %mods);
-        $qast.subtype('zerowidth');
-        if $!negated {
-            $qast.negate(!$qast.negate);
+        # An anchor is already zero width, and changing its subtype would
+        # turn a failing one into a check that always passes.
+        if $qast.rxtype eq 'anchor' {
+            $qast.subtype($qast.subtype eq 'fail' ?? 'pass' !! 'fail') if $!negated;
+        }
+        else {
+            $qast.subtype('zerowidth');
+            $qast.negate(!$qast.negate) if $!negated;
         }
         $qast
     }
@@ -1928,15 +1933,27 @@ class RakuAST::Regex::Assertion::CharClass
             while $i < nqp::elems($!elements) {
                 my $elem := $!elements[$i];
                 my $elem-qast := $elem.IMPL-CCLASS-QAST($context, %mods, False);
-                if $elem.negated {
-                    $elem-qast.subtype('zerowidth');
-                    $qast := QAST::Regex.new:
-                        :rxtype<concat>, :subtype<zerowidth>, :negate,
-                        QAST::Regex.new( :rxtype<conj>, :subtype<zerowidth>, $elem-qast ),
-                        $qast;
-                }
-                else {
+                if !$elem.negated {
                     $qast := QAST::Regex.new( :rxtype<alt>, $qast, $elem-qast );
+                }
+                # An enumeration with nothing in it compiles to an anchor that
+                # fails, and subtracting nothing leaves the class alone.
+                elsif $elem-qast.rxtype ne 'anchor' {
+                    # A subtracted element compiles negated, so a zerowidth
+                    # check of it ahead of the class built so far excludes its
+                    # characters. A subtracted enumeration with more than one
+                    # part already compiles to that check, ahead of the `.`
+                    # that consumes the character.
+                    # Mirrors QRegex::P6Regex::Actions.assertion:sym<[>.
+                    my $check;
+                    if $elem-qast.rxtype eq 'concat' {
+                        $check := $elem-qast[0];
+                    }
+                    else {
+                        $elem-qast.subtype('zerowidth');
+                        $check := QAST::Regex.new( :rxtype<conj>, :subtype<zerowidth>, $elem-qast );
+                    }
+                    $qast := QAST::Regex.new( :rxtype<concat>, $check, $qast );
                 }
                 $i++;
             }
@@ -2115,7 +2132,7 @@ class RakuAST::Regex::CharClassElement::Enumeration
 
         else {
             self.negated ??
-                QAST::Regex.new( :rxtype<concat>, :negate(1),
+                QAST::Regex.new( :rxtype<concat>,
                     QAST::Regex.new( :rxtype<conj>, :subtype<zerowidth>, |@alts ),
                     QAST::Regex.new( :rxtype<cclass>, :name<.> ) ) !!
                 QAST::Regex.new( :rxtype<alt>, |@alts );

--- a/tools/build/raku-ast-compiler.nqp
+++ b/tools/build/raku-ast-compiler.nqp
@@ -103,7 +103,7 @@ grammar RakuASTParser {
         <!ww>
         [
         | \s+
-        | '#' \N+
+        | '#' \N*
         ]*
     }
 


### PR DESCRIPTION
Previously a lookahead over a character class mixing backslash sequences with characters, or subtracting one class from another, consumed a character, and a negated one was not inverted at all.

```
$ raku -e 'say "aa" ~~ /<?[\s a]> ./; say "bb" ~~ /<![\s a]> ./'
｢aa｣
Nil
```

The actual fix is in the regex compiler in Raku/nqp#869. However RakuAST sets the same `zerowidth` and `negate` flags on the `concat` it builds for a subtraction purely as markers, and once the compiler honors them that turns the class into a negated assertion. This drops the markers, and leaves an empty subtraction alone instead of wrapping its failing anchor. It is a no-op with the current nqp so it can land first, with the nqp bump to follow.

The RakuAST source preprocessor also relied on the old behavior, as `<?[\s#]> <ws>` was consuming a bare `#` that its `ws` did not accept as a comment. With a zero width lookahead that looped forever on the one such line in `variable-declaration.rakumod`, so `ws` now accepts an empty comment.

Fixes #4512
