### PR TITLE
RakuAST: fix a third batch of deparse holes found by round tripping raku code

### DIFF
--- a/src/Raku/ast/base.rakumod
+++ b/src/Raku/ast/base.rakumod
@@ -2745,9 +2745,12 @@ class RakuAST::Node {
             return Nil;
         }
         return Nil unless nqp::istype($expr, RakuAST::Parameter);
-        my $where := $expr.where;
-        return Nil unless nqp::isconcrete($where)
-            && nqp::istype($where, RakuAST::Block);
+        # Only a constraint that is smartmatched rather than called can be
+        # a junction of types
+        my $written := $expr.where;
+        return Nil unless nqp::isconcrete($written)
+            && !nqp::istype($written, RakuAST::Code)
+            && !$written.IMPL-PRIMED;
         return Nil if self.IMPL-IN-SOFT-SCOPE($resolver);
         my $Junction := self.IMPL-OPTIMIZE-SETTING-TYPE($resolver, 'Junction');
         return Nil if nqp::isnull($Junction);
@@ -2758,18 +2761,6 @@ class RakuAST::Node {
         # one that counts.
         my $nominal := nqp::getattr($expr.meta-object, Parameter, '$!type');
         return Nil if nqp::istype($Junction, nqp::decont($nominal));
-
-        # The written constraint is the invocant of the ACCEPTS call the
-        # begin-time wrapping built around it.
-        my $statements := $where.body.statement-list.IMPL-UNWRAP-LIST(
-            $where.body.statement-list.statements);
-        return Nil unless nqp::elems($statements) == 1
-            && nqp::istype($statements[0], RakuAST::Statement::Expression);
-        my $bool-call := $statements[0].expression;
-        return Nil unless nqp::istype($bool-call, RakuAST::ApplyPostfix);
-        my $accepts-call := $bool-call.operand;
-        return Nil unless nqp::istype($accepts-call, RakuAST::ApplyPostfix);
-        my $written := $accepts-call.operand;
 
         my $data := self.IMPL-JUNCTION-OF-TYPES($resolver, $written);
         return Nil if nqp::isnull($data);

--- a/src/Raku/ast/expressions.rakumod
+++ b/src/Raku/ast/expressions.rakumod
@@ -2533,9 +2533,12 @@ class RakuAST::WhateverApplicable
             my $operand := $_;
             if nqp::bitand_i(self.operator.IMPL-PRIMES, 1)
             && (nqp::istype($_, RakuAST::Term::Whatever) || nqp::istype($_, RakuAST::Term::HyperWhatever)) {
-                nqp::bindattr_i(self, RakuAST::WhateverApplicable, '$!hyperwhatever', 1)
-                    if nqp::istype($_, RakuAST::Term::HyperWhatever);
-                @operands[$index] := RakuAST::WhateverCode::Argument.new;
+                my $argument := RakuAST::WhateverCode::Argument.new;
+                if nqp::istype($_, RakuAST::Term::HyperWhatever) {
+                    nqp::bindattr_i(self, RakuAST::WhateverApplicable, '$!hyperwhatever', 1);
+                    $argument.set-hyper;
+                }
+                @operands[$index] := $argument;
             }
 
             # If we can prime WhateverCodes, unprime them first, i.e. move the thunk up to this node

--- a/src/Raku/ast/literals.rakumod
+++ b/src/Raku/ast/literals.rakumod
@@ -256,9 +256,14 @@ class RakuAST::QuotedString
             if self.sunk && $value;
     }
 
+    # Whether anything in the string is interpolated, a nested quote
+    # counts by its own segments
     method has-variables() {
         for $!segments {
-            return True if nqp::istype($_,RakuAST::Var);
+            my $segment := nqp::istype($_,RakuAST::QuoteWordsAtom) ?? $_.atom !! $_;
+            return True unless nqp::istype($segment,RakuAST::StrLiteral)
+              || (nqp::istype($segment,RakuAST::QuotedString)
+                   && !$segment.has-variables);
         }
         False
     }

--- a/src/Raku/ast/signature.rakumod
+++ b/src/Raku/ast/signature.rakumod
@@ -578,6 +578,9 @@ class RakuAST::Parameter
     has RakuAST::Parameter::Slurpy $.slurpy;
     has RakuAST::Expression        $.default;
     has RakuAST::Expression        $.where;
+    # The block BEGIN time wraps around a where constraint that is
+    # smartmatched rather than called, so the constraint stays as written
+    has RakuAST::Block             $!where-thunk;
     # Set by the optimize pass when the where constraint is a junction of
     # type objects: the types the argument is checked against inline, and
     # whether it must be all of them rather than any.
@@ -756,6 +759,9 @@ class RakuAST::Parameter
 
     method set-where(RakuAST::Expression $where) {
         nqp::bindattr(self, RakuAST::Parameter, '$!where', $where);
+        nqp::bindattr(self, RakuAST::Parameter, '$!where-thunk', RakuAST::Block);
+        nqp::bindattr(self, RakuAST::Parameter, '$!where-junction-types', Mu);
+        nqp::bindattr_i(self, RakuAST::Parameter, '$!where-junction-all', 0);
         Nil
     }
 
@@ -890,7 +896,12 @@ class RakuAST::Parameter
         $visitor($!type)          if $!type;
         $visitor($!target)        if $!target;
         $visitor($!default)       if $!default;
-        $visitor($!where)         if $!where;
+        if $!where-thunk {
+            $visitor($!where-thunk);
+        }
+        elsif $!where {
+            $visitor($!where);
+        }
         $visitor($!array-shape)   if $!array-shape;
         $visitor($!sub-signature) if $!sub-signature;
         $visitor(self.WHY)        if self.WHY;
@@ -1025,7 +1036,10 @@ class RakuAST::Parameter
                 }
             }
         }
-        if $!where {
+        if $!where-thunk {
+            nqp::push(@post_constraints, $!where-thunk.meta-object);
+        }
+        elsif $!where {
             nqp::push(@post_constraints, $!where.IMPL-PRIMED ?? $!where.IMPL-PRIMED.meta-object !! $!where.meta-object);
         }
         if $!array-shape {
@@ -1176,7 +1190,7 @@ class RakuAST::Parameter
             self.add-sorry: $sorry if $sorry;
         }
 
-        if $!where && (! nqp::istype($!where, RakuAST::Code) || nqp::istype($!where, RakuAST::RegexThunk)) && !$!where.IMPL-PRIMED {
+        if $!where && !$!where-thunk && (! nqp::istype($!where, RakuAST::Code) || nqp::istype($!where, RakuAST::RegexThunk)) && !$!where.IMPL-PRIMED {
             my $block := RakuAST::Block.new(
                 body => RakuAST::Blockoid.new(
                     RakuAST::StatementList.new(
@@ -1201,7 +1215,7 @@ class RakuAST::Parameter
             );
             $block.IMPL-BEGIN($resolver, $context);
             $block.IMPL-CHECK($resolver, $context);
-            nqp::bindattr(self, RakuAST::Parameter, '$!where', $block);
+            nqp::bindattr(self, RakuAST::Parameter, '$!where-thunk', $block);
         }
 
         if $!array-shape {
@@ -2023,7 +2037,7 @@ class RakuAST::Parameter
                             :op<istrue>,
                             QAST::Op.new(
                                 :op('callmethod'), :name('ACCEPTS'),
-                                $!where.IMPL-TO-QAST($context),
+                                ($!where-thunk || $!where).IMPL-TO-QAST($context),
                                 $temp-qast-var
                             )
                         )

--- a/src/Raku/ast/term.rakumod
+++ b/src/Raku/ast/term.rakumod
@@ -434,10 +434,20 @@ class RakuAST::WhateverCode::Argument
   is RakuAST::BeginTime
 {
     has RakuAST::Name $!name;
+    # Set when the argument stands for a ** rather than a *
+    has int $!hyper;
 
     method new() {
         my $obj := nqp::create(self);
         $obj
+    }
+
+    method set-hyper() {
+        nqp::bindattr_i(self, RakuAST::WhateverCode::Argument, '$!hyper', 1);
+    }
+
+    method is-hyper() {
+        $!hyper ?? True !! False
     }
 
     method set-name(RakuAST::Name $name) {

--- a/src/Raku/ast/variable-declaration.rakumod
+++ b/src/Raku/ast/variable-declaration.rakumod
@@ -2103,6 +2103,12 @@ class RakuAST::VarDeclaration::Signature
             $initializer // RakuAST::Initializer);
         nqp::bindattr($obj, RakuAST::VarDeclaration::Signature, '$!sig-literal',
             $sig-literal ?? True !! False);
+        # The variable a parameter declares makes a subset of its type
+        # from the where constraint, and a walk begins it before this
+        # declaration
+        for $obj.IMPL-UNWRAP-LIST($signature.parameters) {
+            $_.target.set-where($_.where) if $_.where && $_.target;
+        }
         $obj
     }
 

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -775,7 +775,14 @@ CODE
             (self.postfix-operand-needs-parens($operand)
               ?? self.parenthesize($operand)
               !! self.deparse($operand)
-            ) ~ $deparsed-postfix
+            )
+              # a term followed by a bare argument list is a routine call
+              ~ (nqp::istype($postfix,RakuAST::Call::Term)
+                  && nqp::istype($operand,RakuAST::Term::Name)
+                  ?? '.'
+                  !! ''
+                )
+              ~ $deparsed-postfix
         }
     }
 

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -349,34 +349,91 @@ CODE
     # backslash and its own brackets
     method assemble-quoted-string($ast, :$raw --> Str:D) {
         my int $interpolated;
-        $ast.segments.map({
-            if nqp::istype($_,RakuAST::StrLiteral) {
+        my @segments := $ast.segments;
+        my str @parts;
+        for @segments.kv -> $i, $segment {
+            if nqp::istype($segment,RakuAST::StrLiteral) {
                 my str $text = $raw
-                  ?? .value.subst('\\','\\\\',:g).subst('<','\\<',:g).subst('>','\\>',:g)
-                  !! .value.raku.substr(1,*-1);
+                  ?? $segment.value.subst('\\','\\\\',:g).subst('<','\\<',:g).subst('>','\\>',:g)
+                  !! $segment.value.raku.substr(1,*-1);
                 if $text {
                     # a bracket right after an interpolation would continue
-                    # it as a call or an index
+                    # it as a call or an index, and so would a dot that
+                    # leads to one
+                    my $next := @segments[$i + 1];
                     $text = '\\' ~ $text
                       if $interpolated
-                      && nqp::index('([{<',$text.substr(0,1)) >= 0;
+                      && (nqp::index('([{<',$text.substr(0,1)) >= 0
+                           || self.dot-continues-interpolation(
+                                $text,
+                                $next.defined
+                                  && !nqp::istype($next,RakuAST::StrLiteral)
+                                  && !nqp::istype($next,RakuAST::QuotedString)
+                              ));
                     $interpolated = 0;
                 }
-                $text
+                @parts.push($text);
             }
             # the text between a nested pair of the delimiters is a quote of
             # its own, one without processors belongs to this one
-            elsif nqp::istype($_,RakuAST::QuotedString) && !.processors {
+            elsif nqp::istype($segment,RakuAST::QuotedString)
+              && !$segment.processors {
                 $interpolated = 0;
-                self.assemble-quoted-string($_, :$raw)
+                @parts.push(self.assemble-quoted-string($segment, :$raw));
             }
             else {
-                $interpolated = 1;
+                # a closure ends the interpolation
+                $interpolated = nqp::istype($segment,RakuAST::Block) ?? 0 !! 1;
                 # a method call only interpolates with its parentheses
-                my $*INTERPOLATING := nqp::istype($_,RakuAST::ApplyPostfix);
-                self.deparse($_)
+                my $*INTERPOLATING := nqp::istype($segment,RakuAST::ApplyPostfix);
+                @parts.push(self.deparse($segment));
             }
-        }).join
+        }
+        @parts.join
+    }
+
+    # Whether text that starts with a dot would continue the
+    # interpolation before it: a chain of method names, each with or
+    # without a dispatch prefix, that ends in a bracket or a quote, or
+    # in a dot when an interpolation follows the text
+    method dot-continues-interpolation(
+      str $text,
+          $next-interpolates
+    --> Bool:D) {
+        my int $chars = nqp::chars($text);
+        my int $i;
+        while $i < $chars && nqp::eqat($text,'.',$i) {
+            ++$i;
+            return True if $i == $chars && $next-interpolates;
+            ++$i if $i < $chars
+              && nqp::index('?&^*+=',nqp::substr($text,$i,1)) >= 0;
+            return True if $i < $chars
+              && nqp::index(q/([{<'"/,nqp::substr($text,$i,1)) >= 0;
+
+            # a method name, a hyphen or apostrophe that a letter follows
+            # and a package separator are part of it
+            my int $start = $i;
+            loop {
+                $i = nqp::findnotcclass(
+                  nqp::const::CCLASS_WORD,$text,$i,$chars - $i
+                );
+                if nqp::eqat($text,'::',$i) {
+                    $i = $i + 2;
+                }
+                elsif $i + 1 < $chars
+                  && nqp::index(q/-'/,nqp::substr($text,$i,1)) >= 0
+                  && nqp::iscclass(nqp::const::CCLASS_ALPHABETIC,$text,$i + 1) {
+                    ++$i;
+                }
+                else {
+                    last;
+                }
+            }
+            return False if $i == $start;
+            return True if $i < $chars
+              && nqp::index('([{<',nqp::substr($text,$i,1)) >= 0;
+        }
+        False
     }
 
     method multiple-processors(str $string, @processors --> Str:D) {

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -385,7 +385,8 @@ CODE
                 # a closure ends the interpolation
                 $interpolated = nqp::istype($segment,RakuAST::Block) ?? 0 !! 1;
                 # a method call only interpolates with its parentheses
-                my $*INTERPOLATING := nqp::istype($segment,RakuAST::ApplyPostfix);
+                my $*INTERPOLATING := nqp::istype($segment,RakuAST::ApplyPostfix)
+                  || nqp::istype($segment,RakuAST::ApplyDottyInfix);
                 @parts.push(self.deparse($segment));
             }
         }
@@ -810,8 +811,11 @@ CODE
 
     multi method deparse(RakuAST::ApplyDottyInfix:D $ast --> Str:D) {
         my $*DELIMITER = '';
+        my str $infix = self.deparse($ast.infix);
+        # whitespace around the infix would end an interpolation
+        $infix = $infix.trim if $*INTERPOLATING;
         self.deparse($ast.left)
-          ~ self.deparse($ast.infix)
+          ~ $infix
           # lose the ".", as it is provided by the infix
           ~ self.deparse($ast.right).substr(1)
     }

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -2958,8 +2958,10 @@ CODE
         self.hsyn('var-term', $.term-whatever)
     }
 
-    multi method deparse(RakuAST::WhateverCode::Argument:D $ --> Str:D) {
-        self.hsyn('var-term', $.term-whatever)
+    multi method deparse(RakuAST::WhateverCode::Argument:D $ast --> Str:D) {
+        self.hsyn('var-term',
+          $ast.is-hyper ?? $.term-hyperwhatever !! $.term-whatever
+        )
     }
 
 #- Ternary ---------------------------------------------------------------------

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -2210,10 +2210,15 @@ CODE
 
 #- Regex::Q --------------------------------------------------------------------
 
-    multi method deparse(RakuAST::Regex::QuantifiedAtom:D $ast --> Str:D) {
+    multi method deparse(
+      RakuAST::Regex::QuantifiedAtom:D $ast, :$whitespace
+    --> Str:D) {
         my str @parts = self.deparse($ast.atom), self.deparse($ast.quantifier);
 
         if $ast.separator -> $separator {
+            # the whitespace of a quantified atom with a separator sits
+            # between the quantifier and the separator
+            @parts.push(' ') if $whitespace;
             @parts.push($ast.trailing-separator ?? '%% ' !! '% ');
             @parts.push(self.deparse($separator));
         }
@@ -2344,7 +2349,10 @@ CODE
 #- Regex::W --------------------------------------------------------------------
 
     multi method deparse(RakuAST::Regex::WithWhitespace:D $ast --> Str:D) {
-        self.deparse($ast.regex) ~ " "
+        my $regex := $ast.regex;
+        nqp::istype($regex,RakuAST::Regex::QuantifiedAtom) && $regex.separator
+          ?? self.deparse($regex, :whitespace)
+          !! self.deparse($regex) ~ " "
     }
 
 #- RegexD ----------------------------------------------------------------------

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -1728,8 +1728,10 @@ CODE
         }
 
         else {
-            @parts.push(self.deparse($signature))
-              if $signature.parameters-initialized;
+            if $signature.parameters-initialized
+              && self.deparse($signature) -> $deparsed {
+                @parts.push($deparsed);
+            }
 
             if $WHY {
                 @parts.push('{');

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -766,6 +766,10 @@ CODE
         @parts.push(
           self.hsyn(%twigil2type{$twigil} // 'var-lexical', $name)
         );
+        @parts.push($ast.sigil eq '%'
+          ?? self.bracketize($_)
+          !! self.squarize($_)
+        ) with $ast.shape;
 
         if $ast.traits.grep({
             nqp::not_i(nqp::istype($_,RakuAST::Trait::WillBuild))

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -147,6 +147,7 @@ class RakuAST::Deparse {
         if nqp::isnull(nqp::getlexcaller('$*INDENT')) {
             my $*INDENT    = "";  # indentation level
             my $*DELIMITER = "";  # delimiter to add, reset if added
+            my $*INTERPOLATING := False;  # in a call interpolated in a string
             {*}
         }
         else {
@@ -371,6 +372,8 @@ CODE
             }
             else {
                 $interpolated = 1;
+                # a method call only interpolates with its parentheses
+                my $*INTERPOLATING := nqp::istype($_,RakuAST::ApplyPostfix);
                 self.deparse($_)
             }
         }).join
@@ -525,7 +528,13 @@ CODE
               ?? self.hsyn("core-$name", self.xsyn('core', $name))
               !! $name
             )
-          ~ ($macroish ?? '' !! self.parenthesize($ast.args, :$only-non-empty))
+          ~ ($macroish && !$*INTERPOLATING
+              ?? ''
+              !! self.parenthesize(
+                   $ast.args,
+                   :only-non-empty($only-non-empty && !$*INTERPOLATING)
+                 )
+            )
     }
 
     method quote-if-needed(str $literal) {
@@ -794,6 +803,7 @@ CODE
 
     multi method deparse(RakuAST::ArgList:D $ast --> Str:D) {
         my $*IN-ARGLIST := True;
+        my $*INTERPOLATING := False;
         # a declaration argument would add the statement delimiter
         my $*DELIMITER = '';
         $ast.args.map({
@@ -885,7 +895,7 @@ CODE
               ?? '&' ~ self.deparse($block.target)
               !! self.deparse($block)
             )
-          ~ self.parenthesize($ast.args, :only-non-empty)
+          ~ self.parenthesize($ast.args, :only-non-empty(!$*INTERPOLATING))
     }
 
     multi method deparse(RakuAST::Call::VarMethod:D $ast --> Str:D) {
@@ -2334,6 +2344,7 @@ CODE
 #- S ---------------------------------------------------------------------------
 
     multi method deparse(RakuAST::SemiList:D $ast --> Str:D) {
+        my $*INTERPOLATING := False;
         my @statements := $ast.statements;
         my $statement  := @statements.head;
         @statements == 1
@@ -2600,6 +2611,7 @@ CODE
     }
 
     multi method deparse(RakuAST::StatementList:D $ast --> Str:D) {
+        my $*INTERPOLATING := False;
 
         if $ast.statements -> @statements {
             my str @parts;

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -837,7 +837,10 @@ CODE
         my     $postfix         := $ast.postfix;
         my str $deparsed-postfix = self.deparse($postfix);
 
-        if $ast.on-topic && nqp::istype($postfix,RakuAST::Call::Method) {
+        # a method call on the topic interpolates only with the topic written
+        if $ast.on-topic
+          && nqp::istype($postfix,RakuAST::Call::Method)
+          && !$*INTERPOLATING {
             $deparsed-postfix
         }
         else {

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -2188,8 +2188,16 @@ CODE
 #- Regex::N --------------------------------------------------------------------
 
     multi method deparse(RakuAST::Regex::NamedCapture:D $ast --> Str:D) {
-        self.hsyn('capture-named', '$<' ~ $ast.name ~ '>=')
-          ~ self.deparse($ast.regex)
+        my str $name  = $ast.name;
+        my int $chars = nqp::chars($name);
+        # a numbered capture is written without the brackets
+        self.hsyn('capture-named',
+          $chars && nqp::findnotcclass(
+            nqp::const::CCLASS_NUMERIC,$name,0,$chars
+          ) == $chars
+            ?? '$' ~ $name ~ '='
+            !! '$<' ~ $name ~ '>='
+        ) ~ self.deparse($ast.regex)
     }
 
     multi method deparse(RakuAST::Regex::Nested:D $ast --> Str:D) {

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -1819,7 +1819,7 @@ CODE
         if $ast.processors -> @processors {
             if @processors == 1 && @processors.head -> $processor {
                 if %single-processor-prefix{$processor} -> str $p is copy {
-                    $p = 'qqx/' if $p eq 'exec' && $ast.has-variables;
+                    $p = 'qqx/' if $processor eq 'exec' && $ast.has-variables;
                     self.hsyn("adverb-q-$p", self.xsyn('adverb-q', $p))
                       ~ $string ~ '/'
                 }

--- a/src/core.c/RakuAST/Deparse.rakumod
+++ b/src/core.c/RakuAST/Deparse.rakumod
@@ -1631,7 +1631,13 @@ CODE
                 @parts.push($var);
                 @parts.push(nqp::x(')',$parens)) if $parens;
                 @parts.push('?') if $ast.is-declared-optional;
-                @parts.push('!') if $ast.is-declared-required;
+                # the is required trait marks the parameter required
+                @parts.push('!') if $ast.is-declared-required
+                  && !$ast.traits.first({
+                       nqp::istype($_,RakuAST::Trait::Is)
+                         && .name
+                         && .name.canonicalize eq 'required'
+                     });
             }
 
             # positional parameter

--- a/src/core.c/RakuAST/Raku.rakumod
+++ b/src/core.c/RakuAST/Raku.rakumod
@@ -1234,7 +1234,10 @@ augment class RakuAST::Node {
     }
 
     multi method raku(RakuAST::Type::Coercion:D: --> Str:D) {
-        self!nameds: (try self.constraint.name.canonicalize eq 'Any')
+        # only the setting Any the constructor supplies is left out
+        my $constraint := self.constraint;
+        self!nameds: nqp::istype($constraint,RakuAST::Type::Setting)
+          && $constraint.name.canonicalize eq 'Any'
           ?? <base-type>
           !! <base-type constraint>
     }

--- a/src/core.c/RakuAST/Raku.rakumod
+++ b/src/core.c/RakuAST/Raku.rakumod
@@ -65,8 +65,13 @@ augment class RakuAST::Node {
 
     method !none() { self.^name ~ '.new' }
 
-    method !literal($value) {
-        self.^name ~ '.new(' ~ nqp::decont($value).raku ~ ')';
+    # a junction value must not autothread, and the base class is only
+    # made through from-value
+    method !literal(Mu $value) {
+        (nqp::eqaddr(self.WHAT,RakuAST::Literal)
+          ?? 'RakuAST::Literal.from-value('
+          !! self.^name ~ '.new('
+        ) ~ nqp::decont($value).raku ~ ')'
     }
 
     method !positional($value) {

--- a/src/core.c/RakuAST/Raku.rakumod
+++ b/src/core.c/RakuAST/Raku.rakumod
@@ -1383,6 +1383,16 @@ augment class RakuAST::Node {
     multi method raku(RakuAST::VarDeclaration::Term:D: --> Str:D) {
         self!nameds: <scope type name initializer>
     }
+
+#- WhateverCode ----------------------------------------------------------------
+
+    # BEGIN time makes one from the * or ** of a WhateverCode expression
+    multi method raku(RakuAST::WhateverCode::Argument:D: --> Str:D) {
+        (self.is-hyper
+          ?? RakuAST::Term::HyperWhatever
+          !! RakuAST::Term::Whatever
+        ).new.raku
+    }
 }
 
 #-------------------------------------------------------------------------------

--- a/t/12-rakuast/block.rakutest
+++ b/t/12-rakuast/block.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 5;
+plan 6;
 
 my $ast;
 my $deparsed;
@@ -219,6 +219,40 @@ CODE
           "$type: Block has default $type parameter";
         lives-ok { $block() },
           "$type: That $type parameter is optional";
+    }
+}
+
+subtest 'A pointy block with an empty signature' => {
+    # -> { 101 }
+    my $signature := RakuAST::Signature.new;
+    $signature.set-parameters-initialized;
+    ast RakuAST::Statement::Expression.new(
+      expression => RakuAST::PointyBlock.new(
+        :$signature,
+        body => RakuAST::Blockoid.new(
+          RakuAST::StatementList.new(
+            RakuAST::Statement::Expression.new(
+              expression => RakuAST::IntLiteral.new(101)
+            )
+          )
+        )
+      )
+    );
+    is-deeply $deparsed, q:to/CODE/.chomp, 'deparse';
+-> {
+    101
+}
+CODE
+
+    for
+      'AST', EVAL($ast),
+      'Str', EVAL($deparsed),
+      'Raku', EVAL(EVAL $raku)
+    -> $type, $block {
+        is $block.signature.params.elems, 0,
+          "$type: The block has no parameters";
+        is $block(), 101,
+          "$type: Invoking the block returns the expected value";
     }
 }
 

--- a/t/12-rakuast/operators.rakutest
+++ b/t/12-rakuast/operators.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 33;
+plan 34;
 
 my $ast;
 my $deparsed;
@@ -501,6 +501,37 @@ subtest 'Declaration as an infix operand in a statement list' => {
     is-deeply $deparsed, "my \$x = 1 and 2;\n\$x\n", 'deparse';
     is-deeply $_, 1, @type[$++]
       for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'Folded junction literal keeps its .raku after BEGIN time' => {
+    # my $j = 1 | "a";
+    # $j
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::VarDeclaration::Simple.new(
+          sigil       => '$',
+          desigilname => RakuAST::Name.from-identifier('j'),
+          initializer => RakuAST::Initializer::Assign.new(
+            RakuAST::ApplyInfix.new(
+              left  => RakuAST::IntLiteral.new(1),
+              infix => RakuAST::Infix.new('|'),
+              right => RakuAST::StrLiteral.new('a')
+            )
+          )
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Var::Lexical.new('$j')
+      )
+    );
+    is-deeply $deparsed, q:to/CODE/, 'deparse';
+my $j = 1 | "a";
+$j
+CODE
+    is $_.raku, 'any(1, "a")', @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+    is EVAL(EVAL 'use experimental :rakuast; ' ~ $ast.raku).raku,
+      'any(1, "a")', 'EVAL of the .raku after BEGIN time';
 }
 
 # vim: expandtab shiftwidth=4

--- a/t/12-rakuast/postfix.rakutest
+++ b/t/12-rakuast/postfix.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 33;
+plan 35;
 
 my $ast;
 my $deparsed;
@@ -790,6 +790,60 @@ t.(1) + $f(1)
 CODE
     is-deeply $_, 84, @type[$++]
       for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'WhateverCode keeps its .raku after BEGIN time' => {
+    # (* > 1)(2)
+    ast RakuAST::ApplyPostfix.new(
+      operand => RakuAST::Circumfix::Parentheses.new(
+        RakuAST::SemiList.new(
+          RakuAST::Statement::Expression.new(
+            expression => RakuAST::ApplyInfix.new(
+              left  => RakuAST::Term::Whatever.new,
+              infix => RakuAST::Infix.new('>'),
+              right => RakuAST::IntLiteral.new(1)
+            )
+          )
+        )
+      ),
+      postfix => RakuAST::Call::Term.new(
+        args => RakuAST::ArgList.new(RakuAST::IntLiteral.new(2))
+      )
+    );
+    is-deeply $deparsed, '(* > 1)(2)', 'deparse';
+    is-deeply $_, True, @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+    is-deeply EVAL(EVAL 'use experimental :rakuast; ' ~ $ast.raku), True,
+      'EVAL of the .raku after BEGIN time';
+}
+
+subtest 'HyperWhateverCode keeps its .raku after BEGIN time' => {
+    # (** + 1)(1, 2)
+    ast RakuAST::ApplyPostfix.new(
+      operand => RakuAST::Circumfix::Parentheses.new(
+        RakuAST::SemiList.new(
+          RakuAST::Statement::Expression.new(
+            expression => RakuAST::ApplyInfix.new(
+              left  => RakuAST::Term::HyperWhatever.new,
+              infix => RakuAST::Infix.new('+'),
+              right => RakuAST::IntLiteral.new(1)
+            )
+          )
+        )
+      ),
+      postfix => RakuAST::Call::Term.new(
+        args => RakuAST::ArgList.new(
+          RakuAST::IntLiteral.new(1),
+          RakuAST::IntLiteral.new(2)
+        )
+      )
+    );
+    is-deeply $deparsed, '(** + 1)(1, 2)', 'deparse';
+    is-deeply $_.List, (2, 3), @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+    is-deeply $ast.DEPARSE, $deparsed, 'deparse after BEGIN time';
+    is-deeply EVAL(EVAL 'use experimental :rakuast; ' ~ $ast.raku).List,
+      (2, 3), 'EVAL of the .raku after BEGIN time';
 }
 
 # vim: expandtab shiftwidth=4

--- a/t/12-rakuast/postfix.rakutest
+++ b/t/12-rakuast/postfix.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 32;
+plan 33;
 
 my $ast;
 my $deparsed;
@@ -723,6 +723,73 @@ subtest 'Literal hash index with an assignee' => {
         is-deeply EVAL($it), 42, "$type: did we get the assigned value";
         is-deeply %h<a>, 42, "$type: was the element assigned";
     }
+}
+
+subtest 'Argument list applied to a term' => {
+    # my \t = {
+    #     41 + $_
+    # };
+    # my $f = t;
+    # t.(1) + $f(1)
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::VarDeclaration::Term.new(
+          name        => RakuAST::Name.from-identifier('t'),
+          initializer => RakuAST::Initializer::Assign.new(
+            RakuAST::Block.new(
+              body => RakuAST::Blockoid.new(
+                RakuAST::StatementList.new(
+                  RakuAST::Statement::Expression.new(
+                    expression => RakuAST::ApplyInfix.new(
+                      left  => RakuAST::IntLiteral.new(41),
+                      infix => RakuAST::Infix.new('+'),
+                      right => RakuAST::Var::Lexical.new('$_')
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::VarDeclaration::Simple.new(
+          sigil       => '$',
+          desigilname => RakuAST::Name.from-identifier('f'),
+          initializer => RakuAST::Initializer::Assign.new(
+            RakuAST::Term::Name.new(RakuAST::Name.from-identifier('t'))
+          )
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::ApplyInfix.new(
+          left  => RakuAST::ApplyPostfix.new(
+            operand => RakuAST::Term::Name.new(
+              RakuAST::Name.from-identifier('t')
+            ),
+            postfix => RakuAST::Call::Term.new(
+              args => RakuAST::ArgList.new(RakuAST::IntLiteral.new(1))
+            )
+          ),
+          infix => RakuAST::Infix.new('+'),
+          right => RakuAST::ApplyPostfix.new(
+            operand => RakuAST::Var::Lexical.new('$f'),
+            postfix => RakuAST::Call::Term.new(
+              args => RakuAST::ArgList.new(RakuAST::IntLiteral.new(1))
+            )
+          )
+        )
+      )
+    );
+    is-deeply $deparsed, q:to/CODE/, 'deparse';
+my \t = {
+    41 + $_
+};
+my $f = t;
+t.(1) + $f(1)
+CODE
+    is-deeply $_, 84, @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
 }
 
 # vim: expandtab shiftwidth=4

--- a/t/12-rakuast/regex.rakutest
+++ b/t/12-rakuast/regex.rakutest
@@ -2,7 +2,7 @@ use v6.e.PREVIEW;
 use nqp;
 use Test;
 
-plan 60;
+plan 61;
 
 my $ast;
 my $deparsed;
@@ -830,6 +830,21 @@ subtest 'Quoted words in a regex holding a slash' => {
     );
     is-deeply $deparsed, '/< a/b c\<d >/', 'deparse';
     match-ok "xc<d", 'c<d';
+}
+
+subtest 'Match with numbered capture' => {
+    # /$0=o/
+    ast RakuAST::Regex::NamedCapture.new(
+      name  => '0',
+      regex => RakuAST::Regex::Literal.new("o"),
+    );
+    is-deeply $deparsed, '/$0=o/', 'deparse';
+
+    for 'AST', $ast, 'Str', $deparsed, 'Raku', EVAL($raku) -> $type, $it {
+        my $regex := EVAL($it);
+        is "foo" ~~ $regex, 'o', "$type: matched";
+        is $/[0], 'o', "$type: capture is numbered";
+    }
 }
 
 # vim: expandtab shiftwidth=4

--- a/t/12-rakuast/regex.rakutest
+++ b/t/12-rakuast/regex.rakutest
@@ -2,7 +2,7 @@ use v6.e.PREVIEW;
 use nqp;
 use Test;
 
-plan 61;
+plan 65;
 
 my $ast;
 my $deparsed;
@@ -845,6 +845,77 @@ subtest 'Match with numbered capture' => {
         is "foo" ~~ $regex, 'o', "$type: matched";
         is $/[0], 'o', "$type: capture is numbered";
     }
+}
+
+subtest 'Separator followed by whitespace' => {
+    # /a+ % b /
+    ast RakuAST::Regex::WithWhitespace.new(
+      RakuAST::Regex::QuantifiedAtom.new(
+        atom       => RakuAST::Regex::Literal.new("a"),
+        quantifier => RakuAST::Regex::Quantifier::OneOrMore.new,
+        separator  => RakuAST::Regex::WithWhitespace.new(
+          RakuAST::Regex::Literal.new("b")
+        )
+      )
+    );
+    is-deeply $deparsed, '/a+ % b /', 'deparse';
+
+    match-ok "xababac", 'ababa';
+}
+
+subtest 'Sigspace separator with whitespace on both sides' => {
+    # /:s a+ % b /
+    ast RakuAST::Regex::Sequence.new(
+      RakuAST::Regex::InternalModifier::Sigspace.new,
+      RakuAST::Regex::WithWhitespace.new(
+        RakuAST::Regex::QuantifiedAtom.new(
+          atom       => RakuAST::Regex::Literal.new("a"),
+          quantifier => RakuAST::Regex::Quantifier::OneOrMore.new,
+          separator  => RakuAST::Regex::WithWhitespace.new(
+            RakuAST::Regex::Literal.new("b")
+          )
+        )
+      )
+    );
+    is-deeply $deparsed, '/:s a+ % b /', 'deparse';
+
+    match-ok "ab ab a", 'ab ab a';
+    match-nok "ab ab";
+}
+
+subtest 'Sigspace separator with whitespace after it only' => {
+    # /:s a+% b /
+    ast RakuAST::Regex::Sequence.new(
+      RakuAST::Regex::InternalModifier::Sigspace.new,
+      RakuAST::Regex::QuantifiedAtom.new(
+        atom       => RakuAST::Regex::Literal.new("a"),
+        quantifier => RakuAST::Regex::Quantifier::OneOrMore.new,
+        separator  => RakuAST::Regex::WithWhitespace.new(
+          RakuAST::Regex::Literal.new("b")
+        )
+      )
+    );
+    is-deeply $deparsed, '/:s a+% b /', 'deparse';
+
+    match-ok "ab ab", 'ab a';
+}
+
+subtest 'Sigspace separator with whitespace before it only' => {
+    # /:s a+ % b/
+    ast RakuAST::Regex::Sequence.new(
+      RakuAST::Regex::InternalModifier::Sigspace.new,
+      RakuAST::Regex::WithWhitespace.new(
+        RakuAST::Regex::QuantifiedAtom.new(
+          atom       => RakuAST::Regex::Literal.new("a"),
+          quantifier => RakuAST::Regex::Quantifier::OneOrMore.new,
+          separator  => RakuAST::Regex::Literal.new("b")
+        )
+      )
+    );
+    is-deeply $deparsed, '/:s a+ % b/', 'deparse';
+
+    match-ok "ab ab a", 'a';
+    match-nok "ab ab";
 }
 
 # vim: expandtab shiftwidth=4

--- a/t/12-rakuast/signature.rakutest
+++ b/t/12-rakuast/signature.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 21;
+plan 22;
 
 my $ast;
 my $deparsed;
@@ -975,6 +975,50 @@ f(42)
 CODE
     is-deeply $_, Int, @type[$++]
       for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'Named parameter made required by a trait' => {
+    # sub (:$named is required) { $named }
+    ast RakuAST::Sub.new(
+      signature => RakuAST::Signature.new(
+        parameters => (
+          RakuAST::Parameter.new(
+            target => RakuAST::ParameterTarget::Var.new(:name<$named>),
+            names  => ['named'],
+            traits => [
+              RakuAST::Trait::Is.new(
+                name => RakuAST::Name.from-identifier('required')
+              ),
+            ]
+          ),
+        )
+      ),
+      body => RakuAST::Blockoid.new(
+        RakuAST::StatementList.new(
+          RakuAST::Statement::Expression.new(
+            expression => RakuAST::Var::Lexical.new('$named')
+          )
+        )
+      )
+    );
+
+    is-deeply $deparsed, q:to/CODE/.chomp, 'deparse';
+sub (:$named is required) {
+    $named
+}
+CODE
+
+    for
+      'AST', EVAL($ast),
+      'Str', EVAL($deparsed),
+      'Raku', EVAL(EVAL $raku)
+    -> $type, $sub {
+        ok $sub.signature.params[0].named, "$type: parameter is named";
+        nok $sub.signature.params[0].optional, "$type: parameter is required";
+        is $sub(named => 42), 42, "$type: the argument is passed";
+        dies-ok { $sub() }, "$type: the argument is required";
+    }
+    is-deeply $ast.DEPARSE, $deparsed, 'deparse after BEGIN time';
 }
 
 # vim: expandtab shiftwidth=4

--- a/t/12-rakuast/signature.rakutest
+++ b/t/12-rakuast/signature.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 22;
+plan 23;
 
 my $ast;
 my $deparsed;
@@ -1019,6 +1019,72 @@ CODE
         dies-ok { $sub() }, "$type: the argument is required";
     }
     is-deeply $ast.DEPARSE, $deparsed, 'deparse after BEGIN time';
+}
+
+subtest 'Where constraint of a parameter stays as written' => {
+    # sub f ($x where Int | Str) { $x }; (try f(1.5)) // f(42)
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Sub.new(
+          name      => RakuAST::Name.from-identifier('f'),
+          signature => RakuAST::Signature.new(
+            parameters => (
+              RakuAST::Parameter.new(
+                target => RakuAST::ParameterTarget::Var.new(:name<$x>),
+                where  => RakuAST::ApplyInfix.new(
+                  left  => RakuAST::Type::Simple.new(
+                    RakuAST::Name.from-identifier('Int')
+                  ),
+                  infix => RakuAST::Infix.new('|'),
+                  right => RakuAST::Type::Simple.new(
+                    RakuAST::Name.from-identifier('Str')
+                  )
+                )
+              ),
+            )
+          ),
+          body => RakuAST::Blockoid.new(
+            RakuAST::StatementList.new(
+              RakuAST::Statement::Expression.new(
+                expression => RakuAST::Var::Lexical.new('$x')
+              )
+            )
+          )
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::ApplyInfix.new(
+          left  => RakuAST::Circumfix::Parentheses.new(
+            RakuAST::SemiList.new(
+              RakuAST::Statement::Expression.new(
+                expression => RakuAST::StatementPrefix::Try.new(
+                  RakuAST::Call::Name.new(
+                    name => RakuAST::Name.from-identifier('f'),
+                    args => RakuAST::ArgList.new(RakuAST::RatLiteral.new(1.5))
+                  )
+                )
+              )
+            )
+          ),
+          infix => RakuAST::Infix.new('//'),
+          right => RakuAST::Call::Name.new(
+            name => RakuAST::Name.from-identifier('f'),
+            args => RakuAST::ArgList.new(RakuAST::IntLiteral.new(42))
+          )
+        )
+      )
+    );
+    is-deeply $deparsed, q:to/CODE/, 'deparse';
+sub f ($x where Int | Str) {
+    $x
+}
+(try f(1.5)) // f(42)
+CODE
+    is-deeply $_, 42, @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+    is-deeply $ast.DEPARSE, $deparsed, 'deparse after BEGIN time';
+    is-deeply EVAL('use experimental :rakuast; ' ~ $ast.raku).DEPARSE,
+      $deparsed, 'deparse of the .raku after BEGIN time';
 }
 
 # vim: expandtab shiftwidth=4

--- a/t/12-rakuast/strings.rakutest
+++ b/t/12-rakuast/strings.rakutest
@@ -4,7 +4,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 23;
+plan 24;
 
 my $ast;
 my $deparsed;
@@ -582,6 +582,44 @@ $_ = 42;
 "val $_.gist() end"
 CODE
     is-deeply $_, 'val 42 end', @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'Dotty infix in an interpolation keeps its shape' => {
+    # my $x = "a";
+    # "$x.=uc() $x"
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::VarDeclaration::Simple.new(
+          sigil       => '$',
+          desigilname => RakuAST::Name.from-identifier('x'),
+          initializer => RakuAST::Initializer::Assign.new(
+            RakuAST::StrLiteral.new('a')
+          )
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::QuotedString.new(
+          :segments[
+            RakuAST::ApplyDottyInfix.new(
+              left  => RakuAST::Var::Lexical.new('$x'),
+              infix => RakuAST::DottyInfix::CallAssign.new,
+              right => RakuAST::Call::Method.new(
+                name => RakuAST::Name.from-identifier('uc')
+              )
+            ),
+            RakuAST::StrLiteral.new(' '),
+            RakuAST::Var::Lexical.new('$x')
+          ]
+        )
+      )
+    );
+
+    is-deeply $deparsed, Q:to/CODE/, 'deparse';
+my $x = "a";
+"$x.=uc() $x"
+CODE
+    is-deeply $_, 'A A', @type[$++]
       for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
 }
 

--- a/t/12-rakuast/strings.rakutest
+++ b/t/12-rakuast/strings.rakutest
@@ -4,7 +4,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 20;
+plan 22;
 
 my $ast;
 my $deparsed;
@@ -420,6 +420,133 @@ my $x = "a";
 }()"
 CODE
     is-deeply $_, 'A', @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'Dot leading to a call after an interpolation is escaped' => {
+    # my $x = "a";
+    # "$x\.Str() $x.txt $x\.foo-bar() $x\.Str.chars() $x\.^name() $x\.'Str'() $x\.Cool::chars() $x. done {
+    #     $x
+    # }.(1) $x\.{
+    #     1
+    # }"
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::VarDeclaration::Simple.new(
+          sigil       => '$',
+          desigilname => RakuAST::Name.from-identifier('x'),
+          initializer => RakuAST::Initializer::Assign.new(
+            RakuAST::StrLiteral.new('a')
+          )
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::QuotedString.new(
+          :segments[
+            RakuAST::Var::Lexical.new('$x'),
+            RakuAST::StrLiteral.new('.Str() '),
+            RakuAST::Var::Lexical.new('$x'),
+            RakuAST::StrLiteral.new('.txt '),
+            RakuAST::Var::Lexical.new('$x'),
+            RakuAST::StrLiteral.new('.foo-bar() '),
+            RakuAST::Var::Lexical.new('$x'),
+            RakuAST::StrLiteral.new('.Str.chars() '),
+            RakuAST::Var::Lexical.new('$x'),
+            RakuAST::StrLiteral.new('.^name() '),
+            RakuAST::Var::Lexical.new('$x'),
+            RakuAST::StrLiteral.new(".'Str'() "),
+            RakuAST::Var::Lexical.new('$x'),
+            RakuAST::StrLiteral.new('.Cool::chars() '),
+            RakuAST::Var::Lexical.new('$x'),
+            RakuAST::StrLiteral.new('. done '),
+            RakuAST::Block.new(
+              body => RakuAST::Blockoid.new(
+                RakuAST::StatementList.new(
+                  RakuAST::Statement::Expression.new(
+                    expression => RakuAST::Var::Lexical.new('$x')
+                  )
+                )
+              )
+            ),
+            RakuAST::StrLiteral.new('.(1) '),
+            RakuAST::Var::Lexical.new('$x'),
+            RakuAST::StrLiteral.new('.'),
+            RakuAST::Block.new(
+              body => RakuAST::Blockoid.new(
+                RakuAST::StatementList.new(
+                  RakuAST::Statement::Expression.new(
+                    expression => RakuAST::IntLiteral.new(1)
+                  )
+                )
+              )
+            )
+          ]
+        )
+      )
+    );
+
+    is-deeply $deparsed, Q:to/CODE/, 'deparse';
+my $x = "a";
+"$x\.Str() $x.txt $x\.foo-bar() $x\.Str.chars() $x\.^name() $x\.'Str'() $x\.Cool::chars() $x. done {
+    $x
+}.(1) $x\.{
+    1
+}"
+CODE
+    is-deeply $_,
+      "a.Str() a.txt a.foo-bar() a.Str.chars() a.^name() a.'Str'() a.Cool::chars() a. done a.(1) a.1",
+      @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'Dot before an interpolated call is escaped' => {
+    # my $x = "a";
+    # sub f { "F" }
+    # "$x\.&f()"
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::VarDeclaration::Simple.new(
+          sigil       => '$',
+          desigilname => RakuAST::Name.from-identifier('x'),
+          initializer => RakuAST::Initializer::Assign.new(
+            RakuAST::StrLiteral.new('a')
+          )
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Sub.new(
+          name => RakuAST::Name.from-identifier('f'),
+          body => RakuAST::Blockoid.new(
+            RakuAST::StatementList.new(
+              RakuAST::Statement::Expression.new(
+                expression => RakuAST::StrLiteral.new('F')
+              )
+            )
+          )
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::QuotedString.new(
+          :segments[
+            RakuAST::Var::Lexical.new('$x'),
+            RakuAST::StrLiteral.new('.'),
+            RakuAST::ApplyPostfix.new(
+              operand => RakuAST::Var::Lexical.new('&f'),
+              postfix => RakuAST::Call::Term.new
+            )
+          ]
+        )
+      )
+    );
+
+    is-deeply $deparsed, Q:to/CODE/, 'deparse';
+my $x = "a";
+sub f {
+    "F"
+}
+"$x\.&f()"
+CODE
+    is-deeply $_, 'a.F', @type[$++]
       for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
 }
 

--- a/t/12-rakuast/strings.rakutest
+++ b/t/12-rakuast/strings.rakutest
@@ -4,7 +4,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 22;
+plan 23;
 
 my $ast;
 my $deparsed;
@@ -547,6 +547,41 @@ sub f {
 "$x\.&f()"
 CODE
     is-deeply $_, 'a.F', @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'Method call on the topic in an interpolation keeps the topic' => {
+    # $_ = 42;
+    # "val $_.gist() end"
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::ApplyInfix.new(
+          left  => RakuAST::Var::Lexical.new('$_'),
+          infix => RakuAST::Infix.new('='),
+          right => RakuAST::IntLiteral.new(42)
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::QuotedString.new(
+          :segments[
+            RakuAST::StrLiteral.new('val '),
+            RakuAST::ApplyPostfix.new(
+              operand => RakuAST::Var::Lexical.new('$_'),
+              postfix => RakuAST::Call::Method.new(
+                name => RakuAST::Name.from-identifier('gist')
+              )
+            ),
+            RakuAST::StrLiteral.new(' end')
+          ]
+        )
+      )
+    );
+
+    is-deeply $deparsed, Q:to/CODE/, 'deparse';
+$_ = 42;
+"val $_.gist() end"
+CODE
+    is-deeply $_, 'val 42 end', @type[$++]
       for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
 }
 

--- a/t/12-rakuast/strings.rakutest
+++ b/t/12-rakuast/strings.rakutest
@@ -4,7 +4,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 24;
+plan 25;
 
 my $ast;
 my $deparsed;
@@ -620,6 +620,43 @@ my $x = "a";
 "$x.=uc() $x"
 CODE
     is-deeply $_, 'A A', @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'Exec processor with an interpolated call keeps interpolating' => {
+    # my $x = "a";
+    # qqx/echo $x.uc()/
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::VarDeclaration::Simple.new(
+          sigil       => '$',
+          desigilname => RakuAST::Name.from-identifier('x'),
+          initializer => RakuAST::Initializer::Assign.new(
+            RakuAST::StrLiteral.new('a')
+          )
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::QuotedString.new(
+          :segments[
+            RakuAST::StrLiteral.new('echo '),
+            RakuAST::ApplyPostfix.new(
+              operand => RakuAST::Var::Lexical.new('$x'),
+              postfix => RakuAST::Call::Method.new(
+                name => RakuAST::Name.from-identifier('uc')
+              )
+            )
+          ],
+          :processors['exec']
+        )
+      )
+    );
+
+    is-deeply $deparsed, Q:to/CODE/, 'deparse';
+my $x = "a";
+qqx/echo $x.uc()/
+CODE
+    is-deeply $_, "A\n", @type[$++]
       for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
 }
 

--- a/t/12-rakuast/strings.rakutest
+++ b/t/12-rakuast/strings.rakutest
@@ -4,7 +4,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 18;
+plan 20;
 
 my $ast;
 my $deparsed;
@@ -312,6 +312,114 @@ subtest 'Quote nested by its own delimiters' => {
 
     is-deeply $deparsed, '"a \{ b }"', 'deparse';
     is-deeply $_, 'a { b }', @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'Method call in an interpolation keeps its parentheses' => {
+    # my $x = 42;
+    # "val $x.Str() end $x.Str().chars() $x.DEFINITE()"
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::VarDeclaration::Simple.new(
+          sigil       => '$',
+          desigilname => RakuAST::Name.from-identifier('x'),
+          initializer => RakuAST::Initializer::Assign.new(
+            RakuAST::IntLiteral.new(42)
+          )
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::QuotedString.new(
+          :segments[
+            RakuAST::StrLiteral.new('val '),
+            RakuAST::ApplyPostfix.new(
+              operand => RakuAST::Var::Lexical.new('$x'),
+              postfix => RakuAST::Call::Method.new(
+                name => RakuAST::Name.from-identifier('Str')
+              )
+            ),
+            RakuAST::StrLiteral.new(' end '),
+            RakuAST::ApplyPostfix.new(
+              operand => RakuAST::ApplyPostfix.new(
+                operand => RakuAST::Var::Lexical.new('$x'),
+                postfix => RakuAST::Call::Method.new(
+                  name => RakuAST::Name.from-identifier('Str')
+                )
+              ),
+              postfix => RakuAST::Call::Method.new(
+                name => RakuAST::Name.from-identifier('chars')
+              )
+            ),
+            RakuAST::StrLiteral.new(' '),
+            RakuAST::ApplyPostfix.new(
+              operand => RakuAST::Var::Lexical.new('$x'),
+              postfix => RakuAST::Call::Method.new(
+                name => RakuAST::Name.from-identifier('DEFINITE')
+              )
+            )
+          ]
+        )
+      )
+    );
+
+    is-deeply $deparsed, Q:to/CODE/, 'deparse';
+my $x = 42;
+"val $x.Str() end $x.Str().chars() $x.DEFINITE()"
+CODE
+    is-deeply $_, 'val 42 end 2 True', @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'Block method call in an interpolation keeps its parentheses' => {
+    # my $x = "a";
+    # "$x.&{
+    #     .uc
+    # }()"
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::VarDeclaration::Simple.new(
+          sigil       => '$',
+          desigilname => RakuAST::Name.from-identifier('x'),
+          initializer => RakuAST::Initializer::Assign.new(
+            RakuAST::StrLiteral.new('a')
+          )
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::QuotedString.new(
+          :segments[
+            RakuAST::ApplyPostfix.new(
+              operand => RakuAST::Var::Lexical.new('$x'),
+              postfix => RakuAST::Call::BlockMethod.new(
+                block => RakuAST::Contextualizer::Item.new(
+                  RakuAST::Block.new(
+                    body => RakuAST::Blockoid.new(
+                      RakuAST::StatementList.new(
+                        RakuAST::Statement::Expression.new(
+                          expression => RakuAST::Term::TopicCall.new(
+                            RakuAST::Call::Method.new(
+                              name => RakuAST::Name.from-identifier('uc')
+                            )
+                          )
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          ]
+        )
+      )
+    );
+
+    is-deeply $deparsed, Q:to/CODE/, 'deparse';
+my $x = "a";
+"$x.&{
+    .uc
+}()"
+CODE
+    is-deeply $_, 'A', @type[$++]
       for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
 }
 

--- a/t/12-rakuast/types.rakutest
+++ b/t/12-rakuast/types.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 12;
+plan 13;
 
 my $ast;
 my $deparsed;
@@ -270,6 +270,23 @@ my Hash:D[Str] %h;
 CODE
     is-deeply $_, 0, @type[$++]
       for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'type with a written Any coercion' => {
+    # Int(Any)
+    ast RakuAST::Type::Coercion.new(
+      base-type  => RakuAST::Type::Simple.new(
+        RakuAST::Name.from-identifier("Int")
+      ),
+      constraint => RakuAST::Type::Simple.new(
+        RakuAST::Name.from-identifier("Any")
+      )
+    );
+    is-deeply $deparsed, 'Int(Any)', 'deparse';
+
+    is-deeply $_, Int(Any), @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+    is-deeply EVAL($raku).DEPARSE, 'Int(Any)', 'deparse of the .raku';
 }
 
 # vim: expandtab shiftwidth=4

--- a/t/12-rakuast/var.rakutest
+++ b/t/12-rakuast/var.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 66;
+plan 68;
 
 my $ast;
 my $deparsed;
@@ -1593,6 +1593,75 @@ CODE
     is-deeply RakuAST::Var::Compiler::Resources.new.raku,
       'RakuAST::Var::Compiler::Resources.new',
       'the .raku of $?RESOURCES takes no arguments';
+}
+
+subtest 'Shaped array declaration' => {
+    # my @a[2; 3];
+    # @a.shape
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::VarDeclaration::Simple.new(
+          sigil       => '@',
+          desigilname => RakuAST::Name.from-identifier('a'),
+          shape       => RakuAST::SemiList.new(
+            RakuAST::Statement::Expression.new(
+              expression => RakuAST::IntLiteral.new(2)
+            ),
+            RakuAST::Statement::Expression.new(
+              expression => RakuAST::IntLiteral.new(3)
+            )
+          )
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::ApplyPostfix.new(
+          operand => RakuAST::Var::Lexical.new('@a'),
+          postfix => RakuAST::Call::Method.new(
+            name => RakuAST::Name.from-identifier('shape')
+          )
+        )
+      )
+    );
+    is-deeply $deparsed, q:to/CODE/, 'deparse';
+my @a[2; 3];
+@a.shape
+CODE
+    is-deeply $_, (2, 3), @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'Shaped hash declaration' => {
+    # my %h{Str};
+    # %h.keyof
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::VarDeclaration::Simple.new(
+          sigil       => '%',
+          desigilname => RakuAST::Name.from-identifier('h'),
+          shape       => RakuAST::SemiList.new(
+            RakuAST::Statement::Expression.new(
+              expression => RakuAST::Type::Simple.new(
+                RakuAST::Name.from-identifier('Str')
+              )
+            )
+          )
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::ApplyPostfix.new(
+          operand => RakuAST::Var::Lexical.new('%h'),
+          postfix => RakuAST::Call::Method.new(
+            name => RakuAST::Name.from-identifier('keyof')
+          )
+        )
+      )
+    );
+    is-deeply $deparsed, q:to/CODE/, 'deparse';
+my %h{Str};
+%h.keyof
+CODE
+    is-deeply $_, Str, @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
 }
 
 # vim: expandtab shiftwidth=4

--- a/t/12-rakuast/var.rakutest
+++ b/t/12-rakuast/var.rakutest
@@ -1,7 +1,7 @@
 use v6.e.PREVIEW;
 use Test;
 
-plan 68;
+plan 69;
 
 my $ast;
 my $deparsed;
@@ -1661,6 +1661,48 @@ my %h{Str};
 %h.keyof
 CODE
     is-deeply $_, Str, @type[$++]
+      for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
+}
+
+subtest 'Signature declaration with a where constraint' => {
+    # my ($a where 1) = 1;
+    # try $a = 2;
+    # $a
+    ast RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::VarDeclaration::Signature.new(
+          signature => RakuAST::Signature.new(
+            parameters => (
+              RakuAST::Parameter.new(
+                target => RakuAST::ParameterTarget::Var.new(:name<$a>),
+                where  => RakuAST::IntLiteral.new(1)
+              ),
+            )
+          ),
+          initializer => RakuAST::Initializer::Assign.new(
+            RakuAST::IntLiteral.new(1)
+          )
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::StatementPrefix::Try.new(
+          RakuAST::ApplyInfix.new(
+            left  => RakuAST::Var::Lexical.new('$a'),
+            infix => RakuAST::Infix.new('='),
+            right => RakuAST::IntLiteral.new(2)
+          )
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Var::Lexical.new('$a')
+      )
+    );
+    is-deeply $deparsed, q:to/CODE/, 'deparse';
+my ($a where 1) = 1;
+try $a = 2;
+$a
+CODE
+    is-deeply $_, 1, @type[$++]
       for EVAL($ast), EVAL($deparsed), EVAL(EVAL $raku);
 }
 


### PR DESCRIPTION
Previously a deparse could come back as text that parses fine and computes something else, which stays invisible unless the output is recompiled and run. These were found the same way as the two earlier batches, by parsing modules and one liners, deparsing them, then compiling and running both the deparse and the `.raku` of the tree, and comparing against the original.

Most of them are in interpolated strings, where the deparse silently changed what the string means. A method call lost the parentheses that make it interpolate at all, so `"val $x.Str() end"` came back as `"val $x.Str end"`. A written `\.` lost its escape, so `"$x\.Str()"` came back as `"$x.Str()"`, which interpolates the call. A call on the topic lost the topic, `"$_.gist()"` becoming `".gist()"`. A dotty infix gained whitespace, `"$x.=uc()"` becoming `"$x .= uc"`, which neither assigns nor calls. And every `qqx/.../` came back as `qx/.../`, because the check compared the prefix against the processor name rather than the processor.

```
$ raku -e 'use experimental :rakuast; say q[my $x = 42; "val $x.Str() end"].AST.DEPARSE'
my $x = 42;
"val $x.Str end"
```

Another group is BEGIN time replacing what was written. A `where` constraint became the block that calls `ACCEPTS` on it, a WhateverCode argument became a node with no name that BEGIN time then rejects, and constant folding a junction of literals produced a literal whose `.raku` autothreaded and failed its own return type check. The parameter one is the only change here with runtime reach. `RakuAST::Parameter` now keeps `$!where` as written and stores the block in `$!where-thunk`, which the binder and the meta object read, while the junction check reads the constraint as written.

The rest are ordinary holes. A shape was dropped from `my @a[2;3]` and `my %h{Str}`, a numbered capture was written as `$<0>=`, an argument list applied to a sigilless term lost its dot and became a routine call, a parameter marked required by a trait was marked again with `!`, a coercion lost a written `Any`, and the whitespace of a quantified atom with a separator was written on the wrong side of the `%`, which changes what matches under `:s`.