### PR TITLE
Measure a case-folded interpolation match against the target

### DIFF
--- a/src/core.c/INTERPOLATE.rakumod
+++ b/src/core.c/INTERPOLATE.rakumod
@@ -316,6 +316,10 @@ augment class Match {
         }
 #?endif
 
+        # a fold can change the grapheme count
+        $len = INTERPOLATE_FOLDED_LENGTH($tgt, $pos, $topic_str, $len)
+          if $match && $len && (im == 1 || im == 3);
+
         if $match
           && nqp::isgt_i($len,$maxlen)
           && nqp::isle_i(nqp::add_i($pos,$len),nqp::chars($tgt)) {
@@ -552,6 +556,10 @@ augment class Match {
                 $match = nqp::eqatic($tgt, $topic_str, $pos);
             }
 
+            # a fold can change the grapheme count
+            $len = INTERPOLATE_FOLDED_LENGTH($tgt, $pos, $topic_str, $len)
+              if $match && $len && ($im == 1 || $im == 3) && !nqp::istype($topic,Regex);
+
             if $match && nqp::isle_i(nqp::add_i($pos,$len),$eos) {
                 my \found := nqp::istype($match, Match)
                   ?? $match
@@ -599,6 +607,25 @@ augment class Match {
             ++$i;
         }
         cursor.'!cursor_start_cur'()
+    }
+
+    # How many target graphemes a case insensitive match took: the shortest
+    # run whose fold is as long as the pattern's, else the pattern's length.
+    sub INTERPOLATE_FOLDED_LENGTH(str $tgt, int $pos, str $topic, int $len --> int) {
+        my int $want = nqp::chars(nqp::fc($topic));
+        my int $eos  = nqp::chars($tgt);
+        return $len
+          if nqp::iseq_i($want,$len)
+          && nqp::isle_i(nqp::add_i($pos,$len),$eos)
+          && nqp::iseq_i(nqp::chars(nqp::fc(nqp::substr($tgt,$pos,$len))),$len);
+
+        my int $k    = 0;
+        my int $have = 0;
+        while nqp::islt_i($have,$want) && nqp::islt_i(nqp::add_i($pos,$k),$eos) {
+            ++$k;
+            $have = nqp::chars(nqp::fc(nqp::substr($tgt,$pos,$k)));
+        }
+        nqp::iseq_i($have,$want) ?? $k !! $len
     }
 
     sub HASH_ASSERTION_RESERVED() {

--- a/t/02-rakudo/regex-interpolation-fold-length.t
+++ b/t/02-rakudo/regex-interpolation-fold-length.t
@@ -1,0 +1,69 @@
+use Test;
+
+plan 21;
+
+# Under :i a string interpolated into a regex is compared after case
+# folding, and folding can change how many graphemes the target and the
+# pattern have. The match has to take from the target the graphemes the
+# comparison consumed, not the pattern's own length, or it ends at the
+# wrong position. The array cases where the element folds to more
+# graphemes than the target use the sequential form: the NFA that picks
+# candidates for `@a` encodes case per codepoint and cannot see SS in ß,
+# exactly as it cannot for the literal `[ SS | x ]`.
+
+is 'ß' ~~ /:i [||@(['SS'])]/, 'ß',
+    'an interpolated array element folding to more graphemes matches a shorter target';
+is ('ß' ~~ /:i [||@(['SS'])]/).to, 1,
+    'the match ends where the target ends';
+
+is 'SS' ~~ /:i @(['ß'])/, 'SS',
+    'an interpolated array element folding to fewer graphemes takes the whole target';
+
+is 'ß' ~~ /:i $('SS')/, 'ß',
+    'an interpolated string folding to more graphemes matches a shorter target';
+is 'SS' ~~ /:i $('ß')/, 'SS',
+    'an interpolated string folding to fewer graphemes takes the whole target';
+
+is 'STRASSE' ~~ /:i $('straße') $/, 'STRASSE',
+    'a fold in the middle of an interpolated string is measured against the target';
+
+is 'aß' ~~ /:i a $('SS') $/, 'aß',
+    'a match after an earlier atom is measured from its own start';
+is 'aSS' ~~ /:i a $('ß') $/, 'aSS',
+    'a match after an earlier atom takes the graphemes from its own start';
+
+is ('ßSSß' ~~ m:i:g/$('SS')/).join('|'), 'ß|SS|ß',
+    'each match under :g advances by the graphemes it took';
+is ('SSSS' ~~ m:i:g/$('ß')/).join('|'), 'SS|SS',
+    'each match of a pattern folding to fewer graphemes advances past the graphemes it took';
+
+is 'ß' ~~ /:i:m $('SS')/, 'ß',
+    'a pattern folding to more graphemes matches under ignorecase and ignoremark';
+is 'SS' ~~ /:i:m $('ß')/, 'SS',
+    'a pattern folding to fewer graphemes takes the whole target under ignorecase and ignoremark';
+
+is 'ﬃ' ~~ /:i $('FFI')/, 'ﬃ',
+    'a ligature folding to three graphemes matches a one grapheme target';
+is 'FFI' ~~ /:i $('ﬃ')/, 'FFI',
+    'a ligature pattern takes all three target graphemes';
+is ('ßß' ~~ /:i $('SSSS')/).to, 2,
+    'two adjacent folding graphemes are both taken';
+
+my $list = ['SS'];
+is 'ß' ~~ /:i [||$list]/, 'ß',
+    'an array held in a scalar folds to match a shorter target';
+
+is 'SSSS' ~~ /:i $('ß')+ $/, 'SSSS',
+    'a quantified pattern takes the target two graphemes at a time';
+
+is 'ß' ~~ /:i @(< SS ß >)/, 'ß',
+    'an unmatchable folding element does not block a later element';
+
+is 'abc' ~~ /:i @(< AB >) c/, 'abc',
+    'an interpolated array element without a fold expansion takes its own length';
+is 'SŚ' ~~ /:m $('SS')/, 'SŚ',
+    'ignoremark alone takes the pattern length';
+is 'Straße' ~~ /:i [||@(< STRASSE >)]/, 'Straße',
+    'a target folding to more graphemes than the interpolated element';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously a string interpolated into a regex under :i was matched with nqp::eqatic and then assumed to have taken as many graphemes from the target as the pattern has. Case folding can change a grapheme count, so `'ß' ~~ /:i $('SS')/` computed an end past the target and was dropped, while `'SS' ~~ /:i $('ß')/` stopped after one grapheme.

This measures the match by folding runs of the target until the fold is as long as the pattern's, and uses that as the length the match took.