### PR TITLE
RakuAST: fix a batch of deparse holes found by round tripping raku code

### DIFF
--- a/src/Raku/ast/name.rakumod
+++ b/src/Raku/ast/name.rakumod
@@ -6,18 +6,22 @@ class RakuAST::Name
     has List $!parts;
     has List $.colonpairs;
 
-    method new(*@parts) {
+    method new(*@parts, List :$colonpairs) {
         my $obj := nqp::create(self);
         nqp::bindattr($obj, RakuAST::Name, '$!parts', @parts);
-        nqp::bindattr($obj, RakuAST::Name, '$!colonpairs', []);
+        my @colonpairs;
+        if $colonpairs {
+            nqp::push(@colonpairs, $_) for self.IMPL-UNWRAP-LIST($colonpairs);
+        }
+        nqp::bindattr($obj, RakuAST::Name, '$!colonpairs', @colonpairs);
         $obj
     }
 
-    method from-identifier(Str $identifier) {
-        self.new(RakuAST::Name::Part::Simple.new($identifier))
+    method from-identifier(Str $identifier, List :$colonpairs) {
+        self.new(RakuAST::Name::Part::Simple.new($identifier), :$colonpairs)
     }
 
-    method from-identifier-parts(*@identifiers) {
+    method from-identifier-parts(*@identifiers, List :$colonpairs) {
         my @parts;
         for @identifiers {
             unless nqp::istype($_, Str) || nqp::isstr($_) {
@@ -25,7 +29,7 @@ class RakuAST::Name
             }
             @parts.push(RakuAST::Name::Part::Simple.new($_));
         }
-        self.new(|@parts)
+        self.new(|@parts, :$colonpairs)
     }
 
     method add-colonpair(RakuAST::ColonPairish $pair) {

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -2330,16 +2330,18 @@ CODE
     }
 
     multi method deparse(RakuAST::Statement::Loop:D $ast --> Str:D) {
-        my $condition := $ast.setup
-          ?? (' ('
-               ~ self.deparse($ast.setup)
-               ~ $.loop-separator
-               ~ self.deparse($ast.condition)
-               ~ $.loop-separator
-               ~ self.deparse($ast.increment)
-               ~ ') '
-             )
-          !! " ";
+        my str $condition = " ";
+        if $ast.setup || $ast.condition || $ast.increment {
+            # a declaration in the setup would add the statement delimiter
+            my $*DELIMITER = '';
+            $condition = ' ('
+              ~ ($ast.setup     ?? self.deparse($ast.setup)     !! '')
+              ~ $.loop-separator
+              ~ ($ast.condition ?? self.deparse($ast.condition) !! '')
+              ~ $.loop-separator
+              ~ ($ast.increment ?? self.deparse($ast.increment) !! '')
+              ~ ') ';
+        }
 
         self.labels($ast)
           ~ self.syn-block('loop')

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -840,13 +840,16 @@ CODE
     multi method deparse(
       RakuAST::ColonPair::Value:D $ast, Str:D $xsyn = ""
     --> Str:D) {
-        my $value  := $ast.value;
+        my $value        := $ast.value;
+        my str $deparsed  = self.deparse($value);
 
         ':'
           ~ self.named-arg($xsyn, $ast.key)
-          ~ (nqp::istype($value,RakuAST::QuotedString)
-              ?? self.deparse($value)
-              !! $.parens-open ~ self.deparse($value) ~ $.parens-close
+          ~ (nqp::istype($value,RakuAST::Circumfix::Parentheses)
+               || (nqp::istype($value,RakuAST::QuotedString)
+                    && $deparsed.starts-with('<'))
+              ?? $deparsed
+              !! $.parens-open ~ $deparsed ~ $.parens-close
             )
     }
 

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -372,6 +372,16 @@ CODE
         }
     }
 
+    # Word characters never need escaping inside <[ ]>.  Everything else
+    # is escaped rather than enumerating which characters are ignored or
+    # meaningful there, such as whitespace, dots, hyphens, backslashes
+    # and the closing bracket
+    method charclass-character(str $char --> Str:D) {
+        nqp::iscclass(nqp::const::CCLASS_WORD,$char,0)
+          ?? $char
+          !! '\\' ~ $char
+    }
+
     method colonpairs($ast, Str:D $xsyn = "") {
         $ast.colonpairs.map({ self.deparse($_, $xsyn) }).join
     }
@@ -1878,13 +1888,15 @@ CODE
     multi method deparse(
       RakuAST::Regex::CharClassEnumerationElement::Character:D $ast
     --> Str:D) {
-        $ast.character
+        self.charclass-character($ast.character)
     }
 
     multi method deparse(
       RakuAST::Regex::CharClassEnumerationElement::Range:D $ast
     --> Str:D) {
-        $ast.from.chr ~ '..' ~ $ast.to.chr
+        self.charclass-character($ast.from.chr)
+          ~ '..'
+          ~ self.charclass-character($ast.to.chr)
     }
 
 #- Regex::Co -------------------------------------------------------------------

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -93,6 +93,8 @@ class RakuAST::Deparse {
     method regex-match-from(--> '<( ') { }
     method regex-match-to(  --> ')> ') { }
 
+    method regex-nested(--> '~ ') { }
+
     method before-infix(--> ' ')  { }
     method after-infix( --> ' ')  { }
 
@@ -1928,6 +1930,14 @@ CODE
     multi method deparse(RakuAST::Regex::NamedCapture:D $ast --> Str:D) {
         self.hsyn('capture-named', '$<' ~ $ast.name ~ '>=')
           ~ self.deparse($ast.regex)
+    }
+
+    multi method deparse(RakuAST::Regex::Nested:D $ast --> Str:D) {
+        my str $goal = self.deparse($ast.goal);
+        $.regex-nested
+          ~ $goal
+          ~ ($goal.ends-with(' ') ?? '' !! ' ')
+          ~ self.deparse($ast.expr)
     }
 
 #- Regex::Q --------------------------------------------------------------------

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -1475,9 +1475,6 @@ CODE
                 elsif $ast.is-declared-optional {
                     @parts.push('?');
                 }
-                elsif $ast.is-declared-required {
-                    @parts.push('!');
-                }
             }
 
             if $ast.traits -> @traits {
@@ -2221,7 +2218,9 @@ CODE
           !! @statements.map({ self.deparse($_) }).join($.list-infix-semi-colon)
     }
 
-    multi method deparse(RakuAST::Signature:D $ast --> Str:D) {
+    multi method deparse(
+      RakuAST::Signature:D $ast, :$no-returns
+    --> Str:D) {
         my str @parts;
 
         if $ast.parameters -> @parameters {
@@ -2252,9 +2251,11 @@ CODE
             }
         }
 
-        with $ast.returns {
-            @parts.push(self.hsyn('arrow-two', '-->'));
-            @parts.push(self.deparse($_));
+        unless $no-returns {
+            with $ast.returns {
+                @parts.push(self.hsyn('arrow-two', '-->'));
+                @parts.push(self.deparse($_));
+            }
         }
 
         @parts.join(' ')
@@ -3052,13 +3053,14 @@ CODE
     multi method deparse(RakuAST::VarDeclaration::Signature:D $ast --> Str:D) {
         my str @parts = self.syn-scope($ast.scope);
         @parts.push(self.syn-type($_)) with $ast.type;
-        @parts.push('(' ~ self.deparse($ast.signature) ~ ')');
-
-        if $ast.initializer -> $initializer {
-            @parts.push(self.deparse($initializer));
-        }
+        # a declared type is stored as the return type as well
+        @parts.push('('
+          ~ self.deparse($ast.signature, :no-returns($ast.type.defined))
+          ~ ')'
+        );
 
         @parts.join(' ')
+          ~ ($ast.initializer ?? self.deparse($ast.initializer) !! '')
     }
 
     multi method deparse(RakuAST::VarDeclaration::Simple:D $ast --> Str:D) {

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -847,7 +847,7 @@ CODE
     }
 
     multi method deparse(RakuAST::Call::Term:D $ast --> Str:D) {
-        self.parenthesize($ast.args, :only-non-empty)
+        self.parenthesize($ast.args)
     }
 
 #- Circumfix -------------------------------------------------------------------

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -2626,9 +2626,11 @@ CODE
         }
         else {
             @parts.push('/');
-            @parts.push(self.deparse($ast.pattern));
+            @parts.push(self.deparse($ast.pattern).subst('/', '\/', :g));
             @parts.push('/');
-            @parts.push(self.deparse($ast.replacement).substr(1,*-1));
+            @parts.push(
+              self.deparse($ast.replacement).substr(1,*-1).subst('/', '\/', :g)
+            );
             @parts.push('/');
         }
 

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -674,6 +674,8 @@ CODE
 #- A ---------------------------------------------------------------------------
 
     multi method deparse(RakuAST::ApplyInfix:D $ast --> Str:D) {
+        # a declaration operand would add the statement delimiter
+        my $*DELIMITER = '';
         my str $deparsed = self.deparse($ast.left)
           ~ $.before-infix
           ~ self.deparse($ast.infix)
@@ -689,6 +691,7 @@ CODE
     }
 
     multi method deparse(RakuAST::ApplyDottyInfix:D $ast --> Str:D) {
+        my $*DELIMITER = '';
         self.deparse($ast.left)
           ~ self.deparse($ast.infix)
           # lose the ".", as it is provided by the infix
@@ -696,6 +699,7 @@ CODE
     }
 
     multi method deparse(RakuAST::ApplyListInfix:D $ast --> Str:D) {
+        my $*DELIMITER = '';
         my $infix       := $ast.infix;
         my str $operator = self.deparse($infix);
 

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -2202,8 +2202,11 @@ CODE
 
     multi method deparse(RakuAST::SemiList:D $ast --> Str:D) {
         my @statements := $ast.statements;
+        my $statement  := @statements.head;
         @statements == 1
-          ?? self.deparse(@statements.head.expression)
+          && !(nqp::istype($statement,RakuAST::Statement::Expression)
+               && ($statement.condition-modifier || $statement.loop-modifier))
+          ?? self.deparse($statement.expression)
           !! @statements.map({ self.deparse($_) }).join($.list-infix-semi-colon)
     }
 

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -399,22 +399,50 @@ CODE
     }
 
     method parenthesize($ast, :$only-non-empty --> Str:D) {
+        # a declaration inside the parens would add the statement delimiter
+        my $*DELIMITER = '';
         my str $deparsed = $ast.defined ?? self.deparse($ast).chomp !! '';
         $deparsed || !$only-non-empty
           ?? $.parens-open ~ $deparsed ~ $.parens-close
           !! $deparsed
     }
 
+        my $*DELIMITER = '';
     method bracketize($ast --> Str:D) {
+        my $*DELIMITER = '';
         $.bracket-open
           ~ ($ast.defined ?? self.deparse($ast) !! '')
           ~ $.bracket-close
     }
 
     method squarize($ast --> Str:D) {
+        my $*DELIMITER = '';
         $.square-open
           ~ ($ast.defined ?? self.deparse($ast) !! '')
           ~ $.square-close
+    }
+
+    # An operand that deparses to more than a single term must be
+    # parenthesized under a postfix, or the postfix binds to its last
+    # term only
+    method postfix-operand-needs-parens($operand --> Bool:D) {
+        nqp::istype($operand,RakuAST::ApplyInfix)
+          || nqp::istype($operand,RakuAST::ApplyListInfix)
+          || nqp::istype($operand,RakuAST::ApplyDottyInfix)
+          || nqp::istype($operand,RakuAST::ApplyPrefix)
+          || nqp::istype($operand,RakuAST::Ternary)
+          || nqp::istype($operand,RakuAST::FatArrow)
+          || nqp::istype($operand,RakuAST::VarDeclaration::Simple)
+          || nqp::istype($operand,RakuAST::VarDeclaration::Term)
+          || nqp::istype($operand,RakuAST::VarDeclaration::Constant)
+          || nqp::istype($operand,RakuAST::VarDeclaration::Signature)
+          || nqp::istype($operand,RakuAST::Block)
+          || nqp::istype($operand,RakuAST::Routine)
+          || nqp::istype($operand,RakuAST::StatementPrefix)
+          || nqp::istype($operand,RakuAST::Term::Reduce)
+          || nqp::istype($operand,RakuAST::Call::Name::WithoutParentheses)
+          ?? True
+          !! False
     }
 
     method meta-infix-letter($ast, str $letter --> Str:D) {
@@ -664,16 +692,11 @@ CODE
             $deparsed-postfix
         }
         else {
-            my     $operand         := $ast.operand;
-            my str $deparsed-operand = self.deparse($operand);
-
-            nqp::istype($operand,RakuAST::ApplyInfix)
-              || nqp::istype($operand,RakuAST::ApplyListInfix)
-              ?? $.parens-open
-                   ~ $deparsed-operand
-                   ~ $.parens-close
-                   ~ $deparsed-postfix
-              !! $deparsed-operand ~ $deparsed-postfix
+            my $operand := $ast.operand;
+            (self.postfix-operand-needs-parens($operand)
+              ?? self.parenthesize($operand)
+              !! self.deparse($operand)
+            ) ~ $deparsed-postfix
         }
     }
 

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -418,6 +418,13 @@ CODE
           !! $deparsed.chomp
     }
 
+    method assignee($ast --> Str:D) {
+        my $assignee := $ast.assignee;
+        nqp::isconcrete($assignee)
+          ?? self.syn-infix-ws($.assign) ~ self.deparse($assignee)
+          !! ''
+    }
+
     method bracketize($ast --> Str:D) {
         my $*DELIMITER = '';
         $.bracket-open
@@ -1567,7 +1574,9 @@ CODE
     }
 
     multi method deparse(RakuAST::Postcircumfix::ArrayIndex:D $ast --> Str:D) {
-        self.squarize($ast.index) ~ self.colonpairs($ast, 'adverb-pc')
+        self.squarize($ast.index)
+          ~ self.colonpairs($ast, 'adverb-pc')
+          ~ self.assignee($ast)
     }
 
     multi method deparse(RakuAST::Postcircumfix::HashIndex:D $ast --> Str:D) {
@@ -1577,7 +1586,9 @@ CODE
     multi method deparse(
       RakuAST::Postcircumfix::LiteralHashIndex:D $ast
     --> Str:D) {
-        self.deparse($ast.index) ~ self.colonpairs($ast, 'adverb-pc')
+        self.deparse($ast.index)
+          ~ self.colonpairs($ast, 'adverb-pc')
+          ~ self.assignee($ast)
     }
 
     multi method deparse(RakuAST::Postfix:D $ast --> Str:D) {

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -2117,6 +2117,16 @@ CODE
             @parts.push($traits);
         }
 
+        my $body := $ast.body;
+        if nqp::istype($body,RakuAST::OnlyStar) {
+            @parts.push(self.deparse($body));
+            if $ast.WHY -> $WHY {
+                my $*DELIMITER = '';
+                return self.add-any-docs(@parts.join(' '), $WHY);
+            }
+            return @parts.join(' ');
+        }
+
         if $ast.WHY -> $WHY {
             @parts.push('{');
             # https://github.com/rakudo/rakudo/issues/5978
@@ -2129,7 +2139,7 @@ CODE
             @parts = @parts.join(' ');
         }
 
-        @parts.push(self.deparse($ast.body));
+        @parts.push(self.deparse($body));
         @parts.push('}');
         @parts.join
     }

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -124,7 +124,7 @@ class RakuAST::Deparse {
     method assign(--> ' = ')  { }
     method bind(  --> ' := ') { }
 
-    method before-list-infix(--> '') { }
+    method before-list-infix(--> ' ') { }
     method after-list-infix(--> ' ') { }
 
     method loop-separator(--> '; ') { }
@@ -667,10 +667,7 @@ CODE
 
     multi method deparse(RakuAST::ApplyListInfix:D $ast --> Str:D) {
         my $infix       := $ast.infix;
-        my str $operator = nqp::istype($infix,RakuAST::MetaInfix)
-          || nqp::istype($infix,RakuAST::Feed)
-          ?? (' ' ~ self.deparse($infix))
-          !! self.deparse($infix);
+        my str $operator = self.deparse($infix);
 
         my str @parts = $ast.operands.map({ self.deparse($_) });
         @parts

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -407,7 +407,17 @@ CODE
           !! $deparsed
     }
 
+    # A block or control statement ends in a newline the enclosing
+    # statement supplies again, an expression statement may end in a
+    # heredoc body that has to stay intact
+    method blorst($blorst --> Str:D) {
         my $*DELIMITER = '';
+        my str $deparsed = self.deparse($blorst);
+        nqp::istype($blorst,RakuAST::Statement::Expression)
+          ?? $deparsed
+          !! $deparsed.chomp
+    }
+
     method bracketize($ast --> Str:D) {
         my $*DELIMITER = '';
         $.bracket-open
@@ -443,6 +453,25 @@ CODE
           || nqp::istype($operand,RakuAST::Call::Name::WithoutParentheses)
           ?? True
           !! False
+    }
+
+    # True only for a statement prefix over a block or a control
+    # statement with no modifier, the one statement whose closing brace
+    # may end it without a delimiter.  Any other trailing brace may close
+    # a subscript, a closure or a hash composer and keeps it
+    method statement-is-prefixed-block($statement --> Bool:D) {
+        if nqp::istype($statement,RakuAST::Statement::Expression)
+          && !$statement.condition-modifier
+          && !$statement.loop-modifier {
+            my $expression := $statement.expression;
+            nqp::istype($expression,RakuAST::StatementPrefix)
+              && !nqp::istype($expression.blorst,RakuAST::Statement::Expression)
+              ?? True
+              !! False
+        }
+        else {
+            False
+        }
     }
 
     method meta-infix-letter($ast, str $letter --> Str:D) {
@@ -547,6 +576,7 @@ CODE
     }
 
     method statement-modifier(str $type, $ast) {
+        my $*DELIMITER = '';
         self.syn-modifier($type) ~ ' ' ~ self.deparse($ast.expression)
     }
 
@@ -2433,7 +2463,9 @@ CODE
                   ?? $.last-statement
                   !! $.end-statement;
                 my $deparsed := self.deparse($statement);
-                $deparsed := $deparsed.chop(2) if $deparsed.ends-with("};\n");
+                $deparsed := $deparsed.chop(2)
+                  if $deparsed.ends-with("};\n")
+                  && self.statement-is-prefixed-block($statement);
 
                 @parts.push($spaces);
                 @parts.push($deparsed);
@@ -2495,18 +2527,16 @@ CODE
         my str $prefix = $ast.type;
         self.hsyn("stmt-prefix-$prefix", self.xsyn('stmt-prefix', $prefix))
           ~ ' '
-          ~ self.deparse($ast.blorst).chomp
+          ~ self.blorst($ast.blorst)
     }
 
     # handles most phasers
     multi method deparse(RakuAST::StatementPrefix::Phaser:D $ast --> Str:D) {
-        my $*DELIMITER = '';
-        self.syn-phaser($ast.type) ~ ' ' ~ self.deparse($ast.blorst).chomp
+        self.syn-phaser($ast.type) ~ ' ' ~ self.blorst($ast.blorst)
     }
 
     multi method deparse(RakuAST::StatementPrefix::Phaser::First:D $ast --> Str:D) {
-        my $*DELIMITER = '';
-        self.syn-phaser($ast.type) ~ ' ' ~ self.deparse($ast.original-blorst).chomp
+        self.syn-phaser($ast.type) ~ ' ' ~ self.blorst($ast.original-blorst)
     }
 
     multi method deparse(

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -2725,6 +2725,24 @@ CODE
         "" # XXX for now
     }
 
+#- Transliteration -------------------------------------------------------------
+
+    multi method deparse(RakuAST::Transliteration:D $ast --> Str:D) {
+        my str @parts = $ast.destructive ?? 'tr' !! 'TR';
+
+        if $ast.adverbs -> @adverbs {
+            @parts.push(self.deparse($_)) for @adverbs;
+        }
+
+        for $ast.left, $ast.right {
+            @parts.push('/');
+            @parts.push(self.deparse($_).substr(1,*-1).subst('/', '\/', :g));
+        }
+        @parts.push('/');
+
+        @parts.join
+    }
+
 #- Type ------------------------------------------------------------------------
 
     multi method deparse(RakuAST::Type::Capture:D $ast --> Str:D) {

--- a/src/core.c/RakuAST/Raku.rakumod
+++ b/src/core.c/RakuAST/Raku.rakumod
@@ -144,6 +144,9 @@ augment class RakuAST::Node {
               my $config := nqp::decont(self.config);
               :config($config.Hash) if $config
           },
+          'destructive', -> {
+              :destructive(self.destructive)
+          },
           'directive', -> {
               :directive if self.directive
           },
@@ -1196,6 +1199,12 @@ augment class RakuAST::Node {
 
     multi method raku(RakuAST::Trait::WillBuild:D: --> Str:D) {
         self!positional(self.expr)
+    }
+
+#- Transliteration -------------------------------------------------------------
+
+    multi method raku(RakuAST::Transliteration:D: --> Str:D) {
+        self!nameds: <destructive left right adverbs>
     }
 
 #- Type ------------------------------------------------------------------------

--- a/src/core.c/RakuAST/Raku.rakumod
+++ b/src/core.c/RakuAST/Raku.rakumod
@@ -864,6 +864,7 @@ augment class RakuAST::Node {
 
     multi method raku(RakuAST::RegexDeclaration:D: --> Str:D) {
         my str @nameds = 'name';
+        @nameds.unshift("multiness") if self.multiness;
         @nameds.unshift("scope") if self.scope ne self.default-scope;
         @nameds.push("signature") if self.signature && self.signature.parameters-initialized;
         @nameds.append: <traits body>;

--- a/src/core.c/RakuAST/Raku.rakumod
+++ b/src/core.c/RakuAST/Raku.rakumod
@@ -564,15 +564,26 @@ augment class RakuAST::Node {
 #- N ---------------------------------------------------------------------------
 
     multi method raku(RakuAST::Name:D: --> Str:D) {
-        my @parts := self.parts;
-        if nqp::istype(@parts.are, RakuAST::Name::Part::Simple) {
+        my @parts      := self.parts;
+        my $colonpairs := self.colonpairs;
+
+        if @parts && nqp::istype(@parts.are, RakuAST::Name::Part::Simple) {
+            my str $args = @parts.map(*.name.raku).join(',');
+            $args ~= ', colonpairs => ' ~ rakufy($colonpairs) if $colonpairs;
             self.^name ~ (@parts.elems == 1
-              ?? ".from-identifier(@parts.head.name.raku())"
-              !! ".from-identifier-parts(@parts.map(*.name.raku).join(','))"
+              ?? ".from-identifier($args)"
+              !! ".from-identifier-parts($args)"
             )
         }
         else {
-            self!positionals(@parts)
+            indent;
+            my str @lines = @parts.map({ $*INDENT ~ rakufy($_) });
+            @lines.push($*INDENT ~ 'colonpairs => ' ~ rakufy($colonpairs))
+              if $colonpairs;
+            dedent;
+            @lines
+              ?? self.^name ~ ".new(\n" ~ @lines.join(",\n") ~ "\n$*INDENT)"
+              !! self.^name ~ '.new()'
         }
     }
 

--- a/src/core.c/RakuAST/Raku.rakumod
+++ b/src/core.c/RakuAST/Raku.rakumod
@@ -905,6 +905,10 @@ augment class RakuAST::Node {
         self!nameds: <name regex>
     }
 
+    multi method raku(RakuAST::Regex::Nested:D: --> Str:D) {
+        self!positionals([self.goal, self.expr])
+    }
+
 #- Regex::Q --------------------------------------------------------------------
 
     multi method raku(RakuAST::Regex::QuantifiedAtom:D: --> Str:D) {

--- a/t/12-rakuast/call-name.rakutest
+++ b/t/12-rakuast/call-name.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 8;
+plan 9;
 
 my $ast;
 my $deparsed;
@@ -119,6 +119,20 @@ subtest 'Can make a call on a term with two positional arguments' => {
     );
     is-deeply $deparsed, '$target(9, 4)', 'deparsed';
     is-deeply $_, 5, @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+my $nullary = -> { 42 }
+subtest 'Can make a call on a term without arguments' => {
+    # $nullary()
+    ast RakuAST::ApplyPostfix.new(
+      operand => RakuAST::Var::Lexical.new('$nullary'),
+      postfix => RakuAST::Call::Term.new(
+        args => RakuAST::ArgList.new
+      )
+    );
+    is-deeply $deparsed, '$nullary()', 'deparsed';
+    is-deeply $_, 42, @type[$++]
       for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
 }
 

--- a/t/12-rakuast/circumfix.rakutest
+++ b/t/12-rakuast/circumfix.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 7;
+plan 8;
 
 my $ast;
 my $deparsed;
@@ -136,6 +136,26 @@ subtest 'Hash composer with list of fat arrows works correctly' => {
     );
     is-deeply $deparsed, '{x => 11, y => 22}', 'deparsed';
     is-deeply $_, {:11x, :22y}, @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'Parenthesized single statement keeps its modifier' => {
+    # (42 if 1)
+    ast RakuAST::Circumfix::Parentheses.new(
+      RakuAST::SemiList.new(
+        RakuAST::Statement::Expression.new(
+          expression => RakuAST::IntLiteral.new(42),
+          condition-modifier => RakuAST::StatementModifier::If.new(
+            RakuAST::Statement::Expression.new(
+              expression => RakuAST::IntLiteral.new(1)
+            )
+          )
+        )
+      )
+    );
+
+    is-deeply $deparsed, '(42 if 1)', 'deparse';
+    is-deeply $_, 42, @type[$++]
       for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
 }
 

--- a/t/12-rakuast/name.rakutest
+++ b/t/12-rakuast/name.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 4;
+plan 6;
 
 subtest "name from identifier" => {
     $_ := RakuAST::Name.from-identifier('foo');
@@ -69,6 +69,38 @@ RakuAST::Name.new(
   )
 )
 CODE
+}
+
+subtest "name from identifier parts with colonpairs" => {
+    $_ := RakuAST::Name.from-identifier-parts('Foo','Bar',
+      colonpairs => (RakuAST::ColonPair::True.new('x'),)
+    );
+    is-deeply .colonpairs.elems, 1, 'Has one colonpair';
+    is-deeply .DEPARSE, 'Foo::Bar:x', 'deparses in an expected way';
+    is-deeply .raku, q:to/CODE/.chomp, "rakufies in an expected way";
+RakuAST::Name.from-identifier-parts("Foo","Bar", colonpairs => (
+  RakuAST::ColonPair::True.new("x"),
+))
+CODE
+    is-deeply EVAL("use experimental :rakuast; " ~ .raku).DEPARSE, .DEPARSE, 'round trips through .raku';
+}
+
+subtest "name from colonpairs only" => {
+    $_ := RakuAST::Name.new(
+      colonpairs => (RakuAST::ColonPair::True.new('x'),)
+    );
+    is-deeply .parts.elems, 0, 'Has no parts';
+    is-deeply .colonpairs.elems, 1, 'Has one colonpair';
+    is-deeply .raku, q:to/CODE/.chomp, "rakufies in an expected way";
+RakuAST::Name.new(
+  colonpairs => (
+    RakuAST::ColonPair::True.new("x"),
+  )
+)
+CODE
+    is-deeply EVAL("use experimental :rakuast; " ~ .raku).colonpairs.elems, 1, 'round trips through .raku';
+    .add-colonpair(RakuAST::ColonPair::True.new('y'));
+    is-deeply .colonpairs.elems, 2, 'a colonpair can still be added';
 }
 
 # vim: expandtab shiftwidth=4

--- a/t/12-rakuast/operators.rakutest
+++ b/t/12-rakuast/operators.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 31;
+plan 33;
 
 my $ast;
 my $deparsed;
@@ -447,6 +447,60 @@ for
             @b.splice;
         }
     }
+}
+
+subtest 'Declaration as a list infix operand in a statement list' => {
+    # my $x = 1, 2; $x
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::ApplyListInfix.new(
+          infix => RakuAST::Infix.new(','),
+          operands => (
+            RakuAST::VarDeclaration::Simple.new(
+              sigil       => '$',
+              desigilname => RakuAST::Name.from-identifier('x'),
+              initializer => RakuAST::Initializer::Assign.new(
+                RakuAST::IntLiteral.new(1)
+              )
+            ),
+            RakuAST::IntLiteral.new(2)
+          )
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Var::Lexical.new('$x')
+      )
+    );
+
+    is-deeply $deparsed, "my \$x = 1, 2;\n\$x\n", 'deparse';
+    is-deeply $_, 1, @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'Declaration as an infix operand in a statement list' => {
+    # my $x = 1 and 2; $x
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::ApplyInfix.new(
+          left => RakuAST::VarDeclaration::Simple.new(
+            sigil       => '$',
+            desigilname => RakuAST::Name.from-identifier('x'),
+            initializer => RakuAST::Initializer::Assign.new(
+              RakuAST::IntLiteral.new(1)
+            )
+          ),
+          infix => RakuAST::Infix.new('and'),
+          right => RakuAST::IntLiteral.new(2)
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Var::Lexical.new('$x')
+      )
+    );
+
+    is-deeply $deparsed, "my \$x = 1 and 2;\n\$x\n", 'deparse';
+    is-deeply $_, 1, @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
 }
 
 # vim: expandtab shiftwidth=4

--- a/t/12-rakuast/operators.rakutest
+++ b/t/12-rakuast/operators.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 30;
+plan 31;
 
 my $ast;
 my $deparsed;
@@ -187,6 +187,22 @@ subtest 'Application of a list infix operator on three operands' => {
 
     is-deeply $deparsed, '10, 11, 12', 'deparse';
     is-deeply $_, (10, 11, 12), @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'Application of a word list infix operator on three operands' => {
+    # 10 min 11 min 12
+    ast RakuAST::ApplyListInfix.new(
+      infix => RakuAST::Infix.new('min'),
+      operands => (
+        RakuAST::IntLiteral.new(10),
+        RakuAST::IntLiteral.new(11),
+        RakuAST::IntLiteral.new(12),
+      )
+    );
+
+    is-deeply $deparsed, '10 min 11 min 12', 'deparse';
+    is-deeply $_, 10, @type[$++]
       for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
 }
 

--- a/t/12-rakuast/pair.rakutest
+++ b/t/12-rakuast/pair.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 8;
+plan 11;
 
 my $ast;
 my $deparsed;
@@ -99,6 +99,53 @@ subtest 'Value colonpair forms a Pair with the correct value (3)' => {
 
     is-deeply $deparsed, ':cheese<cheddar limburg>', 'deparse';
     is-deeply $_, Pair.new('cheese', <cheddar limburg>), @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'Value colonpair with a parenthesized value' => {
+    # :cheese(42)
+    ast RakuAST::ColonPair::Value.new(
+      key => 'cheese',
+      value => RakuAST::Circumfix::Parentheses.new(
+        RakuAST::SemiList.new(
+          RakuAST::Statement::Expression.new(
+            expression => RakuAST::IntLiteral.new(42)
+          )
+        )
+      )
+    );
+
+    is-deeply $deparsed, ':cheese(42)', 'deparse';
+    is-deeply $_, Pair.new('cheese', 42), @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'Value colonpair with a plain quoted string value' => {
+    # :cheese("brie")
+    ast RakuAST::ColonPair::Value.new(
+      key => 'cheese',
+      value => RakuAST::QuotedString.new(
+        segments => [RakuAST::StrLiteral.new('brie')]
+      )
+    );
+
+    is-deeply $deparsed, ':cheese("brie")', 'deparse';
+    is-deeply $_, Pair.new('cheese', 'brie'), @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'Value colonpair with a quoted string value without brackets' => {
+    # :cheese(qqw/brie gouda/)
+    ast RakuAST::ColonPair::Value.new(
+      key => 'cheese',
+      value => RakuAST::QuotedString.new(
+        segments => [RakuAST::StrLiteral.new('brie gouda')],
+        processors => ("words",)
+      )
+    );
+
+    is-deeply $deparsed, ':cheese(qqw/brie gouda/)', 'deparse';
+    is-deeply $_, Pair.new('cheese', ('brie', 'gouda')), @type[$++]
       for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
 }
 

--- a/t/12-rakuast/postfix.rakutest
+++ b/t/12-rakuast/postfix.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 30;
+plan 32;
 
 my $ast;
 my $deparsed;
@@ -674,6 +674,55 @@ $v
 CODE
     is-deeply $_, 1, @type[$++]
       for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'Array index with an assignee' => {
+    my @a;
+
+    # @a[0] = 42
+    ast RakuAST::ApplyPostfix.new(
+      operand => RakuAST::Var::Lexical.new('@a'),
+      postfix => RakuAST::Postcircumfix::ArrayIndex.new(
+        index => RakuAST::SemiList.new(
+          RakuAST::Statement::Expression.new(
+            expression => RakuAST::IntLiteral.new(0)
+          )
+        ),
+        assignee => RakuAST::IntLiteral.new(42)
+      )
+    );
+    is-deeply $deparsed, '@a[0] = 42', 'deparse';
+
+    for 'AST', $ast, 'Str', $deparsed, 'Raku', EVAL($raku) -> $type, $it {
+        @a = ();
+
+        is-deeply EVAL($it), 42, "$type: did we get the assigned value";
+        is-deeply @a[0], 42, "$type: was the element assigned";
+    }
+}
+
+subtest 'Literal hash index with an assignee' => {
+    my %h;
+
+    # %h<a> = 42
+    ast RakuAST::ApplyPostfix.new(
+      operand => RakuAST::Var::Lexical.new('%h'),
+      postfix => RakuAST::Postcircumfix::LiteralHashIndex.new(
+        index => RakuAST::QuotedString.new(
+          segments => [RakuAST::StrLiteral.new('a')],
+          processors => ['words','val']
+        ),
+        assignee => RakuAST::IntLiteral.new(42)
+      )
+    );
+    is-deeply $deparsed, '%h<a> = 42', 'deparse';
+
+    for 'AST', $ast, 'Str', $deparsed, 'Raku', EVAL($raku) -> $type, $it {
+        %h = ();
+
+        is-deeply EVAL($it), 42, "$type: did we get the assigned value";
+        is-deeply %h<a>, 42, "$type: was the element assigned";
+    }
 }
 
 # vim: expandtab shiftwidth=4

--- a/t/12-rakuast/postfix.rakutest
+++ b/t/12-rakuast/postfix.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 20;
+plan 30;
 
 my $ast;
 my $deparsed;
@@ -427,6 +427,252 @@ subtest 'Multi-dimensional hash indexing with colonpairs' => {
 
     is-deeply $deparsed, '%h{"y"; "a"}:v', 'deparse';
     is-deeply $_, 3, @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'Postfix on a parenthesized prefix application' => {
+    # (-1).abs
+    ast RakuAST::ApplyPostfix.new(
+      operand => RakuAST::ApplyPrefix.new(
+        prefix  => RakuAST::Prefix.new('-'),
+        operand => RakuAST::IntLiteral.new(1)
+      ),
+      postfix => RakuAST::Call::Method.new(
+        name => RakuAST::Name.from-identifier('abs')
+      )
+    );
+    is-deeply $deparsed, '(-1).abs', 'deparse';
+    is-deeply $_, 1, @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'Postfix on a parenthesized ternary' => {
+    # (True ?? 2 !! 3).succ
+    ast RakuAST::ApplyPostfix.new(
+      operand => RakuAST::Ternary.new(
+        condition => RakuAST::Term::Name.new(RakuAST::Name.from-identifier('True')),
+        then      => RakuAST::IntLiteral.new(2),
+        else      => RakuAST::IntLiteral.new(3)
+      ),
+      postfix => RakuAST::Call::Method.new(
+        name => RakuAST::Name.from-identifier('succ')
+      )
+    );
+    is-deeply $deparsed, '(True ?? 2 !! 3).succ', 'deparse';
+    is-deeply $_, 3, @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'Postfix on a parenthesized declaration in a statement list' => {
+    # (my $x = 41).succ; $x
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::ApplyPostfix.new(
+          operand => RakuAST::VarDeclaration::Simple.new(
+            sigil       => '$',
+            desigilname => RakuAST::Name.from-identifier('x'),
+            initializer => RakuAST::Initializer::Assign.new(
+              RakuAST::IntLiteral.new(41)
+            )
+          ),
+          postfix => RakuAST::Call::Method.new(
+            name => RakuAST::Name.from-identifier('succ')
+          )
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Var::Lexical.new('$x')
+      )
+    );
+    is-deeply $deparsed, q:to/CODE/, 'deparse';
+(my $x = 41).succ;
+$x
+CODE
+    is-deeply $_, 41, @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'Postfix on a parenthesized call without parentheses' => {
+    # (min 1, 5).succ
+    ast RakuAST::ApplyPostfix.new(
+      operand => RakuAST::Call::Name::WithoutParentheses.new(
+        name => RakuAST::Name.from-identifier('min'),
+        args => RakuAST::ArgList.new(
+          RakuAST::IntLiteral.new(1),
+          RakuAST::IntLiteral.new(5)
+        )
+      ),
+      postfix => RakuAST::Call::Method.new(
+        name => RakuAST::Name.from-identifier('succ')
+      )
+    );
+    is-deeply $deparsed, '(min 1, 5).succ', 'deparse';
+    is-deeply $_, 2, @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'Postfix on a parenthesized reduction' => {
+    # ([*] 2, 3).succ
+    ast RakuAST::ApplyPostfix.new(
+      operand => RakuAST::Term::Reduce.new(
+        infix => RakuAST::Infix.new('*'),
+        args  => RakuAST::ArgList.new(
+          RakuAST::IntLiteral.new(2),
+          RakuAST::IntLiteral.new(3)
+        )
+      ),
+      postfix => RakuAST::Call::Method.new(
+        name => RakuAST::Name.from-identifier('succ')
+      )
+    );
+    is-deeply $deparsed, '([*] 2, 3).succ', 'deparse';
+    is-deeply $_, 7, @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'Postfix on a parenthesized statement prefix' => {
+    # (do 40, 1).elems
+    ast RakuAST::ApplyPostfix.new(
+      operand => RakuAST::StatementPrefix::Do.new(
+        RakuAST::ApplyListInfix.new(
+          infix    => RakuAST::Infix.new(','),
+          operands => (
+            RakuAST::IntLiteral.new(40),
+            RakuAST::IntLiteral.new(1)
+          )
+        )
+      ),
+      postfix => RakuAST::Call::Method.new(
+        name => RakuAST::Name.from-identifier('elems')
+      )
+    );
+    is-deeply $deparsed, '(do 40, 1).elems', 'deparse';
+    is-deeply $_, 2, @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'Postfix on a parenthesized fat arrow pair' => {
+    # (a => 1).key
+    ast RakuAST::ApplyPostfix.new(
+      operand => RakuAST::FatArrow.new(
+        key   => 'a',
+        value => RakuAST::IntLiteral.new(1)
+      ),
+      postfix => RakuAST::Call::Method.new(
+        name => RakuAST::Name.from-identifier('key')
+      )
+    );
+    is-deeply $deparsed, '(a => 1).key', 'deparse';
+    is-deeply $_, 'a', @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'Postfix on a parenthesized sigilless declaration in a statement list' => {
+    # (my \x = 41).succ; x
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::ApplyPostfix.new(
+          operand => RakuAST::VarDeclaration::Term.new(
+            name        => RakuAST::Name.from-identifier('x'),
+            initializer => RakuAST::Initializer::Assign.new(
+              RakuAST::IntLiteral.new(41)
+            )
+          ),
+          postfix => RakuAST::Call::Method.new(
+            name => RakuAST::Name.from-identifier('succ')
+          )
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Term::Name.new(RakuAST::Name.from-identifier('x'))
+      )
+    );
+    is-deeply $deparsed, q:to/CODE/, 'deparse';
+(my \x = 41).succ;
+x
+CODE
+    is-deeply $_, 41, @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'Postfix on a parenthesized block' => {
+    # ({ $_ + 1 })(41)
+    ast RakuAST::ApplyPostfix.new(
+      operand => RakuAST::Block.new(
+        body => RakuAST::Blockoid.new(
+          RakuAST::StatementList.new(
+            RakuAST::Statement::Expression.new(
+              expression => RakuAST::ApplyInfix.new(
+                left  => RakuAST::Var::Lexical.new('$_'),
+                infix => RakuAST::Infix.new('+'),
+                right => RakuAST::IntLiteral.new(1)
+              )
+            )
+          )
+        )
+      ),
+      postfix => RakuAST::Call::Term.new(
+        args => RakuAST::ArgList.new(RakuAST::IntLiteral.new(41))
+      )
+    );
+    is-deeply $deparsed, q:to/CODE/.chomp, 'deparse';
+({
+    $_ + 1
+})(41)
+CODE
+    is-deeply $_, 42, @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'Declaration inside a subscript in a statement list' => {
+    # my %h = a => 1; my $v = %h{my $k = "a"}; $v
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::VarDeclaration::Simple.new(
+          sigil       => '%',
+          desigilname => RakuAST::Name.from-identifier('h'),
+          initializer => RakuAST::Initializer::Assign.new(
+            RakuAST::FatArrow.new(
+              key   => 'a',
+              value => RakuAST::IntLiteral.new(1)
+            )
+          )
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::VarDeclaration::Simple.new(
+          sigil       => '$',
+          desigilname => RakuAST::Name.from-identifier('v'),
+          initializer => RakuAST::Initializer::Assign.new(
+            RakuAST::ApplyPostfix.new(
+              operand => RakuAST::Var::Lexical.new('%h'),
+              postfix => RakuAST::Postcircumfix::HashIndex.new(
+                index => RakuAST::SemiList.new(
+                  RakuAST::Statement::Expression.new(
+                    expression => RakuAST::VarDeclaration::Simple.new(
+                      sigil       => '$',
+                      desigilname => RakuAST::Name.from-identifier('k'),
+                      initializer => RakuAST::Initializer::Assign.new(
+                        RakuAST::StrLiteral.new('a')
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Var::Lexical.new('$v')
+      )
+    );
+    is-deeply $deparsed, q:to/CODE/, 'deparse';
+my %h = a => 1;
+my $v = %h{my $k = "a"};
+$v
+CODE
+    is-deeply $_, 1, @type[$++]
       for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
 }
 

--- a/t/12-rakuast/regex-assertion.rakutest
+++ b/t/12-rakuast/regex-assertion.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 27;
+plan 28;
 
 my $ast;
 my $deparsed;
@@ -218,6 +218,29 @@ subtest 'Negated character class enumeration assertion works' => {
     );
     is-deeply $deparsed, '/<-[a \d c..f]>/', 'deparse';
     match-ok "fooa9cbar", 'o';
+}
+
+subtest 'Character class enumeration with characters needing an escape' => {
+    # /<+[\] \\ \- \  \!..\/]>+/
+    ast RakuAST::Regex::QuantifiedAtom.new(
+      atom => RakuAST::Regex::Assertion::CharClass.new(
+        RakuAST::Regex::CharClassElement::Enumeration.new(
+          elements => [
+            RakuAST::Regex::CharClassEnumerationElement::Character.new("]"),
+            RakuAST::Regex::CharClassEnumerationElement::Character.new("\\"),
+            RakuAST::Regex::CharClassEnumerationElement::Character.new("-"),
+            RakuAST::Regex::CharClassEnumerationElement::Character.new(" "),
+            RakuAST::Regex::CharClassEnumerationElement::Range.new(
+              from => "!".ord,
+              to   => "/".ord
+            )
+          ]
+        )
+      ),
+      quantifier => RakuAST::Regex::Quantifier::OneOrMore.new
+    );
+    is-deeply $deparsed, Q|/<+[\] \\ \- \  \!..\/]>+/|, 'deparse';
+    match-ok "abc]\\- !/x", Q|]\- !/|;
 }
 
 subtest 'Character property assertion works' => {

--- a/t/12-rakuast/regex-declaration.rakutest
+++ b/t/12-rakuast/regex-declaration.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 3;
+plan 5;
 
 my $ast;
 my $deparsed;
@@ -79,6 +79,40 @@ subtest 'Simple rule declaration' => {
           "$type: did we get match for 'aaaa  '";
         is-deeply "aaaa" ~~ /^ <$rule> a $/, Nil,
           "$type: did it not match";
+    }
+}
+
+subtest 'Proto token declaration' => {
+    # my proto token digits {*}
+    ast RakuAST::TokenDeclaration.new(
+      scope     => "my",
+      multiness => "proto",
+      name      => RakuAST::Name.from-identifier("digits"),
+      body      => RakuAST::OnlyStar.new
+    );
+    is-deeply $deparsed, 'my proto token digits {*}', 'deparse';
+
+    for 'AST', $ast, 'Str', $deparsed, 'Raku', EVAL($raku) -> $type, $it {
+        my $token := EVAL($it);
+        is $token.name, 'digits', "$type: is the name ok";
+        ok $token.is_dispatcher, "$type: is it a proto";
+    }
+}
+
+subtest 'Multi token declaration' => {
+    # my multi token aplus { a+ }
+    ast RakuAST::TokenDeclaration.new(
+      scope     => "my",
+      multiness => "multi",
+      name      => RakuAST::Name.from-identifier("aplus"),
+      body      => $body
+    );
+    is-deeply $deparsed, 'my multi token aplus { a+ }', 'deparse';
+    is EVAL($raku).multiness, 'multi', 'Raku: is the multiness kept';
+
+    for 'AST', $ast, 'Str', $deparsed, 'Raku', EVAL($raku) -> $type, $it {
+        my $token := EVAL($it);
+        is "aaaa" ~~ /^ <$token> $/, 'aaaa', "$type: did we get match";
     }
 }
 

--- a/t/12-rakuast/regex-declaration.rakutest
+++ b/t/12-rakuast/regex-declaration.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 5;
+plan 6;
 
 my $ast;
 my $deparsed;
@@ -113,6 +113,32 @@ subtest 'Multi token declaration' => {
     for 'AST', $ast, 'Str', $deparsed, 'Raku', EVAL($raku) -> $type, $it {
         my $token := EVAL($it);
         is "aaaa" ~~ /^ <$token> $/, 'aaaa', "$type: did we get match";
+    }
+}
+
+subtest 'Token declaration with a sym colonpair' => {
+    # my token t:sym<a> { a+ }
+    ast RakuAST::TokenDeclaration.new(
+      scope => "my",
+      name  => RakuAST::Name.from-identifier("t",
+        colonpairs => (
+          RakuAST::ColonPair::Value.new(
+            key   => "sym",
+            value => RakuAST::QuotedString.new(
+              segments   => [RakuAST::StrLiteral.new("a")],
+              processors => <words val>
+            )
+          ),
+        )
+      ),
+      body  => $body
+    );
+    is-deeply $deparsed, 'my token t:sym<a> { a+ }', 'deparse';
+    is EVAL($raku).name.colonpairs.elems, 1, 'Raku: is the colonpair kept';
+    is-deeply EVAL($raku).DEPARSE, $deparsed, 'Raku: does the round trip deparse the same';
+
+    for 'AST', $ast, 'Str', $deparsed, 'Raku', EVAL($raku) -> $type, $it {
+        is "aaa" ~~ EVAL($it), 'aaa', "$type: did we get match";
     }
 }
 

--- a/t/12-rakuast/regex-substitution.rakutest
+++ b/t/12-rakuast/regex-substitution.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 7;
+plan 8;
 
 my $ast;
 my $deparsed;
@@ -188,6 +188,24 @@ CODE
         is EVAL($it).gist, '｢o｣', "$type: did we get right return value";
         is $/.gist, '｢o｣', "$type: did it set \$/ correctly";
         is $string, "fxo", "$type: is the result correct";
+    }
+}
+
+subtest 'Substitution with the delimiter in both sides' => {
+    # s/"a\/b"/x\/y/;
+    ast RakuAST::Substitution.new(
+      pattern     => RakuAST::Regex::Literal.new("a/b"),
+      replacement => RakuAST::QuotedString.new(
+        segments => [RakuAST::StrLiteral.new("x/y")]
+      ),
+    );
+    is-deeply $deparsed, 's/"a\/b"/x\/y/', 'deparse';
+
+    for 'AST', $ast, 'Str', $deparsed, 'Raku', EVAL($raku) -> $type, $it {
+        $_ = "a/b";
+
+        is-deeply EVAL($it).gist, '｢a/b｣', "$type: did we get right return value";
+        is $_, "x/y", "$type: is topic changed";
     }
 }
 

--- a/t/12-rakuast/regex-transliteration.rakutest
+++ b/t/12-rakuast/regex-transliteration.rakutest
@@ -1,0 +1,101 @@
+use v6.e.PREVIEW;
+use Test;
+
+plan 4;
+
+my $ast;
+my $deparsed;
+my $raku;
+sub ast(RakuAST::Node:D $node --> Nil) {
+    $ast      := $node;
+    $deparsed := $ast.DEPARSE;
+    $raku     := 'use experimental :rakuast; ' ~ $ast.raku;
+    diag $deparsed.chomp;
+}
+
+subtest 'Simple transliteration on topic' => {
+    # tr/a..c/x..z/;
+    ast RakuAST::Transliteration.new(
+      left  => RakuAST::QuotedString.new(
+        segments => [RakuAST::StrLiteral.new("a..c")]
+      ),
+      right => RakuAST::QuotedString.new(
+        segments => [RakuAST::StrLiteral.new("x..z")]
+      ),
+      :destructive
+    );
+    is-deeply $deparsed, 'tr/a..c/x..z/', 'deparse';
+
+    for 'AST', $ast, 'Str', $deparsed, 'Raku', EVAL($raku) -> $type, $it {
+        $_ = "abcd";
+
+        isa-ok EVAL($it), StrDistance, "$type: did we get a StrDistance";
+        is $_, "xyzd", "$type: is topic changed";
+    }
+}
+
+subtest 'Simple non-destructive transliteration on topic' => {
+    # TR/a..c/x..z/;
+    ast RakuAST::Transliteration.new(
+      left  => RakuAST::QuotedString.new(
+        segments => [RakuAST::StrLiteral.new("a..c")]
+      ),
+      right => RakuAST::QuotedString.new(
+        segments => [RakuAST::StrLiteral.new("x..z")]
+      ),
+      :!destructive
+    );
+    is-deeply $deparsed, 'TR/a..c/x..z/', 'deparse';
+
+    for 'AST', $ast, 'Str', $deparsed, 'Raku', EVAL($raku) -> $type, $it {
+        $_ = "abcd";
+
+        is-deeply EVAL($it), "xyzd", "$type: did we get right return value";
+        is $_, "abcd", "$type: is topic unchanged";
+    }
+}
+
+subtest 'Transliteration with an adverb' => {
+    # tr:d/a..c/x/;
+    ast RakuAST::Transliteration.new(
+      left  => RakuAST::QuotedString.new(
+        segments => [RakuAST::StrLiteral.new("a..c")]
+      ),
+      right => RakuAST::QuotedString.new(
+        segments => [RakuAST::StrLiteral.new("x")]
+      ),
+      adverbs => [RakuAST::ColonPair::True.new("d")],
+      :destructive
+    );
+    is-deeply $deparsed, 'tr:d/a..c/x/', 'deparse';
+
+    for 'AST', $ast, 'Str', $deparsed, 'Raku', EVAL($raku) -> $type, $it {
+        $_ = "abcd";
+
+        isa-ok EVAL($it), StrDistance, "$type: did we get a StrDistance";
+        is $_, "xd", "$type: is topic changed with unmatched characters deleted";
+    }
+}
+
+subtest 'Transliteration with the delimiter in a side' => {
+    # tr/a\/b/x/;
+    ast RakuAST::Transliteration.new(
+      left  => RakuAST::QuotedString.new(
+        segments => [RakuAST::StrLiteral.new("a/b")]
+      ),
+      right => RakuAST::QuotedString.new(
+        segments => [RakuAST::StrLiteral.new("x")]
+      ),
+      :destructive
+    );
+    is-deeply $deparsed, 'tr/a\/b/x/', 'deparse';
+
+    for 'AST', $ast, 'Str', $deparsed, 'Raku', EVAL($raku) -> $type, $it {
+        $_ = "a/b";
+
+        isa-ok EVAL($it), StrDistance, "$type: did we get a StrDistance";
+        is $_, "xxx", "$type: is the delimiter transliterated as well";
+    }
+}
+
+# vim: expandtab shiftwidth=4

--- a/t/12-rakuast/regex.rakutest
+++ b/t/12-rakuast/regex.rakutest
@@ -2,7 +2,7 @@ use v6.e.PREVIEW;
 use nqp;
 use Test;
 
-plan 56;
+plan 58;
 
 my $ast;
 my $deparsed;
@@ -772,6 +772,45 @@ subtest 'Match with a dba name' => {
     todo('the legacy frontend breaks matching on :dba', 1)
         unless nqp::gethllsym('Raku', 'COMPILER-FRONTEND') eq 'rakuast';
     match-ok "42", '42';
+}
+
+subtest 'Goal matching' => {
+    # /"(" ~ ")" \d+/
+    ast RakuAST::Regex::Sequence.new(
+      RakuAST::Regex::WithWhitespace.new(
+        RakuAST::Regex::Literal.new("(")
+      ),
+      RakuAST::Regex::Nested.new(
+        RakuAST::Regex::WithWhitespace.new(
+          RakuAST::Regex::Literal.new(")")
+        ),
+        RakuAST::Regex::QuantifiedAtom.new(
+          atom       => RakuAST::Regex::CharClass::Digit.new,
+          quantifier => RakuAST::Regex::Quantifier::OneOrMore.new
+        )
+      )
+    );
+    is-deeply $deparsed, '/"(" ~ ")" \d+/', 'deparse';
+
+    match-ok "foo(42)bar", '(42)';
+    match-nok "foo(42bar";
+}
+
+subtest 'Goal matching with a goal that has no trailing whitespace' => {
+    # /"("~ ")" \d+/
+    ast RakuAST::Regex::Sequence.new(
+      RakuAST::Regex::Literal.new("("),
+      RakuAST::Regex::Nested.new(
+        RakuAST::Regex::Literal.new(")"),
+        RakuAST::Regex::QuantifiedAtom.new(
+          atom       => RakuAST::Regex::CharClass::Digit.new,
+          quantifier => RakuAST::Regex::Quantifier::OneOrMore.new
+        )
+      )
+    );
+    is-deeply $deparsed, '/"("~ ")" \d+/', 'deparse';
+
+    match-ok "foo(42)bar", '(42)';
 }
 
 # vim: expandtab shiftwidth=4

--- a/t/12-rakuast/statement-phaser.rakutest
+++ b/t/12-rakuast/statement-phaser.rakutest
@@ -1040,7 +1040,7 @@ while $guard {
     $result = FIRST {
         is-deeply($run, 0, "inside FIRST");
         $guard = False
-    }
+    };
     ++$run
 }
 CODE
@@ -1134,7 +1134,7 @@ sub s {
     $guard = FIRST {
         is-deeply($run, 0, "in FIRST");
         $guard + 1
-    }
+    };
     $run++
 }
 s() xx 3

--- a/t/12-rakuast/statement-prefix.rakutest
+++ b/t/12-rakuast/statement-prefix.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 18;
+plan 21;
 
 my $ast;
 my $deparsed;
@@ -631,6 +631,84 @@ CODE
         is-deeply EVAL($it), Nil, "$type: is the result Nil";
         is-deeply $a, 42, "$type: did the code get run";
     }
+}
+
+subtest 'A statement prefix over a statement emits one delimiter' => {
+    # try 42; 666
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::StatementPrefix::Try.new(
+          RakuAST::Statement::Expression.new(
+            expression => RakuAST::IntLiteral.new(42)
+          )
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::IntLiteral.new(666)
+      )
+    );
+
+    is-deeply $deparsed, "try 42;\n666\n", 'deparse';
+    is-deeply $_, 666, @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'A statement prefix over a heredoc keeps the body intact' => {
+    # my $x = do q:to/END/; hi END; $x
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::VarDeclaration::Simple.new(
+          sigil       => '$',
+          desigilname => RakuAST::Name.from-identifier('x'),
+          initializer => RakuAST::Initializer::Assign.new(
+            RakuAST::StatementPrefix::Do.new(
+              RakuAST::Statement::Expression.new(
+                expression => RakuAST::Heredoc.new(
+                  :segments[RakuAST::StrLiteral.new("hi\n")],
+                  :stop("END\n")
+                )
+              )
+            )
+          )
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Var::Lexical.new('$x')
+      )
+    );
+
+    is-deeply $deparsed, "my \$x = do qq:to/END/\nhi\nEND\n;\n\$x\n", 'deparse';
+    is-deeply $_, "hi\n", @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'A statement prefix over a for loop drops the delimiter' => {
+    # do for 1 { 42 }; 666
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::StatementPrefix::Do.new(
+          RakuAST::Statement::For.new(
+            source => RakuAST::IntLiteral.new(1),
+            body   => RakuAST::Block.new(
+              body => RakuAST::Blockoid.new(
+                RakuAST::StatementList.new(
+                  RakuAST::Statement::Expression.new(
+                    expression => RakuAST::IntLiteral.new(42)
+                  )
+                )
+              )
+            )
+          )
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::IntLiteral.new(666)
+      )
+    );
+
+    is-deeply $deparsed, "do for 1 \{\n    42\n}\n666\n", 'deparse';
+    is-deeply $_, 666, @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
 }
 
 # vim: expandtab shiftwidth=4

--- a/t/12-rakuast/statement.rakutest
+++ b/t/12-rakuast/statement.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 33; # Do not change this file to done-testing
+plan 37; # Do not change this file to done-testing
 
 my $ast;
 my $deparsed;
@@ -49,6 +49,54 @@ CODE
         is $y, $expected,
           "$type: Second side-effecting statement was executed";
         ++$expected;
+    }
+}
+
+subtest 'Statement list keeps the delimiter after a trailing brace' => {
+    # my %h = a => 1; my $x = %h{"a"}; $x
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::VarDeclaration::Simple.new(
+          sigil       => '%',
+          desigilname => RakuAST::Name.from-identifier('h'),
+          initializer => RakuAST::Initializer::Assign.new(
+            RakuAST::FatArrow.new(
+              key   => 'a',
+              value => RakuAST::IntLiteral.new(1)
+            )
+          )
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::VarDeclaration::Simple.new(
+          sigil       => '$',
+          desigilname => RakuAST::Name.from-identifier('x'),
+          initializer => RakuAST::Initializer::Assign.new(
+            RakuAST::ApplyPostfix.new(
+              operand => RakuAST::Var::Lexical.new('%h'),
+              postfix => RakuAST::Postcircumfix::HashIndex.new(
+                index => RakuAST::SemiList.new(
+                  RakuAST::Statement::Expression.new(
+                    expression => RakuAST::StrLiteral.new('a')
+                  )
+                )
+              )
+            )
+          )
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Var::Lexical.new('$x')
+      )
+    );
+    is-deeply $deparsed, q:to/CODE/, 'deparse';
+my %h = a => 1;
+my $x = %h{"a"};
+$x
+CODE
+
+    for 'AST', $ast, 'Str', $deparsed, 'Raku', EVAL($raku) -> $type, $it {
+        is-deeply EVAL($it), 1, "$type: the index is evaluated";
     }
 }
 
@@ -1160,6 +1208,115 @@ CODE
     for 'AST', $ast, 'Str', $deparsed, 'Raku', EVAL($raku) -> $type, $it {
         is-deeply EVAL($it), True, "$type: did eval work";
     }
+}
+
+subtest 'A statement prefix over an expression keeps the delimiter' => {
+    my %h = a => 1;
+
+    # do %h{"a"}; 42
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::StatementPrefix::Do.new(
+          RakuAST::Statement::Expression.new(
+            expression => RakuAST::ApplyPostfix.new(
+              operand => RakuAST::Var::Lexical.new('%h'),
+              postfix => RakuAST::Postcircumfix::HashIndex.new(
+                index => RakuAST::SemiList.new(
+                  RakuAST::Statement::Expression.new(
+                    expression => RakuAST::StrLiteral.new('a')
+                  )
+                )
+              )
+            )
+          )
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::IntLiteral.new(42)
+      )
+    );
+    is-deeply $deparsed, q:to/CODE/, 'deparse';
+do %h{"a"};
+42
+CODE
+    is-deeply $_, 42, @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'A block statement with a modifier keeps the delimiter' => {
+    my %h = a => 1;
+
+    # do { 1 } if %h{"a"}; 42
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::StatementPrefix::Do.new(
+          RakuAST::Block.new(
+            body => RakuAST::Blockoid.new(
+              RakuAST::StatementList.new(
+                RakuAST::Statement::Expression.new(
+                  expression => RakuAST::IntLiteral.new(1)
+                )
+              )
+            )
+          )
+        ),
+        condition-modifier => RakuAST::StatementModifier::If.new(
+          RakuAST::Statement::Expression.new(
+            expression => RakuAST::ApplyPostfix.new(
+              operand => RakuAST::Var::Lexical.new('%h'),
+              postfix => RakuAST::Postcircumfix::HashIndex.new(
+                index => RakuAST::SemiList.new(
+                  RakuAST::Statement::Expression.new(
+                    expression => RakuAST::StrLiteral.new('a')
+                  )
+                )
+              )
+            )
+          )
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::IntLiteral.new(42)
+      )
+    );
+    is-deeply $deparsed, q:to/CODE/, 'deparse';
+do {
+    1
+} if %h{"a"};
+42
+CODE
+    is-deeply $_, 42, @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'A statement prefix over a block drops the delimiter' => {
+    # do { 1 }; 42
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::StatementPrefix::Do.new(
+          RakuAST::Block.new(
+            body => RakuAST::Blockoid.new(
+              RakuAST::StatementList.new(
+                RakuAST::Statement::Expression.new(
+                  expression => RakuAST::IntLiteral.new(1)
+                )
+              )
+            )
+          )
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::IntLiteral.new(42)
+      )
+    );
+    is-deeply $deparsed, q:to/CODE/, 'deparse';
+do {
+    1
+}
+42
+CODE
+    is-deeply $_, 42, @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
 }
 
 subtest 'loop with only a condition and an increment' => {

--- a/t/12-rakuast/statement.rakutest
+++ b/t/12-rakuast/statement.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 29; # Do not change this file to done-testing
+plan 33; # Do not change this file to done-testing
 
 my $ast;
 my $deparsed;
@@ -723,6 +723,55 @@ CODE
     }
 }
 
+subtest 'loop with a declaration in its setup inside a statement list' => {
+    my $count;
+
+    # loop (my $i = 9; $i; --$i) { ++$count }; $count
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Loop.new(
+        setup => RakuAST::VarDeclaration::Simple.new(
+          sigil => '$',
+          desigilname => RakuAST::Name.from-identifier('i'),
+          initializer => RakuAST::Initializer::Assign.new(
+            RakuAST::IntLiteral.new(9)
+          )
+        ),
+        condition => RakuAST::Var::Lexical.new('$i'),
+        increment => RakuAST::ApplyPrefix.new(
+          prefix => RakuAST::Prefix.new('--'),
+          operand => RakuAST::Var::Lexical.new('$i')
+        ),
+        body => RakuAST::Block.new(
+          body => RakuAST::Blockoid.new(
+            RakuAST::StatementList.new(
+              RakuAST::Statement::Expression.new(
+                expression => RakuAST::ApplyPrefix.new(
+                  prefix => RakuAST::Prefix.new('++'),
+                  operand => RakuAST::Var::Lexical.new('$count')
+                )
+              )
+            )
+          )
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Var::Lexical.new('$count')
+      )
+    );
+    is-deeply $deparsed, q:to/CODE/, 'deparse';
+loop (my $i = 9; $i; --$i) {
+    ++$count
+}
+$count
+CODE
+
+    for 'AST', $ast, 'Str', $deparsed, 'Raku', EVAL($raku) -> $type, $it {
+        $count = 0;
+
+        is-deeply EVAL($it), 9, "$type: loop ran as expected";
+    }
+}
+
 subtest 'Statement level for loop' => {
     my $count;
 
@@ -1110,6 +1159,158 @@ CODE
 
     for 'AST', $ast, 'Str', $deparsed, 'Raku', EVAL($raku) -> $type, $it {
         is-deeply EVAL($it), True, "$type: did eval work";
+    }
+}
+
+subtest 'loop with only a condition and an increment' => {
+    my $i;
+    my $count;
+
+    # loop (; $i < 3; $i++) { last if ++$count > 3 }
+    ast RakuAST::Statement::Loop.new(
+      condition => RakuAST::ApplyInfix.new(
+        left  => RakuAST::Var::Lexical.new('$i'),
+        infix => RakuAST::Infix.new('<'),
+        right => RakuAST::IntLiteral.new(3)
+      ),
+      increment => RakuAST::ApplyPostfix.new(
+        operand => RakuAST::Var::Lexical.new('$i'),
+        postfix => RakuAST::Postfix.new(:operator<++>)
+      ),
+      body => RakuAST::Block.new(
+        body => RakuAST::Blockoid.new(
+          RakuAST::StatementList.new(
+            RakuAST::Statement::Expression.new(
+              expression => RakuAST::Call::Name::WithoutParentheses.new(
+                name => RakuAST::Name.from-identifier('last')
+              ),
+              condition-modifier => RakuAST::StatementModifier::If.new(
+                RakuAST::ApplyInfix.new(
+                  left => RakuAST::ApplyPrefix.new(
+                    prefix => RakuAST::Prefix.new('++'),
+                    operand => RakuAST::Var::Lexical.new('$count')
+                  ),
+                  infix => RakuAST::Infix.new('>'),
+                  right => RakuAST::IntLiteral.new(3)
+                )
+              )
+            )
+          )
+        )
+      )
+    );
+    is-deeply $deparsed, q:to/CODE/.chomp, 'deparse';
+loop (; $i < 3; $i++) {
+    last if ++$count > 3
+}
+CODE
+
+    for 'AST', $ast, 'Str', $deparsed, 'Raku', EVAL($raku) -> $type, $it {
+        $i = 0;
+        $count = 0;
+
+        is-deeply EVAL($it), Nil, "$type: loop evaluates to Nil";
+        is-deeply $count, 3, "$type: loop ran as expected";
+    }
+}
+
+subtest 'loop without a condition' => {
+    my $count;
+
+    # loop (my $i = 0; ; $i++) { last if ++$count > 2 }
+    ast RakuAST::Statement::Loop.new(
+      setup => RakuAST::VarDeclaration::Simple.new(
+        sigil => '$',
+        desigilname => RakuAST::Name.from-identifier('i'),
+        initializer => RakuAST::Initializer::Assign.new(
+          RakuAST::IntLiteral.new(0)
+        )
+      ),
+      increment => RakuAST::ApplyPostfix.new(
+        operand => RakuAST::Var::Lexical.new('$i'),
+        postfix => RakuAST::Postfix.new(:operator<++>)
+      ),
+      body => RakuAST::Block.new(
+        body => RakuAST::Blockoid.new(
+          RakuAST::StatementList.new(
+            RakuAST::Statement::Expression.new(
+              expression => RakuAST::Call::Name::WithoutParentheses.new(
+                name => RakuAST::Name.from-identifier('last')
+              ),
+              condition-modifier => RakuAST::StatementModifier::If.new(
+                RakuAST::ApplyInfix.new(
+                  left => RakuAST::ApplyPrefix.new(
+                    prefix => RakuAST::Prefix.new('++'),
+                    operand => RakuAST::Var::Lexical.new('$count')
+                  ),
+                  infix => RakuAST::Infix.new('>'),
+                  right => RakuAST::IntLiteral.new(2)
+                )
+              )
+            )
+          )
+        )
+      )
+    );
+    is-deeply $deparsed, q:to/CODE/.chomp, 'deparse';
+loop (my $i = 0; ; $i++) {
+    last if ++$count > 2
+}
+CODE
+
+    for 'AST', $ast, 'Str', $deparsed, 'Raku', EVAL($raku) -> $type, $it {
+        $count = 0;
+
+        is-deeply EVAL($it), Nil, "$type: loop evaluates to Nil";
+        is-deeply $count, 3, "$type: loop ran until last";
+    }
+}
+
+subtest 'loop without an increment' => {
+    my $count;
+
+    # loop (my $i = 0; $i < 3; ) { $count = ++$i }
+    ast RakuAST::Statement::Loop.new(
+      setup => RakuAST::VarDeclaration::Simple.new(
+        sigil => '$',
+        desigilname => RakuAST::Name.from-identifier('i'),
+        initializer => RakuAST::Initializer::Assign.new(
+          RakuAST::IntLiteral.new(0)
+        )
+      ),
+      condition => RakuAST::ApplyInfix.new(
+        left  => RakuAST::Var::Lexical.new('$i'),
+        infix => RakuAST::Infix.new('<'),
+        right => RakuAST::IntLiteral.new(3)
+      ),
+      body => RakuAST::Block.new(
+        body => RakuAST::Blockoid.new(
+          RakuAST::StatementList.new(
+            RakuAST::Statement::Expression.new(
+              expression => RakuAST::ApplyInfix.new(
+                left  => RakuAST::Var::Lexical.new('$count'),
+                infix => RakuAST::Infix.new('='),
+                right => RakuAST::ApplyPrefix.new(
+                  prefix => RakuAST::Prefix.new('++'),
+                  operand => RakuAST::Var::Lexical.new('$i')
+                )
+              )
+            )
+          )
+        )
+      )
+    );
+    is-deeply $deparsed, q:to/CODE/.chomp, 'deparse';
+loop (my $i = 0; $i < 3; ) {
+    $count = ++$i
+}
+CODE
+
+    for 'AST', $ast, 'Str', $deparsed, 'Raku', EVAL($raku) -> $type, $it {
+        $count = 0;
+
+        is-deeply EVAL($it), Nil, "$type: loop evaluates to Nil";
+        is-deeply $count, 3, "$type: loop ran as expected";
     }
 }
 

--- a/t/12-rakuast/sub.rakutest
+++ b/t/12-rakuast/sub.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 12;
+plan 13;
 
 my $ast;
 my $deparsed;
@@ -437,6 +437,40 @@ CODE
         is-deeply ::<&frobnicate>(), 42, 'can call without args';
         dies-ok { ::<&frobnicate>(666) }, 'can NOT call with positionals';
         dies-ok { ::<&frobnicate>(:bar) }, 'can NOT call with nameds';
+    }
+}
+
+subtest 'A required positional parameter needs no marker' => {
+    # sub ($param) { $param }
+    ast RakuAST::Statement::Expression.new(
+      expression => RakuAST::Sub.new(
+        signature => RakuAST::Signature.new(
+          parameters => (
+            RakuAST::Parameter.new(
+              target => RakuAST::ParameterTarget::Var.new(:name<$param>),
+              :!optional
+            ),
+          )
+        ),
+        body => RakuAST::Blockoid.new(
+          RakuAST::StatementList.new(
+            RakuAST::Statement::Expression.new(
+              expression => RakuAST::Var::Lexical.new('$param')
+            ),
+          )
+        )
+      )
+    );
+    is-deeply $deparsed, q:to/CODE/.chomp, 'deparse';
+sub ($param) {
+    $param
+}
+CODE
+
+    for 'AST', $ast, 'Str', $deparsed, 'Raku', EVAL($raku) -> $type, $it {
+        my $sub := EVAL($it);
+        is-deeply $sub(199), 199, "$type: the argument is passed";
+        dies-ok { $sub() }, "$type: the parameter is still required";
     }
 }
 

--- a/t/12-rakuast/sub.rakutest
+++ b/t/12-rakuast/sub.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 11;
+plan 12;
 
 my $ast;
 my $deparsed;
@@ -438,6 +438,60 @@ CODE
         dies-ok { ::<&frobnicate>(666) }, 'can NOT call with positionals';
         dies-ok { ::<&frobnicate>(:bar) }, 'can NOT call with nameds';
     }
+}
+
+subtest 'A sub with an operator name' => {
+    # sub infix:<+++> ($a, $b) { $a + $b }; 1 +++ 2
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Sub.new(
+          name => RakuAST::Name.from-identifier('infix',
+            colonpairs => (
+              RakuAST::QuotedString.new(
+                segments   => [RakuAST::StrLiteral.new('+++')],
+                processors => <words val>
+              ),
+            )
+          ),
+          signature => RakuAST::Signature.new(
+            parameters => (
+              RakuAST::Parameter.new(
+                target => RakuAST::ParameterTarget::Var.new(:name<$a>)
+              ),
+              RakuAST::Parameter.new(
+                target => RakuAST::ParameterTarget::Var.new(:name<$b>)
+              ),
+            )
+          ),
+          body => RakuAST::Blockoid.new(
+            RakuAST::StatementList.new(
+              RakuAST::Statement::Expression.new(
+                expression => RakuAST::ApplyInfix.new(
+                  left  => RakuAST::Var::Lexical.new('$a'),
+                  infix => RakuAST::Infix.new('+'),
+                  right => RakuAST::Var::Lexical.new('$b')
+                )
+              )
+            )
+          )
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::ApplyInfix.new(
+          left  => RakuAST::IntLiteral.new(1),
+          infix => RakuAST::Infix.new('+++'),
+          right => RakuAST::IntLiteral.new(2)
+        )
+      )
+    );
+    is-deeply $deparsed, q:to/CODE/, 'deparse';
+sub infix:<+++> ($a, $b) {
+    $a + $b
+}
+1 +++ 2
+CODE
+    is-deeply $_, 3, @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
 }
 
 # vim: expandtab shiftwidth=4

--- a/t/12-rakuast/var.rakutest
+++ b/t/12-rakuast/var.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 59;
+plan 63;
 
 my $ast;
 my $deparsed;
@@ -1349,4 +1349,163 @@ subtest 'hash variable with a where guard (failing initializer)' => {
         throws-like { EVAL($it) }, X::TypeCheck::Assignment, "$type: EVAL";
     }
 }
+
+subtest 'Typed signature declaration' => {
+    # my Int ($p, $q) = 3, 4; $q
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::VarDeclaration::Signature.new(
+          scope => 'my',
+          type  => RakuAST::Type::Simple.new(
+            RakuAST::Name.from-identifier('Int')
+          ),
+          signature => RakuAST::Signature.new(
+            parameters => (
+              RakuAST::Parameter.new(
+                target => RakuAST::ParameterTarget::Var.new(:name<$p>),
+                :!optional
+              ),
+              RakuAST::Parameter.new(
+                target => RakuAST::ParameterTarget::Var.new(:name<$q>),
+                :!optional
+              ),
+            ),
+            returns => RakuAST::Type::Simple.new(
+              RakuAST::Name.from-identifier('Int')
+            )
+          ),
+          initializer => RakuAST::Initializer::Assign.new(
+            RakuAST::ApplyListInfix.new(
+              infix    => RakuAST::Infix.new(','),
+              operands => (
+                RakuAST::IntLiteral.new(3),
+                RakuAST::IntLiteral.new(4)
+              )
+            )
+          )
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Var::Lexical.new('$q')
+      )
+    );
+    is-deeply $deparsed, "my Int (\$p, \$q) = 3, 4;\n\$q\n", 'deparse';
+    is-deeply $_, 4, @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'Typed signature declaration with binding' => {
+    # my Int ($p, $q) := 3, 4; $q
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::VarDeclaration::Signature.new(
+          scope => 'my',
+          type  => RakuAST::Type::Simple.new(
+            RakuAST::Name.from-identifier('Int')
+          ),
+          signature => RakuAST::Signature.new(
+            parameters => (
+              RakuAST::Parameter.new(
+                target => RakuAST::ParameterTarget::Var.new(:name<$p>),
+                :!optional
+              ),
+              RakuAST::Parameter.new(
+                target => RakuAST::ParameterTarget::Var.new(:name<$q>),
+                :!optional
+              ),
+            ),
+            returns => RakuAST::Type::Simple.new(
+              RakuAST::Name.from-identifier('Int')
+            )
+          ),
+          initializer => RakuAST::Initializer::Bind.new(
+            RakuAST::ApplyListInfix.new(
+              infix    => RakuAST::Infix.new(','),
+              operands => (
+                RakuAST::IntLiteral.new(3),
+                RakuAST::IntLiteral.new(4)
+              )
+            )
+          )
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Var::Lexical.new('$q')
+      )
+    );
+    is-deeply $deparsed, "my Int (\$p, \$q) := 3, 4;\n\$q\n", 'deparse';
+    is-deeply $_, 4, @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'Typed signature declaration keeps its type' => {
+    # my Int ($p, $q); $p = "x"
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::VarDeclaration::Signature.new(
+          scope => 'my',
+          type  => RakuAST::Type::Simple.new(
+            RakuAST::Name.from-identifier('Int')
+          ),
+          signature => RakuAST::Signature.new(
+            parameters => (
+              RakuAST::Parameter.new(
+                target => RakuAST::ParameterTarget::Var.new(:name<$p>),
+                :!optional
+              ),
+              RakuAST::Parameter.new(
+                target => RakuAST::ParameterTarget::Var.new(:name<$q>),
+                :!optional
+              ),
+            ),
+            returns => RakuAST::Type::Simple.new(
+              RakuAST::Name.from-identifier('Int')
+            )
+          )
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::ApplyInfix.new(
+          left  => RakuAST::Var::Lexical.new('$p'),
+          infix => RakuAST::Infix.new('='),
+          right => RakuAST::StrLiteral.new('x')
+        )
+      )
+    );
+    is-deeply $deparsed, "my Int (\$p, \$q);\n\$p = \"x\"\n", 'deparse';
+    throws-like { EVAL($deparsed) }, X::TypeCheck::Assignment,
+      'Str: the type is enforced';
+}
+
+subtest 'Untyped signature declaration with a return type' => {
+    # my ($p --> Int) = 3; $p
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::VarDeclaration::Signature.new(
+          scope => 'my',
+          signature => RakuAST::Signature.new(
+            parameters => (
+              RakuAST::Parameter.new(
+                target => RakuAST::ParameterTarget::Var.new(:name<$p>),
+                :!optional
+              ),
+            ),
+            returns => RakuAST::Type::Simple.new(
+              RakuAST::Name.from-identifier('Int')
+            )
+          ),
+          initializer => RakuAST::Initializer::Assign.new(
+            RakuAST::IntLiteral.new(3)
+          )
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Var::Lexical.new('$p')
+      )
+    );
+    is-deeply $deparsed, "my (\$p --> Int) = 3;\n\$p\n", 'deparse';
+    is-deeply $_, 3, @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously `.DEPARSE` threw for the regex goal matching operator and for `tr///`, so any file using either could not be deparsed at all. Fixing those and then recompiling the deparsed output of a few dozen real programs showed that "deparses without throwing" was hiding a second class of problem: output that parses but is a different program, or does not parse at all. A postfix on a parenthesized operand lost its parens, `1 min 2` came out as `1min 2`, a `;` was dropped after any statement ending in `}` even when the brace closed a hash index, and a declaration deparsed inside parens, a subscript, a loop spec or an infix operand dragged the enclosing statement's delimiter in with it.

This fixes each of those, plus the smaller fidelity problems that turned up on the way: colonpair values gaining parens on every round trip, unescaped characters in character class enumerations, `{*}` bodies, `s///` and `tr///` not escaping their delimiter, `$c()` losing its parens, index assignments losing their assignee, `.raku` dropping a name's colonpairs so a proto and its `:sym<>` candidates could not survive, and parsed signatures coming out with a redundant `!` on every positional and a duplicated `--> Type` that did not compile.

```
$ raku -e 'use experimental :rakuast; say Q[my $x = (-1).abs, 2; %h{$k} = 42].AST.DEPARSE'
my $x = -1;
.abs, 2;
%h{$k}
```
