### PR TITLE
Match the lookahead greedily in the LTM before-assertion test

### DIFF
--- a/t/02-rakudo/ltm-before-assertion.t
+++ b/t/02-rakudo/ltm-before-assertion.t
@@ -16,7 +16,7 @@ grammar Expr {
     token operation { <circumfix_operation> | <infix_operation_chain> }
     token infix_term { <circumfix_operation> | <term> }
     my $in_ops = "['/'|'-']";
-    rule infix_operation_chain {<before .+? <$in_ops>><infix_term>[ $<op>=<$in_ops> <infix_term>]+}
+    rule infix_operation_chain {<before .+ <$in_ops>><infix_term>[ $<op>=<$in_ops> <infix_term>]+}
     rule circumfix_operation { '(' <expression> ')' }
 }
 
@@ -35,7 +35,7 @@ grammar QExpr {
     token operation { <circumfix_operation> | <infix_operation_chain> }
     token infix_term { <circumfix_operation> | <term> }
     my $in_ops = "['/'|'-']";
-    rule infix_operation_chain {<?before .+? <$in_ops>><infix_term>[ $<op>=<$in_ops> <infix_term>]+}
+    rule infix_operation_chain {<?before .+ <$in_ops>><infix_term>[ $<op>=<$in_ops> <infix_term>]+}
     rule circumfix_operation { '(' <expression> ')' }
 }
 


### PR DESCRIPTION
Previously the test grammar looked ahead with `.+?`, which only contributed to the declarative prefix because the NFA treated a frugal quantifier like a greedy one. S05 ends the longest token at a frugal quantifier, so the test would then assert nothing about the lookahead being inlined, which is what it was written for.

This looks ahead with `.+` instead. Inside a lookahead nothing is consumed, so the assertion succeeds on the same input either way.