### PR TITLE
RakuAST: split long decimal numbers before converting them to Int

### DIFF
--- a/src/Raku/ast/compunit.rakumod
+++ b/src/Raku/ast/compunit.rakumod
@@ -961,38 +961,106 @@ class RakuAST::LiteralBuilder {
     # Build a decimal Int constant and intern it
     method intern-Int(str $source) {
         my $lookup := $!interned-int;
-
-        # Logic to reliably convert a string in a base to n Int
-        my sub build-Int() {
-            my $res := nqp::radix_I(10,$source,0,2,Int);
-            nqp::atpos($res,2) == nqp::chars($source)
-              ?? nqp::atpos($res, 0)
-              !! nqp::die("'$source' is not a valid number")
-        }
-
         nqp::ifnull(
           nqp::atkey($lookup,$source),
-          nqp::bindkey($lookup,$source,build-Int())
+          nqp::bindkey($lookup,$source,
+            nqp::ifnull(
+              self.IMPL-DECIMAL-INT($source),
+              nqp::die("'$source' is not a valid number")
+            )
+          )
         )
+    }
+
+    # Convert an optionally signed decimal literal, single underscores
+    # between digits allowed, to an Int. Returns null on anything else.
+    method IMPL-DECIMAL-INT(str $source) {
+        my int $from := 0;
+        my int $negate;
+        if nqp::eqat($source, '-', 0) || nqp::eqat($source, '−', 0) {
+            $negate := 1;
+            $from   := 1;
+        }
+        elsif nqp::eqat($source, '+', 0) {
+            $from := 1;
+        }
+        my $parsed := self.IMPL-PARSE-DIGITS($source, $from, nqp::chars($source));
+        nqp::isnull($parsed)
+          ?? $parsed
+          !! $negate
+            ?? nqp::neg_I(nqp::atpos($parsed, 0), Int)
+            !! nqp::atpos($parsed, 0)
+    }
+
+    # Returns the Int value of the digits in the given range and the number
+    # of digits in it, underscores not counted, or null when the range is
+    # not digits with single underscores between them. nqp::radix_I is
+    # quadratic in the digit count, so the range is halved recursively
+    # down to at most 18 characters, the longest run of decimal digits
+    # that cannot overflow a native int, and the halves are recombined
+    # with bigint multiplication.
+    method IMPL-PARSE-DIGITS(str $source, int $from, int $to) {
+        my int $n := $to - $from;
+        if $n <= 18 {
+            my $res := nqp::radix(10, nqp::substr($source, $from, $n), 0, 0);
+            return nqp::null unless nqp::atpos($res, 2) == $n;
+            my int $value := nqp::atpos($res, 0);
+            return [nqp::box_i($value, Int), nqp::atpos($res, 1)];
+        }
+
+        # An underscore is only valid between two digits, so one at the
+        # split is dropped rather than left at the edge of either half.
+        my int $mid     := $from + nqp::div_i($n, 2);
+        my int $lo-from := $mid;
+        if nqp::eqat($source, '_', $mid) {
+            $lo-from := $mid + 1;
+        }
+        elsif nqp::eqat($source, '_', $mid - 1) {
+            $mid := $mid - 1;
+        }
+
+        my $hi := self.IMPL-PARSE-DIGITS($source, $from, $mid);
+        return $hi if nqp::isnull($hi);
+        my $lo := self.IMPL-PARSE-DIGITS($source, $lo-from, $to);
+        return $lo if nqp::isnull($lo);
+
+        my int $hi-digits := nqp::atpos($hi, 1);
+        my int $lo-digits := nqp::atpos($lo, 1);
+        my $scale := nqp::pow_I(
+          nqp::box_i(10, Int), nqp::box_i($lo-digits, Int), Num, Int
+        );
+        [
+          nqp::add_I(nqp::mul_I(nqp::atpos($hi, 0), $scale, Int), nqp::atpos($lo, 0), Int),
+          $hi-digits + $lo-digits
+        ]
     }
 
     # Build an Int constant by any base and intern it
     method intern-Int-by-base(str $source, int $base, Mu $error-reporter?) {
-        my $res := nqp::radix_I($base,$source,0,2,Int);
-
-        # Successfully converted to Int
-        if nqp::atpos($res,2) == nqp::chars($source) {
-            my $key := $base == 10 ?? $source !! "$base:$source";
-            nqp::ifnull(
-              nqp::atkey($!interned-int,$key),
-              nqp::bindkey($!interned-int,$key,nqp::atpos($res,0))
-            )
-        }
-        elsif $error-reporter {
-            $error-reporter();
+        my $value;
+        my str $key;
+        if $base == 10 {
+            $value := self.IMPL-DECIMAL-INT($source);
+            $key   := $source;
         }
         else {
-            nqp::die("'$source' is not a valid number")
+            my $res := nqp::radix_I($base,$source,0,2,Int);
+            $value := nqp::atpos($res,2) == nqp::chars($source)
+              ?? nqp::atpos($res,0)
+              !! nqp::null;
+            $key   := "$base:$source";
+        }
+
+        if nqp::isnull($value) {
+            $error-reporter
+              ?? $error-reporter()
+              !! nqp::die("'$source' is not a valid number")
+        }
+        else {
+            nqp::ifnull(
+              nqp::atkey($!interned-int,$key),
+              nqp::bindkey($!interned-int,$key,$value)
+            )
         }
     }
 

--- a/t/02-rakudo/long-int-literal.t
+++ b/t/02-rakudo/long-int-literal.t
@@ -1,0 +1,105 @@
+use nqp;
+use Test;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+
+plan 33;
+
+is EVAL('1' x 37), (10**37 - 1) div 9,
+  'a decimal literal longer than a native int parses exactly';
+is EVAL('9' x 19), 10**19 - 1,
+  'the shortest run of digits that overflows a native int parses exactly';
+is EVAL('١٢٣٤٥٦٧٨٩٠' x 4), 1234567890 * (10**30 + 10**20 + 10**10 + 1),
+  'a long literal of non-ASCII decimal digits parses exactly';
+
+is EVAL('1234567890_1234567890_1234567890_1234567890'),
+  1234567890 * (10**30 + 10**20 + 10**10 + 1),
+  'underscores between digit groups are skipped in a long literal';
+
+is EVAL('123456789_0123456789'), 1234567890123456789,
+  'an underscore halfway through a long literal is skipped';
+
+is EVAL('1_2345678901234567890_1'), 123456789012345678901,
+  'underscores near both ends of a long literal are skipped';
+
+is EVAL('1_2_3_4_5_6_7_8_9_0_1_2_3_4_5_6_7_8_9_0'), 12345678901234567890,
+  'a long literal with an underscore between every digit parses';
+
+is EVAL('-1_2_3_4_5_6_7_8_9_0_1_2_3_4_5_6_7_8_9_0'), -12345678901234567890,
+  'negating a long literal with an underscore between every digit works';
+
+is EVAL('-Ⅼ'), -50,
+  'negating a unicode numeral works';
+is EVAL('sub (-Ⅼ) { "matched" }(-50)'), 'matched',
+  'a negative unicode numeral type constraint dispatches';
+is EVAL('sub (-1234567890_1234567890_1234567890) { "matched" }(-123456789012345678901234567890)'),
+  'matched',
+  'a negative literal type constraint with underscores dispatches';
+
+ok EVAL(q{'a' x 12 ~~ / ^ a ** 1_0..1_2 $ /}),
+  'a regex quantifier range with underscores in its bounds matches';
+ok EVAL(q{'aaa' ~~ / ^ a ** 0_0_0_0_0_0_0_0_0_0_0_0_0_0_0_0_0_0_0_3 $ /}),
+  'a regex quantifier bound with an underscore between every digit matches';
+
+'abcdefghij' ~~ /(.)(.)(.)(.)(.)(.)(.)(.)(.)/;
+is EVAL('$007'), 'h',
+  'a capture index with leading zeros is the same capture';
+is EVAL('$' ~ '0' x 25 ~ '8'), 'i',
+  'a capture index longer than a native int is still exact';
+
+my $builder = RakuAST::LiteralBuilder.new;
+is $builder.intern-Int('1' ~ '_2' x 20), 1 ~ '2' x 20,
+  'the literal builder skips an underscore between every digit';
+is $builder.intern-Int('-4_2'), -42,
+  'the literal builder negates a signed number with an underscore';
+is $builder.intern-Int('+' ~ '9' x 40), 10**40 - 1,
+  'the literal builder accepts a leading plus on a long number';
+is $builder.intern-Int("\x[2212]" ~ '9' x 40), 1 - 10**40,
+  'the literal builder accepts a leading minus sign character';
+throws-like { $builder.intern-Int('1' x 19 ~ '__' ~ '1' x 19) }, Exception,
+  message => /"'" "1" ** 19 "__" "1" ** 19 "'" .* "is not a valid number"/,
+  'the literal builder reports the whole number when one half is malformed';
+dies-ok { $builder.intern-Int('1' x 20 ~ '__' ~ '2' x 20) },
+  'the literal builder rejects a double underscore in a long number';
+dies-ok { $builder.intern-Int('1' x 18 ~ '__' ~ '2' x 20) },
+  'the literal builder rejects a double underscore just before the split';
+dies-ok { $builder.intern-Int('1' x 20 ~ '__' ~ '2' x 18) },
+  'the literal builder rejects a double underscore just after the split';
+dies-ok { $builder.intern-Int('_' ~ '1' x 30) },
+  'the literal builder rejects a leading underscore';
+dies-ok { $builder.intern-Int('1' x 30 ~ '_') },
+  'the literal builder rejects a trailing underscore';
+dies-ok { $builder.intern-Int('1' x 20 ~ 'x' ~ '1' x 20) },
+  'the literal builder rejects a letter inside a long number';
+dies-ok { $builder.intern-Int('-') },
+  'the literal builder rejects a bare sign';
+
+my $reported = 0;
+is $builder.intern-Int-by-base('1' x 20 ~ '__' ~ '2' x 20, 10, { $reported++; 'reported' }),
+  'reported',
+  'the literal builder returns what the base 10 error reporter returns';
+is $reported, 1,
+  'the literal builder calls the base 10 error reporter once';
+dies-ok { $builder.intern-Int-by-base('1' x 20 ~ '__' ~ '2' x 20, 10) },
+  'the literal builder dies on a malformed base 10 number without a reporter';
+
+{
+    my $start = now;
+    EVAL('sub { $' ~ '1' x 1000000 ~ ' }');
+    ok now - $start < 20,
+      'compiling a capture index with a million digits finishes in bounded time';
+}
+
+if nqp::gethllsym('Raku', 'COMPILER-FRONTEND') eq 'rakuast' {
+    my $start = now;
+    my $value = EVAL('1' x 1000000);
+    ok now - $start < 20,
+      'compiling a decimal literal with a million digits finishes in bounded time';
+    ok $value == (10**1000000 - 1) div 9,
+      'a decimal literal with a million digits parses exactly';
+}
+else {
+    skip 'the legacy frontend parses long decimal literals with the VM bigint parser', 2;
+}
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously the literal builder handed a whole decimal digit string to the VM bigint parser, which is quadratic in the digit count. A capture variable, integer literal, or regex quantifier bound with a million digits took around a minute to compile, while the legacy frontend parsed the same capture index into a native int in under a second.

This halves the digit string recursively down to runs that fit a native int, parses those with the native radix op, and recombines the halves with bigint multiplication. An underscore landing on a split is dropped so both halves keep the shape the native op validates. The same million digits now convert in a fraction of a second, and signs, underscores between digits, and malformed input are handled as before.