### PR TITLE
RakuAST: fix a second batch of deparse holes found by round tripping modules

### DIFF
--- a/src/Raku/ast/package.rakumod
+++ b/src/Raku/ast/package.rakumod
@@ -53,6 +53,7 @@ class RakuAST::Package
                           Mu :$how,
                          Str :$repr,
                         Bool :$augmented,
+                        Bool :$is-stub,
                         Bool :$is-require-stub,
                          str :$parsed-declarator,
     RakuAST::Doc::Declarator :$WHY
@@ -67,13 +68,13 @@ class RakuAST::Package
         nqp::bindattr($obj, RakuAST::Package, '$!repr', $repr // Str);
         nqp::bindattr($obj, RakuAST::Package, '$!augmented',$augmented // False);
         nqp::bindattr($obj, RakuAST::Package, '$!is-require-stub',$is-require-stub // False);
+        nqp::bindattr($obj, RakuAST::Package, '$!is-stub', $is-stub // False);
         nqp::bindattr_s($obj, RakuAST::Package, '$!parsed-declarator', $parsed-declarator);
 
         $obj.set-traits($traits) if $traits;
         $obj.replace-body($body, $parameterization);
         $obj.set-WHY($WHY);
 
-        nqp::bindattr($obj, RakuAST::Package, '$!is-stub', False);
         nqp::bindattr($obj, RakuAST::Package, '$!stub-defused', False);
 
         $obj
@@ -538,6 +539,7 @@ class RakuAST::Package::Attachable
                           Mu :$how,
                          Str :$repr,
                         Bool :$augmented,
+                        Bool :$is-stub,
                          str :$parsed-declarator,
     RakuAST::Doc::Declarator :$WHY
     ) {
@@ -551,12 +553,11 @@ class RakuAST::Package::Attachable
         nqp::bindattr($obj, RakuAST::Package, '$!repr', $repr // Str);
         nqp::bindattr($obj, RakuAST::Package, '$!augmented',$augmented // False);
         nqp::bindattr_s($obj, RakuAST::Package, '$!parsed-declarator', $parsed-declarator);
+        nqp::bindattr($obj, RakuAST::Package, '$!is-stub', $is-stub // False);
 
         $obj.set-traits($traits) if $traits;
         $obj.replace-body($body, $parameterization);
         $obj.set-WHY($WHY);
-
-        nqp::bindattr($obj, RakuAST::Package, '$!is-stub', False);
 
         # Set up internal defaults
         nqp::bindattr($obj, RakuAST::Package::Attachable,

--- a/src/Raku/ast/statements.rakumod
+++ b/src/Raku/ast/statements.rakumod
@@ -2799,7 +2799,12 @@ class RakuAST::Statement::Require
     has RakuAST::Package $!module;
     has RakuAST::Node $!existing-lookup;
 
-    method new(RakuAST::Name :$module-name!, RakuAST::Expression :$file, RakuAST::Expression :$argument) {
+    method new(
+           RakuAST::Name :$module-name,
+     RakuAST::Expression :$file,
+     RakuAST::Expression :$argument
+    ) {
+        nqp::die('Must specify a module-name or a file') unless $module-name || $file;
         my $obj := nqp::create(self);
         nqp::bindattr($obj, RakuAST::Statement::Require, '$!module-name', $module-name // RakuAST::Name);
         nqp::bindattr($obj, RakuAST::Statement::Require, '$!file', $file // RakuAST::Expression);

--- a/src/Raku/ast/traits.rakumod
+++ b/src/Raku/ast/traits.rakumod
@@ -177,20 +177,22 @@ class RakuAST::Trait::Is
     has RakuAST::Circumfix $.argument;
     has RakuAST::Type $.type;
 
-    method new(RakuAST::Name :$name!, RakuAST::Circumfix :$argument) {
+    method new(
+           RakuAST::Name :$name,
+           RakuAST::Type :$type,
+      RakuAST::Circumfix :$argument
+    ) {
+        nqp::die('Must specify a name or a type') unless $name || $type;
         my $obj := nqp::create(self);
-        nqp::bindattr($obj, RakuAST::Trait::Is, '$!name', $name);
+        nqp::bindattr($obj, RakuAST::Trait::Is, '$!name', $name // RakuAST::Name);
+        nqp::bindattr($obj, RakuAST::Trait::Is, '$!type', $type // RakuAST::Type);
         nqp::bindattr($obj, RakuAST::Trait::Is, '$!argument',
             $argument // RakuAST::Circumfix);
         $obj
     }
 
     method new-from-type(RakuAST::Type :$type!, RakuAST::Circumfix :$argument) {
-        my $obj := nqp::create(self);
-        nqp::bindattr($obj, RakuAST::Trait::Is, '$!type', $type);
-        nqp::bindattr($obj, RakuAST::Trait::Is, '$!argument',
-            $argument // RakuAST::Circumfix);
-        $obj
+        self.new(:$type, :$argument)
     }
 
     method PERFORM-BEGIN(RakuAST::Resolver $resolver, RakuAST::IMPL::QASTContext $context) {

--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -699,6 +699,7 @@ class RakuAST::VarDeclaration::Simple
     has str                  $.twigil;
     has RakuAST::Initializer $.initializer;
     has RakuAST::Method      $.initializer-method;
+    has int                  $!initializer-in-method;
     has RakuAST::SemiList    $.shape;
     has RakuAST::Package     $.attribute-package;
     has RakuAST::Role        $!generics-package;
@@ -963,7 +964,7 @@ class RakuAST::VarDeclaration::Simple
 
     method visit-children(Code $visitor) {
         $visitor($!type)        if nqp::isconcrete($!type);
-        if nqp::isconcrete($!initializer) {
+        if !$!initializer-in-method && nqp::isconcrete($!initializer) {
             $visitor($!initializer);
             $visitor($!initializer-method) if nqp::isconcrete($!initializer-method);
         }
@@ -1294,9 +1295,9 @@ class RakuAST::VarDeclaration::Simple
                     self.add-trait(
                         RakuAST::Trait::WillBuild.new($method).to-begin-time($resolver, $context)
                     );
-                    # No need anymore, since the initializer is already referenced by the method.
-                    # Avoids double CHECK on the initializer code.
-                    nqp::bindattr(self, RakuAST::VarDeclaration::Simple, '$!initializer', RakuAST::Initializer);
+                    # The initializer stays as written for deparsing. The
+                    # method carries it from here on, so it is not visited again.
+                    nqp::bindattr_i(self, RakuAST::VarDeclaration::Simple, '$!initializer-in-method', 1);
                 }
             }
             else {

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -373,11 +373,13 @@ CODE
     # Word characters never need escaping inside <[ ]>.  Everything else
     # is escaped rather than enumerating which characters are ignored or
     # meaningful there, such as whitespace, dots, hyphens, backslashes
-    # and the closing bracket
+    # and the closing bracket.  A character that does not print is given
+    # by its codepoint, as a backslashed control character does not parse
     method charclass-character(str $char --> Str:D) {
-        nqp::iscclass(nqp::const::CCLASS_WORD,$char,0)
-          ?? $char
-          !! '\\' ~ $char
+        return $char if nqp::iscclass(nqp::const::CCLASS_WORD,$char,0);
+        nqp::iscclass(nqp::const::CCLASS_PRINTING,$char,0)
+          ?? '\\' ~ $char
+          !! '\\x[' ~ $char.ord.base(16) ~ ']'
     }
 
     method colonpairs($ast, Str:D $xsyn = "") {
@@ -1921,10 +1923,18 @@ CODE
     multi method deparse(
       RakuAST::Regex::CharClass::Specified:D $ast
     --> Str:D) {
-        ($ast.negated ?? '\\C' !! '\\c')
-          ~ '['
-          ~ $ast.characters.ords.map(*.uniname).join(', ')
-          ~ ']'
+        my str $characters = $ast.characters;
+        my int $chars      = nqp::chars($characters);
+        my @ords           = $characters.ords;
+
+        # a character that does not print has no name to write
+        nqp::findnotcclass(
+          nqp::const::CCLASS_PRINTING,$characters,0,$chars
+        ) == $chars
+          ?? ($ast.negated ?? '\\C' !! '\\c')
+               ~ '[' ~ @ords.map(*.uniname).join(', ') ~ ']'
+          !! ($ast.negated ?? '\\X' !! '\\x')
+               ~ '[' ~ @ords.map(*.base(16)).join(', ') ~ ']'
     }
 
     multi method deparse(RakuAST::Regex::CharClass::Tab:D $ast --> Str:D) {

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -589,6 +589,10 @@ CODE
         )
     }
 
+    method where-constraint($where --> Str:D) {
+        ' ' ~ self.xsyn('constraint', 'where') ~ ' ' ~ self.deparse($where)
+    }
+
     method statement-modifier(str $type, $ast) {
         my $*DELIMITER = '';
         self.syn-modifier($type) ~ ' ' ~ self.deparse($ast.expression)
@@ -676,12 +680,7 @@ CODE
             }
         }
 
-        if $ast.where -> $where {
-            @parts.push(' ');
-            @parts.push(self.xsyn('constraint', 'where'));
-            @parts.push(' ');
-            @parts.push(self.deparse($where));
-        }
+        @parts.push(self.where-constraint($_)) with $ast.where;
 
         if $ast.initializer -> $initializer {
             @parts.push(self.deparse($initializer));
@@ -1519,6 +1518,8 @@ CODE
             @parts.push(self.deparse($signature));
             @parts.push(')');
         }
+
+        @parts.push(self.where-constraint($_)) with $ast.where;
 
         @parts = self.hsyn('param', @parts.join);
         if $ast.default -> $default {

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -646,13 +646,14 @@ CODE
     }
 
     method syn-type($ast, :$skip) {
-        # a type without a name, such as a coercion, deparses its base
-        # type through this method, so it must not be highlighted twice
-        my int $named = nqp::can($ast,'name');
+        # a derived type, such as a coercion, deparses its base type
+        # through this method, so it must not be highlighted twice
+        my int $named = nqp::istype($ast,RakuAST::Type::Simple)
+          || nqp::istype($ast,RakuAST::Type::Setting);
         my str $name  = self.deparse($named ?? $ast.name !! $ast);
-        $skip && $skip eq $name
-          ?? ""
-          !! $named ?? self.hsyn("type-$name", $name) !! $name
+
+        return "" if $skip && $skip eq $name;
+        $named ?? self.hsyn("type-$name", $name) !! $name
     }
 
     method syn-typer($typer) {
@@ -2942,7 +2943,19 @@ CODE
     }
 
     multi method deparse(RakuAST::Type::Definedness:D $ast --> Str:D) {
-        my str $name   = self.deparse($ast.base-type.name);
+        my $base-type := $ast.base-type;
+
+        # the smiley of a parameterized type goes before the arguments
+        my str $args;
+        if nqp::istype($base-type,RakuAST::Type::Parameterized) {
+            my str $deparsed = self.deparse($base-type.args);
+            $args = "[$deparsed]" if $deparsed;
+            $base-type := $base-type.base-type;
+        }
+
+        my str $name   = self.deparse(
+          nqp::can($base-type,'name') ?? $base-type.name !! $base-type
+        );
         my str $smiley = $ast.definite ?? 'D' !! 'U';
 
         self.hsyn("type-$name", $ast.through-pragma
@@ -2950,7 +2963,7 @@ CODE
             ?? ''
             !! $name
           !! $name ~ self.hsyn("smiley-$smiley", ":$smiley")
-        )
+        ) ~ $args
     }
 
     multi method deparse(RakuAST::Type::Enum:D $ast --> Str:D) {

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -2553,7 +2553,9 @@ CODE
                   if $deparsed.ends-with("};\n")
                   && self.statement-is-prefixed-block($statement);
 
-                @parts.push($spaces);
+                # a doc block carries its own margin
+                @parts.push($spaces)
+                  unless nqp::istype($statement,RakuAST::Doc::Block);
                 @parts.push($deparsed);
                 @parts.push("\n") if $deparsed.ends-with('}');
             }

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -3006,6 +3006,10 @@ CODE
         }
     }
 
+    multi method deparse(RakuAST::Var::Compiler::Block:D $ --> Str:D) {
+        self.hsyn('var-lexical','&?BLOCK')
+    }
+
     multi method deparse(RakuAST::Var::Compiler::File:D $ast --> Str:D) {
         self.hsyn('var-compile',$.var-compiler-file)
     }

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -2308,8 +2308,8 @@ CODE
         my @statements := $ast.statements;
         my $statement  := @statements.head;
         @statements == 1
-          && !(nqp::istype($statement,RakuAST::Statement::Expression)
-               && ($statement.condition-modifier || $statement.loop-modifier))
+          && nqp::istype($statement,RakuAST::Statement::Expression)
+          && !($statement.condition-modifier || $statement.loop-modifier)
           ?? self.deparse($statement.expression)
           !! @statements.map({ self.deparse($_) }).join($.list-infix-semi-colon)
     }

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -1454,9 +1454,11 @@ CODE
         }
 
         if @captures {
-            @parts.push(self.deparse($_)) for @captures;
+            @parts.push(@captures.map({ self.deparse($_) }).join(' '));
+            @parts.push(' ') if $target;
         }
-        elsif $target {
+
+        if $target {
             my str $var = self.deparse($target, :slurpy($ast.slurpy));
 
             # named parameter

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -341,6 +341,7 @@ CODE
          ~ self.syn-modifier($type)
          ~ ' '
          ~ self.deparse($ast.condition)
+         ~ $*DELIMITER
     }
 
     # :raw is for the < > form, which processes no escape but the

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -846,6 +846,17 @@ CODE
         self.method-call($ast, $ast.dispatch || '.')
     }
 
+    multi method deparse(RakuAST::Call::BlockMethod:D $ast --> Str:D) {
+        my $block := $ast.block;
+        # the parser wraps the block of `.&{ }` in an item contextualizer
+        self.syn-routine($ast.dispatch || '.')
+          ~ (nqp::istype($block,RakuAST::Contextualizer::Item)
+              ?? '&' ~ self.deparse($block.target)
+              !! self.deparse($block)
+            )
+          ~ self.parenthesize($ast.args, :only-non-empty)
+    }
+
     multi method deparse(RakuAST::Call::VarMethod:D $ast --> Str:D) {
         my $dispatch := $ast.dispatch;
         self.method-call($ast, ($ast.dispatch || '.') ~ '&')

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -341,10 +341,14 @@ CODE
          ~ self.deparse($ast.condition)
     }
 
-    method assemble-quoted-string($ast --> Str:D) {
+    # :raw is for the < > form, which processes no escape but the
+    # backslash and its own brackets
+    method assemble-quoted-string($ast, :$raw --> Str:D) {
         $ast.segments.map({
             nqp::istype($_,RakuAST::StrLiteral)
-              ?? .value.raku.substr(1,*-1)
+              ?? $raw
+                ?? .value.subst('\\','\\\\',:g).subst('<','\\<',:g).subst('>','\\>',:g)
+                !! .value.raku.substr(1,*-1)
               !! self.deparse($_)
             }).join
     }
@@ -1673,7 +1677,9 @@ CODE
             elsif @processors == 2 && !$ast.has-variables {
                 my str $joined = @processors.join(' ');
                 if $joined eq 'words val' {
-                    $.pointy-open ~ $string ~ $.pointy-close
+                    $.pointy-open
+                      ~ self.assemble-quoted-string($ast, :raw)
+                      ~ $.pointy-close
                 }
                 elsif $joined eq 'quotewords val' {
                     $.double-pointy-open ~ $string ~ $.double-pointy-close

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -765,6 +765,8 @@ CODE
 
     multi method deparse(RakuAST::ArgList:D $ast --> Str:D) {
         my $*IN-ARGLIST := True;
+        # a declaration argument would add the statement delimiter
+        my $*DELIMITER = '';
         $ast.args.map({
             if nqp::istype($_,RakuAST::Heredoc) {
                 my ($top, $bottom) = self.deparse($_, :split);

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -268,7 +268,9 @@ CODE
 
         else {
             @parts.push(self.parenthesize($signature))
-              if $signature && $signature.parameters-initialized;
+              if $signature
+              && $signature.parameters-initialized
+              && ($signature.parameters || $signature.returns);
             add-traits;
 
             if $WHY {

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -634,8 +634,13 @@ CODE
     }
 
     method syn-type($ast, :$skip) {
-        my str $name = self.deparse($ast.name);
-        $skip && $skip eq $name ?? "" !! self.hsyn("type-$name", $name)
+        # a type without a name, such as a coercion, deparses its base
+        # type through this method, so it must not be highlighted twice
+        my int $named = nqp::can($ast,'name');
+        my str $name  = self.deparse($named ?? $ast.name !! $ast);
+        $skip && $skip eq $name
+          ?? ""
+          !! $named ?? self.hsyn("type-$name", $name) !! $name
     }
 
     method syn-typer($typer) {

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -1518,16 +1518,17 @@ CODE
         my $target   := $ast.target;
         my @captures := $ast.type-captures;
         my str @parts;
-        if @captures {
-            @parts.push(@captures.map({ self.deparse($_) }).join(' '));
-        }
-
-        # the implicit Any of a target is not written, a parameter
-        # that is only a type has nothing else to show
-        elsif $ast.type -> $type {
-            if self.deparse($type, :skip($target ?? 'Any' !! '')) -> $deparsed {
+        # the implicit Any of a target or a type capture is not written,
+        # a parameter that is only a type has nothing else to show
+        if $ast.type -> $type {
+            my str $skip = $target || @captures ?? 'Any' !! '';
+            if self.deparse($type, :$skip) -> $deparsed {
                 @parts.push($deparsed);
             }
+        }
+        if @captures {
+            @parts.push(' ') if @parts;
+            @parts.push(@captures.map({ self.deparse($_) }).join(' '));
         }
         @parts.push(' ') if @parts && $target;
 

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -1479,16 +1479,18 @@ CODE
         my $target   := $ast.target;
         my @captures := $ast.type-captures;
         my str @parts;
-        if !@captures && $ast.type -> $type {
-            if self.deparse($type, :skip<Any>) -> $deparsed {
-                @parts.push($deparsed);
-                @parts.push(' ') if $target;
-            }
-        }
-
         if @captures {
             @parts.push(@captures.map({ self.deparse($_) }).join(' '));
         }
+
+        # the implicit Any of a target is not written, a parameter
+        # that is only a type has nothing else to show
+        elsif $ast.type -> $type {
+            if self.deparse($type, :skip($target ?? 'Any' !! '')) -> $deparsed {
+                @parts.push($deparsed);
+            }
+        }
+        @parts.push(' ') if @parts && $target;
 
         if $target {
             my str $var = self.deparse($target, :slurpy($ast.slurpy));

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -1475,7 +1475,7 @@ CODE
               ~ self.deparse($body, :unit).chomp
         }
         else {
-            @parts.push(self.deparse($body));
+            @parts.push($ast.is-stub ?? '{...}' !! self.deparse($body));
             @parts.join(' ')
         }
     }

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -2156,8 +2156,19 @@ CODE
     multi method deparse(RakuAST::Regex::Quote:D $ast --> Str:D) {
         my $quoted := $ast.quoted;
 
+        my @processors := $quoted.processors;
+
+        # the < a b > form, the space after < is what tells it from an assertion
+        if @processors == 1
+          && @processors.head eq 'words'
+          && !$quoted.has-variables {
+            self.hsyn('literal',
+              '< ' ~ self.assemble-quoted-string($quoted, :raw).trim ~ ' >'
+            )
+        }
+
         # Complicated stuff
-        if $quoted.processors {
+        elsif @processors {
             self.hsyn('regex-code', '<{ ')
               ~ self.deparse($quoted)
               ~ self.hsyn('regex-code', ' }>')

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -2231,12 +2231,14 @@ CODE
             # need special handling for declarator doc
             if @parameters.first(*.WHY) {
                 my $last      := @parameters.tail;
-                my $*DELIMITER = $.list-infix-comma.trim ~ "\n";
+                my $*DELIMITER;
 
                 my str @atoms;
                 self.indent('  ');
                 for @parameters -> $param {
-                    $*DELIMITER = "\n" if $param === $last;
+                    $*DELIMITER = $param === $last || $param.invocant
+                      ?? "\n"
+                      !! $.list-infix-comma.trim ~ "\n";
                     @atoms.push($*INDENT);
                     @atoms.push(self.deparse($param));
                 }
@@ -2247,10 +2249,15 @@ CODE
 
             # no special action
             else {
-                my $*DELIMITER = $.list-infix-comma;
+                my $*DELIMITER = '';
+                my $last := @parameters.tail;
                 @parts.push(@parameters.map({
-                    self.deparse($_)
-                }).join.chomp($.list-infix-comma))
+                    # an invocant is set off by its colon, not by a comma
+                    my str $separator = $.list-infix-comma;
+                    $separator = ' ' if .invocant;
+                    $separator = ''  if $_ === $last;
+                    self.deparse($_) ~ $separator
+                }).join)
             }
         }
 

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -865,13 +865,17 @@ CODE
     }
 
     multi method deparse(RakuAST::Call::Name:D $ast --> Str:D) {
-        my $name     := self.deparse($ast.name);
-        my $complete := $name.ends-with('::');
+        my $name-ast := $ast.name;
+        my $args     := $ast.args;
+        my $name     := self.deparse($name-ast);
+        # an indirect lookup without arguments is a term, not a call
+        my $complete := $name.ends-with('::')
+          || !($args && $args.args) && $name-ast.is-indirect-lookup;
 
         $name := self.hsyn("core-$name", self.xsyn('core', $name));
         $complete
           ?? $name
-          !! $name ~ self.parenthesize($ast.args)
+          !! $name ~ self.parenthesize($args)
     }
 
     multi method deparse(RakuAST::Call::Name::WithoutParentheses:D $ast
@@ -1484,7 +1488,6 @@ CODE
 
         if @captures {
             @parts.push(@captures.map({ self.deparse($_) }).join(' '));
-            @parts.push(' ') if $target;
         }
 
         if $target {

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -1514,7 +1514,7 @@ CODE
         }
 
         if $ast.sub-signature -> $signature {
-            @parts.push(' (');
+            @parts.push(@parts ?? ' (' !! '(');
             @parts.push(self.deparse($signature));
             @parts.push(')');
         }

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -363,6 +363,12 @@ CODE
                 }
                 $text
             }
+            # the text between a nested pair of the delimiters is a quote of
+            # its own, one without processors belongs to this one
+            elsif nqp::istype($_,RakuAST::QuotedString) && !.processors {
+                $interpolated = 0;
+                self.assemble-quoted-string($_, :$raw)
+            }
             else {
                 $interpolated = 1;
                 self.deparse($_)

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -1388,6 +1388,15 @@ CODE
             }
         }
 
+        # the parser takes `is repr` out of the traits and stores it on
+        # the package
+        if $ast.repr -> $repr {
+            @parts.push(self.syn-trait('is')
+              ~ ' repr'
+              ~ self.parenthesize(RakuAST::StrLiteral.new($repr))
+            );
+        }
+
         if $ast.traits -> @traits {
             for @traits -> $trait {
                 @parts.push(self.deparse($trait));

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -2647,12 +2647,10 @@ CODE
 
     multi method deparse(RakuAST::Stub:D $ast --> Str:D) {
         my str $hsyn = self.hsyn('stub', $ast.name);
-        if $ast.args -> $real-args {
-            $hsyn ~ ' ' ~ self.deparse($real-args)
-        }
-        else {
-            $hsyn
-        }
+        my $args := $ast.args;
+        $args && $args.args
+          ?? $hsyn ~ ' ' ~ self.deparse($args)
+          !! $hsyn
     }
 
 #- Su --------------------------------------------------------------------------

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -1362,16 +1362,33 @@ CODE
     multi method deparse(RakuAST::Name:D $ast --> Str:D) {
         return '::' if $ast.is-anonymous;
 
-        my @parts := $ast.parts;
-        (nqp::istype(@parts.head,RakuAST::Name::Part::Expression) ?? '::' !! '')
-          ~ @parts.map({
-                nqp::istype($_,RakuAST::Name::Part::Expression)
-                  ?? '(' ~ self.deparse(.expr) ~ ')'
-                  !! nqp::istype($_,RakuAST::Name::Part::Empty)
-                    ?? ''
-                    !! .name
+        my @name-parts := $ast.parts;
+        (nqp::istype(@name-parts.head,RakuAST::Name::Part::Expression) ?? '::' !! '')
+          ~ @name-parts.map({
+                if nqp::istype($_,RakuAST::Name::Part::Expression) {
+                    '(' ~ self.deparse(.expr) ~ ')'
+                }
+                elsif nqp::istype($_,RakuAST::Name::Part::Empty) {
+                    ''
+                }
+                else {
+                    .name
+                }
             }).join('::')
-          ~ $ast.colonpair-suffix
+          ~ $ast.colonpairs.map({
+                if nqp::istype($_,RakuAST::ColonPair) {
+                    self.deparse($_)
+                }
+                # the `<+++>` of an operator name is a bare quote, not a
+                # pair, and an empty `<>` colonpair is a Nil term
+                elsif nqp::istype($_,RakuAST::Term::Name)
+                  && .name.canonicalize eq 'Nil' {
+                    ':<>'
+                }
+                else {
+                    ':' ~ self.deparse($_)
+                }
+            }).join
     }
 
     multi method deparse(RakuAST::Nqp:D $ast --> Str:D) {

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -2969,11 +2969,15 @@ CODE
     multi method deparse(RakuAST::Type::Enum:D $ast --> Str:D) {
         my str @parts = self.syn-typer('enum');
 
+        # the type of the values only parses between a scope and the
+        # declarator, so a type makes the scope explicit: `my Str enum`
+        my $of := $ast.of;
+        @parts.unshift(self.deparse($of)) if $of;
+
         my str $scope = $ast.scope;
         @parts.unshift(self.syn-scope($scope))
-          if $scope && $scope ne $ast.default-scope;
+          if $scope && ($of || $scope ne $ast.default-scope);
 
-        @parts.unshift(self.deparse($_)) with $ast.of;
         @parts.push(self.deparse($_)) with $ast.name;
 
         if $ast.clean-clone.traits -> @traits {

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -272,10 +272,8 @@ CODE
             add-traits;
 
             if $WHY {
-                $*DELIMITER = "";
                 @parts.push('{');
-                return self.add-any-docs(@parts.join(' '), $WHY)
-                  ~ self.deparse($ast.body, :multi).substr(2)  # lose {\n
+                return self.block-with-docs(@parts.join(' '), $WHY, $ast.body)
             }
         }
 
@@ -546,10 +544,11 @@ CODE
 
     method prefix-any-leading-doc(str $body, $WHY) {
         if $WHY && $WHY.leading -> @leading {
+            # the parser stores a leading doc line without its newline
             self.hsyn('doc-leading', @leading.map({
-                self.deparse-unquoted($_).lines(:!chomp).Slip
+                self.deparse-unquoted($_).lines.Slip
             }).map({
-                "#| $_$*INDENT"
+                "#| $_\n$*INDENT"
             }).join)
               ~ $body
         }
@@ -574,6 +573,14 @@ CODE
         else {
             $body ~ $*DELIMITER
         }
+    }
+
+    # a trailing doc follows the opening brace on its line, the body
+    # supplies the newline after the brace
+    method block-with-docs(str $prefix, $WHY, $body --> Str:D) {
+        $*DELIMITER = "";
+        self.add-any-docs($prefix, $WHY).chomp
+          ~ self.deparse($body, :multi).substr(1)  # lose {
     }
 
     method add-any-docs(str $body, $WHY) {
@@ -764,9 +771,7 @@ CODE
 
     multi method deparse(RakuAST::Block:D $ast --> Str:D) {
         if $ast.WHY -> $WHY {
-            $*DELIMITER = "";
-            self.add-any-docs('{', $WHY)
-              ~ self.deparse($ast.body, :multi).substr(2)  # lose {\n
+            self.block-with-docs('{', $WHY, $ast.body)
         }
         else {
             self.deparse($ast.body, |%_)
@@ -1559,10 +1564,8 @@ CODE
               if $signature.parameters-initialized;
 
             if $WHY {
-                $*DELIMITER = "";
                 @parts.push('{');
-                return self.add-any-docs(@parts.join(' '), $WHY)
-                  ~ self.deparse($ast.body, :multi).substr(2)  # lose {\n
+                return self.block-with-docs(@parts.join(' '), $WHY, $ast.body)
             }
         }
 

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -2513,8 +2513,11 @@ CODE
     }
 
     multi method deparse(RakuAST::Statement::Require:D $ast --> Str:D) {
-        self.labels($ast)
-          ~ self.xsyn('use', 'require') ~ ' ' ~ self.deparse($ast.module-name)
+        my str @parts = self.xsyn('use', 'require');
+        @parts.push(self.deparse($_)) with $ast.module-name;
+        @parts.push(self.deparse($_)) with $ast.file;
+        @parts.push(self.deparse($_)) with $ast.argument;
+        self.labels($ast) ~ @parts.join(' ') ~ $*DELIMITER
     }
 
     multi method deparse(RakuAST::Statement::Unless:D $ast --> Str:D) {

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -1335,7 +1335,18 @@ CODE
 #- N ---------------------------------------------------------------------------
 
     multi method deparse(RakuAST::Name:D $ast --> Str:D) {
-        $ast.is-installable ?? $ast.canonicalize !! '::'
+        return '::' if $ast.is-anonymous;
+
+        my @parts := $ast.parts;
+        (nqp::istype(@parts.head,RakuAST::Name::Part::Expression) ?? '::' !! '')
+          ~ @parts.map({
+                nqp::istype($_,RakuAST::Name::Part::Expression)
+                  ?? '(' ~ self.deparse(.expr) ~ ')'
+                  !! nqp::istype($_,RakuAST::Name::Part::Empty)
+                    ?? ''
+                    !! .name
+            }).join('::')
+          ~ $ast.colonpair-suffix
     }
 
     multi method deparse(RakuAST::Nqp:D $ast --> Str:D) {

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -347,13 +347,27 @@ CODE
     # :raw is for the < > form, which processes no escape but the
     # backslash and its own brackets
     method assemble-quoted-string($ast, :$raw --> Str:D) {
+        my int $interpolated;
         $ast.segments.map({
-            nqp::istype($_,RakuAST::StrLiteral)
-              ?? $raw
-                ?? .value.subst('\\','\\\\',:g).subst('<','\\<',:g).subst('>','\\>',:g)
-                !! .value.raku.substr(1,*-1)
-              !! self.deparse($_)
-            }).join
+            if nqp::istype($_,RakuAST::StrLiteral) {
+                my str $text = $raw
+                  ?? .value.subst('\\','\\\\',:g).subst('<','\\<',:g).subst('>','\\>',:g)
+                  !! .value.raku.substr(1,*-1);
+                if $text {
+                    # a bracket right after an interpolation would continue
+                    # it as a call or an index
+                    $text = '\\' ~ $text
+                      if $interpolated
+                      && nqp::index('([{<',$text.substr(0,1)) >= 0;
+                    $interpolated = 0;
+                }
+                $text
+            }
+            else {
+                $interpolated = 1;
+                self.deparse($_)
+            }
+        }).join
     }
 
     method multiple-processors(str $string, @processors --> Str:D) {

--- a/src/core.c/RakuAST/Raku.rakumod
+++ b/src/core.c/RakuAST/Raku.rakumod
@@ -629,7 +629,8 @@ augment class RakuAST::Node {
         self!add-WHY: $self!nameds:
           <scope name how repr traits body>,
           (parameterization => $signature
-            if $signature && $signature.parameters.elems)
+            if $signature && $signature.parameters.elems),
+          (:is-stub if self.is-stub)
     }
 
     multi method raku(RakuAST::Pragma:D: --> Str:D) {

--- a/src/core.c/RakuAST/Raku.rakumod
+++ b/src/core.c/RakuAST/Raku.rakumod
@@ -1271,6 +1271,10 @@ augment class RakuAST::Node {
         self!nameds: <name args>
     }
 
+    multi method raku(RakuAST::Var::Compiler::Distribution:D: --> Str:D) {
+        self!none
+    }
+
     multi method raku(RakuAST::Var::Compiler::File:D: --> Str:D) {
         self!positional(self.file)
     }
@@ -1281,6 +1285,10 @@ augment class RakuAST::Node {
 
     multi method raku(RakuAST::Var::Compiler::Lookup:D: --> Str:D) {
         self!positional(self.name)
+    }
+
+    multi method raku(RakuAST::Var::Compiler::Resources:D: --> Str:D) {
+        self!none
     }
 
     multi method raku(RakuAST::Var::Compiler::Routine:D: --> Str:D) {

--- a/src/core.c/RakuAST/Raku.rakumod
+++ b/src/core.c/RakuAST/Raku.rakumod
@@ -643,6 +643,7 @@ augment class RakuAST::Node {
         @nameds.push("type") if self.type && self.type.DEPARSE ne 'Any';
         @nameds.push("names") if self.names.elems;
         @nameds.push("type-captures") if self.type-captures.elems;
+        @nameds.push("invocant") if self.invocant;
         @nameds.append: <
           target optional slurpy traits default where sub-signature value
         >;

--- a/src/core.c/RakuAST/Raku.rakumod
+++ b/src/core.c/RakuAST/Raku.rakumod
@@ -1053,7 +1053,7 @@ augment class RakuAST::Node {
     }
 
     multi method raku(RakuAST::Statement::Require:D: --> Str:D) {
-        self!nameds: <labels module-name>
+        self!nameds: <labels module-name file argument>
     }
 
     multi method raku(RakuAST::Statement::Unless:D: --> Str:D) {

--- a/src/core.c/RakuAST/Raku.rakumod
+++ b/src/core.c/RakuAST/Raku.rakumod
@@ -1141,6 +1141,7 @@ augment class RakuAST::Node {
 
     multi method raku(RakuAST::Submethod:D: --> Str:D) {
         my str @nameds = 'name';
+        @nameds.unshift("multiness") if self.multiness;
         @nameds.push("signature") if self.signature && self.signature.parameters-initialized;
         @nameds.append: <traits body>;
 

--- a/src/core.c/RakuAST/Raku.rakumod
+++ b/src/core.c/RakuAST/Raku.rakumod
@@ -640,7 +640,11 @@ augment class RakuAST::Node {
 
     multi method raku(RakuAST::Parameter:D: --> Str:D) {
         my str @nameds;
-        @nameds.push("type") if self.type && self.type.DEPARSE ne 'Any';
+        # Any is the implicit type of a target, a parameter that is only
+        # a type has nothing else
+        my $type := self.type;
+        @nameds.push("type")
+          if $type && ($type.DEPARSE ne 'Any' || !self.target);
         @nameds.push("names") if self.names.elems;
         @nameds.push("type-captures") if self.type-captures.elems;
         @nameds.push("invocant") if self.invocant;

--- a/src/core.c/RakuAST/Raku.rakumod
+++ b/src/core.c/RakuAST/Raku.rakumod
@@ -1388,6 +1388,10 @@ augment class RakuAST::Name::Part {
         self.^name
     }
 
+    multi method raku(RakuAST::Name::Part::Empty:D: --> Str:D) {
+        self.^name ~ '.new'
+    }
+
     multi method raku(RakuAST::Name::Part::Expression:D: --> Str:D) {
         my str @parts = self.^name ~ '.new(';
         RakuAST::Node::indent();

--- a/src/core.c/RakuAST/Raku.rakumod
+++ b/src/core.c/RakuAST/Raku.rakumod
@@ -1365,9 +1365,15 @@ augment class RakuAST::Node {
     }
 
     multi method raku(RakuAST::VarDeclaration::Simple:D: --> Str:D) {
+        # the build trait of an attribute is made from its initializer
+        my @traits = self.traits.grep({
+            nqp::not_i(nqp::istype($_,RakuAST::Trait::WillBuild))
+        });
         self!add-WHY:
           self!nameds:
-            <scope original-type shape sigil twigil desigilname traits initializer where>
+            <scope original-type shape sigil twigil desigilname>,
+            (:@traits if @traits),
+            <initializer where>
     }
 
     multi method raku(RakuAST::VarDeclaration::Term:D: --> Str:D) {

--- a/src/core.c/RakuAST/Raku.rakumod
+++ b/src/core.c/RakuAST/Raku.rakumod
@@ -1141,6 +1141,7 @@ augment class RakuAST::Node {
 
     multi method raku(RakuAST::Submethod:D: --> Str:D) {
         my str @nameds = 'name';
+        @nameds.unshift("private")   if self.private;
         @nameds.unshift("multiness") if self.multiness;
         @nameds.push("signature") if self.signature && self.signature.parameters-initialized;
         @nameds.append: <traits body>;

--- a/t/08-performance/11-rakuast-constant-folding.t
+++ b/t/08-performance/11-rakuast-constant-folding.t
@@ -150,7 +150,7 @@ ok optimized-deparse(Q[sub f() { 2 ** 3 }; multi sub infix:<**>(Int $a, Int $b) 
     'a user multi declared after the use keeps the operator';
 {
     my $t = optimized-deparse(Q[sub outer() { 2 ** 3 }; sub inner() { { sub infix:<**>($a, $b) { 'user' }; 2 ** 3 } }]);
-    ok $t.subst(/\s+/, ' ', :g).contains('sub outer () { 8 }') && $t.contains('2 ** 3'),
+    ok $t.subst(/\s+/, ' ', :g).contains('sub outer { 8 }') && $t.contains('2 ** 3'),
         'a user infix in an inner block leaves a use outside it folding and keeps its own';
 }
 {

--- a/t/12-rakuast/call-method.rakutest
+++ b/t/12-rakuast/call-method.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 15;
+plan 17;
 
 my $ast;
 my $deparsed;
@@ -248,6 +248,81 @@ subtest 'Can make a method call on a sub' => {
     );
     is-deeply $deparsed, '"foo".&uc()', 'deparsed';
     is-deeply $_, "FOO", @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'Can call a method held in a variable' => {
+    # my $f = method { self + 1 };
+    # 41.$f
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::VarDeclaration::Simple.new(
+          sigil       => '$',
+          desigilname => RakuAST::Name.from-identifier('f'),
+          initializer => RakuAST::Initializer::Assign.new(
+            RakuAST::Method.new(
+              body => RakuAST::Blockoid.new(
+                RakuAST::StatementList.new(
+                  RakuAST::Statement::Expression.new(
+                    expression => RakuAST::ApplyInfix.new(
+                      left  => RakuAST::Term::Self.new,
+                      infix => RakuAST::Infix.new('+'),
+                      right => RakuAST::IntLiteral.new(1)
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::ApplyPostfix.new(
+          operand => RakuAST::IntLiteral.new(41),
+          postfix => RakuAST::Call::BlockMethod.new(
+            block => RakuAST::Var::Lexical.new('$f')
+          )
+        )
+      )
+    );
+    is-deeply $deparsed, q:to/CODE/, 'deparsed';
+my $f = method {
+    self + 1
+};
+41.$f
+CODE
+    is-deeply $_, 42, @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'Can call a block as a method' => {
+    # 41.&{ $_ + 1 }
+    ast RakuAST::ApplyPostfix.new(
+      operand => RakuAST::IntLiteral.new(41),
+      postfix => RakuAST::Call::BlockMethod.new(
+        block => RakuAST::Contextualizer::Item.new(
+          RakuAST::Block.new(
+            body => RakuAST::Blockoid.new(
+              RakuAST::StatementList.new(
+                RakuAST::Statement::Expression.new(
+                  expression => RakuAST::ApplyInfix.new(
+                    left  => RakuAST::Var::Lexical.new('$_'),
+                    infix => RakuAST::Infix.new('+'),
+                    right => RakuAST::IntLiteral.new(1)
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    );
+    is-deeply $deparsed, q:to/CODE/.chomp, 'deparsed';
+41.&{
+    $_ + 1
+}
+CODE
+    is-deeply $_, 42, @type[$++]
       for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
 }
 

--- a/t/12-rakuast/call-name.rakutest
+++ b/t/12-rakuast/call-name.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 9;
+plan 10;
 
 my $ast;
 my $deparsed;
@@ -197,6 +197,37 @@ subtest 'Can make a call that flattens into hash' => {
     );
     is-deeply $deparsed, 'two-named(|%args)', 'deparsed';
     is-deeply $_, 5.0, "@type[$++]: flattening two named arguments"
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'Declaration as the first argument of a call without parentheses' => {
+    # max my $x = 1, 2;
+    # $x
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Call::Name::WithoutParentheses.new(
+          name => RakuAST::Name.from-identifier('max'),
+          args => RakuAST::ArgList.new(
+            RakuAST::VarDeclaration::Simple.new(
+              sigil       => '$',
+              desigilname => RakuAST::Name.from-identifier('x'),
+              initializer => RakuAST::Initializer::Assign.new(
+                RakuAST::IntLiteral.new(1)
+              )
+            ),
+            RakuAST::IntLiteral.new(2)
+          )
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Var::Lexical.new('$x')
+      )
+    );
+    is-deeply $deparsed, q:to/CODE/, 'deparse';
+max my $x = 1, 2;
+$x
+CODE
+    is-deeply $_, 1, @type[$++]
       for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
 }
 

--- a/t/12-rakuast/circumfix.rakutest
+++ b/t/12-rakuast/circumfix.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 8;
+plan 9;
 
 my $ast;
 my $deparsed;
@@ -156,6 +156,42 @@ subtest 'Parenthesized single statement keeps its modifier' => {
 
     is-deeply $deparsed, '(42 if 1)', 'deparse';
     is-deeply $_, 42, @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'Parenthesized for statement' => {
+    # (for 1 .. 2 { $_ }).elems
+    ast RakuAST::ApplyPostfix.new(
+      operand => RakuAST::Circumfix::Parentheses.new(
+        RakuAST::SemiList.new(
+          RakuAST::Statement::For.new(
+            source => RakuAST::ApplyInfix.new(
+              left  => RakuAST::IntLiteral.new(1),
+              infix => RakuAST::Infix.new('..'),
+              right => RakuAST::IntLiteral.new(2)
+            ),
+            body => RakuAST::Block.new(
+              body => RakuAST::Blockoid.new(
+                RakuAST::StatementList.new(
+                  RakuAST::Statement::Expression.new(
+                    expression => RakuAST::Var::Lexical.new('$_')
+                  )
+                )
+              )
+            )
+          )
+        )
+      ),
+      postfix => RakuAST::Call::Method.new(
+        name => RakuAST::Name.from-identifier('elems')
+      )
+    );
+    is-deeply $deparsed, q:to/CODE/.chomp, 'deparsed';
+(for 1 .. 2 {
+    $_
+}).elems
+CODE
+    is-deeply $_, 2, @type[$++]
       for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
 }
 

--- a/t/12-rakuast/class.rakutest
+++ b/t/12-rakuast/class.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 18;
+plan 19;
 
 my $ast;
 my $deparsed;
@@ -888,6 +888,74 @@ $x
 CODE
     for 'AST', $ast, 'Str', $deparsed, 'Raku', EVAL($raku) -> $type, $it {
         is-deeply EVAL($it), 5, "$type: the native type holds the value";
+    }
+}
+
+subtest 'stubbed class' => {
+    # my class B {...}
+    # my class B {
+    #     method m {
+    #         42
+    #     }
+    # }
+    # B.m
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Class.new(
+          scope   => 'my',
+          name    => RakuAST::Name.from-identifier('B'),
+          is-stub => True,
+          body    => RakuAST::Block.new(
+            body => RakuAST::Blockoid.new(RakuAST::StatementList.new)
+          )
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Class.new(
+          scope => 'my',
+          name  => RakuAST::Name.from-identifier('B'),
+          body  => RakuAST::Block.new(
+            body => RakuAST::Blockoid.new(
+              RakuAST::StatementList.new(
+                RakuAST::Statement::Expression.new(
+                  expression => RakuAST::Method.new(
+                    name => RakuAST::Name.from-identifier('m'),
+                    body => RakuAST::Blockoid.new(
+                      RakuAST::StatementList.new(
+                        RakuAST::Statement::Expression.new(
+                          expression => RakuAST::IntLiteral.new(42)
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::ApplyPostfix.new(
+          operand => RakuAST::Type::Simple.new(
+            RakuAST::Name.from-identifier('B')
+          ),
+          postfix => RakuAST::Call::Method.new(
+            name => RakuAST::Name.from-identifier('m')
+          )
+        )
+      )
+    );
+    is-deeply $deparsed, q:to/CODE/, 'deparse';
+my class B {...}
+my class B {
+    method m {
+        42
+    }
+}
+B.m
+CODE
+    for 'AST', $ast, 'Str', $deparsed, 'Raku', EVAL($raku) -> $type, $it {
+        is-deeply EVAL($it), 42, "$type: the definition completes the stub";
     }
 }
 

--- a/t/12-rakuast/class.rakutest
+++ b/t/12-rakuast/class.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 15;
+plan 16;
 
 my $ast;
 my $deparsed;
@@ -740,6 +740,53 @@ CODE
           "$type: inner class is installed with full nested name";
         is $class.x, 42,
           "$type: inner class method is callable";
+    }
+}
+
+subtest 'class inheriting through a type trait' => {
+    # my class X::Foo is Exception { }; X::Foo.new ~~ Exception
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Class.new(
+          scope  => 'my',
+          name   => RakuAST::Name.from-identifier-parts('X', 'Foo'),
+          traits => (
+            RakuAST::Trait::Is.new-from-type(
+              type => RakuAST::Type::Simple.new(
+                RakuAST::Name.from-identifier('Exception')
+              )
+            ),
+          ),
+          body   => RakuAST::Block.new(
+            body => RakuAST::Blockoid.new(
+              RakuAST::StatementList.new()
+            )
+          )
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::ApplyInfix.new(
+          left  => RakuAST::ApplyPostfix.new(
+            operand => RakuAST::Type::Simple.new(
+              RakuAST::Name.from-identifier-parts('X', 'Foo')
+            ),
+            postfix => RakuAST::Call::Method.new(
+              name => RakuAST::Name.from-identifier('new')
+            )
+          ),
+          infix => RakuAST::Infix.new('~~'),
+          right => RakuAST::Type::Simple.new(
+            RakuAST::Name.from-identifier('Exception')
+          )
+        )
+      )
+    );
+    is-deeply $deparsed, q:to/CODE/, 'deparse';
+my class X::Foo is Exception { }
+X::Foo.new ~~ Exception
+CODE
+    for 'AST', $ast, 'Str', $deparsed, 'Raku', EVAL($raku) -> $type, $it {
+        is-deeply EVAL($it), True, "$type: is an Exception";
     }
 }
 

--- a/t/12-rakuast/class.rakutest
+++ b/t/12-rakuast/class.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 16;
+plan 18;
 
 my $ast;
 my $deparsed;
@@ -787,6 +787,107 @@ X::Foo.new ~~ Exception
 CODE
     for 'AST', $ast, 'Str', $deparsed, 'Raku', EVAL($raku) -> $type, $it {
         is-deeply EVAL($it), True, "$type: is an Exception";
+    }
+}
+
+subtest 'class with a representation' => {
+    # my class Foo is repr("CStruct") { has int $.x }; Foo.REPR
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Class.new(
+          scope => 'my',
+          name  => RakuAST::Name.from-identifier('Foo'),
+          repr  => 'CStruct',
+          body  => RakuAST::Block.new(
+            body => RakuAST::Blockoid.new(
+              RakuAST::StatementList.new(
+                RakuAST::Statement::Expression.new(
+                  expression => RakuAST::VarDeclaration::Simple.new(
+                    scope       => 'has',
+                    type        => RakuAST::Type::Simple.new(
+                      RakuAST::Name.from-identifier('int')
+                    ),
+                    sigil       => '$',
+                    twigil      => '.',
+                    desigilname => RakuAST::Name.from-identifier('x')
+                  )
+                )
+              )
+            )
+          )
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::ApplyPostfix.new(
+          operand => RakuAST::Type::Simple.new(
+            RakuAST::Name.from-identifier('Foo')
+          ),
+          postfix => RakuAST::Call::Method.new(
+            name => RakuAST::Name.from-identifier('REPR')
+          )
+        )
+      )
+    );
+    is-deeply $deparsed, q:to/CODE/, 'deparse';
+my class Foo is repr("CStruct") {
+    has int $.x
+}
+Foo.REPR
+CODE
+    for 'AST', $ast, 'Str', $deparsed, 'Raku', EVAL($raku) -> $type, $it {
+        is-deeply EVAL($it), 'CStruct', "$type: has the representation";
+    }
+}
+
+subtest 'native type with a representation' => {
+    # my native myint is repr("P6int") is Int is nativesize(64) { }
+    # my myint $x = 5;
+    # $x
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Native.new(
+          scope  => 'my',
+          name   => RakuAST::Name.from-identifier('myint'),
+          repr   => 'P6int',
+          traits => (
+            RakuAST::Trait::Is.new-from-type(
+              type => RakuAST::Type::Simple.new(RakuAST::Name.from-identifier('Int'))
+            ),
+            RakuAST::Trait::Is.new(
+              name     => RakuAST::Name.from-identifier('nativesize'),
+              argument => RakuAST::Circumfix::Parentheses.new(
+                RakuAST::SemiList.new(
+                  RakuAST::Statement::Expression.new(
+                    expression => RakuAST::IntLiteral.new(64)
+                  )
+                )
+              )
+            ),
+          ),
+          body   => RakuAST::Block.new(
+            body => RakuAST::Blockoid.new(RakuAST::StatementList.new)
+          )
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::VarDeclaration::Simple.new(
+          type        => RakuAST::Type::Simple.new(RakuAST::Name.from-identifier('myint')),
+          sigil       => '$',
+          desigilname => RakuAST::Name.from-identifier('x'),
+          initializer => RakuAST::Initializer::Assign.new(RakuAST::IntLiteral.new(5))
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Var::Lexical.new('$x')
+      )
+    );
+    is-deeply $deparsed, q:to/CODE/, 'deparse';
+my native myint is repr("P6int") is Int is nativesize(64) { }
+my myint $x = 5;
+$x
+CODE
+    for 'AST', $ast, 'Str', $deparsed, 'Raku', EVAL($raku) -> $type, $it {
+        is-deeply EVAL($it), 5, "$type: the native type holds the value";
     }
 }
 

--- a/t/12-rakuast/class.rakutest
+++ b/t/12-rakuast/class.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 20;
+plan 21;
 
 my $ast;
 my $deparsed;
@@ -1047,6 +1047,67 @@ CODE
         is-deeply EVAL($it), 45, "$type: both candidates dispatch";
     }
     is-deeply EVAL($raku).DEPARSE, $deparsed, 'round trips through .raku';
+}
+
+subtest 'attribute with a computed default' => {
+    # my class D {
+    #     has $.t = 1 + 1
+    # }
+    # D.new.t
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Class.new(
+          scope => 'my',
+          name  => RakuAST::Name.from-identifier('D'),
+          body  => RakuAST::Block.new(
+            body => RakuAST::Blockoid.new(
+              RakuAST::StatementList.new(
+                RakuAST::Statement::Expression.new(
+                  expression => RakuAST::VarDeclaration::Simple.new(
+                    scope       => 'has',
+                    sigil       => '$',
+                    twigil      => '.',
+                    desigilname => RakuAST::Name.from-identifier('t'),
+                    initializer => RakuAST::Initializer::Assign.new(
+                      RakuAST::ApplyInfix.new(
+                        left  => RakuAST::IntLiteral.new(1),
+                        infix => RakuAST::Infix.new('+'),
+                        right => RakuAST::IntLiteral.new(1)
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::ApplyPostfix.new(
+          operand => RakuAST::ApplyPostfix.new(
+            operand => RakuAST::Type::Simple.new(RakuAST::Name.from-identifier('D')),
+            postfix => RakuAST::Call::Method.new(
+              name => RakuAST::Name.from-identifier('new')
+            )
+          ),
+          postfix => RakuAST::Call::Method.new(
+            name => RakuAST::Name.from-identifier('t')
+          )
+        )
+      )
+    );
+    is-deeply $deparsed, q:to/CODE/, 'deparse';
+my class D {
+    has $.t = 1 + 1
+}
+D.new.t
+CODE
+    for 'AST', $ast, 'Str', $deparsed, 'Raku', EVAL($raku) -> $type, $it {
+        is-deeply EVAL($it), 2, "$type: the default is computed";
+    }
+    is-deeply $ast.DEPARSE, $deparsed, 'deparse after the class was compiled';
+    is-deeply 'use experimental :rakuast; ' ~ $ast.raku, $raku,
+      '.raku after the class was compiled';
 }
 
 # vim: expandtab shiftwidth=4

--- a/t/12-rakuast/class.rakutest
+++ b/t/12-rakuast/class.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 19;
+plan 20;
 
 my $ast;
 my $deparsed;
@@ -957,6 +957,96 @@ CODE
     for 'AST', $ast, 'Str', $deparsed, 'Raku', EVAL($raku) -> $type, $it {
         is-deeply EVAL($it), 42, "$type: the definition completes the stub";
     }
+}
+
+subtest 'class with a multi submethod' => {
+    # my class C {
+    #     multi submethod m (Int $x) {
+    #         $x
+    #     }
+    #     multi submethod m (Str $x) {
+    #         $x.chars
+    #     }
+    # }
+    # C.m(42) + C.m("abc")
+    sub candidate($type, $body) {
+        RakuAST::Statement::Expression.new(
+          expression => RakuAST::Submethod.new(
+            multiness => 'multi',
+            name      => RakuAST::Name.from-identifier('m'),
+            signature => RakuAST::Signature.new(
+              parameters => (
+                RakuAST::Parameter.new(
+                  type   => RakuAST::Type::Simple.new(
+                    RakuAST::Name.from-identifier($type)
+                  ),
+                  target => RakuAST::ParameterTarget::Var.new(:name<$x>)
+                ),
+              )
+            ),
+            body => RakuAST::Blockoid.new(
+              RakuAST::StatementList.new(
+                RakuAST::Statement::Expression.new(expression => $body)
+              )
+            )
+          )
+        )
+    }
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Class.new(
+          scope => 'my',
+          name  => RakuAST::Name.from-identifier('C'),
+          body  => RakuAST::Block.new(
+            body => RakuAST::Blockoid.new(
+              RakuAST::StatementList.new(
+                candidate('Int', RakuAST::Var::Lexical.new('$x')),
+                candidate('Str', RakuAST::ApplyPostfix.new(
+                  operand => RakuAST::Var::Lexical.new('$x'),
+                  postfix => RakuAST::Call::Method.new(
+                    name => RakuAST::Name.from-identifier('chars')
+                  )
+                ))
+              )
+            )
+          )
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::ApplyInfix.new(
+          left  => RakuAST::ApplyPostfix.new(
+            operand => RakuAST::Type::Simple.new(RakuAST::Name.from-identifier('C')),
+            postfix => RakuAST::Call::Method.new(
+              name => RakuAST::Name.from-identifier('m'),
+              args => RakuAST::ArgList.new(RakuAST::IntLiteral.new(42))
+            )
+          ),
+          infix => RakuAST::Infix.new('+'),
+          right => RakuAST::ApplyPostfix.new(
+            operand => RakuAST::Type::Simple.new(RakuAST::Name.from-identifier('C')),
+            postfix => RakuAST::Call::Method.new(
+              name => RakuAST::Name.from-identifier('m'),
+              args => RakuAST::ArgList.new(RakuAST::StrLiteral.new('abc'))
+            )
+          )
+        )
+      )
+    );
+    is-deeply $deparsed, q:to/CODE/, 'deparse';
+my class C {
+    multi submethod m (Int $x) {
+        $x
+    }
+    multi submethod m (Str $x) {
+        $x.chars
+    }
+}
+C.m(42) + C.m("abc")
+CODE
+    for 'AST', $ast, 'Str', $deparsed, 'Raku', EVAL($raku) -> $type, $it {
+        is-deeply EVAL($it), 45, "$type: both candidates dispatch";
+    }
+    is-deeply EVAL($raku).DEPARSE, $deparsed, 'round trips through .raku';
 }
 
 # vim: expandtab shiftwidth=4

--- a/t/12-rakuast/class.rakutest
+++ b/t/12-rakuast/class.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 21;
+plan 22;
 
 my $ast;
 my $deparsed;
@@ -1108,6 +1108,85 @@ CODE
     is-deeply $ast.DEPARSE, $deparsed, 'deparse after the class was compiled';
     is-deeply 'use experimental :rakuast; ' ~ $ast.raku, $raku,
       '.raku after the class was compiled';
+}
+
+subtest 'class with a private submethod' => {
+    # my class E {
+    #     submethod !m {
+    #         42
+    #     }
+    #     method n {
+    #         self!m
+    #     }
+    # }
+    # E.n
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Class.new(
+          scope => 'my',
+          name  => RakuAST::Name.from-identifier('E'),
+          body  => RakuAST::Block.new(
+            body => RakuAST::Blockoid.new(
+              RakuAST::StatementList.new(
+                RakuAST::Statement::Expression.new(
+                  expression => RakuAST::Submethod.new(
+                    private => True,
+                    name    => RakuAST::Name.from-identifier('m'),
+                    body    => RakuAST::Blockoid.new(
+                      RakuAST::StatementList.new(
+                        RakuAST::Statement::Expression.new(
+                          expression => RakuAST::IntLiteral.new(42)
+                        )
+                      )
+                    )
+                  )
+                ),
+                RakuAST::Statement::Expression.new(
+                  expression => RakuAST::Method.new(
+                    name => RakuAST::Name.from-identifier('n'),
+                    body => RakuAST::Blockoid.new(
+                      RakuAST::StatementList.new(
+                        RakuAST::Statement::Expression.new(
+                          expression => RakuAST::ApplyPostfix.new(
+                            operand => RakuAST::Term::Self.new,
+                            postfix => RakuAST::Call::PrivateMethod.new(
+                              name => RakuAST::Name.from-identifier('m')
+                            )
+                          )
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::ApplyPostfix.new(
+          operand => RakuAST::Type::Simple.new(RakuAST::Name.from-identifier('E')),
+          postfix => RakuAST::Call::Method.new(
+            name => RakuAST::Name.from-identifier('n')
+          )
+        )
+      )
+    );
+    is-deeply $deparsed, q:to/CODE/, 'deparse';
+my class E {
+    submethod !m {
+        42
+    }
+    method n {
+        self!m
+    }
+}
+E.n
+CODE
+    for 'AST', $ast, 'Str', $deparsed, 'Raku', EVAL($raku) -> $type, $it {
+        is-deeply EVAL($it), 42, "$type: the private submethod is called";
+    }
+    is-deeply EVAL($raku).DEPARSE, $deparsed, 'round trips through .raku';
 }
 
 # vim: expandtab shiftwidth=4

--- a/t/12-rakuast/doc-block.rakutest
+++ b/t/12-rakuast/doc-block.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 11;
+plan 12;
 
 my $ast;
 my $deparsed;
@@ -284,6 +284,70 @@ subtest 'abbreviated defn in a statement list' => {
 
 42
 CODE
+    }
+}
+
+subtest 'pod block inside a class body' => {
+    # my class A {␤    =begin pod␤␤    hi␤    =end pod␤␤    method x {␤        42␤    }␤}␤A.x
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Class.new(
+          scope => 'my',
+          name  => RakuAST::Name.from-identifier('A'),
+          body  => RakuAST::Block.new(
+            body => RakuAST::Blockoid.new(
+              RakuAST::StatementList.new(
+                RakuAST::Doc::Block.new(
+                  margin     => '    ',
+                  type       => 'pod',
+                  paragraphs => ("hi\n",)
+                ),
+                RakuAST::Statement::Expression.new(
+                  expression => RakuAST::Method.new(
+                    name => RakuAST::Name.from-identifier('x'),
+                    body => RakuAST::Blockoid.new(
+                      RakuAST::StatementList.new(
+                        RakuAST::Statement::Expression.new(
+                          expression => RakuAST::IntLiteral.new(42)
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::ApplyPostfix.new(
+          operand => RakuAST::Type::Simple.new(
+            RakuAST::Name.from-identifier('A')
+          ),
+          postfix => RakuAST::Call::Method.new(
+            name => RakuAST::Name.from-identifier('x')
+          )
+        )
+      )
+    );
+
+    for 'Str', $deparsed, 'Raku', $raku.EVAL.DEPARSE -> $type, $it {
+        is-deeply $it, q:to/CODE/, "$type: deparse";
+my class A {
+    =begin pod
+
+    hi
+    =end pod
+
+    method x {
+        42
+    }
+}
+A.x
+CODE
+    }
+    for 'AST', $ast, 'Str', $deparsed, 'Raku', EVAL($raku) -> $type, $it {
+        is-deeply EVAL($it), 42, "$type: the method after the pod block runs";
     }
 }
 

--- a/t/12-rakuast/doc-declarator.rakutest
+++ b/t/12-rakuast/doc-declarator.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 20;
+plan 21;
 
 my $ast;
 my $deparsed;
@@ -854,6 +854,35 @@ CODE
       )
     ),
     'did we find the paragraphs ok';
+}
+
+subtest 'Leading pod declarator without a trailing newline' => {
+    # #| leading comment␤sub a {␤    42␤}
+    ast RakuAST::Sub.new(
+      name => RakuAST::Name.from-identifier("a"),
+      body => RakuAST::Blockoid.new(
+        RakuAST::StatementList.new(
+          RakuAST::Statement::Expression.new(
+            expression => RakuAST::IntLiteral.new(42)
+          )
+        )
+      )
+    ).declarator-docs(
+      leading => ("leading comment",)
+    ), :no-pod;
+
+    for 'Str', $deparsed, 'Raku', $raku.EVAL.DEPARSE -> $type, $it {
+        is-deeply $it, q:to/CODE/.chomp, "$type: deparse";
+#| leading comment
+sub a {
+    42
+}
+CODE
+    }
+    for 'AST', $ast, 'Str', $deparsed, 'Raku', EVAL($raku) -> $type, $it {
+        is-deeply EVAL($it).WHY.leading, "leading comment",
+          "$type: is the leading comment attached";
+    }
 }
 
 # vim: expandtab shiftwidth=4

--- a/t/12-rakuast/enum.rakutest
+++ b/t/12-rakuast/enum.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 7;
+plan 9;
 
 my $ast;
 my $deparsed;
@@ -234,6 +234,66 @@ subtest 'Anonymous enum (enum ::)' => {
         'Source: anonymous enum compiles outside a role';
     is-deeply EVAL('enum :: <a b c>'), $abc,
         'Source: anonymous enum yields expected Map';
+}
+
+subtest 'Enum with a type for its values' => {
+    # my Str enum foo (a => "x"); a.value
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Type::Enum.new(
+          scope => 'my',
+          of    => RakuAST::Type::Simple.new(RakuAST::Name.from-identifier('Str')),
+          name  => RakuAST::Name.from-identifier('foo'),
+          term  => RakuAST::Circumfix::Parentheses.new(
+            RakuAST::SemiList.new(
+              RakuAST::Statement::Expression.new(
+                expression => RakuAST::FatArrow.new(
+                  key   => 'a',
+                  value => RakuAST::StrLiteral.new('x')
+                )
+              )
+            )
+          )
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::ApplyPostfix.new(
+          operand => RakuAST::Term::Name.new(RakuAST::Name.from-identifier('a')),
+          postfix => RakuAST::Call::Method.new(
+            name => RakuAST::Name.from-identifier('value')
+          )
+        )
+      )
+    );
+    is-deeply $deparsed, q:to/CODE/, 'deparse';
+my Str enum foo (a => "x");
+a.value
+CODE
+    is-deeply $_, 'x', @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'Enum with a type for its values and the default scope' => {
+    # our Str enum bar (a => "x")
+    ast RakuAST::Type::Enum.new(
+      scope => 'our',
+      of    => RakuAST::Type::Simple.new(RakuAST::Name.from-identifier('Str')),
+      name  => RakuAST::Name.from-identifier('bar'),
+      term  => RakuAST::Circumfix::Parentheses.new(
+        RakuAST::SemiList.new(
+          RakuAST::Statement::Expression.new(
+            expression => RakuAST::FatArrow.new(
+              key   => 'a',
+              value => RakuAST::StrLiteral.new('x')
+            )
+          )
+        )
+      )
+    );
+    is-deeply $deparsed, 'our Str enum bar (a => "x")', 'deparse';
+    is-deeply EVAL($raku).DEPARSE, $deparsed, 'round trips through .raku';
+    my package four { EVAL($ast); is OUR::<bar>.enums<a>, 'x', 'AST: the enum has the value' }
+    my package five { EVAL($deparsed); is OUR::<bar>.enums<a>, 'x', 'Str: the enum has the value' }
 }
 
 # vim: expandtab shiftwidth=4

--- a/t/12-rakuast/highlight.rakutest
+++ b/t/12-rakuast/highlight.rakutest
@@ -78,7 +78,7 @@ CODE
     <magenta>has</magenta> <green>Str</green> <cyan>$.foo</cyan> <yellow>=</yellow> <red>"foo"</red>;
     <magenta>has</magenta> <green>Int</green> <cyan>$.bar</cyan> <yellow>=</yellow> <red>42</red>;
 
-    <yellow>method</yellow> zippo () {
+    <yellow>method</yellow> zippo {
 
         <yellow><yellow>so</yellow> </yellow><cyan>$!foo</cyan> <yellow>+</yellow> <cyan>$.bar</cyan>
     }

--- a/t/12-rakuast/name.rakutest
+++ b/t/12-rakuast/name.rakutest
@@ -2,7 +2,7 @@ use v6.e.PREVIEW;
 use Test;
 use nqp;
 
-plan 8;
+plan 9;
 
 subtest "name from identifier" => {
     $_ := RakuAST::Name.from-identifier('foo');
@@ -145,6 +145,21 @@ subtest "indirect name lookup as a term" => {
     else {
         skip 'the legacy frontend does not parse an indirect name term', 1;
     }
+    is-deeply EVAL("use experimental :rakuast; " ~ .raku).DEPARSE, .DEPARSE,
+      'round trips through .raku';
+}
+
+subtest "name with a colonpair holding an expression" => {
+    # Foo:ver($v)
+    $_ := RakuAST::Name.from-identifier('Foo',
+      colonpairs => (
+        RakuAST::ColonPair::Value.new(
+          key   => 'ver',
+          value => RakuAST::Var::Lexical.new('$v')
+        ),
+      )
+    );
+    is-deeply .DEPARSE, 'Foo:ver($v)', 'deparses the value in parens';
     is-deeply EVAL("use experimental :rakuast; " ~ .raku).DEPARSE, .DEPARSE,
       'round trips through .raku';
 }

--- a/t/12-rakuast/name.rakutest
+++ b/t/12-rakuast/name.rakutest
@@ -1,7 +1,8 @@
 use v6.e.PREVIEW;
 use Test;
+use nqp;
 
-plan 6;
+plan 8;
 
 subtest "name from identifier" => {
     $_ := RakuAST::Name.from-identifier('foo');
@@ -61,7 +62,7 @@ subtest "name from expressions" => {
     ok .is-identifier, 'the element is NOT considered an identifier';
     is-deeply .parts.elems, 1, 'Has one parts';
     isa-ok .parts[0], RakuAST::Name::Part::Expression, 'second part is ok';
-    is-deeply .DEPARSE, 'Int', 'deparses in an expected way';
+    is-deeply .DEPARSE, '::("Int")', 'deparses in an expected way';
     is-deeply .raku, q:to/CODE/.chomp, "rakufies in an expected way";
 RakuAST::Name.new(
   RakuAST::Name::Part::Expression.new(
@@ -101,6 +102,51 @@ CODE
     is-deeply EVAL("use experimental :rakuast; " ~ .raku).colonpairs.elems, 1, 'round trips through .raku';
     .add-colonpair(RakuAST::ColonPair::True.new('y'));
     is-deeply .colonpairs.elems, 2, 'a colonpair can still be added';
+}
+
+subtest "indirect name lookup" => {
+    # ::("Int")
+    $_ := RakuAST::Term::Name.new(
+      RakuAST::Name.new(
+        RakuAST::Name::Part::Empty.new,
+        RakuAST::Name::Part::Expression.new(RakuAST::StrLiteral.new("Int"))
+      )
+    );
+    is-deeply .DEPARSE, '::("Int")', 'deparses the lookup as written';
+    is-deeply .raku, q:to/CODE/.chomp, "rakufies in an expected way";
+RakuAST::Term::Name.new(
+  RakuAST::Name.new(
+    RakuAST::Name::Part::Empty.new,
+    RakuAST::Name::Part::Expression.new(
+      RakuAST::StrLiteral.new("Int")
+    )
+  )
+)
+CODE
+    is-deeply EVAL($_), Int, 'AST: looks up the type';
+    is-deeply EVAL(.DEPARSE), Int, 'Str: looks up the type';
+    is-deeply EVAL("use experimental :rakuast; " ~ .raku).DEPARSE, .DEPARSE,
+      'round trips through .raku';
+}
+
+subtest "indirect name lookup as a term" => {
+    # IO::("Path")
+    $_ := RakuAST::Call::Name.new(
+      name => RakuAST::Name.new(
+        RakuAST::Name::Part::Simple.new("IO"),
+        RakuAST::Name::Part::Expression.new(RakuAST::StrLiteral.new("Path"))
+      )
+    );
+    is-deeply .DEPARSE, 'IO::("Path")()', 'deparses as a call';
+    is-deeply EVAL($_), IO::Path, 'AST: looks up the type';
+    if nqp::gethllsym('Raku', 'COMPILER-FRONTEND') eq 'rakuast' {
+        is-deeply EVAL(.DEPARSE), IO::Path, 'Str: looks up the type';
+    }
+    else {
+        skip 'the legacy frontend does not parse an indirect name term', 1;
+    }
+    is-deeply EVAL("use experimental :rakuast; " ~ .raku).DEPARSE, .DEPARSE,
+      'round trips through .raku';
 }
 
 # vim: expandtab shiftwidth=4

--- a/t/12-rakuast/name.rakutest
+++ b/t/12-rakuast/name.rakutest
@@ -137,7 +137,7 @@ subtest "indirect name lookup as a term" => {
         RakuAST::Name::Part::Expression.new(RakuAST::StrLiteral.new("Path"))
       )
     );
-    is-deeply .DEPARSE, 'IO::("Path")()', 'deparses as a call';
+    is-deeply .DEPARSE, 'IO::("Path")', 'deparses without a call';
     is-deeply EVAL($_), IO::Path, 'AST: looks up the type';
     if nqp::gethllsym('Raku', 'COMPILER-FRONTEND') eq 'rakuast' {
         is-deeply EVAL(.DEPARSE), IO::Path, 'Str: looks up the type';

--- a/t/12-rakuast/regex-assertion.rakutest
+++ b/t/12-rakuast/regex-assertion.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 28;
+plan 29;
 
 my $ast;
 my $deparsed;
@@ -530,6 +530,26 @@ subtest 'Assertion with callable works' => {
         is $/.list.elems, 0, "$type: No positional captures";
         is $/.hash.elems, 0, "$type: No named captures";
     }
+}
+
+subtest 'Character class enumeration with characters that do not print' => {
+    # /<+[\x[9] \x[B]..\x[C]]>+/
+    ast RakuAST::Regex::QuantifiedAtom.new(
+      atom => RakuAST::Regex::Assertion::CharClass.new(
+        RakuAST::Regex::CharClassElement::Enumeration.new(
+          elements => [
+            RakuAST::Regex::CharClassEnumerationElement::Character.new("\t"),
+            RakuAST::Regex::CharClassEnumerationElement::Range.new(
+              from => 0xB,
+              to   => 0xC
+            )
+          ]
+        )
+      ),
+      quantifier => RakuAST::Regex::Quantifier::OneOrMore.new
+    );
+    is-deeply $deparsed, Q|/<+[\x[9] \x[B]..\x[C]]>+/|, 'deparse';
+    match-ok "a\t\x[B]b", "\t\x[B]";
 }
 
 # vim: expandtab shiftwidth=4

--- a/t/12-rakuast/regex.rakutest
+++ b/t/12-rakuast/regex.rakutest
@@ -2,7 +2,7 @@ use v6.e.PREVIEW;
 use nqp;
 use Test;
 
-plan 58;
+plan 59;
 
 my $ast;
 my $deparsed;
@@ -811,6 +811,13 @@ subtest 'Goal matching with a goal that has no trailing whitespace' => {
     is-deeply $deparsed, '/"("~ ")" \d+/', 'deparse';
 
     match-ok "foo(42)bar", '(42)';
+}
+
+subtest 'Characters that do not print specified by codepoint' => {
+    # /\x[9, B]/
+    ast RakuAST::Regex::CharClass::Specified.new(characters => "\t\x[B]");
+    is-deeply $deparsed, '/\x[9, B]/', 'deparse';
+    match-ok "a\t\x[B]b", "\t\x[B]";
 }
 
 # vim: expandtab shiftwidth=4

--- a/t/12-rakuast/regex.rakutest
+++ b/t/12-rakuast/regex.rakutest
@@ -2,7 +2,7 @@ use v6.e.PREVIEW;
 use nqp;
 use Test;
 
-plan 59;
+plan 60;
 
 my $ast;
 my $deparsed;
@@ -538,14 +538,14 @@ subtest 'Match involving a quoted string with interpolation works' => {
 }
 
 subtest 'Match involving quote words works' => {
-    # /<{ qqw/link inky linky/ }>/
+    # /< link inky linky >/
     ast RakuAST::Regex::Quote.new(
       RakuAST::QuotedString.new(
         :segments[RakuAST::StrLiteral.new('link inky linky')],
         :processors['words']
       )
     );
-    is-deeply $deparsed, '/<{ qqw/link inky linky/ }>/', 'deparse';
+    is-deeply $deparsed, '/< link inky linky >/', 'deparse';
 
     match-ok "slinky sprint", 'linky';
 }
@@ -818,6 +818,18 @@ subtest 'Characters that do not print specified by codepoint' => {
     ast RakuAST::Regex::CharClass::Specified.new(characters => "\t\x[B]");
     is-deeply $deparsed, '/\x[9, B]/', 'deparse';
     match-ok "a\t\x[B]b", "\t\x[B]";
+}
+
+subtest 'Quoted words in a regex holding a slash' => {
+    # /< a/b c\<d >/
+    ast RakuAST::Regex::Quote.new(
+      RakuAST::QuotedString.new(
+        processors => <words>,
+        segments   => (RakuAST::StrLiteral.new(' a/b c<d '),)
+      )
+    );
+    is-deeply $deparsed, '/< a/b c\<d >/', 'deparse';
+    match-ok "xc<d", 'c<d';
 }
 
 # vim: expandtab shiftwidth=4

--- a/t/12-rakuast/signature.rakutest
+++ b/t/12-rakuast/signature.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 20;
+plan 21;
 
 my $ast;
 my $deparsed;
@@ -926,6 +926,55 @@ CODE
     is-deeply $_, 2, @type[$++]
       for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
     is-deeply EVAL($raku).DEPARSE, $deparsed, 'round trips through .raku';
+}
+
+subtest 'Type capture with a type and a target' => {
+    # sub f (Int ::T $x) { T }; f(42)
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Sub.new(
+          name      => RakuAST::Name.from-identifier('f'),
+          signature => RakuAST::Signature.new(
+            parameters => (
+              RakuAST::Parameter.new(
+                type          => RakuAST::Type::Simple.new(
+                  RakuAST::Name.from-identifier('Int')
+                ),
+                type-captures => (
+                  RakuAST::Type::Capture.new(
+                    RakuAST::Name.from-identifier('T')
+                  ),
+                ),
+                target => RakuAST::ParameterTarget::Var.new(:name<$x>)
+              ),
+            )
+          ),
+          body => RakuAST::Blockoid.new(
+            RakuAST::StatementList.new(
+              RakuAST::Statement::Expression.new(
+                expression => RakuAST::Type::Simple.new(
+                  RakuAST::Name.from-identifier('T')
+                )
+              )
+            )
+          )
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Call::Name.new(
+          name => RakuAST::Name.from-identifier('f'),
+          args => RakuAST::ArgList.new(RakuAST::IntLiteral.new(42))
+        )
+      )
+    );
+    is-deeply $deparsed, q:to/CODE/, 'deparse';
+sub f (Int ::T $x) {
+    T
+}
+f(42)
+CODE
+    is-deeply $_, Int, @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
 }
 
 # vim: expandtab shiftwidth=4

--- a/t/12-rakuast/signature.rakutest
+++ b/t/12-rakuast/signature.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 16;
+plan 17;
 
 my $ast;
 my $deparsed;
@@ -721,6 +721,52 @@ my class A {
 A.new.m(42).elems
 CODE
     is-deeply $_, 2, @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'Type capture with a target' => {
+    # sub f (::T $x) { T }; f(42)
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Sub.new(
+          name      => RakuAST::Name.from-identifier('f'),
+          signature => RakuAST::Signature.new(
+            parameters => (
+              RakuAST::Parameter.new(
+                type-captures => (
+                  RakuAST::Type::Capture.new(
+                    RakuAST::Name.from-identifier('T')
+                  ),
+                ),
+                target => RakuAST::ParameterTarget::Var.new(:name<$x>)
+              ),
+            )
+          ),
+          body => RakuAST::Blockoid.new(
+            RakuAST::StatementList.new(
+              RakuAST::Statement::Expression.new(
+                expression => RakuAST::Type::Simple.new(
+                  RakuAST::Name.from-identifier('T')
+                )
+              )
+            )
+          )
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Call::Name.new(
+          name => RakuAST::Name.from-identifier('f'),
+          args => RakuAST::ArgList.new(RakuAST::IntLiteral.new(42))
+        )
+      )
+    );
+    is-deeply $deparsed, q:to/CODE/, 'deparse';
+sub f (::T $x) {
+    T
+}
+f(42)
+CODE
+    is-deeply $_, Int, @type[$++]
       for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
 }
 

--- a/t/12-rakuast/signature.rakutest
+++ b/t/12-rakuast/signature.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 17;
+plan 18;
 
 my $ast;
 my $deparsed;
@@ -767,6 +767,46 @@ sub f (::T $x) {
 f(42)
 CODE
     is-deeply $_, Int, @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'Parameter with a where constraint' => {
+    # sub f ($x where 42) { $x }; f(42)
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Sub.new(
+          name      => RakuAST::Name.from-identifier('f'),
+          signature => RakuAST::Signature.new(
+            parameters => (
+              RakuAST::Parameter.new(
+                target => RakuAST::ParameterTarget::Var.new(:name<$x>),
+                where  => RakuAST::IntLiteral.new(42)
+              ),
+            )
+          ),
+          body => RakuAST::Blockoid.new(
+            RakuAST::StatementList.new(
+              RakuAST::Statement::Expression.new(
+                expression => RakuAST::Var::Lexical.new('$x')
+              )
+            )
+          )
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Call::Name.new(
+          name => RakuAST::Name.from-identifier('f'),
+          args => RakuAST::ArgList.new(RakuAST::IntLiteral.new(42))
+        )
+      )
+    );
+    is-deeply $deparsed, q:to/CODE/, 'deparse';
+sub f ($x where 42) {
+    $x
+}
+f(42)
+CODE
+    is-deeply $_, 42, @type[$++]
       for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
 }
 

--- a/t/12-rakuast/signature.rakutest
+++ b/t/12-rakuast/signature.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 15;
+plan 16;
 
 my $ast;
 my $deparsed;
@@ -644,6 +644,84 @@ subtest 'set-sub-signature mutator on a Parameter' => {
       ),
     );
     is $sub([10, 20]), '10|20', 'mutator path: destructure binds';
+}
+
+subtest 'Invocant parameter with a following parameter' => {
+    # my class A { method m ($self: $x) { $self, $x } }; A.new.m(42).elems
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Class.new(
+          scope => 'my',
+          name  => RakuAST::Name.from-identifier('A'),
+          body  => RakuAST::Block.new(
+            body => RakuAST::Blockoid.new(
+              RakuAST::StatementList.new(
+                RakuAST::Statement::Expression.new(
+                  expression => RakuAST::Method.new(
+                    name      => RakuAST::Name.from-identifier('m'),
+                    signature => RakuAST::Signature.new(
+                      parameters => (
+                        RakuAST::Parameter.new(
+                          target   => RakuAST::ParameterTarget::Var.new(:name<$self>),
+                          invocant => True
+                        ),
+                        RakuAST::Parameter.new(
+                          target => RakuAST::ParameterTarget::Var.new(:name<$x>)
+                        ),
+                      )
+                    ),
+                    body => RakuAST::Blockoid.new(
+                      RakuAST::StatementList.new(
+                        RakuAST::Statement::Expression.new(
+                          expression => RakuAST::ApplyListInfix.new(
+                            infix    => RakuAST::Infix.new(','),
+                            operands => (
+                              RakuAST::Var::Lexical.new('$self'),
+                              RakuAST::Var::Lexical.new('$x'),
+                            )
+                          )
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::ApplyPostfix.new(
+          operand => RakuAST::ApplyPostfix.new(
+            operand => RakuAST::ApplyPostfix.new(
+              operand => RakuAST::Type::Simple.new(
+                RakuAST::Name.from-identifier('A')
+              ),
+              postfix => RakuAST::Call::Method.new(
+                name => RakuAST::Name.from-identifier('new')
+              )
+            ),
+            postfix => RakuAST::Call::Method.new(
+              name => RakuAST::Name.from-identifier('m'),
+              args => RakuAST::ArgList.new(RakuAST::IntLiteral.new(42))
+            )
+          ),
+          postfix => RakuAST::Call::Method.new(
+            name => RakuAST::Name.from-identifier('elems')
+          )
+        )
+      )
+    );
+    is-deeply $deparsed, q:to/CODE/, 'deparse';
+my class A {
+    method m ($self: $x) {
+        $self, $x
+    }
+}
+A.new.m(42).elems
+CODE
+    is-deeply $_, 2, @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
 }
 
 # vim: expandtab shiftwidth=4

--- a/t/12-rakuast/signature.rakutest
+++ b/t/12-rakuast/signature.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 19;
+plan 20;
 
 my $ast;
 my $deparsed;
@@ -878,6 +878,54 @@ f(1, (2, 3))
 CODE
     is-deeply $_, 5, @type[$++]
       for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'Parameter that is only the type Any' => {
+    # sub f (Any, $x) { $x }; f(1, 2)
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Sub.new(
+          name      => RakuAST::Name.from-identifier('f'),
+          signature => RakuAST::Signature.new(
+            parameters => (
+              RakuAST::Parameter.new(
+                type => RakuAST::Type::Simple.new(
+                  RakuAST::Name.from-identifier('Any')
+                )
+              ),
+              RakuAST::Parameter.new(
+                target => RakuAST::ParameterTarget::Var.new(:name<$x>)
+              ),
+            )
+          ),
+          body => RakuAST::Blockoid.new(
+            RakuAST::StatementList.new(
+              RakuAST::Statement::Expression.new(
+                expression => RakuAST::Var::Lexical.new('$x')
+              )
+            )
+          )
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Call::Name.new(
+          name => RakuAST::Name.from-identifier('f'),
+          args => RakuAST::ArgList.new(
+            RakuAST::IntLiteral.new(1),
+            RakuAST::IntLiteral.new(2)
+          )
+        )
+      )
+    );
+    is-deeply $deparsed, q:to/CODE/, 'deparse';
+sub f (Any, $x) {
+    $x
+}
+f(1, 2)
+CODE
+    is-deeply $_, 2, @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+    is-deeply EVAL($raku).DEPARSE, $deparsed, 'round trips through .raku';
 }
 
 # vim: expandtab shiftwidth=4

--- a/t/12-rakuast/signature.rakutest
+++ b/t/12-rakuast/signature.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 18;
+plan 19;
 
 my $ast;
 my $deparsed;
@@ -807,6 +807,76 @@ sub f ($x where 42) {
 f(42)
 CODE
     is-deeply $_, 42, @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'Parameter that is only a sub-signature' => {
+    # sub f ($x, ($y, $z)) { $y + $z }; f(1, (2, 3))
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Sub.new(
+          name      => RakuAST::Name.from-identifier('f'),
+          signature => RakuAST::Signature.new(
+            parameters => (
+              RakuAST::Parameter.new(
+                target => RakuAST::ParameterTarget::Var.new(:name<$x>)
+              ),
+              RakuAST::Parameter.new(
+                sub-signature => RakuAST::Signature.new(
+                  parameters => (
+                    RakuAST::Parameter.new(
+                      target => RakuAST::ParameterTarget::Var.new(:name<$y>)
+                    ),
+                    RakuAST::Parameter.new(
+                      target => RakuAST::ParameterTarget::Var.new(:name<$z>)
+                    ),
+                  )
+                )
+              ),
+            )
+          ),
+          body => RakuAST::Blockoid.new(
+            RakuAST::StatementList.new(
+              RakuAST::Statement::Expression.new(
+                expression => RakuAST::ApplyInfix.new(
+                  left  => RakuAST::Var::Lexical.new('$y'),
+                  infix => RakuAST::Infix.new('+'),
+                  right => RakuAST::Var::Lexical.new('$z')
+                )
+              )
+            )
+          )
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Call::Name.new(
+          name => RakuAST::Name.from-identifier('f'),
+          args => RakuAST::ArgList.new(
+            RakuAST::IntLiteral.new(1),
+            RakuAST::Circumfix::Parentheses.new(
+              RakuAST::SemiList.new(
+                RakuAST::Statement::Expression.new(
+                  expression => RakuAST::ApplyListInfix.new(
+                    infix    => RakuAST::Infix.new(','),
+                    operands => (
+                      RakuAST::IntLiteral.new(2),
+                      RakuAST::IntLiteral.new(3),
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    );
+    is-deeply $deparsed, q:to/CODE/, 'deparse';
+sub f ($x, ($y, $z)) {
+    $y + $z
+}
+f(1, (2, 3))
+CODE
+    is-deeply $_, 5, @type[$++]
       for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
 }
 

--- a/t/12-rakuast/statement.rakutest
+++ b/t/12-rakuast/statement.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 37; # Do not change this file to done-testing
+plan 39; # Do not change this file to done-testing
 
 my $ast;
 my $deparsed;
@@ -1469,6 +1469,52 @@ CODE
         is-deeply EVAL($it), Nil, "$type: loop evaluates to Nil";
         is-deeply $count, 3, "$type: loop ran as expected";
     }
+}
+
+subtest 'require statement with an import list' => {
+    # require Test <&nok>;
+    # &nok.name
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Require.new(
+        module-name => RakuAST::Name.from-identifier('Test'),
+        argument    => RakuAST::QuotedString.new(
+          processors => <words val>,
+          segments   => (RakuAST::StrLiteral.new('&nok'),)
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::ApplyPostfix.new(
+          operand => RakuAST::Var::Lexical.new('&nok'),
+          postfix => RakuAST::Call::Method.new(
+            name => RakuAST::Name.from-identifier('name')
+          )
+        )
+      )
+    );
+    is-deeply $deparsed, Q:to/CODE/, 'deparse';
+require Test <&nok>;
+&nok.name
+CODE
+    is-deeply $_, 'nok', @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'require statement with a file' => {
+    # require "Test.rakumod";
+    # 42
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Require.new(
+        file => RakuAST::StrLiteral.new('Test.rakumod')
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::IntLiteral.new(42)
+      )
+    );
+    is-deeply $deparsed, Q:to/CODE/, 'deparse';
+require "Test.rakumod";
+42
+CODE
+    is-deeply EVAL($raku).DEPARSE, $deparsed, 'round trips through .raku';
 }
 
 # vim: expandtab shiftwidth=4

--- a/t/12-rakuast/statement.rakutest
+++ b/t/12-rakuast/statement.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 39; # Do not change this file to done-testing
+plan 40; # Do not change this file to done-testing
 
 my $ast;
 my $deparsed;
@@ -1515,6 +1515,56 @@ require "Test.rakumod";
 42
 CODE
     is-deeply EVAL($raku).DEPARSE, $deparsed, 'round trips through .raku';
+}
+
+subtest 'repeat while loop followed by a statement' => {
+    # my $i = 0;
+    # repeat {
+    #     $i++
+    # } while $i < 3;
+    # $i
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::VarDeclaration::Simple.new(
+          sigil       => '$',
+          desigilname => RakuAST::Name.from-identifier('i'),
+          initializer => RakuAST::Initializer::Assign.new(
+            RakuAST::IntLiteral.new(0)
+          )
+        )
+      ),
+      RakuAST::Statement::Loop::RepeatWhile.new(
+        condition => RakuAST::ApplyInfix.new(
+          left  => RakuAST::Var::Lexical.new('$i'),
+          infix => RakuAST::Infix.new('<'),
+          right => RakuAST::IntLiteral.new(3)
+        ),
+        body => RakuAST::Block.new(
+          body => RakuAST::Blockoid.new(
+            RakuAST::StatementList.new(
+              RakuAST::Statement::Expression.new(
+                expression => RakuAST::ApplyPostfix.new(
+                  operand => RakuAST::Var::Lexical.new('$i'),
+                  postfix => RakuAST::Postfix.new(:operator<++>)
+                )
+              )
+            )
+          )
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Var::Lexical.new('$i')
+      )
+    );
+    is-deeply $deparsed, Q:to/CODE/, 'deparse';
+my $i = 0;
+repeat {
+    $i++
+} while $i < 3;
+$i
+CODE
+    is-deeply $_, 3, @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
 }
 
 # vim: expandtab shiftwidth=4

--- a/t/12-rakuast/strings.rakutest
+++ b/t/12-rakuast/strings.rakutest
@@ -4,7 +4,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 17;
+plan 18;
 
 my $ast;
 my $deparsed;
@@ -295,6 +295,23 @@ my $x = "a";
 "$x\(1)"
 CODE
     is-deeply $_, 'a(1)', @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'Quote nested by its own delimiters' => {
+    # "a \{ b }"
+    ast RakuAST::QuotedString.new(
+      :segments[
+        RakuAST::StrLiteral.new('a {'),
+        RakuAST::QuotedString.new(
+          :segments[RakuAST::StrLiteral.new(' b ')]
+        ),
+        RakuAST::StrLiteral.new('}')
+      ]
+    );
+
+    is-deeply $deparsed, '"a \{ b }"', 'deparse';
+    is-deeply $_, 'a { b }', @type[$++]
       for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
 }
 

--- a/t/12-rakuast/strings.rakutest
+++ b/t/12-rakuast/strings.rakutest
@@ -4,7 +4,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 14;
+plan 16;
 
 my $ast;
 my $deparsed;
@@ -239,6 +239,31 @@ subtest 'Using the exec processor alone gives expected result' => {
 
     is-deeply $deparsed, 'qx/echo 123/', 'deparse';
     is-deeply $_, "123\n", @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'Words processor keeps the text of the < > form' => {
+    # <$a
+    # b>
+    ast RakuAST::QuotedString.new(
+      :segments[RakuAST::StrLiteral.new("\$a\nb")],
+      :processors['words', 'val']
+    );
+
+    is-deeply $deparsed, "<\$a\nb>", 'deparse';
+    is-deeply $_, ("\$a", "b"), @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'Words processor escapes the backslash and brackets of the < > form' => {
+    # <a\\b c\<d\>e>
+    ast RakuAST::QuotedString.new(
+      :segments[RakuAST::StrLiteral.new('a\\b c<d>e')],
+      :processors['words', 'val']
+    );
+
+    is-deeply $deparsed, '<a\\\\b c\\<d\\>e>', 'deparse';
+    is-deeply $_, ('a\\b', 'c<d>e'), @type[$++]
       for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
 }
 

--- a/t/12-rakuast/strings.rakutest
+++ b/t/12-rakuast/strings.rakutest
@@ -4,7 +4,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 16;
+plan 17;
 
 my $ast;
 my $deparsed;
@@ -264,6 +264,37 @@ subtest 'Words processor escapes the backslash and brackets of the < > form' => 
 
     is-deeply $deparsed, '<a\\\\b c\\<d\\>e>', 'deparse';
     is-deeply $_, ('a\\b', 'c<d>e'), @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'Bracket after an interpolation is escaped' => {
+    # my $x = "a";
+    # "$x\(1)"
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::VarDeclaration::Simple.new(
+          sigil       => '$',
+          desigilname => RakuAST::Name.from-identifier('x'),
+          initializer => RakuAST::Initializer::Assign.new(
+            RakuAST::StrLiteral.new('a')
+          )
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::QuotedString.new(
+          :segments[
+            RakuAST::Var::Lexical.new('$x'),
+            RakuAST::StrLiteral.new('(1)')
+          ]
+        )
+      )
+    );
+
+    is-deeply $deparsed, Q:to/CODE/, 'deparse';
+my $x = "a";
+"$x\(1)"
+CODE
+    is-deeply $_, 'a(1)', @type[$++]
       for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
 }
 

--- a/t/12-rakuast/stubs.rakutest
+++ b/t/12-rakuast/stubs.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 6;
+plan 7;
 
 my $ast;
 my $deparsed;
@@ -151,6 +151,28 @@ subtest 'can make a ??? stub with info' => {
             .resume;
         }
         EVAL($it);
+    }
+}
+
+subtest 'can make a ... stub with an empty argument list' => {
+    # ...
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Stub::Fail.new(args => RakuAST::ArgList.new)
+      )
+    );
+    is-deeply $deparsed, qq/...\n/, 'deparse';
+
+    for 'AST', $ast, 'Str', $deparsed, 'Raku', EVAL($raku) -> $type, $it {
+        my $result := sub () {
+            CONTROL {
+                isa-ok $_, CX::Return, "$type: did we get return?";
+            }
+            EVAL($it);
+        }();
+        isa-ok $result, Failure, "$type: did we get a Failure";
+        isa-ok $result.exception, X::StubCode,
+          "$type: did we get right exception";
     }
 }
 

--- a/t/12-rakuast/sub.rakutest
+++ b/t/12-rakuast/sub.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 13;
+plan 14;
 
 my $ast;
 my $deparsed;
@@ -526,6 +526,39 @@ sub infix:<+++> ($a, $b) {
 CODE
     is-deeply $_, 3, @type[$++]
       for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'Sub with an empty signature' => {
+    # sub f { 42 }; f()
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Sub.new(
+          name      => RakuAST::Name.from-identifier('f'),
+          signature => RakuAST::Signature.new(parameters => ()),
+          body      => RakuAST::Blockoid.new(
+            RakuAST::StatementList.new(
+              RakuAST::Statement::Expression.new(
+                expression => RakuAST::IntLiteral.new(42)
+              )
+            )
+          )
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Call::Name.new(
+          name => RakuAST::Name.from-identifier('f')
+        )
+      )
+    );
+    is-deeply $deparsed, q:to/CODE/, 'deparse';
+sub f {
+    42
+}
+f()
+CODE
+    is-deeply $_, 42, @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+    is-deeply $ast.DEPARSE, $deparsed, 'deparse after the sub was compiled';
 }
 
 # vim: expandtab shiftwidth=4

--- a/t/12-rakuast/types.rakutest
+++ b/t/12-rakuast/types.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 10;
+plan 12;
 
 my $ast;
 my $deparsed;
@@ -159,6 +159,117 @@ subtest 'Multi-part type from the setting' => {
         is-deeply EVAL($it), SETTING-Parts,
           "$type: did we get the setting version";
     }
+}
+
+subtest 'Definedness of a parameterized type' => {
+    # sub f (Positional:D[Int] $x) { $x.elems }; f(Array[Int].new(1, 2))
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Sub.new(
+          name      => RakuAST::Name.from-identifier('f'),
+          signature => RakuAST::Signature.new(
+            parameters => (
+              RakuAST::Parameter.new(
+                type => RakuAST::Type::Definedness.new(
+                  base-type => RakuAST::Type::Parameterized.new(
+                    base-type => RakuAST::Type::Simple.new(
+                      RakuAST::Name.from-identifier('Positional')
+                    ),
+                    args => RakuAST::ArgList.new(
+                      RakuAST::Type::Simple.new(
+                        RakuAST::Name.from-identifier('Int')
+                      )
+                    )
+                  ),
+                  definite => True
+                ),
+                target => RakuAST::ParameterTarget::Var.new(:name<$x>)
+              ),
+            )
+          ),
+          body => RakuAST::Blockoid.new(
+            RakuAST::StatementList.new(
+              RakuAST::Statement::Expression.new(
+                expression => RakuAST::ApplyPostfix.new(
+                  operand => RakuAST::Var::Lexical.new('$x'),
+                  postfix => RakuAST::Call::Method.new(
+                    name => RakuAST::Name.from-identifier('elems')
+                  )
+                )
+              )
+            )
+          )
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Call::Name.new(
+          name => RakuAST::Name.from-identifier('f'),
+          args => RakuAST::ArgList.new(
+            RakuAST::ApplyPostfix.new(
+              operand => RakuAST::Type::Parameterized.new(
+                base-type => RakuAST::Type::Simple.new(
+                  RakuAST::Name.from-identifier('Array')
+                ),
+                args => RakuAST::ArgList.new(
+                  RakuAST::Type::Simple.new(
+                    RakuAST::Name.from-identifier('Int')
+                  )
+                )
+              ),
+              postfix => RakuAST::Call::Method.new(
+                name => RakuAST::Name.from-identifier('new'),
+                args => RakuAST::ArgList.new(
+                  RakuAST::IntLiteral.new(1),
+                  RakuAST::IntLiteral.new(2)
+                )
+              )
+            )
+          )
+        )
+      )
+    );
+    is-deeply $deparsed, q:to/CODE/, 'deparse';
+sub f (Positional:D[Int] $x) {
+    $x.elems
+}
+f(Array[Int].new(1, 2))
+CODE
+    is-deeply $_, 2, @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'Declaration with the definedness of a parameterized type' => {
+    # my Hash:D[Str] %h;
+    # %h.elems
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::VarDeclaration::Simple.new(
+          type        => RakuAST::Type::Definedness.new(
+            base-type => RakuAST::Type::Parameterized.new(
+              base-type => RakuAST::Type::Simple.new(RakuAST::Name.from-identifier('Hash')),
+              args      => RakuAST::ArgList.new(
+                RakuAST::Type::Simple.new(RakuAST::Name.from-identifier('Str'))
+              )
+            ),
+            definite  => True
+          ),
+          sigil       => '%',
+          desigilname => RakuAST::Name.from-identifier('h')
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::ApplyPostfix.new(
+          operand => RakuAST::Var::Lexical.new('%h'),
+          postfix => RakuAST::Call::Method.new(name => RakuAST::Name.from-identifier('elems'))
+        )
+      )
+    );
+    is-deeply $deparsed, q:to/CODE/, 'deparse';
+my Hash:D[Str] %h;
+%h.elems
+CODE
+    is-deeply $_, 0, @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
 }
 
 # vim: expandtab shiftwidth=4

--- a/t/12-rakuast/var.rakutest
+++ b/t/12-rakuast/var.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 63;
+plan 64;
 
 my $ast;
 my $deparsed;
@@ -1505,6 +1505,35 @@ subtest 'Untyped signature declaration with a return type' => {
     );
     is-deeply $deparsed, "my (\$p --> Int) = 3;\n\$p\n", 'deparse';
     is-deeply $_, 3, @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'Lexical variable with a coercion type' => {
+    # my Int() $x = "42"; $x
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::VarDeclaration::Simple.new(
+          type        => RakuAST::Type::Coercion.new(
+            base-type => RakuAST::Type::Simple.new(
+              RakuAST::Name.from-identifier('Int')
+            )
+          ),
+          sigil       => '$',
+          desigilname => RakuAST::Name.from-identifier('x'),
+          initializer => RakuAST::Initializer::Assign.new(
+            RakuAST::StrLiteral.new('42')
+          )
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Var::Lexical.new('$x')
+      )
+    );
+    is-deeply $deparsed, q:to/CODE/, 'deparse';
+my Int() $x = "42";
+$x
+CODE
+    is-deeply $_, 42, @type[$++]
       for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
 }
 

--- a/t/12-rakuast/var.rakutest
+++ b/t/12-rakuast/var.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 64;
+plan 65;
 
 my $ast;
 my $deparsed;
@@ -1534,6 +1534,42 @@ my Int() $x = "42";
 $x
 CODE
     is-deeply $_, 42, @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'The &?BLOCK compile time variable' => {
+    # sub f { &?BLOCK.name }; f()
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Sub.new(
+          name => RakuAST::Name.from-identifier('f'),
+          body => RakuAST::Blockoid.new(
+            RakuAST::StatementList.new(
+              RakuAST::Statement::Expression.new(
+                expression => RakuAST::ApplyPostfix.new(
+                  operand => RakuAST::Var::Compiler::Block.new,
+                  postfix => RakuAST::Call::Method.new(
+                    name => RakuAST::Name.from-identifier('name')
+                  )
+                )
+              )
+            )
+          )
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Call::Name.new(
+          name => RakuAST::Name.from-identifier('f')
+        )
+      )
+    );
+    is-deeply $deparsed, q:to/CODE/, 'deparse';
+sub f {
+    &?BLOCK.name
+}
+f()
+CODE
+    is-deeply $_, 'f', @type[$++]
       for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
 }
 

--- a/t/12-rakuast/var.rakutest
+++ b/t/12-rakuast/var.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 65;
+plan 66;
 
 my $ast;
 my $deparsed;
@@ -1571,6 +1571,28 @@ f()
 CODE
     is-deeply $_, 'f', @type[$++]
       for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'The $?DISTRIBUTION compile time variable' => {
+    # $?DISTRIBUTION;
+    # 42
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Var::Compiler::Distribution.new
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::IntLiteral.new(42)
+      )
+    );
+    is-deeply $deparsed, q:to/CODE/, 'deparse';
+$?DISTRIBUTION;
+42
+CODE
+    is-deeply $_, 42, @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+    is-deeply RakuAST::Var::Compiler::Resources.new.raku,
+      'RakuAST::Var::Compiler::Resources.new',
+      'the .raku of $?RESOURCES takes no arguments';
 }
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously #6659 got a few dozen example programs round tripping, but sweeping real modules through the same parse, deparse, recompile and `.raku` round trip (rakudo's own `lib`, zef and about thirty ecosystem modules) showed the deparser still lost or mangled a good part of the language. A leading `#|` doc glued onto its declaration because the parser stores the line without its newline, an invocant parameter came out as `$self:, $x`, a `where` constraint, the target of a type capture and the `is repr` of a class or native were dropped outright, and `.raku` could not rebuild a class with a type trait, a stubbed package, a multi or private submethod, a `require` with an import list or a `$?DISTRIBUTION`. An attribute default that is not a literal was lost as soon as the class was compiled, since BEGIN time moves it into the build method and cleared the initializer.

This fixes each of those and the rest that turned up on the way: coercion and `Hash:D[Str]` types in declarations, `::("Name")` lookups and the colonpairs of a name, control characters in character classes, the words of `< >` kept as written, `< a b >` in a regex, a bracket after an interpolation, a `q{ {nested} }` quote, `.$f()` and `.&{ }` calls, `&?BLOCK`, typed enums, a pod block inside a package, a `repeat` loop and a `for` in parentheses ending their statement, and the empty `()` every routine was given although its `.raku` omitted it. Each commit carries a hand built test that fails without it, and `make test` passes under both frontends.

The one change outside the deparser is keeping the initializer of an attribute on its declaration once the build method holds it, with a flag so it is not visited twice, and leaving the generated build trait out of the `.raku` so that BEGIN time makes it again.

```
$ raku -e 'use experimental :rakuast; say Q[#| frobnicates
class A is repr("CStruct") { has int $.t = 1 + 1; method m($self: Int ::T $x where 42) { } }].AST.DEPARSE'
#| frobnicatesclass A {
    has int $.t;
    method m ($self:, ::T) { }
}
```
