### PR TITLE
Rebuild a flattened method table that came from deserialization

### DIFF
--- a/src/Perl6/Metamodel/Configuration.nqp
+++ b/src/Perl6/Metamodel/Configuration.nqp
@@ -90,6 +90,11 @@ class Perl6::Metamodel::Configuration {
           !! $utility_class.NEXT-ID
     }
 
+    # Tags the flattened method tables the classes cache with this process,
+    # so a table that was serialized is rebuilt before it is used.
+    my $method_table_epoch := nqp::list;
+    method method_table_epoch() { $method_table_epoch }
+
     method set_language_revision_type($type) {
         $language-revision-type := $type
     }

--- a/src/Perl6/Metamodel/MROBasedMethodDispatch.nqp
+++ b/src/Perl6/Metamodel/MROBasedMethodDispatch.nqp
@@ -6,6 +6,10 @@ role Perl6::Metamodel::MROBasedMethodDispatch {
     # megamorphic callsite involves the class, so calculated and cached on
     # demand.
     has $!cached_all_method_table;
+    # The process that built the table.  A table that came back from
+    # deserialization predates the methods added since it was built, and
+    # adding a method only invalidates the table of the class it names.
+    has $!cached_all_method_table_epoch;
 
     # Resolve a method. On MoarVM, with the generalized dispatch mechanism,
     # this is called to bootstrap callsites. On backends without that, it
@@ -114,7 +118,9 @@ role Perl6::Metamodel::MROBasedMethodDispatch {
 
     method all_method_table($target) {
         my $table := $!cached_all_method_table;
-        unless nqp::isconcrete($table) {
+        my $epoch := Perl6::Metamodel::Configuration.method_table_epoch;
+        unless nqp::isconcrete($table)
+          && nqp::eqaddr($!cached_all_method_table_epoch, $epoch) {
             $table  := nqp::hash;
             my $mro := self.mro($target);
 
@@ -132,6 +138,7 @@ role Perl6::Metamodel::MROBasedMethodDispatch {
             }
             nqp::scwbdisable;
             $!cached_all_method_table := $table;
+            $!cached_all_method_table_epoch := $epoch;
             nqp::scwbenable;
         }
 

--- a/src/vm/moar/dispatchers.nqp
+++ b/src/vm/moar/dispatchers.nqp
@@ -1210,6 +1210,11 @@ nqp::register('raku-meth-call-mega', -> $capture {
     if nqp::isconcrete(nqp::atkey(%lookup, $name)) {
         my $Tobj := nqp::track('arg', $capture, 0);
         my $Thow := nqp::track('how', $Tobj);
+
+        # A table that came from deserialization carries the tag of the
+        # process that built it, so it fails this guard and gets rebuilt
+        nqp::guard('literal', nqp::track('attr',
+          $Thow, Perl6::Metamodel::ClassHOW, '$!cached_all_method_table_epoch'));
         my $Ttable := nqp::track('attr',
           $Thow, Perl6::Metamodel::ClassHOW, '$!cached_all_method_table');
         my $Tname := nqp::track('arg', $capture, 1);
@@ -4056,6 +4061,12 @@ nqp::register('raku-find-meth-mega', -> $capture {
     # Make sure there's a method table from now on
     $how.all_method_table($obj);
 
+    # A table that came from deserialization carries the tag of the
+    # process that built it, so it fails this guard and gets rebuilt
+    my $Thow := nqp::track('how', nqp::track('arg', $capture, 0));
+    nqp::guard('literal', nqp::track('attr',
+      $Thow, Perl6::Metamodel::ClassHOW, '$!cached_all_method_table_epoch'));
+
     # Track the HOW and then the attribute holding the table.  Do the
     # lookup of the method in the table we found in the meta-object.
     # If it's not found, the outcome will be a null, which is exactly
@@ -4064,9 +4075,7 @@ nqp::register('raku-find-meth-mega', -> $capture {
       $capture,
       nqp::syscall('dispatcher-index-tracked-lookup-table',
         nqp::track('attr',
-          nqp::track('how', nqp::track('arg', $capture, 0)),
-          Perl6::Metamodel::ClassHOW,
-          '$!cached_all_method_table'
+          $Thow, Perl6::Metamodel::ClassHOW, '$!cached_all_method_table'
         ),
         nqp::track('arg', $capture, 1)
       )

--- a/t/02-rakudo/megamorphic-augmented-method.t
+++ b/t/02-rakudo/megamorphic-augmented-method.t
@@ -1,0 +1,103 @@
+use v6.e.PREVIEW;
+use experimental :rakuast;
+use Test;
+
+plan 4;
+
+# A call site that has seen many types looks a method up in the flattened
+# method table each class caches.  A precompiled module carries the tables
+# its classes built while it compiled, and adding a method to a parent
+# class afterwards clears only the table of that parent.
+
+# The setting augments RakuAST::Node with .raku after some of those tables
+# were built, so a table read back from the setting still names the method
+# Mu provides.
+{
+    # every node class the parse of this source produces, once each
+    my $source = Q:to/CODE/;
+    my Int $a = 1;
+    my @b = 1e0, 1.5, "a", v1, $a, $*b, :c, :!d;
+    my @c = @b[0], |@b;
+    sub f(Int $x, *@y, :$z --> Str) { $x ?? "x" !! "y" }
+    class C { has $.e; method m { $!e }; }
+    for @b -> $g { say $g }
+    if $a { A: while 1 { last A } }
+    my $h = -$a + $a * 2 ** 3;
+    $h++;
+    "$a" ~~ /a+ <[b]> ^ $/;
+    CODE
+    my @nodes;
+    my %seen;
+    sub walk($node) {
+        @nodes.push($node) unless %seen{$node.^name}++;
+        $node.visit-children(&walk);
+    }
+    walk($source.AST);
+
+    sub site(Mu $node) { $node.raku }
+    site($_) for @nodes;
+
+    my $block = "=begin pod\n\nhi\n\n=end pod\n".AST.statements.head;
+    is site($block), $block.raku,
+      'a megamorphic call site finds the .raku the setting added to RakuAST::Node';
+
+    my $doc = RakuAST::Doc::Paragraph.new('hi');
+    is site($doc), $doc.raku,
+      'a megamorphic call site finds the .raku of a doc paragraph';
+}
+
+# The same through a module of our own: its compilation builds the table
+# of the subclass through a megamorphic site, the module is precompiled,
+# and the program that loads it adds a method to the parent.
+{
+    my $dir = $*TMPDIR.add("megamorphic-augmented-" ~ $*PID);
+    sub remove(IO::Path $path) {
+        if $path.d {
+            remove($_) for $path.dir;
+            $path.rmdir;
+        }
+        else {
+            $path.unlink;
+        }
+    }
+    LEAVE remove($dir) if $dir.e;
+    $dir.add('lib').mkdir;
+    $dir.add('lib/Stale.rakumod').spurt: Q:to/MODULE/;
+    unit module Stale;
+    class Top is export { method who { 'top' } }
+    class Middle is Top is export { }
+    class Bottom is Middle is export { }
+    my @fillers = BEGIN (^20).map({
+        Metamodel::ClassHOW.new_type(name => "Filler$_").^compose
+    });
+    sub site(Mu $o) { $o.WHICH }
+    BEGIN { site($_) for @fillers; site(Bottom) }
+    MODULE
+
+    my $program = Q:to/PROGRAM/;
+    use Stale;
+    use MONKEY-TYPING;
+    augment class Middle { method who { 'middle' } }
+    my @others = (^20).map({
+        my $type = Metamodel::ClassHOW.new_type(name => "Other$_");
+        $type.^add_method('who', method { 'other' });
+        $type.^compose
+    });
+    sub site(Mu $o) { $o.who }
+    site($_) for @others;
+    print site(Bottom.new);
+    PROGRAM
+
+    my @command = $*EXECUTABLE, '-I' ~ $dir.add('lib'), '-e', $program;
+    my $first = run |@command, :out, :err;
+    is $first.out.slurp(:close), 'middle',
+      'the program finds the added method with the module compiled in process';
+    $first.err.slurp(:close);
+
+    my $second = run |@command, :out, :err;
+    is $second.out.slurp(:close), 'middle',
+      'the program finds the added method with the module loaded from its precompilation';
+    $second.err.slurp(:close);
+}
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Previously a call site that had seen many types looked its method up in the flattened method table each class caches on its meta-object. Adding a method to a class clears the table of that class only, so a subclass whose table was built before the addition kept resolving the name to the method higher in the hierarchy. The setting builds such tables for the RakuAST node classes while it compiles and then augments RakuAST::Node with .raku, so a table read back from the setting still named Mu.raku, and .raku of a large tree wrote some nodes as a bare constructor call. A precompiled module that built a table while compiling has the same problem once the program that loads it adds a method to a parent class.

This tags a table with an object made once per process and rebuilds a table whose tag is not that object. A table that was serialized carries the tag of the process that built it, which the deserializing process never matches, so it is rebuilt before its first use. The megamorphic dispatch programs guard on the tag as well, since a program installed at a call site reads the table of every later type straight off its meta-object.