### PR TITLE
Compare routine identity instead of addresses in the qualified call test

### DIFF
--- a/t/02-rakudo/qualified-call-shared-module-state.t
+++ b/t/02-rakudo/qualified-call-shared-module-state.t
@@ -1,7 +1,7 @@
 use lib <t/02-rakudo/test-packages>;
 use Test;
 
-plan 2;
+plan 4;
 
 # Qualified calls from two precompiled consumers must reach the same
 # routine and the same module state. Binding the callee at consumer
@@ -10,9 +10,14 @@ plan 2;
 
 use QualifiedCallSetter;
 use QualifiedCallGetter;
+use QualifiedCallState;
 
 QualifiedCallSetter::set-it(42);
 is QualifiedCallGetter::get-it(), 42,
     'module state set through one precompiled consumer is visible through another';
-is QualifiedCallSetter::whoami-via-call(), QualifiedCallGetter::whoami-via-call(),
+ok QualifiedCallSetter::whoami-via-call() === QualifiedCallGetter::whoami-via-call(),
     'qualified calls from both consumers invoke the same routine instance';
+ok QualifiedCallSetter::whoami-via-call() === &QualifiedCallState::whoami,
+    'the setter consumer invokes the routine in the live stash';
+ok QualifiedCallGetter::whoami-via-call() === &QualifiedCallState::whoami,
+    'the getter consumer invokes the routine in the live stash';

--- a/t/02-rakudo/test-packages/QualifiedCallState.rakumod
+++ b/t/02-rakudo/test-packages/QualifiedCallState.rakumod
@@ -1,6 +1,6 @@
-unit module QualifiedCallState;
-
-my $state = 0;
-our sub set-state($v) { $state = $v }
-our sub get-state()   { $state      }
-our sub whoami()      { &?ROUTINE.WHERE }
+module QualifiedCallState {
+    my $state = 0;
+    our sub set-state($v) { $state = $v }
+    our sub get-state()   { $state      }
+    our sub whoami()      { &?ROUTINE   }
+}


### PR DESCRIPTION
Previously the shared module state test proved both consumers reached the same routine by comparing two .WHERE results taken in separate calls. A closure clone bound into the stash at module load lives in the nursery, and a nursery collection between the two calls moves it, so the same object reported two addresses and the test failed at random. This returns the routine itself and compares the two references with ===, so identity is decided in one expression instead of from addresses that a collection can invalidate between calls.

The state module also moves to block form. A unit scoped lexical is static and stays shared even when each consumer holds a private copy of the routine, so the state assertion could not fail. A block scoped lexical is captured by the copy, which is the shape Intl::CLDR has. Both consumers are now also checked against the live stash entry so the identity assertion cannot pass on two undefined results.