### PR TITLE
RakuAST: reject a character class in a transliteration

### DIFF
--- a/src/Raku/Grammar.nqp
+++ b/src/Raku/Grammar.nqp
@@ -6553,33 +6553,23 @@ grammar Raku::QGrammar is HLL::Grammar does Raku::Common {
         }
         token escape:ch { $<ch> = [\S] { self.ccstate($<ch>) } }
 
+        # Every escape here names a character.  A class like \d names none, so
+        # it is left to the unrecognized sequence panic.
         token backslash:delim { <text=.starter> | <text=.stopper> }
         token backslash:sym<\\> { <text=.sym> }
         token backslash:sym<a> { :i <sym> }
         token backslash:sym<b> { :i <sym> }
         token backslash:sym<c> { :i <sym> <charspec> }
-        token backslash:sym<d> { :i <sym> { $*CCSTATE := '' } }
         token backslash:sym<e> { :i <sym> }
         token backslash:sym<f> { :i <sym> }
-        token backslash:sym<h> { :i <sym> { $*CCSTATE := '' } }
         token backslash:sym<N> { <?before 'N{'<.[A..Z]>> <.obs('\N{CHARNAME}','\c[CHARNAME]')>  }
         token backslash:sym<n> { :i <sym> }
         token backslash:sym<o> { :i :dba('octal character') <sym> [ <octint> | '[' ~ ']' <octints> | '{' <.obsbrace> ] }
         token backslash:sym<r> { :i <sym> }
-        token backslash:sym<s> { :i <sym> { $*CCSTATE := '' } }
         token backslash:sym<t> { :i <sym> }
-        token backslash:sym<v> { :i <sym> { $*CCSTATE := '' } }
-        token backslash:sym<w> { :i <sym> { $*CCSTATE := '' } }
         token backslash:sym<x> { :i :dba('hex character') <sym> [ <hexint> | '[' ~ ']' <hexints> | '{' <.obsbrace> ] }
         token backslash:sym<0> { <sym> }
 
-        # keep random backslashes like qq does
-        token backslash:misc { {}
-            [
-            | $<text>=(\W)
-            | $<x>=(\w) <.typed_panic: 'X::Backslash::UnrecognizedSequence', :sequence(~$<x>)>
-            ]
-        }
         multi method tweak_q($v) { self.panic("Too late for :q") }
         multi method tweak_qq($v) { self.panic("Too late for :qq") }
         multi method tweak_cc($v) { self.panic("Too late for :cc") }

--- a/t/02-rakudo/tr-backslash-escapes.t
+++ b/t/02-rakudo/tr-backslash-escapes.t
@@ -1,0 +1,85 @@
+use Test;
+use nqp;
+
+plan 24;
+
+# A transliteration takes literal characters and ranges, not the character
+# classes a regex takes.  A class names no single character, so it is rejected
+# the same way an unknown backslash sequence is rejected in a string.
+
+use MONKEY-SEE-NO-EVAL;
+
+is EVAL(Q{my $s = 'abc'; $s ~~ tr/a..c/x..z/; $s}), 'xyz',
+  'a transliteration range maps each character in its order';
+
+is EVAL(Q{my $s = "a\tb"; $s ~~ tr/\t/./; $s}), 'a.b',
+  'a tab escape transliterates the tab it names';
+
+is EVAL(Q{my $s = "a\tb\nc"; $s ~~ tr/\t..\n/XY/; $s}), "aXbYc",
+  'a range between two escapes maps every character between them';
+
+is EVAL(Q{my $s = 'ABCD'; $s ~~ tr/\x41..\x43/x..z/; $s}), 'xyzD',
+  'a range between two hex escapes maps every character between them';
+
+throws-like Q{my $s = 'a'; $s ~~ tr/a-c/x-z/}, X::Obsolete,
+  message => /'Unsupported use of - as character range'/,
+  'a hyphen range in a transliteration names the Raku spelling instead';
+
+throws-like Q{my $s = 'a'; $s ~~ tr/../x/}, X::Comp::AdHoc,
+  message => /'Range missing start character on the left'/,
+  'a transliteration range with no left character is rejected';
+
+throws-like Q{my $s = 'a'; $s ~~ tr/\t../x/}, X::Comp::AdHoc,
+  message => /'Range missing stop character on the right'/,
+  'a transliteration range with no right character is rejected';
+
+# Legacy parses these escapes to nothing, so they vanish from the character
+# list and every character after one pairs with the wrong replacement.  An
+# unrecognized letter panics there without naming itself.
+if nqp::ifnull(nqp::gethllsym('Raku', 'COMPILER-FRONTEND'), '') eq 'rakuast' {
+    for <d s w h v> -> $class {
+        throws-like Q{my $s = 'a'; $s ~~ tr/\} ~ $class ~ Q{/./},
+          X::Backslash::UnrecognizedSequence, sequence => $class,
+          "the \\$class character class in a transliteration is rejected and named";
+    }
+
+    for <D S W H V> -> $class {
+        throws-like Q{my $s = 'a'; $s ~~ tr/\} ~ $class ~ Q{/./},
+          X::Backslash::UnrecognizedSequence, sequence => $class,
+          "the negated \\$class character class in a transliteration is rejected and named";
+    }
+
+    throws-like Q{my $s = 'a'; $s ~~ tr/\z/./},
+      X::Backslash::UnrecognizedSequence, sequence => 'z',
+      'a backslash before any other letter is rejected and named';
+
+    throws-like Q{my $s = 'a'; $s ~~ tr/\9/./},
+      X::Backslash::UnrecognizedSequence, message => /'$8'/,
+      'a backslash before a digit still suggests the capture variable';
+
+    throws-like Q{my $s = 'ab'; $s ~~ tr/ab/x\d/},
+      X::Backslash::UnrecognizedSequence, sequence => 'd',
+      'a character class in the replacement list is rejected and named';
+
+    throws-like Q{my $s = 'xd'; $s ~~ tr/x\d/ab/},
+      X::Backslash::UnrecognizedSequence, sequence => 'd',
+      'a character class after a literal character is rejected and named';
+
+    throws-like Q{my $s = 'a'; my $r = TR/\d/./ given $s},
+      X::Backslash::UnrecognizedSequence, sequence => 'd',
+      'a character class in the returning transliteration form is rejected';
+
+    throws-like Q{my $s = 'a'; $s ~~ tr:d/\d//},
+      X::Backslash::UnrecognizedSequence, sequence => 'd',
+      'a character class under the delete adverb is rejected';
+
+    # An escaped non-word character has to keep its value.  Losing it drops
+    # the character from the list, which shifts every pair after it.
+    is EVAL(Q{my $s = 'a-b.c d'; $s ~~ tr/\-\.\ /XYZ/; $s}), 'aXbYcZd',
+      'an escaped hyphen, dot and space each transliterate as themselves';
+}
+else {
+    skip 'the legacy frontend parses these escapes differently', 17;
+}
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
A transliteration takes literal characters and ranges. The quote language it is parsed in declared tokens for \d, \h, \s, \v and \w, but nothing ever made a value for them, so each one reached the segment list as an NQPMu and the compiler died on it with "Cannot find method 'return-type'". The documented semantics do not want them either. tr/// works as it does in Perl, over characters and ranges.

That language also declared a misc backslash of its own with no action method under any name. Its word branch called typed_panic, which this grammar spells typed-panic, so an unknown letter after a backslash died with "Cannot find method 'typed_panic'" rather than naming what was wrong. Its other branch is reached only when the base language loses a protoregex tie, and it would give every escaped punctuation character the same NQPMu death.

Deleting both leaves these escapes to the backslash tokens the base quote language supplies. Those have actions, and they raise X::Backslash::UnrecognizedSequence carrying the letter it is about, so tr/\d/./ now says "Unrecognized backslash sequence: '\d'". That is what a string literal has always said.