### PR TITLE
Make quote parsing linear in the number of escapes

### DIFF
--- a/src/Perl6/Grammar.nqp
+++ b/src/Perl6/Grammar.nqp
@@ -5625,47 +5625,59 @@ grammar Perl6::QGrammar is HLL::Grammar does STD {
     }
 
     token do_nibbling {
-        :my $from := self.pos;
-        :my $to   := $from;
+        :my @nibbles := @*nibbles;
+        :my @from := nqp::list_i(self.pos);   # a list so the subrules can advance it
         [
             <!stopper>
             [
-            || <starter> <nibbler> <stopper>
-                {
-                    my $c := $/;
-                    $to   := $<starter>[-1].from;
-                    if $from != $to {
-                        nqp::push(@*nibbles, nqp::substr($c.orig, $from, $to - $from));
-                    }
-
-                    nqp::push(@*nibbles, $<starter>[-1].Str);
-                    nqp::push(@*nibbles, $<nibbler>[-1]);
-                    nqp::push(@*nibbles, $<stopper>[-1].Str);
-
-                    $from := $to := $c.pos;
-                }
-            || <escape>
-                {
-                    my $c := $/;
-                    $to   := $<escape>[-1].from;
-                    if $from != $to {
-                        nqp::push(@*nibbles, nqp::substr($c.orig, $from, $to - $from));
-                    }
-
-                    nqp::push(@*nibbles, $<escape>[-1]);
-
-                    $from := $to := $c.pos;
-                }
+            || <.nibble_nesting(@from, @nibbles)>
+            || <.nibble_escape(@from, @nibbles)>
             || .
             ]
         ]*
         {
             my $c := $/;
-            $to   := $c.pos;
+            my int $from := nqp::atpos_i(@from, 0);
+            my int $to   := $c.pos;
             $*LASTQUOTE := [self.pos, $to];
-            if $from != $to || !@*nibbles {
-                nqp::push(@*nibbles, nqp::substr($c.orig, $from, $to - $from));
+            if $from != $to || !@nibbles {
+                nqp::push(@nibbles, nqp::substr($c.orig, $from, $to - $from));
             }
+        }
+    }
+
+    # separate tokens so each block sees a short capture stack, not the whole string's
+    token nibble_nesting(@from, @nibbles) {
+        <starter> <nibbler> <stopper>
+        {
+            my $c := $/;
+            my int $from := nqp::atpos_i(@from, 0);
+            my int $to   := $<starter>.from;
+            if $from != $to {
+                nqp::push(@nibbles, nqp::substr($c.orig, $from, $to - $from));
+            }
+
+            nqp::push(@nibbles, $<starter>.Str);
+            nqp::push(@nibbles, $<nibbler>);
+            nqp::push(@nibbles, $<stopper>.Str);
+
+            nqp::bindpos_i(@from, 0, $c.pos);
+        }
+    }
+
+    token nibble_escape(@from, @nibbles) {
+        <escape>
+        {
+            my $c := $/;
+            my int $from := nqp::atpos_i(@from, 0);
+            my int $to   := $<escape>.from;
+            if $from != $to {
+                nqp::push(@nibbles, nqp::substr($c.orig, $from, $to - $from));
+            }
+
+            nqp::push(@nibbles, $<escape>);
+
+            nqp::bindpos_i(@from, 0, $c.pos);
         }
     }
 

--- a/src/Raku/Grammar.nqp
+++ b/src/Raku/Grammar.nqp
@@ -6472,51 +6472,59 @@ grammar Raku::QGrammar is HLL::Grammar does Raku::Common {
     }
 
     token do-nibbling {
-        :my int $from := self.pos;
-        :my int $to   := $from;
-        :my $orig     := self.orig;
+        :my @from := nqp::list_i(self.pos);   # a list so the subrules can advance it
         :my @NIBBLES;
         [
           <!stopper>
           [
-            || <starter>
-               <nibbler>
-               <stopper>
-               {
-                   my $c := $/;
-                   my $starter := $<starter>.pop;
-                   $to   := $starter.from;
-                   nqp::push(@NIBBLES,nqp::substr($orig,$from,$to - $from))
-                     if $from != $to;
-
-                   nqp::push(@NIBBLES,$starter.Str);
-                   nqp::push(@NIBBLES,$<nibbler>.pop);
-                   nqp::push(@NIBBLES,$<stopper>.pop.Str);
-
-                   $from := $to := $c.pos;
-               }
-            || <escape>
-               {
-                   my $c      := $/;
-                   my $escape := $<escape>.pop;
-                   $to        := $escape.from;
-                   nqp::push(@NIBBLES,nqp::substr($orig,$from,$to - $from))
-                     if $from != $to;
-
-                   nqp::push(@NIBBLES,$escape);
-
-                   $from := $to := $c.pos;
-               }
+            || <.nibble-nesting(@from, @NIBBLES)>
+            || <.nibble-escape(@from, @NIBBLES)>
             || .
           ]
         ]*
         {
             my $c := $/;
-            $to   := $c.pos;
+            my int $from := nqp::atpos_i(@from,0);
+            my int $to   := $c.pos;
             $*LASTQUOTE := [self.pos, $to];
-            nqp::push(@NIBBLES,nqp::substr($orig,$from,$to - $from))
+            nqp::push(@NIBBLES,nqp::substr($c.orig,$from,$to - $from))
               if $from != $to || !@NIBBLES;
             @*NIBBLES := @NIBBLES;
+        }
+    }
+
+    # separate tokens so each block sees a short capture stack, not the whole string's
+    token nibble-nesting(@from, @NIBBLES) {
+        <starter>
+        <nibbler>
+        <stopper>
+        {
+            my $c := $/;
+            my int $from := nqp::atpos_i(@from,0);
+            my int $to   := $<starter>.from;
+            nqp::push(@NIBBLES,nqp::substr($c.orig,$from,$to - $from))
+              if $from != $to;
+
+            nqp::push(@NIBBLES,$<starter>.Str);
+            nqp::push(@NIBBLES,$<nibbler>);
+            nqp::push(@NIBBLES,$<stopper>.Str);
+
+            nqp::bindpos_i(@from,0,$c.pos);
+        }
+    }
+
+    token nibble-escape(@from, @NIBBLES) {
+        <escape>
+        {
+            my $c := $/;
+            my int $from := nqp::atpos_i(@from,0);
+            my int $to   := $<escape>.from;
+            nqp::push(@NIBBLES,nqp::substr($c.orig,$from,$to - $from))
+              if $from != $to;
+
+            nqp::push(@NIBBLES,$<escape>);
+
+            nqp::bindpos_i(@from,0,$c.pos);
         }
     }
 

--- a/t/02-rakudo/quote-nibbling.t
+++ b/t/02-rakudo/quote-nibbling.t
@@ -1,0 +1,113 @@
+use Test;
+
+plan 31;
+
+# The quote parser splits a quoted construct into literal pieces, nested
+# quotes and escapes.  The cases below pin the boundaries between those
+# pieces.  They go through EVAL so a parse failure is reported at the case
+# that hit it rather than as a file that does not compile.
+
+use MONKEY-SEE-NO-EVAL;
+
+is EVAL(Q{"\ta"}), "\ta",
+  'an escape at the start of a string keeps the text that follows it';
+
+is EVAL(Q{"a\t"}), "a\t",
+  'an escape at the end of a string keeps the text before it';
+
+is EVAL(Q{"a\tb"}), "a\tb",
+  'an escape between two pieces of text keeps both';
+
+is EVAL(Q{"\t"}), "\t",
+  'a string that is nothing but an escape yields just that escape';
+
+is EVAL(Q{"\t\n"}), "\t\n",
+  'two adjacent escapes yield no empty piece between them';
+
+is EVAL(Q{""}), '',
+  'an empty string yields the empty string';
+
+is EVAL(Q{q{a{b}c}}), 'a{b}c',
+  'a nested delimiter pair inside a single quoted string stays literal';
+
+is EVAL(Q{Q«a«b»c»}), 'a«b»c',
+  'a nested angle delimiter pair inside Q stays literal';
+
+is EVAL(Q{q{a{}b}}), 'a{}b',
+  'an empty nested delimiter pair yields both of its delimiters';
+
+is EVAL(Q{q{a{b}}}), 'a{b}',
+  'a nested pair at the end of a quote closes before the quote does';
+
+is EVAL(Q{q{{a}{b}}}), 'a}{b',
+  'a doubled opening brace is the delimiter, not a nested pair';
+
+is EVAL(Q{Q«a«b»«c»d»}), 'a«b»«c»d',
+  'two adjacent nested pairs keep the text on both sides of each';
+
+is EVAL(Q{q{a\{b\}c}}), 'a{b}c',
+  'a backslash before a nesting delimiter keeps it from nesting';
+
+throws-like Q[q{a{b}], Exception,
+  message => /"Couldn't find terminator }"/,
+  'a nested pair with no outer terminator names the missing terminator';
+
+is EVAL(Q{"a{ "b{ "c\td" }e" }f"}), "abc\tdef",
+  'three levels of interpolated string nest without losing a piece';
+
+is EVAL(Q{q{x\qq[{1+1}]y}}), 'x2y',
+  'a qq escape re-enters the quote parser inside a single quoted string';
+
+is-deeply EVAL(Q{qqw{a {1+1} c}}), ('a', '{1+1}', 'c'),
+  'a brace delimiter makes an inner brace a nesting rather than a closure';
+
+is EVAL(Q{"\x41\o101\c[LATIN SMALL LETTER A]"}), 'AAa',
+  'three numeric and named escapes in a row each yield one character';
+
+is EVAL(Q{qq:to/END/
+a\tb
+END}), "a\tb\n",
+  'an escape inside a heredoc body is honoured';
+
+is EVAL(Q{my $s = 'abc'; $s ~~ tr/a..c/x..z/; $s}), 'xyz',
+  'a transliteration range maps each character in its order';
+
+throws-like Q{my $s = 'a'; $s ~~ tr/a-c/x-z/}, X::Obsolete,
+  message => /'Unsupported use of - as character range'/,
+  'a hyphen range in a transliteration names the Raku spelling';
+
+throws-like Q{my $s = 'a'; $s ~~ tr/../x/}, Exception,
+  message => /'Range missing start character on the left'/,
+  'a transliteration range with no left character is rejected';
+
+is EVAL(Q{"{1+1}"}), '2',
+  'a string that is nothing but an interpolation yields just that interpolation';
+
+is EVAL(Q{"{1}{2}"}), '12',
+  'two adjacent interpolations yield no empty piece between them';
+
+is EVAL(Q{"{1+1}\t"}), "2\t",
+  'an escape directly after an interpolation leaves no piece between them';
+
+is EVAL(Q{"\t{1+1}"}), "\t2",
+  'an interpolation directly after an escape leaves no piece between them';
+
+is EVAL(Q{my $a = 'X'; my $b = 'Y'; "p$a\tq$b r"}), "pX\tqY r",
+  'a variable interpolation between literal pieces keeps both of them';
+
+is EVAL(Q{my @a = 1, 2; "<@a[1]>"}), '<2>',
+  'an indexed array interpolation is one escape, not the text around it';
+
+is EVAL(Q{my $a = 'xy'; "$a.uc()"}), 'XY',
+  'a method call interpolation consumes the call and nothing after it';
+
+# The quote records where it started so a runaway one can name that line.
+throws-like qq{say "a\nb" 1;}, X::Syntax::Confused,
+  message => /'runaway multi-line "" quote starting at line 1'/,
+  'a confused parse after a multi line quote names the line the quote opened on';
+
+throws-like qq{say <<a\nb>> 1;}, X::Syntax::Confused,
+  message => /'runaway multi-line <<>> quote starting at line 1'/,
+  'the runaway hint spells a double angle quote with both of its brackets';
+
+# vim: expandtab shiftwidth=4

--- a/t/08-performance/40-quote-escape-scaling.t
+++ b/t/08-performance/40-quote-escape-scaling.t
@@ -1,0 +1,45 @@
+use Test;
+
+plan 3;
+
+# The quote parser runs a code block after every escape it matches, and a
+# code block builds $/ by walking the capture stack of the cursor it runs
+# in.  Keep that stack short and an escape costs a small constant.  Let it
+# grow with the escapes already matched and the parse turns quadratic.  The
+# ratio below catches that well before the parse is slow enough to notice.
+
+use MONKEY-SEE-NO-EVAL;
+
+# A quadratic parse gets worse as $atoms grows, measuring 5x at 500 and 83x
+# at 8000, while a linear one stays near 2x whatever $atoms is.  Lowering
+# $atoms without lowering $budget stops this catching a quadratic parse.
+my int $atoms  = 8000;
+my int $budget = 10;
+
+# Both sources spell a string of the same length.  'ab\"' is four source
+# characters for three result ones, so 'abc' is its unescaped twin.
+sub escaped-source(--> Str:D) { 'my $s = "' ~ ('ab\"' x $atoms) ~ '"; $s.chars' }
+sub plain-source(  --> Str:D) { 'my $s = "' ~ ('abc'  x $atoms) ~ '"; $s.chars' }
+
+sub fastest-of-three(Str:D $source --> Duration:D) {
+    (^3).map({ my $started = now; EVAL $source; now - $started }).min
+}
+
+# These two also warm the compiler up on both shapes, so the timing below
+# does not pay for machinery on its first measurement alone.
+is EVAL(escaped-source()), $atoms * 3,
+  "a string of $atoms escapes compiles to the {$atoms * 3} characters it spells";
+
+is EVAL(plain-source()), $atoms * 3,
+  "a string of {$atoms * 3} plain characters compiles to that many characters";
+
+# Escaped first, so anything left to warm up lands on the numerator and
+# reads as a worse ratio rather than a better one.
+my $escaped = fastest-of-three(escaped-source());
+my $plain   = fastest-of-three(plain-source());
+
+cmp-ok $escaped, '<', $plain * $budget,
+  "an escaped string parses within $budget times the cost of the same"
+    ~ " string unescaped ({($escaped / $plain).round(0.1)}x)";
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously a quoted string with n backslash escapes or n nested delimiter pairs took O(n**2) to parse. The nibbler loop matched <escape> and <starter> <nibbler> <stopper> as capturing subrules and ran a code block after each one. A code block in a regex binds $/, and doing so rebuilds the match by walking every capture on the cursor's stack. Each escape added a capture to the loop's cursor, so the k-th block walked k entries. A string of 16000 escapes took 214 seconds, and the 150000 escape .raku of a large JSON literal did not finish.

This moves each of those two alternatives into a token of its own and calls them non-capturing. The block that records an escape or a nested quote runs inside the new token against at most three captures, and the loop's own cursor captures nothing. The same 16000 escape string parses in 0.66 seconds. Where the pending literal text starts and where the pieces go are arguments to the new tokens rather than contextuals, since an undeclared contextual in NQP is an empty list that accepts a push without complaint.

An ordinary character is now tested against two tokens before the fallback consumes it, which makes an escape free literal a few percent slower per character. Both frontends had the same loop and both get the change. tr/// runs through the same nibbler and speeds up with it.