### PR TITLE
Better error when crawling files for "use lib" or RAKULIB fails, and warn about too big dir trees

### DIFF
--- a/src/core.c/CompUnit/Repository/FileSystem.rakumod
+++ b/src/core.c/CompUnit/Repository/FileSystem.rakumod
@@ -333,16 +333,30 @@ class CompUnit::Repository::FileSystem
 
         # Set up hash of hashes of files found that could be modules.
         # Then select the most prominent one from there when done.
-        my %provides-exts = @!extensions.map(* => True);
-        my $provides-files := ls($!prefix.absolute).grep({ my $ext = $_.extension; %provides-exts{$ext} });
         my %provides;
-        %provides{
-          .subst(:g, /\//, "::")
-          .subst(:g, /\:\:+/, '::')
-          .subst(/^.*?'::'/, '')
-          .subst(/\..*/, '')
-        }{ $SPEC.extension($_) } = $_
-          for $provides-files.map(&to-relative);
+
+        try {
+            my %provides-exts = @!extensions.map(* => True);
+            my int $total-files = 0;
+            my $provides-files := ls($!prefix.absolute).grep({ $total-files++; my $ext = $_.extension; %provides-exts{$ext} });
+
+            %provides{
+              .subst(:g, /\//, "::")
+              .subst(:g, /\:\:+/, '::')
+              .subst(/^.*?'::'/, '')
+              .subst(/\..*/, '')
+            }{ $SPEC.extension($_) } = $_
+              for $provides-files.map(&to-relative);
+
+            CATCH {
+                die("Setting up lib path $!prefix.absolute():" ~ ($total-files ?? " after crawling $total-files files:" !! "") ~ "\n    $_");
+            }
+
+            if $total-files > 10000 {
+                my int $relevant-files = %provides.elems();
+                warn("The path $!prefix.absolute() has $total-files files in it (but " ~ ($relevant-files ?? "only $relevant-files" !! "no") ~ " relevant files).\n  Did you put it into rakudo's module search path by accident?");
+            }
+        }
 
         # precedence is determined by the order of @!extensions
         $_ = @!extensions.map(-> $ext { $_{$ext} }).first(*.defined)


### PR DESCRIPTION
Instead of giving just the underlying error message when crawling files fails for whatever reason, we output a hint that it's related to setting up a lib path.

For now, I just chose 10k files crawled as a reasonable "did you really mean to do this?" threshold.

Using "warn" is not my favourite way to do this, but I'm not sure if I can add a WORRY from this piece of code, since it may run at run-time as well.

```
timo@pebbsi:/var/home/timo/.var$ rakudo -I . -e 'say "hi"; use JSON::Fast; say "bye";'
===SORRY!=== Error while compiling -e
Setting up lib path /var/home/timo/.var: after crawling 790729 files:
    Failed to stat file: no such file or directory
at -e:1
timo@pebbsi:/var/home/timo/.var$ cd app/org.mozilla.firefox/
timo@pebbsi:/var/home/timo/.var/app/org.mozilla.firefox$ rakudo -I . -e 'say "hi"; use JSON::Fast; say "bye";'
The path /var/home/timo/.var/app/org.mozilla.firefox has 59721 files in it (but no relevant files).
  Did you put it into rakudo's module search path by accident?
  in any statement_control at /var/home/timo/raku/prefix/share/perl6/lib/Perl6/Grammar.moarvm line 1
hi
bye
```