### PR TITLE
Look ahead greedily for a bare rational or complex literal

### DIFF
--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -3426,10 +3426,10 @@ sub, perhaps you accidentally placed a semicolon after routine's definition?"
     token sign { '+' | '-' | '−' | '' }
 
     token rat_number { '<' <bare_rat_number> '>' }
-    token bare_rat_number { <?before <.[-−+0..9<>:boxd]>+? '/'> <nu=.signed-integer> '/' <de=integer> }
+    token bare_rat_number { <?before <.[-−+0..9<>:boxd]>+ '/'> <nu=.signed-integer> '/' <de=integer> }
 
     token complex_number { '<' <bare_complex_number> '>' }
-    token bare_complex_number { <?before <.[-−+0..9<>:.eEboxdInfNa\\]>+? 'i'> <re=.signed-number> <?[-−+]> <im=.signed-number> \\? 'i' }
+    token bare_complex_number { <?before <.[-−+0..9<>:.eEboxdInfNa\\]>+ 'i'> <re=.signed-number> <?[-−+]> <im=.signed-number> \\? 'i' }
 
     token typename(:$needs-whitespace) {
         :my %colonpairs;

--- a/src/Raku/Grammar.nqp
+++ b/src/Raku/Grammar.nqp
@@ -4631,13 +4631,13 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
         ]
     }
     token bare-rational-number {
-        <?before <.[-−+0..9<>:boxd]>+? '/'>
+        <?before <.[-−+0..9<>:boxd]>+ '/'>
         <nu=.signed-integer> '/' <de=integer>
     }
 
     token complex-number { '<' <bare-complex-number> '>' }
     token bare-complex-number {
-        <?before <.[-−+0..9<>:.eEboxdInfNa\\]>+? 'i'>
+        <?before <.[-−+0..9<>:.eEboxdInfNa\\]>+ 'i'>
         <re=.signed-number> <?[-−+]> <im=.signed-number> \\? 'i'
     }
 


### PR DESCRIPTION
Previously `bare_rat_number` and `bare_complex_number`, and their RakuAST counterparts, looked ahead with `+?` to tell `<1/2>` and `<1+2i>` apart from quote words. Inside a lookahead nothing is consumed, and neither `/` nor `i` is in the character class being scanned, so a frugal scan and a greedy scan stop at the same place and the assertion succeeds on the same input either way.

This looks ahead with `+` instead. S05 ends the longest token at a frugal quantifier, and a greedy scan declares the same prefix whether or not the NFA follows that rule, so the literal stays ranked ahead of quote words either way instead of tying with them on a single `<`.