### PR TITLE
Stop :s substitution copying marks into the replacement

### DIFF
--- a/src/Raku/Grammar.nqp
+++ b/src/Raku/Grammar.nqp
@@ -65,10 +65,13 @@ role Raku::Common {
 
     # Control special functionality associated with rx adverbs, also in
     # natural slangs
-    method adverb-rx2str-control(str $key) {
+    my constant SIGSPACE-ADVERBS := nqp::hash(
+      's', 1, 'sigspace', 1, 'ss', 1, 'samespace', 1
+    );
+    method adverb-rx2str-control(str $key, int $negated = 0) {
         my str $translated := self.adverb-rx2str($key);
-        if $translated eq 's' {
-            try $*WHITESPACE-OK := 1;
+        if nqp::existskey(SIGSPACE-ADVERBS, $translated) {
+            %*RX<sigspace> := $negated ?? 0 !! 1;
         }
         $translated
     }
@@ -4326,7 +4329,7 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
         :my %*RX;
         :my $*INTERPOLATE := 1;
         :my $*IN-DECL := 'rule';
-        :my $*WHITESPACE-OK := 1;
+        { %*RX<sigspace> := 1 }
         <regex-def>
     }
 
@@ -4781,7 +4784,6 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
     token quote:sym</ /> {
         :my %*RX;
         :my $*INTERPOLATE := 1;
-        :my $*WHITESPACE-OK := 0;
         '/'
         <nibble(self.quote-lang(self.Regex, '/', '/'))>
         [ '/' || <.panic: "Unable to parse regex; couldn't find final '/'"> ]
@@ -4791,7 +4793,6 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
         <.quote-lang-rx>
         :my %*RX;
         :my $*INTERPOLATE := 1;
-        :my $*WHITESPACE-OK := 0;
         {}  # make sure $/ gets set
         <.qok($/)>
         <rx-adverbs>
@@ -4803,7 +4804,6 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
         <.quote-lang-m>
         :my %*RX;
         :my $*INTERPOLATE   := 1;
-        :my $*WHITESPACE-OK := 0;
         {}  # make sure $/ gets set
         <.qok($/)>
         <rx-adverbs>
@@ -4815,8 +4815,7 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
         <.quote-lang-ms>
         :my %*RX;
         :my $*INTERPOLATE   := 1;
-        :my $*WHITESPACE-OK := 1;
-        { %*RX<s> := 1 }
+        { %*RX<s> := 1; %*RX<sigspace> := 1 }
         <.qok($/)>
         <rx-adverbs>
         <quibble(self.Regex(%*RX<P5>))>
@@ -4827,7 +4826,6 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
         <.quote-lang-s>
         :my %*RX;
         :my $*INTERPOLATE   := 1;
-        :my $*WHITESPACE-OK := 0;
         {}  # make sure $/ gets set
         <.qok($/)>
         <rx-adverbs>
@@ -4839,8 +4837,7 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
         <.quote-lang-ss>
         :my %*RX;
         :my $*INTERPOLATE   := 1;
-        :my $*WHITESPACE-OK := 1;
-        { %*RX<s> := 1 }
+        { %*RX<s> := 1; %*RX<sigspace> := 1 }
         <.qok($/)>
         <rx-adverbs>
         <sibble(self.Regex(%*RX<P5>), self.Quote, 'qq')>
@@ -4851,7 +4848,6 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
         <.quote-lang-S>
         :my %*RX;
         :my $*INTERPOLATE   := 1;
-        :my $*WHITESPACE-OK := 0;
         {}  # make sure $/ gets set
         <.qok($/)>
         <rx-adverbs>
@@ -4863,8 +4859,7 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
         <.quote-lang-Ss>
         :my %*RX;
         :my $*INTERPOLATE   := 1;
-        :my $*WHITESPACE-OK := 1;
-        { %*RX<s> := 1 }
+        { %*RX<s> := 1; %*RX<sigspace> := 1 }
         <.qok($/)>
         <rx-adverbs>
         <sibble(self.Regex(%*RX<P5>), self.Quote, 'qq')>
@@ -4984,7 +4979,10 @@ grammar Raku::Grammar is HLL::Grammar does Raku::Common {
         {
             for $<quotepair> {
                 my $ast := $_.ast;
-                $ast.set-key(self.adverb-rx2str-control($ast.key));
+                $ast.set-key(
+                  self.adverb-rx2str-control($ast.key,
+                    $_<neg> || ($_<num> && !+~$_<num>) ?? 1 !! 0)
+                );
             }
         }
     }
@@ -6697,7 +6695,9 @@ grammar Raku::RegexGrammar is QRegex::P6Regex::Grammar does Raku::Common {
         :my $*MODIFIER;
         {
             $*NEGATED := $<n>[0] gt '' ?? ($<n>[0] eq '!' ?? 1 !! !+$<n>[0]) !! 0;
-            $*MODIFIER := self.slangs<MAIN>.adverb-rx2str-control(~$<modifier>);
+            $*MODIFIER := self.slangs<MAIN>.adverb-rx2str-control(
+              ~$<modifier>, $*NEGATED ?? 1 !! 0
+            );
         }
     }
 
@@ -6753,7 +6753,7 @@ grammar Raku::RegexGrammar is QRegex::P6Regex::Grammar does Raku::Common {
         [
           | \w
           [ <?before ' ' \w <!before <.quantifier> > >
-            <!{ $*WHITESPACE-OK }>
+            <!{ %*RX<sigspace> || $*HAS_GOAL }>
             <.typed-worry: 'X::Syntax::Regex::InsignificantWhitespace'>
           ]?
           <.SIGOK>

--- a/src/core.c/Str.rakumod
+++ b/src/core.c/Str.rakumod
@@ -1785,7 +1785,9 @@ my class Str does Stringy { # declared in BOOTSTRAP
                             ?? -> $w,$p { $w.samemark($p).samecase($p) }
                             !! case
                                 ?? -> $w,$p { $w.samecase($p) }
-                                !! -> $w,$p { $w.samemark($p) }
+                                !! mark
+                                    ?? -> $w,$p { $w.samemark($p) }
+                                    !! Callable;
                             nqp::push_s($result,nqp::unbox_s(
                               $it!word-by-word($mstr,&filter,:samespace(?space))
                             ) );

--- a/src/core.c/Str.rakumod
+++ b/src/core.c/Str.rakumod
@@ -1751,7 +1751,7 @@ my class Str does Stringy { # declared in BOOTSTRAP
         # need to do something special
         if SDS || space || case || mark || callable {
             my \noargs        := callable ?? $replacement.count == 0 !! False;
-            my \fancy         := space || case || mark || word_by_word;
+            my \fancy         := space || case || mark;
             my \case-and-mark := case && mark;
 
             # fast path for something like `s:g[ \w+ ] = "foo"`

--- a/t/05-messages/10-warnings.t
+++ b/t/05-messages/10-warnings.t
@@ -3,7 +3,7 @@ use nqp;
 use Test;
 use Test::Helpers;
 
-plan 24;
+plan 40;
 
 subtest 'Supply.interval with negative value warns' => {
     plan 2;
@@ -172,5 +172,70 @@ if nqp::gethllsym('Raku', 'COMPILER-FRONTEND') eq 'rakuast' {
 else {
     skip 'the source split is placed by the RakuAST frontend', 1;
 }
+
+# https://github.com/rakudo/rakudo/issues/2765
+is-run ｢print so "a b" ~~ m:s/a b/｣,
+    ':s on a match does not warn about a space between atoms',
+    :out<True>, :err('');
+
+is-run ｢print so "(ab)" ~~ / "(" ~ ")" [ a b ] /｣,
+    'a space between atoms after a goal separator does not warn',
+    :out<True>, :err('');
+
+is-run ｢$_ = "a b"; s:ss/a b/x/; print $_｣,
+    ':ss on a substitution parses the regex with sigspace and does not warn',
+    :out<x>, :err('');
+
+is-run ｢print so "a b" ~~ m:sigspace/a b/｣,
+    ':sigspace on a match does not warn about a space between atoms',
+    :out<True>, :err('');
+
+is-run ｢print S:samespace/a b/x/ given "a b"｣,
+    ':samespace on a non-destructive substitution does not warn',
+    :out<x>, :err('');
+
+is-run ｢grammar G { token T { :s a b } }; print so "a b" ~~ /<G::T>/｣,
+    ':s inside a token does not warn about a space between atoms',
+    :out<True>, :err('');
+
+is-run ｢grammar G { regex T { :sigspace a b } }; print so "a b" ~~ /<G::T>/｣,
+    ':sigspace inside a regex does not warn about a space between atoms',
+    :out<True>, :err('');
+
+is-run ｢$_ = "ab"; s:!s/a b/x/; print $_｣,
+    'a negated :s on a substitution still warns about a space between atoms',
+    :out<x>, :err(/'Space is not significant'/);
+
+is-run ｢print so "ab" ~~ m:!sigspace/a b/｣,
+    'a negated :sigspace on a match still warns about a space between atoms',
+    :out<True>, :err(/'Space is not significant'/);
+
+is-run ｢$_ = "ab"; s:0s/a b/x/; print $_｣,
+    'a :0s adverb on a substitution still warns about a space between atoms',
+    :out<x>, :err(/'Space is not significant'/);
+
+is-run ｢print so "ab" ~~ / :!s a b /｣,
+    'a negated :s inside a regex still warns about a space between atoms',
+    :out<True>, :err(/'Space is not significant'/);
+
+is-run ｢grammar G { rule T { :!s a b } }; print so "ab" ~~ /<G::T>/｣,
+    'a negated :s inside a rule still warns about a space between atoms',
+    :out<True>, :err(/'Space is not significant'/);
+
+is-run ｢grammar G { rule T { a [ :!s b ] c d } }; print so "a b c d" ~~ /<G::T>/｣,
+    'a negated :s inside a group does not reach the rest of the rule',
+    :out<True>, :err('');
+
+is-run ｢print so "ab cd e f gh" ~~ / a [ :s b [ :!s cd ] e f ] g h /｣,
+    'sigspace changes inside nested groups do not reach the rest of the regex',
+    :out<True>, :err(/'Space is not significant'/);
+
+is-run ｢print so "abc de" ~~ / a [ :s bc ] d e /｣,
+    'a :s inside a group does not silence the warning after the group',
+    :out<True>, :err(/'Space is not significant'/);
+
+is-run ｢grammar G { rule R { a { my token T { c d } } b } }; print so "a b" ~~ /<G::R>/｣,
+    'a token declared inside a rule body block warns about a space between atoms',
+    :out<True>, :err(/'Space is not significant'/);
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
A substitution with `:sigspace` but no `:samemark` was still running the replacement through samemark:

```
my $a = "Å"; $a ~~ s:s/(.)/b$0b/; dd $a;   # Str $a = "b̊Åb̊", expected "bÅb"
```

`Str!APPLY-MATCHES` picks a word-by-word filter whenever sigspace is on, and the filter chain fell through to samemark when neither `:ii` nor `:mm` was asked for. The first commit only applies a filter for the adverb that was actually given. Both frontends go through that method so this covers both.

While testing this under RakuAST, `s:ss/a b/x/`, `m:sigspace/a b/` and `S:samespace/a b/x/` all emitted the "Space is not significant" worry even though the regex was parsed with sigspace, and going further `s:!s/a b/x/` did not warn, a `:!s` inside a group leaked to the rest of the regex, and `:s` inside a `token` warned. The second commit moves the flag the worry reads into `%*RX`, which the regex grammar already copies per group, and matches legacy on a 28 case probe of adverb spellings, negation forms, groups, declarators and goal separators. Tests for those are in t/05-messages/10-warnings.t.

The third commit lets a plain `:s` substitution skip the word-by-word pass entirely, since without `:ss`, `:ii` or `:mm` that pass returns the replacement unchanged. It now costs the same as `s///` with no adverbs.

The existing roast test for `ss:i:m` had this bug baked into its expectation; that is corrected separately in Raku/roast#909

Fixes #2765
