### PR TITLE
Match the initializer symbol before rejecting a signature declaration

### DIFF
--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -3055,8 +3055,8 @@ sub, perhaps you accidentally placed a semicolon after routine's definition?"
 
     proto token initializer { <...> }
     token initializer:sym<=> {
-            [<!{$*IN_SIG_DECL // 0 }> || <.typed_panic: "X::Syntax::Variable::SignatureAssignment"> ]
         <sym>
+        [<!{$*IN_SIG_DECL // 0 }> || <.typed_panic: "X::Syntax::Variable::SignatureAssignment"> ]
         [
             <.ws>
             [

--- a/t/02-rakudo/signature-literal-declaration.t
+++ b/t/02-rakudo/signature-literal-declaration.t
@@ -1,7 +1,7 @@
 use Test;
 use MONKEY-SEE-NO-EVAL;
 
-plan 5;
+plan 6;
 
 # A `my :(...)` signature literal declaration binds the right-hand side
 # against the signature. It binds only (`:=`) and requires an initializer,
@@ -20,6 +20,13 @@ plan 5;
 {
     our :($a, $b) := (1, 2);
     is "$a $b", "1 2", 'our :(...) := binds';
+}
+
+# The assignment check applies to the declaration's own initializer, not
+# to a declaration nested in the bound expression.
+{
+    my :($a, $b) := (my $c = 3, 4);
+    is "$a $b $c", "3 4 3", 'a plain assignment nested in the bound expression is not rejected';
 }
 
 # Assignment is not allowed for a signature literal: it binds, so `=` is an


### PR DESCRIPTION
Previously initializer:sym<=> checked for a signature declaration before matching its symbol, so that group led the candidate and set its declarative prefix. Once a sequential alternation ends the prefix, that candidate has an empty prefix and gets tried on any input. A my :(...) declaration with no initializer at all then died with the assignment error instead of the missing initializer one.

This matches the symbol first, so the candidate is only tried when an assignment is actually there.