### PR TITLE
Take apart only an index or coercion on the right of but and does

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -8056,14 +8056,18 @@ Did you mean a call like '"
                     CATCH { $past.push($rhs); }
                 }
             }
+            elsif (!$rhs.name || $rhs.name eq '&postcircumfix:<{ }>')
+              && +@($rhs) == 2
+              && $rhs[0].has_compile_time_value
+              && !nqp::isconcrete($rhs[0].compile_time_value) {
+                # Role<value> and Role(value) are split into the role and a
+                # named value; any other call is one argument even when its
+                # own arguments look the same.
+                $past.push($rhs[0]); $rhs[1].named('value');
+                $past.push($rhs[1]);
+            }
             else {
-                if +@($rhs) == 2 && $rhs[0].has_compile_time_value {
-                    $past.push($rhs[0]); $rhs[1].named('value');
-                    $past.push($rhs[1]);
-                }
-                else {
-                    $past.push($rhs);
-                }
+                $past.push($rhs);
             }
         }
         elsif nqp::istype($rhs, QAST::Stmts) && +@($rhs) == 1 &&

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -1081,19 +1081,18 @@ class RakuAST::Mixin
             :name('&infix:<' ~ self.operator ~ '>'),
             $left-qast
         );
-        if nqp::istype($right-qast, QAST::Op) && $right-qast.op eq 'call' {
-            if $right-qast.name && +@($right-qast) == 1 {
-                $qast.push($right-qast);
-            }
-            else {
-                if +@($right-qast) == 2 && $right-qast[0].has_compile_time_value {
-                    $qast.push($right-qast[0]); $right-qast[1].named('value');
-                    $qast.push($right-qast[1]);
-                }
-                else {
-                    $qast.push($right-qast);
-                }
-            }
+        # Role<value> and Role(value) are split into the role and a named
+        # value; any other call is one argument even when its own
+        # arguments look the same.
+        if nqp::istype($right-qast, QAST::Op)
+          && ($right-qast.op eq 'call' || $right-qast.op eq 'callstatic')
+          && (!$right-qast.name || $right-qast.name eq '&postcircumfix:<{ }>')
+          && +@($right-qast) == 2
+          && $right-qast[0].has_compile_time_value
+          && !nqp::isconcrete($right-qast[0].compile_time_value) {
+            $qast.push($right-qast[0]);
+            $right-qast[1].named('value');
+            $qast.push($right-qast[1]);
         }
         elsif nqp::istype($right-qast, QAST::Stmts) && +@($right-qast) == 1 &&
                 nqp::istype($right-qast[0], QAST::Op) && $right-qast[0].name eq '&infix:<,>' {

--- a/t/02-rakudo/mixin-value-hash-index.t
+++ b/t/02-rakudo/mixin-value-hash-index.t
@@ -1,0 +1,61 @@
+use Test;
+
+plan 10;
+
+# `$x but Role<value>`, `$x does Role<value>` and `$x but Role(value)`
+# hand the role and a named value to the mixin operator, so a role with
+# one public attribute has it initialized from the value. Any other call
+# on the right hand side mixes in its result.
+
+my role Typed { has $.type }
+
+{
+    my $x = 42 but Typed<and>;
+    is $x.type, 'and', 'but Role<value> initializes the attribute';
+    isa-ok $x, Int, 'but Role<value> keeps the original type';
+}
+
+{
+    my $x = 43;
+    $x does Typed<and>;
+    is $x.type, 'and', 'does Role<value> initializes the attribute';
+}
+
+{
+    my $x = 44 but Typed<<and>>;
+    is $x.type, 'and', 'but Role<<value>> initializes the attribute';
+}
+
+{
+    my $x = 45 but Typed<a b>;
+    is-deeply $x.type, $("a", "b"),
+        'but Role<a b> initializes the attribute with the list';
+}
+
+{
+    my $x = 46 but Typed("and");
+    is $x.type, 'and', 'but Role(value) initializes the attribute';
+}
+
+{
+    my $s = "b";
+    is (47 but "a" ~ $s).Str, "ab",
+        'but with a concatenation on the right mixes in its result';
+    is (48 but 1 + 2 * $s.chars).Int, 3,
+        'but with an addition on the right mixes in its result';
+}
+
+{
+    sub two($a, $b) { Typed }
+    my $x = 49 but two(Typed, "x");
+    is-deeply $x.type, Any,
+        'but with a two argument sub call on the right calls the sub';
+}
+
+{
+    my $r = Typed;
+    dies-ok { 50 but $r<and> },
+        'but with an index on a variable is not taken apart';
+}
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously both frontends split any call op on the right of but or does whose first argument had a compile time value into the role and a named value argument, so `42 but "a" ~ $s` and `42 but f(Role, "x")` went to the operator as a role plus value instead of as the result of the call. The RakuAST frontend had escaped that for operator calls, which it compiled to a static call op the split did not recognize, but the index call in `42 but Role<value>` now compiles to that op too, so it passed the result of indexing the role type object and died mixing in Any. This limits the split to a hash index or a coercion whose target is a type object, on either call op, in both frontends.