### PR TITLE
Throw for a hash used as a regex assertion

### DIFF
--- a/src/Perl6/Actions.nqp
+++ b/src/Perl6/Actions.nqp
@@ -12018,6 +12018,9 @@ class Perl6::RegexActions is QRegex::P6Regex::Actions does STDActions {
     }
 
     method assertion:sym<var>($/) {
+        if nqp::eqat(~$<var>, '%', 0) {
+            $<var>.typed_panic('X::Syntax::Reserved', :reserved('use of a hash as a regex assertion'))
+        }
         if $<arglist> {
             my $ast := make QAST::Regex.new(
                 QAST::NodeList.new(

--- a/src/Raku/Actions.nqp
+++ b/src/Raku/Actions.nqp
@@ -5470,6 +5470,9 @@ class Raku::RegexActions is HLL::Actions does Raku::CommonActions {
     }
 
     method assertion:sym<var>($/) {
+        if nqp::eqat(~$<var>, '%', 0) {
+            $<var>.typed-panic('X::Syntax::Reserved', :reserved('use of a hash as a regex assertion'))
+        }
         if $<call> {
             my $node := Nodify('Regex::Assertion::Callable');
             self.attach: $/, $<arglist>

--- a/src/core.c/INTERPOLATE.rakumod
+++ b/src/core.c/INTERPOLATE.rakumod
@@ -334,10 +334,12 @@ augment class Match {
     proto method INTERPOLATE_ASSERTION(|) is implementation-detail {*}
 
     multi method INTERPOLATE_ASSERTION(Associative:D $, $, $, $, $, $) {
-        return self.'!cursor_start_cur'().'!cursor_start_cur'()
+        HASH_ASSERTION_RESERVED()
     }
 
     multi method INTERPOLATE_ASSERTION(Iterable:D \var, int \im, int \monkey, int \s, $, \context) {
+        HASH_ASSERTION_RESERVED() if nqp::istype(var,Associative);
+
         my str $tgt = self.target;
         my int $pos = nqp::getattr_i(self, $?CLASS, '$!pos');
         my int $start  = 1;
@@ -355,6 +357,12 @@ augment class Match {
             my int $elems = varlist.elems; # reifies
             my \list     := nqp::getattr(varlist,List,'$!reified');
 
+            # reject a hash element before any element gets tried
+            my int $j = -1;
+            HASH_ASSERTION_RESERVED()
+              if nqp::istype(nqp::atpos(list,$j),Associative)
+              while nqp::islt_i(++$j,$elems);
+
             # Order matters for sequential matching, so no NFA involved.
             if s {
                 $order := $elems
@@ -367,7 +375,7 @@ augment class Match {
                 my Mu \nfa  := QRegex::NFA.new;
                 my Mu \alts := nqp::setelems(nqp::list,$elems);
                 my int $fate = 0;
-                my int $j    = -1;
+                $j = -1;
 
                 while nqp::islt_i(++$j,$elems) {
                     my Mu $topic := nqp::atpos(list,$j);
@@ -375,7 +383,6 @@ augment class Match {
 
                     # We are in a regex assertion, the strings we get will
                     # be treated as regex rules.
-                    return self.'!cursor_start_cur'() if nqp::istype($topic,Associative);
                     my $rx := MAKE_REGEX($topic,im == 1 || im == 3,im == 2 || im == 3,monkey,context);
                     nfa.mergesubstates($start,0,nqp::decont($fate),nqp::findmethod($rx,'NFA')($rx),Mu);
 
@@ -577,9 +584,6 @@ augment class Match {
 
             # We are in a regex assertion, the strings we get will be
             # treated as regex rules.
-            return cursor.'!cursor_start_cur'()
-              if nqp::istype($topic,Associative);
-
             my $rx := MAKE_REGEX($topic,$im == 1 || $im == 3,$im == 2 || $im == 3,$monkey,context);
             my $match := cursor.$rx;
             if $match {
@@ -595,6 +599,12 @@ augment class Match {
             ++$i;
         }
         cursor.'!cursor_start_cur'()
+    }
+
+    sub HASH_ASSERTION_RESERVED() {
+        X::Syntax::Reserved.new(
+          reserved => "use of a hash as a regex assertion",
+        ).throw
     }
 
     sub FLAG_SLOT(\i, \m, int \monkey --> int) {

--- a/t/02-rakudo/regex-hash-assertion-reserved.t
+++ b/t/02-rakudo/regex-hash-assertion-reserved.t
@@ -1,0 +1,46 @@
+use Test;
+
+plan 9;
+
+# A hash interpolated into a regex is reserved. The plain `$h` form and
+# every assertion form throw X::Syntax::Reserved, a hash variable at
+# compile time and a hash reached through a scalar or an array at match
+# time, whatever the hash holds and wherever it sits among the elements.
+
+my $h = { a => 1 };
+my $e = {};
+
+throws-like { 'a' ~~ / <$h> / }, X::Syntax::Reserved,
+    'a hash in a scalar assertion is reserved';
+
+throws-like { 'a' ~~ / <$e> / }, X::Syntax::Reserved,
+    'an empty hash in a scalar assertion is reserved';
+
+throws-like 'my %h = a => 1; "a" ~~ / <%h> /', X::Syntax::Reserved,
+    message => /'hash as a regex assertion'/,
+    'a hash variable assertion is reserved';
+
+throws-like 'my %e; "a" ~~ / <%e> /', X::Syntax::Reserved,
+    message => /'hash as a regex assertion'/,
+    'an empty hash variable assertion is reserved';
+
+throws-like 'my %h; "a" ~~ / [ ||<%h> ] /', X::Syntax::Reserved,
+    message => /'hash as a regex assertion'/,
+    'a sequential hash variable assertion is reserved';
+
+my @a = 'ab', $h, 'a';
+throws-like { 'ab' ~~ / <@a> / }, X::Syntax::Reserved,
+    'a hash element of an array assertion is reserved';
+
+my @b = 'a', $h;
+throws-like { 'a' ~~ / [ ||<@b> ] / }, X::Syntax::Reserved,
+    'a hash element after a matching element of a sequential array assertion is reserved';
+
+my @c = 'x', $h, 'a';
+throws-like { 'a' ~~ / [ ||<@c> ] / }, X::Syntax::Reserved,
+    'a hash element after a failing element of a sequential array assertion is reserved';
+
+throws-like { 'a' ~~ / $h / }, X::Syntax::Reserved,
+    'a hash interpolated outside an assertion is reserved';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously a hash interpolated as a regex assertion, `<$h>`, `<%h>`, or a hash element of `<@a>`, matched nothing and said so to nobody, while the plain `$h` form threw X::Syntax::Reserved. Roast marks the hash assertion as reserved too.

This rejects a hash variable assertion at compile time in both frontends, the way the plain `%h` form is rejected, and throws the same X::Syntax::Reserved at match time for a hash reached through a scalar or an array. An array is scanned for hash elements before any element is tried, so the sequential `||` form rejects a hash whether or not an earlier element matches, the same as the NFA form.