### PR TITLE
RakuAST: look up a sigiled indirect name at run time

### DIFF
--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -2736,6 +2736,13 @@ class Raku::Actions is HLL::Actions does Raku::CommonActions {
                 $*R.declare-lexical($ast);
             }
 
+            # indirect name like &::("foo"): looked up at run time
+            elsif $desigilname.is-indirect-lookup {
+                $ast := Nodify('Var::Package').new(
+                  :$sigil, :name($desigilname)
+                );
+            }
+
             # simple variable
             elsif $desigilname.is-identifier {
 

--- a/t/02-rakudo/indirect-name-constant.t
+++ b/t/02-rakudo/indirect-name-constant.t
@@ -1,7 +1,7 @@
 use lib <t/02-rakudo/test-packages>;
 use Test;
 
-plan 11;
+plan 14;
 
 # `require` merges the required unit's symbols into the caller's
 # %?REQUIRE-SYMBOLS, which the runtime symbolic lookup consults before
@@ -44,6 +44,15 @@ is "{ ::("BundleShadow").which }", 'required',
 
 is 5.&::("bundle-shadow"), 'required-5',
     'a .&::("...") call runs the symbolic lookup that sees require-injected subs';
+
+is &::("bundle-shadow")(5), 'required-5',
+    'a &::("...") variable runs the symbolic lookup that sees require-injected subs';
+
+is 5.&::("bundle-shadow")(), 'required-5',
+    'a .&::("...")() call runs the symbolic lookup that sees require-injected subs';
+
+is 5.&::("bundle-shadow").uc, 'REQUIRED-5',
+    'a method call on a .&::("...") result runs the symbolic lookup';
 
 my $hyper-name = "bundle-shadow";
 is-deeply (1, 2)>>.&::($hyper-name), ("required-1", "required-2"),


### PR DESCRIPTION
Previously a sigiled indirect name written with a constant string, like &::("foo") or $::("bar"), compiled as a plain lexical of that name. The runtime symbolic lookup consults the symbols a require merged into the caller before anything visible at compile time, so a require-injected sub was never seen, while the legacy frontend compiles these as runtime lookups.

This compiles a sigiled indirect name as a package variable, which emits the runtime lookup with the sigil.